### PR TITLE
shorten poke intervals on systems tests

### DIFF
--- a/tests/system/providers/amazon/aws/example_athena.py
+++ b/tests/system/providers/amazon/aws/example_athena.py
@@ -102,6 +102,7 @@ with DAG(
         query=query_create_database,
         database=athena_database,
         output_location=f"s3://{s3_bucket}/",
+        sleep_time=1,
     )
 
     create_table = AthenaOperator(
@@ -109,6 +110,7 @@ with DAG(
         query=query_create_table,
         database=athena_database,
         output_location=f"s3://{s3_bucket}/",
+        sleep_time=1,
     )
 
     # [START howto_operator_athena]
@@ -117,6 +119,7 @@ with DAG(
         query=query_read_table,
         database=athena_database,
         output_location=f"s3://{s3_bucket}/",
+        sleep_time=1,
     )
     # [END howto_operator_athena]
 
@@ -133,6 +136,7 @@ with DAG(
         database=athena_database,
         output_location=f"s3://{s3_bucket}/",
         trigger_rule=TriggerRule.ALL_DONE,
+        sleep_time=1,
     )
 
     drop_database = AthenaOperator(
@@ -141,6 +145,7 @@ with DAG(
         database=athena_database,
         output_location=f"s3://{s3_bucket}/",
         trigger_rule=TriggerRule.ALL_DONE,
+        sleep_time=1,
     )
 
     delete_s3_bucket = S3DeleteBucketOperator(

--- a/tests/system/providers/amazon/aws/example_athena.py
+++ b/tests/system/providers/amazon/aws/example_athena.py
@@ -119,9 +119,9 @@ with DAG(
         query=query_read_table,
         database=athena_database,
         output_location=f"s3://{s3_bucket}/",
-        sleep_time=1,
     )
     # [END howto_operator_athena]
+    read_table.sleep_time = 1
 
     # [START howto_sensor_athena]
     await_query = AthenaSensor(

--- a/tests/system/providers/amazon/aws/example_batch.py
+++ b/tests/system/providers/amazon/aws/example_batch.py
@@ -178,6 +178,7 @@ with DAG(
         compute_environment=batch_job_compute_environment_name,
     )
     # [END howto_sensor_batch_compute_environment]
+    wait_for_compute_environment_valid.poke_interval = 1
 
     # [START howto_sensor_batch_job_queue]
     wait_for_job_queue_valid = BatchJobQueueSensor(
@@ -185,6 +186,7 @@ with DAG(
         job_queue=batch_job_queue_name,
     )
     # [END howto_sensor_batch_job_queue]
+    wait_for_job_queue_valid.poke_interval = 1
 
     # [START howto_operator_batch]
     submit_batch_job = BatchOperator(
@@ -209,11 +211,13 @@ with DAG(
     wait_for_compute_environment_disabled = BatchComputeEnvironmentSensor(
         task_id="wait_for_compute_environment_disabled",
         compute_environment=batch_job_compute_environment_name,
+        poke_interval=1,
     )
 
     wait_for_job_queue_modified = BatchJobQueueSensor(
         task_id="wait_for_job_queue_modified",
         job_queue=batch_job_queue_name,
+        poke_interval=1,
     )
 
     wait_for_job_queue_deleted = BatchJobQueueSensor(

--- a/tests/system/providers/amazon/aws/example_cloudformation.py
+++ b/tests/system/providers/amazon/aws/example_cloudformation.py
@@ -79,6 +79,7 @@ with DAG(
         stack_name=cloudformation_stack_name,
     )
     # [END howto_sensor_cloudformation_create_stack]
+    wait_for_stack_create.poke_interval = 10
 
     # [START howto_operator_cloudformation_delete_stack]
     delete_stack = CloudFormationDeleteStackOperator(
@@ -94,6 +95,7 @@ with DAG(
         stack_name=cloudformation_stack_name,
     )
     # [END howto_sensor_cloudformation_delete_stack]
+    wait_for_stack_delete.poke_interval = 10
 
     chain(
         # TEST SETUP

--- a/tests/system/providers/amazon/aws/example_dms.py
+++ b/tests/system/providers/amazon/aws/example_dms.py
@@ -367,9 +367,9 @@ with DAG(
     await_task_stop = DmsTaskCompletedSensor(
         task_id="await_task_stop",
         replication_task_arn=task_arn,
-        poke_interval=10,
     )
     # [END howto_sensor_dms_task_completed]
+    await_task_stop.poke_interval = 10
 
     # [START howto_operator_dms_delete_task]
     delete_task = DmsDeleteTaskOperator(

--- a/tests/system/providers/amazon/aws/example_dms.py
+++ b/tests/system/providers/amazon/aws/example_dms.py
@@ -352,6 +352,7 @@ with DAG(
         replication_task_arn=task_arn,
         target_statuses=["running"],
         termination_statuses=["stopped", "deleting", "failed"],
+        poke_interval=10,
     )
 
     # [START howto_operator_dms_stop_task]
@@ -366,6 +367,7 @@ with DAG(
     await_task_stop = DmsTaskCompletedSensor(
         task_id="await_task_stop",
         replication_task_arn=task_arn,
+        poke_interval=10,
     )
     # [END howto_sensor_dms_task_completed]
 

--- a/tests/system/providers/amazon/aws/example_lambda.py
+++ b/tests/system/providers/amazon/aws/example_lambda.py
@@ -97,6 +97,7 @@ with models.DAG(
         function_name=lambda_function_name,
     )
     # [END howto_sensor_lambda_function_state]
+    wait_lambda_function_state.poke_interval = 1
 
     # [START howto_operator_invoke_lambda_function]
     invoke_lambda_function = AwsLambdaInvokeFunctionOperator(

--- a/tests/system/providers/amazon/aws/example_quicksight.py
+++ b/tests/system/providers/amazon/aws/example_quicksight.py
@@ -190,6 +190,7 @@ with DAG(
         ingestion_id=ingestion_id,
     )
     # [END howto_sensor_quicksight]
+    await_job.poke_interval = 10
 
     delete_bucket = S3DeleteBucketOperator(
         task_id="delete_s3_bucket",

--- a/tests/system/providers/amazon/aws/example_sagemaker.py
+++ b/tests/system/providers/amazon/aws/example_sagemaker.py
@@ -527,6 +527,7 @@ with DAG(
     # [START howto_sensor_sagemaker_auto_ml]
     await_automl = SageMakerAutoMLSensor(job_name=test_setup["auto_ml_job_name"], task_id="await_auto_ML")
     # [END howto_sensor_sagemaker_auto_ml]
+    await_automl.poke_interval = 10
 
     # [START howto_operator_sagemaker_start_pipeline]
     start_pipeline1 = SageMakerStartPipelineOperator(
@@ -553,6 +554,7 @@ with DAG(
         pipeline_exec_arn=start_pipeline2.output,
     )
     # [END howto_sensor_sagemaker_pipeline]
+    await_pipeline2.poke_interval = 10
 
     # [START howto_operator_sagemaker_experiment]
     create_experiment = SageMakerCreateExperimentOperator(

--- a/tests/system/providers/amazon/aws/example_step_functions.py
+++ b/tests/system/providers/amazon/aws/example_step_functions.py
@@ -92,6 +92,7 @@ with DAG(
         task_id="wait_for_execution", execution_arn=execution_arn
     )
     # [END howto_sensor_step_function_execution]
+    wait_for_execution.poke_interval = 1
 
     # [START howto_operator_step_function_get_execution_output]
     get_execution_output = StepFunctionGetExecutionOutputOperator(


### PR DESCRIPTION
since https://github.com/apache/airflow/pull/28528 was merged, we respect the polling times instead of pinging the API constantly. This means that some tests that have sensors that used to wait for a very short time are now taking a lot longer because they wait for nothing.

I went through the "duration" metric for system tests, and looked at the ones that had a noticeable increase in run time in the last runs, then adapted the poke intervals to adapt them to the actual waiting time.

shorten sleep time on athena sys test. 2 minutes faster.
set shorter polling times of fast ops in batch sys test - 4min faster
shorter polling on cloudformation systest - 1min30s faster
shorter polling time on lambda sys test - 1 min faster
shorter wait on quicksight
shorter waits for sagemaker test
shorten wait time for setp_functions, 50s faster
shorter wait on dms. This one is important so that we don't miss the running status

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
