### PR TITLE
SQLA20: Replace Session.query(...).get by Session.get

### DIFF
--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -362,7 +362,7 @@ def update_dag_run_state(*, dag_id: str, dag_run_id: str, session: Session = NEW
         set_dag_run_state_to_queued(dag=dag, run_id=dag_run.run_id, commit=True)
     else:
         set_dag_run_state_to_failed(dag=dag, run_id=dag_run.run_id, commit=True)
-    dag_run = session.query(DagRun).get(dag_run.id)
+    dag_run = session.get(DagRun, dag_run.id)
     return dagrun_schema.dump(dag_run)
 
 

--- a/airflow/api_connexion/endpoints/event_log_endpoint.py
+++ b/airflow/api_connexion/endpoints/event_log_endpoint.py
@@ -37,7 +37,7 @@ from airflow.utils.session import NEW_SESSION, provide_session
 @provide_session
 def get_event_log(*, event_log_id: int, session: Session = NEW_SESSION) -> APIResponse:
     """Get a log entry."""
-    event_log = session.query(Log).get(event_log_id)
+    event_log = session.get(Log, event_log_id)
     if event_log is None:
         raise NotFound("Event Log not found")
     return event_log_schema.dump(event_log)

--- a/airflow/api_connexion/endpoints/import_error_endpoint.py
+++ b/airflow/api_connexion/endpoints/import_error_endpoint.py
@@ -37,7 +37,7 @@ from airflow.utils.session import NEW_SESSION, provide_session
 @provide_session
 def get_import_error(*, import_error_id: int, session: Session = NEW_SESSION) -> APIResponse:
     """Get an import error."""
-    error = session.query(ImportErrorModel).get(import_error_id)
+    error = session.get(ImportErrorModel, import_error_id)
 
     if error is None:
         raise NotFound(

--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -530,8 +530,8 @@ def post_set_task_instances_state(*, dag_id: str, session: Session = NEW_SESSION
             detail=f"Task instance not found for task {task_id!r} on execution_date {execution_date}"
         )
 
-    if run_id and not session.query(TI).get(
-        {"task_id": task_id, "dag_id": dag_id, "run_id": run_id, "map_index": -1}
+    if run_id and not session.get(
+        TI, {"task_id": task_id, "dag_id": dag_id, "run_id": run_id, "map_index": -1}
     ):
         error_message = f"Task instance not found for task {task_id!r} on DAG run with ID {run_id!r}"
         raise NotFound(detail=error_message)
@@ -583,8 +583,8 @@ def patch_task_instance(
     if not dag.has_task(task_id):
         raise NotFound("Task not found", detail=f"Task {task_id!r} not found in DAG {dag_id!r}")
 
-    ti: TI | None = session.query(TI).get(
-        {"task_id": task_id, "dag_id": dag_id, "run_id": dag_run_id, "map_index": map_index}
+    ti: TI | None = session.get(
+        TI, {"task_id": task_id, "dag_id": dag_id, "run_id": dag_run_id, "map_index": map_index}
     )
 
     if not ti:

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -730,7 +730,7 @@ class DagFileProcessor(LoggingMixin):
             from airflow.models.serialized_dag import SerializedDagModel
 
             try:
-                model = session.query(SerializedDagModel).get(simple_ti.dag_id)
+                model = session.get(SerializedDagModel, simple_ti.dag_id)
                 if model:
                     task = model.dag.get_task(simple_ti.task_id)
             except (exc.NoResultFound, TaskNotFound):

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -3244,7 +3244,11 @@ class DagModel(Base):
     @staticmethod
     @provide_session
     def get_dagmodel(dag_id, session=NEW_SESSION):
-        return session.query(DagModel).options(joinedload(DagModel.parent_dag)).get(dag_id)
+        return session.get(
+            DagModel,
+            dag_id,
+            options=[joinedload(DagModel.parent_dag)],
+        )
 
     @classmethod
     @provide_session

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1294,7 +1294,7 @@ class DagRun(Base, LoggingMixin):
         if self.log_template_id is None:  # DagRun created before LogTemplate introduction.
             template = session.query(LogTemplate).order_by(LogTemplate.id).first()
         else:
-            template = session.query(LogTemplate).get(self.log_template_id)
+            template = session.get(LogTemplate, self.log_template_id)
         if template is None:
             raise AirflowException(
                 f"No log_template entry found for ID {self.log_template_id!r}. "

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -230,7 +230,7 @@ class SecurityManager(BaseSecurityManager):
             return False
 
     def get_user_by_id(self, pk):
-        return self.get_session.query(self.user_model).get(pk)
+        return self.get_session.get(self.user_model, pk)
 
     def add_role(self, name: str) -> Role | None:
         role = self.find_role(name)
@@ -248,7 +248,7 @@ class SecurityManager(BaseSecurityManager):
         return role
 
     def update_role(self, role_id, name: str) -> Role | None:
-        role = self.get_session.query(self.role_model).get(role_id)
+        role = self.get_session.get(self.role_model, role_id)
         if not role:
             return None
         try:

--- a/tests/always/test_connection.py
+++ b/tests/always/test_connection.py
@@ -681,7 +681,7 @@ class TestConnection(unittest.TestCase):
 
             self.mask_secret.reset_mock()
 
-            from_db = session.query(Connection).get(conn.id)
+            from_db = session.get(Connection, conn.id)
             from_db.extra_dejson
 
             assert self.mask_secret.mock_calls == [

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -1598,13 +1598,14 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         self.create_task_instances(session)
 
         NEW_STATE = "failed"
-        mock_set_task_instance_state.return_value = session.query(TaskInstance).get(
+        mock_set_task_instance_state.return_value = session.get(
+            TaskInstance,
             {
                 "task_id": "print_the_context",
                 "dag_id": "example_python_operator",
                 "run_id": "TEST_DAG_RUN_ID",
                 "map_index": -1,
-            }
+            },
         )
         response = self.client.patch(
             self.ENDPOINT_URL,
@@ -1636,13 +1637,14 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         self.create_task_instances(session)
 
         NEW_STATE = "failed"
-        mock_set_task_instance_state.return_value = session.query(TaskInstance).get(
+        mock_set_task_instance_state.return_value = session.get(
+            TaskInstance,
             {
                 "task_id": "print_the_context",
                 "dag_id": "example_python_operator",
                 "run_id": "TEST_DAG_RUN_ID",
                 "map_index": -1,
-            }
+            },
         )
         response = self.client.patch(
             self.ENDPOINT_URL,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -532,7 +532,7 @@ def dag_maker(request):
 
             dag.clear(session=self.session)
             dag.sync_to_db(processor_subdir=self.processor_subdir, session=self.session)
-            self.dag_model = self.session.query(DagModel).get(dag.dag_id)
+            self.dag_model = self.session.get(DagModel, dag.dag_id)
 
             if self.want_serialized:
                 self.serialized_model = SerializedDagModel(

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -715,7 +715,7 @@ class TestDagFileProcessorManager:
         assert sum(stat.run_count for stat in manager._file_stats.values()) == 3
 
         with create_session() as session:
-            assert session.query(DagModel).get(dag_id) is not None
+            assert session.get(DagModel, dag_id) is not None
 
     @conf_vars({("core", "load_examples"): "False"})
     @pytest.mark.backend("mysql", "postgres")

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1575,7 +1575,7 @@ class TestSchedulerJob:
         self.scheduler_job.dagbag = dag_maker.dagbag
 
         session = settings.Session()
-        orm_dag = session.query(DagModel).get(dag.dag_id)
+        orm_dag = session.get(DagModel, dag.dag_id)
         assert orm_dag is not None
         for _ in range(20):
             self.scheduler_job._create_dag_runs([orm_dag], session)
@@ -1650,7 +1650,7 @@ class TestSchedulerJob:
         self.scheduler_job.dagbag = dag_maker.dagbag
 
         session = settings.Session()
-        orm_dag = session.query(DagModel).get(dag.dag_id)
+        orm_dag = session.get(DagModel, dag.dag_id)
         assert orm_dag is not None
 
         self.scheduler_job._create_dag_runs([orm_dag], session)
@@ -3431,7 +3431,7 @@ class TestSchedulerJob:
         assert dr1.data_interval_end == DEFAULT_DATE + timedelta(minutes=1)
 
         # Verify that dag_model.next_dagrun is set to next interval
-        dag_model = session.query(DagModel).get(dag.dag_id)
+        dag_model = session.get(DagModel, dag.dag_id)
         assert dag_model.next_dagrun == DEFAULT_DATE + timedelta(minutes=1)
         assert dag_model.next_dagrun_data_interval_start == DEFAULT_DATE + timedelta(minutes=1)
         assert dag_model.next_dagrun_data_interval_end == DEFAULT_DATE + timedelta(minutes=2)
@@ -3450,7 +3450,7 @@ class TestSchedulerJob:
 
         # Test that 'dag_model.next_dagrun' has not been changed because of newly created external
         # triggered DagRun.
-        dag_model = session.query(DagModel).get(dag.dag_id)
+        dag_model = session.get(DagModel, dag.dag_id)
         assert dag_model.next_dagrun == DEFAULT_DATE + timedelta(minutes=1)
         assert dag_model.next_dagrun_data_interval_start == DEFAULT_DATE + timedelta(minutes=1)
         assert dag_model.next_dagrun_data_interval_end == DEFAULT_DATE + timedelta(minutes=2)
@@ -3542,7 +3542,7 @@ class TestSchedulerJob:
         self.scheduler_job.executor = MockExecutor()
         self.scheduler_job.processor_agent = mock.MagicMock(spec=DagFileProcessorAgent)
 
-        my_dag = session.query(DagModel).get(dag.dag_id)
+        my_dag = session.get(DagModel, dag.dag_id)
         self.scheduler_job._create_dag_runs([my_dag], session)
         # Run relevant part of scheduling again to assert run2 has been scheduled
         self.scheduler_job._schedule_dag_run(run1, session)
@@ -3672,7 +3672,7 @@ class TestSchedulerJob:
         for _ in range(3):
             self.scheduler_job._do_scheduling(session)
 
-        model: DagModel = session.query(DagModel).get(dag.dag_id)
+        model: DagModel = session.get(DagModel, dag.dag_id)
 
         # Pre-condition
         assert DagRun.active_runs_of_dags(session=session) == {"test_dag": 3}
@@ -3687,7 +3687,6 @@ class TestSchedulerJob:
         for _ in range(5):
             self.scheduler_job._do_scheduling(session)
             complete_one_dagrun()
-            model: DagModel = session.query(DagModel).get(dag.dag_id)
 
         expected_execution_dates = [datetime.datetime(2016, 1, d, tzinfo=timezone.utc) for d in range(1, 6)]
         dagrun_execution_dates = [
@@ -4474,7 +4473,7 @@ class TestSchedulerJob:
 
         # Create DagRun
         session = settings.Session()
-        orm_dag = session.query(DagModel).get(dag.dag_id)
+        orm_dag = session.get(DagModel, dag.dag_id)
         self.scheduler_job._create_dag_runs([orm_dag], session)
 
         drs = DagRun.find(dag_id=dag.dag_id, session=session)

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -829,7 +829,7 @@ class TestDag:
         dag.clear()
         DAG.bulk_write_to_db([dag], session=session)
 
-        model = session.query(DagModel).get((dag.dag_id,))
+        model = session.get(DagModel, dag.dag_id)
 
         assert model.next_dagrun == DEFAULT_DATE
         assert model.next_dagrun_create_after == DEFAULT_DATE + timedelta(days=1)
@@ -843,12 +843,12 @@ class TestDag:
         assert dr is not None
         DAG.bulk_write_to_db([dag])
 
-        model = session.query(DagModel).get((dag.dag_id,))
+        model = session.get(DagModel, dag.dag_id)
         # We signal "at max active runs" by saying this run is never eligible to be created
         assert model.next_dagrun_create_after is None
         # test that bulk_write_to_db again doesn't update next_dagrun_create_after
         DAG.bulk_write_to_db([dag])
-        model = session.query(DagModel).get((dag.dag_id,))
+        model = session.get(DagModel, dag.dag_id)
         assert model.next_dagrun_create_after is None
 
     def test_bulk_write_to_db_has_import_error(self):
@@ -863,7 +863,7 @@ class TestDag:
         dag.clear()
         DAG.bulk_write_to_db([dag], session=session)
 
-        model = session.query(DagModel).get((dag.dag_id,))
+        model = session.get(DagModel, dag.dag_id)
 
         assert not model.has_import_errors
 
@@ -871,13 +871,13 @@ class TestDag:
         model.has_import_errors = True
         session.merge(model)
         session.flush()
-        model = session.query(DagModel).get((dag.dag_id,))
+        model = session.get(DagModel, dag.dag_id)
         # assert
         assert model.has_import_errors
         # parse
         DAG.bulk_write_to_db([dag])
 
-        model = session.query(DagModel).get((dag.dag_id,))
+        model = session.get(DagModel, dag.dag_id)
         # assert that has_import_error is now false
         assert not model.has_import_errors
         session.close()
@@ -1350,7 +1350,7 @@ class TestDag:
         )
         dag.sync_to_db()
         with create_session() as session:
-            model = session.query(DagModel).get((dag.dag_id,))
+            model = session.get(DagModel, dag.dag_id)
 
         # Even though there is a run for this date already, it is marked as manual/external, so we should
         # create a scheduled one anyway!
@@ -1377,7 +1377,7 @@ class TestDag:
         # Then sync again after creating the dag run -- this should update next_dagrun
         dag.sync_to_db()
         with create_session() as session:
-            model = session.query(DagModel).get((dag.dag_id,))
+            model = session.get(DagModel, dag.dag_id)
 
         assert model.next_dagrun is None
         assert model.next_dagrun_create_after is None

--- a/tests/models/test_serialized_dag.py
+++ b/tests/models/test_serialized_dag.py
@@ -86,12 +86,12 @@ class TestSerializedDagModel:
         assert dag_updated is True
 
         with create_session() as session:
-            s_dag = session.query(SDM).get(example_bash_op_dag.dag_id)
+            s_dag = session.get(SDM, example_bash_op_dag.dag_id)
 
             # Test that if DAG is not changed, Serialized DAG is not re-written and last_updated
             # column is not updated
             dag_updated = SDM.write_dag(dag=example_bash_op_dag)
-            s_dag_1 = session.query(SDM).get(example_bash_op_dag.dag_id)
+            s_dag_1 = session.get(SDM, example_bash_op_dag.dag_id)
 
             assert s_dag_1.dag_hash == s_dag.dag_hash
             assert s_dag.last_updated == s_dag_1.last_updated
@@ -102,7 +102,7 @@ class TestSerializedDagModel:
             assert set(example_bash_op_dag.tags) == {"example", "example2", "new_tag"}
 
             dag_updated = SDM.write_dag(dag=example_bash_op_dag)
-            s_dag_2 = session.query(SDM).get(example_bash_op_dag.dag_id)
+            s_dag_2 = session.get(SDM, example_bash_op_dag.dag_id)
 
             assert s_dag.last_updated != s_dag_2.last_updated
             assert s_dag.dag_hash != s_dag_2.dag_hash
@@ -117,12 +117,12 @@ class TestSerializedDagModel:
         assert dag_updated is True
 
         with create_session() as session:
-            s_dag = session.query(SDM).get(example_bash_op_dag.dag_id)
+            s_dag = session.get(SDM, example_bash_op_dag.dag_id)
 
             # Test that if DAG is not changed, Serialized DAG is not re-written and last_updated
             # column is not updated
             dag_updated = SDM.write_dag(dag=example_bash_op_dag, processor_subdir="/tmp/test")
-            s_dag_1 = session.query(SDM).get(example_bash_op_dag.dag_id)
+            s_dag_1 = session.get(SDM, example_bash_op_dag.dag_id)
 
             assert s_dag_1.dag_hash == s_dag.dag_hash
             assert s_dag.last_updated == s_dag_1.last_updated
@@ -131,7 +131,7 @@ class TestSerializedDagModel:
 
             # Update DAG
             dag_updated = SDM.write_dag(dag=example_bash_op_dag, processor_subdir="/tmp/other")
-            s_dag_2 = session.query(SDM).get(example_bash_op_dag.dag_id)
+            s_dag_2 = session.get(SDM, example_bash_op_dag.dag_id)
 
             assert s_dag.processor_subdir != s_dag_2.processor_subdir
             assert dag_updated is True

--- a/tests/models/test_variable.py
+++ b/tests/models/test_variable.py
@@ -250,7 +250,7 @@ class TestVariable:
 
             self.mask_secret.reset_mock()
 
-            session.query(Variable).get(var.id)
+            session.get(Variable, var.id)
 
             assert self.mask_secret.mock_calls == [
                 # We should have called it _again_ when loading from the DB

--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -363,6 +363,6 @@ def test_process_form_invalid_extra_removed(admin_client):
 
     assert resp.status_code == 200
     with create_session() as session:
-        conn = session.query(Connection).get(1)
+        conn = session.get(Connection, 1)
 
     assert conn.extra == '{"foo": "bar"}'


### PR DESCRIPTION
related: #28723

Replace abstract `session.query(User).get(5)` by `session.get(User, 5)` ([1.4/2.0 compatible](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-20-get-to-session)). First from the list:  [2.0 Migration - ORM Usage](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-orm-usage)

Note: most of the legacy usage found by regex: `query\(.*\.get\(` so there is possible that unchanged part still exists.