### PR TITLE
Fix task id when making the mapped task label in graph view

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -90,7 +90,7 @@ const updateNodeLabels = (node, instances) => {
   let { label } = node.value;
   // Check if there is a count of mapped instances
   if ((tasks[node.id] && tasks[node.id].is_mapped) || node.value.isMapped) {
-    const firstChildId = node.children[0].id;
+    const id = !!node.children && node.children.length ? node.children[0].id : node.value.id;
 
     let count = ' ';
 
@@ -98,8 +98,8 @@ const updateNodeLabels = (node, instances) => {
     // TODO: update this count for when we can nest mapped tasks inside of mapped task groups
     if (instances[node.id] && instances[node.id].mapped_states) {
       count = instances[node.id].mapped_states.length;
-    } else if (firstChildId && instances[firstChildId]) {
-      count = instances[firstChildId].mapped_states.length;
+    } else if (id && instances[id]) {
+      count = instances[id].mapped_states.length;
     }
 
     if (!label.includes(`[${count}]`)) {


### PR DESCRIPTION
Something broke with node information on the graph view. We should get the task id differently now.

Fixes: https://github.com/apache/airflow/issues/28988

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
