### PR TITLE
Add interactive testing in Breeze option in testing docs

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -232,13 +232,42 @@ for debugging purposes, enter:
     pytest --log-cli-level=DEBUG tests/core/test_core.py::TestCore
 
 
+Running Tests using Breeze interactive shell
+--------------------------------------------
+
+You can run tests interactively using regular pytest commands inside the Breeze shell. This has the
+advantage, that Breeze container has all the dependencies installed that are needed to run the tests
+and it will ask you to rebuild the image if it is needed and some new dependencies should be installed.
+
+By using interactive shell and iterating over the tests, you can iterate and re-run tests one-by-one
+or group by group right after you modified them.
+
+Entering the shell is as easy as:
+
+.. code-block:: bash
+
+     breeze
+
+This should drop you into the container.
+
+You can also use other switches (like ``--backend`` for example) to configure the environment for your
+tests (and for example to switch to different database backend - see ``--help`` for more details).
+
+Once you enter the container, you might run regular pytest commands. For example:
+
+.. code-block:: bash
+
+    pytest --log-cli-level=DEBUG tests/core/test_core.py::TestCore
+
+
 Running Tests using Breeze from the Host
 ----------------------------------------
 
 If you wish to only run tests and not to drop into the shell, apply the
 ``tests`` command. You can add extra targets and pytest flags after the ``--`` command. Note that
 often you want to run the tests with a clean/reset db, so usually you want to add ``--db-reset`` flag
-to breeze.
+to breeze command. The Breeze image usually will have all the dependencies needed and it
+will ask you to rebuild the image if it is needed and some new dependencies should be installed.
 
 .. code-block:: bash
 
@@ -273,50 +302,6 @@ You can also limit the set of providers you would like to run tests of
 .. code-block:: bash
 
     breeze testing tests --test-type "Providers[airbyte,http]"
-
-Running Tests of a specified type from the Host
------------------------------------------------
-
-You can also run tests for a specific test type. For the stability and performance point of view,
-we separated tests into different test types to be run separately.
-
-You can select the test type by adding ``--test-type TEST_TYPE`` before the test command. There are two
-kinds of test types:
-
-* Per-directories types are added to select subset of the tests based on sub-directories in ``tests`` folder.
-  Example test types there - Core, Providers, CLI. The only action that happens when you choose the right
-  test folders are pre-selected. It is only useful for those types of tests to choose the test type
-  when you do not specify test to run.
-
-  Runs all core tests:
-
-  .. code-block:: bash
-
-       breeze testing tests --test-type Core  --db-reset tests
-
-  Runs all provider tests:
-
-  .. code-block:: bash
-
-       breeze testing tests --test-type Providers --db-reset tests
-
-* Special kinds of tests Quarantined, Postgres, MySQL, which are marked with pytest
-  marks and for those you need to select the type using test-type switch. If you want to run such tests
-  using breeze, you need to pass appropriate ``--test-type`` otherwise the test will be skipped.
-  Similarly to the per-directory tests if you do not specify the test or tests to run,
-  all tests of a given type are run
-
-  Run quarantined test_task_command.py test:
-
-  .. code-block:: bash
-
-       breeze testing tests --test-type Quarantined tests tests/cli/commands/test_task_command.py --db-reset
-
-  Run all Quarantined tests:
-
-  .. code-block:: bash
-
-       breeze testing tests --test-type Quarantined tests --db-reset
 
 
 Running full Airflow unit test suite in parallel

--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -24,6 +24,7 @@ from datetime import datetime
 import click
 from click import IntRange
 
+from airflow_breeze.commands.ci_image_commands import rebuild_or_pull_ci_image_if_needed
 from airflow_breeze.global_constants import ALLOWED_TEST_TYPE_CHOICES, all_selective_test_types
 from airflow_breeze.params.build_prod_params import BuildProdParams
 from airflow_breeze.params.shell_params import ShellParams
@@ -394,6 +395,7 @@ def tests(
         forward_ports=False,
         test_type=test_type,
     )
+    rebuild_or_pull_ci_image_if_needed(command_params=exec_shell_params)
     cleanup_python_generated_files()
     if run_in_parallel:
         run_tests_in_parallel(


### PR DESCRIPTION
The interactive testing is one of the most efficient ways of
running and re-running tests in Breeze. This option is now
explicitly documented.

In case of ``testing test`` command the image is also rebuild if
neeed.

The section about "test-type" was redundant with previous paragraph
and we have simplified some test type so that there is no more
need to explicitly explain it either.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
