### PR TITLE
BigQueryCreateExternalTableOperator Fix test for field delimiter not working with csv

### DIFF
--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -239,7 +239,7 @@ class TestBigQueryCreateExternalTableOperator(unittest.TestCase):
                     "autodetect": True,
                     "compression": "NONE",
                     "csvOptions": {
-                        "fieldDelimeter": ",",
+                        "fieldDelimiter": ",",
                         "skipLeadingRows": 0,
                         "quote": None,
                         "allowQuotedNewlines": False,


### PR DESCRIPTION
There is a typo when populating the externalDataConfiguration. Within the csvOptions the property needs to be called "fieldDelimiter"

Documentation of the BigQuery csvOptions: https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#CsvOptions

related: #28856

@eladkal thank you for reviewing the other PR, here is the PR for the modified test

@FedericaLionetto



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
