### PR TITLE
Avoid circular import from S3HookUriParseFailure

### DIFF
--- a/airflow/providers/amazon/aws/exceptions.py
+++ b/airflow/providers/amazon/aws/exceptions.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 
 # Note: Any AirflowException raised is expected to cause the TaskInstance
 #       to be marked in an ERROR state


### PR DESCRIPTION
Otherwise, webserver fails to start when s3 configured.
