### PR TITLE
Don't schedule downstream or emit end_of_log on task deferral

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -139,6 +139,13 @@ if TYPE_CHECKING:
 PAST_DEPENDS_MET = "past_depends_met"
 
 
+class ArgDeferred:
+    """sentinel."""
+
+
+DEFERRED = ArgDeferred()
+
+
 @contextlib.contextmanager
 def set_current_context(context: Context) -> Generator[Context, None, None]:
     """
@@ -1356,7 +1363,7 @@ class TaskInstance(Base, LoggingMixin):
         job_id: str | None = None,
         pool: str | None = None,
         session: Session = NEW_SESSION,
-    ) -> None:
+    ) -> ArgDeferred | None:
         """
         Immediately runs the task (without checking or changing db state
         before execution) and then sets the appropriate final state after
@@ -1406,7 +1413,7 @@ class TaskInstance(Base, LoggingMixin):
                 session.add(Log(self.state, self))
                 session.merge(self)
                 session.commit()
-            return
+            return DEFERRED
         except AirflowSkipException as e:
             # Recording SKIP
             # log only if exception has any arguments to prevent log flooding

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -360,7 +360,9 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
         if self.closed:
             return
 
-        if not self.mark_end_on_close:
+        # todo: remove `getattr` when min airflow version >= 2.6
+        if not self.mark_end_on_close or getattr(self, "ctx_task_deferred", None):
+            # when we're closing due to task deferral, don't mark end of log
             self.closed = True
             return
 

--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -24,10 +24,13 @@ import os
 import psutil
 from setproctitle import setproctitle
 
+from airflow.models.taskinstance import ArgDeferred
 from airflow.settings import CAN_FORK
 from airflow.task.task_runner.base_task_runner import BaseTaskRunner
 from airflow.utils.dag_parsing_context import _airflow_parsing_context_manager
 from airflow.utils.process_utils import reap_process_group, set_new_process_group
+
+DEFERRAL_EXIT_CODE = 100
 
 
 class StandardTaskRunner(BaseTaskRunner):
@@ -92,8 +95,10 @@ class StandardTaskRunner(BaseTaskRunner):
                     dag_id=self._task_instance.dag_id,
                     task_id=self._task_instance.task_id,
                 ):
-                    args.func(args, dag=self.dag)
+                    ret = args.func(args, dag=self.dag)
                     return_code = 0
+                    if isinstance(ret, ArgDeferred):
+                        return_code = DEFERRAL_EXIT_CODE
             except Exception as exc:
                 return_code = 1
 

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -69,6 +69,13 @@ class FileTaskHandler(logging.Handler):
         :meta private:
         """
 
+        self.ctx_task_deferred = False
+        """
+        If true, task exited with deferral to trigger.
+
+        Some handlers emit "end of log" markers, and may not wish to do so when task defers.
+        """
+
     def set_context(self, ti: TaskInstance) -> None | SetContextPropagate:
         """
         Provide task_instance context to airflow task handler.

--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -31,7 +31,6 @@ from airflow.settings import IS_K8S_EXECUTOR_POD
 # 7-bit C1 ANSI escape sequences
 ANSI_ESCAPE = re.compile(r"\x1B[@-_][0-?]*[ -/]*[@-~]")
 
-
 # Private: A sentinel objects
 class SetContextPropagate(enum.Enum):
     """:meta private:"""


### PR DESCRIPTION
When the task run ends in a deferral, we should neither emit the "end of log" marker nor run the follow-on schedule check.
