### PR TITLE
Use compat for cached_property in AWS Batch modules

### DIFF
--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -25,16 +25,9 @@ An Airflow operator for AWS Batch services
 """
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING, Any, Sequence
 
-from airflow.providers.amazon.aws.utils import trim_none_values
-
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    from cached_property import cached_property
-
+from airflow.compat.functools import cached_property
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook
@@ -44,6 +37,7 @@ from airflow.providers.amazon.aws.links.batch import (
     BatchJobQueueLink,
 )
 from airflow.providers.amazon.aws.links.logs import CloudWatchEventsLink
+from airflow.providers.amazon.aws.utils import trim_none_values
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context

--- a/airflow/providers/amazon/aws/sensors/batch.py
+++ b/airflow/providers/amazon/aws/sensors/batch.py
@@ -16,14 +16,9 @@
 # under the License.
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING, Sequence
 
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    from cached_property import cached_property
-
+from airflow.compat.functools import cached_property
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook
 from airflow.sensors.base import BaseSensorOperator
@@ -132,7 +127,7 @@ class BatchComputeEnvironmentSensor(BaseSensorOperator):
         )
 
     def poke(self, context: Context) -> bool:
-        response = self.hook.client.describe_compute_environments(
+        response = self.hook.client.describe_compute_environments(  # type: ignore[union-attr]
             computeEnvironments=[self.compute_environment]
         )
 
@@ -198,7 +193,9 @@ class BatchJobQueueSensor(BaseSensorOperator):
         )
 
     def poke(self, context: Context) -> bool:
-        response = self.hook.client.describe_job_queues(jobQueues=[self.job_queue])
+        response = self.hook.client.describe_job_queues(  # type: ignore[union-attr]
+            jobQueues=[self.job_queue]
+        )
 
         if len(response["jobQueues"]) == 0:
             if self.treat_non_existing_as_deleted:


### PR DESCRIPTION
The `airflow.compat.functools` module has been available since 2.1.2. The AWS Batch modules should use this available compat for `cached_property` rather than duplicating the logic.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
