### PR TITLE
Add command to export purged records to CSV files

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1611,7 +1611,7 @@ DB_COMMANDS = (
     ActionCommand(
         name="export-cleaned",
         help="Export cleaned data from the archive tables",
-        func=lazy_load_command("airflow.cli.commands.db_command.export_archived"),
+        func=lazy_load_command("airflow.cli.commands.db_command.export_cleaned"),
         args=(
             ARG_DB_EXPORT_FORMAT,
             ARG_DB_OUTPUT_PATH,

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -488,6 +488,11 @@ ARG_DB_OUTPUT_PATH = Arg(
     help="The path to the output directory to export the cleaned data. This directory must exist.",
     required=True,
 )
+ARG_DB_DROP_ARCHIVES = Arg(
+    ("--drop-archives",),
+    help="Drop the archive tables after exporting. Use with caution.",
+    action="store_true",
+)
 
 # pool
 ARG_POOL_NAME = Arg(("pool",), metavar="NAME", help="Pool name")
@@ -1615,6 +1620,8 @@ DB_COMMANDS = (
         args=(
             ARG_DB_EXPORT_FORMAT,
             ARG_DB_OUTPUT_PATH,
+            ARG_DB_DROP_ARCHIVES,
+            ARG_DB_TABLES,
         ),
     ),
 )

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -481,6 +481,7 @@ ARG_DB_EXPORT_FORMAT = Arg(
     ("--export-format",),
     help="The file format to export the cleaned data",
     choices=("csv",),
+    default="csv",
 )
 ARG_DB_OUTPUT_PATH = Arg(
     ("--output-path",),

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -142,7 +142,16 @@ class Arg:
 
     def add_to_parser(self, parser: argparse.ArgumentParser):
         """Add this argument to an ArgumentParser."""
+        if "metavar" in self.kwargs and "type" not in self.kwargs:
+            if self.kwargs["metavar"] == "DIRPATH":
+                type = lambda x: self._is_valid_directory(parser, x)
+                self.kwargs["type"] = type
         parser.add_argument(*self.flags, **self.kwargs)
+
+    def _is_valid_directory(self, parser, arg):
+        if not os.path.isdir(arg):
+            parser.error(f"The directory '{arg}' does not exist!")
+        return arg
 
 
 def positive_int(*, allow_zero):
@@ -475,8 +484,8 @@ ARG_DB_EXPORT_FORMAT = Arg(
 )
 ARG_DB_OUTPUT_PATH = Arg(
     ("--output-path",),
-    metavar="FILEPATH",
-    help="The output to export the cleaned data",
+    metavar="DIRPATH",
+    help="The path to the output directory to export the cleaned data. This directory must exist.",
     required=True,
 )
 

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -468,7 +468,17 @@ ARG_DB_SKIP_ARCHIVE = Arg(
     help="Don't preserve purged records in an archive table.",
     action="store_true",
 )
-
+ARG_DB_EXPORT_FORMAT = Arg(
+    ("--export-format",),
+    help="The file format to export the cleaned data",
+    choices=("csv",),
+)
+ARG_DB_OUTPUT_PATH = Arg(
+    ("--output-path",),
+    metavar="FILEPATH",
+    help="The output to export the cleaned data",
+    required=True,
+)
 
 # pool
 ARG_POOL_NAME = Arg(("pool",), metavar="NAME", help="Pool name")
@@ -1587,6 +1597,15 @@ DB_COMMANDS = (
             ARG_VERBOSE,
             ARG_YES,
             ARG_DB_SKIP_ARCHIVE,
+        ),
+    ),
+    ActionCommand(
+        name="export-cleaned",
+        help="Export cleaned data from the archive tables",
+        func=lazy_load_command("airflow.cli.commands.db_command.export_archived"),
+        args=(
+            ARG_DB_EXPORT_FORMAT,
+            ARG_DB_OUTPUT_PATH,
         ),
     ),
 )

--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -215,4 +215,6 @@ def export_cleaned(args):
     export_cleaned_records(
         export_format=args.export_format,
         output_path=args.output_path,
+        table_names=args.tables,
+        drop_archives=args.drop_archives,
     )

--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -212,8 +212,6 @@ def cleanup_tables(args):
 @cli_utils.action_cli(check_db=False)
 def export_archived(args):
     """Exports archived records from metadata database."""
-    if not os.path.exists(args.output_path):
-        raise AirflowException(f"The specified --output-path {args.output_path} does not exist.")
     export_archived_records(
         export_format=args.export_format,
         output_path=args.output_path,

--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -27,7 +27,7 @@ from airflow import settings
 from airflow.exceptions import AirflowException
 from airflow.utils import cli as cli_utils, db
 from airflow.utils.db import REVISION_HEADS_MAP
-from airflow.utils.db_cleanup import config_dict, run_cleanup
+from airflow.utils.db_cleanup import config_dict, export_archived_records, run_cleanup
 from airflow.utils.process_utils import execute_interactive
 
 
@@ -206,4 +206,15 @@ def cleanup_tables(args):
         verbose=args.verbose,
         confirm=not args.yes,
         skip_archive=args.skip_archive,
+    )
+
+
+@cli_utils.action_cli(check_db=False)
+def export_archived(args):
+    """Exports archived records from metadata database."""
+    if not os.path.exists(args.output_path):
+        raise AirflowException(f"The specified --output-path {args.output_path} does not exist.")
+    export_archived_records(
+        export_format=args.export_format,
+        output_path=args.output_path,
     )

--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -27,7 +27,7 @@ from airflow import settings
 from airflow.exceptions import AirflowException
 from airflow.utils import cli as cli_utils, db
 from airflow.utils.db import REVISION_HEADS_MAP
-from airflow.utils.db_cleanup import config_dict, export_archived_records, run_cleanup
+from airflow.utils.db_cleanup import config_dict, export_cleaned_records, run_cleanup
 from airflow.utils.process_utils import execute_interactive
 
 
@@ -210,9 +210,9 @@ def cleanup_tables(args):
 
 
 @cli_utils.action_cli(check_db=False)
-def export_archived(args):
+def export_cleaned(args):
     """Exports archived records from metadata database."""
-    export_archived_records(
+    export_cleaned_records(
         export_format=args.export_format,
         output_path=args.output_path,
     )

--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -127,7 +127,7 @@ def _check_for_rows(*, query: Query, print_rows=False):
     return num_entities
 
 
-def _dump_db(*, target_table, file_path, export_format, session):
+def _dump_table_to_file(*, target_table, file_path, export_format, session):
     if export_format == "csv":
         with open(file_path, "w") as f:
             csv_writer = csv.writer(f)

--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import csv
 import logging
+import os
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
@@ -128,7 +129,7 @@ def _check_for_rows(*, query: Query, print_rows=False):
 
 def _dump_db(*, target_table, file_path, export_format, session):
     if export_format == "csv":
-        with open(file_path + ".csv", "w") as f:
+        with open(file_path, "w") as f:
             csv_writer = csv.writer(f)
             cursor = session.execute(text(f"SELECT * FROM {target_table}"))
             csv_writer.writerow(cursor.keys())
@@ -393,7 +394,7 @@ def export_archived_records(export_format, output_path, session: Session = NEW_S
         if table_name.startswith(ARCHIVE_TABLE_PREFIX):
             _dump_db(
                 target_table=table_name,
-                file_path=f"{output_path}/{table_name}",
+                file_path=os.path.join(output_path, f"{table_name}.{export_format}"),
                 export_format=export_format,
                 session=session,
             )

--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -386,13 +386,13 @@ def run_cleanup(
 
 
 @provide_session
-def export_archived_records(export_format, output_path, session: Session = NEW_SESSION):
+def export_cleaned_records(export_format, output_path, session: Session = NEW_SESSION):
     """Export cleaned data to the given output path in the given format."""
     inspector = inspect(session.bind)
     table_names = inspector.get_table_names()
     for table_name in table_names:
         if table_name.startswith(ARCHIVE_TABLE_PREFIX):
-            _dump_db(
+            _dump_table_to_file(
                 target_table=table_name,
                 file_path=os.path.join(output_path, f"{table_name}.{export_format}"),
                 export_format=export_format,

--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -34,6 +34,7 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Query, Session, aliased
 from sqlalchemy.sql.expression import ClauseElement, Executable, tuple_
 
+from airflow import AirflowException
 from airflow.cli.simple_table import AirflowConsole
 from airflow.models import Base
 from airflow.utils import timezone
@@ -134,6 +135,8 @@ def _dump_table_to_file(*, target_table, file_path, export_format, session):
             cursor = session.execute(text(f"SELECT * FROM {target_table}"))
             csv_writer.writerow(cursor.keys())
             csv_writer.writerows(cursor.fetchall())
+    else:
+        raise AirflowException(f"Export format {export_format} is not supported.")
 
 
 def _do_delete(*, query, orm_model, skip_archive, session):

--- a/docs/apache-airflow/howto/usage-cli.rst
+++ b/docs/apache-airflow/howto/usage-cli.rst
@@ -217,6 +217,17 @@ You can use the ``--dry-run`` option to print the row counts in the primary tabl
 
 By default, ``db clean`` will archive purged rows in tables of the form ``_airflow_deleted__<table>__<timestamp>``.  If you don't want the data preserved in this way, you may supply argument ``--skip-archive``.
 
+Export the purged records from the archive tables
+-------------------------------------------------
+The ``db export-cleaned`` command exports the contents of the archived tables, created by the ``db clean`` command,
+to a specified format, by default to a CSV file. The exported file will contain the records that were purged from the
+primary tables during the ``db clean`` process.
+
+You can specify the export format using ``--export-format`` option. The default format is csv.
+
+You must also specify the location of the path to which you want to export the data using ``--output-path`` option.
+
+
 Beware cascading deletes
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow/howto/usage-cli.rst
+++ b/docs/apache-airflow/howto/usage-cli.rst
@@ -223,10 +223,14 @@ The ``db export-cleaned`` command exports the contents of the archived tables, c
 to a specified format, by default to a CSV file. The exported file will contain the records that were purged from the
 primary tables during the ``db clean`` process.
 
-You can specify the export format using ``--export-format`` option. The default format is csv.
+You can specify the export format using ``--export-format`` option. The default format is csv and is also the only
+supported format at the moment.
 
-You must also specify the location of the path to which you want to export the data using ``--output-path`` option.
+You must also specify the location of the path to which you want to export the data using ``--output-path`` option. This
+location must exist.
 
+Other options include: ``--tables`` to specify the tables to export, ``--drop-archives`` to drop the archive tables after
+exporting.
 
 Beware cascading deletes
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/cli/commands/test_db_command.py
+++ b/tests/cli/commands/test_db_command.py
@@ -448,3 +448,37 @@ class TestCLIDBClean:
             confirm=True,
             skip_archive=False,
         )
+
+    @patch("airflow.cli.commands.db_command.export_archived_records")
+    @patch("airflow.cli.commands.db_command.os.path.exists")
+    def test_export_archived_records(self, os_mock, export_archived_mock):
+        args = self.parser.parse_args(
+            [
+                "db",
+                "export-cleaned",
+                "--export-format",
+                "csv",
+                "--output-path",
+                "path",
+            ]
+        )
+        db_command.export_archived(args)
+
+        export_archived_mock.assert_called_once_with(export_format="csv", output_path="path")
+
+    @patch("airflow.cli.commands.db_command.export_archived_records")
+    def test_non_existing_output_path_raises(self, archived_record_mock):
+        args = self.parser.parse_args(
+            [
+                "db",
+                "export-cleaned",
+                "--export-format",
+                "csv",
+                "--output-path",
+                "path",
+            ]
+        )
+        with pytest.raises(AirflowException) as excinfo:
+            db_command.export_archived(args)
+        assert "The specified --output-path path does not exist." == str(excinfo.value)
+        archived_record_mock.assert_not_called()

--- a/tests/cli/commands/test_db_command.py
+++ b/tests/cli/commands/test_db_command.py
@@ -464,4 +464,52 @@ class TestCLIDBClean:
         )
         db_command.export_cleaned(args)
 
-        export_archived_mock.assert_called_once_with(export_format="csv", output_path="path")
+        export_archived_mock.assert_called_once_with(
+            export_format="csv", output_path="path", table_names=None, drop_archives=False
+        )
+
+    @pytest.mark.parametrize(
+        "extra_args, expected", [(["--tables", "hello, goodbye"], ["hello", "goodbye"]), ([], None)]
+    )
+    @patch("airflow.cli.commands.db_command.export_cleaned_records")
+    @patch("airflow.cli.commands.db_command.os.path.isdir", return_value=True)
+    def test_tables_in_export_archived_records_command(
+        self, os_mock, export_archived_mock, extra_args, expected
+    ):
+        args = self.parser.parse_args(
+            [
+                "db",
+                "export-cleaned",
+                "--export-format",
+                "csv",
+                "--output-path",
+                "path",
+                *extra_args,
+            ]
+        )
+        db_command.export_cleaned(args)
+        export_archived_mock.assert_called_once_with(
+            export_format="csv", output_path="path", table_names=expected, drop_archives=False
+        )
+
+    @pytest.mark.parametrize("extra_args, expected", [(["--drop-archives"], True), ([], False)])
+    @patch("airflow.cli.commands.db_command.export_cleaned_records")
+    @patch("airflow.cli.commands.db_command.os.path.isdir", return_value=True)
+    def test_drop_archives_in_export_archived_records_command(
+        self, os_mock, export_archived_mock, extra_args, expected
+    ):
+        args = self.parser.parse_args(
+            [
+                "db",
+                "export-cleaned",
+                "--export-format",
+                "csv",
+                "--output-path",
+                "path",
+                *extra_args,
+            ]
+        )
+        db_command.export_cleaned(args)
+        export_archived_mock.assert_called_once_with(
+            export_format="csv", output_path="path", table_names=None, drop_archives=expected
+        )

--- a/tests/cli/commands/test_db_command.py
+++ b/tests/cli/commands/test_db_command.py
@@ -449,7 +449,7 @@ class TestCLIDBClean:
             skip_archive=False,
         )
 
-    @patch("airflow.cli.commands.db_command.export_archived_records")
+    @patch("airflow.cli.commands.db_command.export_cleaned_records")
     @patch("airflow.cli.commands.db_command.os.path.isdir", return_value=True)
     def test_export_archived_records(self, os_mock, export_archived_mock):
         args = self.parser.parse_args(
@@ -462,6 +462,6 @@ class TestCLIDBClean:
                 "path",
             ]
         )
-        db_command.export_archived(args)
+        db_command.export_cleaned(args)
 
         export_archived_mock.assert_called_once_with(export_format="csv", output_path="path")

--- a/tests/cli/commands/test_db_command.py
+++ b/tests/cli/commands/test_db_command.py
@@ -450,7 +450,7 @@ class TestCLIDBClean:
         )
 
     @patch("airflow.cli.commands.db_command.export_archived_records")
-    @patch("airflow.cli.commands.db_command.os.path.exists")
+    @patch("airflow.cli.commands.db_command.os.path.isdir", return_value=True)
     def test_export_archived_records(self, os_mock, export_archived_mock):
         args = self.parser.parse_args(
             [
@@ -465,20 +465,3 @@ class TestCLIDBClean:
         db_command.export_archived(args)
 
         export_archived_mock.assert_called_once_with(export_format="csv", output_path="path")
-
-    @patch("airflow.cli.commands.db_command.export_archived_records")
-    def test_non_existing_output_path_raises(self, archived_record_mock):
-        args = self.parser.parse_args(
-            [
-                "db",
-                "export-cleaned",
-                "--export-format",
-                "csv",
-                "--output-path",
-                "path",
-            ]
-        )
-        with pytest.raises(AirflowException) as excinfo:
-            db_command.export_archived(args)
-        assert "The specified --output-path path does not exist." == str(excinfo.value)
-        archived_record_mock.assert_not_called()

--- a/tests/cli/commands/test_db_command.py
+++ b/tests/cli/commands/test_db_command.py
@@ -456,8 +456,6 @@ class TestCLIDBClean:
             [
                 "db",
                 "export-cleaned",
-                "--export-format",
-                "csv",
                 "--output-path",
                 "path",
             ]
@@ -480,8 +478,6 @@ class TestCLIDBClean:
             [
                 "db",
                 "export-cleaned",
-                "--export-format",
-                "csv",
                 "--output-path",
                 "path",
                 *extra_args,
@@ -502,8 +498,6 @@ class TestCLIDBClean:
             [
                 "db",
                 "export-cleaned",
-                "--export-format",
-                "csv",
                 "--output-path",
                 "path",
                 *extra_args,

--- a/tests/utils/test_db_cleanup.py
+++ b/tests/utils/test_db_cleanup.py
@@ -339,7 +339,7 @@ class TestDBCleanup:
         export_archived_records(export_format="csv", output_path="path", session=session)
         dump_mock.assert_called_once_with(
             target_table=f"{ARCHIVE_TABLE_PREFIX}dag_run",
-            file_path=f"path/{ARCHIVE_TABLE_PREFIX}dag_run",
+            file_path=f"path/{ARCHIVE_TABLE_PREFIX}dag_run.csv",
             export_format="csv",
             session=session,
         )
@@ -349,7 +349,7 @@ class TestDBCleanup:
         mockopen = mock_open()
         with patch("airflow.utils.db_cleanup.open", mockopen, create=True):
             _dump_db(
-                target_table="mytable", file_path="dags/myfile", export_format="csv", session=MagicMock()
+                target_table="mytable", file_path="dags/myfile.csv", export_format="csv", session=MagicMock()
             )
             mockopen.assert_called_once_with("dags/myfile.csv", "w")
             writer = mock_csv.writer

--- a/tests/utils/test_db_cleanup.py
+++ b/tests/utils/test_db_cleanup.py
@@ -31,6 +31,7 @@ from pytest import param
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.declarative import DeclarativeMeta
 
+from airflow import AirflowException
 from airflow.models import DagModel, DagRun, TaskInstance
 from airflow.operators.python import PythonOperator
 from airflow.utils.db_cleanup import (
@@ -405,6 +406,16 @@ class TestDBCleanup:
             writer.assert_called_once()
             writer.return_value.writerow.assert_called_once()
             writer.return_value.writerows.assert_called_once()
+
+    def test_dump_table_to_file_raises_if_format_not_supported(self):
+        with pytest.raises(AirflowException) as exc_info:
+            _dump_table_to_file(
+                target_table="mytable",
+                file_path="dags/myfile.json",
+                export_format="json",
+                session=MagicMock(),
+            )
+        assert "Export format json is not supported" in str(exc_info.value)
 
 
 def create_tis(base_date, num_tis, external_trigger=False):


### PR DESCRIPTION
This adds `airflow db export-cleaned --export-format csv --output-path /some/path` command
to export records from the archived tables to csv files
