### PR TITLE
Ensure non-JSON types go through encoder

### DIFF
--- a/airflow/utils/json.py
+++ b/airflow/utils/json.py
@@ -60,24 +60,30 @@ class WebEncoder(json.JSONEncoder):
             if isinstance(data, dict) and DATA in data:
                 return data[DATA]
 
+        if isinstance(o, (set, frozenset)):
+            return list(o)
+
         try:
             data = serialize(o)
-            if isinstance(data, dict) and CLASSNAME in data:
-                # this is here for backwards compatibility
-                if (
-                    data[CLASSNAME].startswith("numpy")
-                    or data[CLASSNAME] == "kubernetes.client.models.v1_pod.V1Pod"
-                ):
-                    return data[DATA]
-            return data
         except TypeError:
-            raise
+            return super().default(o)
+
+        if isinstance(data, dict) and CLASSNAME in data:
+            # this is here for backwards compatibility
+            if (
+                data[CLASSNAME].startswith("numpy")
+                or data[CLASSNAME] == "kubernetes.client.models.v1_pod.V1Pod"
+            ):
+                return data[DATA]
+        return data
 
 
 class XComEncoder(json.JSONEncoder):
     """This encoder serializes any object that has attr, dataclass or a custom serializer."""
 
     def default(self, o: object) -> Any:
+        if isinstance(o, (set, frozenset)):
+            return list(o)
         try:
             return serialize(o)
         except TypeError:


### PR DESCRIPTION
Additional encoding logic is added for frozenset and set so the output is JSON-compatible.

Also removed some unnecessary error handling. The default encoder simply raises TypeError, so we don't need to catch TypeError from serialize().

Fix #28741.