### PR TITLE
Resolve all variables in pickled XCom iterator

### DIFF
--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -731,7 +731,12 @@ class LazyXComAccess(collections.abc.Sequence):
         # do the same for count(), but I think it should be performant enough to
         # calculate only that eagerly.
         with self._get_bound_query() as query:
-            statement = query.statement.compile(query.session.get_bind())
+            statement = query.statement.compile(
+                query.session.get_bind(),
+                # This inlines all the values into the SQL string to simplify
+                # cross-process commuinication as much as possible.
+                compile_kwargs={"literal_binds": True},
+            )
             return (str(statement), query.count())
 
     def __setstate__(self, state: Any) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -298,7 +298,7 @@ def skip_if_not_marked_with_backend(selected_backend, item):
         if selected_backend in backend_names:
             return
     pytest.skip(
-        f"The test is skipped because it does not have the right backend marker "
+        f"The test is skipped because it does not have the right backend marker. "
         f"Only tests marked with pytest.mark.backend('{selected_backend}') are run: {item}"
     )
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -3607,8 +3607,26 @@ def test_lazy_xcom_access_does_not_pickle_session(dag_maker, session):
     run: DagRun = dag_maker.create_dagrun()
     run.get_task_instance("t", session=session).xcom_push("xxx", 123, session=session)
 
-    original = LazyXComAccess.build_from_xcom_query(session.query(XCom))
+    query = session.query(XCom.value).filter_by(
+        dag_id=run.dag_id,
+        run_id=run.run_id,
+        task_id="t",
+        map_index=-1,
+        key="xxx",
+    )
+
+    original = LazyXComAccess.build_from_xcom_query(query)
     processed = pickle.loads(pickle.dumps(original))
+
+    # After the object went through pickling, the underlying ORM query should be
+    # replaced by one backed by a literal SQL string with all variables binded.
+    sql_lines = [line.strip() for line in str(processed._query.statement.compile(None)).splitlines()]
+    assert sql_lines == [
+        "SELECT xcom.value",
+        "FROM xcom",
+        "WHERE xcom.dag_id = 'test_dag' AND xcom.run_id = 'test' "
+        "AND xcom.task_id = 't' AND xcom.map_index = -1 AND xcom.\"key\" = 'xxx'",
+    ]
 
     assert len(processed) == 1
     assert list(processed) == [123]


### PR DESCRIPTION
This is needed for cross-process communication.

See discussion starting here: https://github.com/apache/airflow/pull/28191#issuecomment-1384931149

One thing I’m not sure about is the test; testing against a raw SQL string feels very brittle and can break from engine to engine, or SQLAlchemy version to version. But I can’t think of a better way.