### PR TITLE
Add `hook_params` to `GCSBlobTrigger` docstring

### DIFF
--- a/airflow/providers/google/cloud/triggers/gcs.py
+++ b/airflow/providers/google/cloud/triggers/gcs.py
@@ -34,6 +34,8 @@ class GCSBlobTrigger(BaseTrigger):
     :param object_name: the file or folder present in the bucket
     :param google_cloud_conn_id: reference to the Google Connection
     :param poke_interval: polling period in seconds to check for file/folder
+    :param hook_params: Extra config params to be passed to the underlying GCSAsyncHook.
+        Should match the desired hook constructor params.
     """
 
     def __init__(


### PR DESCRIPTION
This parameter's info is missing from the docstring and, therefore, would be missing from the Python API documentation.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
