### PR TITLE
Snowflake Provider Package - hide host from UI

### DIFF
--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -74,7 +74,7 @@ class SnowflakeHook(DbApiHook):
     """
     A client to interact with Snowflake.
 
-    This hook requires the snowflake_conn_id connection. The snowflake host, login,
+    This hook requires the snowflake_conn_id connection. The snowflake account, login,
     and, password field must be setup in the connection. Other inputs can be defined
     in the connection or hook instantiation.
 
@@ -143,7 +143,7 @@ class SnowflakeHook(DbApiHook):
         import json
 
         return {
-            "hidden_fields": ["port"],
+            "hidden_fields": ["port", "host"],
             "relabeling": {},
             "placeholders": {
                 "extra": json.dumps(


### PR DESCRIPTION
Addresses an unfinished problem relating to ~~#29207~~ #24572

In #24573, the Snowflake provider package's documentation was updated to reflect the fact that the `host` is never used in the `SnowflakeHook()`.

However, it still shows up in the UI. I didn't realize that this could be hidden until just now after helping someone with another problem related to hooking up the Snowflake connection. So we should remove it.

(You can CTRL+F the Snowflake hook source code to confirm the host really is never used as part of the connection.)