### PR TITLE
Chart: Update default git-sync version to 3.6.2

### DIFF
--- a/airflow/kubernetes/pod_template_file_examples/git_sync_template.yaml
+++ b/airflow/kubernetes/pod_template_file_examples/git_sync_template.yaml
@@ -26,7 +26,7 @@ metadata:
 spec:
   initContainers:
     - name: git-sync
-      image: "k8s.gcr.io/git-sync/git-sync:v3.4.0"
+      image: "k8s.gcr.io/git-sync/git-sync:v3.6.2"
       env:
         - name: GIT_SYNC_BRANCH
           value: "v2-2-stable"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -680,7 +680,7 @@
                         "tag": {
                             "description": "The gitSync image tag.",
                             "type": "string",
-                            "default": "v3.4.0"
+                            "default": "v3.6.2"
                         },
                         "pullPolicy": {
                             "description": "The gitSync image pull policy.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -93,7 +93,7 @@ images:
     pullPolicy: IfNotPresent
   gitSync:
     repository: k8s.gcr.io/git-sync/git-sync
-    tag: v3.4.0
+    tag: v3.6.2
     pullPolicy: IfNotPresent
 
 # Select certain nodes for airflow pods.


### PR DESCRIPTION
This is Helm/Kubernetes change only to update the git-sync container from v3.4.0 to v3.6.2.

The v3.4.0 version is a bit old and has several security vulnerabilities.


snyk container test k8s.gcr.io/git-sync/git-sync:v3.4.0
```
✗ High severity vulnerability found in zlib/zlib1g
  Description: Out-of-bounds Write
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-ZLIB-2433934
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > zlib/zlib1g@1:1.2.11.dfsg-1
  Fixed in: 1:1.2.11.dfsg-1+deb10u1

✗ High severity vulnerability found in xz-utils/liblzma5
  Description: Improper Input Validation
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-XZUTILS-2444279
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > xz-utils/liblzma5@5.2.4-1
  Fixed in: 5.2.4-1+deb10u1

✗ High severity vulnerability found in openssl/libssl1.1
  Description: Loop with Unreachable Exit Condition ('Infinite Loop')
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-OPENSSL-2426310
  Introduced through: openssh/openssh-client@1:7.9p1-10+deb10u2, socat@1.7.3.2-2, ca-certificates@20200601~deb10u2, git@1:2.30.2-1~bpo10+1
  From: openssh/openssh-client@1:7.9p1-10+deb10u2 > openssl/libssl1.1@1.1.1d-0+deb10u7
  From: socat@1.7.3.2-2 > openssl/libssl1.1@1.1.1d-0+deb10u7
  From: ca-certificates@20200601~deb10u2 > openssl@1.1.1d-0+deb10u7 > openssl/libssl1.1@1.1.1d-0+deb10u7
  and 2 more...
  Fixed in: 1.1.1d-0+deb10u8

✗ High severity vulnerability found in ncurses/libtinfo6
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-NCURSES-2767192
  Introduced through: openssh/openssh-client@1:7.9p1-10+deb10u2
  From: openssh/openssh-client@1:7.9p1-10+deb10u2 > libedit/libedit2@3.1-20181209-1 > ncurses/libtinfo6@6.1+20181013-2+deb10u2
  Fixed in: 6.1+20181013-2+deb10u3

✗ High severity vulnerability found in krb5/libkrb5support0
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-KRB5-3120879
  Introduced through: git@1:2.30.2-1~bpo10+1, openssh/openssh-client@1:7.9p1-10+deb10u2
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2 > krb5/libgssapi-krb5-2@1.17-3+deb10u3 > krb5/libkrb5support0@1.17-3+deb10u3
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2 > krb5/libgssapi-krb5-2@1.17-3+deb10u3 > krb5/libk5crypto3@1.17-3+deb10u3 > krb5/libkrb5support0@1.17-3+deb10u3
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2 > krb5/libgssapi-krb5-2@1.17-3+deb10u3 > krb5/libkrb5-3@1.17-3+deb10u3 > krb5/libkrb5support0@1.17-3+deb10u3
  and 7 more...
  Fixed in: 1.17-3+deb10u5

✗ High severity vulnerability found in gzip
  Description: Improper Input Validation
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-GZIP-2444259
  Introduced through: gzip@1.9-3
  From: gzip@1.9-3
  Fixed in: 1.9-3+deb10u1

✗ High severity vulnerability found in gnutls28/libgnutls30
  Description: Double Free
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-GNUTLS28-2964217
  Introduced through: apt@1.8.2.3, git@1:2.30.2-1~bpo10+1
  From: apt@1.8.2.3 > gnutls28/libgnutls30@3.6.7-4+deb10u7
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2 > gnutls28/libgnutls30@3.6.7-4+deb10u7
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2 > openldap/libldap-2.4-2@2.4.47+dfsg-3+deb10u6 > gnutls28/libgnutls30@3.6.7-4+deb10u7
  and 1 more...
  Fixed in: 3.6.7-4+deb10u9

✗ High severity vulnerability found in gmp/libgmp10
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-GMP-1920939
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2 > gnutls28/libgnutls30@3.6.7-4+deb10u7 > gmp/libgmp10@2:6.1.2+dfsg-4
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2 > rtmpdump/librtmp1@2.4+20151223.gitfa8646d.1-2 > gmp/libgmp10@2:6.1.2+dfsg-4
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2 > gnutls28/libgnutls30@3.6.7-4+deb10u7 > nettle/libhogweed4@3.4.1-1+deb10u1 > gmp/libgmp10@2:6.1.2+dfsg-4
  Fixed in: 2:6.1.2+dfsg-4+deb10u1

✗ High severity vulnerability found in glibc/libc-bin
  Description: Reachable Assertion
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-GLIBC-1065768
  Introduced through: glibc/libc-bin@2.28-10, meta-common-packages@meta
  From: glibc/libc-bin@2.28-10
  From: meta-common-packages@meta > glibc/libc6@2.28-10
  Fixed in: 2.28-10+deb10u2

✗ High severity vulnerability found in glibc/libc-bin
  Description: Off-by-one Error
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-GLIBC-2340921
  Introduced through: glibc/libc-bin@2.28-10, meta-common-packages@meta
  From: glibc/libc-bin@2.28-10
  From: meta-common-packages@meta > glibc/libc6@2.28-10
  Fixed in: 2.28-10+deb10u2

✗ High severity vulnerability found in glibc/libc-bin
  Description: Out-of-bounds Write
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-GLIBC-559488
  Introduced through: glibc/libc-bin@2.28-10, meta-common-packages@meta
  From: glibc/libc-bin@2.28-10
  From: meta-common-packages@meta > glibc/libc6@2.28-10

✗ High severity vulnerability found in glibc/libc-bin
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-GLIBC-559493
  Introduced through: glibc/libc-bin@2.28-10, meta-common-packages@meta
  From: glibc/libc-bin@2.28-10
  From: meta-common-packages@meta > glibc/libc6@2.28-10
  Fixed in: 2.28-10+deb10u2

✗ High severity vulnerability found in glibc/libc-bin
  Description: Signed to Unsigned Conversion Error
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-GLIBC-564233
  Introduced through: glibc/libc-bin@2.28-10, meta-common-packages@meta
  From: glibc/libc-bin@2.28-10
  From: meta-common-packages@meta > glibc/libc6@2.28-10
  Fixed in: 2.28-10+deb10u2

✗ High severity vulnerability found in gcc-8/libstdc++6
  Description: Information Exposure
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-GCC8-347558
  Introduced through: gcc-8/libstdc++6@8.3.0-6, apt@1.8.2.3, meta-common-packages@meta
  From: gcc-8/libstdc++6@8.3.0-6
  From: apt@1.8.2.3 > gcc-8/libstdc++6@8.3.0-6
  From: apt@1.8.2.3 > apt/libapt-pkg5.0@1.8.2.3 > gcc-8/libstdc++6@8.3.0-6
  and 2 more...

✗ High severity vulnerability found in expat/libexpat1
  Description: Incorrect Calculation
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-EXPAT-2329087
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > expat/libexpat1@2.2.6-2+deb10u1
  Fixed in: 2.2.6-2+deb10u2

✗ High severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-EXPAT-2330888
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > expat/libexpat1@2.2.6-2+deb10u1
  Fixed in: 2.2.6-2+deb10u2

✗ High severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-EXPAT-2331795
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > expat/libexpat1@2.2.6-2+deb10u1
  Fixed in: 2.2.6-2+deb10u2

✗ High severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-EXPAT-2331796
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > expat/libexpat1@2.2.6-2+deb10u1
  Fixed in: 2.2.6-2+deb10u2

✗ High severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-EXPAT-2331820
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > expat/libexpat1@2.2.6-2+deb10u1
  Fixed in: 2.2.6-2+deb10u2

✗ High severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-EXPAT-2384929
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > expat/libexpat1@2.2.6-2+deb10u1
  Fixed in: 2.2.6-2+deb10u2

✗ High severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-EXPAT-2406126
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > expat/libexpat1@2.2.6-2+deb10u1
  Fixed in: 2.2.6-2+deb10u3

✗ High severity vulnerability found in expat/libexpat1
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-EXPAT-3061092
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > expat/libexpat1@2.2.6-2+deb10u1
  Fixed in: 2.2.6-2+deb10u6

✗ High severity vulnerability found in cyrus-sasl2/libsasl2-modules-db
  Description: SQL Injection
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-CYRUSSASL2-2412041
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2 > openldap/libldap-2.4-2@2.4.47+dfsg-3+deb10u6 > cyrus-sasl2/libsasl2-2@2.1.27+dfsg-1+deb10u1 > cyrus-sasl2/libsasl2-modules-db@2.1.27+dfsg-1+deb10u1
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2 > openldap/libldap-2.4-2@2.4.47+dfsg-3+deb10u6 > cyrus-sasl2/libsasl2-2@2.1.27+dfsg-1+deb10u1
  Fixed in: 2.1.27+dfsg-1+deb10u2

✗ High severity vulnerability found in curl/libcurl3-gnutls
  Description: Cleartext Transmission of Sensitive Information
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-CURL-1585139
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2
  Fixed in: 7.64.0-4+deb10u3

✗ High severity vulnerability found in curl/libcurl3-gnutls
  Description: Improper Authentication
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-CURL-2805484
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2
  Fixed in: 7.64.0-4+deb10u3

✗ High severity vulnerability found in curl/libcurl3-gnutls
  Description: Improper Certificate Validation
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-CURL-2813757
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2
  Fixed in: 7.64.0-4+deb10u3

✗ High severity vulnerability found in curl/libcurl3-gnutls
  Description: Loop with Unreachable Exit Condition ('Infinite Loop')
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-CURL-2813772
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2
  Fixed in: 7.64.0-4+deb10u3

✗ Critical severity vulnerability found in zlib/zlib1g
  Description: Out-of-bounds Write
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-ZLIB-2976149
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > zlib/zlib1g@1:1.2.11.dfsg-1
  Fixed in: 1:1.2.11.dfsg-1+deb10u2

✗ Critical severity vulnerability found in openssl/libssl1.1
  Description: OS Command Injection
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-OPENSSL-2807585
  Introduced through: openssh/openssh-client@1:7.9p1-10+deb10u2, socat@1.7.3.2-2, ca-certificates@20200601~deb10u2, git@1:2.30.2-1~bpo10+1
  From: openssh/openssh-client@1:7.9p1-10+deb10u2 > openssl/libssl1.1@1.1.1d-0+deb10u7
  From: socat@1.7.3.2-2 > openssl/libssl1.1@1.1.1d-0+deb10u7
  From: ca-certificates@20200601~deb10u2 > openssl@1.1.1d-0+deb10u7 > openssl/libssl1.1@1.1.1d-0+deb10u7
  and 2 more...
  Fixed in: 1.1.1n-0+deb10u2

✗ Critical severity vulnerability found in openssl/libssl1.1
  Description: OS Command Injection
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-OPENSSL-2933515
  Introduced through: openssh/openssh-client@1:7.9p1-10+deb10u2, socat@1.7.3.2-2, ca-certificates@20200601~deb10u2, git@1:2.30.2-1~bpo10+1
  From: openssh/openssh-client@1:7.9p1-10+deb10u2 > openssl/libssl1.1@1.1.1d-0+deb10u7
  From: socat@1.7.3.2-2 > openssl/libssl1.1@1.1.1d-0+deb10u7
  From: ca-certificates@20200601~deb10u2 > openssl@1.1.1d-0+deb10u7 > openssl/libssl1.1@1.1.1d-0+deb10u7
  and 2 more...
  Fixed in: 1.1.1n-0+deb10u3

✗ Critical severity vulnerability found in openldap/libldap-common
  Description: SQL Injection
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-OPENLDAP-2808412
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2 > openldap/libldap-2.4-2@2.4.47+dfsg-3+deb10u6 > openldap/libldap-common@2.4.47+dfsg-3+deb10u6
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2 > openldap/libldap-2.4-2@2.4.47+dfsg-3+deb10u6
  Fixed in: 2.4.47+dfsg-3+deb10u7

✗ Critical severity vulnerability found in libtasn1-6
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-LIBTASN16-3061094
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2 > gnutls28/libgnutls30@3.6.7-4+deb10u7 > libtasn1-6@4.13-3
  Fixed in: 4.13-3+deb10u1

✗ Critical severity vulnerability found in glibc/libc-bin
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-GLIBC-1296899
  Introduced through: glibc/libc-bin@2.28-10, meta-common-packages@meta
  From: glibc/libc-bin@2.28-10
  From: meta-common-packages@meta > glibc/libc6@2.28-10
  Fixed in: 2.28-10+deb10u2

✗ Critical severity vulnerability found in glibc/libc-bin
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-GLIBC-1315333
  Introduced through: glibc/libc-bin@2.28-10, meta-common-packages@meta
  From: glibc/libc-bin@2.28-10
  From: meta-common-packages@meta > glibc/libc6@2.28-10
  Fixed in: 2.28-10+deb10u2

✗ Critical severity vulnerability found in glibc/libc-bin
  Description: Buffer Overflow
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-GLIBC-2340915
  Introduced through: glibc/libc-bin@2.28-10, meta-common-packages@meta
  From: glibc/libc-bin@2.28-10
  From: meta-common-packages@meta > glibc/libc6@2.28-10
  Fixed in: 2.28-10+deb10u2

✗ Critical severity vulnerability found in glibc/libc-bin
  Description: Buffer Overflow
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-GLIBC-2340923
  Introduced through: glibc/libc-bin@2.28-10, meta-common-packages@meta
  From: glibc/libc-bin@2.28-10
  From: meta-common-packages@meta > glibc/libc6@2.28-10
  Fixed in: 2.28-10+deb10u2

✗ Critical severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-EXPAT-2331803
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > expat/libexpat1@2.2.6-2+deb10u1
  Fixed in: 2.2.6-2+deb10u2

✗ Critical severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-EXPAT-2331813
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > expat/libexpat1@2.2.6-2+deb10u1
  Fixed in: 2.2.6-2+deb10u2

✗ Critical severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-EXPAT-2331818
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > expat/libexpat1@2.2.6-2+deb10u1
  Fixed in: 2.2.6-2+deb10u2

✗ Critical severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-EXPAT-2359258
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > expat/libexpat1@2.2.6-2+deb10u1
  Fixed in: 2.2.6-2+deb10u2

✗ Critical severity vulnerability found in expat/libexpat1
  Description: Improper Encoding or Escaping of Output
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-EXPAT-2403513
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > expat/libexpat1@2.2.6-2+deb10u1
  Fixed in: 2.2.6-2+deb10u3

✗ Critical severity vulnerability found in expat/libexpat1
  Description: Exposure of Resource to Wrong Sphere
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-EXPAT-2403518
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > expat/libexpat1@2.2.6-2+deb10u1
  Fixed in: 2.2.6-2+deb10u3

✗ Critical severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-EXPAT-2406128
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > expat/libexpat1@2.2.6-2+deb10u1
  Fixed in: 2.2.6-2+deb10u3

✗ Critical severity vulnerability found in expat/libexpat1
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-EXPAT-3023032
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > expat/libexpat1@2.2.6-2+deb10u1
  Fixed in: 2.2.6-2+deb10u5

✗ Critical severity vulnerability found in dpkg
  Description: Directory Traversal
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-DPKG-2847944
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > dpkg@1.19.7
  Fixed in: 1.19.8

✗ Critical severity vulnerability found in curl/libcurl3-gnutls
  Description: Exposure of Resource to Wrong Sphere
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-CURL-3065760
  Introduced through: git@1:2.30.2-1~bpo10+1
  From: git@1:2.30.2-1~bpo10+1 > curl/libcurl3-gnutls@7.64.0-4+deb10u2
```


As a comparison, the v3.6.2 has only two known High and two known Critical vulnerabilities:

snyk container test k8s.gcr.io/git-sync/git-sync:v3.6.2
```
✗ High severity vulnerability found in curl/libcurl3-gnutls
  Description: Cleartext Transmission of Sensitive Information
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-CURL-3066040
  Introduced through: git@1:2.30.2-1
  From: git@1:2.30.2-1 > curl/libcurl3-gnutls@7.74.0-1.3+deb11u3

✗ High severity vulnerability found in curl/libcurl3-gnutls
  Description: Cleartext Transmission of Sensitive Information
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-CURL-3179181
  Introduced through: git@1:2.30.2-1
  From: git@1:2.30.2-1 > curl/libcurl3-gnutls@7.74.0-1.3+deb11u3

✗ Critical severity vulnerability found in libtasn1-6
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-LIBTASN16-3061097
  Introduced through: git@1:2.30.2-1
  From: git@1:2.30.2-1 > curl/libcurl3-gnutls@7.74.0-1.3+deb11u3 > gnutls28/libgnutls30@3.7.1-5+deb11u2 > libtasn1-6@4.16.0-2
  Fixed in: 4.16.0-2+deb11u1

✗ Critical severity vulnerability found in curl/libcurl3-gnutls
  Description: Exposure of Resource to Wrong Sphere
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-CURL-3065656
  Introduced through: git@1:2.30.2-1
  From: git@1:2.30.2-1 > curl/libcurl3-gnutls@7.74.0-1.3+deb11u3
```

