### PR TITLE
Use thin/passthrough hook instead of one-liner hook method

### DIFF
--- a/airflow/providers/amazon/aws/hooks/emr.py
+++ b/airflow/providers/amazon/aws/hooks/emr.py
@@ -179,15 +179,6 @@ class EmrHook(AwsBaseHook):
                 )
         return response["StepIds"]
 
-    def terminate_job_flow(self, job_flow_id: str) -> None:
-        """
-        Terminate a given EMR cluster (job flow) by id. If TerminationProtected=True on the cluster,
-        termination will be unsuccessful.
-
-        :param job_flow_id: id of the job flow to terminate
-        """
-        self.get_conn().terminate_job_flows(JobFlowIds=[job_flow_id])
-
     def test_connection(self):
         """
         Return failed state for test Amazon Elastic MapReduce Connection (untestable).

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -611,10 +611,13 @@ class EmrCreateJobFlowOperator(BaseOperator):
             return self._job_flow_id
 
     def on_kill(self) -> None:
-        """Terminate job flow."""
+        """
+        Terminate the EMR cluster (job flow). If TerminationProtected=True on the cluster,
+        termination will be unsuccessful.
+        """
         if self._job_flow_id:
             self.log.info("Terminating job flow %s", self._job_flow_id)
-            self._emr_hook.terminate_job_flow(self._job_flow_id)
+            self._emr_hook.conn.terminate_job_flows(JobFlowIds=[self._job_flow_id])
 
 
 class EmrModifyClusterOperator(BaseOperator):


### PR DESCRIPTION
Use the hook to get a boto connection and make the api call from operator method. Defining one-liner hook methods that are just calling boto are not ideal.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
