### PR TITLE
Set Buildx build command progress to auto

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -438,7 +438,7 @@ def prepare_docker_build_cache_command(
     build_flags = image_params.extra_docker_build_flags
     final_command = []
     final_command.extend(["docker"])
-    final_command.extend(["buildx", "build", "--builder", image_params.builder, "--progress=tty"])
+    final_command.extend(["buildx", "build", "--builder", image_params.builder, "--progress=auto"])
     final_command.extend(build_flags)
     final_command.extend(["--pull"])
     final_command.extend(arguments)
@@ -475,7 +475,7 @@ def prepare_base_build_command(image_params: CommonBuildParams) -> list[str]:
                 "build",
                 "--builder",
                 image_params.builder,
-                "--progress=tty",
+                "--progress=auto",
                 "--push" if image_params.push else "--load",
             ]
         )


### PR DESCRIPTION
When running the command `breeze ci-image build` our CI returns the error `ERROR: failed to get console: provided file is not a console`. Setting the `progress` attribute to `auto` fixes the issue and I could not notice any regression on terminal.

See discussion here https://apache-airflow.slack.com/archives/CQ9QHSFQX/p1674507774211199

