### PR TITLE
Change awkward wording about extenibility

### DIFF
--- a/docs/apache-airflow/howto/custom-operator.rst
+++ b/docs/apache-airflow/howto/custom-operator.rst
@@ -22,7 +22,7 @@ Creating a custom Operator
 
 
 Airflow allows you to create new operators to suit the requirements of you or your team.
-The extensibility is one of the many reasons which makes Apache Airflow powerful.
+This extensibility is one of the many features which make Apache Airflow powerful.
 
 You can create any operator you want by extending the :class:`airflow.models.baseoperator.BaseOperator`
 


### PR DESCRIPTION
Wording of this sentence was awkward, so I propose this change.

Alternate wording:
```
The extensibility is one of the many reasons that Apache Airflow is powerful.
```

In either version, the word "so" can be added as an intensifier before "powerful".


