### PR TITLE
Remove swagger-ui extra from connexion to resolve CVE-2019-17495

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1030,7 +1030,7 @@ ARG PYTHON_BASE_IMAGE
 ARG AIRFLOW_IMAGE_REPOSITORY="https://github.com/apache/airflow"
 
 # By increasing this number we can do force build of all dependencies
-ARG DEPENDENCIES_EPOCH_NUMBER="6"
+ARG DEPENDENCIES_EPOCH_NUMBER="7"
 
 # Make sure noninteractive debian install is used and language variables set
 ENV PYTHON_BASE_IMAGE=${PYTHON_BASE_IMAGE} \

--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -208,7 +208,11 @@ def init_api_connexion(app: Flask) -> None:
             return views.method_not_allowed(ex)
 
     spec_dir = path.join(ROOT_APP_DIR, "api_connexion", "openapi")
-    options = {"swagger_ui": conf.getboolean("webserver", "enable_swagger_ui", fallback=True)}
+    swagger_ui_dir = path.join(ROOT_APP_DIR, "www", "static", "dist", "swagger-ui")
+    options = {
+        "swagger_ui": conf.getboolean("webserver", "enable_swagger_ui", fallback=True),
+        "swagger_path": swagger_ui_dir,
+    }
     connexion_app = App(__name__, specification_dir=spec_dir, skip_error_handlers=True, options=options)
     connexion_app.app = app
     api_bp = connexion_app.add_api(

--- a/airflow/www/package.json
+++ b/airflow/www/package.json
@@ -120,6 +120,7 @@
     "react-textarea-autosize": "^8.3.4",
     "redoc": "^2.0.0-rc.72",
     "remark-gfm": "^3.0.1",
+    "swagger-ui-dist": "3.52.0",
     "type-fest": "^2.17.0",
     "url-search-params-polyfill": "^8.1.0"
   },

--- a/airflow/www/templates/swagger-ui/index.j2
+++ b/airflow/www/templates/swagger-ui/index.j2
@@ -1,0 +1,87 @@
+{#
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+#}
+
+<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>{{ title | default('Swagger UI') }}</title>
+    <link rel="stylesheet" type="text/css" href="./swagger-ui.css" />
+    <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
+    <style>
+      html
+      {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
+      *,
+      *:before,
+      *:after
+      {
+        box-sizing: inherit;
+      }
+      body
+      {
+        margin:0;
+        background: #fafafa;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="./swagger-ui-bundle.js" charset="UTF-8"> </script>
+    <script src="./swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
+    <script>
+    window.onload = function() {
+      // Begin Swagger UI call region
+      const ui = SwaggerUIBundle({
+        url: "{{ openapi_spec_url }}",
+        {% if urls is defined %}
+        urls: {{ urls|tojson|safe }},
+        {% endif %}
+        validatorUrl: {{ validatorUrl | default('null') }},
+        {% if configUrl is defined %}
+        configUrl: "{{ configUrl }}",
+        {% endif %}
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout"
+      });
+      {% if initOAuth is defined %}
+      ui.initOAuth(
+        {{ initOAuth|tojson|safe }}
+      )
+      {% endif %}
+      // End Swagger UI call region
+      window.ui = ui;
+    };
+  </script>
+  </body>
+</html>

--- a/airflow/www/webpack.config.js
+++ b/airflow/www/webpack.config.js
@@ -259,6 +259,14 @@ const config = {
           from: 'node_modules/jshint/dist/jshint.js',
           flatten: true,
         },
+        {
+          from: 'templates/swagger-ui',
+          to: `${BUILD_DIR}/swagger-ui`,
+        },
+        {
+          from: 'node_modules/swagger-ui-dist',
+          to: `${BUILD_DIR}/swagger-ui`,
+        },
       ],
     }),
     new LicensePlugin({

--- a/airflow/www/yarn.lock
+++ b/airflow/www/yarn.lock
@@ -10462,6 +10462,11 @@ svgo@^2.7.0:
     picocolors "^1.0.0"
     stable "^0.1.8"
 
+swagger-ui-dist@3.52.0:
+  version "3.52.0"
+  resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-3.52.0.tgz#cb16ec6dcdf134ff47cbfe57cba7be7748429142"
+  integrity sha512-SGfhW8FCih00QG59PphdeAUtTNw7HS5k3iPqDZowerPw9mcbhKchUb12kbROk99c1X6RTWW1gB1kqgfnYGuCSg==
+
 swagger2openapi@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/swagger2openapi/-/swagger2openapi-7.0.6.tgz#20a2835b8edfc0f4c08036b20cb51e8f78a420bf"

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,7 @@ install_requires =
     # Update CustomTTYColoredFormatter to remove
     colorlog>=4.0.2, <5.0
     configupdater>=3.1.1
-    connexion[swagger-ui,flask]>=2.10.0
+    connexion[flask]>=2.10.0
     cron-descriptor>=1.2.24
     croniter>=0.3.17
     cryptography>=0.9.3


### PR DESCRIPTION
install `swagger-ui-dist` via npm package rather then install installing `swagger-ui-bundle` from `connexion[swagger-ui]` extra which contains version 2.2.10 which is vulnerable to CVE-2019-17495.

closes: #28381 