### PR TITLE
Fix system test example_redshift_s3_transfers.py

### DIFF
--- a/tests/system/providers/amazon/aws/example_redshift_s3_transfers.py
+++ b/tests/system/providers/amazon/aws/example_redshift_s3_transfers.py
@@ -54,9 +54,9 @@ IP_PERMISSION = {
     "IpRanges": [{"CidrIp": "0.0.0.0/0", "Description": "Test description"}],
 }
 
-S3_KEY = "s3_key"
+S3_KEY = "s3_output_"
 S3_KEY_2 = "s3_key_2"
-S3_KEY_PREFIX = "s3_"
+S3_KEY_PREFIX = "s3_k"
 REDSHIFT_TABLE = "test_table"
 
 SQL_CREATE_TABLE = f"""


### PR DESCRIPTION
This [commit](https://github.com/aws-mwaa/upstream-to-airflow/commit/3a7cb66784894b414a4c8d6e5020030fe90d8384) made the system test example_redshift_s3_transfers failed. The files generated as output were being used as input in the task transfer_s3_to_redshift_multiple