### PR TITLE
Add `on_kill()` to `DataprocInstantiateInlineWorkflowTemplateOperator`

### DIFF
--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -1779,6 +1779,10 @@ class DataprocInstantiateInlineWorkflowTemplateOperator(BaseOperator):
         self.log.info("Template instantiated. Workflow Id : %s", self.workflow_id)
         operation.result()
         self.log.info("Workflow %s completed successfully", self.workflow_id)
+    
+    def on_kill(self):
+        if self.operation:
+            self.operation.cancel()
 
 
 class DataprocSubmitJobOperator(BaseOperator):


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
This PR add support for cancelling a long running operation when DataprocInstantiateInlineWorkflowTemplateOperator is killed.

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
