### PR TITLE
Revert "Fixed test and remove pytest.mark.xfail for test_exc_tb"

### DIFF
--- a/tests/utils/log/test_secrets_masker.py
+++ b/tests/utils/log/test_secrets_masker.py
@@ -123,6 +123,7 @@ class TestSecretsMasker:
             """
         )
 
+    @pytest.mark.xfail(reason="Cannot filter secrets in traceback source")
     def test_exc_tb(self, logger, caplog):
         """
         Show it is not possible to filter secrets in the source.
@@ -150,7 +151,7 @@ class TestSecretsMasker:
             ERROR Err
             Traceback (most recent call last):
               File ".../test_secrets_masker.py", line {line}, in test_exc_tb
-                raise RuntimeError("Cannot connect to user:password")
+                raise RuntimeError("Cannot connect to user:***)
             RuntimeError: Cannot connect to user:***
             """
         )


### PR DESCRIPTION
Reverts apache/airflow#23650

No no no. That was there for a reason. By making this test pass you are encoding that the _wrong_ behaviour is good.

If you want to get rid of the xfail _DO NOT_ just do this.