### PR TITLE
Handling error on cluster policy itself

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -169,6 +169,10 @@ class AirflowClusterPolicyViolation(AirflowException):
     """Raise when there is a violation of a Cluster Policy in DAG definition."""
 
 
+class AirflowClusterPolicyError(AirflowException):
+    """Raise when there is an error except AirflowClusterPolicyViolation in Cluster Policy."""
+
+
 class AirflowTimetableInvalid(AirflowException):
     """Raise when a DAG has an invalid timetable."""
 

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -437,23 +437,9 @@ class DagBag(LoggingMixin):
             try:
                 dag.validate()
                 self.bag_dag(dag=dag, root_dag=dag)
-            except AirflowTimetableInvalid as exception:
+            except Exception as e:
                 self.log.exception("Failed to bag_dag: %s", dag.fileloc)
-                self.import_errors[dag.fileloc] = f"Invalid timetable expression: {exception}"
-                self.file_last_changed[dag.fileloc] = file_last_changed_on_disk
-            except AirflowClusterPolicyError as exception:
-                self.log.exception("Failed to bag_dag: %s", dag.fileloc)
-                self.import_errors[dag.fileloc] = f"Error on cluster policy itself: {exception}"
-                self.file_last_changed[dag.fileloc] = file_last_changed_on_disk
-            except (
-                AirflowClusterPolicyViolation,
-                AirflowDagCycleException,
-                AirflowDagDuplicatedIdException,
-                AirflowDagInconsistent,
-                ParamValidationError,
-            ) as exception:
-                self.log.exception("Failed to bag_dag: %s", dag.fileloc)
-                self.import_errors[dag.fileloc] = str(exception)
+                self.import_errors[dag.fileloc] = str(e)
                 self.file_last_changed[dag.fileloc] = file_last_changed_on_disk
             else:
                 found_dags.append(dag)

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -41,9 +41,6 @@ from airflow.exceptions import (
     AirflowClusterPolicyViolation,
     AirflowDagCycleException,
     AirflowDagDuplicatedIdException,
-    AirflowDagInconsistent,
-    AirflowTimetableInvalid,
-    ParamValidationError,
     RemovedInAirflow3Warning,
 )
 from airflow.stats import Stats

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -487,7 +487,7 @@ class TestCliDags:
         with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
             dag_command.dag_list_import_errors(args)
             out = temp_stdout.getvalue()
-        assert "Invalid timetable expression" in out
+        assert "[0 100 * * *] is not acceptable, out of range" in out
         assert dag_path in out
 
     def test_cli_list_dag_runs(self):


### PR DESCRIPTION
We use Airflow cluster policy to ensure some dynamic DAGs and tasks to follow some constraints.

But, we realized when there is some error on cluster policy itself(= any errors except intentional AirflowClusterPolicyViolation), ALL THE DAGs cannot be loaded. and there is no warning message on web UI and no error records on metadb import_error table.

(In our case, unintentional error was raised because the assumed environment variable was not present in the Airflow scheduler pod of stage environment.)

I think if those exceptions are passed unconditionally, there will be some risks to pass bad DAGs/tasks (= if cluster policy is healthy one, those will not pass the validation on cluster policy.)