### PR TITLE
Fix commit message for constraints

### DIFF
--- a/scripts/ci/constraints/ci_commit_constraints.sh
+++ b/scripts/ci/constraints/ci_commit_constraints.sh
@@ -23,8 +23,12 @@ git diff --color --exit-code --ignore-matching-lines="^#.*" || \
 git commit --all --message "Updating constraints. Build id:${CI_BUILD_ID}
 
 This update in constraints is automatically committed by the CI 'constraints-push' step based on
-HEAD of '${CI_REF}' in '${CI_TARGET_REPO}'
-with commit sha ${COMMIT_SHA}.
+'${GITHUB_REF}' in the '${GITHUB_REPOSITORY}' repository with commit sha ${GITHUB_SHA}.
+
+The action that build those constraints can be found at https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/
+
+The image tag used for that build was: ${IMAGE_TAG}. You can enter Breeze environment
+with this image by running 'breeze shell --image-tag ${IMAGE_TAG}'
 
 All tests passed in this build so we determined we can push the updated constraints.
 


### PR DESCRIPTION
A long time ago in a galaxy far away ...

We had a code that make our CI variables independent from the CI Actions used and we used CI_* prefixes to distinguish those values. This reflected the time when we moved from Travis to GitHub Actions and we wanted to keep the possibility to support both. Those variables have been since removed, but there was that one single planet (err. script) where the remnant of the old Jedi order (err. variables) remained and they caused rather meaningless commit messages for constraints.

This PR updates the commit messages to be more meaningful, including direct links to the action that updated the constraints and helpful description on how you can easily run breeze with the exact set of dependencies that were used for it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
