### PR TITLE
Add a summary table at the end of system test execs

### DIFF
--- a/tests/system/utils/__init__.py
+++ b/tests/system/utils/__init__.py
@@ -16,13 +16,50 @@
 # under the License.
 from __future__ import annotations
 
+import logging
 import os
+from datetime import timedelta
+from typing import Callable
 
+from tabulate import tabulate
+
+from airflow.utils.context import Context
 from airflow.utils.state import State
 
 
 def get_test_run(dag):
+    def callback(context: Context):
+        ti = context["dag_run"].get_task_instances()
+        if not ti:
+            logging.warning("could not retrieve tasks that ran in the DAG, cannot display a summary")
+            return
+
+        ti.sort(key=lambda x: x.end_date)
+
+        headers = ["Task ID", "Status", "Duration (s)"]
+        results = []
+        # computing time using previous task's end time
+        # because task.duration only counts last poke for sensors.
+        # Only produces meaningful results when running sequentially, which is the case for system tests
+        prev_time = ti[0].end_date - timedelta(seconds=ti[0].duration)
+        for t in ti:
+            results.append([t.task_id, t.state, f"{(t.end_date - prev_time).total_seconds():.1f}"])
+            prev_time = t.end_date
+
+        logging.info("EXECUTION SUMMARY:\n" + tabulate(results, headers=headers, tablefmt="fancy_grid"))
+
+    def add_callback(current: list[Callable] | Callable | None, new: Callable) -> list[Callable] | Callable:
+        if not current:
+            return new
+        elif isinstance(current, list):
+            current.append(new)
+            return current
+        else:
+            return [current, new]
+
     def test_run():
+        dag.on_failure_callback = add_callback(dag.on_failure_callback, callback)
+        dag.on_success_callback = add_callback(dag.on_success_callback, callback)
         dag.clear(dag_run_state=State.QUEUED)
         dag.run()
 


### PR DESCRIPTION
In my experience, it's currently hard to see exactly what error caused an example dag/system test to fail, because it doesn't stop right away, and teardown tasks can error as well, so it becomes an adventure up the logs to find the source of the problem.
To help with that, I propose adding a summary of the run at the end of the execution with the status of the tasks. it looks like this (in this case I ran the example_batch from aws system tests):
![image](https://user-images.githubusercontent.com/114772123/213582735-d026a29a-ea63-4845-ace1-d40a0c0b68a6.png)
and in case of failure:
![image](https://user-images.githubusercontent.com/114772123/213582772-2c207308-7d00-4e98-bdb2-1419224058a1.png)

I'm hooking myself to the dag callback to do this, and pulling the info from the tasks. I added a little duration summary as well as a freebie.

It's going to be run at the end of every system test, so I guess it could be nice to get a review from some other providers who run their system tests as well :)