### PR TITLE
Use boto3 intersphinx inventory in documentation/docstrings.

### DIFF
--- a/airflow/providers/amazon/aws/hooks/appflow.py
+++ b/airflow/providers/amazon/aws/hooks/appflow.py
@@ -31,19 +31,15 @@ if TYPE_CHECKING:
 
 class AppflowHook(AwsBaseHook):
     """
-    Interact with Amazon Appflow, using the boto3 library.
-    Hook attribute ``conn`` has all methods that listed in documentation.
+    Interact with Amazon Appflow.
+    Provide thin wrapper around :external+boto3:py:class:`boto3.client("appflow") <Appflow.Client>`.
+
+    Additional arguments (such as ``aws_conn_id``) may be specified and
+    are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/appflow.html
-        - https://docs.aws.amazon.com/appflow/1.0/APIReference/Welcome.html
-
-    Additional arguments (such as ``aws_conn_id`` or ``region_name``) may be specified and
-        are passed down to the underlying AwsBaseHook.
-
-    .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
-
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - `Amazon Appflow API Reference <https://docs.aws.amazon.com/appflow/1.0/APIReference/Welcome.html>`__
     """
 
     EVENTUAL_CONSISTENCY_OFFSET: int = 15  # seconds

--- a/airflow/providers/amazon/aws/hooks/athena.py
+++ b/airflow/providers/amazon/aws/hooks/athena.py
@@ -35,17 +35,18 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 
 class AthenaHook(AwsBaseHook):
     """
-    Interact with AWS Athena to run, poll queries and return query results
+    Interact with Amazon Athena.
+    Provide thick wrapper around :external+boto3:py:class:`boto3.client("athena") <Athena.Client>`.
+
+    :param sleep_time: Time (in seconds) to wait between two consecutive calls to check query status on Athena
+    :param log_query: Whether to log athena query and other execution params when it's executed.
+        Defaults to *True*.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
-
-    :param sleep_time: Time (in seconds) to wait between two consecutive calls to check query status on Athena
-    :param log_query: Whether to log athena query and other execution params when it's executed.
-        Defaults to *True*.
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     INTERMEDIATE_STATES = (
@@ -79,12 +80,14 @@ class AthenaHook(AwsBaseHook):
         """
         Run Presto query on athena with provided config and return submitted query_execution_id
 
+        .. seealso::
+            - :external+boto3:py:meth:`Athena.Client.start_query_execution`
+
         :param query: Presto query to run
         :param query_context: Context in which query need to be run
         :param result_configuration: Dict with path to store results in and config related to encryption
         :param client_request_token: Unique token created by user to avoid multiple executions of same query
         :param workgroup: Athena workgroup name, when not specified, will be 'primary'
-        :return: str
         """
         params = {
             "QueryString": query,
@@ -105,8 +108,10 @@ class AthenaHook(AwsBaseHook):
         """
         Fetch the status of submitted athena query. Returns None or one of valid query states.
 
+        .. seealso::
+            - :external+boto3:py:meth:`Athena.Client.get_query_execution`
+
         :param query_execution_id: Id of submitted athena query
-        :return: str
         """
         response = self.get_conn().get_query_execution(QueryExecutionId=query_execution_id)
         state = None
@@ -125,8 +130,10 @@ class AthenaHook(AwsBaseHook):
         """
         Fetch the reason for a state change (e.g. error message). Returns None or reason string.
 
+        .. seealso::
+            - :external+boto3:py:meth:`Athena.Client.get_query_execution`
+
         :param query_execution_id: Id of submitted athena query
-        :return: str
         """
         response = self.get_conn().get_query_execution(QueryExecutionId=query_execution_id)
         reason = None
@@ -149,10 +156,12 @@ class AthenaHook(AwsBaseHook):
         Fetch submitted athena query results. returns none if query is in intermediate state or
         failed/cancelled state else dict of query output
 
+        .. seealso::
+            - :external+boto3:py:meth:`Athena.Client.get_query_results`
+
         :param query_execution_id: Id of submitted athena query
         :param next_token_id:  The token that specifies where to start pagination.
         :param max_results: The maximum number of results (rows) to return in this request.
-        :return: dict
         """
         query_state = self.check_query_status(query_execution_id)
         if query_state is None:
@@ -182,11 +191,13 @@ class AthenaHook(AwsBaseHook):
         failed/cancelled state else a paginator to iterate through pages of results. If you
         wish to get all results at once, call build_full_result() on the returned PageIterator
 
+        .. seealso::
+            - :external+boto3:py:class:`Athena.Paginator.GetQueryResults`
+
         :param query_execution_id: Id of submitted athena query
         :param max_items: The total number of items to return.
         :param page_size: The size of each page.
         :param starting_token: A token to specify where to start paginating.
