### PR TITLE
mark DBs created during RDS system tests as not publicly accessible

### DIFF
--- a/tests/system/providers/amazon/aws/example_rds_event.py
+++ b/tests/system/providers/amazon/aws/example_rds_event.py
@@ -75,6 +75,7 @@ with DAG(
             "MasterUserPassword": "rds_password",
             "AllocatedStorage": 20,
             "DBName": rds_db_name,
+            "PubliclyAccessible": False,
         },
     )
 

--- a/tests/system/providers/amazon/aws/example_rds_export.py
+++ b/tests/system/providers/amazon/aws/example_rds_export.py
@@ -86,6 +86,7 @@ with DAG(
             "MasterUserPassword": "rds_password",
             "AllocatedStorage": 20,
             "DBName": rds_db_name,
+            "PubliclyAccessible": False,
         },
     )
 

--- a/tests/system/providers/amazon/aws/example_rds_instance.py
+++ b/tests/system/providers/amazon/aws/example_rds_instance.py
@@ -59,6 +59,7 @@ with DAG(
             "MasterUsername": RDS_USERNAME,
             "MasterUserPassword": RDS_PASSWORD,
             "AllocatedStorage": 20,
+            "PubliclyAccessible": False,
         },
     )
     # [END howto_operator_rds_create_db_instance]

--- a/tests/system/providers/amazon/aws/example_rds_snapshot.py
+++ b/tests/system/providers/amazon/aws/example_rds_snapshot.py
@@ -62,6 +62,7 @@ with DAG(
             "MasterUserPassword": "rds_password",
             "AllocatedStorage": 20,
             "DBName": rds_db_name,
+            "PubliclyAccessible": False,
         },
     )
 


### PR DESCRIPTION
there is a security risk with having DBs publicly accessible, even if it's for a short time span and they are deleted afterwards.

ran the tests on my machine, and they still pass with this config.