### PR TITLE
Fix airflow_dags_mount formatting

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -428,8 +428,8 @@ server_tls_key_file = /etc/pgbouncer/server.key
 
 {{ define "airflow_dags_mount" -}}
 - name: dags
-  mountPath: {{ (printf "%s/dags" .Values.airflowHome) }}
-  {{ if .Values.dags.persistence.subPath -}}
+  mountPath: {{ (printf "%s/dags" .Values.airflowHome) -}}
+  {{- if .Values.dags.persistence.subPath }}
   subPath: {{ .Values.dags.persistence.subPath }}
   {{- end }}
   readOnly: {{ .Values.dags.gitSync.enabled | ternary "True" "False" }}


### PR DESCRIPTION
Fixes formatting issues for `airflow_dags_mount`.

Related: #29273, #29288