-        :return: PageIterator
         """
         query_state = self.check_query_status(query_execution_id)
         if query_state is None:
@@ -223,7 +234,6 @@ class AthenaHook(AwsBaseHook):
         :param query_execution_id: Id of submitted athena query
         :param max_tries: Deprecated - Use max_polling_attempts instead
         :param max_polling_attempts: Number of times to poll for query state before function exits
-        :return: str
         """
         if max_tries:
             warnings.warn(
@@ -277,8 +287,10 @@ class AthenaHook(AwsBaseHook):
         Function to get the output location of the query results
         in s3 uri format.
 
+        .. seealso::
+            - :external+boto3:py:meth:`Athena.Client.get_query_execution`
+
         :param query_execution_id: Id of submitted athena query
-        :return: str
         """
         output_location = None
         if query_execution_id:
@@ -303,8 +315,10 @@ class AthenaHook(AwsBaseHook):
         """
         Cancel the submitted athena query
 
+        .. seealso::
+            - :external+boto3:py:meth:`Athena.Client.stop_query_execution`
+
         :param query_execution_id: Id of submitted athena query
-        :return: dict
         """
         self.log.info("Stopping Query with executionId - %s", query_execution_id)
         return self.get_conn().stop_query_execution(QueryExecutionId=query_execution_id)

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -76,7 +76,7 @@ class BaseSessionFactory(LoggingMixin):
     creation or to support custom federation.
 
     .. seealso::
-        :ref:`howto/connection:aws:session-factory`
+        - :ref:`howto/connection:aws:session-factory`
     """
 
     def __init__(
@@ -378,8 +378,8 @@ class BaseSessionFactory(LoggingMixin):
 
 class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
     """
-    Interact with AWS.
-    This class is a thin wrapper around the boto3 python library.
+    Generic class for interact with AWS.
+    This class provide a thin wrapper around the boto3 python library.
 
     :param aws_conn_id: The Airflow connection used for AWS credentials.
         If this is None or empty then the default boto3 behaviour is used. If
@@ -389,8 +389,12 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
     :param verify: Whether or not to verify SSL certificates. See:
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
-    :param client_type: boto3.client client_type. Eg 's3', 'emr' etc
-    :param resource_type: boto3.resource resource_type. Eg 'dynamodb' etc
+    :param client_type: Reference to :external:py:meth:`boto3.client service_name \
+        <boto3.session.Session.client>`, e.g. 'emr', 'batch', 's3', etc.
+        Mutually exclusive with ``resource_type``.
+    :param resource_type: Reference to :external:py:meth:`boto3.resource service_name \
+        <boto3.session.Session.resource>`, e.g. 's3', 'ec2', 'dynamodb', etc.
+        Mutually exclusive with ``client_type``.
     :param config: Configuration for botocore client. See:
         https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
     """
@@ -809,12 +813,25 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
 
 class AwsBaseHook(AwsGenericHook[Union[boto3.client, boto3.resource]]):
     """
-    Interact with AWS.
-    This class is a thin wrapper around the boto3 python library
-    with basic conn annotation.
+    Base class for interact with AWS.
+    This class provide a thin wrapper around the boto3 python library.
 
-    .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsGenericHook`
+    :param aws_conn_id: The Airflow connection used for AWS credentials.
+        If this is None or empty then the default boto3 behaviour is used. If
+        running Airflow in a distributed manner and aws_conn_id is None or
+        empty, then default boto3 configuration would be used (and must be
+        maintained on each worker node).
+    :param verify: Whether or not to verify SSL certificates. See:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param client_type: Reference to :external:py:meth:`boto3.client service_name \
+        <boto3.session.Session.client>`, e.g. 'emr', 'batch', 's3', etc.
+        Mutually exclusive with ``resource_type``.
+    :param resource_type: Reference to :external:py:meth:`boto3.resource service_name \
+        <boto3.session.Session.resource>`, e.g. 's3', 'ec2', 'dynamodb', etc.
+        Mutually exclusive with ``client_type``.
+    :param config: Configuration for botocore client. See:
+        https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
     """
 
 

--- a/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -137,11 +137,11 @@ class BatchProtocol(Protocol):
 
 class BatchClientHook(AwsBaseHook):
     """
-    A client for AWS Batch services.
+    Interact with AWS Batch.
+    Provide thick wrapper around :external+boto3:py:class:`boto3.client("batch") <Batch.Client>`.
 
     :param max_retries: exponential back-off retries, 4200 = 48 hours;
         polling is only used when waiters is None
-
     :param status_retries: number of HTTP retries to get job status, 10;
         polling is only used when waiters is None
 
@@ -164,8 +164,11 @@ class BatchClientHook(AwsBaseHook):
         convenience method is provided for this, e.g. to get a random delay of
         10 sec +/- 5 sec: ``delay = BatchClient.add_jitter(10, width=5, minima=0)``
 
+    Additional arguments (such as ``aws_conn_id``) may be specified and
+    are passed down to the underlying AwsBaseHook.
+
     .. seealso::
-        - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
         - https://docs.aws.amazon.com/general/latest/gr/api-retries.html
         - https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
     """

--- a/airflow/providers/amazon/aws/hooks/cloud_formation.py
+++ b/airflow/providers/amazon/aws/hooks/cloud_formation.py
@@ -27,19 +27,27 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 class CloudFormationHook(AwsBaseHook):
     """
     Interact with AWS CloudFormation.
+    Provide thin wrapper around
+    :external+boto3:py:class:`boto3.client("cloudformation") <CloudFormation.Client>`.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(client_type="cloudformation", *args, **kwargs)
 
     def get_stack_status(self, stack_name: client | resource) -> dict | None:
-        """Get stack status from CloudFormation."""
+        """
+        Get stack status from CloudFormation.
+
+        .. seealso::
+            - :external+boto3:py:meth:`CloudFormation.Client.describe_stacks`
+
+        """
         self.log.info("Poking for stack %s", stack_name)
 
         try:
@@ -55,6 +63,9 @@ class CloudFormationHook(AwsBaseHook):
         """
         Create stack in CloudFormation.
 
+        .. seealso::
+            - :external+boto3:py:meth:`CloudFormation.Client.create_stack`
+
         :param stack_name: stack_name.
         :param cloudformation_parameters: parameters to be passed to CloudFormation.
         """
@@ -65,6 +76,9 @@ class CloudFormationHook(AwsBaseHook):
     def delete_stack(self, stack_name: str, cloudformation_parameters: dict | None = None) -> None:
         """
         Delete stack in CloudFormation.
+
+        .. seealso::
+            - :external+boto3:py:meth:`CloudFormation.Client.delete_stack`
 
         :param stack_name: stack_name.
         :param cloudformation_parameters: parameters to be passed to CloudFormation (optional).

--- a/airflow/providers/amazon/aws/hooks/dms.py
+++ b/airflow/providers/amazon/aws/hooks/dms.py
@@ -33,19 +33,28 @@ class DmsTaskWaiterStatus(str, Enum):
 
 
 class DmsHook(AwsBaseHook):
-    """Interact with AWS Database Migration Service."""
+    """
+    Interact with AWS Database Migration Service (DMS).
+    Provide thin wrapper around
+    :external+boto3:py:class:`boto3.client("dms") <DatabaseMigrationService.Client>`.
 
-    def __init__(
-        self,
-        *args,
-        **kwargs,
-    ):
+    Additional arguments (such as ``aws_conn_id``) may be specified and
+    are passed down to the underlying AwsBaseHook.
+
+    .. seealso::
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+    """
+
+    def __init__(self, *args, **kwargs):
         kwargs["client_type"] = "dms"
         super().__init__(*args, **kwargs)
 
     def describe_replication_tasks(self, **kwargs) -> tuple[str | None, list]:
         """
         Describe replication tasks
+
+        .. seealso::
+            - :external+boto3:py:meth:`DatabaseMigrationService.Client.describe_replication_tasks`
 
         :return: Marker and list of replication tasks
         """
@@ -57,9 +66,12 @@ class DmsHook(AwsBaseHook):
     def find_replication_tasks_by_arn(self, replication_task_arn: str, without_settings: bool | None = False):
         """
         Find and describe replication tasks by task ARN
+
+        .. seealso::
+            - :external+boto3:py:meth:`DatabaseMigrationService.Client.describe_replication_tasks`
+
         :param replication_task_arn: Replication task arn
         :param without_settings: Indicates whether to return task information with settings.
-
         :return: list of replication tasks that match the ARN
         """
         _, tasks = self.describe_replication_tasks(
@@ -105,7 +117,10 @@ class DmsHook(AwsBaseHook):
         **kwargs,
     ) -> str:
         """
-        Create DMS replication task
+        Create DMS replication task.
+
+        .. seealso::
+            - :external+boto3:py:meth:`DatabaseMigrationService.Client.create_replication_task`
 
         :param replication_task_id: Replication task id
         :param source_endpoint_arn: Source endpoint ARN
@@ -140,6 +155,9 @@ class DmsHook(AwsBaseHook):
         """
         Starts replication task.
 
+        .. seealso::
+            - :external+boto3:py:meth:`DatabaseMigrationService.Client.start_replication_task`
+
         :param replication_task_arn: Replication task ARN
         :param start_replication_task_type: Replication task start type (default='start-replication')
             ('start-replication'|'resume-processing'|'reload-target')
@@ -155,6 +173,9 @@ class DmsHook(AwsBaseHook):
         """
         Stops replication task.
 
+        .. seealso::
+            - :external+boto3:py:meth:`DatabaseMigrationService.Client.stop_replication_task`
+
         :param replication_task_arn: Replication task ARN
         """
         dms_client = self.get_conn()
@@ -162,7 +183,10 @@ class DmsHook(AwsBaseHook):
 
     def delete_replication_task(self, replication_task_arn):
         """
-        Starts replication task deletion and waits for it to be deleted
+        Starts replication task deletion and waits for it to be deleted.
+
+        .. seealso::
+            - :external+boto3:py:meth:`DatabaseMigrationService.Client.delete_replication_task`
 
         :param replication_task_arn: Replication task ARN
         """

--- a/airflow/providers/amazon/aws/hooks/dynamodb.py
+++ b/airflow/providers/amazon/aws/hooks/dynamodb.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module contains the AWS DynamoDB hook"""
+"""This module contains the Amazon DynamoDB Hook"""
 from __future__ import annotations
 
 from typing import Iterable
@@ -26,16 +26,18 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 
 class DynamoDBHook(AwsBaseHook):
     """
-    Interact with AWS DynamoDB.
+    Interact with Amazon DynamoDB.
+    Provide thick wrapper around
+    :external+boto3:py:class:`boto3.resource("dynamodb") <DynamoDB.ServiceResource>`.
+
+    :param table_keys: partition key and sort key
+    :param table_name: target DynamoDB table
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
-
-    :param table_keys: partition key and sort key
-    :param table_name: target DynamoDB table
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     def __init__(
@@ -47,7 +49,16 @@ class DynamoDBHook(AwsBaseHook):
         super().__init__(*args, **kwargs)
 
     def write_batch_data(self, items: Iterable) -> bool:
-        """Write batch items to DynamoDB table with provisioned throughout capacity."""
+        """
+        Write batch items to DynamoDB table with provisioned throughout capacity.
+
+        .. seealso::
+            - :external+boto3:py:meth:`DynamoDB.ServiceResource.Table`
+            - :external+boto3:py:meth:`DynamoDB.Table.batch_writer`
+            - :external+boto3:py:meth:`DynamoDB.Table.put_item`
+
+        :param items: list of DynamoDB items.
+        """
         try:
             table = self.get_conn().Table(self.table_name)
 

--- a/airflow/providers/amazon/aws/hooks/ec2.py
+++ b/airflow/providers/amazon/aws/hooks/ec2.py
@@ -49,13 +49,18 @@ def only_client_type(func):
 
 class EC2Hook(AwsBaseHook):
     """
-    Interact with AWS EC2 Service.
+    Interact with Amazon Elastic Compute Cloud (EC2).
+    Provide thick wrapper around :external+boto3:py:class:`boto3.client("ec2") <EC2.Client>`
+    or :external+boto3:py:class:`boto3.resource("ec2") <EC2.ServiceResource>`.
+
+    :param api_type: If set to ``client_type`` then hook use ``boto3.client("ec2")`` capabilities,
+        If set to ``resource_type`` then hook use ``boto3.resource("ec2")`` capabilities.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     API_TYPES = frozenset({"resource_type", "client_type"})

--- a/airflow/providers/amazon/aws/hooks/ecr.py
+++ b/airflow/providers/amazon/aws/hooks/ecr.py
@@ -50,13 +50,14 @@ class EcrCredentials:
 
 class EcrHook(AwsBaseHook):
     """
-    Interact with Amazon Elastic Container Registry (ECR)
+    Interact with Amazon Elastic Container Registry (ECR).
+    Provide thin wrapper around :external+boto3:py:class:`boto3.client("ecr") <ECR.Client>`.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     def __init__(self, **kwargs):
@@ -66,16 +67,14 @@ class EcrHook(AwsBaseHook):
     def get_temporary_credentials(self, registry_ids: list[str] | str | None = None) -> list[EcrCredentials]:
         """Get temporary credentials for Amazon ECR.
 
-        Return list of :class:`~airflow.providers.amazon.aws.hooks.ecr.EcrCredentials`,
-        obtained credentials valid for 12 hours.
+        .. seealso::
+            - :external+boto3:py:meth:`ECR.Client.get_authorization_token`
 
         :param registry_ids: Either AWS Account ID or list of AWS Account IDs that are associated
             with the registries from which credentials are obtained. If you do not specify a registry,
             the default registry is assumed.
-
-        .. seealso::
-            - `boto3 ECR client get_authorization_token method <https://boto3.amazonaws.com/v1/documentation/\
-               api/latest/reference/services/ecr.html#ECR.Client.get_authorization_token>`_.
+        :return: list of :class:`airflow.providers.amazon.aws.hooks.ecr.EcrCredentials`,
+            obtained credentials valid for 12 hours.
         """
         registry_ids = registry_ids or None
         if isinstance(registry_ids, str):

--- a/airflow/providers/amazon/aws/hooks/ecs.py
+++ b/airflow/providers/amazon/aws/hooks/ecs.py
@@ -88,20 +88,16 @@ class EcsTaskStates(Enum):
 
 class EcsHook(AwsGenericHook):
     """
-    Interact with AWS Elastic Container Service, using the boto3 library
-    Hook attribute `conn` has all methods that listed in documentation
+    Interact with Amazon Elastic Container Service (ECS).
+    Provide thin wrapper around :external+boto3:py:class:`boto3.client("ecs") <ECS.Client>`.
+
+    Additional arguments (such as ``aws_conn_id``) may be specified and
+    are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html
-        - https://docs.aws.amazon.com/AmazonECS/latest/APIReference/Welcome.html
-
-    Additional arguments (such as ``aws_conn_id`` or ``region_name``) may be specified and
-        are passed down to the underlying AwsBaseHook.
-
-    .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsGenericHook`
-
-    :param aws_conn_id: The Airflow connection used for AWS credentials.
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - `Amazon Elastic Container Service \
+        <https://docs.aws.amazon.com/AmazonECS/latest/APIReference/Welcome.html>`__
     """
 
     def __init__(self, *args, **kwargs) -> None:
@@ -109,12 +105,40 @@ class EcsHook(AwsGenericHook):
         super().__init__(*args, **kwargs)
 
     def get_cluster_state(self, cluster_name: str) -> str:
+        """
+        Get ECS Cluster state.
+
+        .. seealso::
+            - :external+boto3:py:meth:`ECS.Client.describe_clusters`
+
+        :param cluster_name: ECS Cluster name or full cluster Amazon Resource Name (ARN) entry.
+        """
         return self.conn.describe_clusters(clusters=[cluster_name])["clusters"][0]["status"]
 
     def get_task_definition_state(self, task_definition: str) -> str:
+        """
+        Get ECS Task Definition state.
+
+        .. seealso::
+            - :external+boto3:py:meth:`ECS.Client.describe_task_definition`
+
+        :param task_definition: The family for the latest ACTIVE revision,
+            family and revision ( family:revision ) for a specific revision in the family,
+            or full Amazon Resource Name (ARN) of the task definition to describe.
+        """
         return self.conn.describe_task_definition(taskDefinition=task_definition)["taskDefinition"]["status"]
 
     def get_task_state(self, cluster, task) -> str:
+        """
+        Get ECS Task state.
+
+        .. seealso::
+            - :external+boto3:py:meth:`ECS.Client.describe_tasks`
+
+        :param cluster: The short name or full Amazon Resource Name (ARN)
+            of the cluster that hosts the task or tasks to describe.
+        :param task: Task ID or full ARN entry.
+        """
         return self.conn.describe_tasks(cluster=cluster, tasks=[task])["tasks"][0]["lastStatus"]
 
 

--- a/airflow/providers/amazon/aws/hooks/eks.py
+++ b/airflow/providers/amazon/aws/hooks/eks.py
@@ -77,13 +77,14 @@ class NodegroupStates(Enum):
 
 class EksHook(AwsBaseHook):
     """
-    Interact with Amazon EKS, using the boto3 library.
+    Interact with Amazon Elastic Kubernetes Service (EKS).
+    Provide thin wrapper around :external+boto3:py:class:`boto3.client("eks") <EKS.Client>`.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     client_type = "eks"
@@ -101,6 +102,9 @@ class EksHook(AwsBaseHook):
     ) -> dict:
         """
         Creates an Amazon EKS control plane.
+
+        .. seealso::
+            - :external+boto3:py:meth:`EKS.Client.create_cluster`
 
         :param name: The unique name to give to your Amazon EKS Cluster.
         :param roleArn: The Amazon Resource Name (ARN) of the IAM role that provides permissions
@@ -130,6 +134,9 @@ class EksHook(AwsBaseHook):
     ) -> dict:
         """
         Creates an Amazon EKS managed node group for an Amazon EKS Cluster.
+
+        .. seealso::
+            - :external+boto3:py:meth:`EKS.Client.create_nodegroup`
 
         :param clusterName: The name of the Amazon EKS cluster to create the EKS Managed Nodegroup in.
         :param nodegroupName: The unique name to give your managed nodegroup.
@@ -176,6 +183,9 @@ class EksHook(AwsBaseHook):
         """
         Creates an AWS Fargate profile for an Amazon EKS cluster.
 
+        .. seealso::
+            - :external+boto3:py:meth:`EKS.Client.create_fargate_profile`
+
         :param clusterName: The name of the Amazon EKS cluster to apply the Fargate profile to.
         :param fargateProfileName: The name of the Fargate profile.
         :param podExecutionRoleArn: The Amazon Resource Name (ARN) of the pod execution role to
@@ -205,6 +215,9 @@ class EksHook(AwsBaseHook):
         """
         Deletes the Amazon EKS Cluster control plane.
 
+        .. seealso::
+            - :external+boto3:py:meth:`EKS.Client.delete_cluster`
+
         :param name: The name of the cluster to delete.
 
         :return: Returns descriptive information about the deleted EKS Cluster.
@@ -219,6 +232,9 @@ class EksHook(AwsBaseHook):
     def delete_nodegroup(self, clusterName: str, nodegroupName: str) -> dict:
         """
         Deletes an Amazon EKS managed node group from a specified cluster.
+
+        .. seealso::
+            - :external+boto3:py:meth:`EKS.Client.delete_nodegroup`
 
         :param clusterName: The name of the Amazon EKS Cluster that is associated with your nodegroup.
         :param nodegroupName: The name of the nodegroup to delete.
@@ -239,6 +255,9 @@ class EksHook(AwsBaseHook):
     def delete_fargate_profile(self, clusterName: str, fargateProfileName: str) -> dict:
         """
         Deletes an AWS Fargate profile from a specified Amazon EKS cluster.
+
+        .. seealso::
+            - :external+boto3:py:meth:`EKS.Client.delete_fargate_profile`
 
         :param clusterName: The name of the Amazon EKS cluster associated with the Fargate profile to delete.
         :param fargateProfileName: The name of the Fargate profile to delete.
@@ -262,6 +281,9 @@ class EksHook(AwsBaseHook):
         """
         Returns descriptive information about an Amazon EKS Cluster.
 
+        .. seealso::
+            - :external+boto3:py:meth:`EKS.Client.describe_cluster`
+
         :param name: The name of the cluster to describe.
         :param verbose: Provides additional logging if set to True.  Defaults to False.
 
@@ -282,6 +304,9 @@ class EksHook(AwsBaseHook):
     def describe_nodegroup(self, clusterName: str, nodegroupName: str, verbose: bool = False) -> dict:
         """
         Returns descriptive information about an Amazon EKS managed node group.
+
+        .. seealso::
+            - :external+boto3:py:meth:`EKS.Client.describe_nodegroup`
 
         :param clusterName: The name of the Amazon EKS Cluster associated with the nodegroup.
         :param nodegroupName: The name of the nodegroup to describe.
@@ -312,6 +337,9 @@ class EksHook(AwsBaseHook):
         """
         Returns descriptive information about an AWS Fargate profile.
 
+        .. seealso::
+            - :external+boto3:py:meth:`EKS.Client.describe_fargate_profile`
+
         :param clusterName: The name of the Amazon EKS Cluster associated with the Fargate profile.
         :param fargateProfileName: The name of the Fargate profile to describe.
         :param verbose: Provides additional logging if set to True.  Defaults to False.
@@ -340,6 +368,9 @@ class EksHook(AwsBaseHook):
         """
         Returns the current status of a given Amazon EKS Cluster.
 
+        .. seealso::
+            - :external+boto3:py:meth:`EKS.Client.describe_cluster`
+
         :param clusterName: The name of the cluster to check.
 
         :return: Returns the current status of a given Amazon EKS Cluster.
@@ -356,6 +387,9 @@ class EksHook(AwsBaseHook):
     def get_fargate_profile_state(self, clusterName: str, fargateProfileName: str) -> FargateProfileStates:
         """
         Returns the current status of a given AWS Fargate profile.
+
+        .. seealso::
+            - :external+boto3:py:meth:`EKS.Client.describe_fargate_profile`
 
         :param clusterName: The name of the Amazon EKS Cluster associated with the Fargate profile.
         :param fargateProfileName: The name of the Fargate profile to check.
@@ -380,6 +414,9 @@ class EksHook(AwsBaseHook):
     def get_nodegroup_state(self, clusterName: str, nodegroupName: str) -> NodegroupStates:
         """
         Returns the current status of a given Amazon EKS managed node group.
+
+        .. seealso::
+            - :external+boto3:py:meth:`EKS.Client.describe_nodegroup`
 
         :param clusterName: The name of the Amazon EKS Cluster associated with the nodegroup.
         :param nodegroupName: The name of the nodegroup to check.
@@ -406,6 +443,9 @@ class EksHook(AwsBaseHook):
         """
         Lists all Amazon EKS Clusters in your AWS account.
 
+        .. seealso::
+            - :external+boto3:py:meth:`EKS.Client.list_clusters`
+
         :param verbose: Provides additional logging if set to True.  Defaults to False.
 
         :return: A List containing the cluster names.
@@ -422,6 +462,9 @@ class EksHook(AwsBaseHook):
     ) -> list:
         """
         Lists all Amazon EKS managed node groups associated with the specified cluster.
+
+        .. seealso::
+            - :external+boto3:py:meth:`EKS.Client.list_nodegroups`
 
         :param clusterName: The name of the Amazon EKS Cluster containing nodegroups to list.
         :param verbose: Provides additional logging if set to True.  Defaults to False.
@@ -440,6 +483,9 @@ class EksHook(AwsBaseHook):
     ) -> list:
         """
         Lists all AWS Fargate profiles associated with the specified cluster.
+
+        .. seealso::
+            - :external+boto3:py:meth:`EKS.Client.list_fargate_profiles`
 
         :param clusterName: The name of the Amazon EKS Cluster containing Fargate profiles to list.
         :param verbose: Provides additional logging if set to True.  Defaults to False.

--- a/airflow/providers/amazon/aws/hooks/elasticache_replication_group.py
+++ b/airflow/providers/amazon/aws/hooks/elasticache_replication_group.py
@@ -25,7 +25,8 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 
 class ElastiCacheReplicationGroupHook(AwsBaseHook):
     """
-    Interact with AWS ElastiCache
+    Interact with Amazon ElastiCache.
+    Provide thick wrapper around :external+boto3:py:class:`boto3.client("elasticache") <ElastiCache.Client>`.
 
     :param max_retries: Max retries for checking availability of and deleting replication group
             If this is not supplied then this is defaulted to 10
@@ -33,6 +34,12 @@ class ElastiCacheReplicationGroupHook(AwsBaseHook):
             If this is not supplied then this is defaulted to 1
     :param initial_poke_interval: Initial sleep time in seconds
             If this is not supplied then this is defaulted to 60 seconds
+
+    Additional arguments (such as ``aws_conn_id``) may be specified and
+    are passed down to the underlying AwsBaseHook.
+
+    .. seealso::
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     TERMINAL_STATES = frozenset({"available", "create-failed", "deleting"})
@@ -54,7 +61,10 @@ class ElastiCacheReplicationGroupHook(AwsBaseHook):
 
     def create_replication_group(self, config: dict) -> dict:
         """
-        Call ElastiCache API for creating a replication group
+        Creates a Redis (cluster mode disabled) or a Redis (cluster mode enabled) replication group.
+
+        .. seealso::
+            - :external+boto3:py:meth:`ElastiCache.Client.create_replication_group`
 
         :param config: Configuration for creating the replication group
         :return: Response from ElastiCache create replication group API
@@ -63,7 +73,10 @@ class ElastiCacheReplicationGroupHook(AwsBaseHook):
 
     def delete_replication_group(self, replication_group_id: str) -> dict:
         """
-        Call ElastiCache API for deleting a replication group
+        Deletes an existing replication group.
+
+        .. seealso::
+            - :external+boto3:py:meth:`ElastiCache.Client.delete_replication_group`
 
         :param replication_group_id: ID of replication group to delete
         :return: Response from ElastiCache delete replication group API
@@ -72,7 +85,10 @@ class ElastiCacheReplicationGroupHook(AwsBaseHook):
 
     def describe_replication_group(self, replication_group_id: str) -> dict:
         """
-        Call ElastiCache API for describing a replication group
+        Get information about a particular replication group.
+
+        .. seealso::
+            - :external+boto3:py:meth:`ElastiCache.Client.describe_replication_groups`
 
         :param replication_group_id: ID of replication group to describe
         :return: Response from ElastiCache describe replication group API
@@ -81,7 +97,10 @@ class ElastiCacheReplicationGroupHook(AwsBaseHook):
 
     def get_replication_group_status(self, replication_group_id: str) -> str:
         """
-        Get current status of replication group
+        Get current status of replication group.
+
+        .. seealso::
+            - :external+boto3:py:meth:`ElastiCache.Client.describe_replication_groups`
 
         :param replication_group_id: ID of replication group to check for status
         :return: Current status of replication group

--- a/airflow/providers/amazon/aws/hooks/glacier.py
+++ b/airflow/providers/amazon/aws/hooks/glacier.py
@@ -23,7 +23,16 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 
 
 class GlacierHook(AwsBaseHook):
-    """Hook for connection with Amazon Glacier"""
+    """
+    Interact with Amazon Glacier.
+    Provide thin wrapper around :external+boto3:py:class:`boto3.client("glacier") <Glacier.Client>`.
+
+    Additional arguments (such as ``aws_conn_id``) may be specified and
+    are passed down to the underlying AwsBaseHook.
+
+    .. seealso::
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+    """
 
     def __init__(self, aws_conn_id: str = "aws_default") -> None:
         super().__init__(client_type="glacier")
@@ -32,6 +41,9 @@ class GlacierHook(AwsBaseHook):
     def retrieve_inventory(self, vault_name: str) -> dict[str, Any]:
         """
         Initiate an Amazon Glacier inventory-retrieval job
+
+        .. seealso::
+            - :external+boto3:py:meth:`Glacier.Client.initiate_job`
 
         :param vault_name: the Glacier vault on which job is executed
         """
@@ -46,6 +58,9 @@ class GlacierHook(AwsBaseHook):
         """
         Retrieve the results of an Amazon Glacier inventory-retrieval job
 
+        .. seealso::
+            - :external+boto3:py:meth:`Glacier.Client.get_job_output`
+
         :param vault_name: the Glacier vault on which job is executed
         :param job_id: the job ID was returned by retrieve_inventory()
         """
@@ -57,6 +72,9 @@ class GlacierHook(AwsBaseHook):
         """
         Retrieve the status of an Amazon S3 Glacier job, such as an
         inventory-retrieval job
+
+        .. seealso::
+            - :external+boto3:py:meth:`Glacier.Client.describe_job`
 
         :param vault_name: the Glacier vault on which job is executed
         :param job_id: the job ID was returned by retrieve_inventory()

--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -34,7 +34,8 @@ FAILURE_LOG_FILTER = "?ERROR ?Exception"
 
 class GlueJobHook(AwsBaseHook):
     """
-    Interact with AWS Glue - create job, trigger, crawler
+    Interact with AWS Glue.
+    Provide thick wrapper around :external+boto3:py:class:`boto3.client("glue") <Glue.Client>`.
 
     :param s3_bucket: S3 bucket where logs and local etl script will be uploaded
     :param job_name: unique job name per AWS account
@@ -46,6 +47,12 @@ class GlueJobHook(AwsBaseHook):
     :param region_name: aws region name (example: us-east-1)
     :param iam_role_name: AWS IAM Role for Glue Job Execution
     :param create_job_kwargs: Extra arguments for Glue Job Creation
+
+    Additional arguments (such as ``aws_conn_id``) may be specified and
+    are passed down to the underlying AwsBaseHook.
+
+    .. seealso::
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     JOB_POLL_INTERVAL = 6  # polls job status after every JOB_POLL_INTERVAL seconds
@@ -122,11 +129,16 @@ class GlueJobHook(AwsBaseHook):
         return ret_config
 
     def list_jobs(self) -> list:
-        """:return: Lists of Jobs"""
+        """
+        Get list of Jobs.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Glue.Client.get_jobs`
+        """
         return self.get_conn().get_jobs()
 
     def get_iam_execution_role(self) -> dict:
-        """:return: iam role for job execution"""
+        """Get IAM Role for job execution."""
         try:
             iam_client = self.get_session(region_name=self.region_name).client(
                 "iam", endpoint_url=self.conn_config.endpoint_url, config=self.config, verify=self.verify
@@ -144,9 +156,10 @@ class GlueJobHook(AwsBaseHook):
         run_kwargs: dict | None = None,
     ) -> dict[str, str]:
         """
-        Initializes connection with AWS Glue
-        to run job
-        :return:
+        Initializes connection with AWS Glue to run job.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Glue.Client.start_job_run`
         """
         script_arguments = script_arguments or {}
         run_kwargs = run_kwargs or {}
@@ -160,8 +173,12 @@ class GlueJobHook(AwsBaseHook):
 
     def get_job_state(self, job_name: str, run_id: str) -> str:
         """
-        Get state of the Glue job. The job state can be
-        running, finished, failed, stopped or timeout.
+        Get state of the Glue job.
+        The job state can be running, finished, failed, stopped or timeout.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Glue.Client.get_job_run`
+
         :param job_name: unique job name per AWS account
         :param run_id: The job-run ID of the predecessor job run
         :return: State of the Glue job
@@ -216,9 +233,9 @@ class GlueJobHook(AwsBaseHook):
 
     def job_completion(self, job_name: str, run_id: str, verbose: bool = False) -> dict[str, str]:
         """
-        Waits until Glue job with job_name completes or
-        fails and return final state if finished.
-        Raises AirflowException when the job failed
+        Waits until Glue job with job_name completes or fails and return final state if finished.
+        Raises AirflowException when the job failed.
+
         :param job_name: unique job name per AWS account
         :param run_id: The job-run ID of the predecessor job run
         :param verbose: If True, more Glue Job Run logs show in the Airflow Task Logs.  (default: False)
@@ -258,7 +275,10 @@ class GlueJobHook(AwsBaseHook):
 
     def has_job(self, job_name) -> bool:
         """
-        Checks if the job already exists
+        Checks if the job already exists.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Glue.Client.get_job`
 
         :param job_name: unique job name per AWS account
         :return: Returns True if the job already exists and False if not.
@@ -273,7 +293,10 @@ class GlueJobHook(AwsBaseHook):
 
     def update_job(self, **job_kwargs) -> bool:
         """
-        Updates job configurations
+        Updates job configurations.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Glue.Client.update_job`
 
         :param job_kwargs: Keyword args that define the configurations used for the job
         :return: True if job was updated and false otherwise
@@ -294,7 +317,12 @@ class GlueJobHook(AwsBaseHook):
 
     def create_or_update_glue_job(self) -> str | None:
         """
-        Creates(or updates) and returns the Job name
+        Creates (or updates) and returns the Job name.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Glue.Client.update_job`
+            - :external+boto3:py:meth:`Glue.Client.create_job`
+
         :return:Name of the Job
         """
         config = self.create_glue_job_config()

--- a/airflow/providers/amazon/aws/hooks/glue_crawler.py
+++ b/airflow/providers/amazon/aws/hooks/glue_crawler.py
@@ -28,12 +28,15 @@ from airflow.providers.amazon.aws.hooks.sts import StsHook
 class GlueCrawlerHook(AwsBaseHook):
     """
     Interacts with AWS Glue Crawler.
+    Provide thin wrapper around :external+boto3:py:class:`boto3.client("glue") <Glue.Client>`.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - `AWS Glue crawlers and classifiers \
+        <https://docs.aws.amazon.com/glue/latest/dg/components-overview.html#crawling-intro>`__
     """
 
     def __init__(self, *args, **kwargs):
@@ -47,7 +50,7 @@ class GlueCrawlerHook(AwsBaseHook):
 
     def has_crawler(self, crawler_name) -> bool:
         """
-        Checks if the crawler already exists
+        Checks if the crawler already exists.
 
         :param crawler_name: unique crawler name per AWS account
         :return: Returns True if the crawler already exists and False if not.
@@ -62,7 +65,10 @@ class GlueCrawlerHook(AwsBaseHook):
 
     def get_crawler(self, crawler_name: str) -> dict:
         """
-        Gets crawler configurations
+        Gets crawler configurations.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Glue.Client.get_crawler`
 
         :param crawler_name: unique crawler name per AWS account
         :return: Nested dictionary of crawler configurations
@@ -71,7 +77,10 @@ class GlueCrawlerHook(AwsBaseHook):
 
     def update_crawler(self, **crawler_kwargs) -> bool:
         """
-        Updates crawler configurations
+        Updates crawler configurations.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Glue.Client.update_crawler`
 
         :param crawler_kwargs: Keyword args that define the configurations used for the crawler
         :return: True if crawler was updated and false otherwise
@@ -95,7 +104,10 @@ class GlueCrawlerHook(AwsBaseHook):
 
     def update_tags(self, crawler_name: str, crawler_tags: dict) -> bool:
         """
-        Updates crawler tags
+        Updates crawler tags.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Glue.Client.tag_resource`
 
         :param crawler_name: Name of the crawler for which to update tags
         :param crawler_tags: Dictionary of new tags. If empty, all tags will be deleted
@@ -132,7 +144,10 @@ class GlueCrawlerHook(AwsBaseHook):
 
     def create_crawler(self, **crawler_kwargs) -> str:
         """
-        Creates an AWS Glue Crawler
+        Creates an AWS Glue Crawler.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Glue.Client.create_crawler`
 
         :param crawler_kwargs: Keyword args that define the configurations used to create the crawler
         :return: Name of the crawler
@@ -143,7 +158,10 @@ class GlueCrawlerHook(AwsBaseHook):
 
     def start_crawler(self, crawler_name: str) -> dict:
         """
-        Triggers the AWS Glue crawler
+        Triggers the AWS Glue Crawler.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Glue.Client.start_crawler`
 
         :param crawler_name: unique crawler name per AWS account
         :return: Empty dictionary

--- a/airflow/providers/amazon/aws/hooks/kinesis.py
+++ b/airflow/providers/amazon/aws/hooks/kinesis.py
@@ -25,15 +25,16 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 
 class FirehoseHook(AwsBaseHook):
     """
-    Interact with AWS Kinesis Firehose.
+    Interact with Amazon Kinesis Firehose.
+    Provide thick wrapper around :external+boto3:py:class:`boto3.client("firehose") <Firehose.Client>`.
+
+    :param delivery_stream: Name of the delivery stream
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
-
-    :param delivery_stream: Name of the delivery stream
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     def __init__(self, delivery_stream: str, *args, **kwargs) -> None:
@@ -42,5 +43,11 @@ class FirehoseHook(AwsBaseHook):
         super().__init__(*args, **kwargs)
 
     def put_records(self, records: Iterable):
-        """Write batch records to Kinesis Firehose"""
+        """Write batch records to Kinesis Firehose
+
+        .. seealso::
+            - :external+boto3:py:meth:`Firehose.Client.put_record_batch`
+
+        :param records: list of records
+        """
         return self.get_conn().put_record_batch(DeliveryStreamName=self.delivery_stream, Records=records)

--- a/airflow/providers/amazon/aws/hooks/lambda_function.py
+++ b/airflow/providers/amazon/aws/hooks/lambda_function.py
@@ -26,29 +26,17 @@ from airflow.providers.amazon.aws.utils import trim_none_values
 
 class LambdaHook(AwsBaseHook):
     """
-    Interact with AWS Lambda
+    Interact with AWS Lambda.
+    Provide thin wrapper around :external+boto3:py:class:`boto3.client("lambda") <Lambda.Client>`.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
-
-    :param function_name: AWS Lambda Function Name
-    :param invocation_type: AWS Lambda Invocation Type (RequestResponse, Event etc)
-    :param log_type: Tail Invocation Request
-    :param client_context: Up to 3,583 bytes of base64-encoded data about the invoking client
-        to pass to the function in the context object.
-    :param payload: The JSON that you want to provide to your Lambda function as input.
-    :param qualifier: AWS Lambda Function Version or Alias Name
-
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
-    def __init__(
-        self,
-        *args,
-        **kwargs,
-    ) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         kwargs["client_type"] = "lambda"
         super().__init__(*args, **kwargs)
 
@@ -62,7 +50,20 @@ class LambdaHook(AwsBaseHook):
         payload: str | None = None,
         qualifier: str | None = None,
     ):
-        """Invoke Lambda Function. Refer to the boto3 documentation for more info."""
+        """
+        Invoke Lambda Function.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Lambda.Client.invoke`
+
+        :param function_name: AWS Lambda Function Name
+        :param invocation_type: AWS Lambda Invocation Type (RequestResponse, Event etc)
+        :param log_type: Tail Invocation Request
+        :param client_context: Up to 3,583 bytes of base64-encoded data about the invoking client
+            to pass to the function in the context object.
+        :param payload: The JSON that you want to provide to your Lambda function as input.
+        :param qualifier: AWS Lambda Function Version or Alias Name
+        """
         invoke_args = {
             "FunctionName": function_name,
             "InvocationType": invocation_type,
@@ -98,6 +99,51 @@ class LambdaHook(AwsBaseHook):
         code_signing_config_arn: str | None = None,
         architectures: list[str] | None = None,
     ) -> dict:
+        """
+        Creates a Lambda function.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Lambda.Client.create_function`
+            - `Configuring a Lambda function to access resources in a VPC \
+            <https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html>`__
+
+        :param function_name: AWS Lambda Function Name
+        :param runtime: The identifier of the function's runtime.
+            Runtime is required if the deployment package is a .zip file archive.
+        :param role: The Amazon Resource Name (ARN) of the function's execution role.
+        :param handler: The name of the method within your code that Lambda calls to run your function.
+            Handler is required if the deployment package is a .zip file archive.
+        :param code: The code for the function.
+        :param description: A description of the function.
+        :param timeout: The amount of time (in seconds) that Lambda
+            allows a function to run before stopping it.
+        :param memory_size: The amount of memory available to the function at runtime.
+            Increasing the function memory also increases its CPU allocation.
+        :param publish: Set to true to publish the first version of the function during creation.
+        :param vpc_config: For network connectivity to Amazon Web Services resources in a VPC,
+            specify a list of security groups and subnets in the VPC.
+        :param package_type: The type of deployment package.
+            Set to `Image` for container image and set to `Zip` for .zip file archive.
+        :param dead_letter_config: A dead-letter queue configuration that specifies the queue or topic
+            where Lambda sends asynchronous events when they fail processing.
+        :param environment: Environment variables that are accessible from function code during execution.
+        :param kms_key_arn: The ARN of the Key Management Service (KMS) key that's used to
+            encrypt your function's environment variables.
+            If it's not provided, Lambda uses a default service key.
+        :param tracing_config: Set `Mode` to `Active` to sample and trace
+            a subset of incoming requests with X-Ray.
+        :param tags: A list of tags to apply to the function.
+        :param layers: A list of function layers to add to the function's execution environment.
+            Specify each layer by its ARN, including the version.
+        :param file_system_configs: Connection settings for an Amazon EFS file system.
+        :param image_config: Container image configuration values that override
+            the values in the container image Dockerfile.
+        :param code_signing_config_arn: To enable code signing for this function,
+            specify the ARN of a code-signing configuration.
+            A code-signing configuration includes a set of signing profiles,
+            which define the trusted publishers for this function.
+        :param architectures: The instruction set architecture that the function supports.
+        """
         if package_type == "Zip":
             if handler is None:
                 raise TypeError("Parameter 'handler' is required if 'package_type' is 'Zip'")

--- a/airflow/providers/amazon/aws/hooks/logs.py
+++ b/airflow/providers/amazon/aws/hooks/logs.py
@@ -28,13 +28,14 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 
 class AwsLogsHook(AwsBaseHook):
     """
-    Interact with AWS CloudWatch Logs
+    Interact with Amazon CloudWatch Logs.
+    Provide thin wrapper around :external+boto3:py:class:`boto3.client("logs") <CloudWatchLogs.Client>`.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     def __init__(self, *args, **kwargs) -> None:
@@ -52,6 +53,9 @@ class AwsLogsHook(AwsBaseHook):
         """
         A generator for log items in a single stream. This will yield all the
         items that are available at the current moment.
+
+        .. seealso::
+            - :external+boto3:py:meth:`CloudWatchLogs.Client.get_log_events`
 
         :param log_group: The name of the log group.
         :param log_stream_name: The name of the specific stream.

--- a/airflow/providers/amazon/aws/hooks/quicksight.py
+++ b/airflow/providers/amazon/aws/hooks/quicksight.py
@@ -30,11 +30,13 @@ from airflow.providers.amazon.aws.hooks.sts import StsHook
 class QuickSightHook(AwsBaseHook):
     """
     Interact with Amazon QuickSight.
+    Provide thin wrapper around :external+boto3:py:class:`boto3.client("quicksight") <QuickSight.Client>`.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
+
     .. seealso::
-    :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     NON_TERMINAL_STATES = {"INITIALIZED", "QUEUED", "RUNNING"}
@@ -57,6 +59,9 @@ class QuickSightHook(AwsBaseHook):
     ) -> dict:
         """
         Creates and starts a new SPICE ingestion for a dataset. Refreshes the SPICE datasets
+
+        .. seealso::
+            - :external+boto3:py:meth:`QuickSight.Client.create_ingestion`
 
         :param data_set_id:  ID of the dataset used in the ingestion.
         :param ingestion_id: ID for the ingestion.
@@ -94,6 +99,9 @@ class QuickSightHook(AwsBaseHook):
     def get_status(self, aws_account_id: str, data_set_id: str, ingestion_id: str) -> str:
         """
         Get the current status of QuickSight Create Ingestion API.
+
+        .. seealso::
+            - :external+boto3:py:meth:`QuickSight.Client.describe_ingestion`
 
         :param aws_account_id: An AWS Account ID
         :param data_set_id: QuickSight Data Set ID

--- a/airflow/providers/amazon/aws/hooks/rds.py
+++ b/airflow/providers/amazon/aws/hooks/rds.py
@@ -30,21 +30,16 @@ if TYPE_CHECKING:
 
 class RdsHook(AwsGenericHook["RDSClient"]):
     """
-    Interact with AWS RDS using proper client from the boto3 library.
+    Interact with Amazon Relational Database Service (RDS).
+    Provide thin wrapper around :external+boto3:py:class:`boto3.client("rds") <RDS.Client>`.
 
-    Hook attribute `conn` has all methods that listed in documentation
-
-    .. seealso::
-        - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds.html
-        - https://docs.aws.amazon.com/rds/index.html
-
-    Additional arguments (such as ``aws_conn_id`` or ``region_name``) may be specified and
+    Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsGenericHook`
-
-    :param aws_conn_id: The Airflow connection used for AWS credentials.
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - `Amazon RDS and Aurora Documentation \
+        <https://docs.aws.amazon.com/rds/index.html>`__
     """
 
     def __init__(self, *args, **kwargs) -> None:
@@ -55,9 +50,11 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         """
         Get the current state of a DB instance snapshot.
 
+        .. seealso::
+            - :external+boto3:py:meth:`RDS.Client.describe_db_snapshots`
+
         :param snapshot_id: The ID of the target DB instance snapshot
         :return: Returns the status of the DB snapshot as a string (eg. "available")
-        :rtype: str
         :raises AirflowNotFoundException: If the DB instance snapshot does not exist.
         """
         try:
@@ -72,8 +69,11 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         self, snapshot_id: str, target_state: str, check_interval: int = 30, max_attempts: int = 40
     ) -> None:
         """
-        Polls :py:meth:`RDS.Client.describe_db_snapshots` until the target state is reached.
+        Polls DB Snapshots until the target state is reached.
         An error is raised after a max number of attempts.
+
+        .. seealso::
+            - :external+boto3:py:meth:`RDS.Client.describe_db_snapshots`
 
         :param snapshot_id: The ID of the target DB instance snapshot
         :param target_state: Wait until this state is reached
@@ -99,9 +99,11 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         """
         Get the current state of a DB cluster snapshot.
 
+        .. seealso::
+            - :external+boto3:py:meth:`RDS.Client.describe_db_cluster_snapshots`
+
         :param snapshot_id: The ID of the target DB cluster.
         :return: Returns the status of the DB cluster snapshot as a string (eg. "available")
-        :rtype: str
         :raises AirflowNotFoundException: If the DB cluster snapshot does not exist.
         """
         try:
@@ -116,17 +118,16 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         self, snapshot_id: str, target_state: str, check_interval: int = 30, max_attempts: int = 40
     ) -> None:
         """
-        Polls :py:meth:`RDS.Client.describe_db_cluster_snapshots` until the target state is reached.
+        Polls DB Cluster Snapshots until the target state is reached.
         An error is raised after a max number of attempts.
+
+        .. seealso::
+            - :external+boto3:py:meth:`RDS.Client.describe_db_cluster_snapshots`
 
         :param snapshot_id: The ID of the target DB cluster snapshot
         :param target_state: Wait until this state is reached
         :param check_interval: The amount of time in seconds to wait between attempts
         :param max_attempts: The maximum number of attempts to be made
-
-        .. seealso::
-            A list of possible values for target_state:
-            https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds.html#RDS.Client.describe_db_cluster_snapshots
         """
 
         def poke():
