### PR TITLE
Hide `extra` field in Azure Blob Storage wasb

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -113,14 +113,13 @@ class WasbHook(BaseHook):
     def get_ui_field_behaviour() -> dict[str, Any]:
         """Returns custom field behaviour"""
         return {
-            "hidden_fields": ["schema", "port"],
+            "hidden_fields": ["schema", "port", "extra"],
             "relabeling": {
                 "login": "Blob Storage Login (optional)",
                 "password": "Blob Storage Key (optional)",
                 "host": "Account Name (Active Directory Auth)",
             },
             "placeholders": {
-                "extra": "additional options for use with FileService and AzureFileVolume",
                 "login": "account name",
                 "password": "secret",
                 "host": "account url",

--- a/tests/providers/microsoft/azure/hooks/test_wasb.py
+++ b/tests/providers/microsoft/azure/hooks/test_wasb.py
@@ -413,7 +413,6 @@ class TestWasbHook:
         Note: remove this test when removing ensure_prefixes (after min airflow version >= 2.5.0
         """
         assert list(WasbHook.get_ui_field_behaviour()["placeholders"].keys()) == [
-            "extra",
             "login",
             "password",
             "host",


### PR DESCRIPTION
Closes https://github.com/apache/airflow/issues/28884

Hides the `extra` field from `wasb` protocol hook in Azure Blob Storage.
