### PR TITLE
Check for run_id url param when linking to graph/gantt views

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -176,7 +176,12 @@ def get_safe_url(url):
 def get_date_time_num_runs_dag_runs_form_data(www_request, session, dag):
     """Get Execution Data, Base Date & Number of runs from a Request"""
     date_time = www_request.args.get("execution_date")
-    if date_time:
+    run_id = www_request.args.get("run_id")
+    # First check run id, then check execution date, if not fall back on the latest dagrun
+    if run_id:
+        dagrun = dag.get_dagrun(run_id=run_id, session=session)
+        date_time = dagrun.execution_date
+    elif date_time:
         date_time = _safe_parse_datetime(date_time)
     else:
         date_time = dag.get_latest_execution_date(session=session) or timezone.utcnow()
@@ -184,6 +189,8 @@ def get_date_time_num_runs_dag_runs_form_data(www_request, session, dag):
     base_date = www_request.args.get("base_date")
     if base_date:
         base_date = _safe_parse_datetime(base_date)
+    elif run_id:
+        base_date = (timezone.utcnow() + timedelta(seconds=1)).replace(microsecond=0)
     else:
         # The DateTimeField widget truncates milliseconds and would loose
         # the first dag run. Round to next second.


### PR DESCRIPTION
Some parts of the app linked over to the graph and gantt views with a `run_id=` param, but we weren't actually using that param to decide which run to show for a user. 
Now, we will first check for `run_id`, and only use `execution_date` if `run_id` isn't specified.

Fixes: https://github.com/apache/airflow/issues/28155

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
