### PR TITLE
Improve serialization of tuples and sets

### DIFF
--- a/airflow/datasets/__init__.py
+++ b/airflow/datasets/__init__.py
@@ -29,7 +29,7 @@ class Dataset:
     uri: str = attr.field(validator=[attr.validators.min_len(1), attr.validators.max_len(3000)])
     extra: dict[str, Any] | None = None
 
-    version: ClassVar[int] = 1
+    __version__: ClassVar[int] = 1
 
     @uri.validator
     def _check_uri(self, attr, uri: str):

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -105,14 +105,8 @@ def serialize(o: object, depth: int = 0) -> U | None:
 
         return o
 
-    # tuples and plain dicts are iterated over recursively
-    if isinstance(o, _builtin_collections):
-        s = [serialize(d, depth + 1) for d in o]
-        if isinstance(o, tuple):
-            return tuple(s)
-        if isinstance(o, set):
-            return set(s)
-        return s
+    if isinstance(o, list):
+        return [serialize(d, depth + 1) for d in o]
 
     if isinstance(o, dict):
         if CLASSNAME in o or SCHEMA_ID in o:
@@ -181,8 +175,16 @@ def deserialize(o: T | None, full=True, type_hint: Any = None) -> object:
     if isinstance(o, _primitives):
         return o
 
+    # tuples, sets are included here for backwards compatibility
     if isinstance(o, _builtin_collections):
-        return [deserialize(d) for d in o]
+        col = [deserialize(d) for d in o]
+        if isinstance(o, tuple):
+            return tuple(col)
+
+        if isinstance(o, set):
+            return set(col)
+
+        return col
 
     if not isinstance(o, dict):
         raise TypeError()

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -68,8 +68,13 @@ def encode(cls: str, version: int, data: T) -> dict[str, str | int | T]:
     return {CLASSNAME: cls, VERSION: version, DATA: data}
 
 
-def decode(d: dict[str, str | int | T]) -> tuple:
-    return d[CLASSNAME], d[VERSION], d.get(DATA, None)
+def decode(d: dict[str, Any]) -> tuple[str, int, Any]:
+    classname = d[CLASSNAME]
+    version = d[VERSION]
+    if not isinstance(classname, str) or not isinstance(version, int):
+        raise ValueError(f"can not decode {d!r}")
+    data = d.get(DATA, None)
+    return classname, version, data
 
 
 def serialize(o: object, depth: int = 0) -> U | None:
@@ -201,7 +206,7 @@ def deserialize(o: T | None, full=True, type_hint: Any = None) -> object:
     cls: Any
     version = 0
     value: Any = None
-    classname: str = ""
+    classname = ""
 
     if type_hint:
         cls = type_hint
@@ -212,7 +217,7 @@ def deserialize(o: T | None, full=True, type_hint: Any = None) -> object:
     if CLASSNAME in o and VERSION in o:
         classname, version, value = decode(o)
 
-    if classname == "":
+    if not classname:
         raise TypeError("classname cannot be empty")
 
     # only return string representation

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -200,8 +200,8 @@ def deserialize(o: T | None, full=True, type_hint: Any = None) -> object:
     # custom deserialization starts here
     cls: Any
     version = 0
-    value: Any
-    classname: str
+    value: Any = None
+    classname: str = ""
 
     if type_hint:
         cls = type_hint
@@ -211,6 +211,9 @@ def deserialize(o: T | None, full=True, type_hint: Any = None) -> object:
 
     if CLASSNAME in o and VERSION in o:
         classname, version, value = decode(o)
+
+    if classname == "":
+        raise TypeError("classname cannot be empty")
 
     # only return string representation
     if not full:
@@ -271,10 +274,12 @@ def _stringify(classname: str, version: int, value: T | None) -> str:
 
     s = f"{classname}@version={version}("
     if isinstance(value, _primitives):
+        print("PRIMITIVE")
         s += f"{value})"
     elif isinstance(value, _builtin_collections):
         s += ",".join(str(deserialize(value, full=False)))
     elif isinstance(value, dict):