@@ -147,9 +148,11 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         """
         Gets the current state of an RDS snapshot export to Amazon S3.
 
+        .. seealso::
+            - :external+boto3:py:meth:`RDS.Client.describe_export_tasks`
+
         :param export_task_id: The identifier of the target snapshot export task.
         :return: Returns the status of the snapshot export task as a string (eg. "canceled")
-        :rtype: str
         :raises AirflowNotFoundException: If the export task does not exist.
         """
         try:
@@ -164,17 +167,16 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         self, export_task_id: str, target_state: str, check_interval: int = 30, max_attempts: int = 40
     ) -> None:
         """
-        Polls :py:meth:`RDS.Client.describe_export_tasks` until the target state is reached.
+        Polls export tasks until the target state is reached.
         An error is raised after a max number of attempts.
+
+        .. seealso::
+            - :external+boto3:py:meth:`RDS.Client.describe_export_tasks`
 
         :param export_task_id: The identifier of the target snapshot export task.
         :param target_state: Wait until this state is reached
         :param check_interval: The amount of time in seconds to wait between attempts
         :param max_attempts: The maximum number of attempts to be made
-
-        .. seealso::
-            A list of possible values for target_state:
-            https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds.html#RDS.Client.describe_export_tasks
         """
 
         def poke():
