### PR TITLE
Use entire tenant domain name in dbt Cloud connection

### DIFF
--- a/docs/apache-airflow-providers-dbt-cloud/connections.rst
+++ b/docs/apache-airflow-providers-dbt-cloud/connections.rst
@@ -15,6 +15,9 @@
     specific language governing permissions and limitations
     under the License.
 
+.. spelling::
+
+    getdbt
 
 
 .. _howto/connection:dbt-cloud:
@@ -65,10 +68,14 @@ Login (optional)
       If an Account ID is not provided in an Airflow connection, ``account_id`` *must* be explicitly passed to
       an operator or hook method.
 
-Schema (optional)
-    The Tenant name for your dbt Cloud environment (i.e. https://my-tenant.getdbt.com). This is particularly
-    useful when using a single-tenant dbt Cloud instance. If a Tenant name is not provided, "cloud"
-    will be used as the default value (i.e. https://cloud.getdbt.com) assuming a multi-tenant instance.
+Host (optional)
+    The Tenant domain for your dbt Cloud environment (e.g. "my-tenant.getdbt.com"). This is particularly
+    useful when using a single-tenant dbt Cloud instance or `other dbt Cloud regions <https://docs.getdbt.com/docs/deploy/regions-ip-addresses>`__
+    like EMEA or a Virtual Private dbt Cloud. If a Tenant domain is not provided, "cloud.getdbt.com" will be
+    used as the default value assuming a multi-tenant instance in the North America region.
+
+    If using the Connection form in the Airflow UI, the Tenant domain can also be stored in the "Tenant"
+    field.
 
 When specifying the connection as an environment variable, you should specify it following the standard syntax
 of a database connection. Note that all components of the URI should be URL-encoded.
@@ -88,11 +95,11 @@ For example, to add a connection with the connection ID of "dbt_cloud_default":
 
         export AIRFLOW_CONN_DBT_CLOUD_DEFAULT='dbt-cloud://:api_token@'
 
-    When specifying Tenant name:
+    When specifying a Tenant domain:
 
     .. code-block:: bash
 
-        export AIRFLOW_CONN_DBT_CLOUD_DEFAULT='dbt-cloud://:api_token@:/my-tenant'
+        export AIRFLOW_CONN_DBT_CLOUD_DEFAULT='dbt-cloud://:api_token@my-tenant.getdbt.com'
 
 You can refer to the documentation on
 :ref:`creating connections via environment variables <environment_variables_secrets_backend>` for more

--- a/tests/providers/dbt/cloud/hooks/test_dbt_cloud.py
+++ b/tests/providers/dbt/cloud/hooks/test_dbt_cloud.py
@@ -38,7 +38,7 @@ NO_ACCOUNT_ID_CONN = "no_account_id_conn"
 SINGLE_TENANT_CONN = "single_tenant_conn"
 DEFAULT_ACCOUNT_ID = 11111
 ACCOUNT_ID = 22222
-SINGLE_TENANT_SCHEMA = "single.tenant"
+SINGLE_TENANT_DOMAIN = "single.tenant.getdbt.com"
 TOKEN = "token"
 PROJECT_ID = 33333
 JOB_ID = 4444
@@ -123,18 +123,18 @@ class TestDbtCloudHook:
             password=TOKEN,
         )
 
-        # Connection with `schema` parameter set
-        schema_conn = Connection(
+        # Connection with `host` parameter set
+        host_conn = Connection(
             conn_id=SINGLE_TENANT_CONN,
             conn_type=DbtCloudHook.conn_type,
             login=DEFAULT_ACCOUNT_ID,
             password=TOKEN,
-            schema=SINGLE_TENANT_SCHEMA,
+            host=SINGLE_TENANT_DOMAIN,
         )
 
         db.merge_conn(account_id_conn)
         db.merge_conn(no_account_id_conn)
-        db.merge_conn(schema_conn)
+        db.merge_conn(host_conn)
 
     @pytest.mark.parametrize(
         argnames="conn_id, url",
@@ -146,6 +146,15 @@ class TestDbtCloudHook:
         assert hook.auth_type == TokenAuth
         assert hook.method == "POST"
         assert hook.dbt_cloud_conn_id == conn_id
+
+    @pytest.mark.parametrize(
+        argnames="conn_id, url",
+        argvalues=[(ACCOUNT_ID_CONN, BASE_URL), (SINGLE_TENANT_CONN, SINGLE_TENANT_URL)],
+        ids=["multi-tenant", "single-tenant"],
+    )
+    def test_tenant_base_url(self, conn_id, url):
+        hook = DbtCloudHook(conn_id)
+        hook.get_conn()
         assert hook.base_url == url
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Closes: #27146

Currently users can connect to both single-tenant and multi-tenant instances of dbt Cloud. However, for the enterprise tier, [there is a new region offered as well as private instance support](https://docs.getdbt.com/docs/deploy/regions-ip-addresses). The existing `tenant` value does not cover the ability to modify the entire domain name which could be required for users on the enterprise plan.

This enhancement allows users to specify the tenant domain they wish to connect to while keeping the "cloud.getdbt.com" domain as the default. Additionally, backward compat is implemented for those who are only specifying the third-level domain for single-tenant instances and wish to upgrade the provider version.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
