### PR TITLE
Provide the missing connection id for the parent classes of snowflake operators

### DIFF
--- a/airflow/providers/snowflake/operators/snowflake.py
+++ b/airflow/providers/snowflake/operators/snowflake.py
@@ -199,7 +199,7 @@ class SnowflakeCheckOperator(SQLCheckOperator):
         session_parameters: dict | None = None,
         **kwargs,
     ) -> None:
-        super().__init__(sql=sql, parameters=parameters, **kwargs)
+        super().__init__(sql=sql, parameters=parameters, conn_id=snowflake_conn_id, **kwargs)
         self.snowflake_conn_id = snowflake_conn_id
         self.sql = sql
         self.autocommit = autocommit
@@ -265,7 +265,9 @@ class SnowflakeValueCheckOperator(SQLValueCheckOperator):
         session_parameters: dict | None = None,
         **kwargs,
     ) -> None:
-        super().__init__(sql=sql, pass_value=pass_value, tolerance=tolerance, **kwargs)
+        super().__init__(
+            sql=sql, pass_value=pass_value, tolerance=tolerance, conn_id=snowflake_conn_id, **kwargs
+        )
         self.snowflake_conn_id = snowflake_conn_id
         self.sql = sql
         self.autocommit = autocommit
@@ -344,6 +346,7 @@ class SnowflakeIntervalCheckOperator(SQLIntervalCheckOperator):
             metrics_thresholds=metrics_thresholds,
             date_filter_column=date_filter_column,
             days_back=days_back,
+            conn_id=snowflake_conn_id,
             **kwargs,
         )
         self.snowflake_conn_id = snowflake_conn_id


### PR DESCRIPTION
closes: #29198

---

In the operators `SnowflakeCheckOperator`, `SnowflakeValueCheckOperator` and `SnowflakeIntervalCheckOperator` we are extending some operators from the provider common SQL, but we don't provide the snowflake connection id to the parent class. In this PR, I'm using the `snowflake_conn_id` as a connection id for the parent operator.