### PR TITLE
Add norm to triage group

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -74,6 +74,7 @@ github:
     - gmcdonald
     - mhenc
     - ferruzzi
+    - norm
 
 notifications:
   jobs: jobs@airflow.apache.org


### PR DESCRIPTION
@norm is going to help manage issues for AIP-52.