### PR TITLE
add retries to stop_pipeline on conflict

### DIFF
--- a/tests/providers/amazon/aws/hooks/test_sagemaker.py
+++ b/tests/providers/amazon/aws/hooks/test_sagemaker.py
@@ -793,7 +793,9 @@ class TestSageMakerHook:
     @patch("airflow.providers.amazon.aws.hooks.sagemaker.SageMakerHook.conn", new_callable=mock.PropertyMock)
     def test_stop_pipeline_waits_for_completion_even_when_already_stopped(self, mock_conn):
         mock_conn().stop_pipeline_execution.side_effect = ClientError(
-            error_response={"Error": {"Message": "Only pipelines with 'Executing' status can be stopped"}},
+            error_response={
+                "Error": {"Message": "Only pipelines with 'Executing' status can be stopped", "Code": "0"}
+            },
             operation_name="empty",
         )
         mock_conn().describe_pipeline_execution.side_effect = [
@@ -811,7 +813,9 @@ class TestSageMakerHook:
     @patch("airflow.providers.amazon.aws.hooks.sagemaker.SageMakerHook.conn", new_callable=mock.PropertyMock)
     def test_stop_pipeline_raises_when_already_stopped_if_specified(self, mock_conn):
         error = ClientError(
-            error_response={"Error": {"Message": "Only pipelines with 'Executing' status can be stopped"}},
+            error_response={
+                "Error": {"Message": "Only pipelines with 'Executing' status can be stopped", "Code": "0"}
+            },
             operation_name="empty",
         )
         mock_conn().stop_pipeline_execution.side_effect = error
@@ -822,6 +826,38 @@ class TestSageMakerHook:
             hook.stop_pipeline(pipeline_exec_arn="test", fail_if_not_running=True)
 
         assert raised_exception.value == error
+
+    @patch("airflow.providers.amazon.aws.hooks.sagemaker.SageMakerHook.conn", new_callable=mock.PropertyMock)
+    def test_stop_pipeline_retries_on_conflict(self, mock_conn):
+        conflict_error = ClientError(
+            error_response={"Error": {"Code": "ConflictException"}},
+            operation_name="empty",
+        )
+        mock_conn().stop_pipeline_execution.side_effect = [
+            conflict_error,
+            conflict_error,
+            None,
+        ]
+
+        hook = SageMakerHook(aws_conn_id="aws_default")
+        hook.stop_pipeline(pipeline_exec_arn="test")
+
+        assert mock_conn().stop_pipeline_execution.call_count == 3
+
+    @patch("airflow.providers.amazon.aws.hooks.sagemaker.SageMakerHook.conn", new_callable=mock.PropertyMock)
+    def test_stop_pipeline_fails_if_all_retries_error(self, mock_conn):
+        conflict_error = ClientError(
+            error_response={"Error": {"Message": "blah", "Code": "ConflictException"}},
+            operation_name="empty",
+        )
+        mock_conn().stop_pipeline_execution.side_effect = conflict_error
+
+        hook = SageMakerHook(aws_conn_id="aws_default")
+        with pytest.raises(ClientError) as raised_exception:
+            hook.stop_pipeline(pipeline_exec_arn="test")
+
+        assert mock_conn().stop_pipeline_execution.call_count == 3
+        assert raised_exception.value == conflict_error
 
     @patch("airflow.providers.amazon.aws.hooks.sagemaker.SageMakerHook.conn", new_callable=mock.PropertyMock)
     def test_create_model_package_group(self, mock_conn):


### PR DESCRIPTION
Explained in comments in the code, but there is a race condition when stopping a pipeline that can make the operation fail if it's in the middle of two steps.
It should be very rare in real life, but happens more often on our system tests, which run a dummy pipeline made of very short steps.
Boto doesn't retry it because its retry strategy doesn't include either 409 HTTP codes nor ConflictExceptions, which can happen for good reasons when trying to create resources that already exist for instance.

Sagemaker team might implement a fix/retry on the server side, but in the meantime, we can fix it here.