### PR TITLE
Use `schedule` param rather than `timetable` in Timetables docs

### DIFF
--- a/docs/apache-airflow/authoring-and-scheduling/timetable.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/timetable.rst
@@ -78,9 +78,7 @@ A timetable that accepts a cron expression, and triggers DAG runs according to i
     from airflow.timetables.trigger import CronTriggerTimetable
 
 
-    @dag(
-        timetable=CronTriggerTimetable("0 1 * * 3", timezone="UTC"),  # At 01:00 on Wednesday
-    )
+    @dag(schedule=CronTriggerTimetable("0 1 * * 3", timezone="UTC"), ...)  # At 01:00 on Wednesday
     def example_dag():
         pass
 
@@ -97,11 +95,12 @@ run's data interval would span the specified duration, and *ends* with the trigg
 
     @dag(
         # Runs every Friday at 18:00 to cover the work week (9:00 Monday to 18:00 Friday).
-        timetable=CronTriggerTimetable(
+        schedule=CronTriggerTimetable(
             "0 18 * * 5",
             timezone="UTC",
             interval=timedelta(days=4, hours=9),
         ),
+        ...,
     )
     def example_dag():
         pass
@@ -158,7 +157,7 @@ first) event for the data interval, otherwise manual runs will run with a ``data
 
 
     @dag(
-        timetable=EventsTimetable(
+        schedule=EventsTimetable(
             event_dates=[
                 pendulum.datetime(2022, 4, 5, 8, 27, tz="America/Chicago"),
                 pendulum.datetime(2022, 4, 17, 8, 27, tz="America/Chicago"),
@@ -167,6 +166,7 @@ first) event for the data interval, otherwise manual runs will run with a ``data
             description="My Team's Baseball Games",
             restrict_to_events=False,
         ),
+        ...,
     )
     def example_dag():
         pass

--- a/docs/apache-airflow/howto/timetable.rst
+++ b/docs/apache-airflow/howto/timetable.rst
@@ -78,9 +78,9 @@ file:
     with DAG(
         dag_id="example_after_workday_timetable_dag",
         start_date=pendulum.datetime(2021, 3, 10, tz="UTC"),
-        timetable=AfterWorkdayTimetable(),
+        schedule=AfterWorkdayTimetable(),
         tags=["example", "timetable"],
-    ) as dag:
+    ):
         ...
 
 
@@ -200,9 +200,9 @@ For reference, here's our plugin and DAG files in their entirety:
     with DAG(
         dag_id="example_workday_timetable",
         start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
-        timetable=AfterWorkdayTimetable(),
+        schedule=AfterWorkdayTimetable(),
         tags=["example", "timetable"],
-    ) as dag:
+    ):
         EmptyOperator(task_id="run_this")
 
 
@@ -270,9 +270,9 @@ So for a DAG declared like this:
 .. code-block:: python
 
     with DAG(
-        timetable=SometimeAfterWorkdayTimetable(Time(8)),  # 8am.
+        schedule=SometimeAfterWorkdayTimetable(Time(8)),  # 8am.
         ...,
-    ) as dag:
+    ):
         ...
 
 The *Schedule* column would say ``after each workday, at 08:00:00``.
@@ -312,9 +312,9 @@ So for a DAG declared like this:
 .. code-block:: python
 
     with DAG(
-        timetable=SometimeAfterWorkdayTimetable(Time(8)),  # 8am.
+        schedule=SometimeAfterWorkdayTimetable(Time(8)),  # 8am.
         ...,
-    ) as dag:
+    ):
         ...
 
 The *i* icon  would show,  ``Schedule: after each workday, at 08:00:00``.


### PR DESCRIPTION
As of 2.4.0, the `timetable` DAG param has been deprecated with preference for `schedule`. The docs for Timetables still reference `timetable` in the code examples.

P.S. Small "bonus" added of removing the `as dag:` registration of DAGs initialized with a content manager too.