### PR TITLE
add missing "words" to the dictionary

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -154,6 +154,7 @@ Beauchemin
 Behaviour
 behaviour
 behaviours
+BestCandidate
 Bigquery
 bigquery
 BigQueryHook
@@ -1269,6 +1270,7 @@ SearchResultGenerator
 SecretManagerClient
 secretRef
 secretRefs
+SecretsManagerBackend
 securable
 securecookie
 securestring


### PR DESCRIPTION
building the doc is currently broken (at least locally) due to those 2 words, coming from 
https://github.com/apache/airflow/blob/5246c009c557b4f6bdf1cd62bf9b89a2da63f630/airflow/providers/amazon/CHANGELOG.rst#L33
and
https://github.com/apache/airflow/blob/e8533d295e6d25296e23d8e1b8c07a441df55964/airflow/providers/amazon/aws/operators/sagemaker.py#L990