### PR TITLE
Make the S3-to-SQL system test self-contained

### DIFF
--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -207,7 +207,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
         :ref:`howto/operator:SQLExecuteQueryOperator`
     """
 
-    template_fields: Sequence[str] = ("sql", "parameters")
+    template_fields: Sequence[str] = ("conn_id", "sql", "parameters")
     template_ext: Sequence[str] = (".sql", ".json")
     template_fields_renderers = {"sql": "sql", "parameters": "json"}
     ui_color = "#cdaaed"
@@ -556,7 +556,7 @@ class SQLTableCheckOperator(BaseSQLOperator):
         :ref:`howto/operator:SQLTableCheckOperator`
     """
 
-    template_fields = ("partition_clause", "table", "sql")
+    template_fields = ("partition_clause", "table", "sql", "conn_id")
 
     template_fields_renderers = {"sql": "sql"}
 

--- a/tests/system/providers/amazon/aws/example_s3_to_sql.py
+++ b/tests/system/providers/amazon/aws/example_s3_to_sql.py
@@ -136,8 +136,7 @@ with DAG(
         task_id="wait_cluster_available",
         cluster_identifier=redshift_cluster_identifier,
         target_status="available",
-        poke_interval=15,
-        timeout=60 * 10,
+        poke_interval=5,
     )
 
     set_up_connection = create_connection(conn_id_name, cluster_id=redshift_cluster_identifier)