+        print(f"DICT {value}")
         for k, v in value.items():
             s += f"{k}={deserialize(v, full=False)},"
         s = s[:-1] + ")"

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -270,9 +270,10 @@ def _match(classname: str) -> bool:
 
 
 def _stringify(classname: str, version: int, value: T | None) -> str:
-    """
-    Returns a previously serialized object in a somewhat human-readable format. It is not designed to
-    be exact and will not extensively traverse the whole tree of an object.
+    """Convert a previously serialized object in a somewhat human-readable format.
+
+    This function is not designed to be exact, and will not extensively traverse
+    the whole tree of an object.
     """
     if classname in _stringifiers:
         return _stringifiers[classname].stringify(classname, version, value)
@@ -292,7 +293,7 @@ def _stringify(classname: str, version: int, value: T | None) -> str:
 
 
 def _register():
-    """Register builtin serializers and deserializers for types that don't have any themselves"""
+    """Register builtin serializers and deserializers for types that don't have any themselves."""
     _serializers.clear()
     _deserializers.clear()
     _stringifiers.clear()
@@ -300,14 +301,14 @@ def _register():
     with Stats.timer("serde.load_serializers") as timer:
         for _, name, _ in iter_namespace(airflow.serialization.serializers):
             name = import_module(name)
-            for s in getattr(name, "serializers", list()):
+            for s in getattr(name, "serializers", ()):
                 if not isinstance(s, str):
                     s = qualname(s)
                 if s in _serializers and _serializers[s] != name:
                     raise AttributeError(f"duplicate {s} for serialization in {name} and {_serializers[s]}")
                 log.debug("registering %s for serialization", s)
                 _serializers[s] = name
-            for d in getattr(name, "deserializers", list()):
+            for d in getattr(name, "deserializers", ()):
                 if not isinstance(d, str):
                     d = qualname(d)
                 if d in _deserializers and _deserializers[d] != name:
@@ -315,7 +316,7 @@ def _register():
                 log.debug("registering %s for deserialization", d)
                 _deserializers[d] = name
                 _extra_allowed.add(d)
-            for c in getattr(name, "stringifiers", list()):
+            for c in getattr(name, "stringifiers", ()):
                 if not isinstance(c, str):
                     c = qualname(c)
                 if c in _deserializers and _deserializers[c] != name:

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -71,9 +71,12 @@ def encode(cls: str, version: int, data: T) -> dict[str, str | int | T]:
 def decode(d: dict[str, Any]) -> tuple[str, int, Any]:
     classname = d[CLASSNAME]
     version = d[VERSION]
+
     if not isinstance(classname, str) or not isinstance(version, int):
-        raise ValueError(f"can not decode {d!r}")
+        raise ValueError(f"cannot decode {d!r}")
+
     data = d.get(DATA)
+
     return classname, version, data
 
 

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -91,6 +91,11 @@ def serialize(o: object, depth: int = 0) -> U | None:
     2. A registered serializer in the namespace of ``airflow.serialization.serializers``
     3. Annotations from attr or dataclass.
 
+    Limitations: attr and dataclass objects can lose type information for nested objects
+    as they do not store this when calling ``asdict``. This means that at deserialization values
+    will be deserialized as a dict as opposed to reinstating the object. Provide
+    your own serializer to work around this.
+
     :param o: The object to serialize.
     :param depth: Private tracker for nested serialization.
     :raise TypeError: A serializer cannot be found.

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -274,12 +274,11 @@ def _stringify(classname: str, version: int, value: T | None) -> str:
 
     s = f"{classname}@version={version}("
     if isinstance(value, _primitives):
-        print("PRIMITIVE")
         s += f"{value})"
     elif isinstance(value, _builtin_collections):
+        # deserialized values can be != str
         s += ",".join(str(deserialize(value, full=False)))
     elif isinstance(value, dict):
-        print(f"DICT {value}")
         for k, v in value.items():
             s += f"{k}={deserialize(v, full=False)},"
         s = s[:-1] + ")"

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -73,7 +73,7 @@ def decode(d: dict[str, Any]) -> tuple[str, int, Any]:
     version = d[VERSION]
     if not isinstance(classname, str) or not isinstance(version, int):
         raise ValueError(f"can not decode {d!r}")
