### PR TITLE
Fixed MyPy errors introduced by new mysql-connector-python

### DIFF
--- a/airflow/providers/apache/hive/transfers/mysql_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/mysql_to_hive.py
@@ -143,12 +143,13 @@ class MySqlToHiveOperator(BaseOperator):
                 encoding="utf-8",
             )
             field_dict = OrderedDict()
-            for field in cursor.description:
-                field_dict[field[0]] = self.type_map(field[1])
+            if cursor.description is not None:
+                for field in cursor.description:
+                    field_dict[field[0]] = self.type_map(field[1])
             csv_writer.writerows(cursor)
             f.flush()
             cursor.close()
-            conn.close()
+            conn.close()  # type: ignore[misc]
             self.log.info("Loading file into Hive")
             hive.load_file(
                 f.name,

--- a/airflow/providers/mysql/hooks/mysql.py
+++ b/airflow/providers/mysql/hooks/mysql.py
@@ -78,7 +78,7 @@ class MySqlHook(DbApiHook):
         if hasattr(conn.__class__, "autocommit") and isinstance(conn.__class__.autocommit, property):
             conn.autocommit = autocommit
         else:
-            conn.autocommit(autocommit)
+            conn.autocommit(autocommit)  # type: ignore[operator]
 
     def get_autocommit(self, conn: MySQLConnectionTypes) -> bool:
         """
@@ -93,7 +93,7 @@ class MySqlHook(DbApiHook):
         if hasattr(conn.__class__, "autocommit") and isinstance(conn.__class__.autocommit, property):
             return conn.autocommit
         else:
-            return conn.get_autocommit()
+            return conn.get_autocommit()  # type: ignore[union-attr]
 
     def _get_conn_config_mysql_client(self, conn: Connection) -> dict:
         conn_config = {
@@ -199,7 +199,7 @@ class MySqlHook(DbApiHook):
             """
         )
         conn.commit()
-        conn.close()
+        conn.close()  # type: ignore[misc]
 
     def bulk_dump(self, table: str, tmp_file: str) -> None:
         """Dump a database table into a tab-delimited file."""
@@ -212,7 +212,7 @@ class MySqlHook(DbApiHook):
             """
         )
         conn.commit()
-        conn.close()
+        conn.close()  # type: ignore[misc]
 
     @staticmethod
     def _serialize_cell(cell: object, conn: Connection | None = None) -> Any:
@@ -283,4 +283,4 @@ class MySqlHook(DbApiHook):
 
         cursor.close()
         conn.commit()
-        conn.close()
+        conn.close()  # type: ignore[misc]


### PR DESCRIPTION
The new (8.0.32) mysql-connector-python introduces more typing and failed our MySQL provider mypy tests (because we are handling also other mysql clients)

Adding some excludes and handling None better for description solves the problem

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
