### PR TITLE
Update owner list for release dockerhub image workflow

### DIFF
--- a/.github/workflows/release_dockerhub_image.yml
+++ b/.github/workflows/release_dockerhub_image.yml
@@ -76,6 +76,7 @@ jobs:
       "ephraimbuddy",
       "jedcunningham",
       "kaxil",
+      "pierrejeambrun",
       "potiuk",
       ]'), github.event.sender.login)
     steps:


### PR DESCRIPTION
Add pierrejeambrun to owners of `Release PROD images` workflow.

Tried to keep the list sorted :)