### PR TITLE
AWS system tests selective log purge

### DIFF
--- a/tests/system/providers/amazon/aws/example_sagemaker.py
+++ b/tests/system/providers/amazon/aws/example_sagemaker.py
@@ -55,7 +55,7 @@ from airflow.providers.amazon.aws.sensors.sagemaker import (
     SageMakerTuningSensor,
 )
 from airflow.utils.trigger_rule import TriggerRule
-from tests.system.providers.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder, purge_logs
+from tests.system.providers.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder, prune_logs
 
 DAG_ID = "example_sagemaker"
 
@@ -437,17 +437,6 @@ def delete_ecr_repository(repository_name):
 
 
 @task(trigger_rule=TriggerRule.ALL_DONE)
-def delete_logs(env_id):
-    generated_logs = [
-        # Format: ('log group name', 'log stream prefix')
-        ("/aws/sagemaker/ProcessingJobs", env_id),
-        ("/aws/sagemaker/TrainingJobs", env_id),
-        ("/aws/sagemaker/TransformJobs", env_id),
-    ]
-    purge_logs(generated_logs)
-
-
-@task(trigger_rule=TriggerRule.ALL_DONE)
 def delete_model_group(group_name, model_version_arn):
     sgmk_client = boto3.client("sagemaker")
     # need to destroy model registered in group first
@@ -501,9 +490,10 @@ with DAG(
     catchup=False,
 ) as dag:
     test_context = sys_test_context_task()
+    env_id = test_context[ENV_ID_KEY]
 
     test_setup = set_up(
-        env_id=test_context[ENV_ID_KEY],
+        env_id=env_id,
         role_arn=test_context[ROLE_ARN_KEY],
     )
 
@@ -658,6 +648,15 @@ with DAG(
         force_delete=True,
     )
 
+    log_cleanup = prune_logs(
+        [
+            # Format: ('log group name', 'log stream prefix')
+            ("/aws/sagemaker/ProcessingJobs", env_id),
+            ("/aws/sagemaker/TrainingJobs", env_id),
+            ("/aws/sagemaker/TransformJobs", env_id),
+        ]
+    )
+
     chain(
         # TEST SETUP
         test_context,
@@ -690,6 +689,7 @@ with DAG(
         delete_pipeline(test_setup["pipeline_name"]),
         delete_logs(test_context[ENV_ID_KEY]),
         delete_docker_image(test_setup["docker_image"]),
+        log_cleanup,
     )
 
     from tests.system.utils.watcher import watcher

--- a/tests/system/providers/amazon/aws/example_sagemaker.py
+++ b/tests/system/providers/amazon/aws/example_sagemaker.py
@@ -687,7 +687,6 @@ with DAG(
         delete_bucket,
         delete_experiment(test_setup["experiment_name"]),
         delete_pipeline(test_setup["pipeline_name"]),
-        delete_logs(test_context[ENV_ID_KEY]),
         delete_docker_image(test_setup["docker_image"]),
         log_cleanup,
     )

--- a/tests/system/providers/amazon/aws/utils/__init__.py
+++ b/tests/system/providers/amazon/aws/utils/__init__.py
@@ -30,6 +30,8 @@ from botocore.exceptions import ClientError, NoCredentialsError
 
 from airflow.decorators import task
 from airflow.providers.amazon.aws.hooks.ssm import SsmHook
+from airflow.utils.state import State
+from airflow.utils.trigger_rule import TriggerRule
 
 ENV_ID_ENVIRON_KEY: str = "SYSTEM_TESTS_ENV_ID"
 ENV_ID_KEY: str = "ENV_ID"
@@ -249,7 +251,43 @@ def set_env_id() -> str:
     return env_id
 
 
-def purge_logs(
+def all_tasks_passed(ti) -> bool:
+    task_runs = ti.get_dagrun().get_task_instances()
+    return all([_task.state != State.FAILED for _task in task_runs])
+
+
+@task(trigger_rule=TriggerRule.ALL_DONE)
+def prune_logs(
+    logs: list[tuple[str, str | None]],
+    force_delete: bool = False,
+    retry: bool = False,
+    retry_times: int = 3,
+    ti=None,
+):
+    """
+    If all tasks in this dagrun have succeeded, then delete the associated logs.
+    Otherwise, append the logs with a retention policy.  This allows the logs
+    to be used for troubleshooting but assures they won't build up indefinitely.
+
+    :param logs: A list of log_group/stream_prefix tuples to delete.
+    :param force_delete: Whether to check log streams within the log group before
+        removal. If True, removes the log group and all its log streams inside it.
+    :param retry: Whether to retry if the log group/stream was not found. In some
+        cases, the log group/stream is created seconds after the main resource has
+        been created. By default, it retries for 3 times with a 5s waiting period.
+    :param retry_times: Number of retries.
+    :param ti: Used to check the status of the tasks. This gets pulled from the
+        DAG's context and does not need to be passed manually.
+    """
+    if all_tasks_passed(ti):
+        _purge_logs(logs, force_delete, retry, retry_times)
+    else:
+        client: BaseClient = boto3.client("logs")
+        for group, _ in logs:
+            client.put_retention_policy(logGroupName=group, retentionInDays=30)
+
+
+def _purge_logs(
     test_logs: list[tuple[str, str | None]],
     force_delete: bool = False,
     retry: bool = False,
@@ -291,7 +329,7 @@ def purge_logs(
                 raise e
 
             sleep(PURGE_LOGS_INTERVAL_PERIOD)
-            purge_logs(
+            _purge_logs(
                 test_logs=test_logs,
                 force_delete=force_delete,
                 retry=retry,


### PR DESCRIPTION
Currently all AWS system tests which create a Cloudwatch Log delete them when the test is done on a `trigger_rule=ALL_DONE` basis.  With this change if the test fails then a retention policy will be applied to the relevant logs instead of deleting them so the logs can be used to troubleshoot the failing test but they will still eventually clean themselves up.  If the test passes then there is non change, the logs are deleted immediately.