### PR TITLE
Fix kerberos authentication for the REST API.

### DIFF
--- a/airflow/api/auth/backend/kerberos_auth.py
+++ b/airflow/api/auth/backend/kerberos_auth.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+from airflow.utils.airflow_flask_app import get_airflow_app
+
 #
 # Copyright (c) 2013, Michael Komitee
 # All rights reserved.
@@ -141,7 +143,7 @@ def requires_authentication(function: T):
             token = "".join(header.split()[1:])
             return_code = _gssapi_authenticate(token)
             if return_code == kerberos.AUTH_GSS_COMPLETE:
-                g.user = ctx.kerberos_user
+                g.user = get_airflow_app().appbuilder.sm.find_user(username=ctx.kerberos_user)
                 response = function(*args, **kwargs)
                 response = make_response(response)
                 if ctx.kerberos_token is not None:

--- a/docs/apache-airflow/administration-and-deployment/security/api.rst
+++ b/docs/apache-airflow/administration-and-deployment/security/api.rst
@@ -83,6 +83,9 @@ To enable Kerberos authentication, set the following in the configuration:
 The Kerberos service is configured as ``airflow/fully.qualified.domainname@REALM``. Make sure this
 principal exists in the keytab file.
 
+You have to make sure to name your users with the kerberos full username/realm in order to make it
+works. This means that your user name should be ``user_name@KERBEROS-REALM``.
+
 Basic authentication
 ''''''''''''''''''''
 


### PR DESCRIPTION
Previously we assigned kerberos user name directly to the flask user,
but this had no chance to work because we expect FAB user there and
our security code crash with 'str' has no attribute 'perms'.

This PR uses Kerberos username (including the Kerberos realm) to
retrieve the user from the security manager. This means that
the user name has to have the form of `user_name@KERBEROS_REALM`.

The reason why we are not using email (despite similarities of
the realm and domain name is that those are often different. Email
domain names have often nothing to do the with the realms within
organisations, and it seems safer to put fully qualified names
including the realm in order to uniquely identify the users in
case the organisation uses more than one REALM.

Fixes: https://github.com/apache/airflow/issues/28919

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
