### PR TITLE
Add deferrable mode in RedshiftPauseClusterOperator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -801,6 +801,30 @@ jobs:
         run: breeze ci fix-ownership
         if: always()
 
+  tests-aws-async-provider:
+    timeout-minutes: 50
+    name: "Pytest for AWS Async Provider"
+    runs-on: "${{needs.build-info.outputs.runs-on}}"
+    needs: [build-info, wait-for-ci-images]
+    if: needs.build-info.outputs.run-tests == 'true'
+    steps:
+      - name: Cleanup repo
+        shell: bash
+        run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: "Prepare breeze & CI image"
+        uses: ./.github/actions/prepare_breeze_and_image
+      - name: "Run AWS Async Test"
+        run: "breeze shell \
+        'pip install aiobotocore>=2.1.1 && pytest /opt/airflow/tests/providers/amazon/aws/deferrable'"
+      - name: "Post Tests"
+        uses: ./.github/actions/post_tests
+      - name: "Fix ownership"
+        run: breeze ci fix-ownership
+        if: always()
 
   tests-helm:
     timeout-minutes: 80

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -54,7 +54,6 @@ from airflow.configuration import conf
 from airflow.exceptions import (
     AirflowException,
     AirflowNotFoundException,
-    AirflowOptionalProviderFeatureException,
 )
 from airflow.hooks.base import BaseHook
 from airflow.providers.amazon.aws.utils.connection_wrapper import AwsConnectionWrapper
