### PR TITLE
Fix PgBouncer after postgres subchart upgrade

### DIFF
--- a/chart/newsfragments/27353.significant.rst
+++ b/chart/newsfragments/27353.significant.rst
@@ -1,0 +1,21 @@
+The helm chart is now using a newer version of bitnami/postgresql (from 10.5.3 to 12.1.9)
+
+The version of postgresql installed is still version 11.
+
+This version of the chart uses different variable names for setting usernames and passwords in the postgres database.
+
+- ``postgresql.auth.enablePostgresUser`` is used to determine if the "postgres" admin account will be created.
+- ``postgresql.auth.postgresPassword`` sets the password for the "postgres" user.
+- ``postgresql.auth.username`` and ``postrgesql.auth.password`` are used to set credentials for a non-admin account if desired.
+- ``postgresql.postgresqlUsername`` and ``postgresql.postresqlPassword``, which were used in the previous version of the chart, are no longer used.
+
+Users will need to change these variable names in their values files if they are using the helm chart.
+
+If you are upgrading an existing helm release with the built-in postgres database, you will either need to delete your release and reinstall fresh, or manually delete these 2 objects:
+
+```
+kubectl delete secret {RELEASE_NAME}-postgresql
+kubectl delete statefulset {RELEASE_NAME}-postgresql
+```
+
+As a reminder, it is recommended to `set up an external database <https://airflow.apache.org/docs/helm-chart/stable/production-guide.html#database>`_ in production.

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -5200,6 +5200,18 @@
                     "type": "boolean",
                     "default": true
                 },
+                "images": {
+                    "description": "PostgreSQL image values.",
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "tag": {
+                            "description": "The PostgreSQL image tag.",
+                            "type": "string",
+                            "default": "11"
+                        }
+                    }
+                },
                 "auth": {
                     "description": "PostgreSQL authentication values.",
                     "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1702,6 +1702,8 @@ cleanup:
 # Not recommended for production
 postgresql:
   enabled: true
+  image:
+    tag: "11"
   auth:
     enablePostgresUser: true
     postgresPassword: postgres

--- a/newsfragments/27353.significant.rst
+++ b/newsfragments/27353.significant.rst
@@ -1,8 +1,0 @@
-The helm chart is now using a newer version of bitnami/postgresql (from 10.5.3 to 12.1.9)
-
-This version of the chart uses different variable names for setting usernames and passwords in the postgres database.
-```postgresql.auth.enablePostgresUser``` is used to determine if the "postgres" admin account will be created.
-```postgresql.auth.postgresPassword``` sets the password for the "postgres" user.
-```postgresql.auth.username``` and ```postrgesql.auth.password``` are used to set credentials for a non-admin account if desired.
-```postgresql.postgresqlUsername``` and ```postgresql.postresqlPassword```, which were used in the previous version of the chart, are no longer used.
-Users will need to change these variable names in their values files if they are using the helm chart.


### PR DESCRIPTION
The recent postgres subchart upgrade had some issues: #29071

The biggest was the upgrade from PG 11 -> 15 resulted in the default `password_encryption` switching from `md5` to `scram-sha-256`. Simply moving back to 11 is the easiest remediation, and is acceptable since it is the oldest version Airflow supports (as of today in 2.5).

Additionally, when updating the subchart, updating existing releases using built-in postgres was broken. As production use cases shouldn't be using built-in postgres, and it's easy to work around when hit, I've just documented the steps to proceed with the upgrade.

cc @snjypl 