### PR TITLE
[KubernetesExecutor] make the number of log lines to read from the worker pod configurable

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2591,6 +2591,13 @@ kubernetes_executor:
       type: integer
       example: ~
       default: "100"
+    running_pod_tail_lines:
+      description: |
+        The number of lines (from the end) of the logs to read from the worker pod's base container.
+      version_added: 2.6.0
+      type: integer
+      example: ~
+      default: "100"
 sensors:
   description: ~
   options:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1302,6 +1302,9 @@ worker_pods_queued_check_interval = 60
 # You may want this higher if you have a very large cluster and/or use ``multi_namespace_mode``.
 worker_pods_pending_timeout_batch_size = 100
 
+# The number of lines (from the end) of the logs to read from the worker pod's base container.
+running_pod_tail_lines = 100
+
 [sensors]
 # Sensor default timeout, 7 days by default (7 * 24 * 60 * 60).
 default_timeout = 604800

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -788,7 +788,10 @@ class KubernetesExecutor(BaseExecutor):
 
             client = get_kube_client()
 
-            log += f"*** Trying to get logs (last 100 lines) from worker pod {ti.hostname} ***\n\n"
+            log += (
+                f"*** Trying to get logs (last {self.kube_config.running_pod_tail_lines} lines) "
+                f"from worker pod {ti.hostname} ***\n\n"
+            )
             selector = PodGenerator.build_selector_for_k8s_executor_pod(
                 dag_id=ti.dag_id,
                 task_id=ti.task_id,
@@ -811,7 +814,7 @@ class KubernetesExecutor(BaseExecutor):
                 namespace=namespace,
                 container="base",
                 follow=False,
-                tail_lines=100,
+                tail_lines=self.kube_config.running_pod_tail_lines,
                 _preload_content=False,
             )
 

--- a/airflow/kubernetes/kube_config.py
+++ b/airflow/kubernetes/kube_config.py
@@ -103,3 +103,5 @@ class KubeConfig:
                 f"[{self.kubernetes_section}] 'delete_option_kwargs' expected a JSON dict, got "
                 + type(self.delete_option_kwargs).__name__
             )
+
+        self.running_pod_tail_lines = conf.getint(self.kubernetes_section, "running_pod_tail_lines")


### PR DESCRIPTION
Now the `KubernetesExecutor` supports method `get_task_log()` (in `main` branch). However, the number of lines to read is hard-coded to be 100.

It can be imagined that in many cases people may need more logs. And it would be nice to make this number of log lines to read from worker pod configurable. So that users can adjust according to their certain environment.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
