### PR TITLE
Fix masking of non-sensitive environment variables

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -1149,8 +1149,8 @@ class AirflowConfigParser(ConfigParser):
             if not display_sensitive and env_var != self._env_var_name("core", "unit_test_mode"):
                 # Don't hide cmd/secret values here
                 if not env_var.lower().endswith("cmd") and not env_var.lower().endswith("secret"):
-                    opt = "< hidden >"
-
+                    if (section, key) in self.sensitive_config_values:
+                        opt = "< hidden >"
             elif raw:
                 opt = opt.replace("%", "%%")
             if display_source:

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -64,6 +64,7 @@ def restore_env():
     "os.environ",
     {
         "AIRFLOW__TESTSECTION__TESTKEY": "testvalue",
+        "AIRFLOW__CORE__FERNET_KEY": "testvalue",
         "AIRFLOW__TESTSECTION__TESTPERCENT": "with%percent",
         "AIRFLOW__TESTCMDENV__ITSACOMMAND_CMD": 'echo -n "OK"',
         "AIRFLOW__TESTCMDENV__NOTACOMMAND_CMD": 'echo -n "NOT OK"',
@@ -135,15 +136,16 @@ class TestConf:
         assert cfg_dict["core"]["percent"] == "with%inside"
 
         # test env vars
-        assert cfg_dict["testsection"]["testkey"] == "< hidden >"
-        assert cfg_dict["kubernetes_environment_variables"]["AIRFLOW__TESTSECTION__TESTKEY"] == "< hidden >"
+        assert cfg_dict["testsection"]["testkey"] == "testvalue"
+        assert cfg_dict["kubernetes_environment_variables"]["AIRFLOW__TESTSECTION__TESTKEY"] == "nested"
 
     def test_conf_as_dict_source(self):
         # test display_source
         cfg_dict = conf.as_dict(display_source=True)
         assert cfg_dict["core"]["load_examples"][1] == "airflow.cfg"
         assert cfg_dict["database"]["load_default_connections"][1] == "airflow.cfg"
-        assert cfg_dict["testsection"]["testkey"] == ("< hidden >", "env var")
+        assert cfg_dict["testsection"]["testkey"] == ("testvalue", "env var")
+        assert cfg_dict["core"]["fernet_key"] == ("< hidden >", "env var")
 
     def test_conf_as_dict_sensitive(self):
         # test display_sensitive


### PR DESCRIPTION
Environment variables are hidden even when we set expose-config to non-sensitive-only. This PR changes it to work like every other source, the items are only hidden when they are sensitive

Closes: https://github.com/apache/airflow/issues/28756
