### PR TITLE
Move local_infile option from extra to hook parameter

### DIFF
--- a/airflow/providers/mysql/CHANGELOG.rst
+++ b/airflow/providers/mysql/CHANGELOG.rst
@@ -27,6 +27,15 @@ used with MySQL server 5.6.4 through 5.7.
 Changelog
 ---------
 
+4.0.0
+.....
+
+Breaking Changes
+~~~~~~~~~~~~~~~~
+
+You can no longer pass "local_infile" as extra in the connection. You should pass it instead as
+hook's "local_infile" parameter when you create the MySqlHook (either directly or via hook_params).
+
 3.4.0
 .....
 

--- a/airflow/providers/mysql/provider.yaml
+++ b/airflow/providers/mysql/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `MySQL <https://www.mysql.com/products/>`__
 
 versions:
+  - 4.0.0
   - 3.4.0
   - 3.3.0
   - 3.2.1

--- a/airflow/providers/mysql/transfers/vertica_to_mysql.py
+++ b/airflow/providers/mysql/transfers/vertica_to_mysql.py
@@ -49,9 +49,8 @@ class VerticaToMySqlOperator(BaseOperator):
         import, typically used to move data from staging to production
         and issue cleanup commands. (templated)
     :param bulk_load: flag to use bulk_load option.  This loads MySQL directly
-        from a tab-delimited text file using the LOAD DATA LOCAL INFILE command.
-        This option requires an extra connection parameter for the
-        destination MySQL connection: {'local_infile': true}.
+        from a tab-delimited text file using the LOAD DATA LOCAL INFILE command. The MySQL
+        server must support loading local files via this command (it is disabled by default).
     """
 
     template_fields: Sequence[str] = ("sql", "mysql_table", "mysql_preoperator", "mysql_postoperator")
@@ -86,7 +85,7 @@ class VerticaToMySqlOperator(BaseOperator):
 
     def execute(self, context: Context):
         vertica = VerticaHook(vertica_conn_id=self.vertica_conn_id)
-        mysql = MySqlHook(mysql_conn_id=self.mysql_conn_id)
+        mysql = MySqlHook(mysql_conn_id=self.mysql_conn_id, local_infile=self.bulk_load)
 
         if self.bulk_load:
             self._bulk_load_transfer(mysql, vertica)

--- a/docs/apache-airflow-providers-mysql/connections/mysql.rst
+++ b/docs/apache-airflow-providers-mysql/connections/mysql.rst
@@ -46,9 +46,6 @@ Extra (optional)
       * ``charset``: specify charset of the connection
       * ``cursor``: one of ``sscursor``, ``dictcursor``, ``ssdictcursor`` . Specifies cursor class to be
         used
-      * ``local_infile``: controls MySQL's LOCAL capability (permitting local data loading by
-        clients). See `MySQLdb docs <https://mysqlclient.readthedocs.io/user_guide.html>`_
-        for details.
       * ``unix_socket``: UNIX socket used instead of the default socket.
       * ``ssl``: Dictionary of SSL parameters that control connecting using SSL. Those
         parameters are server specific and should contain ``ca``, ``cert``, ``key``, ``capath``,
@@ -99,14 +96,7 @@ Extra (optional)
           If encounter UnicodeDecodeError while working with MySQL connection, check
           the charset defined is matched to the database charset.
 
-    For ``mysql-connector-python`` the following extras are supported:
+    For ``mysql-connector-python`` no extras are supported:
 
-      * ``allow_local_infile``: Whether to enable ``LOAD DATA LOCAL INFILE`` capability.
-
-      Example "extras" field:
-
-      .. code-block:: json
-
-         {
-            "allow_local_infile": true
-         }
+In both cases, when you want to use ``LOAD DATA LOCAL INFILE`` SQL commands of MySQl, you need to create the
+Hook with "local_infile" parameter set to True.

--- a/tests/providers/apache/hive/transfers/test_hive_to_mysql.py
+++ b/tests/providers/apache/hive/transfers/test_hive_to_mysql.py
@@ -49,7 +49,9 @@ class TestHiveToMySqlTransfer(TestHiveEnvironment):
 
         mock_hive_hook.assert_called_once_with(hiveserver2_conn_id=self.kwargs["hiveserver2_conn_id"])
         mock_hive_hook.return_value.get_records.assert_called_once_with("sql", parameters={})
-        mock_mysql_hook.assert_called_once_with(mysql_conn_id=self.kwargs["mysql_conn_id"])
+        mock_mysql_hook.assert_called_once_with(
+            mysql_conn_id=self.kwargs["mysql_conn_id"], local_infile=False
+        )
         mock_mysql_hook.return_value.insert_rows.assert_called_once_with(
             table=self.kwargs["mysql_table"], rows=mock_hive_hook.return_value.get_records.return_value
         )
@@ -84,6 +86,7 @@ class TestHiveToMySqlTransfer(TestHiveEnvironment):
 
         HiveToMySqlOperator(**self.kwargs).execute(context=context)
 
+        mock_mysql_hook.assert_called_once_with(mysql_conn_id=self.kwargs["mysql_conn_id"], local_infile=True)
         mock_tmp_file_context.assert_called_once_with()
         mock_hive_hook.return_value.to_csv.assert_called_once_with(
             self.kwargs["sql"],

--- a/tests/providers/mysql/hooks/test_mysql.py
+++ b/tests/providers/mysql/hooks/test_mysql.py
@@ -123,7 +123,7 @@ class TestMySqlHookConn:
 
     @mock.patch("MySQLdb.connect")
     def test_get_conn_local_infile(self, mock_connect):
-        self.connection.extra = json.dumps({"local_infile": True})
+        self.db_hook.local_infile = True
         self.db_hook.get_conn()
         assert mock_connect.call_count == 1
         args, kwargs = mock_connect.call_args
@@ -219,8 +219,8 @@ class TestMySqlHookConnMySqlConnectorPython:
     @mock.patch("mysql.connector.connect")
     def test_get_conn_allow_local_infile(self, mock_connect):
         extra_dict = self.connection.extra_dejson
-        extra_dict.update(allow_local_infile=True)
         self.connection.extra = json.dumps(extra_dict)
+        self.db_hook.local_infile = True
         self.db_hook.get_conn()
         assert mock_connect.call_count == 1
         args, kwargs = mock_connect.call_args
@@ -406,7 +406,7 @@ class TestMySql:
     @mock.patch.dict(
         "os.environ",
         {
-            "AIRFLOW_CONN_AIRFLOW_DB": "mysql://root@mysql/airflow?charset=utf8mb4&local_infile=1",
+            "AIRFLOW_CONN_AIRFLOW_DB": "mysql://root@mysql/airflow?charset=utf8mb4",
         },
     )
     def test_mysql_hook_test_bulk_load(self, client):
@@ -419,7 +419,7 @@ class TestMySql:
                 f.write("\n".join(records).encode("utf8"))
                 f.flush()
 
-                hook = MySqlHook("airflow_db")
+                hook = MySqlHook("airflow_db", local_infile=True)
                 with closing(hook.get_conn()) as conn:
                     with closing(conn.cursor()) as cursor:
                         cursor.execute(


### PR DESCRIPTION
This change is to move local_infile parameter from connection extra to Hook. Since this feature is only used for very specific cases, it belongs to the "action" it executes not to the connection defined in general. For example in Hive and Vertica transfers, the capability of local_inline is simply exnabled by bulk_load parameter - and it allows to use the same connection in both cases.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
