### PR TITLE
log the observed status in redshift sensor

### DIFF
--- a/airflow/providers/amazon/aws/sensors/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/sensors/redshift_cluster.py
@@ -56,8 +56,14 @@ class RedshiftClusterSensor(BaseSensorOperator):
         self.aws_conn_id = aws_conn_id
 
     def poke(self, context: Context):
-        self.log.info("Poking for status : %s\nfor cluster %s", self.target_status, self.cluster_identifier)
-        return self.hook.cluster_status(self.cluster_identifier) == self.target_status
+        current_status = self.hook.cluster_status(self.cluster_identifier)
+        self.log.info(
+            "Poked cluster %s for status '%s', found status '%s'",
+            self.cluster_identifier,
+            self.target_status,
+            current_status,
+        )
+        return current_status == self.target_status
 
     @deprecated(reason="use `hook` property instead.")
     def get_hook(self) -> RedshiftHook:


### PR DESCRIPTION
this sensor only checks against the "wanted" status, and not other possibly terminal statuses.
So if the cluster takes an unexpected branch and ends up in a semi-terminal state, this is completely invisible, and would only fail with an uninformative timeout after a long time.

The "proper" fix would be to have a list of terminal states to check against, but I don't have enough redshift knowledge to know what's terminal in the long list of possible statuses:

- available
- available, prep-for-resize
- available, resize-cleanup
- cancelling-resize
- creating
- deleting
- final-snapshot
- hardware-failure
- incompatible-hsm
- incompatible-network
- incompatible-parameters
- incompatible-restore
- modifying
- paused
- rebooting
- renaming
- resizing
- rotating-keys
- storage-full
- updating-hsm

So I'm taking this poor man's approach that'd at least allow us to get a sense of what happened from looking at the logs.

(also, since the sensor is very generic, I think it'd be super hard to do because `storage-full` for instance could be terminal in some cases, except if we run a step to free space and are waiting on the cluster leaving that state ? So many possibilities...)