### PR TITLE
Mark `test_process_sigterm_works_with_retries` quarantined again

### DIFF
--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -830,6 +830,7 @@ def test_number_of_queries_single_loop(mock_get_task_runner, dag_maker):
         job.run()
 
 
+@pytest.mark.quarantined
 class TestSigtermOnRunner:
     """Test receive SIGTERM Task Runner."""
 


### PR DESCRIPTION
Unfortunately this test still not stable and first run 🤦‍♂️ 🤦‍♂️ 🤦‍♂️  in main failed again.

https://github.com/apache/airflow/actions/runs/3971462849/jobs/6808560333:
```console
        finally:
            proc.kill()
    
        assert retry_callback_called.value == 1
        with create_session() as session:
            ti = (
                session.query(TaskInstance)
                .filter(
                    TaskInstance.dag_id == dag_id,
                    TaskInstance.task_id == task_id,
                    TaskInstance.run_id == run_id,
                )
                .one()
            )
>       assert ti.state == State.UP_FOR_RETRY
E       AssertionError: assert 'running' == <TaskInstance...up_for_retry'>
E         - up_for_retry
E         + running

tests/jobs/test_local_task_job.py:895: AssertionError
```

This error basically mean that we send SIGKILL `proc.kill()` before state changed but callback already executed.

Note: We do not check state in the previous version of the test, only callback result