### PR TITLE
Reconfigure integration with codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -16,14 +16,25 @@
 # specific language governing permissions and limitations
 # under the License.
 
-[report]
-omit =
-    tests/*
-    scripts/*
-    dev/*
-    airflow/migrations/*
-    airflow/www/node_modules/**
-    airflow/_vendor/**
-
 [run]
+branch = True
 relative_files = True
+source = airflow
+omit =
+    airflow/_vendor/**
+    airflow/contrib/**
+    airflow/example_dags/**
+    airflow/migrations/**
+    airflow/providers/**/example_dags/**
+    airflow/www/node_modules/**
+
+[report]
+skip_empty = True
+exclude_lines =
+    pragma: no cover
+    @abstractmethod
+    @abstractproperty
+    def __repr__
+    raise NotImplementedError
+    if __name__ == .__main__.:
+    if TYPE_CHECKING:

--- a/.github/actions/post_tests/action.yml
+++ b/.github/actions/post_tests/action.yml
@@ -35,19 +35,25 @@ runs:
         name: container-logs-${{env.JOB_ID}}
         path: "./files/container_logs*"
         retention-days: 7
-    - name: "Upload artifact for coverage"
-      uses: actions/upload-artifact@v3
-      if: env.COVERAGE == 'true'
-      with:
-        name: coverage-${{env.JOB_ID}}
-        path: ./files/coverage*.xml
-        retention-days: 7
     - name: "Upload artifact for warnings"
       uses: actions/upload-artifact@v3
       with:
         name: test-warnings-${{env.JOB_ID}}
         path: ./files/warnings-*.txt
         retention-days: 7
+    - name: "Move coverage artifacts in separate directory"
+      if: env.COVERAGE == 'true' && env.TEST_TYPES != 'Helm'
+      shell: bash
+      run: |
+        mkdir ./files/coverage-reposts
+        mv ./files/coverage*.xml ./files/coverage-reposts/ || true
+    - name: "Upload all coverage reports to codecov"
+      uses: codecov/codecov-action@v3
+      if: env.COVERAGE == 'true' && env.TEST_TYPES != 'Helm'
+      with:
+        name: coverage-${{env.JOB_ID}}
+        flags: python-${{env.PYTHON_MAJOR_MINOR_VERSION}},${{env.BACKEND}}-${{env.BACKEND_VERSION}}
+        directory: "./files/coverage-reposts/"
     - name: "Fix ownership"
       shell: bash
       run: breeze ci fix-ownership

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1138,43 +1138,6 @@ jobs:
           Post Tests: ${{needs.build-info.outputs.default-python-version}}:Quarantined"
         uses: ./.github/actions/post_tests
 
-  upload-coverage:
-    timeout-minutes: 15
-    name: "Upload coverage"
-    runs-on: "${{needs.build-info.outputs.runs-on}}"
-    continue-on-error: true
-    needs:
-      - build-info
-      - tests-postgres
-      - tests-sqlite
-      - tests-mysql
-      - tests-mssql
-      - tests-quarantined
-      - tests-integration-postgres
-      - tests-integration-mysql
-    env:
-      RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
-    # Only upload coverage on merges to main
-    if: needs.build-info.outputs.run-coverage == 'true'
-    steps:
-      - name: Cleanup repo
-        run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
-      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-          submodules: recursive
-      - name: "Download all artifacts from the current build"
-        uses: actions/download-artifact@v3
-        with:
-          path: ./coverage-files
-      - name: "Removes unnecessary artifacts"
-        run: ls ./coverage-files | grep -v coverage | xargs rm -rfv
-      - name: "Upload all coverage reports to codecov"
-        uses: ./.github/actions/codecov-action
-        with:
-          directory: "./coverage-files"
-
   summarize-warnings:
     timeout-minutes: 15
     name: "Summarize warnings"

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule ".github/actions/configure-aws-credentials"]
 	path = .github/actions/configure-aws-credentials
 	url = https://github.com/aws-actions/configure-aws-credentials
-[submodule ".github/actions/codecov-action"]
-	path = .github/actions/codecov-action
-	url = https://github.com/codecov/codecov-action
 [submodule ".github/actions/github-push-action"]
 	path = .github/actions/github-push-action
 	url = https://github.com/ad-m/github-push-action

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -857,9 +857,10 @@ EXTRA_PYTEST_ARGS=(
 if [[ "${TEST_TYPE}" == "Helm" ]]; then
     _cpus="$(grep -c 'cpu[0-9]' /proc/stat)"
     echo "Running tests with ${_cpus} CPUs in parallel"
-    # Enable parallelism
+    # Enable parallelism and disable coverage
     EXTRA_PYTEST_ARGS+=(
         "-n" "${_cpus}"
+        "--no-cov"
     )
 else
     EXTRA_PYTEST_ARGS+=(
@@ -869,7 +870,7 @@ fi
 
 if [[ ${ENABLE_TEST_COVERAGE:="false"} == "true" ]]; then
     EXTRA_PYTEST_ARGS+=(
-        "--cov=airflow/"
+        "--cov=airflow"
         "--cov-config=.coveragerc"
         "--cov-report=xml:/files/coverage-${TEST_TYPE/\[*\]/}-${BACKEND}.xml"
     )

--- a/codecov.yml
+++ b/codecov.yml
@@ -81,12 +81,13 @@ coverage:
         only_pulls: false
         paths:
           - "airflow"
-parsers:
-  gcov:
-    branch_detection:
-      conditional: true
-      loop: true
-      method: false
-      macro: false
+
+ignore:
+  - "airflow/_vendor"
+  - "airflow/contrib"
+  - "airflow/example_dags"
+  - "airflow/migrations"
+  - "airflow/providers/**/example_dags"
+  - "airflow/www/node_modules"
 
 comment: false

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -307,9 +307,10 @@ EXTRA_PYTEST_ARGS=(
 if [[ "${TEST_TYPE}" == "Helm" ]]; then
     _cpus="$(grep -c 'cpu[0-9]' /proc/stat)"
     echo "Running tests with ${_cpus} CPUs in parallel"
-    # Enable parallelism
+    # Enable parallelism and disable coverage
     EXTRA_PYTEST_ARGS+=(
         "-n" "${_cpus}"
+        "--no-cov"
     )
 else
     EXTRA_PYTEST_ARGS+=(
@@ -319,7 +320,7 @@ fi
 
 if [[ ${ENABLE_TEST_COVERAGE:="false"} == "true" ]]; then
     EXTRA_PYTEST_ARGS+=(
-        "--cov=airflow/"
+        "--cov=airflow"
         "--cov-config=.coveragerc"
         "--cov-report=xml:/files/coverage-${TEST_TYPE/\[*\]/}-${BACKEND}.xml"
     )

--- a/scripts/in_container/run_ci_tests.sh
+++ b/scripts/in_container/run_ci_tests.sh
@@ -45,7 +45,6 @@ fi
 set +x
 if [[ "${RES}" == "0" && ( ${CI:="false"} == "true" || ${CI} == "True" ) ]]; then
     echo "All tests successful"
-    cp .coverage /files
 fi
 
 MAIN_GITHUB_REPOSITORY="apache/airflow"


### PR DESCRIPTION
~Change some setting for coverage and CMD arguments.~
~No idea is help or not but right now codecov doesn't happy about our reports~
<details>
  <summary><s>Initial codecov warning</s></summary>
  
  ![image](https://user-images.githubusercontent.com/3998685/214460037-ed1cae2b-2149-4077-838a-37184b5d257c.png)
  
</details>

I guess there is an issue to send really huge payload to `codecov`. Right now we send all coverage reports to codecov if every tests run in main green (all-or-nothing) as result we send 200-400 MiB of reports.

1. Send after each individual test run. Drawback if only one test actually run and other failed we will have non-relevant info.
2. Remove git submodule to repo with codecov action.
3. Some minor changes in `.coveragerc` and `codecov.yml`

I keep CI pipeline unchanged, only merged to main would send to codecov but we could tune it later
