### PR TITLE
Demonstrate usage of the PythonSensor

### DIFF
--- a/airflow/example_dags/example_sensors.py
+++ b/airflow/example_dags/example_sensors.py
@@ -99,13 +99,11 @@ with DAG(
         task_id="create_file_after_3_seconds", bash_command="sleep 3; touch /tmp/temporary_file_for_testing"
     )
 
-    # [START example_python_sensors]
     t8 = PythonSensor(task_id="success_sensor_python", python_callable=success_callable)
 
     t9 = PythonSensor(
         task_id="failure_timeout_sensor_python", timeout=3, soft_fail=True, python_callable=failure_callable
     )
-    # [END example_python_sensors]
 
     # [START example_day_of_week_sensor]
     t10 = DayOfWeekSensor(

--- a/docs/apache-airflow/howto/operator/python.rst
+++ b/docs/apache-airflow/howto/operator/python.rst
@@ -225,9 +225,9 @@ Jinja templating can be used in same way as described for the PythonOperator.
 PythonSensor
 ============
 
-A sensor to wait for an arbitrary callable to return ``True`` is available via ``@task.sensor`` and
-``airflow.sensors.python.PythonSensor``. The callable should return a boolean ``True`` or ``False``,
-indicating whether the condition is met. For example:
+A PythonSensor waits for a certain condition to be ``True``, for example to wait for a file to exist. The
+PythonSensor is available via ``@task.sensor`` and ``airflow.sensors.python.PythonSensor``. The callable
+should return a boolean ``True`` or ``False``, indicating whether a condition is met. For example:
 
 .. code-block:: python
 
@@ -249,5 +249,5 @@ indicating whether the condition is met. For example:
 
     example()
 
-This code sample will give two tasks waiting for the same condition to be ``True``, (1) TaskFlow API sensor
-using ``@task.sensor`` and (2) classic PythonSensor referring to the callable.
+This code sample will give two tasks waiting for the current minute to be even; (1) TaskFlow API sensor using
+``@task.sensor`` and (2) classic PythonSensor referring to the callable.

--- a/docs/apache-airflow/howto/operator/python.rst
+++ b/docs/apache-airflow/howto/operator/python.rst
@@ -239,12 +239,19 @@ should return a boolean ``True`` or ``False``, indicating whether a condition is
 
     @dag(start_date=datetime.datetime(2023, 1, 1), schedule=None)
     def example():
+
+        # TaskFlow sensor
         @task.sensor
-        def wait_for_success():
+        def wait_for_success_taskflow():
             return datetime.datetime.now().minute % 2 == 0
 
-        wait_for_success()
-        PythonSensor(task_id="wait_for_even_minute", python_callable=wait_for_success)
+        wait_for_success_taskflow()
+
+        # Equivalent functionality using PythonSensor class
+        def wait_for_success_pythonsensor():
+            return datetime.datetime.now().minute % 2 == 0
+
+        PythonSensor(task_id="wait_for_success_pythonsensor", python_callable=wait_for_success_pythonsensor)
 
 
     example()

--- a/docs/apache-airflow/howto/operator/python.rst
+++ b/docs/apache-airflow/howto/operator/python.rst
@@ -225,11 +225,29 @@ Jinja templating can be used in same way as described for the PythonOperator.
 PythonSensor
 ============
 
-Use the :class:`~airflow.sensors.python.PythonSensor` to use arbitrary callable for sensing. The callable
-should return True when it succeeds, False otherwise.
+A sensor to wait for an arbitrary callable to return ``True`` is available via ``@task.sensor`` and
+``airflow.sensors.python.PythonSensor``. The callable should return a boolean ``True`` or ``False``,
+indicating whether the condition is met. For example:
 
-.. exampleinclude:: /../../airflow/example_dags/example_sensors.py
-    :language: python
-    :dedent: 4
-    :start-after: [START example_python_sensors]
-    :end-before: [END example_python_sensors]
+.. code-block:: python
+
+    import datetime
+
+    from airflow.decorators import dag, task
+    from airflow.sensors.python import PythonSensor
+
+
+    @dag(start_date=datetime.datetime(2023, 1, 1), schedule=None)
+    def example():
+        @task.sensor
+        def wait_for_success():
+            return datetime.datetime.now().minute % 2 == 0
+
+        wait_for_success()
+        PythonSensor(task_id="wait_for_even_minute", python_callable=wait_for_success)
+
+
+    example()
+
+This code sample will give two tasks waiting for the same condition to be ``True``, (1) TaskFlow API sensor
+using ``@task.sensor`` and (2) classic PythonSensor referring to the callable.


### PR DESCRIPTION
Update of the https://airflow.apache.org/docs/apache-airflow/stable/howto/operator/python.html#pythonsensor paragraph. All other paragraphs in the doc also demonstrate the taskflow-style operator, but the PythonSensor paragraph did not. This PR shows both style + adds a reproducible example.

**Before:**
![image](https://user-images.githubusercontent.com/6249654/214429622-2008f5a6-4930-4b42-96bd-5fae8b39db66.png)

**After:**
![image](https://user-images.githubusercontent.com/6249654/215771106-1d67a6a3-02e8-422b-8f89-365cf4e1cd37.png)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
