### PR TITLE
Emit dagrun duration when it fails because of a timeout

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1325,6 +1325,8 @@ class SchedulerJob(BaseJob):
             )
 
             dag_run.notify_dagrun_state_changed()
+            duration = dag_run.end_date - dag_run.start_date
+            Stats.timing(f"dagrun.duration.failed.{dag_run.dag_id}", duration)
             return callback_to_execute
 
         if dag_run.execution_date > timezone.utcnow() and not dag.allow_future_exec_dates:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #29013
---
**^ Add meaningful description above**

Currently the duration of the finished dagruns are emitted in the method `update_state`, which is called only if the dagrun is not timeout, and we don't emit any metric when the dagrun is timeout.
This PR add the missing `Stats.timing` to the timeout case.

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
