### PR TITLE
Allow nested attr in elasticsearch host_field

### DIFF
--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -179,7 +179,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
     def _group_logs_by_host(self, logs):
         grouped_logs = defaultdict(list)
         for log in logs:
-            key = getattr(log, self.host_field, "default_host")
+            key = safe_attrgetter(self.host_field, obj=log, default="default_host")
             grouped_logs[key].append(log)
 
         return grouped_logs
@@ -407,3 +407,18 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
     def supports_external_link(self) -> bool:
         """Whether we can support external links"""
         return bool(self.frontend)
+
+
+def safe_attrgetter(*items, obj, default):
+    """
+    Get items from obj but return default if not found
+
+    :meta private:
+    """
+    val = None
+    try:
+        val = attrgetter(*items)(obj)
+    except AttributeError:
+        pass
+
+    return val or default

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -413,8 +413,8 @@ def getattr_nested(obj, item, default):
     """
     Get item from obj but return default if not found
 
-    E.g. calling ``getattr_nested('b.c', a, "NA")`` will return
-    ``a.b.c`` if such a value exists
+    E.g. calling ``getattr_nested(a, 'b.c', "NA")`` will return
+    ``a.b.c`` if such a value exists, and "NA" otherwise.
 
     :meta private:
     """

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -418,13 +418,7 @@ def getattr_nested(obj, item, default):
 
     :meta private:
     """
-    NOTSET = object()
-    val = NOTSET
     try:
-        val = attrgetter(item)(obj)
+        return attrgetter(item)(obj)
     except AttributeError:
-        pass
-    if val is NOTSET:
         return default
-    else:
-        return val

--- a/tests/providers/elasticsearch/log/test_es_task_handler.py
+++ b/tests/providers/elasticsearch/log/test_es_task_handler.py
@@ -31,7 +31,7 @@ import pendulum
 import pytest
 
 from airflow.configuration import conf
-from airflow.providers.elasticsearch.log.es_task_handler import ElasticsearchTaskHandler
+from airflow.providers.elasticsearch.log.es_task_handler import ElasticsearchTaskHandler, safe_attrgetter
 from airflow.utils import timezone
 from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.timezone import datetime
@@ -590,3 +590,15 @@ class TestElasticsearchTaskHandler:
         assert first_log["asctime"] == t1.format("YYYY-MM-DDTHH:mm:ss.SSSZZ")
         assert second_log["asctime"] == t2.format("YYYY-MM-DDTHH:mm:ss.SSSZZ")
         assert third_log["asctime"] == t3.format("YYYY-MM-DDTHH:mm:ss.SSSZZ")
+
+
+def test_safe_attrgetter():
+    class A:
+        a = "hi"
+
+    a = A()
+    a.b = a
+    assert safe_attrgetter("a", "b.a", obj=a, default=None) == ("hi", "hi")
+    assert safe_attrgetter("a", obj=a, default=None) == "hi"
+    assert safe_attrgetter("aa", obj=a, default="heya") == "heya"
+    assert safe_attrgetter("aa", obj=a, default=None) is None

--- a/tests/providers/elasticsearch/log/test_es_task_handler.py
+++ b/tests/providers/elasticsearch/log/test_es_task_handler.py
@@ -31,7 +31,7 @@ import pendulum
 import pytest
 
 from airflow.configuration import conf
-from airflow.providers.elasticsearch.log.es_task_handler import ElasticsearchTaskHandler, safe_attrgetter
+from airflow.providers.elasticsearch.log.es_task_handler import ElasticsearchTaskHandler, getattr_nested
 from airflow.utils import timezone
 from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.timezone import datetime
@@ -598,7 +598,7 @@ def test_safe_attrgetter():
 
     a = A()
     a.b = a
-    assert safe_attrgetter("a", "b.a", obj=a, default=None) == ("hi", "hi")
-    assert safe_attrgetter("a", obj=a, default=None) == "hi"
-    assert safe_attrgetter("aa", obj=a, default="heya") == "heya"
-    assert safe_attrgetter("aa", obj=a, default=None) is None
+    assert getattr_nested(a, "b.a", None) == "hi"
+    assert getattr_nested(a, "a", None) == "hi"
+    assert getattr_nested(a, "aa", "heya") == "heya"
+    assert getattr_nested(a, "aa", None) is None

--- a/tests/providers/elasticsearch/log/test_es_task_handler.py
+++ b/tests/providers/elasticsearch/log/test_es_task_handler.py
@@ -594,11 +594,15 @@ class TestElasticsearchTaskHandler:
 
 def test_safe_attrgetter():
     class A:
-        a = "hi"
+        ...
 
     a = A()
-    a.b = a
-    assert getattr_nested(a, "b.a", None) == "hi"
-    assert getattr_nested(a, "a", None) == "hi"
-    assert getattr_nested(a, "aa", "heya") == "heya"
-    assert getattr_nested(a, "aa", None) is None
+    a.b = "b"
+    a.c = None
+    a.x = a
+    a.x.d = "blah"
+    assert getattr_nested(a, "b", None) == "b"  # regular getattr
+    assert getattr_nested(a, "x.d", None) == "blah"  # nested val
+    assert getattr_nested(a, "aa", "heya") == "heya"  # respects non-none default
+    assert getattr_nested(a, "c", "heya") is None  # respects none value
+    assert getattr_nested(a, "aa", None) is None  # respects none default


### PR DESCRIPTION
Sometimes we may need to use nested field e.g. with filebeat:

AIRFLOW__ELASTICSEARCH__HOST_FIELD=host.name

Currently this will not fail but will return "default_host" -- the default value.
