### PR TITLE
Fix support for macros with dots in DataProcJobBuilder

### DIFF
--- a/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/airflow/providers/google/cloud/hooks/dataproc.py
@@ -63,7 +63,7 @@ class DataProcJobBuilder:
         job_type: str,
         properties: dict[str, str] | None = None,
     ) -> None:
-        name = f"{task_id.replace('.', '_')}_{uuid.uuid4()!s:.8}"
+        name = f"{task_id}_{uuid.uuid4()!s:.8}"
         self.job_type = job_type
         self.job: dict[str, Any] = {
             "job": {
@@ -180,12 +180,11 @@ class DataProcJobBuilder:
 
     def set_job_name(self, name: str) -> None:
         """
-        Set Dataproc job name. Job name is sanitized, replacing dots by underscores.
+        Set Dataproc job name.
 
         :param name: Job name.
         """
-        sanitized_name = f"{name.replace('.', '_')}_{uuid.uuid4()!s:.8}"
-        self.job["job"]["reference"]["job_id"] = sanitized_name
+        self.job["job"]["reference"]["job_id"] = f"{name}_{uuid.uuid4()!s:.8}"
 
     def build(self) -> dict:
         """

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -887,7 +887,7 @@ class DataprocJobBaseOperator(BaseOperator):
         self,
         *,
         region: str,
-        job_name: str = "{{task.task_id}}_{{ds_nodash}}",
+        job_name: str = "{{task.task_id.replace('.', '_')}}_{{ds_nodash}}",
         cluster_name: str = "cluster-1",
         project_id: str | None = None,
         dataproc_properties: dict | None = None,

--- a/tests/providers/google/cloud/hooks/test_dataproc.py
+++ b/tests/providers/google/cloud/hooks/test_dataproc.py
@@ -1006,17 +1006,9 @@ class TestDataProcJobBuilder:
         self.builder.set_python_main(main)
         assert main == self.builder.job["job"][self.job_type]["main_python_file_uri"]
 
-    @pytest.mark.parametrize(
-        "job_name",
-        [
-            pytest.param("name", id="simple"),
-            pytest.param("name_with_dash", id="name with underscores"),
-            pytest.param("group.name", id="name with dot"),
-            pytest.param("group.name_with_dash", id="name with dot and underscores"),
-        ],
-    )
     @mock.patch(DATAPROC_STRING.format("uuid.uuid4"))
-    def test_set_job_name(self, mock_uuid, job_name):
+    def test_set_job_name(self, mock_uuid):
+        job_name = "name"
         uuid = "test_uuid"
         expected_job_name = f"{job_name}_{uuid[:8]}".replace(".", "_")
         mock_uuid.return_value = uuid


### PR DESCRIPTION
Do not sanitize job name in DataProcJobBuilder because it can use Jinja macros. Move sanitization to DataprocJobBaseOperator default value for job_name parameter to keep supporting task groups.

Fixes #28810