### PR TITLE
Change parameters conn_id into mongo_conn_id

### DIFF
--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -46,15 +46,15 @@ class MongoHook(BaseHook):
         when connecting to MongoDB.
     """
 
-    conn_name_attr = "conn_id"
+    conn_name_attr = "mongo_conn_id"
     default_conn_name = "mongo_default"
     conn_type = "mongo"
     hook_name = "MongoDB"
 
-    def __init__(self, conn_id: str = default_conn_name, *args, **kwargs) -> None:
+    def __init__(self, mongo_conn_id: str = default_conn_name, *args, **kwargs) -> None:
         super().__init__()
-        self.mongo_conn_id = conn_id
-        self.connection = self.get_connection(conn_id)
+        self.mongo_conn_id = mongo_conn_id
+        self.connection = self.get_connection(mongo_conn_id)
         self.extras = self.connection.extra_dejson.copy()
         self.client = None
         self.uri = self._create_uri()


### PR DESCRIPTION
It looks like all manuals speak about mongo_conn_id, but the code uses conn_id. Hence is ignoring the mongo_conn_id that is set and falls back to the default connection. Hope this helps.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
