### PR TITLE
Fixed link to airflow variable in docs

### DIFF
--- a/docs/apache-airflow/howto/dynamic-dag-generation.rst
+++ b/docs/apache-airflow/howto/dynamic-dag-generation.rst
@@ -39,9 +39,9 @@ Dynamic DAGs with environment variables
 If you want to use variables to configure your code, you should always use
 `environment variables <https://wiki.archlinux.org/title/environment_variables>`_ in your
 top-level code rather than :doc:`Airflow Variables </core-concepts/variables>`. Using Airflow Variables
-at top-level code creates a connection to metadata DB of Airflow to fetch the value, which can slow
-down parsing and place extra load on the DB. See the :ref:`best_practices/airflow_variables`
-on how to make best use of Airflow Variables in your DAGs using Jinja templates .
+in top-level code creates a connection to the metadata DB of Airflow to fetch the value, which can slow
+down parsing and place extra load on the DB. See the `best practices on Airflow Variables <best_practices/airflow_variables>`_
+to make the best use of Airflow Variables in your DAGs using Jinja templates.
 
 For example you could set ``DEPLOYMENT`` variable differently for your production and development
 environments. The variable ``DEPLOYMENT`` could be set to ``PROD`` in your production environment and to

--- a/docs/apache-airflow/howto/dynamic-dag-generation.rst
+++ b/docs/apache-airflow/howto/dynamic-dag-generation.rst
@@ -40,7 +40,7 @@ If you want to use variables to configure your code, you should always use
 `environment variables <https://wiki.archlinux.org/title/environment_variables>`_ in your
 top-level code rather than :doc:`Airflow Variables </core-concepts/variables>`. Using Airflow Variables
 at top-level code creates a connection to metadata DB of Airflow to fetch the value, which can slow
-down parsing and place extra load on the DB. See the `Airflow Variables <_best_practices/airflow_variables>`_
+down parsing and place extra load on the DB. See the :ref:`best_practices/airflow_variables`
 on how to make best use of Airflow Variables in your DAGs using Jinja templates .
 
 For example you could set ``DEPLOYMENT`` variable differently for your production and development


### PR DESCRIPTION
Background:

While going through the Dynamic DAG Generation doc -> https://airflow.apache.org/docs/apache-airflow/stable/howto/dynamic-dag-generation.html, found out one of the links to best practices while using airflow variable didn't work with error 404 not found. Have made changes and fixed the reference that points to the correct link now which is -> https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html#airflow-variables. 

Changes done: 

replaced ``` `Airflow Variables <_best_practices/airflow_variables>`_``` with ```:ref:`best_practices/airflow_variables` ```
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
