### PR TITLE
Make allowed_deserialization_classes more intuitive

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -225,7 +225,7 @@ core:
       description: |
         What classes can be imported during deserialization. This is a multi line value.
         The individual items will be parsed as regexp. Python built-in classes (like dict)
-        are always allowed
+        are always allowed. Bare "." will be replaced so you can set airflow.* .
       version_added: 2.5.0
       type: string
       default: 'airflow\..*'

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -137,7 +137,7 @@ enable_xcom_pickling = False
 
 # What classes can be imported during deserialization. This is a multi line value.
 # The individual items will be parsed as regexp. Python built-in classes (like dict)
-# are always allowed
+# are always allowed. Bare "." will be replaced so you can set airflow.* .
 allowed_deserialization_classes = airflow\..*
 
 # When a task is killed forcefully, this is the amount of time in seconds that

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -299,6 +299,7 @@ def _compile_patterns():
 
     _patterns.clear()  # ensure to reinit
     for p in patterns:
+        p = re.sub(r"(\w)\.", r"\1\..", p)
         _patterns.append(re.compile(p))
 
 

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -31,8 +31,9 @@ from airflow.serialization.serde import (
     SCHEMA_ID,
     VERSION,
     _compile_patterns,
+    _match,
     deserialize,
-    serialize, _match,
+    serialize,
 )
 from airflow.utils.module_loading import qualname
 from tests.test_utils.config import conf_vars

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -32,7 +32,7 @@ from airflow.serialization.serde import (
     VERSION,
     _compile_patterns,
     deserialize,
-    serialize,
+    serialize, _match,
 )
 from airflow.utils.module_loading import qualname
 from tests.test_utils.config import conf_vars
@@ -180,6 +180,16 @@ class TestSerDe:
             deserialize(e)
 
         assert f"{qualname(Z)} was not found in allow list" in str(ex.value)
+
+    @conf_vars(
+        {
+            ("core", "allowed_deserialization_classes"): "tests.*",
+        }
+    )
+    def test_allow_list_replace(self):
+        _compile_patterns()
+        assert _match("tests.airflow.deep")
+        assert _match("testsfault") is False
 
     def test_incompatible_version(self):
         data = dict(


### PR DESCRIPTION
Regexps can be tough to get right. Typically someone would like to allow any classes below 'mymodule' to match. For example, 'mymodule.dataclasses' by setting allowed_deserialization_classes to 'mymodule.*'. However this matches everything starting with mymodule, so also mymodulemalicious. This change replaces bare '.' with '\..' so it matches the literal '.' as well.

@kaxil 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
