### PR TITLE
[docs] change context example to no longer use as variable

### DIFF
--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -40,7 +40,7 @@ which will add the DAG to anything inside it implicitly::
     with DAG(
         "my_dag_name", start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
         schedule="@daily", catchup=False
-    ) as dag:
+    ):
         op = EmptyOperator(task_id="task")
 
 Or, you can use a standard constructor, passing the dag into any


### PR DESCRIPTION
Due to: https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#dags-used-in-a-context-manager-no-longer-need-to-be-assigned-to-a-module-variable-23592

DAGs using the context manager no longer need `with DAG(...) as dag:` to register, thus the first example in the DAGs concept should be updated to reflect this.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
