### PR TITLE
Update go client gen command

### DIFF
--- a/clients/gen/go.sh
+++ b/clients/gen/go.sh
@@ -31,6 +31,7 @@ readonly VERSION
 go_config=(
     "packageVersion=${VERSION}"
     "enumClassPrefix=true"
+    "structPrefix=true"
 )
 
 validate_input "$@"


### PR DESCRIPTION
When we have multiple tags on an endpoint in the spec, client generation will succeed but with go code not valid. (Struct redefined). We have such a case [here](https://github.com/apache/airflow/blob/main/airflow/api_connexion/openapi/v1.yaml#L912
)

Cf:
https://github.com/OpenAPITools/openapi-generator/issues/741

This updates the go client to add the required option to avoid name conflicts in internal functions