### PR TITLE
Fix TestSsmHooks which is not compatible with `moto==4.1.1`

### DIFF
--- a/tests/providers/amazon/aws/hooks/test_ssm.py
+++ b/tests/providers/amazon/aws/hooks/test_ssm.py
@@ -38,7 +38,9 @@ class TestSsmHooks:
     def setup_tests(self):
         with mock_ssm():
             self.hook = SsmHook(region_name=REGION)
-            self.hook.conn.put_parameter(Name=EXISTING_PARAM_NAME, Value=PARAM_VALUE, Overwrite=True)
+            self.hook.conn.put_parameter(
+                Type="String", Name=EXISTING_PARAM_NAME, Value=PARAM_VALUE, Overwrite=True
+            )
             yield
 
     def test_hook(self) -> None:


### PR DESCRIPTION
Recent version of [`moto==4.1.1`](https://github.com/getmoto/moto/blob/master/CHANGELOG.md#411) broke our main, this PR introduce fixe. 

The problem that we do not pass all mandatory fields to SsmClient.put_parameter method and `moto` before 4.1.1 ignored this check: https://github.com/getmoto/moto/pull/5835
