### PR TITLE
Fix GoogleDriveHook writing files to trashed folders on upload v2

### DIFF
--- a/airflow/providers/google/suite/hooks/drive.py
+++ b/airflow/providers/google/suite/hooks/drive.py
@@ -81,7 +81,8 @@ class GoogleDriveHook(GoogleBaseHook):
         for current_folder in folders:
             self.log.debug("Looking for %s directory with %s parent", current_folder, current_parent)
             conditions = [
-                "mimeType = 'application/vnd.google-apps.folder'",
+                "trashed=false",
+                "mimeType='application/vnd.google-apps.folder'",
                 f"name='{current_folder}'",
                 f"'{current_parent}' in parents",
             ]


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fixes a bug introduced in https://github.com/apache/airflow/pull/25675 where file uploads write to trash.

I'm unable to test this E2E because I don't have Google Suite. If anyone has it, can they patch this PR and give this a try? This is a simple dag that can be used:

```py
from airflow import DAG

from airflow.providers.google.suite.transfers.local_to_drive import LocalFilesystemToGoogleDriveOperator
from airflow.providers.google.cloud.transfers.gdrive_to_local import GoogleDriveToLocalOperator

DEFAULT_TASK_ARGS = {
    "owner": "gcp-data-platform",
    "retries": 1,
    "retry_delay": 10,
    "start_date": "2022-08-01",
}

with DAG(
    max_active_runs=1,
    max_active_tasks=2,
    catchup=False,
    schedule_interval="@daily",
    dag_id="test_gdrive",
    default_args=DEFAULT_TASK_ARGS,
) as dag:

    local_to_gdrive = LocalFilesystemToGoogleDriveOperator(
        task_id="local_to_gdrive",
        local_paths=["./*"],
        drive_folder="test-folder",
    )

    gdrive_to_local =  GoogleDriveToLocalOperator(
        task_id="gdrive_to_local",
        output_file="data/abc.txt",
        folder_id="1r9tcYbardpQdfasdw-BlkjfadDqjmGXDzsXWQCU7LSK8jLv9dgTIy0",
        file_name="abc.txt",
    )
```

Replace: https://github.com/apache/airflow/pull/28141

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
