### PR TITLE
Fix label name for `reauth` field in Docker Connection

### DIFF
--- a/airflow/providers/docker/hooks/docker.py
+++ b/airflow/providers/docker/hooks/docker.py
@@ -172,7 +172,10 @@ class DockerHook(BaseHook):
         from wtforms import BooleanField, StringField
 
         return {
-            "reauth": BooleanField(lazy_gettext("Disable SSL")),
+            "reauth": BooleanField(
+                lazy_gettext("Reauthenticate"),
+                description="Whether or not to refresh existing authentication on the Docker server.",
+            ),
             "email": StringField(lazy_gettext("Email"), widget=BS3TextFieldWidget()),
         }
 


### PR DESCRIPTION
Follow up: https://github.com/apache/airflow/issues/28938#issuecomment-1384150283

![image](https://user-images.githubusercontent.com/3998685/212714757-0b546563-6aa4-4d07-902e-2b3ff80aa129.png)
