### PR TITLE
Bugfix/global volumes in pod template file

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -71,6 +71,9 @@ spec:
 {{- if or .Values.dags.gitSync.enabled .Values.dags.persistence.enabled }}
         {{- include "airflow_dags_mount" . | nindent 8 }}
 {{- end }}
+{{- if .Values.volumeMounts }}
+{{- toYaml .Values.volumeMounts | nindent 8 }}
+{{- end }}
 {{- if .Values.workers.extraVolumeMounts }}
 {{ toYaml .Values.workers.extraVolumeMounts | indent 8 }}
 {{- end }}
@@ -115,6 +118,9 @@ spec:
   - configMap:
       name: {{ include "airflow_config" . }}
     name: config
+  {{- if .Values.volumes }}
+  {{- toYaml .Values.volumes | nindent 2 }}
+  {{- end }}
   {{- if .Values.workers.extraVolumes }}
   {{ toYaml .Values.workers.extraVolumes | nindent 2 }}
   {{- end }}

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -152,7 +152,7 @@ spec:
             {{ toYaml .Values.dagProcessor.resources | nindent 12 }}
           volumeMounts:
             {{- if .Values.volumeMounts }}
-            {{ toYaml .Values.volumeMounts | nindent 12 }}
+            {{- toYaml .Values.volumeMounts | nindent 12 }}
             {{- end }}
             {{- if .Values.dagProcessor.extraVolumeMounts }}
             {{ toYaml .Values.dagProcessor.extraVolumeMounts | nindent 12 }}

--- a/chart/templates/flower/flower-deployment.yaml
+++ b/chart/templates/flower/flower-deployment.yaml
@@ -102,7 +102,7 @@ spec:
           volumeMounts:
 {{- include "airflow_config_mount" . | nindent 12 }}
             {{- if .Values.volumeMounts }}
-            {{ toYaml .Values.volumeMounts | nindent 12 }}
+            {{- toYaml .Values.volumeMounts | nindent 12 }}
             {{- end }}
             {{- if .Values.flower.extraVolumeMounts }}
             {{ toYaml .Values.flower.extraVolumeMounts | nindent 12 }}

--- a/chart/templates/jobs/create-user-job.yaml
+++ b/chart/templates/jobs/create-user-job.yaml
@@ -107,7 +107,7 @@ spec:
           volumeMounts:
 {{- include "airflow_config_mount" . | nindent 12 }}
 {{- if .Values.volumeMounts }}
-{{ toYaml .Values.volumeMounts | nindent 12 }}
+{{- toYaml .Values.volumeMounts | nindent 12 }}
 {{- end }}
 {{- if .Values.createUserJob.extraVolumeMounts }}
 {{ toYaml .Values.createUserJob.extraVolumeMounts | nindent 12 }}

--- a/chart/templates/jobs/migrate-database-job.yaml
+++ b/chart/templates/jobs/migrate-database-job.yaml
@@ -108,7 +108,7 @@ spec:
           volumeMounts:
 {{- include "airflow_config_mount" . | nindent 12 }}
 {{- if .Values.volumeMounts }}
-{{ toYaml .Values.volumeMounts | nindent 12 }}
+{{- toYaml .Values.volumeMounts | nindent 12 }}
 {{- end }}
 {{- if .Values.migrateDatabaseJob.extraVolumeMounts }}
 {{ toYaml .Values.migrateDatabaseJob.extraVolumeMounts | nindent 12 }}

--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -136,7 +136,7 @@ spec:
               readOnly: true
 {{- end }}
 {{- if .Values.volumeMounts }}
