### PR TITLE
Initialize and validate conf early and intentionally

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -40,6 +40,14 @@ if os.environ.get("_AIRFLOW_PATCH_GEVENT"):
 
     patch_all()
 
+# The configuration module initializes and validates the conf object as a side effect the first
+# time it is imported. If it is not imported before importing the settings module, the conf
+# object will then be initted/validated as a side effect of it being imported in settings,
+# however this can cause issues since those modules are very tightly coupled and can
+# very easily cause import cycles in the conf init/validate code (since downstream code from
+# those functions likely import settings).
+# configuration is therefore initted early here, simply by importing it.
+from airflow import configuration
 from airflow import settings
 
 __all__ = ["__version__", "login", "DAG", "PY36", "PY37", "PY38", "PY39", "PY310", "XComArg"]


### PR DESCRIPTION
#### Background:
The first time `airflow.configuration` is imported triggers all the code that creates and validates the `conf` object to run (since that code lives at the module level in `configuration.py`). At the moment that first import of `airflow.configuration` just _happens_ to be in `airflow.settings` (when settings is imported in `airflow.__init__`). This has a critical side effect that no code in `conf` can use or import any code that uses `airflow.settings` because this would cause an import cycle (since `airflow.settings` is what imported `ariflow.configuration` to then trigger the `conf` object construction). But a TONNE of things in airflow use `airflow.settings`, so it's very difficult to add or change code in `conf` without needing to import something that uses `airflow.settings`.

#### What this change does:
This tactical code change intentionally imports `airflow.configuration` in `airflow.__init__` **before** `airflow.setttings` imports it. This allows the construction and validation of the `conf` object to happen **outside the scope of the `airflow.settings` module** which means it's much easier to add/modify code in `conf` without causing import cycles (which I need to do for another code change, which started this whole investigation).

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
