### PR TITLE
Add log for AWS Glue Job Console URL

### DIFF
--- a/airflow/providers/amazon/aws/links/glue.py
+++ b/airflow/providers/amazon/aws/links/glue.py
@@ -19,11 +19,11 @@ from __future__ import annotations
 from airflow.providers.amazon.aws.links.base_aws import BASE_AWS_CONSOLE_LINK, BaseAwsLink
 
 
-class GlueJobLogsLink(BaseAwsLink):
-    """Helper class for constructing AWS Glue Job Logs Link"""
+class GlueJobRunDetailsLink(BaseAwsLink):
+    """Helper class for constructing AWS Glue Job Run Details Link"""
 
-    name = "AWS Glue Job Logs"
-    key = "glue_job_logs"
+    name = "AWS Glue Job Run Details"
+    key = "glue_job_run_details"
     format_str = (
         BASE_AWS_CONSOLE_LINK + "/gluestudio/home?region={region_name}#/job/{job_name}/run/{job_run_id}"
     )

--- a/airflow/providers/amazon/aws/links/glue.py
+++ b/airflow/providers/amazon/aws/links/glue.py
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.providers.amazon.aws.links.base_aws import BASE_AWS_CONSOLE_LINK, BaseAwsLink
+
+
+class GlueJobLogsLink(BaseAwsLink):
+    """Helper class for constructing AWS Glue Job Logs Link"""
+
+    name = "AWS Glue Job Logs"
+    key = "glue_job_logs"
+    format_str = (
+        BASE_AWS_CONSOLE_LINK + "/gluestudio/home?region={region_name}#/job/{job_name}/run/{job_run_id}"
+    )

--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import os.path
+import urllib.parse
 from typing import TYPE_CHECKING, Sequence
 
 from airflow.models import BaseOperator
@@ -144,6 +145,12 @@ class GlueJobOperator(BaseOperator):
             self.wait_for_completion,
         )
         glue_job_run = glue_job.initialize_job(self.script_args, self.run_job_kwargs)
+        glue_job_run_url = (
+            f"https://{glue_job.conn_region_name}.console.aws.amazon.com/gluestudio/home?"
+            + f"region={glue_job.conn_region_name}#/job/{urllib.parse.quote(self.job_name, safe='')}/run/"
+            + glue_job_run["JobRunId"]
+        )
+        self.log.info("You can monitor this Glue Job run at: %s", glue_job_run_url)
         if self.wait_for_completion:
             glue_job_run = glue_job.job_completion(self.job_name, glue_job_run["JobRunId"], self.verbose)
             self.log.info(

--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -25,7 +25,7 @@ from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.glue import GlueJobHook
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.links.base_aws import BASE_AWS_CONSOLE_LINK
-from airflow.providers.amazon.aws.links.glue import GlueJobLogsLink
+from airflow.providers.amazon.aws.links.glue import GlueJobRunDetailsLink
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -72,7 +72,7 @@ class GlueJobOperator(BaseOperator):
     }
     ui_color = "#ededed"
 
-    operator_extra_links = (GlueJobLogsLink(),)
+    operator_extra_links = (GlueJobRunDetailsLink(),)
 
     def __init__(
         self,
@@ -154,7 +154,7 @@ class GlueJobOperator(BaseOperator):
             + f"region={glue_job.conn_region_name}#/job/{urllib.parse.quote(self.job_name, safe='')}/run/"
             + glue_job_run["JobRunId"]
         )
