### PR TITLE
Remove `@pytest.mark.quarantined` from stable quarantine tests

### DIFF
--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -107,7 +107,6 @@ class TestCeleryExecutor:
     def test_supports_sentry(self):
         assert CeleryExecutor.supports_sentry
 
-    @pytest.mark.quarantined
     @pytest.mark.backend("mysql", "postgres")
     def test_exception_propagation(self, caplog):
         caplog.set_level(logging.ERROR, logger="airflow.executors.celery_executor.BulkStateFetcher")

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -397,7 +397,6 @@ class TestLocalTaskJob:
             ]
         )
 
-    @pytest.mark.quarantined
     @patch.object(StandardTaskRunner, "return_code")
     def test_localtaskjob_maintain_heart_rate(self, mock_return_code, caplog, create_dummy_dag):
 


### PR DESCRIPTION
related: #28658

Currently all tests pass either local run or quarantined pipeline in CI. I've just remove flag from all test for check in all possible backends.

Most of the issues in the past related to MySQL 5.7 which almost reach [EOL](https://endoflife.software/applications/databases/mysql), however quarantined pipeline run only with SQLite backend.

**Update**
After couple runs we found that only [tests/executors/test_celery_executor.py::TestLocalTaskJob::test_process_sigterm_works_with_retries](https://github.com/apache/airflow/blob/ce677862be4a7de777208ba9ba9e62bcd0415393/tests/jobs/test_local_task_job.py#L771-L776) is still flaky