### PR TITLE
Fix Trigger DAG w/config origin url

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -236,7 +236,13 @@
                   <button type="submit" class="dropdown-form-btn">Trigger DAG</button>
                 </form>
               </li>
-              <li><a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=url_for(request.endpoint, dag_id=dag.dag_id)) }}">Trigger DAG w/ config</a></li>
+              <li>
+                {% if 'dag_id' in request.args %}
+                  <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=url_for(request.endpoint, **request.args)) }}">
+                {% else %}
+                  <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=url_for(request.endpoint, dag_id=dag.dag_id, **request.args)) }}">
+                {% endif %}
+                Trigger DAG w/ config</a></li>
             </ul>
           </div>
           <a href="{{ url_for('Airflow.delete', dag_id=dag.dag_id, redirect_url=url_for(request.endpoint, dag_id=dag.dag_id)) }}" title="Delete&nbsp;DAG" class="btn btn-default btn-icon-only{{ ' disabled' if not dag.can_delete }}"


### PR DESCRIPTION
closes: #29197

---

This PR fixes the origin url for the Trigger DAG w/config web page, where currently, it redirects to the origin endpoint with the param dag_id, but for some origins, this lead to a error 400.
For example, when we navigate to the Trigger DAG w/config page from the endpoint tasks, the origin url will be `/tasks?dag_id=<dag_id>` without the `task_id`, the `execution_date` and the `map_index`, so when it redirect to this origin url, we get `Bad Request Invalid datetime: None`. To fix this problem, I redirect to the origin endpoint with all the origin params and I add `dag_id` if it doesn't exist in the origin params.