### PR TITLE
Fix parameters not passed in BigQueryColumnCheckOperator test

### DIFF
--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -1725,7 +1725,7 @@ def test_bigquery_column_check_operator_succeeds(mock_job, mock_hook, check_type
 @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryJob")
 def test_bigquery_column_check_operator_fails(mock_job, mock_hook, check_type, check_value, check_result):
     mock_job.result.return_value.to_dataframe.return_value = pd.DataFrame(
-        {"col_name": ["col1"], "check_type": ["min"], "check_result": [1]}
+        {"col_name": ["col1"], "check_type": ["min"], "check_result": [check_result]}
     )
     mock_hook.return_value.insert_job.return_value = mock_job
 
@@ -1734,7 +1734,7 @@ def test_bigquery_column_check_operator_fails(mock_job, mock_hook, check_type, c
         table=TEST_TABLE_ID,
         use_legacy_sql=False,
         column_mapping={
-            "col1": {"min": {"equal_to": 0}},
+            "col1": {"min": {check_type: check_value}},
         },
     )
     with pytest.raises(AirflowException):


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fixes a minor issue in a previous commit of mine with the BigQueryColumnCheckOperator fail test where parameters are not being properly passed through. Copy and paste error here. Sorry!

In breeze shell:

```bash
root@6b51158cc469:/opt/airflow# pytest -v tests/providers/google/cloud/operators/test_bigquery.py::test_bigquery_column_check_operator_fails
/usr/local/lib/python3.7/site-packages/pytest_asyncio/plugin.py:177: DeprecationWarning: You're using an outdated version of pytest. Newer releases of pytest-asyncio will not be compatible with this pytest version. Please update pytest to version 7 or later.
  DeprecationWarning,
========================================================== test session starts ===========================================================
platform linux -- Python 3.7.16, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /opt/airflow, configfile: pytest.ini
plugins: time-machine-2.9.0, asyncio-0.20.3, xdist-3.1.0, timeouts-1.2.1, capture-warnings-0.0.4, anyio-3.6.2, requests-mock-1.10.0, cov-4.0.0, instafail-0.4.2, httpx-0.21.2, rerunfailures-9.1.1
asyncio: mode=strict
setup timeout: 0.0s, execution timeout: 0.0s, teardown timeout: 0.0s
collected 5 items

tests/providers/google/cloud/operators/test_bigquery.py::test_bigquery_column_check_operator_fails[equal_to-0-1] PASSED            [ 20%]
tests/providers/google/cloud/operators/test_bigquery.py::test_bigquery_column_check_operator_fails[greater_than-0--1] PASSED       [ 40%]
tests/providers/google/cloud/operators/test_bigquery.py::test_bigquery_column_check_operator_fails[less_than-0-1] PASSED           [ 60%]
tests/providers/google/cloud/operators/test_bigquery.py::test_bigquery_column_check_operator_fails[geq_to-0--1] PASSED             [ 80%]
tests/providers/google/cloud/operators/test_bigquery.py::test_bigquery_column_check_operator_fails[leq_to-0-1] PASSED              [100%]

============================================================ warnings summary ============================================================
tests/providers/google/cloud/operators/test_bigquery.py::test_bigquery_column_check_operator_fails[equal_to-0-1]
tests/providers/google/cloud/operators/test_bigquery.py::test_bigquery_column_check_operator_fails[equal_to-0-1]
  /usr/local/lib/python3.7/site-packages/connexion/decorators/validation.py:16: DeprecationWarning: Accessing jsonschema.draft4_format_checker is deprecated and will be removed in a future release. Instead, use the FORMAT_CHECKER attribute on the corresponding Validator.
    from jsonschema import Draft4Validator, ValidationError, draft4_format_checker

tests/providers/google/cloud/operators/test_bigquery.py::test_bigquery_column_check_operator_fails[equal_to-0-1]
  /opt/airflow/airflow/example_dags/example_sensor_decorator.py:64: RemovedInAirflow3Warning: Param `schedule_interval` is deprecated and will be removed in a future release. Please use `schedule` instead.
    tutorial_etl_dag = example_sensor_decorator()

tests/providers/google/cloud/operators/test_bigquery.py::test_bigquery_column_check_operator_fails[equal_to-0-1]
  /opt/airflow/airflow/example_dags/example_subdag_operator.py:45: RemovedInAirflow3Warning: This class is deprecated. Please use `airflow.utils.task_group.TaskGroup`.
    subdag=subdag(DAG_NAME, "section-1", dag.default_args),

tests/providers/google/cloud/operators/test_bigquery.py::test_bigquery_column_check_operator_fails[equal_to-0-1]
  /opt/airflow/airflow/example_dags/example_subdag_operator.py:54: RemovedInAirflow3Warning: This class is deprecated. Please use `airflow.utils.task_group.TaskGroup`.
    subdag=subdag(DAG_NAME, "section-2", dag.default_args),

-- Docs: https://docs.pytest.org/en/stable/warnings.html
===================================================== 5 passed, 5 warnings in 18.96s =====================================================
```

cc @eladkal 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
