### PR TITLE
Allow PATCH role endpoint to remove permissions not included in PATCH call

### DIFF
--- a/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
+++ b/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
@@ -136,7 +136,7 @@ def patch_role(*, role_name: str, update_mask: UpdateMask = None) -> APIResponse
     if "permissions" in data:
         perms = [(item["action"]["name"], item["resource"]["name"]) for item in data["permissions"] if item]
         _check_action_and_resource(security_manager, perms)
-        security_manager.bulk_sync_roles([{"role": role_name, "perms": perms}])
+        security_manager.patch_role_permissions(role, perms)
     new_name = data.get("name")
     if new_name is not None and new_name != role.name:
         security_manager.update_role(role_id=role.id, name=new_name)


### PR DESCRIPTION
closes: #25734 

Rationale:
`PATCH /api/v1/roles/[role]` previously would only ever append permissions to a role, never removing permissions that were omitted from the `PATCH` call. This makes it impossible to programmatically remove permissions from a role via the API.

Change:
This change changes the behavior of the `PATCH` api for roles to allow for both adding and removing permissions based on which permissions are passed via the `PATCH` call.

Permissions omitted from the API call are removed from the role. Permissions passed via the API call are added to the role.

Notes:
This technically could be considered a breaking change. The way the `PATCH` endpoint is currently implemented is not how it _should_ work (based on how `PATCH` endpoints generally work) but users could have built their systems using this awkward behavior.