### PR TITLE
Renaming nose compatible methods in flavour of regular pytest naming

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -21,6 +21,9 @@ addopts =
     --verbosity=2
     ; Disable `flaky` plugin for pytest. This plugin conflicts with `rerunfailures` because provide same marker.
     -p no:flaky
+    ; Disable `nose` builtin plugin for pytest. This feature deprecated in 7.2 and will be removed in pytest>=8
+    ; And we focus on use native pytest capabilities rather than adopt another frameworks.
+    -p no:nose
 norecursedirs =
     .eggs
     airflow

--- a/tests/api/common/test_mark_tasks.py
+++ b/tests/api/common/test_mark_tasks.py
@@ -71,7 +71,7 @@ class TestMarkTasks:
         ]
 
     @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup_tests(self):
 
         clear_db_runs()
         drs = _create_dagruns(

--- a/tests/providers/amazon/aws/hooks/test_ssm.py
+++ b/tests/providers/amazon/aws/hooks/test_ssm.py
@@ -33,11 +33,13 @@ PARAM_VALUE = "value"
 DEFAULT_VALUE = "default"
 
 
-@mock_ssm
 class TestSsmHooks:
-    def setup(self):
-        self.hook = SsmHook(region_name=REGION)
-        self.hook.conn.put_parameter(Name=EXISTING_PARAM_NAME, Value=PARAM_VALUE, Overwrite=True)
+    @pytest.fixture(autouse=True)
+    def setup_tests(self):
+        with mock_ssm():
+            self.hook = SsmHook(region_name=REGION)
+            self.hook.conn.put_parameter(Name=EXISTING_PARAM_NAME, Value=PARAM_VALUE, Overwrite=True)
+            yield
 
     def test_hook(self) -> None:
         assert self.hook.conn is not None

--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -51,7 +51,7 @@ def logmock():
 class TestCloudwatchTaskHandler:
     @conf_vars({("logging", "remote_log_conn_id"): "aws_default"})
     @pytest.fixture(autouse=True)
-    def setup(self, create_log_template, tmp_path_factory):
+    def setup_tests(self, create_log_template, tmp_path_factory):
         self.remote_log_group = "log_group_name"
         self.region_name = "us-west-2"
         self.local_log_location = str(tmp_path_factory.mktemp("local-cloudwatch-log-location"))

--- a/tests/providers/amazon/aws/log/test_s3_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_s3_task_handler.py
@@ -45,7 +45,7 @@ def s3mock():
 class TestS3TaskHandler:
     @conf_vars({("logging", "remote_log_conn_id"): "aws_default"})
     @pytest.fixture(autouse=True)
-    def setup(self, create_log_template, tmp_path_factory):
+    def setup_tests(self, create_log_template, tmp_path_factory):
         self.remote_log_base = "s3://bucket/remote/log/location"
         self.remote_log_location = "s3://bucket/remote/log/location/1.log"
         self.remote_log_key = "remote/log/location/1.log"

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -87,7 +87,7 @@ def create_context(task, persist_to_db=False, map_index=None):
 @pytest.mark.execution_timeout(300)
 class TestKubernetesPodOperator:
     @pytest.fixture(autouse=True)
-    def setup(self, dag_maker):
+    def setup_tests(self, dag_maker):
         self.create_pod_patch = patch(f"{POD_MANAGER_CLASS}.create_pod")
         self.await_pod_patch = patch(f"{POD_MANAGER_CLASS}.await_pod_start")
         self.await_pod_completion_patch = patch(f"{POD_MANAGER_CLASS}.await_pod_completion")


### PR DESCRIPTION
In pytest 7.2 execute nose compatible methods such as `setup()`/`teardown()` was removed: https://github.com/pytest-dev/pytest/issues/9886

Even though we use old version of pytest it better resolve it before we upgrade to the newest `pytest`

Most of the methods in this PR are actually fixtures and I don't think it affected by this deprecation.