### PR TITLE
FTP operator has logic in __init__

### DIFF
--- a/airflow/providers/sftp/operators/sftp.py
+++ b/airflow/providers/sftp/operators/sftp.py
@@ -104,10 +104,8 @@ class SFTPOperator(BaseOperator):
         self.remote_filepath = remote_filepath
 
     def execute(self, context: Any) -> str | list[str] | None:
-        local_filepath_was_str = False
         if isinstance(self.local_filepath, str):
             local_filepath_array = [self.local_filepath]
-            local_filepath_was_str = True
         else:
             local_filepath_array = self.local_filepath
 
@@ -189,4 +187,4 @@ class SFTPOperator(BaseOperator):
         except Exception as e:
             raise AirflowException(f"Error while transferring {file_msg}, error: {str(e)}")
 
-        return local_filepath_array[0] if local_filepath_was_str else local_filepath_array
+        return self.local_filepath

--- a/tests/providers/ftp/operators/test_ftp.py
+++ b/tests/providers/ftp/operators/test_ftp.py
@@ -167,7 +167,7 @@ class TestFTPFileTransmitOperator:
                 ftp_conn_id=DEFAULT_CONN_ID,
                 local_filepath="/tmp/test",
                 remote_filepath=["/tmp/test1", "/tmp/test2"],
-            )
+            ).execute(None)
 
         with pytest.raises(ValueError):
             FTPFileTransmitOperator(
@@ -175,7 +175,7 @@ class TestFTPFileTransmitOperator:
                 ftp_conn_id=DEFAULT_CONN_ID,
                 local_filepath=["/tmp/test1", "/tmp/test2"],
                 remote_filepath="/tmp/test1",
-            )
+            ).execute(None)
 
 
 class TestFTPSFileTransmitOperator:


### PR DESCRIPTION
Fixes: https://github.com/apache/airflow/issues/29070
Move the logic from __init__ to execute for FTP operator

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
