### PR TITLE
Migrate Models XCom get*/clear* to internal API

### DIFF
--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -26,6 +26,7 @@ from flask import Response
 
 from airflow.api_connexion.types import APIResponse
 from airflow.dag_processing.manager import DagFileProcessorManager
+from airflow.models import XCom
 from airflow.serialization.serialized_objects import BaseSerialization
 
 log = logging.getLogger(__name__)
@@ -40,6 +41,10 @@ def _initialize_map() -> dict[str, Callable]:
         DagFileProcessor.update_import_errors,
         DagModel.get_paused_dag_ids,
         DagFileProcessorManager.clear_nonexistent_import_errors,
+        XCom.get_value,
+        XCom.get_one,
+        XCom.get_many,
+        XCom.clear,
     ]
     return {f"{func.__module__}.{func.__name__}": func for func in functions}
 


### PR DESCRIPTION
Migration of following methods of `Models.XCom` to Internal API.

- get*
- clear*

closes: #28612 