### PR TITLE
Fix incorrect comments in worker-kedaautoscaler.yaml

### DIFF
--- a/chart/templates/workers/worker-kedaautoscaler.yaml
+++ b/chart/templates/workers/worker-kedaautoscaler.yaml
@@ -37,10 +37,10 @@ spec:
   scaleTargetRef:
     kind: {{ ternary "StatefulSet" "Deployment" .Values.workers.persistence.enabled }}
     name: {{ .Release.Name }}-worker
-  pollingInterval:  {{ .Values.workers.keda.pollingInterval }}   # Optional. Default: 30 seconds
-  cooldownPeriod: {{ .Values.workers.keda.cooldownPeriod }}    # Optional. Default: 300 seconds
+  pollingInterval:  {{ .Values.workers.keda.pollingInterval }}   # Optional. Default: 5 seconds
+  cooldownPeriod: {{ .Values.workers.keda.cooldownPeriod }}    # Optional. Default: 30 seconds
   minReplicaCount: {{ .Values.workers.keda.minReplicaCount }}   # Optional. Default: 0
-  maxReplicaCount: {{ .Values.workers.keda.maxReplicaCount }}   # Optional. Default: 100
+  maxReplicaCount: {{ .Values.workers.keda.maxReplicaCount }}   # Optional. Default: 10
 {{- if .Values.workers.keda.advanced }}
   advanced:
 {{ toYaml .Values.workers.keda.advanced | indent 4 }}

--- a/chart/templates/workers/worker-kedaautoscaler.yaml
+++ b/chart/templates/workers/worker-kedaautoscaler.yaml
@@ -37,10 +37,10 @@ spec:
   scaleTargetRef:
     kind: {{ ternary "StatefulSet" "Deployment" .Values.workers.persistence.enabled }}
     name: {{ .Release.Name }}-worker
-  pollingInterval:  {{ .Values.workers.keda.pollingInterval }}   # Optional. Default: 5 seconds
-  cooldownPeriod: {{ .Values.workers.keda.cooldownPeriod }}    # Optional. Default: 30 seconds
-  minReplicaCount: {{ .Values.workers.keda.minReplicaCount }}   # Optional. Default: 0
-  maxReplicaCount: {{ .Values.workers.keda.maxReplicaCount }}   # Optional. Default: 10
+  pollingInterval:  {{ .Values.workers.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.workers.keda.cooldownPeriod }}
+  minReplicaCount: {{ .Values.workers.keda.minReplicaCount }}
+  maxReplicaCount: {{ .Values.workers.keda.maxReplicaCount }}
 {{- if .Values.workers.keda.advanced }}
   advanced:
 {{ toYaml .Values.workers.keda.advanced | indent 4 }}


### PR DESCRIPTION
Currently, some comments in `worker-kedaautoscaler.yaml` are inconsistent with corresponding default values in `values.yaml`. This PR corrects those comments.

https://github.com/apache/airflow/blob/493b433ad57088a5f5cabc466c949445e500b4c1/chart/templates/workers/worker-kedaautoscaler.yaml#L40-L43

https://github.com/apache/airflow/blob/493b433ad57088a5f5cabc466c949445e500b4c1/chart/values.yaml#L498-L513