@@ -188,9 +190,11 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         """
         Gets the current state of an RDS snapshot export to Amazon S3.
 
+        .. seealso::
+            - :external+boto3:py:meth:`RDS.Client.describe_event_subscriptions`
+
         :param subscription_name: The name of the target RDS event notification subscription.
         :return: Returns the status of the event subscription as a string (eg. "active")
-        :rtype: str
         :raises AirflowNotFoundException: If the event subscription does not exist.
         """
         try:
@@ -205,17 +209,16 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         self, subscription_name: str, target_state: str, check_interval: int = 30, max_attempts: int = 40
     ) -> None:
         """
-        Polls :py:meth:`RDS.Client.describe_event_subscriptions` until the target state is reached.
+        Polls Even Subscriptions until the target state is reached.
         An error is raised after a max number of attempts.
+
+        .. seealso::
+            - :external+boto3:py:meth:`RDS.Client.describe_event_subscriptions`
 
         :param subscription_name: The name of the target RDS event notification subscription.
         :param target_state: Wait until this state is reached
         :param check_interval: The amount of time in seconds to wait between attempts
         :param max_attempts: The maximum number of attempts to be made
-
-        .. seealso::
-            A list of possible values for target_state:
-            https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds.html#RDS.Client.describe_event_subscriptions
         """
 
         def poke():
