### PR TITLE
Strip markup from app_name if instance_name_has_markup = True

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import html.parser
 import re
 import warnings
 from datetime import timedelta
@@ -75,6 +76,18 @@ def sync_appbuilder_roles(flask_app):
         flask_app.appbuilder.sm.sync_roles()
 
 
+def strip_tags(input_html: str) -> str:
+    """Strips tags from HTML"""
+    parts: list[str] = []
+
+    class TagStripParser(html.parser.HTMLParser):
+        def handle_data(self, d: str) -> None:
+            parts.append(d)
+
+    TagStripParser().feed(input_html)
+    return "".join(parts)
+
+
 def create_app(config=None, testing=False):
     """Create a new instance of Airflow WWW app"""
     flask_app = Flask(__name__)
@@ -90,7 +103,7 @@ def create_app(config=None, testing=False):
         section="webserver", key="instance_name_has_markup", fallback=False
     )
     if instance_name_has_markup:
-        instance_name = re.sub(r"<[^<]+?>", "", instance_name)
+        instance_name = strip_tags(instance_name)
 
     flask_app.config["APP_NAME"] = instance_name
 

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -86,7 +86,9 @@ def create_app(config=None, testing=False):
     flask_app.config["SQLALCHEMY_DATABASE_URI"] = conf.get("database", "SQL_ALCHEMY_CONN")
 
     instance_name = conf.get(section="webserver", key="instance_name", fallback="Airflow")
-    instance_name_has_markup = conf.getboolean(section="webserver", key="instance_name_has_markup", fallback=False)
+    instance_name_has_markup = conf.getboolean(
+        section="webserver", key="instance_name_has_markup", fallback=False
+    )
     if instance_name_has_markup:
         instance_name = re.sub(r"<[^<]+?>", "", instance_name)
 

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import html.parser
-import re
 import warnings
 from datetime import timedelta
 from tempfile import gettempdir

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -76,7 +76,7 @@ def sync_appbuilder_roles(flask_app):
         flask_app.appbuilder.sm.sync_roles()
 
 
-def strip_tags(input_html: str) -> str:
+def _strip_tags(input_html: str) -> str:
     """Strips tags from HTML"""
     parts: list[str] = []
 
@@ -103,7 +103,7 @@ def create_app(config=None, testing=False):
         section="webserver", key="instance_name_has_markup", fallback=False
     )
     if instance_name_has_markup:
-        instance_name = strip_tags(instance_name)
+        instance_name = _strip_tags(instance_name)
 
     flask_app.config["APP_NAME"] = instance_name
 

--- a/tests/www/views/test_views_base.py
+++ b/tests/www/views/test_views_base.py
@@ -19,12 +19,14 @@ from __future__ import annotations
 
 import datetime
 import json
+from unittest import mock
 
 import pytest
 
 from airflow.jobs.base_job import BaseJob
 from airflow.utils import timezone
 from airflow.utils.session import create_session
+from airflow.www import app as application
 from tests.test_utils.asserts import assert_queries_count
 from tests.test_utils.config import conf_vars
 from tests.test_utils.www import check_content_in_response, check_content_not_in_response
@@ -400,12 +402,21 @@ def test_page_instance_name_xss_prevention(admin_client):
         check_content_not_in_response(xss_string, resp)
 
 
-@conf_vars(
-    {
-        ("webserver", "instance_name"): "<b>Bold Site Title Test</b>",
-        ("webserver", "instance_name_has_markup"): "True",
-    }
-)
+instance_name_with_markup_conf = {
+    ("webserver", "instance_name"): "<b>Bold Site Title Test</b>",
+    ("webserver", "instance_name_has_markup"): "True",
+}
+
+
+@conf_vars(instance_name_with_markup_conf)
 def test_page_instance_name_with_markup(admin_client):
     resp = admin_client.get("home", follow_redirects=True)
     check_content_in_response("<b>Bold Site Title Test</b>", resp)
+    check_content_not_in_response("&lt;b&gt;Bold Site Title Test&lt;/b&gt;", resp)
+    # check_content_not_in_response("DAGs - Airflow", resp)
+
+
+@conf_vars(instance_name_with_markup_conf)
+def test_page_instance_name_with_markup_title():
+    appbuilder = application.create_app(testing=True).appbuilder
+    assert appbuilder.app_name == "Bold Site Title Test"

--- a/tests/www/views/test_views_base.py
+++ b/tests/www/views/test_views_base.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import datetime
 import json
-from unittest import mock
 
 import pytest
 
@@ -413,7 +412,6 @@ def test_page_instance_name_with_markup(admin_client):
     resp = admin_client.get("home", follow_redirects=True)
     check_content_in_response("<b>Bold Site Title Test</b>", resp)
     check_content_not_in_response("&lt;b&gt;Bold Site Title Test&lt;/b&gt;", resp)
-    # check_content_not_in_response("DAGs - Airflow", resp)
 
 
 @conf_vars(instance_name_with_markup_conf)


### PR DESCRIPTION
Closes https://github.com/apache/airflow/issues/28888

if `webserver.instance_name_has_markup = True`, we strip markup from `flask_app.config["APP_NAME"]`, preventing it to show up as a sanitized HTML in the `<title>` tag.

