### PR TITLE
Add configuration_overrides to templated fields

### DIFF
--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -391,6 +391,7 @@ class EmrContainerOperator(BaseOperator):
         "execution_role_arn",
         "release_label",
         "job_driver",
+        "configuration_overrides",
     )
     ui_color = "#f9c915"
 


### PR DESCRIPTION
Added `configuration_overrides` to the templated fields, as can be required to be templated in case of changing log_groups and log_prefixes in AWS CloudWatch.

Required templating:
```
{'monitoringConfiguration': {
  'persistentAppUI': 'ENABLED',
  'cloudWatchMonitoringConfiguration': {
    'logGroupName': '{{ var.value.emr_jobs_log_group }}',
    'logStreamNamePrefix': '{{ task_instance_key_str }}'
  }}}
```

This change should not impact anything as far as I can tell, just expand the templating of the operator to cover realistic cases.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