-    data = d.get(DATA, None)
+    data = d.get(DATA)
     return classname, version, data
 
 

--- a/airflow/serialization/serializers/builtin.py
+++ b/airflow/serialization/serializers/builtin.py
@@ -26,8 +26,9 @@ if TYPE_CHECKING:
 
 __version__ = 1
 
-serializers = [frozenset, set, tuple]
+serializers = ["builtins.frozenset", "builtins.set", "builtins.tuple"]
 deserializers = serializers
+stringifiers = serializers
 
 
 def serialize(o: object) -> tuple[U, str, int, bool]:
@@ -48,3 +49,11 @@ def deserialize(classname: str, version: int, data: list) -> tuple | set | froze
         return frozenset(data)
 
     raise TypeError(f"do not know how to deserialize {classname}")
+
+
+def stringify(classname: str, version: int, data: list) -> str:
+    if classname not in stringifiers:
+        return TypeError(f"do not know how to stringify {classname}")
+
+    s = ",".join(str(d) for d in data)
+    return f"({s})"

--- a/airflow/serialization/serializers/builtin.py
+++ b/airflow/serialization/serializers/builtin.py
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from airflow.utils.module_loading import qualname
+
+if TYPE_CHECKING:
+    from airflow.serialization.serde import U
+
+__version__ = 1
+
+serializers = [frozenset, set, tuple]
+deserializers = serializers
+
+
+def serialize(o: object) -> tuple[U, str, int, bool]:
+    return list(cast(list, o)), qualname(o), __version__, True
+
+
+def deserialize(classname: str, version: int, data: list) -> tuple | set | frozenset:
+    if version > __version__:
+        raise TypeError("serialized version is newer than class version")
+
+    if classname == qualname(tuple):
+        return tuple(data)
+
+    if classname == qualname(set):
+        return set(data)
+
+    if classname == qualname(frozenset):
+        return frozenset(data)
+
+    raise TypeError(f"do not know how to deserialize {classname}")

--- a/airflow/serialization/serializers/builtin.py
+++ b/airflow/serialization/serializers/builtin.py
@@ -53,7 +53,7 @@ def deserialize(classname: str, version: int, data: list) -> tuple | set | froze
 
 def stringify(classname: str, version: int, data: list) -> str:
     if classname not in stringifiers:
-        return TypeError(f"do not know how to stringify {classname}")
+        raise TypeError(f"do not know how to stringify {classname}")
 
     s = ",".join(str(d) for d in data)
     return f"({s})"

--- a/airflow/utils/json.py
+++ b/airflow/utils/json.py
@@ -88,6 +88,10 @@ class XComEncoder(json.JSONEncoder):
         if isinstance(o, dict) and (CLASSNAME in o or SCHEMA_ID in o):
             raise AttributeError(f"reserved key {CLASSNAME} found in dict to serialize")
 
+        # tuples are not preserved by std python serializer
+        if isinstance(o, tuple):
+            o = self.default(o)
+
         return super().encode(o)
 
 

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -179,7 +179,7 @@ class TestAirflowTaskDecorator(BasePythonTest):
         ti = dr.get_task_instances()[0]
 
         assert res.operator.multiple_outputs is False
-        assert ti.xcom_pull() == [8, 4]
+        assert ti.xcom_pull() == (8, 4)
         assert ti.xcom_pull(key="return_value_0") is None
         assert ti.xcom_pull(key="return_value_1") is None
 
@@ -197,7 +197,7 @@ class TestAirflowTaskDecorator(BasePythonTest):
         ti = dr.get_task_instances()[0]
 
         assert not ident.operator.multiple_outputs
-        assert ti.xcom_pull() == [35, 36]
+        assert ti.xcom_pull() == (35, 36)
         assert ti.xcom_pull(key="return_value_0") is None
         assert ti.xcom_pull(key="return_value_1") is None
 

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -280,12 +280,18 @@ class TestSerDe:
         e = serialize(i)
         s = deserialize(e, full=False)
 
