### PR TITLE
Fix helm chart create scheduler service to  serve task logs for LocalKubernetesExecutor

### DIFF
--- a/chart/templates/scheduler/scheduler-service.yaml
+++ b/chart/templates/scheduler/scheduler-service.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Airflow Scheduler Service
 #################################
-{{- if or (eq .Values.executor "LocalExecutor") (eq .Values.executor "LocalKubernetesExecutor") (eq .Values.executor "SequentialExecutor") }}
+{{- if or (eq .Values.executor "LocalExecutor") (eq .Values.executor "LocalKubernetesExecutor") }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/chart/templates/scheduler/scheduler-service.yaml
+++ b/chart/templates/scheduler/scheduler-service.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Airflow Scheduler Service
 #################################
-{{- if eq .Values.executor "LocalExecutor" }}
+{{- if or (eq .Values.executor "LocalExecutor") (eq .Values.executor "LocalKubernetesExecutor") (eq .Values.executor "SequentialExecutor") }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/tests/charts/test_scheduler.py
+++ b/tests/charts/test_scheduler.py
@@ -745,7 +745,6 @@ class TestSchedulerService:
             ("CeleryKubernetesExecutor", False),
             ("KubernetesExecutor", False),
             ("LocalKubernetesExecutor", True),
-            ("SequentialExecutor", True),
         ],
     )
     def test_should_create_scheduler_service_for_specific_executors(self, executor, creates_service):

--- a/tests/charts/test_scheduler.py
+++ b/tests/charts/test_scheduler.py
@@ -737,6 +737,34 @@ class TestSchedulerNetworkPolicy:
 
 
 class TestSchedulerService:
+    @pytest.mark.parametrize(
+        "executor, creates_service",
+        [
+            ("LocalExecutor", True),
+            ("CeleryExecutor", False),
+            ("CeleryKubernetesExecutor", False),
+            ("KubernetesExecutor", False),
+            ("LocalKubernetesExecutor", True),
+            ("SequentialExecutor", True),
+        ],
+    )
+    def test_should_create_scheduler_service_for_specific_executors(self, executor, creates_service):
+        docs = render_chart(
+            values={
+                "executor": executor,
+                "scheduler": {
+                    "labels": {"test_label": "test_label_value"},
+                },
+            },
+            show_only=["templates/scheduler/scheduler-service.yaml"],
+        )
+        if creates_service:
+            assert jmespath.search("kind", docs[0]) == "Service"
+            assert "test_label" in jmespath.search("metadata.labels", docs[0])
+            assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
+        else:
+            assert docs == []
+
     def test_should_add_component_specific_labels(self):
         docs = render_chart(
             values={


### PR DESCRIPTION
currently helm chart only created the `airflow-scheduler` service exposing the `task-logs` for `LocalExecutor`. 

it needs to create the service for  `LocalKubernetesExecutor` 



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
