### PR TITLE
AIP-44 Fix support for classmethods and method mapping

### DIFF
--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -81,7 +81,6 @@ def internal_airflow_api(body: dict[str, Any]) -> APIResponse:
 
     log.debug("Calling method %.", {method_name})
     try:
-        log.warning(params)
         output = handler(**params)
         output_json = BaseSerialization.serialize(output)
         log.debug("Returning response")

--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -51,7 +51,7 @@ def _initialize_map() -> dict[str, Callable]:
         Variable.update,
         Variable.delete,
     ]
-    return {f"{func.__module__}.{func.__name__}": func for func in functions}
+    return {f"{func.__module__}.{func.__qualname__}": func for func in functions}
 
 
 def internal_airflow_api(body: dict[str, Any]) -> APIResponse:
@@ -81,6 +81,7 @@ def internal_airflow_api(body: dict[str, Any]) -> APIResponse:
 
     log.debug("Calling method %.", {method_name})
     try:
+        log.warning(params)
         output = handler(**params)
         output_json = BaseSerialization.serialize(output)
         log.debug("Returning response")

--- a/airflow/api_internal/internal_api_call.py
+++ b/airflow/api_internal/internal_api_call.py
@@ -104,6 +104,9 @@ def internal_api_call(func: Callable[PS, RT]) -> Callable[PS, RT]:
         arguments_dict = dict(bound.arguments)
         if "session" in arguments_dict:
             del arguments_dict["session"]
+        if "cls" in arguments_dict:  # used by @classmethod
+            del arguments_dict["cls"]
+
         args_json = json.dumps(BaseSerialization.serialize(arguments_dict))
         method_name = f"{func.__module__}.{func.__qualname__}"
         result = make_jsonrpc_request(method_name, args_json)

--- a/tests/api_internal/test_internal_api_call.py
+++ b/tests/api_internal/test_internal_api_call.py
@@ -66,6 +66,11 @@ class TestInternalApiCall:
     def fake_method_with_params(dag_id: str, task_id: int, session) -> str:
         return f"local-call-with-params-{dag_id}-{task_id}"
 
+    @classmethod
+    @internal_api_call
+    def fake_class_method_with_params(cls, dag_id: str, session) -> str:
+        return f"local-classmethod-call-with-params-{dag_id}"
+
     @conf_vars(
         {
             ("core", "database_access_isolation"): "false",
@@ -137,6 +142,44 @@ class TestInternalApiCall:
                         {
                             "dag_id": "fake-dag",
                             "task_id": 123,
+                        }
+                    )
+                ),
+            }
+        )
+        mock_requests.post.assert_called_once_with(
+            url="http://localhost:8888/internal_api/v1/rpcapi",
+            data=expected_data,
+            headers={"Content-Type": "application/json"},
+        )
+
+    @conf_vars(
+        {
+            ("core", "database_access_isolation"): "true",
+            ("core", "internal_api_url"): "http://localhost:8888",
+        }
+    )
+    @mock.patch("airflow.api_internal.internal_api_call.requests")
+    def test_remote_classmethod_call_with_params(self, mock_requests):
+        response = requests.Response()
+        response.status_code = 200
+
+        response._content = json.dumps(BaseSerialization.serialize("remote-call"))
+
+        mock_requests.post.return_value = response
+
+        result = TestInternalApiCall.fake_class_method_with_params("fake-dag", session="session")
+
+        assert result == "remote-call"
+        expected_data = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "tests.api_internal.test_internal_api_call.TestInternalApiCall."
+                "fake_class_method_with_params",
+                "params": json.dumps(
+                    BaseSerialization.serialize(
+                        {
+                            "dag_id": "fake-dag",
                         }
                     )
                 ),


### PR DESCRIPTION
This fixes two bugs:
- support for classmethods
- Inconsistent method name (send by client vs map on server) introduced in https://github.com/apache/airflow/pull/28693