### PR TITLE
Fix `project-name` generation for Providers `test-type` in Breeze

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import os
+import re
 import sys
 from datetime import datetime
 
@@ -198,8 +199,9 @@ def _run_test(
     return result.returncode, f"Test: {exec_shell_params.test_type}"
 
 
-def _file_name_from_test_type(test_type):
-    return test_type.lower().replace("[", "_").replace("]", "").replace(",", "_")[:30]
+def _file_name_from_test_type(test_type: str):
+    test_type_no_brackets = test_type.lower().replace("[", "_").replace("]", "")
+    return re.sub("[,\.]", "_", test_type_no_brackets)[:30]
 
 
 def _run_tests_in_pool(


### PR DESCRIPTION
The `breeze testing tests --test-type "Providers[...]"` command would fail for an invalid `project-name` for `docker compose` if the provider(s) specified required a dotted path (e.g. `microsoft.azure`, `dbt.cloud`, etc.).

For example:
```bash
~/code/airflow
> breeze testing tests --test-type "Providers[dbt.cloud]"
Docker filesystem: apfs
Good version of Docker: 20.10.21.
Good version of docker-compose: 2.13.0
Good Docker context used: default.
"airflow-test-providers_dbt.cloud" is not a valid project name
"airflow-test-providers_dbt.cloud" is not a valid project name
"airflow-test-providers_dbt.cloud" is not a valid project name
```

This fixes the `project-name` generation in Breeze when using the `Providers` test type for those dotted-path providers.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
