### PR TITLE
Constrain Paramiko version to prevent auth SFTP issues

### DIFF
--- a/constraints-3.10.txt
+++ b/constraints-3.10.txt
@@ -420,7 +420,7 @@ pandas-gbq==0.17.9
 pandas==1.5.2
 papermill==2.4.0
 parameterized==0.8.1
-paramiko==2.12.0
+paramiko==2.8.1
 parso==0.8.3
 partd==1.3.0
 pathable==0.4.3

--- a/constraints-3.11.txt
+++ b/constraints-3.11.txt
@@ -414,7 +414,7 @@ pandas-gbq==0.17.9
 pandas==1.5.1
 papermill==2.4.0
 parameterized==0.8.1
-paramiko==2.11.0
+paramiko==2.8.1
 parso==0.8.3
 partd==1.3.0
 pathspec==0.9.0

--- a/constraints-3.7.txt
+++ b/constraints-3.7.txt
@@ -421,7 +421,7 @@ pandas-gbq==0.17.9
 pandas==1.3.5
 papermill==2.4.0
 parameterized==0.8.1
-paramiko==2.12.0
+paramiko==2.8.1
 parso==0.8.3
 partd==1.3.0
 pathable==0.4.3

--- a/constraints-3.8.txt
+++ b/constraints-3.8.txt
@@ -422,7 +422,7 @@ pandas-gbq==0.17.9
 pandas==1.5.2
 papermill==2.4.0
 parameterized==0.8.1
-paramiko==2.12.0
+paramiko==2.8.1
 parso==0.8.3
 partd==1.3.0
 pathable==0.4.3

--- a/constraints-3.9.txt
+++ b/constraints-3.9.txt
@@ -420,7 +420,7 @@ pandas-gbq==0.17.9
 pandas==1.5.2
 papermill==2.4.0
 parameterized==0.8.1
-paramiko==2.12.0
+paramiko==2.8.1
 parso==0.8.3
 partd==1.3.0
 pathable==0.4.3

--- a/constraints-source-providers-3.10.txt
+++ b/constraints-source-providers-3.10.txt
@@ -341,7 +341,7 @@ pandas-gbq==0.17.9
 pandas==1.5.2
 papermill==2.4.0
 parameterized==0.8.1
-paramiko==2.12.0
+paramiko==2.8.1
 parso==0.8.3
 partd==1.3.0
 pathable==0.4.3

--- a/constraints-source-providers-3.11.txt
+++ b/constraints-source-providers-3.11.txt
@@ -338,7 +338,7 @@ pandas-gbq==0.17.9
 pandas==1.5.1
 papermill==2.4.0
 parameterized==0.8.1
-paramiko==2.11.0
+paramiko==2.8.1
 parso==0.8.3
 partd==1.3.0
 pathspec==0.9.0

--- a/constraints-source-providers-3.7.txt
+++ b/constraints-source-providers-3.7.txt
@@ -342,7 +342,7 @@ pandas-gbq==0.17.9
 pandas==1.3.5
 papermill==2.4.0
 parameterized==0.8.1
-paramiko==2.12.0
+paramiko==2.8.1
 parso==0.8.3
 partd==1.3.0
 pathable==0.4.3

--- a/constraints-source-providers-3.8.txt
+++ b/constraints-source-providers-3.8.txt
@@ -343,7 +343,7 @@ pandas-gbq==0.17.9
 pandas==1.5.2
 papermill==2.4.0
 parameterized==0.8.1
-paramiko==2.12.0
+paramiko==2.8.1
 parso==0.8.3
 partd==1.3.0
 pathable==0.4.3

--- a/constraints-source-providers-3.9.txt
+++ b/constraints-source-providers-3.9.txt
@@ -341,7 +341,7 @@ pandas-gbq==0.17.9
 pandas==1.5.2
 papermill==2.4.0
 parameterized==0.8.1
-paramiko==2.12.0
+paramiko==2.8.1
 parso==0.8.3
 partd==1.3.0
 pathable==0.4.3


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This pr constraints the Paramiko version to prevent authentication errors in the Airflow SFTP sensor.

This fix relates to the following issue in Paramiko: https://github.com/paramiko/paramiko/issues/1839

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
