### PR TITLE
Move project and license docs down to start with developer-focused docs

### DIFF
--- a/docs/apache-airflow/index.rst
+++ b/docs/apache-airflow/index.rst
@@ -131,8 +131,6 @@ so coding will always be required.
     :caption: Content
 
     Overview <self>
-    project
-    license
     start
     installation/index
     tutorial/index
@@ -148,6 +146,8 @@ so coding will always be required.
     Release Policies <release-process>
     release_notes
     privacy_notice
+    project
+    license
 
 .. toctree::
     :hidden:


### PR DESCRIPTION
I suggest moving the project and license docs down in the main menu, to bring the quick start guide to the top. I think 99% of the docs readers want to understand Airflow better. The project & license docs are very specific, and only of interest to a few readers.

**Current structure (Airflow 2.5.1):**
![image](https://user-images.githubusercontent.com/6249654/212558037-ba3dc6ae-d4e7-4960-9480-92d4d5e94211.png)

**Proposed:**
![image](https://user-images.githubusercontent.com/6249654/212558083-25d9a8bc-f651-44ab-a747-2a700e25e4a1.png)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
