### PR TITLE
Remove misleading docstring on dagrun_timeout

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -308,8 +308,7 @@ class DAG(LoggingMixin):
         number of DAG runs in a running state, the scheduler won't create
         new active DAG runs
     :param dagrun_timeout: specify how long a DagRun should be up before
-        timing out / failing, so that new DagRuns can be created. The timeout
-        is only enforced for scheduled DagRuns.
+        timing out / failing, so that new DagRuns can be created.
     :param sla_miss_callback: specify a function or list of functions to call when reporting SLA
         timeouts. See :ref:`sla_miss_callback<concepts:sla_miss_callback>` for
         more information about the function signature and parameters that are


### PR DESCRIPTION
This docstring is no longer correct (since 2.0) and should be removed