-{{ toYaml .Values.volumeMounts | nindent 12 }}
+{{- toYaml .Values.volumeMounts | nindent 12 }}
 {{- end }}
 {{- if .Values.pgbouncer.extraVolumeMounts }}
 {{ toYaml .Values.pgbouncer.extraVolumeMounts | indent 12 }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -142,7 +142,7 @@ spec:
           volumeMounts:
 {{- include "airflow_config_mount" . | nindent 12 }}
 {{- if .Values.volumeMounts }}
-{{ toYaml .Values.volumeMounts | nindent 12 }}
+{{- toYaml .Values.volumeMounts | nindent 12 }}
 {{- end }}
 {{- if .Values.scheduler.extraVolumeMounts }}
 {{ toYaml .Values.scheduler.extraVolumeMounts | indent 12 }}
@@ -221,7 +221,7 @@ spec:
 {{- include "airflow_dags_mount" . | nindent 12 }}
 {{- end }}
 {{- if .Values.volumeMounts }}
-{{ toYaml .Values.volumeMounts | nindent 12 }}
+{{- toYaml .Values.volumeMounts | nindent 12 }}
 {{- end }}
 {{- if .Values.scheduler.extraVolumeMounts }}
 {{ toYaml .Values.scheduler.extraVolumeMounts | indent 12 }}
@@ -250,7 +250,7 @@ spec:
             - name: logs
               mountPath: {{ template "airflow_logs" . }}
 {{- if .Values.volumeMounts }}
-{{ toYaml .Values.volumeMounts | nindent 12 }}
+{{- toYaml .Values.volumeMounts | nindent 12 }}
 {{- end }}
 {{- if .Values.scheduler.extraVolumeMounts }}
 {{ toYaml .Values.scheduler.extraVolumeMounts | indent 12 }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -122,7 +122,7 @@ spec:
           volumeMounts:
 {{- include "airflow_config_mount" . | nindent 12 }}
             {{- if .Values.volumeMounts }}
-            {{ toYaml .Values.volumeMounts | nindent 12 }}
+            {{- toYaml .Values.volumeMounts | nindent 12 }}
             {{- end }}
             {{- if .Values.triggerer.extraVolumeMounts }}
             {{ toYaml .Values.triggerer.extraVolumeMounts | nindent 12 }}
@@ -161,7 +161,7 @@ spec:
             {{ toYaml .Values.triggerer.resources | nindent 12 }}
           volumeMounts:
             {{- if .Values.volumeMounts }}
-            {{ toYaml .Values.volumeMounts | nindent 12 }}
+            {{- toYaml .Values.volumeMounts | nindent 12 }}
             {{- end }}
             {{- if .Values.triggerer.extraVolumeMounts }}
             {{ toYaml .Values.triggerer.extraVolumeMounts | nindent 12 }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -134,7 +134,7 @@ spec:
           volumeMounts:
 {{- include "airflow_config_mount" . | nindent 12 }}
 {{- if .Values.volumeMounts }}
-{{ toYaml .Values.volumeMounts | nindent 12 }}
+{{- toYaml .Values.volumeMounts | nindent 12 }}
 {{- end }}
 {{- if .Values.webserver.extraVolumeMounts }}
 {{ toYaml .Values.webserver.extraVolumeMounts | indent 12 }}
@@ -190,7 +190,7 @@ spec:
               mountPath: {{ template "airflow_logs" . }}
 {{- end }}
 {{- if .Values.volumeMounts }}
-{{ toYaml .Values.volumeMounts | nindent 12 }}
+{{- toYaml .Values.volumeMounts | nindent 12 }}
 {{- end }}
 {{- if .Values.webserver.extraVolumeMounts }}
 {{ toYaml .Values.webserver.extraVolumeMounts | indent 12 }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -152,7 +152,7 @@ spec:
           volumeMounts:
 {{- include "airflow_config_mount" . | nindent 12 }}
 {{- if .Values.volumeMounts }}
-{{ toYaml .Values.volumeMounts | nindent 12 }}
+{{- toYaml .Values.volumeMounts | nindent 12 }}
 {{- end }}
 {{- if .Values.workers.extraVolumeMounts }}
 {{ toYaml .Values.workers.extraVolumeMounts | indent 12 }}
@@ -209,7 +209,7 @@ spec:
               containerPort: {{ .Values.ports.workerLogs }}
           volumeMounts:
 {{- if .Values.volumeMounts }}
-{{ toYaml .Values.volumeMounts | nindent 12 }}
+{{- toYaml .Values.volumeMounts | nindent 12 }}
 {{- end }}
 {{- if .Values.workers.extraVolumeMounts }}
 {{ toYaml .Values.workers.extraVolumeMounts | indent 12 }}
@@ -271,7 +271,7 @@ spec:
             - name: logs
               mountPath: {{ template "airflow_logs" . }}
 {{- if .Values.volumeMounts }}
-{{ toYaml .Values.volumeMounts | nindent 12 }}
+{{- toYaml .Values.volumeMounts | nindent 12 }}
 {{- end }}
 {{- if .Values.workers.extraVolumeMounts }}
 {{ toYaml .Values.workers.extraVolumeMounts | indent 12 }}
@@ -303,7 +303,7 @@ spec:
               mountPath: {{ .Values.kerberos.ccacheMountPath | quote }}
               readOnly: false
 {{- if .Values.volumeMounts }}
-{{ toYaml .Values.volumeMounts | nindent 12 }}
+{{- toYaml .Values.volumeMounts | nindent 12 }}
 {{- end }}
 {{- if .Values.workers.extraVolumeMounts }}
 {{ toYaml .Values.workers.extraVolumeMounts | indent 12 }}

--- a/tests/charts/test_pod_template_file.py
+++ b/tests/charts/test_pod_template_file.py
@@ -147,6 +147,21 @@ class TestPodTemplateFile:
             "readOnly": expected_read_only,
         } in jmespath.search("spec.containers[0].volumeMounts", docs[0])
 
+    def test_should_add_global_volume_and_global_volume_mount(self):
+        expected_volume = {"name": "test-volume", "emptyDir": {}}
+        expected_volume_mount = {"name": "test-volume", "mountPath": "/opt/test"}
+        docs = render_chart(
+            values={
+                "volumes": [expected_volume],
+                "volumeMounts": [expected_volume_mount],
+            },
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert expected_volume in jmespath.search("spec.volumes", docs[0])
+        assert expected_volume_mount in jmespath.search("spec.containers[0].volumeMounts", docs[0])
+
     def test_validate_if_ssh_params_are_added(self):
         docs = render_chart(
             values={


### PR DESCRIPTION
Globally defined volumes are missing in the [pod-template-file](https://github.com/apache/airflow/blob/helm-chart/1.8.0rc1/chart/files/pod-template-file.kubernetes-helm-yaml) which will make pod spawning fail on clusters where readOnlyRootFilesystem is True and a volume for airflow home has been set globally. Workaround would be to set that volume in each system's extraVolumes and extraVolumeMounts but that would greatly reduce the functionality of global volumes and volume mounts.
This PR fixes that issue.

Related: #27420 #29273, #29288