@@ -229,9 +232,11 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         """
         Get the current state of a DB instance.
 
+        .. seealso::
+            - :external+boto3:py:meth:`RDS.Client.describe_db_instances`
+
         :param db_instance_id: The ID of the target DB instance.
         :return: Returns the status of the DB instance as a string (eg. "available")
-        :rtype: str
         :raises AirflowNotFoundException: If the DB instance does not exist.
         """
         try:
@@ -246,18 +251,16 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         self, db_instance_id: str, target_state: str, check_interval: int = 30, max_attempts: int = 40
     ) -> None:
         """
-        Polls :py:meth:`RDS.Client.describe_db_instances` until the target state is reached.
+        Polls DB Instances until the target state is reached.
         An error is raised after a max number of attempts.
+
+        .. seealso::
+            - :external+boto3:py:meth:`RDS.Client.describe_db_instances`
 
         :param db_instance_id: The ID of the target DB instance.
         :param target_state: Wait until this state is reached
         :param check_interval: The amount of time in seconds to wait between attempts
         :param max_attempts: The maximum number of attempts to be made
-
-        .. seealso::
-            For information about DB instance statuses, see Viewing DB instance status in the Amazon RDS
-            User Guide.
-            https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/accessing-monitoring.html#Overview.DBInstance.Status
         """
 
         def poke():
@@ -278,9 +281,11 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         """
         Get the current state of a DB cluster.
 
+        .. seealso::
+            - :external+boto3:py:meth:`RDS.Client.describe_db_clusters`
+
         :param db_cluster_id: The ID of the target DB cluster.
         :return: Returns the status of the DB cluster as a string (eg. "available")
-        :rtype: str
         :raises AirflowNotFoundException: If the DB cluster does not exist.
         """
         try:
@@ -295,18 +300,16 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         self, db_cluster_id: str, target_state: str, check_interval: int = 30, max_attempts: int = 40
     ) -> None:
         """
-        Polls :py:meth:`RDS.Client.describe_db_clusters` until the target state is reached.
+        Polls DB Clusters until the target state is reached.
         An error is raised after a max number of attempts.
+
+        .. seealso::
+            - :external+boto3:py:meth:`RDS.Client.describe_db_clusters`
 
         :param db_cluster_id: The ID of the target DB cluster.
         :param target_state: Wait until this state is reached
         :param check_interval: The amount of time in seconds to wait between attempts
         :param max_attempts: The maximum number of attempts to be made
-
-        .. seealso::
-            For information about DB instance statuses, see Viewing DB instance status in the Amazon RDS
-            User Guide.
-            https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/accessing-monitoring.html#Overview.DBInstance.Status
         """
 
         def poke():

--- a/airflow/providers/amazon/aws/hooks/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/hooks/redshift_cluster.py
@@ -26,15 +26,14 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 
 class RedshiftHook(AwsBaseHook):
     """
-    Interact with AWS Redshift, using the boto3 library
+    Interact with Amazon Redshift.
+    Provide thin wrapper around :external+boto3:py:class:`boto3.client("redshift") <Redshift.Client>`.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
-
-    :param aws_conn_id: The Airflow connection used for AWS credentials.
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     template_fields: Sequence[str] = ("cluster_identifier",)
@@ -53,6 +52,9 @@ class RedshiftHook(AwsBaseHook):
     ) -> dict[str, Any]:
         """
         Creates a new cluster with the specified parameters
+
+        .. seealso::
+            - :external+boto3:py:meth:`Redshift.Client.create_cluster`
 
         :param cluster_identifier: A unique identifier for the cluster.
         :param node_type: The node type to be provisioned for the cluster.
@@ -82,6 +84,9 @@ class RedshiftHook(AwsBaseHook):
         """
         Return status of a cluster
 
+        .. seealso::
+            - :external+boto3:py:meth:`Redshift.Client.describe_clusters`
+
         :param cluster_identifier: unique identifier of a cluster
         :param skip_final_cluster_snapshot: determines cluster snapshot creation
         :param final_cluster_snapshot_identifier: Optional[str]
@@ -101,6 +106,9 @@ class RedshiftHook(AwsBaseHook):
         """
         Delete a cluster and optionally create a snapshot
 
+        .. seealso::
+            - :external+boto3:py:meth:`Redshift.Client.delete_cluster`
+
         :param cluster_identifier: unique identifier of a cluster
         :param skip_final_cluster_snapshot: determines cluster snapshot creation
         :param final_cluster_snapshot_identifier: name of final cluster snapshot
@@ -118,6 +126,9 @@ class RedshiftHook(AwsBaseHook):
         """
         Gets a list of snapshots for a cluster
 
+        .. seealso::
+            - :external+boto3:py:meth:`Redshift.Client.describe_cluster_snapshots`
+
         :param cluster_identifier: unique identifier of a cluster
         """
         response = self.get_conn().describe_cluster_snapshots(ClusterIdentifier=cluster_identifier)
@@ -132,6 +143,9 @@ class RedshiftHook(AwsBaseHook):
         """
         Restores a cluster from its snapshot
 
+        .. seealso::
+            - :external+boto3:py:meth:`Redshift.Client.restore_from_cluster_snapshot`
+
         :param cluster_identifier: unique identifier of a cluster
         :param snapshot_identifier: unique identifier for a snapshot of a cluster
         """
@@ -145,6 +159,9 @@ class RedshiftHook(AwsBaseHook):
     ) -> str:
         """
         Creates a snapshot of a cluster
+
+        .. seealso::
+            - :external+boto3:py:meth:`Redshift.Client.create_cluster_snapshot`
 
         :param snapshot_identifier: unique identifier for a snapshot of a cluster
         :param cluster_identifier: unique identifier of a cluster

--- a/airflow/providers/amazon/aws/hooks/redshift_data.py
+++ b/airflow/providers/amazon/aws/hooks/redshift_data.py
@@ -27,20 +27,17 @@ if TYPE_CHECKING:
 
 class RedshiftDataHook(AwsGenericHook["RedshiftDataAPIServiceClient"]):
     """
-    Interact with AWS Redshift Data, using the boto3 library
-    Hook attribute `conn` has all methods that listed in documentation
+    Interact with Amazon Redshift Data API.
+    Provide thin wrapper around
+    :external+boto3:py:class:`boto3.client("redshift-data") <RedshiftDataAPIService.Client>`.
+
+    Additional arguments (such as ``aws_conn_id``) may be specified and
+    are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/redshift-data.html
-        - https://docs.aws.amazon.com/redshift-data/latest/APIReference/Welcome.html
-
-    Additional arguments (such as ``aws_conn_id`` or ``region_name``) may be specified and
-        are passed down to the underlying AwsBaseHook.
-
-    .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsGenericHook`
-
-    :param aws_conn_id: The Airflow connection used for AWS credentials.
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - `Amazon Redshift Data API \
+        <https://docs.aws.amazon.com/redshift-data/latest/APIReference/Welcome.html>`__
     """
 
     def __init__(self, *args, **kwargs) -> None:

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -108,7 +108,9 @@ def unify_bucket_name_and_key(func: T) -> T:
 
 class S3Hook(AwsBaseHook):
     """
-    Interact with AWS S3, using the boto3 library.
+    Interact with Amazon Simple Storage Service (S3).
+    Provide thick wrapper around :external+boto3:py:class:`boto3.client("s3") <S3.Client>`
+    and :external+boto3:py:class:`boto3.resource("s3") <S3.ServiceResource>`.
 
     :param transfer_config_args: Configuration object for managed S3 transfers.
     :param extra_args: Extra arguments that may be passed to the download/upload operations.
