### PR TITLE
Annotate KubeExecutor pods that we don't delete

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -52,6 +52,7 @@ from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 ALL_NAMESPACES = "ALL_NAMESPACES"
+POD_DONE_KEY = "airflow_done"
 
 # TaskInstance key, command, configuration, pod_template_file
 KubernetesJobType = Tuple[TaskInstanceKey, CommandType, Any, Optional[str]]
@@ -366,6 +367,18 @@ class AirflowKubernetesScheduler(LoggingMixin):
             # If the pod is already deleted
             if e.status != 404:
                 raise
+
+    def patch_done_with_pod(self, *, pod_id: str, namespace: str):
+        """Add a "done" annotation to ensure we don't continually adopt pods"""
+        self.log.debug("Patching pod %s in namespace %s to mark it as done", pod_id, namespace)
+        try:
+            self.kube_client.patch_namespaced_pod(
+                name=pod_id,
+                namespace=namespace,
+                body={"metadata": {"labels": {POD_DONE_KEY: "True"}}},
+            )
+        except ApiException as e:
+            self.log.info("Failed to patch pod %s with done annotation. Reason: %s", pod_id, e)
 
     def sync(self) -> None:
         """
@@ -743,6 +756,9 @@ class KubernetesExecutor(BaseExecutor):
                 if state != State.FAILED or self.kube_config.delete_worker_pods_on_failure:
                     self.kube_scheduler.delete_pod(pod_id, namespace)
                     self.log.info("Deleted pod: %s in namespace %s", str(key), str(namespace))
+            else:
+                self.kube_scheduler.patch_done_with_pod(pod_id=pod_id, namespace=namespace)
+                self.log.info("Patched pod %s in namespace %s to mark it as done", str(key), str(namespace))
             try:
                 self.running.remove(key)
             except KeyError:
@@ -809,7 +825,9 @@ class KubernetesExecutor(BaseExecutor):
         new_worker_id_label = pod_generator.make_safe_label_value(self.scheduler_job_id)
         query_kwargs = {
             "field_selector": "status.phase=Succeeded",
-            "label_selector": f"kubernetes_executor=True,airflow-worker!={new_worker_id_label}",
+            "label_selector": (
+                f"kubernetes_executor=True,airflow-worker!={new_worker_id_label},{POD_DONE_KEY}!=True"
+            ),
         }
         pod_list = self._list_pods(query_kwargs)
         for pod in pod_list:

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -581,10 +581,12 @@ class TestKubernetesExecutor:
 
     @mock.patch("airflow.executors.kubernetes_executor.KubernetesJobWatcher")
     @mock.patch("airflow.executors.kubernetes_executor.get_kube_client")
-    @mock.patch("airflow.executors.kubernetes_executor.AirflowKubernetesScheduler.delete_pod")
+    @mock.patch("airflow.executors.kubernetes_executor.AirflowKubernetesScheduler")
     def test_change_state_skip_pod_deletion(
-        self, mock_delete_pod, mock_get_kube_client, mock_kubernetes_job_watcher
+        self, mock_kubescheduler, mock_get_kube_client, mock_kubernetes_job_watcher
     ):
+        mock_delete_pod = mock_kubescheduler.return_value.delete_pod
+        mock_patch_pod = mock_kubescheduler.return_value.patch_done_with_pod
         executor = self.kubernetes_executor
         executor.kube_config.delete_worker_pods = False
         executor.kube_config.delete_worker_pods_on_failure = False
@@ -592,18 +594,21 @@ class TestKubernetesExecutor:
         executor.start()
         try:
             key = ("dag_id", "task_id", "run_id", "try_number2")
-            executor._change_state(key, State.SUCCESS, "pod_id", "default")
+            executor._change_state(key, State.SUCCESS, "pod_id", "test-namespace")
             assert executor.event_buffer[key][0] == State.SUCCESS
             mock_delete_pod.assert_not_called()
+            mock_patch_pod.assert_called_once_with(pod_id="pod_id", namespace="test-namespace")
         finally:
             executor.end()
 
     @mock.patch("airflow.executors.kubernetes_executor.KubernetesJobWatcher")
     @mock.patch("airflow.executors.kubernetes_executor.get_kube_client")
-    @mock.patch("airflow.executors.kubernetes_executor.AirflowKubernetesScheduler.delete_pod")
+    @mock.patch("airflow.executors.kubernetes_executor.AirflowKubernetesScheduler")
     def test_change_state_failed_pod_deletion(
-        self, mock_delete_pod, mock_get_kube_client, mock_kubernetes_job_watcher
+        self, mock_kubescheduler, mock_get_kube_client, mock_kubernetes_job_watcher
     ):
+        mock_delete_pod = mock_kubescheduler.return_value.delete_pod
+        mock_patch_pod = mock_kubescheduler.return_value.patch_done_with_pod
         executor = self.kubernetes_executor
         executor.kube_config.delete_worker_pods_on_failure = True
 
@@ -613,6 +618,7 @@ class TestKubernetesExecutor:
             executor._change_state(key, State.FAILED, "pod_id", "test-namespace")
             assert executor.event_buffer[key][0] == State.FAILED
             mock_delete_pod.assert_called_once_with("pod_id", "test-namespace")
+            mock_patch_pod.assert_not_called()
         finally:
             executor.end()
 
@@ -775,7 +781,7 @@ class TestKubernetesExecutor:
         mock_kube_client.list_namespaced_pod.assert_called_once_with(
             namespace="somens",
             field_selector="status.phase=Succeeded",
-            label_selector="kubernetes_executor=True,airflow-worker!=modified",
+            label_selector="kubernetes_executor=True,airflow-worker!=modified,airflow_done!=True",
         )
         assert len(pod_names) == mock_kube_client.patch_namespaced_pod.call_count
         mock_kube_client.patch_namespaced_pod.assert_has_calls(

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -586,7 +586,7 @@ class TestKubernetesExecutor:
         self, mock_kubescheduler, mock_get_kube_client, mock_kubernetes_job_watcher
     ):
         mock_delete_pod = mock_kubescheduler.return_value.delete_pod
-        mock_patch_pod = mock_kubescheduler.return_value.patch_done_with_pod
+        mock_patch_pod = mock_kubescheduler.return_value.patch_pod_executor_done
         executor = self.kubernetes_executor
         executor.kube_config.delete_worker_pods = False
         executor.kube_config.delete_worker_pods_on_failure = False
@@ -608,7 +608,7 @@ class TestKubernetesExecutor:
         self, mock_kubescheduler, mock_get_kube_client, mock_kubernetes_job_watcher
     ):
         mock_delete_pod = mock_kubescheduler.return_value.delete_pod
-        mock_patch_pod = mock_kubescheduler.return_value.patch_done_with_pod
+        mock_patch_pod = mock_kubescheduler.return_value.patch_pod_executor_done
         executor = self.kubernetes_executor
         executor.kube_config.delete_worker_pods_on_failure = True
 
@@ -781,7 +781,7 @@ class TestKubernetesExecutor:
         mock_kube_client.list_namespaced_pod.assert_called_once_with(
             namespace="somens",
             field_selector="status.phase=Succeeded",
-            label_selector="kubernetes_executor=True,airflow-worker!=modified,airflow_done!=True",
+            label_selector="kubernetes_executor=True,airflow-worker!=modified,airflow_executor_done!=True",
         )
         assert len(pod_names) == mock_kube_client.patch_namespaced_pod.call_count
         mock_kube_client.patch_namespaced_pod.assert_has_calls(


### PR DESCRIPTION
We weren't keeping track of which pods we'd finished with yet, so if you had `[kubernetes_executor] delete_worker_pods` false, your KubeExecutor would adopt every single remaining pod when starting up. Every time.

We now annotate them with `airflow_executor_done` when processing a pods event from the watcher, so we can ignore the pod when doing adoption.