### PR TITLE
Move imports in AWS SqlToS3Operator transfer to callable function

### DIFF
--- a/airflow/providers/amazon/aws/transfers/sql_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/sql_to_s3.py
@@ -31,8 +31,9 @@ from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
     from pandas import DataFrame
+    
+    from airflow.utils.context import Context
 
 
 class FILE_FORMAT(enum.Enum):

--- a/airflow/providers/amazon/aws/transfers/sql_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/sql_to_s3.py
@@ -32,7 +32,7 @@ from airflow.providers.common.sql.hooks.sql import DbApiHook
 
 if TYPE_CHECKING:
     from pandas import DataFrame
-    
+
     from airflow.utils.context import Context
 
 

--- a/airflow/providers/amazon/aws/transfers/sql_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/sql_to_s3.py
@@ -32,6 +32,7 @@ from airflow.providers.common.sql.hooks.sql import DbApiHook
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
+    from pandas import DataFrame
 
 
 class FILE_FORMAT(enum.Enum):
@@ -127,22 +128,18 @@ class SqlToS3Operator(BaseOperator):
             raise AirflowException(f"The argument file_format doesn't support {file_format} value.")
 
     @staticmethod
-    def _fix_dtypes(df, file_format: FILE_FORMAT) -> None:
+    def _fix_dtypes(df: DataFrame, file_format: FILE_FORMAT) -> None:
         """
         Mutate DataFrame to set dtypes for float columns containing NaN values.
         Set dtype of object to str to allow for downstream transformations.
         """
         try:
             import numpy as np
-            from pandas import DataFrame, Float64Dtype, Int64Dtype
+            from pandas import Float64Dtype, Int64Dtype
         except ImportError as e:
             from airflow.exceptions import AirflowOptionalProviderFeatureException
 
             raise AirflowOptionalProviderFeatureException(e)
-
-        # DataFrame type checking should be postponed because of imports order
-        if not isinstance(df, DataFrame):
-            raise TypeError('The given dataframe is not a valid pandas DataFrame')
 
         for col in df:
 


### PR DESCRIPTION
closes: #29036

Moved heavy imports `numpy` and `pandas` to the body of the static function `_fix_dtypes` to comply with the [Best Practices](https://airflow.apache.org/docs/apache-airflow/2.3.3/best-practices.html#top-level-python-code) and avoid `DagBag` fill timeouts.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
