### PR TITLE
Removal of flake8 file has broken breeze bind mounts

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -77,7 +77,6 @@ VOLUMES_FOR_SELECTED_MOUNTS = [
     (".build", "/opt/airflow/.build"),
     (".coveragerc", "/opt/airflow/.coveragerc"),
     (".dockerignore", "/opt/airflow/.dockerignore"),
-    (".flake8", "/opt/airflow/.flake8"),
     (".github", "/opt/airflow/.github"),
     (".inputrc", "/root/.inputrc"),
     (".rat-excludes", "/opt/airflow/.rat-excludes"),

--- a/scripts/ci/docker-compose/local.yml
+++ b/scripts/ci/docker-compose/local.yml
@@ -43,9 +43,6 @@ services:
         source: ../../../.dockerignore
         target: /opt/airflow/.dockerignore
       - type: bind
-        source: ../../../.flake8
-        target: /opt/airflow/.flake8
-      - type: bind
         source: ../../../.github
         target: /opt/airflow/.github
       - type: bind


### PR DESCRIPTION
Don't try mount .flake8 anymore, it has been removed in #28893

When running `breeze tests ....`, got the following:
```
ERROR: for airflow-test-all_airflow_run  Cannot create container for service airflow: invalid mount config for type "bind": bind source path does not exist: /home//onikolas/code/oss/airflow/team_fork_2/.flake8
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
