### PR TITLE
Decrypt SecureString value obtained by SsmHook

### DIFF
--- a/airflow/providers/amazon/aws/hooks/ssm.py
+++ b/airflow/providers/amazon/aws/hooks/ssm.py
@@ -40,6 +40,7 @@ class SsmHook(AwsBaseHook):
     def get_parameter_value(self, parameter: str, default: str | ArgNotSet = NOTSET) -> str:
         """
         Returns the value of the provided Parameter or an optional default.
+        Decrypt value for secure string Parameter.
 
         .. seealso::
             - :external+boto3:py:meth:`SSM.Client.get_parameter`
@@ -48,7 +49,7 @@ class SsmHook(AwsBaseHook):
         :param default: Optional default value to return if none is found.
         """
         try:
-            return self.conn.get_parameter(Name=parameter)["Parameter"]["Value"]
+            return self.conn.get_parameter(Name=parameter, WithDecryption=True)["Parameter"]["Value"]
         except self.conn.exceptions.ParameterNotFound:
             if isinstance(default, ArgNotSet):
                 raise

--- a/tests/providers/amazon/aws/hooks/test_ssm.py
+++ b/tests/providers/amazon/aws/hooks/test_ssm.py
@@ -33,13 +33,19 @@ PARAM_VALUE = "value"
 DEFAULT_VALUE = "default"
 
 
-class TestSsmHooks:
-    @pytest.fixture(autouse=True)
-    def setup_tests(self):
+class TestSsmHook:
+    @pytest.fixture(
+        autouse=True,
+        params=[
+            pytest.param("String", id="unencrypted-string"),
+            pytest.param("SecureString", id="encrypted-string"),
+        ],
+    )
+    def setup_tests(self, request):
         with mock_ssm():
             self.hook = SsmHook(region_name=REGION)
             self.hook.conn.put_parameter(
-                Type="String", Name=EXISTING_PARAM_NAME, Value=PARAM_VALUE, Overwrite=True
+                Type=request.param, Name=EXISTING_PARAM_NAME, Value=PARAM_VALUE, Overwrite=True
             )
             yield
 


### PR DESCRIPTION
Right now if we try to get SecureString by `SsmHook.get_parameter_value` then we get encrypted value, which is useless for further usage without decryption.

```python
from airflow.providers.amazon.aws.hooks.ssm import SsmHook

hook = SsmHook(aws_conn_id=None, region_name="eu-west-1")
print(hook.get_parameter_value("/airflow/config/boom"))
```

**Without this changes**

```console
AQICAHiA4cbp5//uho/.../Mlb3cleB4/7XXjkh
```

**After this changes**
```console
postgresql+psycopg2://airflow:insecurepassword@postgres/airflow
```

WDYT, should we also mask value if value has type `SecureString`?
