### PR TITLE
Fix @task.kubernetes to receive input and send output

### DIFF
--- a/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
@@ -115,8 +115,7 @@ class _KubernetesDecoratedOperator(DecoratedOperator, KubernetesPodOperator):
             input_filename = os.path.join(tmp_dir, "script.in")
 
             with open(input_filename, "wb") as file:
-                if self.op_args or self.op_kwargs:
-                    self.pickling_library.dump({"args": self.op_args, "kwargs": self.op_kwargs}, file)
+                self.pickling_library.dump({"args": self.op_args, "kwargs": self.op_kwargs}, file)
 
             py_source = self._get_python_source()
             jinja_context = {

--- a/airflow/providers/cncf/kubernetes/python_kubernetes_script.jinja2
+++ b/airflow/providers/cncf/kubernetes/python_kubernetes_script.jinja2
@@ -18,6 +18,7 @@
 -#}
 
 import json
+import {{ pickling_library }}
 import sys
 
 {# Check whether Airflow is available in the environment.
@@ -34,7 +35,7 @@ if sys.version_info >= (3,6):
 
 {% if op_args or op_kwargs %}
 with open(sys.argv[1], "rb") as file:
-    arg_dict = json.loads(file.read())
+    arg_dict = {{ pickling_library }}.load(file)
 {% else %}
 arg_dict = {"args": [], "kwargs": {}}
 {% endif %}

--- a/airflow/providers/cncf/kubernetes/python_kubernetes_script.jinja2
+++ b/airflow/providers/cncf/kubernetes/python_kubernetes_script.jinja2
@@ -17,7 +17,7 @@
  under the License.
 -#}
 
-import {{ pickling_library }}
+import json
 import sys
 
 {# Check whether Airflow is available in the environment.
@@ -34,7 +34,7 @@ if sys.version_info >= (3,6):
 
 {% if op_args or op_kwargs %}
 with open(sys.argv[1], "rb") as file:
-    arg_dict = {{ pickling_library }}.load(file)
+    arg_dict = json.loads(file.read())
 {% else %}
 arg_dict = {"args": [], "kwargs": {}}
 {% endif %}
@@ -42,3 +42,8 @@ arg_dict = {"args": [], "kwargs": {}}
 # Script
 {{ python_callable_source }}
 res = {{ python_callable }}(*arg_dict["args"], **arg_dict["kwargs"])
+
+# Write output
+with open(sys.argv[2], "w") as file:
+    if res is not None:
+        file.write(json.dumps(res))

--- a/tests/providers/cncf/kubernetes/decorators/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/decorators/test_kubernetes.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import base64
 from unittest import mock
 
 import pytest
@@ -98,11 +97,7 @@ def test_basic_kubernetes(dag_maker, session, mock_create_pod: mock.Mock, mock_h
     assert len(containers) == 1
     assert containers[0].command[0] == "bash"
     assert len(containers[0].args) == 0
-
-    assert containers[0].env[0].name == "__PYTHON_SCRIPT"
-    assert containers[0].env[0].value
-    assert containers[0].env[1].name == "__PYTHON_INPUT"
-    assert not containers[0].env[1].value
+    assert containers[0].env == []
 
 
 def test_kubernetes_with_input_output(
@@ -143,15 +138,7 @@ def test_kubernetes_with_input_output(
     assert len(containers) == 2
     assert containers[0].command[0] == "bash"
     assert len(containers[0].args) == 0
-
-    assert containers[0].env[0].name == "__PYTHON_SCRIPT"
-    assert containers[0].env[0].value
-    assert containers[0].env[1].name == "__PYTHON_INPUT"
-    assert containers[0].env[1].value
-
-    # Ensure we pass input through a b64 encoded env var
-    decoded_input = base64.b64decode(containers[0].env[1].value).decode("utf-8")
-    assert decoded_input == '{"args": ["arg1", "arg2"], "kwargs": {"kwarg1": "kwarg1"}}'
+    assert containers[0].env == []
 
     # Second container is xcom image
     assert containers[1].image == XCOM_IMAGE

--- a/tests/providers/cncf/kubernetes/decorators/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/decorators/test_kubernetes.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+import base64
+import pickle
 from unittest import mock
 
 import pytest
@@ -97,7 +99,10 @@ def test_basic_kubernetes(dag_maker, session, mock_create_pod: mock.Mock, mock_h
     assert len(containers) == 1
     assert containers[0].command[0] == "bash"
     assert len(containers[0].args) == 0
-    assert containers[0].env == []
+    assert containers[0].env[0].name == "__PYTHON_SCRIPT"
+    assert containers[0].env[0].value
+    assert containers[0].env[1].name == "__PYTHON_INPUT"
+    assert not containers[0].env[1].value
 
 
 def test_kubernetes_with_input_output(
@@ -138,7 +143,15 @@ def test_kubernetes_with_input_output(
     assert len(containers) == 2
     assert containers[0].command[0] == "bash"
     assert len(containers[0].args) == 0
-    assert containers[0].env == []
+
+    assert containers[0].env[0].name == "__PYTHON_SCRIPT"
+    assert containers[0].env[0].value
+    assert containers[0].env[1].name == "__PYTHON_INPUT"
+    assert containers[0].env[1].value
+
+    # Ensure we pass input through a b64 encoded env var
+    decoded_input = pickle.loads(base64.b64decode(containers[0].env[1].value))
+    assert decoded_input == {"args": ("arg1", "arg2"), "kwargs": {"kwarg1": "kwarg1"}}
 
     # Second container is xcom image
     assert containers[1].image == XCOM_IMAGE

--- a/tests/providers/cncf/kubernetes/decorators/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/decorators/test_kubernetes.py
@@ -102,7 +102,10 @@ def test_basic_kubernetes(dag_maker, session, mock_create_pod: mock.Mock, mock_h
     assert containers[0].env[0].name == "__PYTHON_SCRIPT"
     assert containers[0].env[0].value
     assert containers[0].env[1].name == "__PYTHON_INPUT"
-    assert not containers[0].env[1].value
+
+    # Ensure we pass input through a b64 encoded env var
+    decoded_input = pickle.loads(base64.b64decode(containers[0].env[1].value))
+    assert decoded_input == {"args": [], "kwargs": {}}
 
 
 def test_kubernetes_with_input_output(

--- a/tests/providers/cncf/kubernetes/decorators/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/decorators/test_kubernetes.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import base64
 from unittest import mock
 
 import pytest
@@ -29,6 +30,8 @@ KPO_MODULE = "airflow.providers.cncf.kubernetes.operators.kubernetes_pod"
 POD_MANAGER_CLASS = "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager"
 HOOK_CLASS = "airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesHook"
 
+XCOM_IMAGE = "XCOM_IMAGE"
+
 
 @pytest.fixture(autouse=True)
 def mock_create_pod() -> mock.Mock:
@@ -38,6 +41,18 @@ def mock_create_pod() -> mock.Mock:
 @pytest.fixture(autouse=True)
 def mock_await_pod_start() -> mock.Mock:
     return mock.patch(f"{POD_MANAGER_CLASS}.await_pod_start").start()
+
+
+@pytest.fixture(autouse=True)
+def await_xcom_sidecar_container_start() -> mock.Mock:
+    return mock.patch(f"{POD_MANAGER_CLASS}.await_xcom_sidecar_container_start").start()
+
+
+@pytest.fixture(autouse=True)
+def extract_xcom() -> mock.Mock:
+    f = mock.patch(f"{POD_MANAGER_CLASS}.extract_xcom").start()
+    f.return_value = '{"key1": "value1", "key2": "value2"}'
+    return f
 
 
 @pytest.fixture(autouse=True)
@@ -81,11 +96,63 @@ def test_basic_kubernetes(dag_maker, session, mock_create_pod: mock.Mock, mock_h
 
     containers = mock_create_pod.call_args[1]["pod"].spec.containers
     assert len(containers) == 1
-    assert containers[0].command == ["bash"]
+    assert containers[0].command[0] == "bash"
+    assert len(containers[0].args) == 0
 
-    assert len(containers[0].args) == 2
-    assert containers[0].args[0] == "-cx"
-    assert containers[0].args[1].endswith("/tmp/script.py")
+    assert containers[0].env[0].name == "__PYTHON_SCRIPT"
+    assert containers[0].env[0].value
+    assert containers[0].env[1].name == "__PYTHON_INPUT"
+    assert not containers[0].env[1].value
 
-    assert containers[0].env[-1].name == "__PYTHON_SCRIPT"
-    assert containers[0].env[-1].value
+
+def test_kubernetes_with_input_output(
+    dag_maker, session, mock_create_pod: mock.Mock, mock_hook: mock.Mock
+) -> None:
+    with dag_maker(session=session) as dag:
+
+        @task.kubernetes(
+            image="python:3.10-slim-buster",
+            in_cluster=False,
+            cluster_context="default",
+            config_file="/tmp/fake_file",
+        )
+        def f(arg1, arg2, kwarg1=None, kwarg2=None):
+            return {"key1": "value1", "key2": "value2"}
+
+        f.override(task_id="my_task_id", do_xcom_push=True)("arg1", "arg2", kwarg1="kwarg1")
+
+    dr = dag_maker.create_dagrun()
+    (ti,) = dr.task_instances
+
+    mock_hook.return_value.get_xcom_sidecar_container_image.return_value = XCOM_IMAGE
+
+    dag.get_task("my_task_id").execute(context=ti.get_template_context(session=session))
+
+    mock_hook.assert_called_once_with(
+        conn_id=None,
+        in_cluster=False,
+        cluster_context="default",
+        config_file="/tmp/fake_file",
+    )
+    assert mock_create_pod.call_count == 1
+    assert mock_hook.return_value.get_xcom_sidecar_container_image.call_count == 1
+
+    containers = mock_create_pod.call_args[1]["pod"].spec.containers
+
+    # First container is Python script
+    assert len(containers) == 2
+    assert containers[0].command[0] == "bash"
+    assert len(containers[0].args) == 0
+
+    assert containers[0].env[0].name == "__PYTHON_SCRIPT"
+    assert containers[0].env[0].value
+    assert containers[0].env[1].name == "__PYTHON_INPUT"
+    assert containers[0].env[1].value
+
+    # Ensure we pass input through a b64 encoded env var
+    decoded_input = base64.b64decode(containers[0].env[1].value).decode("utf-8")
+    assert decoded_input == '{"args": ["arg1", "arg2"], "kwargs": {"kwarg1": "kwarg1"}}'
+
+    # Second container is xcom image
+    assert containers[1].image == XCOM_IMAGE
+    assert containers[1].volume_mounts[0].mount_path == "/airflow/xcom"


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: https://github.com/apache/airflow/issues/28933

`@task.kubernetes` currently does not handle receiving input nor does it properly return output. This PR addresses these issues by passing input to the K8's pod (via an env var) and output where the K8's xcom sidecar expects it (as /airflow/xcom/result.json).

It also seemed like the initial implementation did not properly base64 encode / decode the values. Since there might be unusual characters / line breaks in both the function and inputs, I added base64 encoding to the env var setting (similar to how it's handled in  [docker](https://github.com/apache/airflow/blob/2.5.0/airflow/providers/docker/decorators/docker.py#L50)). 

## Testing

To test, I started Airflow w/ breeze (`breeze --python 3.9 --backend postgres start-airflow`), added a google_cloud_default connection_id to my sandbox GCP project, and copied my kube_config file to /files/.kube/config. Because I am using GCP, I needed to install gcloud. I do so with the following commands in the breeze shell:

```sh
curl -sSL https://sdk.cloud.google.com > /tmp/gcloud_installer && bash /tmp/gcloud_installer --install-dir=$AIRFLOW_HOME --disable-prompts
source /root/airflow/google-cloud-sdk/completion.bash.inc
source /root/airflow/google-cloud-sdk/path.bash.inc
```

I then ran this test DAG:

```py
import os

from airflow import DAG
from airflow.decorators import task

DEFAULT_TASK_ARGS = {
    "owner": "gcp-data-platform",
    "start_date": "2022-12-16",
    "retries": 0,
}

@task.kubernetes(
    image="python:3.8-slim-buster",
    namespace=os.getenv("AIRFLOW__KUBERNETES_EXECUTOR__NAMESPACE", "airflow-default"),
    in_cluster=False,
    config_file="/files/.kube/config",
)
def k8s_basic() -> str:
    import time
    time.sleep(1)


@task.kubernetes(
    image="python:3.8-slim-buster",
    namespace=os.getenv("AIRFLOW__KUBERNETES_EXECUTOR__NAMESPACE", "airflow-default"),
    in_cluster=False,
    config_file="/files/.kube/config",
    # multiple_outputs=True,
)
def k8s_func(val: str = "a") -> str:
    import time
    time.sleep(1)

    print(f"Got val: {val}")
    return {"a": val, "d": [1, 2, 3], "f": {1: val}}


with DAG(
    schedule_interval="@daily",
    max_active_runs=1,
    max_active_tasks=5,
    catchup=False,
    dag_id="test_k8s_decorator",
    default_args=DEFAULT_TASK_ARGS,
) as dag:

    basic = k8s_basic()

    no_input_or_output = k8s_func()

    with_input = k8s_func.override(task_id="with_input")("b")

    with_input_and_output = k8s_func.override(task_id="with_input_and_output", do_xcom_push=True)("b")

    no_input_and_output = k8s_func.override(task_id="no_input_and_output", do_xcom_push=True)()

```

## Results

<img width="764" alt="image" src="https://user-images.githubusercontent.com/9200263/212512546-94413de9-4250-45e4-842f-031efbcf8631.png">

With Input:

<img width="1116" alt="image" src="https://user-images.githubusercontent.com/9200263/212512870-9f83ad57-1396-4577-ac0c-e71d0fe5e02a.png">

With Input and Output:

<img width="848" alt="image" src="https://user-images.githubusercontent.com/9200263/212513081-7c2a1374-a660-41e7-b5e9-ddceb559c6ac.png">

No input and Output:

<img width="924" alt="image" src="https://user-images.githubusercontent.com/9200263/212513245-b62ad85a-b43e-44bd-a0f6-8bacdd3ac2b9.png">

With multiple_outputs = True:

<img width="764" alt="image" src="https://user-images.githubusercontent.com/9200263/212513610-f454edce-e0f2-4739-bf79-e180467830f3.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
