### PR TITLE
Add worker service account for LocalKubernetesExecutor

### DIFF
--- a/chart/templates/workers/worker-serviceaccount.yaml
+++ b/chart/templates/workers/worker-serviceaccount.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Airflow Worker ServiceAccount
 #################################
-{{- if and .Values.workers.serviceAccount.create (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") (eq .Values.executor "KubernetesExecutor")) }}
+{{- if and .Values.workers.serviceAccount.create (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") (eq .Values.executor "KubernetesExecutor") (eq .Values.executor "LocalKubernetesExecutor")) }}
 kind: ServiceAccount
 apiVersion: v1
 metadata:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
---
`HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods \"extract-57f0f8f6590045d59eb2d36ce2bacb53\" is forbidden: error looking up service account airflow/airflow-worker: serviceaccount \"airflow-worker\" not found","reason":"Forbidden","details":{"name":"extract-57f0f8f6590045d59eb2d36ce2bacb53","kind":"pods"},"code":403}`
`WARNING - ApiException when attempting to run task, re-queueing. Reason: 'Forbidden'. Message: pods "extract-57f0f8f6590045d59eb2d36ce2bacb53" is forbidden: error looking up service account airflow/airflow-worker: serviceaccount "airflow-worker" not found`

When using the `KubernetesExecutor` as part of `LocalKubernetesExecutor`, it will fail due to a missing worker service account. This PR fixes that issue. Have tested this fix on the latest helm chart version.

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
