### PR TITLE
Patch only single label when marking KPO checked

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -711,9 +711,11 @@ class KubernetesPodOperator(BaseOperator):
     def patch_already_checked(self, pod: k8s.V1Pod, *, reraise=True):
         """Add an "already checked" annotation to ensure we don't reattach on retries"""
         with _optionally_suppress(reraise=reraise):
-            pod.metadata.labels[self.POD_CHECKED_KEY] = "True"
-            body = PodGenerator.serialize_pod(pod)
-            self.client.patch_namespaced_pod(pod.metadata.name, pod.metadata.namespace, body)
+            self.client.patch_namespaced_pod(
+                name=pod.metadata.name,
+                namespace=pod.metadata.namespace,
+                body={"metadata": {"labels": {self.POD_CHECKED_KEY: "True"}}},
+            )
 
     def on_kill(self) -> None:
         if self.pod:

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -999,6 +999,18 @@ class TestKubernetesPodOperator:
         mock_patch_already_checked.assert_called_once()
         mock_delete_pod.assert_not_called()
 
+    @patch(HOOK_CLASS, new=MagicMock)
+    def test_patch_already_checked(self):
+        """Make sure we patch the pods with the right label"""
+        k = KubernetesPodOperator(task_id="task")
+        pod = k.build_pod_request_obj()
+        k.patch_already_checked(pod)
+        k.client.patch_namespaced_pod.assert_called_once_with(
+            name=pod.metadata.name,
+            namespace=pod.metadata.namespace,
+            body={"metadata": {"labels": {"already_checked": "True"}}},
+        )
+
     def test_task_id_as_name(self):
         k = KubernetesPodOperator(
             task_id=".hi.-_09HI",


### PR DESCRIPTION
Instead of sending over a whole pod, we can simply send over the label to add to the pod instead. This is less work for us, and also avoids any issues like #24015.

Fixes #24015