### PR TITLE
Pin ruff to specific version and prevent from "fixing" cli conftest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -172,7 +172,7 @@ repos:
         # Since ruff makes use of multiple cores we _purposefully_ don't run this in docker so it can use the
         # host CPU to it's fullest
         entry: ruff --fix --no-update-check --force-exclude
-        additional_dependencies: ['ruff>=0.0.219']
+        additional_dependencies: ['ruff==0.0.226']
         files: \.pyi?$
         exclude: ^airflow/_vendor/
   - repo: https://github.com/psf/black

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -27,7 +27,7 @@ from airflow.executors import celery_executor, celery_kubernetes_executor
 from tests.test_utils.config import conf_vars
 
 # Create custom executors here because conftest is imported first
-custom_executor_module = type(sys)("custom_executor")
+custom_executor_module = type(sys)("custom_executor")  # noqa
 custom_executor_module.CustomCeleryExecutor = type(  # type:  ignore
     "CustomCeleryExecutor", (celery_executor.CeleryExecutor,), {}
 )


### PR DESCRIPTION
New Ruff release started to "fix" our cli conftest cofiguration, leading to mypy complaining about the changed line.

This change prevents ruff from "fixing" the line as well as pins ruff to latest released version so that any future changes are applied deliberately when we upgrade.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
