### PR TITLE
Allow URI without authority and host blocks in `airflow connections add`

### DIFF
--- a/airflow/cli/commands/connection_command.py
+++ b/airflow/cli/commands/connection_command.py
@@ -132,9 +132,8 @@ def _is_stdout(fileio: io.TextIOWrapper) -> bool:
 
 
 def _valid_uri(uri: str) -> bool:
-    """Check if a URI is valid, by checking if both scheme and netloc are available."""
-    uri_parts = urlsplit(uri)
-    return uri_parts.scheme != "" and uri_parts.netloc != ""
+    """Check if a URI is valid, by checking if scheme (conn_type) provided."""
+    return urlsplit(uri).scheme != ""
 
 
 @cache


### PR DESCRIPTION
Right now it is not possible to add Connection URI which does not contain authority and host block [without workaround](https://github.com/apache/airflow/issues/28766#issuecomment-1375346374) even if it valid connection

```console

❯ airflow connections add aws-conn --conn-uri "aws://"
The URI provided to --conn-uri is invalid: aws://
```

closes: https://github.com/apache/airflow/issues/28766
relates to: https://github.com/apache/airflow/pull/28852