### PR TITLE
Add handling logic on CeleryExecutor to reschedule task stuck in queued status

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2034,6 +2034,20 @@ celery:
       type: integer
       example: ~
       default: "3"
+    task_stuck_in_queued_check_interval:
+      description: |
+        How often in seconds to check for task instances stuck in "queued" status
+      version_added: 2.5.1
+      type: integer
+      example: ~
+      default: ~
+    task_stuck_in_queued_timeout:
+      description: |
+        How long in seconds to determine whether task instances are stuck in "queued" status
+      version_added: 2.5.1
+      type: integer
+      example: ~
+      default: "600"
     worker_precheck:
       description: |
         Worker initialisation check to validate Metadata Database connection

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1046,6 +1046,12 @@ stalled_task_timeout = 0
 # due to ``AirflowTaskTimeout`` error before giving up and marking Task as failed.
 task_publish_max_retries = 3
 
+# How often in seconds to check for task instances stuck in "queued" status
+# task_stuck_in_queued_check_interval =
+
+# How long in seconds to determine whether task instances are stuck in "queued" status
+task_stuck_in_queued_timeout = 600
+
 # Worker initialisation check to validate Metadata Database connection
 worker_precheck = False
 


### PR DESCRIPTION
related: #ISSUE
- closes: https://github.com/apache/airflow/discussions/28714
- closes: https://github.com/apache/airflow/issues/28206
- closes: https://github.com/apache/airflow/issues/21225
- closes: https://github.com/apache/airflow/issues/28120

---

We have been using Airflow with Celery executor on EKS to schedule up to 8,000 task instances per day on production data pipeline, and suffered from task instances stuck in `queued` status.

On average, we found 1~3 task instances stuck in `queued` states per day, and those tasks did not conform execution_timeout or write any task logs, because they had not been launched by any celery worker!

I found logic for handling similar issues on `KubernetesExecutor`'s method: `clear_not_launched_queued_tasks()`
- https://github.com/apache/airflow/blob/main/airflow/executors/kubernetes_executor.py#L495

So, I had made a custom DAG and task to perform similar operation(find tasks stuck in queued status, and re-schedule those by updating state field to `scheduled` with sqlalchemy query (like `{TaskInstance.state: State.SCHEDULED}`)

this DAG works very well for the last few months, but on last Friday, we got very funny situation that task instance of this custom DAG was stuck in queued state. so, I guess this checking logic will be better if it is located on the executor code side with airflow built-in `sched` based scheduler(`EventScheduler`), like KubernetesExecutor.

If we know the root cause of this problem, there will be more elegant solution. but, I read some related issues linked above, and guess there is not just one reason to make stuck tasks, case by case. (Some parts of this issue is marked as fixed, but the issues remains consistently to latest release (`v2.5`)
- https://github.com/apache/airflow/issues/21225#issuecomment-1097162847