### PR TITLE
Fix UIAlert should_show when AUTH_ROLE_PUBLIC set

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -823,10 +823,11 @@ class UIAlert:
         self.message = Markup(message) if html else message
 
     def should_show(self, securitymanager: SecurityManager) -> bool:
-        """
-        Determine if the user should see the message based on their role membership.
-        If the user is anonymous and AUTH_ROLE_PUBLIC is set in webserver_config.py,
-        provide that user with the AUTH_ROLE_PUBLIC role.
+        """Determine if the user should see the message.
+        
+        The decision is based on the user's role. If ``AUTH_ROLE_PUBLIC`` is
+        set in ``webserver_config.py``, An anonymous user would have the
+        ``AUTH_ROLE_PUBLIC`` role.
         """
         if self.roles:
             current_user = securitymanager.current_user

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -831,9 +831,9 @@ class UIAlert:
         """
         if self.roles:
             current_user = securitymanager.current_user
-            if current_user:
+            if current_user is not None:
                 user_roles = {r.name for r in securitymanager.current_user.roles}
-            elif current_user is None and "AUTH_ROLE_PUBLIC" in securitymanager.appbuilder.get_app.config:
+            elif "AUTH_ROLE_PUBLIC" in securitymanager.appbuilder.get_app.config:
                 # If the current_user is anonymous, assign AUTH_ROLE_PUBLIC role (if it exists) to them
                 user_roles = {securitymanager.appbuilder.get_app.config["AUTH_ROLE_PUBLIC"]}
             else:

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -831,8 +831,6 @@ class UIAlert:
         """
         if self.roles:
             current_user = securitymanager.current_user
-            user_roles = set()
-
             if current_user:
                 user_roles = {r.name for r in securitymanager.current_user.roles}
             elif current_user is None and "AUTH_ROLE_PUBLIC" in securitymanager.appbuilder.get_app.config:

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -56,6 +56,8 @@ if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
     from sqlalchemy.sql.operators import ColumnOperators
 
+    from airflow.www.fab_security.sqla.manager import SecurityManager
+
 
 def datetime_to_string(value: DateTime | None) -> str | None:
     if value is None:
@@ -820,7 +822,7 @@ class UIAlert:
         self.html = html
         self.message = Markup(message) if html else message
 
-    def should_show(self, securitymanager) -> bool:
+    def should_show(self, securitymanager: SecurityManager) -> bool:
         """
         Determine if the user should see the message based on their role membership.
         If the user is anonymous and AUTH_ROLE_PUBLIC is set in webserver_config.py,
@@ -830,7 +832,7 @@ class UIAlert:
             current_user = securitymanager.current_user
             user_roles = set()
 
-            if current_user and hasattr(current_user, "roles") and len(current_user.roles) > 0:
+            if current_user:
                 user_roles = {r.name for r in securitymanager.current_user.roles}
             elif current_user is None and "AUTH_ROLE_PUBLIC" in securitymanager.appbuilder.get_app.config:
                 # If the current_user is anonymous, assign AUTH_ROLE_PUBLIC role (if it exists) to them

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -824,7 +824,7 @@ class UIAlert:
 
     def should_show(self, securitymanager: SecurityManager) -> bool:
         """Determine if the user should see the message.
-        
+
         The decision is based on the user's role. If ``AUTH_ROLE_PUBLIC`` is
         set in ``webserver_config.py``, An anonymous user would have the
         ``AUTH_ROLE_PUBLIC`` role.

--- a/tests/test_utils/www.py
+++ b/tests/test_utils/www.py
@@ -32,6 +32,13 @@ def client_with_login(app, **kwargs):
     return client
 
 
+def client_without_login(app):
+    # Anonymous users can only view if AUTH_ROLE_PUBLIC is set to non-Public
+    app.config["AUTH_ROLE_PUBLIC"] = "Viewer"
+    client = app.test_client()
+    return client
+
+
 def check_content_in_response(text, resp, resp_code=200):
     resp_html = resp.data.decode("utf-8")
     assert resp_code == resp.status_code

--- a/tests/www/views/conftest.py
+++ b/tests/www/views/conftest.py
@@ -29,7 +29,7 @@ from airflow.models import DagBag
 from airflow.www.app import create_app
 from tests.test_utils.api_connexion_utils import delete_user
 from tests.test_utils.decorators import dont_initialize_flask_app_submodules
-from tests.test_utils.www import client_with_login
+from tests.test_utils.www import client_with_login, client_without_login
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -121,6 +121,11 @@ def viewer_client(app):
 @pytest.fixture()
 def user_client(app):
     return client_with_login(app, username="test_user", password="test_user")
+
+
+@pytest.fixture()
+def anonymous_client(app):
+    return client_without_login(app)
 
 
 class _TemplateWithContext(NamedTuple):

--- a/tests/www/views/test_views_home.py
+++ b/tests/www/views/test_views_home.py
@@ -203,6 +203,11 @@ def test_home_robots_header_in_response(user_client):
 @pytest.mark.parametrize(
     "client, flash_message, expected",
     [
+        ("anonymous_client", UIAlert("hello world"), True),
+        ("anonymous_client", UIAlert("hello world", roles=["Viewer"]), True),
+        ("anonymous_client", UIAlert("hello world", roles=["User"]), False),
+        ("anonymous_client", UIAlert("hello world", roles=["Viewer", "User"]), True),
+        ("anonymous_client", UIAlert("hello world", roles=["Admin"]), False),
         ("user_client", UIAlert("hello world"), True),
         ("user_client", UIAlert("hello world", roles=["User"]), True),
         ("user_client", UIAlert("hello world", roles=["User", "Admin"]), True),


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: https://github.com/apache/airflow/issues/28746

If we detect that the securitymanager.current_user is None, we should not attempt to get its roles attribute.

Instead, we can check to see if the AUTH_ROLE_PUBLIC is set in webserver_config.py which will tell us if a public role is being used. If it is, we can assume that because the current_user is None, the current_user's role is the public role.

Needed to add an anonymous_client fixture to simulate AUTH_ROLE_PUBLIC being set and an anonymous user hitting home.

cc @pierrejeambrun

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
