### PR TITLE
Remove executor coupling in conf validation

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -43,6 +43,7 @@ from typing_extensions import overload
 
 from airflow.compat.functools import cached_property
 from airflow.exceptions import AirflowConfigException
+from airflow.executors.executor_loader import ExecutorLoader
 from airflow.secrets import DEFAULT_SECRETS_SEARCH_PATH, BaseSecretsBackend
 from airflow.utils import yaml
 from airflow.utils.module_loading import import_string
@@ -434,13 +435,11 @@ class AirflowConfigParser(ConfigParser):
         Values are considered invalid when they conflict with other config values
         or system-level limitations and requirements.
         """
-        is_executor_without_sqlite_support = self.get("core", "executor") not in (
-            "DebugExecutor",
-            "SequentialExecutor",
-        )
+        executor, _ = ExecutorLoader.import_default_executor_cls()
         is_sqlite = "sqlite" in self.get("database", "sql_alchemy_conn")
-        if is_sqlite and is_executor_without_sqlite_support:
-            raise AirflowConfigException(f"error: cannot use sqlite with the {self.get('core', 'executor')}")
+
+        if is_sqlite and not executor.is_single_threaded:
+            raise AirflowConfigException(f"error: cannot use sqlite with the {executor.__name__}")
         if is_sqlite:
             import sqlite3
 

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -113,6 +113,7 @@ class BaseExecutor(LoggingMixin):
     callback_sink: BaseCallbackSink | None = None
 
     is_local: bool = False
+    is_single_threaded: bool = False
     change_sensor_mode_to_reschedule: bool = False
 
     serve_logs: bool = False

--- a/airflow/executors/celery_kubernetes_executor.py
+++ b/airflow/executors/celery_kubernetes_executor.py
@@ -42,14 +42,13 @@ class CeleryKubernetesExecutor(LoggingMixin):
     supports_pickling: bool = True
     supports_sentry: bool = False
     change_sensor_mode_to_reschedule: bool = False
+    is_single_threaded: bool = False
+    is_local: bool = False
+    serve_logs: bool = False
 
     callback_sink: BaseCallbackSink | None = None
 
     KUBERNETES_QUEUE = conf.get("celery_kubernetes_executor", "kubernetes_queue")
-
-    is_local: bool = False
-
-    serve_logs: bool = False
 
     def __init__(self, celery_executor: CeleryExecutor, kubernetes_executor: KubernetesExecutor):
         super().__init__()

--- a/airflow/executors/debug_executor.py
+++ b/airflow/executors/debug_executor.py
@@ -44,6 +44,7 @@ class DebugExecutor(BaseExecutor):
 
     _terminated = threading.Event()
     change_sensor_mode_to_reschedule: bool = True
+    is_single_threaded: bool = True
 
     def __init__(self):
         super().__init__()

--- a/airflow/executors/local_kubernetes_executor.py
+++ b/airflow/executors/local_kubernetes_executor.py
@@ -42,14 +42,13 @@ class LocalKubernetesExecutor(LoggingMixin):
     supports_pickling: bool = False
     supports_sentry: bool = False
     change_sensor_mode_to_reschedule: bool = False
+    is_single_threaded: bool = False
+    is_local: bool = False
+    serve_logs: bool = True
 
     callback_sink: BaseCallbackSink | None = None
 
     KUBERNETES_QUEUE = conf.get("local_kubernetes_executor", "kubernetes_queue")
-
-    is_local: bool = False
-
-    serve_logs: bool = True
 
     def __init__(self, local_executor: LocalExecutor, kubernetes_executor: KubernetesExecutor):
         super().__init__()

--- a/airflow/executors/sequential_executor.py
+++ b/airflow/executors/sequential_executor.py
@@ -46,7 +46,7 @@ class SequentialExecutor(BaseExecutor):
 
     supports_pickling: bool = False
     is_local: bool = True
-
+    is_single_threaded: bool = True
     serve_logs: bool = True
 
     def __init__(self):

--- a/tests/executors/test_base_executor.py
+++ b/tests/executors/test_base_executor.py
@@ -44,6 +44,10 @@ def test_is_local_default_value():
     assert not BaseExecutor.is_local
 
 
+def test_is_single_threaded_default_value():
+    assert not BaseExecutor.is_single_threaded
+
+
 def test_get_task_log():
     executor = BaseExecutor()
     ti = TaskInstance(task=BaseOperator(task_id="dummy"))

--- a/tests/executors/test_celery_kubernetes_executor.py
+++ b/tests/executors/test_celery_kubernetes_executor.py
@@ -43,6 +43,9 @@ class TestCeleryKubernetesExecutor:
     def test_serve_logs_default_value(self):
         assert not CeleryKubernetesExecutor.serve_logs
 
+    def test_is_single_threaded_default_value(self):
+        assert not CeleryKubernetesExecutor.is_single_threaded
+
     def test_queued_tasks(self):
         celery_executor_mock = mock.MagicMock()
         k8s_executor_mock = mock.MagicMock()

--- a/tests/executors/test_debug_executor.py
+++ b/tests/executors/test_debug_executor.py
@@ -115,3 +115,9 @@ class TestDebugExecutor:
                 mock.call(ti2.key, State.UPSTREAM_FAILED),
             ]
         )
+
+    def test_reschedule_mode(self):
+        assert DebugExecutor.change_sensor_mode_to_reschedule
+
+    def test_is_single_threaded(self):
+        assert DebugExecutor.is_single_threaded

--- a/tests/executors/test_local_kubernetes_executor.py
+++ b/tests/executors/test_local_kubernetes_executor.py
@@ -38,6 +38,9 @@ class TestLocalKubernetesExecutor:
     def test_serve_logs_default_value(self):
         assert LocalKubernetesExecutor.serve_logs
 
+    def test_is_single_threaded_default_value(self):
+        assert not LocalKubernetesExecutor.is_single_threaded
+
     def test_queued_tasks(self):
         local_executor_mock = mock.MagicMock()
         k8s_executor_mock = mock.MagicMock()

--- a/tests/executors/test_sequential_executor.py
+++ b/tests/executors/test_sequential_executor.py
@@ -35,6 +35,9 @@ class TestSequentialExecutor:
     def test_serve_logs_default_value(self):
         assert SequentialExecutor.serve_logs
 
+    def test_is_single_threaded_default_value(self):
+        assert SequentialExecutor.is_single_threaded
+
     @mock.patch("airflow.executors.sequential_executor.SequentialExecutor.sync")
     @mock.patch("airflow.executors.base_executor.BaseExecutor.trigger_tasks")
     @mock.patch("airflow.executors.base_executor.Stats.gauge")


### PR DESCRIPTION
Use a generic approach to check for single threaded executors that can support DBs like sqlite.

An `is_single_threaded` property was added to the base executor interface (with a default of False) and implemented by the Debug and Sequential executors (set to True). This keeps the same behaviour as previous but without core aireflow code statically coupling to the above two executors.  

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