-        GlueJobLogsLink.persist(
+        GlueJobRunDetailsLink.persist(
             context=context,
             operator=self,
             region_name=glue_job.conn_region_name,

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -566,6 +566,7 @@ extra-links:
   - airflow.providers.amazon.aws.links.batch.BatchJobQueueLink
   - airflow.providers.amazon.aws.links.emr.EmrClusterLink
   - airflow.providers.amazon.aws.links.emr.EmrLogsLink
+  - airflow.providers.amazon.aws.links.glue.GlueJobLogsLink
   - airflow.providers.amazon.aws.links.logs.CloudWatchEventsLink
 
 connection-types:

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -566,7 +566,7 @@ extra-links:
   - airflow.providers.amazon.aws.links.batch.BatchJobQueueLink
   - airflow.providers.amazon.aws.links.emr.EmrClusterLink
   - airflow.providers.amazon.aws.links.emr.EmrLogsLink
-  - airflow.providers.amazon.aws.links.glue.GlueJobLogsLink
+  - airflow.providers.amazon.aws.links.glue.GlueJobRunDetailsLink
   - airflow.providers.amazon.aws.links.logs.CloudWatchEventsLink
 
 connection-types:

--- a/tests/providers/amazon/aws/links/test_links.py
+++ b/tests/providers/amazon/aws/links/test_links.py
@@ -27,6 +27,7 @@ from airflow.providers.amazon.aws.links.batch import (
     BatchJobQueueLink,
 )
 from airflow.providers.amazon.aws.links.emr import EmrClusterLink
+from airflow.providers.amazon.aws.links.glue import GlueJobLogsLink
 from airflow.providers.amazon.aws.links.logs import CloudWatchEventsLink
 from airflow.serialization.serialized_objects import SerializedDAG
 
@@ -77,6 +78,11 @@ AWS_LINKS = [
         f"https://console.{AWS_DOMAIN}/cloudwatch/home?region=ap-southeast-2"
         f"#logsV2:log-groups/log-group/%2Ftest%2Flogs%2Fgroup"
         f"/log-events/test%2Fstream%2Fd56a66bb98a14c4593defa1548686edf",
+    ),
+    (
+        GlueJobLogsLink,
+        {"job_run_id": "11111", "job_name": "test_job_name"},
+        f"https://console.{AWS_DOMAIN}/gluestudio/home?region={REGION_NAME}#/job/test_job_name/run/11111",
     ),
 ]
 

--- a/tests/providers/amazon/aws/links/test_links.py
+++ b/tests/providers/amazon/aws/links/test_links.py
@@ -27,7 +27,7 @@ from airflow.providers.amazon.aws.links.batch import (
     BatchJobQueueLink,
 )
 from airflow.providers.amazon.aws.links.emr import EmrClusterLink
-from airflow.providers.amazon.aws.links.glue import GlueJobLogsLink
+from airflow.providers.amazon.aws.links.glue import GlueJobRunDetailsLink
 from airflow.providers.amazon.aws.links.logs import CloudWatchEventsLink
 from airflow.serialization.serialized_objects import SerializedDAG
 
@@ -80,7 +80,7 @@ AWS_LINKS = [
         f"/log-events/test%2Fstream%2Fd56a66bb98a14c4593defa1548686edf",
     ),
     (
-        GlueJobLogsLink,
+        GlueJobRunDetailsLink,
         {"job_run_id": "11111", "job_name": "test_job_name"},
         f"https://console.{AWS_DOMAIN}/gluestudio/home?region={REGION_NAME}#/job/test_job_name/run/11111",
     ),

--- a/tests/providers/amazon/aws/operators/test_glue.py
+++ b/tests/providers/amazon/aws/operators/test_glue.py
@@ -24,7 +24,7 @@ from airflow.configuration import conf
 from airflow.models import TaskInstance
 from airflow.providers.amazon.aws.hooks.glue import GlueJobHook
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-from airflow.providers.amazon.aws.links.base_aws import BASE_AWS_CONSOLE_LINK
+from airflow.providers.amazon.aws.links.glue import GlueJobRunDetailsLink
 from airflow.providers.amazon.aws.operators.glue import GlueJobOperator
 
 TASK_ID = "test_glue_operator"
@@ -177,9 +177,10 @@ class TestGlueJobOperator:
         mock_initialize_job.return_value = {"JobRunState": "RUNNING", "JobRunId": JOB_RUN_ID}
         mock_get_job_state.return_value = "SUCCEEDED"
 
+        aws_domain = GlueJobRunDetailsLink.get_aws_domain("aws")
         glue_job_run_url = (
-            f"{BASE_AWS_CONSOLE_LINK}/gluestudio/home?"
-            + f"region={region}#/job/test_job_name%2Fwith_slash/run/{JOB_RUN_ID}"
+            f"https://console.{aws_domain}/gluestudio/home?region="
+            + f"{region}#/job/test_job_name%2Fwith_slash/run/{JOB_RUN_ID}"
         )
 
         with mock.patch.object(glue.log, "info") as mock_log_info:

--- a/tests/providers/amazon/aws/operators/test_glue.py
+++ b/tests/providers/amazon/aws/operators/test_glue.py
@@ -24,6 +24,7 @@ from airflow.configuration import conf
 from airflow.models import TaskInstance
 from airflow.providers.amazon.aws.hooks.glue import GlueJobHook
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.amazon.aws.links.base_aws import BASE_AWS_CONSOLE_LINK
 from airflow.providers.amazon.aws.operators.glue import GlueJobOperator
 
 TASK_ID = "test_glue_operator"
@@ -91,7 +92,7 @@ class TestGlueJobOperator:
         mock_initialize_job.return_value = {"JobRunState": "RUNNING", "JobRunId": JOB_RUN_ID}
         mock_get_job_state.return_value = "SUCCEEDED"
 
-        glue.execute({})
+        glue.execute(mock.MagicMock())
 
         mock_initialize_job.assert_called_once_with({}, {})
         mock_print_job_logs.assert_not_called()
@@ -116,7 +117,7 @@ class TestGlueJobOperator:
         mock_initialize_job.return_value = {"JobRunState": "RUNNING", "JobRunId": JOB_RUN_ID}
         mock_get_job_state.return_value = "SUCCEEDED"
 
-        glue.execute({})
+        glue.execute(mock.MagicMock())
 
         mock_initialize_job.assert_called_once_with({}, {})
         mock_print_job_logs.assert_called_once_with(
@@ -147,7 +148,7 @@ class TestGlueJobOperator:
         )
         mock_initialize_job.return_value = {"JobRunState": "RUNNING", "JobRunId": JOB_RUN_ID}
 
-        job_run_id = glue.execute({})
+        job_run_id = glue.execute(mock.MagicMock())
 
         mock_initialize_job.assert_called_once_with({}, {})
         mock_job_completion.assert_not_called()
@@ -177,12 +178,12 @@ class TestGlueJobOperator:
         mock_get_job_state.return_value = "SUCCEEDED"
 
         glue_job_run_url = (
-            f"https://{region}.console.aws.amazon.com/gluestudio/home?"
+            f"{BASE_AWS_CONSOLE_LINK}/gluestudio/home?"
             + f"region={region}#/job/test_job_name%2Fwith_slash/run/{JOB_RUN_ID}"
         )
 
         with mock.patch.object(glue.log, "info") as mock_log_info:
-            job_run_id = glue.execute({})
-        assert job_run_id == JOB_RUN_ID
-        print(mock_log_info.call_args_list)
+            job_run_id = glue.execute(mock.MagicMock())
+            assert job_run_id == JOB_RUN_ID
+
         mock_log_info.assert_any_call("You can monitor this Glue Job run at: %s", glue_job_run_url)


### PR DESCRIPTION
It is possible to view the current job run in the AWS Console.

I add a log pointing to the URL that shows the current job run for convenience.

I also slightly modify the test to include job use a job name with slash, which is a valid job name.
