### PR TITLE
Fix bitnami/postgresql subchart upgrade

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4422,7 +4422,7 @@
                 "auth_type": {
                     "description": "Method of authenticating users",
                     "type": "string",
-                    "default": "md5"
+                    "default": "scram-sha-256"
                 },
                 "auth_file": {
                     "description": "The name of the file to load user names and passwords from",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1428,7 +1428,7 @@ pgbouncer:
   command: ["pgbouncer", "-u", "nobody", "/etc/pgbouncer/pgbouncer.ini"]
   # Args to use for PgBouncer(templated).
   args: ~
-  auth_type: md5
+  auth_type: scram-sha-256
   auth_file: /etc/pgbouncer/users.txt
 
   # annotations to be added to the PgBouncer deployment

--- a/tests/charts/test_pgbouncer.py
+++ b/tests/charts/test_pgbouncer.py
@@ -469,7 +469,7 @@ class TestPgbouncerConfig:
         }
         ini = self._get_pgbouncer_ini(values)
 
-        assert "auth_type = md5" in ini
+        assert "auth_type = scram-sha-256" in ini
         assert "auth_file = /etc/pgbouncer/users.txt" in ini
 
     def test_auth_type_file_overrides(self):


### PR DESCRIPTION
The PR changes default `pgbouncer.auth_type` value to `scram-sha-256`.
It fixes the case when installing the chart with enabled `pgbouncer`, i.e. the following deployment:
```
helm install test chart --set pgbouncer.enabled=true
```
The issue was introduced when bitnami/postgres subchart was upgraded to 12.1.9 version. Previous bitnami/postgres subchart deploys Postgres 11 with default auth type md5, current version deploys Postgres 15 with default auth type scram-sha-256.

related: https://github.com/apache/airflow/pull/29071 and https://github.com/apache/airflow/pull/29207