### PR TITLE
Clarify graph view dynamic task labels

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -88,18 +88,19 @@ let innerSvg = d3.select('#graph-svg g');
 const updateNodeLabels = (node, instances) => {
   let haveLabelsChanged = false;
   let { label } = node.value;
-  // Check if there is a count of mapped instances
-  if ((tasks[node.id] && tasks[node.id].is_mapped) || node.value.isMapped) {
-    const id = !!node.children && node.children.length ? node.children[0].id : node.value.id;
 
+  const isGroupMapped = node.value.isMapped;
+  const isTaskMapped = tasks[node.id] && tasks[node.id].is_mapped;
+
+  if (isTaskMapped || isGroupMapped) {
+    // get count from mapped_states or the first child's mapped_states
+    const id = isGroupMapped ? node.children[0].id : node.id;
+    const instance = instances[id];
     let count = ' ';
 
-    // get count from mapped_states or the first child's mapped_states
     // TODO: update this count for when we can nest mapped tasks inside of mapped task groups
-    if (instances[node.id] && instances[node.id].mapped_states) {
-      count = instances[node.id].mapped_states.length;
-    } else if (id && instances[id]) {
-      count = instances[id].mapped_states.length;
+    if (instance && instance.mapped_states) {
+      count = instance.mapped_states.length;
     }
 
     if (!label.includes(`[${count}]`)) {


### PR DESCRIPTION
Fixing an issue reported in https://github.com/apache/airflow/issues/28973
Closes: https://github.com/apache/airflow/issues/29105

Skipped dynamic tasks put us in a position where a task was mapped but it had not mapped states and updating the graph labels would fail.

Also, handling mapped tasks vs mapped task groups were confusing. This PR aims to simplify that.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