@@ -123,7 +125,7 @@ class S3Hook(AwsBaseHook):
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     def __init__(
@@ -215,6 +217,9 @@ class S3Hook(AwsBaseHook):
         """
         Check if bucket_name exists.
 
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Client.head_bucket`
+
         :param bucket_name: the name of the bucket
         :return: True if it exists and False if not.
         """
@@ -240,7 +245,10 @@ class S3Hook(AwsBaseHook):
     @provide_bucket_name
     def get_bucket(self, bucket_name: str | None = None) -> object:
         """
-        Returns a boto3.S3.Bucket object
+        Returns a :py:class:`S3.Bucket` object
+
+        .. seealso::
+            - :external+boto3:py:meth:`S3.ServiceResource.Bucket`
 
         :param bucket_name: the name of the bucket
         :return: the bucket object to the bucket name.
@@ -257,6 +265,9 @@ class S3Hook(AwsBaseHook):
     def create_bucket(self, bucket_name: str | None = None, region_name: str | None = None) -> None:
         """
         Creates an Amazon S3 bucket.
+
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Client.create_bucket`
 
         :param bucket_name: The name of the bucket
         :param region_name: The name of the aws region in which to create the bucket.
@@ -303,6 +314,9 @@ class S3Hook(AwsBaseHook):
     ) -> list:
         """
         Lists prefixes in a bucket under prefix
+
+        .. seealso::
+            - :external+boto3:py:class:`S3.Paginator.ListObjectsV2`
 
         :param bucket_name: the name of the bucket
         :param prefix: a key prefix
@@ -357,6 +371,9 @@ class S3Hook(AwsBaseHook):
     ) -> list:
         """
         Lists keys in a bucket under prefix and not containing delimiter
+
+        .. seealso::
+            - :external+boto3:py:class:`S3.Paginator.ListObjectsV2`
 
         :param bucket_name: the name of the bucket
         :param prefix: a key prefix
@@ -430,6 +447,9 @@ class S3Hook(AwsBaseHook):
         """
         Lists metadata objects in a bucket under prefix
 
+        .. seealso::
+            - :external+boto3:py:class:`S3.Paginator.ListObjectsV2`
+
         :param prefix: a key prefix
         :param bucket_name: the name of the bucket
         :param page_size: pagination size
@@ -456,6 +476,9 @@ class S3Hook(AwsBaseHook):
         """
         Retrieves metadata of an object
 
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Client.head_object`
+
         :param key: S3 key that will point to the file
         :param bucket_name: Name of the bucket in which the file is stored
         :return: metadata of an object
@@ -474,6 +497,9 @@ class S3Hook(AwsBaseHook):
         """
         Checks if a key exists in a bucket
 
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Client.head_object`
+
         :param key: S3 key that will point to the file
         :param bucket_name: Name of the bucket in which the file is stored
         :return: True if the key exists and False if not.
@@ -485,7 +511,10 @@ class S3Hook(AwsBaseHook):
     @provide_bucket_name
     def get_key(self, key: str, bucket_name: str | None = None) -> S3Transfer:
         """
-        Returns a boto3.s3.Object
+        Returns a :py:class:`S3.Object`.
+
+        .. seealso::
+            - :external+boto3:py:meth:`S3.ServiceResource.Object`
 
         :param key: the path to the key
         :param bucket_name: the name of the bucket
@@ -506,6 +535,9 @@ class S3Hook(AwsBaseHook):
     def read_key(self, key: str, bucket_name: str | None = None) -> str:
         """
         Reads a key from S3
+
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Object.get`
 
         :param key: S3 key that will point to the file
         :param bucket_name: Name of the bucket in which the file is stored
@@ -528,6 +560,9 @@ class S3Hook(AwsBaseHook):
         """
         Reads a key with S3 Select.
 
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Client.select_object_content`
+
         :param key: S3 key that will point to the file
         :param bucket_name: Name of the bucket in which the file is stored
         :param expression: S3 Select expression
@@ -535,10 +570,6 @@ class S3Hook(AwsBaseHook):
         :param input_serialization: S3 Select input data serialization format
         :param output_serialization: S3 Select output data serialization format
         :return: retrieved subset of original data by S3 Select
-
-        .. seealso::
-            For more details about S3 Select parameters:
-            https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.select_object_content
         """
         expression = expression or "SELECT * FROM S3Object"
         expression_type = expression_type or "SQL"
@@ -614,6 +645,9 @@ class S3Hook(AwsBaseHook):
         """
         Loads a local file to S3
 
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Client.upload_file`
+
         :param filename: path to the file to load.
         :param key: S3 key that will point to the file
         :param bucket_name: Name of the bucket in which to store the file
@@ -664,6 +698,9 @@ class S3Hook(AwsBaseHook):
         This is provided as a convenience to drop a string in S3. It uses the
         boto infrastructure to ship a file to s3.
 
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Client.upload_fileobj`
+
         :param string_data: str to set as content for the key.
         :param key: S3 key that will point to the file
         :param bucket_name: Name of the bucket in which to store the file
@@ -712,6 +749,9 @@ class S3Hook(AwsBaseHook):
         This is provided as a convenience to drop bytes data into S3. It uses the
         boto infrastructure to ship a file to s3.
 
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Client.upload_fileobj`
+
         :param bytes_data: bytes to set as content for the key.
         :param key: S3 key that will point to the file
         :param bucket_name: Name of the bucket in which to store the file
@@ -739,6 +779,9 @@ class S3Hook(AwsBaseHook):
     ) -> None:
         """
         Loads a file object to S3
+
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Client.upload_fileobj`
 
         :param file_obj: The file-like object to set as the content for the S3 key.
         :param key: S3 key that will point to the file
@@ -791,6 +834,9 @@ class S3Hook(AwsBaseHook):
         """
         Creates a copy of an object that is already stored in S3.
 
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Client.copy_object`
+
         Note: the S3 connection used here needs to have access to both
         source and destination bucket/key.
 
@@ -834,6 +880,9 @@ class S3Hook(AwsBaseHook):
         """
         To delete s3 bucket, delete all s3 bucket objects and then delete the bucket.
 
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Client.delete_bucket`
+
         :param bucket_name: Bucket name
         :param force_delete: Enable this to delete bucket even if not empty
         :return: None
@@ -847,6 +896,9 @@ class S3Hook(AwsBaseHook):
     def delete_objects(self, bucket: str, keys: str | list) -> None:
         """
         Delete keys from the bucket.
+
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Client.delete_objects`
 
         :param bucket: Name of the bucket in which you are going to delete object(s)
         :param keys: The key(s) to delete from S3 bucket.
@@ -885,6 +937,9 @@ class S3Hook(AwsBaseHook):
     ) -> str:
         """
         Downloads a file from the S3 location to the local file system.
+
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Object.download_fileobj`
 
         :param key: The key path in S3.
         :param bucket_name: The specific bucket to use.
@@ -953,6 +1008,9 @@ class S3Hook(AwsBaseHook):
         """
         Generate a presigned url given a client, its method, and arguments
 
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Client.generate_presigned_url`
+
         :param client_method: The client method to presign for.
         :param params: The parameters normally passed to ClientMethod.
         :param expires_in: The number of seconds the presigned url is valid for.
@@ -976,6 +1034,9 @@ class S3Hook(AwsBaseHook):
         """
         Gets a List of tags from a bucket.
 
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Client.get_bucket_tagging`
+
         :param bucket_name: The name of the bucket.
         :return: A List containing the key/value pairs for the tags
         """
@@ -998,6 +1059,9 @@ class S3Hook(AwsBaseHook):
     ) -> None:
         """
         Overwrites the existing TagSet with provided tags.  Must provide either a TagSet or a key/value pair.
+
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Client.put_bucket_tagging`
 
         :param tag_set: A List containing the key/value pairs for the tags.
         :param key: The Key for the new TagSet entry.
@@ -1026,6 +1090,9 @@ class S3Hook(AwsBaseHook):
     def delete_bucket_tagging(self, bucket_name: str | None = None) -> None:
         """
         Deletes all tags from a bucket.
