### PR TITLE
Small fixups to CI diagrams

### DIFF
--- a/CI_DIAGRAMS.md
+++ b/CI_DIAGRAMS.md
@@ -112,9 +112,9 @@ sequenceDiagram
     opt
         Note over Tests: Generate constraints
     end
+    Note over Tests: Build ARM CI images
     Tests -->> Airflow Repo: Status update
     deactivate Airflow Repo
-    Note over Tests: Build ARM CI images
     deactivate Tests
 ```
 
@@ -204,9 +204,9 @@ sequenceDiagram
     opt
         Note over Tests: Generate constraints
     end
+    Note over Tests: Build ARM CI images
     Tests -->> Airflow Repo: Status update
     deactivate Airflow Repo
-    Note over Tests: Build ARM CI images
     deactivate Tests
 ```
 
@@ -287,15 +287,11 @@ sequenceDiagram
         end
     end
     Note over Tests: Generate constraints
-    opt In merge run?
-        Tests ->> Airflow Repo: Push constraints if changed
-    end
-    opt In merge run?
-        Note over Tests: Build CI Images<br>[latest]<br>Use latest constraints
-        Tests ->> GitHub Registry: Push CI Image<br>[latest]
-        Note over Tests: Build PROD Images<br>[latest]<br>Use latest constraints
-        Tests ->> GitHub Registry: Push PROD Image<br>[latest]
-    end
+    Tests ->> Airflow Repo: Push constraints if changed
+    Note over Tests: Build CI Images<br>[latest]<br>Use latest constraints
+    Tests ->> GitHub Registry: Push CI Image<br>[latest]
+    Note over Tests: Build PROD Images<br>[latest]<br>Use latest constraints
+    Tests ->> GitHub Registry: Push PROD Image<br>[latest]
     Tests -->> Airflow Repo: Status update
     deactivate Airflow Repo
     deactivate Tests
@@ -381,8 +377,8 @@ sequenceDiagram
     Tests ->> GitHub Registry: Push CI Image cache + latest
     Note over Tests: Build PROD Images<br>[latest]<br>Use latest constraints
     Tests ->> GitHub Registry: Push PROD Image cache + latest
+    Note over Tests: Build ARM CI images
     Tests -->> Airflow Repo: Status update
     deactivate Airflow Repo
-    Note over Tests: Build ARM CI images
     deactivate Tests
 ```


### PR DESCRIPTION
There are few small fixups in CI diagrams that would reflect better the current flow:

* while Build ARM images is not dependency of other jobs, they contribute to overall build status
* Canary run is always run as "merge" run so there is no conditional needed there.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