@@ -989,15 +988,6 @@ class AwsBaseAsyncHook(AwsBaseHook):
     :param resource_type: boto3.resource resource_type. Eg 'dynamodb' etc
     :param config: Configuration for botocore client.
     """
-
-    def __init__(self, **kwargs) -> None:
-        try:
-            import aiobotocore
-        except ImportError:
-            raise AirflowOptionalProviderFeatureException(
-                "AWS deferrable operator feature is disable. To enable it please install aiobotocore>=2.1.1"
-            )
-        super().__init__(**kwargs)
 
     def get_async_session(self) -> AioSession:
         """Get the underlying aiobotocore.session.AioSession(...)."""

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -992,7 +992,7 @@ class AwsBaseAsyncHook(AwsBaseHook):
 
     def __init__(self, **kwargs) -> None:
         try:
-            pass
+            import aiobotocore
         except ImportError:
             raise AirflowOptionalProviderFeatureException(
                 "AWS deferrable operator feature is disable. To enable it please install aiobotocore>=2.1.1"

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -51,7 +51,11 @@ from slugify import slugify
 
 from airflow.compat.functools import cached_property
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException, AirflowNotFoundException
+from airflow.exceptions import (
+    AirflowException,
+    AirflowNotFoundException,
+    AirflowOptionalProviderFeatureException,
+)
 from airflow.hooks.base import BaseHook
 from airflow.providers.amazon.aws.utils.connection_wrapper import AwsConnectionWrapper
 from airflow.providers.amazon.aws.waiters.base_waiter import BaseBotoWaiter
@@ -61,7 +65,6 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.log.secrets_masker import mask_secret
 
 BaseAwsConnection = TypeVar("BaseAwsConnection", bound=Union[boto3.client, boto3.resource])
-
 
 if TYPE_CHECKING:
     from airflow.models.connection import Connection  # Avoid circular imports.
@@ -877,3 +880,137 @@ def _parse_s3_config(config_file_name: str, config_format: str | None = "boto", 
         config_format=config_format,
         profile=profile,
     )
+
+
+try:
+    import aiobotocore.credentials
+    from aiobotocore.session import AioSession, get_session
+except ImportError:
+    pass
+
+
+class BaseAsyncSessionFactory(BaseSessionFactory):
+    """
+    Base AWS Session Factory class to handle aiobotocore session creation.
+
+    It currently, handles ENV, AWS secret key and STS client method ``assume_role``
+    provided in Airflow connection
+    """
+
+    async def get_role_credentials(self) -> dict:
+        """Get the role_arn, method credentials from connection details and get the role credentials detail"""
+        async with self._basic_session.create_client("sts", region_name=self.region_name) as client:
+            response = await client.assume_role(
+                RoleArn=self.role_arn,
+                RoleSessionName=self._strip_invalid_session_name_characters(f"Airflow_{self.conn.conn_id}"),
+                **self.conn.assume_role_kwargs,
+            )
+            return response["Credentials"]
+
+    async def _get_refresh_credentials(self) -> dict[str, Any]:
+        self.log.debug("Refreshing credentials")
+        assume_role_method = self.conn.assume_role_method
+        if assume_role_method != "assume_role":
+            raise NotImplementedError(f"assume_role_method={assume_role_method} not expected")
+
+        credentials = await self.get_role_credentials()
+
+        expiry_time = credentials["Expiration"].isoformat()
+        self.log.debug("New credentials expiry_time: %s", expiry_time)
+        credentials = {
+            "access_key": credentials.get("AccessKeyId"),
+            "secret_key": credentials.get("SecretAccessKey"),
+            "token": credentials.get("SessionToken"),
+            "expiry_time": expiry_time,
+        }
+        return credentials
+
+    def _get_session_with_assume_role(self) -> AioSession:
+
+        assume_role_method = self.conn.assume_role_method
+        if assume_role_method != "assume_role":
+            raise NotImplementedError(f"assume_role_method={assume_role_method} not expected")
+
+        credentials = aiobotocore.credentials.AioRefreshableCredentials.create_from_metadata(
+            metadata=self._get_refresh_credentials(),
+            refresh_using=self._get_refresh_credentials,
+            method="sts-assume-role",
+        )
+
+        session = aiobotocore.session.get_session()
+        session._credentials = credentials
+        return session
+
+    @cached_property
+    def _basic_session(self) -> AioSession:
+        """Cached property with basic aiobotocore.session.AioSession."""
+        session_kwargs = self.conn.session_kwargs
+        aws_access_key_id = session_kwargs.get("aws_access_key_id")
+        aws_secret_access_key = session_kwargs.get("aws_secret_access_key")
+        aws_session_token = session_kwargs.get("aws_session_token")
+        region_name = session_kwargs.get("region_name")
+        profile_name = session_kwargs.get("profile_name")
+
+        aio_session = get_session()
+        if profile_name is not None:
+            aio_session.set_config_variable("profile", profile_name)
+        if aws_access_key_id or aws_secret_access_key or aws_session_token:
+            aio_session.set_credentials(
+                access_key=aws_access_key_id,
+                secret_key=aws_secret_access_key,
+                token=aws_session_token,
+            )
+        if region_name is not None:
+            aio_session.set_config_variable("region", region_name)
+        return aio_session
+
+    def create_session(self) -> AioSession:
+        """Create aiobotocore Session from connection and config."""
+        if not self._conn:
+            self.log.info("No connection ID provided. Fallback on boto3 credential strategy")
+            return get_session()
+        elif not self.role_arn:
+            return self._basic_session
+        return self._get_session_with_assume_role()
+
+
+class AwsBaseAsyncHook(AwsBaseHook):
+    """
+    Interacts with AWS using aiobotocore asynchronously.
+
+    :param aws_conn_id: The Airflow connection used for AWS credentials.
+        If this is None or empty then the default botocore behaviour is used. If
+        running Airflow in a distributed manner and aws_conn_id is None or
+        empty, then default botocore configuration would be used (and must be
+        maintained on each worker node).
+    :param verify: Whether to verify SSL certificates.
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param client_type: boto3.client client_type. Eg 's3', 'emr' etc
+    :param resource_type: boto3.resource resource_type. Eg 'dynamodb' etc
+    :param config: Configuration for botocore client.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        try:
+            pass
+        except ImportError:
+            raise AirflowOptionalProviderFeatureException(
+                "AWS deferrable operator feature is disable. To enable it please install aiobotocore>=2.1.1"
+            )
+        super().__init__(**kwargs)
+
+    def get_async_session(self) -> AioSession:
+        """Get the underlying aiobotocore.session.AioSession(...)."""
+        return BaseAsyncSessionFactory(
+            conn=self.conn_config, region_name=self.region_name, config=self.config
+        ).create_session()
+
+    async def get_client_async(self):
+        """Get the underlying aiobotocore client using aiobotocore session"""
+        return self.get_async_session().create_client(
+            self.client_type,
+            region_name=self.region_name,
+            verify=self.verify,
+            endpoint_url=self.conn_config.endpoint_url,
+            config=self.config,
+        )

