### PR TITLE
Properly test that audit log secrets are masked for connection objects

### DIFF
--- a/tests/test_utils/www.py
+++ b/tests/test_utils/www.py
@@ -104,11 +104,16 @@ def _check_last_log_masked_connection(session, dag_id, event, execution_date):
     )
     assert len(logs) >= 1
     extra = ast.literal_eval(logs[0].extra)
-    for k, v in extra:
-        if k == "password":
-            assert v == "***"
-        if k == "extra":
-            assert v == '{"x_secret": "***", "y_secret": "***"}'
+    assert extra == [
+        ("conn_id", "test_conn"),
+        ("conn_type", "http"),
+        ("description", "description"),
+        ("host", "localhost"),
+        ("port", "8080"),
+        ("username", "root"),
+        ("password", "***"),
+        ("extra", '{"x_secret": "***", "y_secret": "***"}'),
+    ]
 
 
 def _check_last_log_masked_variable(session, dag_id, event, execution_date):

--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -40,11 +40,14 @@ CONNECTION = {
     "password": "admin",
 }
 
-CONNECTION_WITH_EXTRA = CONNECTION.update(
-    {
-        "extra": '{"x_secret": "testsecret","y_secret": "test"}',
-    }
-)
+
+def conn_with_extra():
+    CONNECTION.update(
+        {
+            "extra": '{"x_secret": "testsecret","y_secret": "test"}',
+        }
+    )
+    return CONNECTION
 
 
 @pytest.fixture(autouse=True)
@@ -62,7 +65,7 @@ def test_create_connection(admin_client, session):
 
 def test_action_logging_connection_masked_secrets(session, admin_client):
     init_views.init_connection_form()
-    admin_client.post("/connection/add", data=CONNECTION_WITH_EXTRA, follow_redirects=True)
+    admin_client.post("/connection/add", data=conn_with_extra(), follow_redirects=True)
     _check_last_log_masked_connection(session, dag_id=None, event="connection.create", execution_date=None)
 
 


### PR DESCRIPTION
The previous test was wrong as the connection was updated in place which returned None

