### PR TITLE
Revert "Remove conn.close() ignores (#29005)"

### DIFF
--- a/airflow/providers/apache/hive/transfers/mysql_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/mysql_to_hive.py
@@ -149,7 +149,7 @@ class MySqlToHiveOperator(BaseOperator):
             csv_writer.writerows(cursor)
             f.flush()
             cursor.close()
-            conn.close()
+            conn.close()  # type: ignore[misc]
             self.log.info("Loading file into Hive")
             hive.load_file(
                 f.name,

--- a/airflow/providers/mysql/hooks/mysql.py
+++ b/airflow/providers/mysql/hooks/mysql.py
@@ -78,7 +78,7 @@ class MySqlHook(DbApiHook):
         if hasattr(conn.__class__, "autocommit") and isinstance(conn.__class__.autocommit, property):
             conn.autocommit = autocommit
         else:
-            conn.autocommit(autocommit)
+            conn.autocommit(autocommit)  # type: ignore[operator]
 
     def get_autocommit(self, conn: MySQLConnectionTypes) -> bool:
         """
@@ -93,7 +93,7 @@ class MySqlHook(DbApiHook):
         if hasattr(conn.__class__, "autocommit") and isinstance(conn.__class__.autocommit, property):
             return conn.autocommit
         else:
-            return conn.get_autocommit()
+            return conn.get_autocommit()  # type: ignore[union-attr]
 
     def _get_conn_config_mysql_client(self, conn: Connection) -> dict:
         conn_config = {
@@ -199,7 +199,7 @@ class MySqlHook(DbApiHook):
             """
         )
         conn.commit()
-        conn.close()
+        conn.close()  # type: ignore[misc]
 
     def bulk_dump(self, table: str, tmp_file: str) -> None:
         """Dump a database table into a tab-delimited file."""
@@ -212,7 +212,7 @@ class MySqlHook(DbApiHook):
             """
         )
         conn.commit()
-        conn.close()
+        conn.close()  # type: ignore[misc]
 
     @staticmethod
     def _serialize_cell(cell: object, conn: Connection | None = None) -> Any:
@@ -283,4 +283,4 @@ class MySqlHook(DbApiHook):
 
         cursor.close()
         conn.commit()
-        conn.close()
+        conn.close()  # type: ignore[misc]


### PR DESCRIPTION
This reverts commit 85f8df7b8a18e1147c7e014a7af7fc4e66aaa8be.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