--- a/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.redshift_cluster import RedshiftHook
+from airflow.providers.amazon.aws.triggers.redshift_cluster import RedshiftClusterTrigger
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -447,6 +448,7 @@ class RedshiftPauseClusterOperator(BaseOperator):
 
     :param cluster_identifier: id of the AWS Redshift Cluster
     :param aws_conn_id: aws connection to use
+    :param deferrable: Run operator in the deferrable mode. This mode requires an additional aiobotocore>=
     """
 
     template_fields: Sequence[str] = ("cluster_identifier",)
@@ -458,11 +460,15 @@ class RedshiftPauseClusterOperator(BaseOperator):
         *,
         cluster_identifier: str,
         aws_conn_id: str = "aws_default",
+        deferrable: bool = False,
+        poll_interval: int = 10,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.cluster_identifier = cluster_identifier
         self.aws_conn_id = aws_conn_id
+        self.deferrable = deferrable
+        self.poll_interval = poll_interval
         # These parameters are added to address an issue with the boto3 API where the API
         # prematurely reports the cluster as available to receive requests. This causes the cluster
         # to reject initial attempts to pause the cluster despite reporting the correct state.
@@ -472,18 +478,48 @@ class RedshiftPauseClusterOperator(BaseOperator):
     def execute(self, context: Context):
         redshift_hook = RedshiftHook(aws_conn_id=self.aws_conn_id)
 
-        while self._attempts >= 1:
-            try:
-                redshift_hook.get_conn().pause_cluster(ClusterIdentifier=self.cluster_identifier)
-                return
-            except redshift_hook.get_conn().exceptions.InvalidClusterStateFault as error:
-                self._attempts = self._attempts - 1
+        if self.deferrable:
+            self.defer(
+                timeout=self.execution_timeout,
+                trigger=RedshiftClusterTrigger(
+                    task_id=self.task_id,
+                    poll_interval=self.poll_interval,
+                    aws_conn_id=self.aws_conn_id,
+                    cluster_identifier=self.cluster_identifier,
+                    attempts=self._attempts,
+                    operation_type="pause_cluster",
+                ),
+                method_name="execute_complete",
+            )
+        else:
+            while self._attempts >= 1:
+                try:
+                    redshift_hook.get_conn().pause_cluster(ClusterIdentifier=self.cluster_identifier)
+                    return
+                except redshift_hook.get_conn().exceptions.InvalidClusterStateFault as error:
+                    self._attempts = self._attempts - 1
 
-                if self._attempts > 0:
-                    self.log.error("Unable to pause cluster. %d attempts remaining.", self._attempts)
-                    time.sleep(self._attempt_interval)
-                else:
-                    raise error
+                    if self._attempts > 0:
+                        self.log.error("Unable to pause cluster. %d attempts remaining.", self._attempts)
+                        time.sleep(self._attempt_interval)
+                    else:
+                        raise error
+
+    def execute_complete(self, context: Context, event: Any = None) -> None:
+        """
+        Callback for when the trigger fires - returns immediately.
+        Relies on trigger to throw an exception, otherwise it assumes execution was
+        successful.
+        """
+        if event:
+            if "status" in event and event["status"] == "error":
+                msg = f"{event['status']}: {event['message']}"
+                raise AirflowException(msg)
+            elif "status" in event and event["status"] == "success":
+                self.log.info("%s completed successfully.", self.task_id)
+                self.log.info("Paused cluster successfully")
+        else:
+            raise AirflowException("No event received from trigger")
 
 
 class RedshiftDeleteClusterOperator(BaseOperator):

--- a/airflow/providers/amazon/aws/triggers/__init__.py
+++ b/airflow/providers/amazon/aws/triggers/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/amazon/aws/triggers/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/triggers/redshift_cluster.py
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import Any, AsyncIterator
+
+from airflow.providers.amazon.aws.hooks.redshift_cluster import RedshiftAsyncHook
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+
+class RedshiftClusterTrigger(BaseTrigger):
+    """AWS Redshift trigger"""
+
+    def __init__(
+        self,
+        task_id: str,
+        aws_conn_id: str,
+        cluster_identifier: str,
+        operation_type: str,
+        attempts: int,
+        poll_interval: float = 5.0,
+    ):
+        super().__init__()
+        self.task_id = task_id
+        self.poll_interval = poll_interval
+        self.aws_conn_id = aws_conn_id
+        self.cluster_identifier = cluster_identifier
+        self.operation_type = operation_type
+        self.attempts = attempts
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        return (
+            "airflow.providers.amazon.aws.triggers.redshift_cluster.RedshiftClusterTrigger",
+            {
+                "task_id": self.task_id,
+                "poll_interval": self.poll_interval,
+                "aws_conn_id": self.aws_conn_id,
+                "cluster_identifier": self.cluster_identifier,
+                "attempts": self.attempts,
+                "operation_type": self.operation_type,
+            },
+        )
+
+    async def run(self) -> AsyncIterator["TriggerEvent"]:
+        hook = RedshiftAsyncHook(aws_conn_id=self.aws_conn_id)
+        while self.attempts >= 1:
+            self.attempts = self.attempts - 1
+            try:
+                if self.operation_type == "pause_cluster":
+                    response = await hook.pause_cluster(
+                        cluster_identifier=self.cluster_identifier,
+                        poll_interval=self.poll_interval,
+                    )
+                    if response.get("status") == "success":
+                        yield TriggerEvent(response)
+                    else:
+                        if self.attempts < 1:
+                            yield TriggerEvent({"status": "error", "message": f"{self.task_id} failed"})
+                else:
+                    yield TriggerEvent(f"{self.operation_type} is not supported")
+            except Exception as e:
+                if self.attempts < 1:
+                    yield TriggerEvent({"status": "error", "message": str(e)})

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -55,6 +55,7 @@ dependencies:
   - apache-airflow>=2.3.0
   - apache-airflow-providers-common-sql>=1.3.1
   - boto3>=1.24.0
+  - asgiref
   # watchtower 3 has been released end Jan and introduced breaking change across the board that might
   # change logging behaviour:
   # https://github.com/kislyuk/watchtower/blob/develop/Changes.rst#changes-for-v300-2022-01-26
@@ -596,3 +597,4 @@ additional-extras:
   - name: pandas
     dependencies:
       - pandas>=0.17.1
+      - aiobotocore>=2.1.1

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -597,4 +597,6 @@ additional-extras:
   - name: pandas
     dependencies:
       - pandas>=0.17.1
+  - name: aiobotocore
+    dependencies:
       - aiobotocore>=2.1.1

--- a/docs/apache-airflow-providers-amazon/deferrable.rst
+++ b/docs/apache-airflow-providers-amazon/deferrable.rst
@@ -25,7 +25,7 @@ We have added ``aiobotocore`` as an addition dependency. So if you want to use A
 manage this by yourself.
 
 We have introduced an async hook to manage authentication between to the AWS services asynchronously. The
-AWS async hook currently support the default botocore authentication mechanism i'e if Airflow connection is
+AWS async hook currently support the default botocore authentication mechanism i.e if Airflow connection is
 not provided then provider will try to find the credential param in environment variable. If the Airflow connection is
 provided then basic auth with secret-key/access-key-id/profile/token and arn-method should work.
 

--- a/docs/apache-airflow-providers-amazon/deferrable.rst
+++ b/docs/apache-airflow-providers-amazon/deferrable.rst
@@ -21,10 +21,10 @@ AWS Deferrable Operators
 
 The AWS deferrable operators depends on ``aiobotocore>=2.1.1`` library. Unfortunately, currently we can't add this to
 core AWS provider dependencies because of a conflicting version of ``botocore`` between ``aiobotocore`` and ``boto3``.
-We have added aiobotcore as an addition dependency. So if you want to use AWS deferrable operator then you will have to
+We have added ``aiobotocore`` as an addition dependency. So if you want to use AWS deferrable operator then you will have to
 manage this by yourself.
 
-We have introduced an async hook called AwsBaseAsyncHook to manage authentication between Airflow and AWS. The
+We have introduced an async hook to manage authentication between to the AWS services asynchronously. The
 AwsBaseAsyncHook hook currently support the default botocore authentication mechanism i'e if Airflow connection is
 not provided then provider will try to find the credential param in environment variable. If the Airflow connection is
 provided then basic auth with secret-key/access-key-id/profile/token and arn-method should work.

--- a/docs/apache-airflow-providers-amazon/deferrable.rst
+++ b/docs/apache-airflow-providers-amazon/deferrable.rst
@@ -25,7 +25,7 @@ We have added ``aiobotocore`` as an addition dependency. So if you want to use A
 manage this by yourself.
 
 We have introduced an async hook to manage authentication between to the AWS services asynchronously. The
-AwsBaseAsyncHook hook currently support the default botocore authentication mechanism i'e if Airflow connection is
+AWS async hook currently support the default botocore authentication mechanism i'e if Airflow connection is
 not provided then provider will try to find the credential param in environment variable. If the Airflow connection is
 provided then basic auth with secret-key/access-key-id/profile/token and arn-method should work.
 

--- a/docs/apache-airflow-providers-amazon/index.rst
+++ b/docs/apache-airflow-providers-amazon/index.rst
@@ -27,6 +27,7 @@ Content
 
     Connection types <connections/index>
     Operators <operators/index>
+    Deferrable Operators <deferrable>
     Secrets backends <secrets-backends/index>
     Logging for Tasks <logging/index>
 

--- a/docs/apache-airflow-providers-amazon/operators/deferrable.rst
+++ b/docs/apache-airflow-providers-amazon/operators/deferrable.rst
@@ -1,0 +1,33 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+========================
+AWS Deferrable Operators
+========================
+
+The AWS deferrable operators depends on ``aiobotocore>=2.1.1`` library. Unfortunately, currently we can't add this to
+core AWS provider dependencies because of a conflicting version of ``botocore`` between ``aiobotocore`` and ``boto3``.
+We have added aiobotcore as an addition dependency. So if you want to use AWS deferrable operator then you will have to
+manage this by yourself.
+
+We have introduced an async hook called AwsBaseAsyncHook to manage authentication between Airflow and AWS. The
+AwsBaseAsyncHook hook currently support the default botocore authentication mechanism i'e if Airflow connection is
+not provided then provider will try to find the credential param in environment variable. If the Airflow connection is
+provided then basic auth with secret-key/access-key-id/profile/token and arn-method should work.
+
+To use deferrable operator we have exposed ``deferrable`` param in those operators which support deferrable execution.
+By default ``deferrable`` is set to ``False`` set this to ``True`` to run operator in asynchronous mode.

--- a/docs/apache-airflow-providers-amazon/operators/redshift_cluster.rst
+++ b/docs/apache-airflow-providers-amazon/operators/redshift_cluster.rst
@@ -65,8 +65,9 @@ To resume a 'paused' Amazon Redshift cluster you can use
 Pause an Amazon Redshift cluster
 ================================
 
-To pause an 'available' Amazon Redshift cluster you can use
-:class:`RedshiftPauseClusterOperator <airflow.providers.amazon.aws.operators.redshift_cluster>`
+To pause an ``available`` Amazon Redshift cluster you can use
+:class:`RedshiftPauseClusterOperator <airflow.providers.amazon.aws.operators.redshift_cluster>`.
+You can also run this operator in deferrable mode by setting ``deferrable`` param to ``True``
 
 .. exampleinclude:: /../../tests/system/providers/amazon/aws/example_redshift.py
     :language: python

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -16,6 +16,8 @@ adls
 afterall
 AgentKey
 aio
+aiobotocore
+AioSession
 Airbnb
 airbnb
 Airbyte

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -19,6 +19,7 @@
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
+      "asgiref",
       "boto3>=1.24.0",
       "jsonpath_ng>=1.5.3",
       "mypy-boto3-appflow>=1.24.0",

--- a/tests/providers/amazon/aws/deferrable/__init__.py
+++ b/tests/providers/amazon/aws/deferrable/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/amazon/aws/deferrable/hooks/__init__.py
+++ b/tests/providers/amazon/aws/deferrable/hooks/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/amazon/aws/deferrable/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/deferrable/hooks/test_base_aws.py
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import ANY
+
+import pytest
+
+from airflow.models.connection import Connection
+from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseAsyncHook
+from tests.providers.amazon.aws.utils.compat import async_mock
+
+try:
+    from aiobotocore.credentials import AioCredentials
+except ImportError:
+    pass
+
+pytest.importorskip("aiobotocore")
+
+
+class TestAwsBaseAsyncHook:
+    @staticmethod
+    def compare_aio_cred(first, second):
+        if not type(first) == type(second):
+            return False
+        if first.access_key != second.access_key:
+            return False
+        if first.secret_key != second.secret_key:
+            return False
+        if first.method != second.method:
+            return False
+        if first.token != second.token:
+            return False
+        return True
+
+    class Matcher:
+        def __init__(self, compare, obj):
+            self.compare = compare
+            self.obj = obj
+
+        def __eq__(self, other):
+            return self.compare(self.obj, other)
+
+    @pytest.mark.asyncio
+    @async_mock.patch("airflow.hooks.base.BaseHook.get_connection")
+    @async_mock.patch("aiobotocore.session.AioClientCreator.create_client")
+    async def test_get_client_async(self, mock_client, mock_get_connection):
+        """Check the connection credential passed while creating client"""
+        mock_get_connection.return_value = Connection(
+            conn_id="aws_default1",
+            extra="""{
+                        "aws_secret_access_key": "mock_aws_access_key",
+                        "aws_access_key_id": "mock_aws_access_key_id",
+                        "region_name": "us-east-2"
+                    }""",
+        )
+
+        hook = AwsBaseAsyncHook(client_type="S3", aws_conn_id="aws_default1")
+        cred = await hook.get_async_session().get_credentials()
+
+        # check credential have same values as intended
+        assert cred.__dict__ == {
+            "access_key": "mock_aws_access_key_id",
+            "method": "explicit",
+            "secret_key": "mock_aws_access_key",
+            "token": None,
+        }
+
+        aio_cred = AioCredentials(
+            access_key="mock_aws_access_key_id",
+            method="explicit",
+            secret_key="mock_aws_access_key",
+        )
+
+        await (await hook.get_client_async())._coro
+        # Test the aiobotocore client created with right param
+        mock_client.assert_called_once_with(
+            service_name="S3",
+            region_name="us-east-2",
+            is_secure=True,
+            endpoint_url=None,
+            verify=None,
+            credentials=self.Matcher(self.compare_aio_cred, aio_cred),
+            scoped_config={},
+            client_config=ANY,
+            api_version=None,
+        )

--- a/tests/providers/amazon/aws/deferrable/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/deferrable/hooks/test_base_aws.py
@@ -98,4 +98,5 @@ class TestAwsBaseAsyncHook:
             scoped_config={},
             client_config=ANY,
             api_version=None,
+            auth_token=None,
         )

--- a/tests/providers/amazon/aws/deferrable/hooks/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/deferrable/hooks/test_redshift_cluster.py
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from botocore.exceptions import ClientError
+
+from airflow.providers.amazon.aws.hooks.redshift_cluster import RedshiftAsyncHook
+from tests.providers.amazon.aws.utils.compat import async_mock
+
+pytest.importorskip("aiobotocore")
+
+
+class TestRedshiftAsyncHook:
+    @pytest.mark.asyncio
+    @async_mock.patch("aiobotocore.client.AioBaseClient._make_api_call")
+    async def test_cluster_status(self, mock_make_api_call):
+        """Test that describe_clusters get called with correct param"""
+        hook = RedshiftAsyncHook(aws_conn_id="aws_default", client_type="redshift", resource_type="redshift")
+        await hook.cluster_status(cluster_identifier="redshift_cluster_1")
+        mock_make_api_call.assert_called_once_with(
+            "DescribeClusters", {"ClusterIdentifier": "redshift_cluster_1"}
+        )
+
+    @pytest.mark.asyncio
+    @async_mock.patch("aiobotocore.client.AioBaseClient._make_api_call")
+    async def test_pause_cluster(self, mock_make_api_call):
+        """Test that pause_cluster get called with correct param"""
+        hook = RedshiftAsyncHook(aws_conn_id="aws_default", client_type="redshift", resource_type="redshift")
+        await hook.pause_cluster(cluster_identifier="redshift_cluster_1")
+        mock_make_api_call.assert_called_once_with(
+            "PauseCluster", {"ClusterIdentifier": "redshift_cluster_1"}
+        )
+
+    @pytest.mark.asyncio
+    @async_mock.patch(
+        "airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftAsyncHook.get_client_async"
+    )
+    @async_mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftAsyncHook.cluster_status")
+    async def test_get_cluster_status(self, cluster_status, mock_client):
+        """Test get_cluster_status async function with success response"""
+        flag = asyncio.Event()
+        cluster_status.return_value = {"status": "success", "cluster_state": "available"}
+        hook = RedshiftAsyncHook(aws_conn_id="aws_default")
+        result = await hook.get_cluster_status("redshift_cluster_1", "available", flag)
+        assert result == {"status": "success", "cluster_state": "available"}
+
+    @pytest.mark.asyncio
+    @async_mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftAsyncHook.cluster_status")
+    async def test_get_cluster_status_exception(self, cluster_status):
+        """Test get_cluster_status async function with exception response"""
+        flag = asyncio.Event()
+        cluster_status.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "SomeServiceException",
+                    "Message": "Details/context around the exception or error",
+                },
+            },
+            operation_name="redshift",
+        )
+        hook = RedshiftAsyncHook(aws_conn_id="aws_default")
+        result = await hook.get_cluster_status("test-identifier", "available", flag)
+        assert result == {
+            "status": "error",
+            "message": "An error occurred (SomeServiceException) when calling the "
+            "redshift operation: Details/context around the exception or error",
+        }

--- a/tests/providers/amazon/aws/deferrable/triggers/__init__.py
+++ b/tests/providers/amazon/aws/deferrable/triggers/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/amazon/aws/deferrable/triggers/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/deferrable/triggers/test_redshift_cluster.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from airflow.providers.amazon.aws.triggers.redshift_cluster import (
+    RedshiftClusterTrigger,
+)
+from airflow.triggers.base import TriggerEvent
+from tests.providers.amazon.aws.utils.compat import async_mock
+
+TASK_ID = "redshift_trigger_check"
+POLLING_PERIOD_SECONDS = 1.0
+
+
+@pytest.mark.skipif(not bool(importlib.util.find_spec("aiobotocore")), reason="aiobotocore require")
+class TestRedshiftClusterTrigger:
+    def test_pause_serialization(self):
+        """
+        Asserts that the RedshiftClusterTrigger correctly serializes its arguments
+        and classpath.
+        """
+        trigger = RedshiftClusterTrigger(
+            task_id=TASK_ID,
+            poll_interval=POLLING_PERIOD_SECONDS,
+            aws_conn_id="test_redshift_conn_id",
+            cluster_identifier="mock_cluster_identifier",
+            attempts=10,
+            operation_type="pause_cluster",
+        )
+        classpath, kwargs = trigger.serialize()
+        assert classpath == "airflow.providers.amazon.aws.triggers.redshift_cluster.RedshiftClusterTrigger"
+        assert kwargs == {
+            "task_id": TASK_ID,
+            "poll_interval": POLLING_PERIOD_SECONDS,
+            "aws_conn_id": "test_redshift_conn_id",
+            "cluster_identifier": "mock_cluster_identifier",
+            "attempts": 10,
+            "operation_type": "pause_cluster",
+        }
+
+    @pytest.mark.asyncio
+    @async_mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftAsyncHook.pause_cluster")
+    async def test_pause_trigger_run(self, mock_pause_cluster):
+        """
+        Test trigger event for the pause_cluster response
+        """
+        trigger = RedshiftClusterTrigger(
+            task_id=TASK_ID,
+            poll_interval=POLLING_PERIOD_SECONDS,
+            aws_conn_id="test_redshift_conn_id",
+            cluster_identifier="mock_cluster_identifier",
+            attempts=1,
+            operation_type="pause_cluster",
+        )
+        generator = trigger.run()
+        await generator.asend(None)
+        mock_pause_cluster.assert_called_once_with(
+            cluster_identifier="mock_cluster_identifier", poll_interval=1.0
+        )
+
+    @pytest.mark.asyncio
+    @async_mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftAsyncHook.pause_cluster")
+    async def test_pause_trigger_failure(self, mock_pause_cluster):
+        """Test trigger event when pause cluster raise exception"""
+        mock_pause_cluster.side_effect = Exception("Test exception")
+        trigger = RedshiftClusterTrigger(
+            task_id=TASK_ID,
+            poll_interval=POLLING_PERIOD_SECONDS,
+            aws_conn_id="test_redshift_conn_id",
+            cluster_identifier="mock_cluster_identifier",
+            attempts=1,
+            operation_type="pause_cluster",
+        )
+        task = [i async for i in trigger.run()]
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) in task

--- a/tests/providers/amazon/aws/utils/compat.py
+++ b/tests/providers/amazon/aws/utils/compat.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+__all__ = ["async_mock", "AsyncMock"]
+
+import sys
+
+if sys.version_info < (3, 8):
+    # For compatibility with Python 3.7
+    from asynctest import mock as async_mock
+
+    # ``asynctest.mock.CoroutineMock`` which provide compatibility not working well with autospec=True
+    # as result "TypeError: object MagicMock can't be used in 'await' expression" could be raised.
+    # Best solution in this case provide as spec actual awaitable object
+    # >>> from tests.providers.amazon.cloud.utils.compat import AsyncMock
+    # >>> from foo.bar import SpamEgg
+    # >>> mock_something = AsyncMock(SpamEgg)
+    from asynctest.mock import CoroutineMock as AsyncMock
+else:
+    from unittest import mock as async_mock
+    from unittest.mock import AsyncMock


### PR DESCRIPTION
Add a `deferrable` param in RedshiftPauseClusterOperator. This will help to run `RedshiftPauseClusterOperator` operator in async/deferrable mode.

Currently, AWS does not maintain the async version of boto3 so I need to depend on [aiobotcore](https://github.com/aio-libs/aiobotocore) an async version for AWS botocore. Unfortunately, `aiobotocore` depend on [botocore>=1.27.59,<1.27.60](https://github.com/aio-libs/aiobotocore/blob/master/setup.py#L10) while boto3 depend on [botocore>=1.29.78,<1.30.0](https://github.com/boto/boto3/blob/develop/setup.py#L16) and boto3 is core dependency in our provider so we can not add `aiobotcore` in core dependency.

In this PR, I'm adding `aiobotocore` as an additional dependency until https://github.com/aio-libs/aiobotocore/issues/976 has been resolved.

I'm adding `AwsBaseAsyncHook` a basic async AWS  hook. This will at present support the default `botocore` auth i'e if airflow connection is not provided then auth using ENV and if airflow connection is provided then basic auth with secret-key/access-key-id/profile/token and arn-method. maybe we can support the other auth incrementally depending on the community interest. 

Because the dependency making things a little bit complicated so I have created a new test module `deferrable` inside AWS provider tests and I'm keeping the async-related test in this particular module. I have also added a new CI job to test/run the AWS deferable operator tests and I'm ignoring the deferable tests in other CI job test runs.

Add a trigger class which will wait until the Redshift pause request reaches a terminal state i.e paused or fail, We also have retry logic like the sync operator.

This PR donates the following developed RedshiftPauseClusterOperatorAsync` in [astronomer-providers](https://github.com/astronomer/astronomer-providers) repo to apache airflow.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