--- a/tests/system/providers/amazon/aws/example_s3_to_sql.py
+++ b/tests/system/providers/amazon/aws/example_s3_to_sql.py
@@ -66,8 +66,7 @@ SAMPLE_DATA = r"""1,Caipirinha,Cachaca
 
 @task
 def create_connection(conn_id_name: str, cluster_id: str):
-    redshift_hook = RedshiftHook()
-    cluster_endpoint = redshift_hook.conn.describe_clusters(ClusterIdentifier=cluster_id)["Clusters"][0]
+    cluster_endpoint = RedshiftHook().conn.describe_clusters(ClusterIdentifier=cluster_id)["Clusters"][0]
     conn = Connection(
         conn_id=conn_id_name,
         conn_type="redshift",
@@ -88,19 +87,13 @@ def setup_security_group(sec_group_name: str, ip_permissions: list[dict]):
     default_vpc = client.describe_vpcs(Filters=[{"Name": "is-default", "Values": ["true"]}])["Vpcs"][0]
 
     security_group = client.create_security_group(
-        Description="Redshift-system-test",
-        GroupName=sec_group_name,
-        VpcId=default_vpc["VpcId"],
+        Description="Redshift-system-test", GroupName=sec_group_name, VpcId=default_vpc["VpcId"]
     )
     client.get_waiter("security_group_exists").wait(
-        GroupIds=[security_group["GroupId"]],
-        GroupNames=[sec_group_name],
-        WaiterConfig={"Delay": 15, "MaxAttempts": 4},
+        GroupIds=[security_group["GroupId"]], GroupNames=[sec_group_name]
     )
     client.authorize_security_group_ingress(
-        GroupId=security_group["GroupId"],
-        GroupName=sec_group_name,
-        IpPermissions=ip_permissions,
+        GroupId=security_group["GroupId"], GroupName=sec_group_name, IpPermissions=ip_permissions
     )
     return security_group["GroupId"]
 

--- a/tests/system/providers/amazon/aws/example_s3_to_sql.py
+++ b/tests/system/providers/amazon/aws/example_s3_to_sql.py
@@ -18,14 +18,24 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from airflow import DAG
+import boto3
+
+from airflow import DAG, settings
+from airflow.decorators import task
+from airflow.models import Connection
 from airflow.models.baseoperator import chain
+from airflow.providers.amazon.aws.hooks.redshift_cluster import RedshiftHook
+from airflow.providers.amazon.aws.operators.redshift_cluster import (
+    RedshiftCreateClusterOperator,
+    RedshiftDeleteClusterOperator,
+)
 from airflow.providers.amazon.aws.operators.s3 import (
     S3CreateBucketOperator,
     S3CreateObjectOperator,
     S3DeleteBucketOperator,
     S3DeleteObjectsOperator,
 )
+from airflow.providers.amazon.aws.sensors.redshift_cluster import RedshiftClusterSensor
 from airflow.providers.amazon.aws.transfers.s3_to_sql import S3ToSqlOperator
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator, SQLTableCheckOperator
 from airflow.utils.trigger_rule import TriggerRule
@@ -36,12 +46,68 @@ sys_test_context_task = SystemTestContextBuilder().build()
 
 DAG_ID = "example_s3_to_sql"
 
+DB_LOGIN = "adminuser"
+DB_PASS = "MyAmazonPassword1"
+DB_NAME = "dev"
+
+IP_PERMISSION = {
+    "FromPort": -1,
+    "IpProtocol": "All",
+    "IpRanges": [{"CidrIp": "0.0.0.0/0", "Description": "Test description"}],
+}
+
 SQL_TABLE_NAME = "cocktails"
 SQL_COLUMN_LIST = ["cocktail_id", "cocktail_name", "base_spirit"]
 SAMPLE_DATA = r"""1,Caipirinha,Cachaca
 2,Bramble,Gin
 3,Daiquiri,Rum
 """
+
+
+@task
+def create_connection(conn_id_name: str, cluster_id: str):
+    redshift_hook = RedshiftHook()
+    cluster_endpoint = redshift_hook.conn.describe_clusters(ClusterIdentifier=cluster_id)["Clusters"][0]
+    conn = Connection(
+        conn_id=conn_id_name,
+        conn_type="redshift",
+        host=cluster_endpoint["Endpoint"]["Address"],
+        login=DB_LOGIN,
+        password=DB_PASS,
+        port=cluster_endpoint["Endpoint"]["Port"],
+        schema=cluster_endpoint["DBName"],
+    )
+    session = settings.Session()
+    session.add(conn)
+    session.commit()
+
+
+@task
+def setup_security_group(sec_group_name: str, ip_permissions: list[dict]):
+    client = boto3.client("ec2")
+    default_vpc = client.describe_vpcs(Filters=[{"Name": "is-default", "Values": ["true"]}])["Vpcs"][0]
+
+    security_group = client.create_security_group(
+        Description="Redshift-system-test",
+        GroupName=sec_group_name,
+        VpcId=default_vpc["VpcId"],
+    )
+    client.get_waiter("security_group_exists").wait(
+        GroupIds=[security_group["GroupId"]],
+        GroupNames=[sec_group_name],
+        WaiterConfig={"Delay": 15, "MaxAttempts": 4},
+    )
+    client.authorize_security_group_ingress(
+        GroupId=security_group["GroupId"],
+        GroupName=sec_group_name,
+        IpPermissions=ip_permissions,
+    )
+    return security_group["GroupId"]
+
+
+@task(trigger_rule=TriggerRule.ALL_DONE)
+def delete_security_group(sec_group_id: str, sec_group_name: str):
+    boto3.client("ec2").delete_security_group(GroupId=sec_group_id, GroupName=sec_group_name)
 
 
 with DAG(
@@ -54,9 +120,34 @@ with DAG(
 
     test_context = sys_test_context_task()
     env_id = test_context[ENV_ID_KEY]
-
+    conn_id_name = f"{env_id}-conn-id"
+    redshift_cluster_identifier = f"{env_id}-redshift-cluster"
+    sg_name = f"{env_id}-sg"
     s3_bucket_name = f"{env_id}-bucket"
     s3_key = f"{env_id}/files/cocktail_list.csv"
+
+    set_up_sg = setup_security_group(sec_group_name=sg_name, ip_permissions=[IP_PERMISSION])
+
+    create_cluster = RedshiftCreateClusterOperator(
+        task_id="create_cluster",
+        cluster_identifier=redshift_cluster_identifier,
+        vpc_security_group_ids=[set_up_sg],
+        publicly_accessible=True,
+        cluster_type="single-node",
+        node_type="dc2.large",
+        master_username=DB_LOGIN,
+        master_user_password=DB_PASS,
+    )
+
+    wait_cluster_available = RedshiftClusterSensor(
+        task_id="wait_cluster_available",
+        cluster_identifier=redshift_cluster_identifier,
+        target_status="available",
+        poke_interval=15,
+        timeout=60 * 10,
+    )
+
+    set_up_connection = create_connection(conn_id_name, cluster_id=redshift_cluster_identifier)
 
     create_bucket = S3CreateBucketOperator(
         task_id="create_bucket",
@@ -73,7 +164,7 @@ with DAG(
 
     create_table = SQLExecuteQueryOperator(
         task_id="create_sample_table",
-        conn_id="sql_default",
+        conn_id=conn_id_name,
         sql=f"""
             CREATE TABLE IF NOT EXISTS {SQL_TABLE_NAME} (
             cocktail_id INT NOT NULL,
@@ -101,6 +192,7 @@ with DAG(
         table=SQL_TABLE_NAME,
         column_list=SQL_COLUMN_LIST,
         parser=parse_csv_to_list,
+        sql_conn_id=conn_id_name,
     )
     # [END howto_transfer_s3_to_sql]
 
@@ -124,12 +216,13 @@ with DAG(
         table=SQL_TABLE_NAME,
         column_list=SQL_COLUMN_LIST,
         parser=parse_csv_to_generator,
+        sql_conn_id=conn_id_name,
     )
     # [END howto_transfer_s3_to_sql_generator]
 
     check_table = SQLTableCheckOperator(
         task_id="check_table",
-        conn_id="sql_default",
+        conn_id=conn_id_name,
         table=SQL_TABLE_NAME,
         checks={
             "row_count_check": {"check_statement": "COUNT(*) = 6"},
@@ -137,7 +230,7 @@ with DAG(
     )
 
     drop_table = SQLExecuteQueryOperator(
-        conn_id="sql_default",
+        conn_id=conn_id_name,
         trigger_rule=TriggerRule.ALL_DONE,
         task_id="drop_table",
         sql=f"DROP TABLE {SQL_TABLE_NAME}",
@@ -157,9 +250,24 @@ with DAG(
         force_delete=True,
     )
 
+    delete_cluster = RedshiftDeleteClusterOperator(
+        task_id="delete_cluster",
+        cluster_identifier=redshift_cluster_identifier,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
+    delete_sg = delete_security_group(
+        sec_group_id=set_up_sg,
+        sec_group_name=sg_name,
+    )
+
     chain(
         # TEST SETUP
         test_context,
+        set_up_sg,
+        create_cluster,
+        wait_cluster_available,
+        set_up_connection,
         create_bucket,
         create_object,
         create_table,
@@ -171,6 +279,8 @@ with DAG(
         drop_table,
         delete_s3_objects,
         delete_s3_bucket,
+        delete_cluster,
+        delete_sg,
     )
 
     list(dag.tasks) >> watcher()


### PR DESCRIPTION
The test was relying on an existing default-sql connection which doesn't exist in the test environment.  Added the code to create and then teardown the Connection. 

With these changes, the test will run successfully on the CI infra and can be added to our[ System Test Dashboard](https://aws-mwaa.github.io/open-source/system-tests/dashboard.html)

@maggesssss Since you wrote the original test, does this look good to you?

cc: @o-nikolas @vincbeck @syedahsn @vandonr-amz 