+
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Client.delete_bucket_tagging`
 
         :param bucket_name: The name of the bucket.
         :return: None

--- a/airflow/providers/amazon/aws/hooks/sagemaker.py
+++ b/airflow/providers/amazon/aws/hooks/sagemaker.py
@@ -137,12 +137,13 @@ def secondary_training_status_message(
 class SageMakerHook(AwsBaseHook):
     """
     Interact with Amazon SageMaker.
+    Provide thick wrapper around :external+boto3:py:class:`boto3.client("sagemaker") <SageMaker.Client>`.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     non_terminal_states = {"InProgress", "Stopping"}
@@ -370,6 +371,9 @@ class SageMakerHook(AwsBaseHook):
         Starts a transform job. A transform job uses a trained model to get inferences
         on a dataset and saves these results to an Amazon S3 location that you specify.
 
+        .. seealso::
+            - :external+boto3:py:meth:`SageMaker.Client.create_transform_job`
+
         :param config: the config for transform job
         :param wait_for_completion: if the program should keep running until job finishes
         :param check_interval: the time interval in seconds which the operator
@@ -406,6 +410,9 @@ class SageMakerHook(AwsBaseHook):
         experience on SageMaker to run your data processing workloads, such as feature
         engineering, data validation, model evaluation, and model interpretation.
 
+        .. seealso::
+            - :external+boto3:py:meth:`SageMaker.Client.create_processing_job`
+
         :param config: the config for processing job
         :param wait_for_completion: if the program should keep running until job finishes
         :param check_interval: the time interval in seconds which the operator
@@ -433,6 +440,9 @@ class SageMakerHook(AwsBaseHook):
         image that contains inference code, artifacts (from prior training), and a custom
         environment map that the inference code uses when you deploy the model for predictions.
 
+        .. seealso::
+            - :external+boto3:py:meth:`SageMaker.Client.create_model`
+
         :param config: the config for model
         :return: A response to model creation
         """
@@ -446,8 +456,9 @@ class SageMakerHook(AwsBaseHook):
         the resources that you want Amazon SageMaker to provision.
 
         .. seealso::
-             :class:`~airflow.providers.amazon.aws.hooks.sagemaker.SageMakerHook.create_model`
-             :class:`~airflow.providers.amazon.aws.hooks.sagemaker.SageMakerHook.create_endpoint`
+            - :external+boto3:py:meth:`SageMaker.Client.create_endpoint_config`
+            - :class:`airflow.providers.amazon.aws.hooks.sagemaker.SageMakerHook.create_model`
+            - :class:`airflow.providers.amazon.aws.hooks.sagemaker.SageMakerHook.create_endpoint`
 
         :param config: the config for endpoint-config
         :return: A response to endpoint config creation
@@ -468,9 +479,10 @@ class SageMakerHook(AwsBaseHook):
         the compute resources up and down as needed to handle your request traffic.
 
         Requires an Endpoint Config.
-         .. seealso::
-             :class:`~airflow.providers.amazon.aws.hooks.sagemaker.SageMakerHook.create_endpoint_config`
 
+        .. seealso::
+            - :external+boto3:py:meth:`SageMaker.Client.create_endpoint`
+            - :class:`airflow.providers.amazon.aws.hooks.sagemaker.SageMakerHook.create_endpoint`
 
         :param config: the config for endpoint
         :param wait_for_completion: if the program should keep running until job finishes
@@ -505,6 +517,9 @@ class SageMakerHook(AwsBaseHook):
         newly created endpoint, and then deletes resources provisioned for the
         endpoint using the previous EndpointConfig (there is no availability loss).
 
+        .. seealso::
+            - :external+boto3:py:meth:`SageMaker.Client.update_endpoint`
+
         :param config: the config for endpoint
         :param wait_for_completion: if the program should keep running until job finishes
         :param check_interval: the time interval in seconds which the operator
@@ -529,6 +544,9 @@ class SageMakerHook(AwsBaseHook):
     def describe_training_job(self, name: str):
         """
         Return the training job info associated with the name
+
+        .. seealso::
+            - :external+boto3:py:meth:`SageMaker.Client.describe_training_job`
 
         :param name: the name of the training job
         :return: A dict contains all the training job info
@@ -600,6 +618,9 @@ class SageMakerHook(AwsBaseHook):
         """
         Return the tuning job info associated with the name
 
+        .. seealso::
+            - :external+boto3:py:meth:`SageMaker.Client.describe_hyper_parameter_tuning_job`
+
         :param name: the name of the tuning job
         :return: A dict contains all the tuning job info
         """
@@ -618,6 +639,9 @@ class SageMakerHook(AwsBaseHook):
         """
         Return the transform job info associated with the name
 
+        .. seealso::
+            - :external+boto3:py:meth:`SageMaker.Client.describe_transform_job`
+
         :param name: the name of the transform job
         :return: A dict contains all the transform job info
         """
@@ -626,6 +650,9 @@ class SageMakerHook(AwsBaseHook):
     def describe_processing_job(self, name: str) -> dict:
         """
         Return the processing job info associated with the name
+
+        .. seealso::
+            - :external+boto3:py:meth:`SageMaker.Client.describe_processing_job`
 
         :param name: the name of the processing job
         :return: A dict contains all the processing job info
@@ -636,6 +663,9 @@ class SageMakerHook(AwsBaseHook):
         """
         Return the endpoint config info associated with the name
 
+        .. seealso::
+            - :external+boto3:py:meth:`SageMaker.Client.describe_endpoint_config`
+
         :param name: the name of the endpoint config
         :return: A dict contains all the endpoint config info
         """
@@ -643,6 +673,11 @@ class SageMakerHook(AwsBaseHook):
 
     def describe_endpoint(self, name: str) -> dict:
         """
+        Returns the description of an endpoint.
+
+        .. seealso::
+            - :external+boto3:py:meth:`SageMaker.Client.describe_endpoint`
+
         :param name: the name of the endpoint
         :return: A dict contains all the endpoint info
         """
@@ -805,7 +840,7 @@ class SageMakerHook(AwsBaseHook):
             list_training_jobs(name_contains="myjob", StatusEquals="Failed")
 
         .. seealso::
-            https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.list_training_jobs
+            - :external+boto3:py:meth:`SageMaker.Client.list_training_jobs`
 
         :param name_contains: (optional) partial name to match
         :param max_results: (optional) maximum number of results to return. None returns infinite results
@@ -833,7 +868,7 @@ class SageMakerHook(AwsBaseHook):
             list_transform_jobs(name_contains="myjob", StatusEquals="Failed")
 
         .. seealso::
-            https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.list_transform_jobs
+            - :external+boto3:py:meth:`SageMaker.Client.list_transform_jobs`
 
         :param name_contains: (optional) partial name to match
         :param max_results: (optional) maximum number of results to return. None returns infinite results
@@ -857,7 +892,7 @@ class SageMakerHook(AwsBaseHook):
             list_processing_jobs(NameContains="myjob", StatusEquals="Failed")
 
         .. seealso::
-            https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.list_processing_jobs
+            - :external+boto3:py:meth:`SageMaker.Client.list_processing_jobs`
 
         :param kwargs: (optional) kwargs to boto3's list_training_jobs method
         :return: results of the list_processing_jobs request
@@ -1002,7 +1037,11 @@ class SageMakerHook(AwsBaseHook):
             raise
 
     def delete_model(self, model_name: str):
-        """Delete SageMaker model
+        """
+        Delete SageMaker model.
+
+        .. seealso::
+            - :external+boto3:py:meth:`SageMaker.Client.delete_model`
 
         :param model_name: name of the model
         """
@@ -1013,7 +1052,12 @@ class SageMakerHook(AwsBaseHook):
             raise
 
     def describe_pipeline_exec(self, pipeline_exec_arn: str, verbose: bool = False):
-        """Get info about a SageMaker pipeline execution
+        """
+        Get info about a SageMaker pipeline execution.
+
+        .. seealso::
+            - :external+boto3:py:meth:`SageMaker.Client.describe_pipeline_execution`
+            - :external+boto3:py:meth:`SageMaker.Client.list_pipeline_execution_steps`
 
         :param pipeline_exec_arn: arn of the pipeline execution
         :param verbose: Whether to log details about the steps status in the pipeline execution
@@ -1039,7 +1083,10 @@ class SageMakerHook(AwsBaseHook):
         verbose: bool = True,
     ) -> str:
         """
-        Start a new execution for a SageMaker pipeline
+        Start a new execution for a SageMaker pipeline.
+
+        .. seealso::
+            - :external+boto3:py:meth:`SageMaker.Client.start_pipeline_execution`
 
         :param pipeline_name: Name of the pipeline to start (this is _not_ the ARN).
         :param display_name: The name this pipeline execution will have in the UI. Doesn't need to be unique.
@@ -1088,6 +1135,9 @@ class SageMakerHook(AwsBaseHook):
     ) -> str:
         """Stop SageMaker pipeline execution
 
+        .. seealso::
+            - :external+boto3:py:meth:`SageMaker.Client.stop_pipeline_execution`
+
         :param pipeline_exec_arn: Amazon Resource Name (ARN) of the pipeline execution.
             It's the ARN of the pipeline itself followed by "/execution/" and an id.
         :param wait_for_completion: Whether to wait for the pipeline to reach a final state.
@@ -1134,6 +1184,9 @@ class SageMakerHook(AwsBaseHook):
     def create_model_package_group(self, package_group_name: str, package_group_desc: str = "") -> bool:
         """
         Creates a Model Package Group if it does not already exist
+
+        .. seealso::
+            - :external+boto3:py:meth:`SageMaker.Client.create_model_package_group`
 
         :param package_group_name: Name of the model package group to create if not already present.
         :param package_group_desc: Description of the model package group, if it was to be created (optional).
@@ -1186,6 +1239,9 @@ class SageMakerHook(AwsBaseHook):
         """
         Creates an auto ML job, learning to predict the given column from the data provided through S3.
         The learning output is written to the specified S3 location.
+
+        .. seealso::
+            - :external+boto3:py:meth:`SageMaker.Client.create_auto_ml_job`
 
         :param job_name: Name of the job to create, needs to be unique within the account.
         :param s3_input: The S3 location (folder or file) where to fetch the data.

--- a/airflow/providers/amazon/aws/hooks/secrets_manager.py
+++ b/airflow/providers/amazon/aws/hooks/secrets_manager.py
@@ -26,12 +26,14 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 class SecretsManagerHook(AwsBaseHook):
     """
     Interact with Amazon SecretsManager Service.
+    Provide thin wrapper around
+    :external+boto3:py:class:`boto3.client("secretsmanager") <SecretsManager.Client>`.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
-    .. see also::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+    .. seealso::
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     def __init__(self, *args, **kwargs):
@@ -41,6 +43,9 @@ class SecretsManagerHook(AwsBaseHook):
         """
         Retrieve secret value from AWS Secrets Manager as a str or bytes
         reflecting format it stored in the AWS Secrets Manager
+
+        .. seealso::
+            - :external+boto3:py:meth:`SecretsManager.Client.get_secret_value`
 
         :param secret_name: name of the secrets.
         :return: Union[str, bytes] with the information about the secrets

--- a/airflow/providers/amazon/aws/hooks/ses.py
+++ b/airflow/providers/amazon/aws/hooks/ses.py
@@ -26,12 +26,13 @@ from airflow.utils.email import build_mime_message
 class SesHook(AwsBaseHook):
     """
     Interact with Amazon Simple Email Service.
+    Provide thin wrapper around :external+boto3:py:class:`boto3.client("ses") <SES.Client>`.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     def __init__(self, *args, **kwargs) -> None:
@@ -55,6 +56,9 @@ class SesHook(AwsBaseHook):
     ) -> dict:
         """
         Send email using Amazon Simple Email Service
+
+        .. seealso::
+            - :external+boto3:py:meth:`SES.Client.send_raw_email`
 
         :param mail_from: Email address to set as email's from
         :param to: List of email addresses to set as email's to

--- a/airflow/providers/amazon/aws/hooks/sns.py
+++ b/airflow/providers/amazon/aws/hooks/sns.py
@@ -40,12 +40,13 @@ def _get_message_attribute(o):
 class SnsHook(AwsBaseHook):
     """
     Interact with Amazon Simple Notification Service.
+    Provide thin wrapper around :external+boto3:py:class:`boto3.client("sns") <SNS.Client>`.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     def __init__(self, *args, **kwargs):
@@ -59,7 +60,10 @@ class SnsHook(AwsBaseHook):
         message_attributes: dict | None = None,
     ):
         """
-        Publish a message to a topic or an endpoint.
+        Publish a message to a SNS topic or an endpoint.
+
+        .. seealso::
+            - :external+boto3:py:meth:`SNS.Client.publish`
 
         :param target_arn: either a TopicArn or an EndpointArn
         :param message: the default message you want to send

--- a/airflow/providers/amazon/aws/hooks/sqs.py
+++ b/airflow/providers/amazon/aws/hooks/sqs.py
@@ -24,12 +24,13 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 class SqsHook(AwsBaseHook):
     """
     Interact with Amazon Simple Queue Service.
+    Provide thin wrapper around :external+boto3:py:class:`boto3.client("sqs") <SQS.Client>`.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     def __init__(self, *args, **kwargs) -> None:
@@ -38,14 +39,14 @@ class SqsHook(AwsBaseHook):
 
     def create_queue(self, queue_name: str, attributes: dict | None = None) -> dict:
         """
-        Create queue using connection object
+        Create queue using connection object.
+
+        .. seealso::
+            - :external+boto3:py:meth:`SQS.Client.create_queue`
 
         :param queue_name: name of the queue.
         :param attributes: additional attributes for the queue (default: None)
-            For details of the attributes parameter see :py:meth:`SQS.create_queue`
-
-        :return: dict with the information about the queue
-            For details of the returned value see :py:meth:`SQS.create_queue`
+        :return: dict with the information about the queue.
         """
         return self.get_conn().create_queue(QueueName=queue_name, Attributes=attributes or {})
 
@@ -58,18 +59,17 @@ class SqsHook(AwsBaseHook):
         message_group_id: str | None = None,
     ) -> dict:
         """
-        Send message to the queue
+        Send message to the queue.
+
+        .. seealso::
+            - :external+boto3:py:meth:`SQS.Client.send_message`
 
         :param queue_url: queue url
         :param message_body: the contents of the message
         :param delay_seconds: seconds to delay the message
         :param message_attributes: additional attributes for the message (default: None)
-            For details of the attributes parameter see :py:meth:`botocore.client.SQS.send_message`
         :param message_group_id: This applies only to FIFO (first-in-first-out) queues. (default: None)
-            For details of the attributes parameter see :py:meth:`botocore.client.SQS.send_message`
-
         :return: dict with the information about the message sent
-            For details of the returned value see :py:meth:`botocore.client.SQS.send_message`
         """
         params = {
             "QueueUrl": queue_url,

--- a/airflow/providers/amazon/aws/hooks/ssm.py
+++ b/airflow/providers/amazon/aws/hooks/ssm.py
@@ -23,15 +23,14 @@ from airflow.utils.types import NOTSET, ArgNotSet
 
 class SsmHook(AwsBaseHook):
     """
-    Interact with Amazon Systems Manager (SSM) using the boto3 library.
-    All API calls available through the Boto API are also available here.
-    See: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ssm.html#client
+    Interact with Amazon Systems Manager (SSM).
+    Provide thin wrapper around :external+boto3:py:class:`boto3.client("ssm") <SSM.Client>`.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     def __init__(self, *args, **kwargs) -> None:
@@ -41,6 +40,9 @@ class SsmHook(AwsBaseHook):
     def get_parameter_value(self, parameter: str, default: str | ArgNotSet = NOTSET) -> str:
         """
         Returns the value of the provided Parameter or an optional default.
+
+        .. seealso::
+            - :external+boto3:py:meth:`SSM.Client.get_parameter`
 
         :param parameter: The SSM Parameter name to return the value for.
         :param default: Optional default value to return if none is found.

--- a/airflow/providers/amazon/aws/hooks/step_function.py
+++ b/airflow/providers/amazon/aws/hooks/step_function.py
@@ -24,12 +24,13 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 class StepFunctionHook(AwsBaseHook):
     """
     Interact with an AWS Step Functions State Machine.
+    Provide thin wrapper around :external+boto3:py:class:`boto3.client("stepfunctions") <SFN.Client>`.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     def __init__(self, *args, **kwargs) -> None:
@@ -44,12 +45,14 @@ class StepFunctionHook(AwsBaseHook):
     ) -> str:
         """
         Start Execution of the State Machine.
-        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/stepfunctions.html#SFN.Client.start_execution
 
-        :param state_machine_arn: AWS Step Function State Machine ARN
+        .. seealso::
+            - :external+boto3:py:meth:`SFN.Client.start_execution`
+
+        :param state_machine_arn: AWS Step Function State Machine ARN.
         :param name: The name of the execution.
-        :param state_machine_input: JSON data input to pass to the State Machine
-        :return: Execution ARN
+        :param state_machine_input: JSON data input to pass to the State Machine.
+        :return: Execution ARN.
         """
         execution_args = {"stateMachineArn": state_machine_arn}
         if name is not None:
@@ -68,9 +71,11 @@ class StepFunctionHook(AwsBaseHook):
     def describe_execution(self, execution_arn: str) -> dict:
         """
         Describes a State Machine Execution
-        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/stepfunctions.html#SFN.Client.describe_execution
 
-        :param execution_arn: ARN of the State Machine Execution
-        :return: Dict with Execution details
+        .. seealso::
+            - :external+boto3:py:meth:`SFN.Client.describe_execution`
+
+        :param execution_arn: ARN of the State Machine Execution.
+        :return: Dict with execution details.
         """
         return self.get_conn().describe_execution(executionArn=execution_arn)

--- a/airflow/providers/amazon/aws/hooks/sts.py
+++ b/airflow/providers/amazon/aws/hooks/sts.py
@@ -21,19 +21,25 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 
 class StsHook(AwsBaseHook):
     """
-    Interact with AWS Security Token Service (STS)
+    Interact with AWS Security Token Service (STS).
+    Provide thin wrapper around :external+boto3:py:class:`boto3.client("sts") <STS.Client>`.
 
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
+
     .. seealso::
-    :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(client_type="sts", *args, **kwargs)
 
     def get_account_number(self) -> str:
-        """Get the account Number"""
+        """Get the account Number.
+
+        .. seealso::
+            - :external+boto3:py:meth:`STS.Client.get_caller_identity`
+        """
         try:
             return self.get_conn().get_caller_identity()["Account"]
         except Exception as general_error:

--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -52,35 +52,23 @@ class BatchOperator(BaseOperator):
         :ref:`howto/operator:BatchOperator`
 
     :param job_name: the name for the job that will run on AWS Batch (templated)
-
     :param job_definition: the job definition name on AWS Batch
-
     :param job_queue: the queue name on AWS Batch
-
     :param overrides: the `containerOverrides` parameter for boto3 (templated)
-
     :param array_properties: the `arrayProperties` parameter for boto3
-
     :param parameters: the `parameters` for boto3 (templated)
-
     :param job_id: the job ID, usually unknown (None) until the
         submit_job operation gets the jobId defined by AWS Batch
-
     :param waiters: an :py:class:`.BatchWaiters` object (see note below);
         if None, polling is used with max_retries and status_retries.
-
     :param max_retries: exponential back-off retries, 4200 = 48 hours;
         polling is only used when waiters is None
-
     :param status_retries: number of HTTP retries to get job status, 10;
         polling is only used when waiters is None
-
     :param aws_conn_id: connection id of AWS credentials / region name. If None,
         credential boto3 strategy will be used.
-
     :param region_name: region name to use in AWS Hook.
         Override the region_name in connection (if provided)
-
     :param tags: collection of tags to apply to the AWS Batch job submission
         if None, no tags are submitted
 

--- a/airflow/providers/amazon/aws/operators/cloud_formation.py
+++ b/airflow/providers/amazon/aws/operators/cloud_formation.py
@@ -35,7 +35,6 @@ class CloudFormationCreateStackOperator(BaseOperator):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:CloudFormationCreateStackOperator`
 
