### PR TITLE
Assign `datasetReference` by default in `create_empty_dataset` of BigQueryHook

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -425,7 +425,10 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets#resource
         :param exists_ok: If ``True``, ignore "already exists" errors when creating the dataset.
         """
-        dataset_reference = dataset_reference or {"datasetReference": {}}
+        dataset_reference = dataset_reference or {}
+
+        if "datasetReference" not in dataset_reference:
+            dataset_reference["datasetReference"] = {}
 
         for param, value in zip(["datasetId", "projectId"], [dataset_id, project_id]):
             specified_param = dataset_reference["datasetReference"].get(param)

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -1487,6 +1487,22 @@ class TestDatasetsOperations(_BigQueryBaseTestClass):
             dataset=api_repr.return_value, exists_ok=True
         )
 
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Dataset")
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Client")
+    def test_create_empty_dataset_without_datasetreference_key(self, mock_client, mock_dataset):
+        dataset = {"defaultTableExpirationMs": str(1000 * 60 * 60 * 24 * 30)}
+        dataset_copy = dataset.copy()
+        self.hook.create_empty_dataset(
+            dataset_reference=dataset, dataset_id="DATASET_ID", project_id="PROJECT_ID"
+        )
+        assert dataset["defaultTableExpirationMs"] == dataset_copy["defaultTableExpirationMs"]
+        assert dataset["datasetReference"] == {"datasetId": "DATASET_ID", "projectId": "PROJECT_ID"}
+        api_repr = mock_dataset.from_api_repr
+        api_repr.assert_called_once_with(dataset)
+        mock_client.return_value.create_dataset.assert_called_once_with(
+            dataset=api_repr.return_value, exists_ok=True
+        )
+
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Client")
     def test_get_dataset(self, mock_client):
         _expected_result = {


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
solves: #16101
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
