### PR TITLE
Fix params rendering in AzureSynapseHook Python API docs

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/synapse.py
+++ b/airflow/providers/microsoft/azure/hooks/synapse.py
@@ -50,6 +50,7 @@ class AzureSynapseSparkBatchRunStatus:
 class AzureSynapseHook(BaseHook):
     """
     A hook to interact with Azure Synapse.
+
     :param azure_synapse_conn_id: The :ref:`Azure Synapse connection id<howto/connection:synapse>`.
     :param spark_pool: The Apache Spark pool used to submit the job
     """


### PR DESCRIPTION
Trivial update to add a newline between the description and `:param:` directives in the AzureSynapseHook docstring. This allows the parameters to be rendered properly in the Python API documentation for better readability.

**Before**
<img width="915" alt="image" src="https://user-images.githubusercontent.com/48934154/213469583-70033240-c4b5-424b-bac5-408e52c67acf.png">

**After**
<img width="910" alt="image" src="https://user-images.githubusercontent.com/48934154/213469659-ac4b7d5f-036e-4765-9505-dc43a48eb9eb.png">

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