+        print(s)
         assert f"{qualname(V)}@version={V.__version__}" in s
         # asdict from dataclasses removes class information
         assert "w={'x': 10}" in s
         assert "l=['l1', 'l2']" in s
         assert "t=(1,2)" in s
         assert "c=10" in s
+        e["__data__"]["t"] = (1, 2)
+        print(f"XXXX: {e}")
+
+        s = deserialize(e, full=False)
+        print(f"XXX: {s}")
 
     @pytest.mark.parametrize(
         "obj, expected",

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -280,7 +280,6 @@ class TestSerDe:
         e = serialize(i)
         s = deserialize(e, full=False)
 
-        print(s)
         assert f"{qualname(V)}@version={V.__version__}" in s
         # asdict from dataclasses removes class information
         assert "w={'x': 10}" in s
@@ -288,10 +287,8 @@ class TestSerDe:
         assert "t=(1,2)" in s
         assert "c=10" in s
         e["__data__"]["t"] = (1, 2)
-        print(f"XXXX: {e}")
 
         s = deserialize(e, full=False)
-        print(f"XXX: {s}")
 
     @pytest.mark.parametrize(
         "obj, expected",

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -104,17 +104,34 @@ class TestSerDe:
         e = serialize(i)
         assert i == e
 
-    def test_ser_iterables(self):
+    def test_ser_collections(self):
         i = [1, 2]
-        e = serialize(i)
+        e = deserialize(serialize(i))
         assert i == e
 
         i = ("a", "b", "a", "c")
-        e = serialize(i)
+        e = deserialize(serialize(i))
         assert i == e
 
         i = {2, 3}
-        e = serialize(i)
+        e = deserialize(serialize(i))
+        assert i == e
+
+        i = frozenset({6, 7})
+        e = deserialize(serialize(i))
+        assert i == e
+
+    def test_der_collections_compat(self):
+        i = [1, 2]
+        e = deserialize(i)
+        assert i == e
+
+        i = ("a", "b", "a", "c")
+        e = deserialize(i)
+        assert i == e
+
+        i = {2, 3}
+        e = deserialize(i)
         assert i == e
 
     def test_ser_plain_dict(self):

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -84,7 +84,7 @@ class W:
 class V:
     __version__: ClassVar[int] = 1
     w: W
-    l: list
+    s: list
     t: tuple
     c: int
 

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -283,7 +283,7 @@ class TestSerDe:
         assert f"{qualname(V)}@version={V.__version__}" in s
         # asdict from dataclasses removes class information
         assert "w={'x': 10}" in s
-        assert "l=['l1', 'l2']" in s
+        assert "s=['l1', 'l2']" in s
         assert "t=(1,2)" in s
         assert "c=10" in s
         e["__data__"]["t"] = (1, 2)

--- a/tests/utils/test_json.py
+++ b/tests/utils/test_json.py
@@ -78,3 +78,20 @@ class TestXComEncoder:
         s = json.dumps(u, cls=utils_json.XComEncoder)
         o = json.loads(s, cls=utils_json.XComDecoder, object_hook=utils_json.XComDecoder.orm_object_hook)
         assert o == f"{U.__module__}.{U.__qualname__}@version={U.__version__}(x={x})"
+
+    def test_collections(self):
+        i = [1, 2]
+        e = json.loads(json.dumps(i, cls=utils_json.XComEncoder), cls=utils_json.XComDecoder)
+        assert i == e
+
+        i = ("a", "b", "a", "c")
+        e = json.loads(json.dumps(i, cls=utils_json.XComEncoder), cls=utils_json.XComDecoder)
+        assert i == e
+
+        i = {2, 3}
+        e = json.loads(json.dumps(i, cls=utils_json.XComEncoder), cls=utils_json.XComDecoder)
+        assert i == e
+
+        i = frozenset({6, 7})
+        e = json.loads(json.dumps(i, cls=utils_json.XComEncoder), cls=utils_json.XComDecoder)
+        assert i == e


### PR DESCRIPTION
Sets cannot be encoded into JSON directly
and tuples loose information when serialized into JSON directly. We now serialize both into a dict and encode them properly.

@uranusjr 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
