### PR TITLE
Fix CVE-2022-1941

### DIFF
--- a/constraints-3.9.txt
+++ b/constraints-3.9.txt
@@ -445,7 +445,7 @@ prison==0.2.1
 prometheus-client==0.15.0
 prompt-toolkit==3.0.36
 proto-plus==1.19.6
-protobuf==3.20.0
+protobuf==3.20.3
 psutil==5.9.4
 psycopg2-binary==2.9.5
 psycopg2==2.9.5


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2022-1941

It also currently flags Airflow 2.5.1 by various vulnerability analysis software (since its using 3.20.0)

PS: for most of libs I saw limiter on 3.20.3, but this PR could also be adjusted to 3.20.2 for more minimal impact (since 3.20.2 introduces the patch)