-
     :param stack_name: stack name (templated)
     :param cloudformation_parameters: parameters to be passed to CloudFormation.
     :param aws_conn_id: aws connection to uses

--- a/docs/apache-airflow-providers-amazon/connections/aws.rst
+++ b/docs/apache-airflow-providers-amazon/connections/aws.rst
@@ -26,7 +26,8 @@ The Amazon Web Services connection type enables the :ref:`AWS Integrations
 Authenticating to AWS
 ---------------------
 
-Authentication may be performed using any of the `boto3 options <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials>`_. Alternatively, one can pass credentials in as a Connection initialisation parameter.
+Authentication may be performed using any of the options described in Boto3 Guide :external+boto3:ref:`guide_credentials`.
+Alternatively, one can pass credentials in as a Connection initialisation parameter.
 
 To use IAM instance profile, create an "empty" connection (i.e. one with no AWS Access Key ID or AWS Secret Access Key
 specified, or ``aws://``).
@@ -66,8 +67,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in AWS
     connection. All parameters are optional.
 
-    The following extra parameters used to create an initial
-    `boto3.session.Session <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html>`__:
+    The following extra parameters used to create an initial :external:py:class:`boto3.session.Session`:
 
     * ``aws_access_key_id``: AWS access key ID used for the initial connection.
     * ``aws_secret_access_key``: AWS secret access key used for the initial connection
@@ -87,9 +87,8 @@ Extra (optional)
       if not specified then **assume_role** is used.
     * ``assume_role_kwargs``: Additional **kwargs** passed to ``assume_role_method``.
 
-    The following extra parameters used for
-    `boto3.client <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client>`__
-    and `boto3.resource <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.resource>`__:
+    The following extra parameters pass to :external:py:meth:`boto3.session.Session.client`
+    or :external:py:meth:`boto3.session.Session.resource`.
 
     * ``config_kwargs``: Additional **kwargs** used to construct a
       `botocore.config.Config <https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html>`__.
@@ -110,8 +109,7 @@ Extra (optional)
     * ``profile``: If you are getting your credentials from the ``s3_config_file``
       you can specify the profile with this parameter.
     * ``host``: Used as connection's URL. Use ``endpoint_url`` instead.
-    * ``session_kwargs``: Additional **kwargs** passed to
-      `boto3.session.Session <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html>`__.
+    * ``session_kwargs``: Additional **kwargs** passed to :external:py:class:`boto3.session.Session`.
 
 If you are configuring the connection via a URI, ensure that all components of the URI are URL-encoded.
 
@@ -214,7 +212,7 @@ This assumes all other Connection fields eg **AWS Access Key ID** or **AWS Secre
     }
 
 .. seealso::
-    https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerole
+    - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerole
 
 
 3. Configuring an outbound HTTP proxy
@@ -279,9 +277,9 @@ The following settings may be used within the ``assume_role_with_saml`` containe
     The ``python-gssapi`` library is outdated, and conflicts with some versions of ``paramiko`` which Airflow uses elsewhere.
 
 .. seealso::
-    :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
-    https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithsaml
-    https://pypi.org/project/requests-gssapi/
+    - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+    - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithsaml
+    - https://pypi.org/project/requests-gssapi/
 
 
 Avoid Throttling exceptions
@@ -301,7 +299,7 @@ If you encounter throttling exceptions, you may change the mode to ``standard`` 
 
 
 .. seealso::
-    https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html#retries
+    - Boto3 Guide: :external+boto3:ref:`guide_retries`
 
 Set in Connection
 ^^^^^^^^^^^^^^^^^
@@ -352,8 +350,7 @@ Session Factory
 ---------------
 
 The default ``BaseSessionFactory`` for the connection can handle most of the authentication methods for AWS.
-In the case that you would like to have full control of
-`boto3 session <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html>`__ creation or
+In the case that you would like to have full control of :external:py:class:`boto3.session.Session` creation or
 you are using custom `federation <https://aws.amazon.com/identity/federation/>`__ that requires
 `external process to source the credentials <https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html>`__,
 you can subclass :class:`~airflow.providers.amazon.aws.hooks.base_aws.BaseSessionFactory` and override ``create_session``
@@ -667,7 +664,11 @@ You can configure connection, also using environmental variable :envvar:`AIRFLOW
 Using IAM Roles for Service Accounts (IRSA) on EKS
 ----------------------------------------------------------------
 
-If you are running Airflow on `Amazon EKS <https://aws.amazon.com/eks/>`_, you can grant AWS related permission (such as S3 Read/Write for remote logging) to the Airflow service by granting the IAM role to it's service account. IRSA provides fine-grained permission management for apps(e.g., pods) that run on EKS and use other AWS services. These could be apps that use S3, any other AWS services like Secrets Manager, CloudWatch, DynamoDB etc.
+If you are running Airflow on `Amazon EKS <https://aws.amazon.com/eks/>`_,
+you can grant AWS related permission (such as S3 Read/Write for remote logging) to the Airflow service
+by granting the IAM role to it's service account.
+IRSA provides fine-grained permission management for apps(e.g., pods) that run on EKS and use other AWS services.
+These could be apps that use S3, any other AWS services like Secrets Manager, CloudWatch, DynamoDB etc.
 
 To activate this, the following steps must be followed:
 
@@ -676,10 +677,15 @@ To activate this, the following steps must be followed:
 3. Add the corresponding IAM Role to the Airflow service account as an annotation.
 
 .. seealso::
-    https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
+    - https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
 
-Then you can find ``AWS_ROLE_ARN`` and ``AWS_WEB_IDENTITY_TOKEN_FILE`` in environment variables of appropriate pods that `Amazon EKS Pod Identity Web Hook <https://github.com/aws/amazon-eks-pod-identity-webhook>`__ added. Then `boto3 <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials>`__ will configure credentials using those variables.
-In order to use IRSA in Airflow, you have to create an aws connection with all fields empty. If a field such as ``role-arn`` is set, Airflow does not follow the boto3 default flow because it manually create a session using connection fields. If you did not change the default connection ID, an empty AWS connection named ``aws_default`` would be enough.
+Then you can find ``AWS_ROLE_ARN`` and ``AWS_WEB_IDENTITY_TOKEN_FILE`` in environment variables of appropriate pods that
+`Amazon EKS Pod Identity Web Hook <https://github.com/aws/amazon-eks-pod-identity-webhook>`__ added.
+Then `boto3 <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials>`__
+will configure credentials using those variables. In order to use IRSA in Airflow, you have to create an aws connection
+with all fields empty. If a field such as ``role-arn`` is set, Airflow does not follow the boto3 default flow because
+it manually create a session using connection fields.
+If you did not change the default connection ID, an empty AWS connection named ``aws_default`` would be enough.
 
 Create IAM Role for Service Account(IRSA) using eksctl
 ------------------------------------------------------
@@ -693,13 +699,16 @@ Create IAM Role for Service Account(IRSA) using eksctl
 
     eksctl utils associate-iam-oidc-provider --cluster="<EKS_CLUSTER_ID>" --approve
 
-4. Replace ``EKS_CLUSTER_ID``, ``SERVICE_ACCOUNT_NAME`` and ``NAMESPACE`` and execute the the following command. This command will use an existing EKS Cluster ID and create an IAM role, service account and namespace.
+4. Replace ``EKS_CLUSTER_ID``, ``SERVICE_ACCOUNT_NAME`` and ``NAMESPACE`` and execute the the following command.
+This command will use an existing EKS Cluster ID and create an IAM role, service account and namespace.
 
 .. code-block:: bash
 
     eksctl create iamserviceaccount --cluster="<EKS_CLUSTER_ID>" --name="<SERVICE_ACCOUNT_NAME>" --namespace="<NAMESPACE>" --attach-policy-arn="<IAM_POLICY_ARN>" --approve``
 
-This is an example command with values. This example is using managed policy with full S3 permissions attached to the IAM role. We highly recommend you to create a restricted IAM policy with necessary permissions to S3, Secrets Manager, CloudWatch etc. and use it with ``--attach-policy-arn``.
+This is an example command with values. This example is using managed policy with full
+S3 permissions attached to the IAM role. We highly recommend you to create a restricted IAM policy
+with necessary permissions to S3, Secrets Manager, CloudWatch etc. and use it with ``--attach-policy-arn``.
 
 .. code-block:: bash
 
@@ -712,8 +721,10 @@ Create IAM Role for Service Account(IRSA) using Terraform
 
 For Terraform users, IRSA roles can be created using `Amazon EKS Blueprints for Terraform <https://github.com/aws-ia/terraform-aws-eks-blueprints>`_ module.
 
-This module creates a new IAM Role, service account and namespace. This will associate IAM role with the service account and adds the annotation to the service account.
-You need to create an IAM policy with the required permissions that you would like the containers in your pods to have. Replace ``IAM_POLICY_ARN`` with your IAM policy ARN, other required inputs as shown below and run ``terraform apply``.
+This module creates a new IAM Role, service account and namespace.
+This will associate IAM role with the service account and adds the annotation to the service account.
+You need to create an IAM policy with the required permissions that you would like the containers in your pods to have.
+Replace ``IAM_POLICY_ARN`` with your IAM policy ARN, other required inputs as shown below and run ``terraform apply``.
 
 .. code-block:: terraform
 
@@ -727,4 +738,5 @@ You need to create an IAM policy with the required permissions that you would li
       kubernetes_service_account = "<SERVICE_ACCOUNT_NAME>"
     }
 
-Once the Terraform module is applied then you can use the service account in your Airflow deployments or with Kubernetes Pod Operator.
+Once the Terraform module is applied then you can use the service account in your Airflow deployments
+or with Kubernetes Pod Operator.


### PR DESCRIPTION
Update Amazon Provider documentation and Hooks docstrings with references to [Intersphinx Inventory](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html)

1. Make Hooks docstring more consistant to each other. Mark each hook which is intend to be a wrapper to boto3 client/resource is it **Thin** (provide only arguments described in AwsBaseHook) wrapper or **Think** (contain additional arguments in constructor)
2. Add links to appropriate boto3 client/resource method/class in hooks methods doctrings, if applicable
3. Remove useless type hinting for params / returns in docstring - we have annotation for that.
4. Most of the references use prefix `:external+boto3:` for avoid overlapping with botocore inventory, we do not use this inventory yet.

There is quite a few changes, if someone interested I attach [archive](https://github.com/apache/airflow/files/10418519/apache-airflow-providers-amazon.zip) with locally built documentation.
