### PR TITLE
AIP-44 Initialize methods map for Internal API RPC endpoint in the method

### DIFF
--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -17,8 +17,10 @@
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
+from typing import Any, Callable
 
 from flask import Response
 
@@ -28,25 +30,17 @@ from airflow.serialization.serialized_objects import BaseSerialization
 log = logging.getLogger(__name__)
 
 
-def _initialize_map() -> dict:
-    def _build_methods_map(list) -> dict:
-        return {f"{func.__module__}.{func.__name__}": func for func in list}
-
+@functools.lru_cache()
+def _initialize_map() -> dict[str, Callable]:
     from airflow.dag_processing.processor import DagFileProcessor
 
-    return _build_methods_map(
-        [
-            DagFileProcessor.update_import_errors,
-        ]
-    )
+    functions: list[Callable] = [
+        DagFileProcessor.update_import_errors,
+    ]
+    return {f"{func.__module__}.{func.__name__}": func for func in functions}
 
 
-METHODS_MAP = _initialize_map()
-
-
-def internal_airflow_api(
-    body: dict,
-) -> APIResponse:
+def internal_airflow_api(body: dict[str, Any]) -> APIResponse:
     """Handler for Internal API /internal_api/v1/rpcapi endpoint."""
     log.debug("Got request")
     json_rpc = body.get("jsonrpc")
@@ -54,12 +48,14 @@ def internal_airflow_api(
         log.error("Not jsonrpc-2.0 request.")
         return Response(response="Expected jsonrpc 2.0 request.", status=400)
 
-    method_name = str(body.get("method"))
-    if method_name not in METHODS_MAP:
+    methods_map = _initialize_map()
+
+    method_name = body.get("method")
+    if method_name not in methods_map:
         log.error("Unrecognized method: %s.", method_name)
         return Response(response=f"Unrecognized method: {method_name}.", status=400)
 
-    handler = METHODS_MAP[method_name]
+    handler = methods_map[method_name]
     params = {}
     try:
         if body.get("params"):

--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -23,7 +23,6 @@ import logging
 from flask import Response
 
 from airflow.api_connexion.types import APIResponse
-from airflow.dag_processing.processor import DagFileProcessor
 from airflow.serialization.serialized_objects import BaseSerialization
 
 log = logging.getLogger(__name__)
@@ -33,11 +32,17 @@ def _build_methods_map(list) -> dict:
     return {f"{func.__module__}.{func.__name__}": func for func in list}
 
 
-METHODS_MAP = _build_methods_map(
-    [
-        DagFileProcessor.update_import_errors,
-    ]
-)
+def _initialize_map() -> dict:
+    from airflow.dag_processing.processor import DagFileProcessor
+
+    return _build_methods_map(
+        [
+            DagFileProcessor.update_import_errors,
+        ]
+    )
+
+
+METHODS_MAP = _initialize_map()
 
 
 def internal_airflow_api(

--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -28,11 +28,10 @@ from airflow.serialization.serialized_objects import BaseSerialization
 log = logging.getLogger(__name__)
 
 
-def _build_methods_map(list) -> dict:
-    return {f"{func.__module__}.{func.__name__}": func for func in list}
-
-
 def _initialize_map() -> dict:
+    def _build_methods_map(list) -> dict:
+        return {f"{func.__module__}.{func.__name__}": func for func in list}
+
     from airflow.dag_processing.processor import DagFileProcessor
 
     return _build_methods_map(


### PR DESCRIPTION
To avoid potential cyclic dependencies