### PR TITLE
fix: type annotation for `num_of_dpus` in GlueJobHook

### DIFF
--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -65,7 +65,7 @@ class GlueJobHook(AwsBaseHook):
         concurrent_run_limit: int = 1,
         script_location: str | None = None,
         retry_limit: int = 0,
-        num_of_dpus: int | None = None,
+        num_of_dpus: int | float | None = None,
         iam_role_name: str | None = None,
         create_job_kwargs: dict | None = None,
         *args,
@@ -92,7 +92,7 @@ class GlueJobHook(AwsBaseHook):
         elif worker_type_exists and not num_workers_exists:
             raise ValueError("Need to specify NumberOfWorkers when specifying custom WorkerType")
         elif num_of_dpus is None:
-            self.num_of_dpus = 10
+            self.num_of_dpus: int | float = 10
         else:
             self.num_of_dpus = num_of_dpus
 

--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -82,7 +82,7 @@ class GlueJobOperator(BaseOperator):
         concurrent_run_limit: int | None = None,
         script_args: dict | None = None,
         retry_limit: int = 0,
-        num_of_dpus: int | None = None,
+        num_of_dpus: int | float | None = None,
         aws_conn_id: str = "aws_default",
         region_name: str | None = None,
         s3_bucket: str | None = None,


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/29091

Simple fix of type annotation for `num_of_dpus` according to [AWS Glue Documentation](https://docs.aws.amazon.com/glue/latest/webapi/API_CreateJob.html#Glue-CreateJob-request-MaxCapacity)

@Taragolis may you please review this PR?