### PR TITLE
Fix webserver.service.ports formatting

### DIFF
--- a/chart/templates/webserver/webserver-service.yaml
+++ b/chart/templates/webserver/webserver-service.yaml
@@ -42,11 +42,10 @@ spec:
     component: webserver
     release: {{ .Release.Name }}
   ports:
-  {{ range .Values.webserver.service.ports }}
-    -
-      {{- range $key, $val := . }}
-      {{ $key }}: {{ tpl (toString $val) $ }}
-      {{- end }}
+  {{- range .Values.webserver.service.ports }}
+    - {{ range $key, $val := . }}
+      {{- $key }}: {{ tpl (toString $val) $ }}
+      {{ end }}
   {{- end }}
   {{- if .Values.webserver.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.webserver.service.loadBalancerIP }}


### PR DESCRIPTION
Fixes formatting issues for `webserver.service.ports`.

Related: #29273, #29288