### PR TITLE
Remove limit for dnspython after eventlet got fixed

### DIFF
--- a/airflow/providers/apache/cassandra/provider.yaml
+++ b/airflow/providers/apache/cassandra/provider.yaml
@@ -36,11 +36,6 @@ versions:
 dependencies:
   - apache-airflow>=2.3.0
   - cassandra-driver>=3.13.0
-  # dnspython 2.3.0 is not compatible with eventlet that cassandra-driver uses under-the-hood
-  # This can be removed when the issue is resolved (reported in two places):
-  # * https://github.com/eventlet/eventlet/issues/781
-  # * https://datastax-oss.atlassian.net/browse/PYTHON-1320
-  - dnspython<2.3.0
 
 integrations:
   - integration-name: Apache Cassandra

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -53,8 +53,7 @@
   "apache.cassandra": {
     "deps": [
       "apache-airflow>=2.3.0",
-      "cassandra-driver>=3.13.0",
-      "dnspython<2.3.0"
+      "cassandra-driver>=3.13.0"
     ],
     "cross-providers-deps": []
   },

--- a/setup.py
+++ b/setup.py
@@ -216,12 +216,7 @@ def write_version(filename: str = str(AIRFLOW_SOURCES_ROOT / "airflow" / "git_ve
 # If you change this mark you should also change ./scripts/ci/check_order_setup.py
 # Start dependencies group
 async_packages = [
-    # dnspython 2.3.0 is not compatible with eventlet.
-    # This can be removed when the issue is resolved (reported in two places):
-    # * https://github.com/eventlet/eventlet/issues/781
-    # * https://datastax-oss.atlassian.net/browse/PYTHON-1320
-    "dnspython<2.3.0",
-    "eventlet>=0.9.7",
+    "eventlet>=0.33.3",
     "gevent>=0.13",
     "greenlet>=0.4.9",
 ]


### PR DESCRIPTION
The https://github.com/eventlet/eventlet/pull/782 fixed error that caused the need to limit dnspython and eventlet 0.33.3 has been released. We can now remove the limit
for dnspython as long as we also limit eventlet to >=0.33.3.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
