### PR TITLE
Fixing Task Duration view in case of manual DAG runs only (#22015)

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1541,7 +1541,6 @@ class DAG(LoggingMixin):
                 hour=0, minute=0, second=0, microsecond=0
             )
 
-        print("=S=", start_date)
         query = self._get_task_instances(
             task_ids=None,
             start_date=start_date,

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -112,8 +112,6 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-_T = TypeVar("_T")
-
 DEFAULT_VIEW_PRESETS = ["grid", "graph", "duration", "gantt", "landing_times"]
 ORIENTATION_PRESETS = ["LR", "TB", "RL", "BT"]
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1505,21 +1505,41 @@ class DAG(LoggingMixin):
         have less if there are less than ``num`` scheduled DAG runs before
         ``base_date``, or more if there are manual task runs between the
         requested period, which does not count toward ``num``.
+
+        When there are only manual DAG runs found, the ``num`` of task 
+        instances will include manual DAG run types before ``base_date``.
+        If neither are found, it will return an empty list.
         """
         min_date: datetime | None = (
             session.query(DagRun.execution_date)
             .filter(
                 DagRun.dag_id == self.dag_id,
                 DagRun.execution_date <= base_date,
-                DagRun.run_type != DagRunType.MANUAL,
+                DagRun.run_type != DagRunType.MANUAL
             )
             .order_by(DagRun.execution_date.desc())
             .offset(num)
             .limit(1)
             .scalar()
         )
+
         if min_date is None:
-            min_date = timezone.utc_epoch()
+            min_date: datetime | None = (
+            session.query(DagRun.execution_date)
+            .filter(
+                DagRun.dag_id == self.dag_id,
+                DagRun.execution_date <= base_date
+            )
+            .order_by(DagRun.execution_date.desc())
+            .offset(num)
+            .limit(1)
+            .scalar()
+        )
+
+        if min_date is None:
+            # fast return as there are no DAG runs ``num`` before ``base_date`` to be found.
+            return list()
+
         return self.get_task_instances(start_date=min_date, end_date=base_date, session=session)
 
     @provide_session

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -43,7 +43,6 @@ from typing import (
     Iterator,
     List,
     Sequence,
-    TypeVar,
     Union,
     cast,
     overload,


### PR DESCRIPTION
Currently, if a DAG history is solely comprised of manual runs, they cannot be filtered down by `nums` in the duration view, because in this case, the min_date defaults to the current utc_epoch. Consequently, an unlimited number of DAG runs is displayed. With the implemented fallback, the behavior for mixed (scheduled + manual) DAG runs is similar to the default behavior, as it is for manual-only runs. It was implemented this way to avoid breaking changes.

closes: #22015