### PR TITLE
AIP-44 Support TaskInstance serialization/deserialization.

### DIFF
--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -97,7 +97,7 @@ def dag_backfill(args, dag=None):
             dr = DagRun(dag.dag_id, execution_date=args.start_date)
             for task in dag.tasks:
                 print(f"Task {task.task_id} located in DAG {dag.dag_id}")
-                ti = TaskInstance(task, run_id=None)
+                ti = TaskInstance.from_task(task, run_id=None)
                 ti.dag_run = dr
                 ti.dry_run()
         else:

--- a/airflow/cli/commands/kubernetes_command.py
+++ b/airflow/cli/commands/kubernetes_command.py
@@ -43,7 +43,7 @@ def generate_pod_yaml(args):
     dr = DagRun(dag.dag_id, execution_date=execution_date)
     kube_config = KubeConfig()
     for task in dag.tasks:
-        ti = TaskInstance(task, None)
+        ti = TaskInstance.from_task(task, None)
         ti.dag_run = dr
         pod = PodGenerator.construct_pod(
             dag_id=args.dag_id,

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -176,7 +176,7 @@ def _get_ti(
                 f"run_id or execution_date of {exec_date_or_run_id!r} not found"
             )
         # TODO: Validate map_index is in range?
-        ti = TaskInstance(task, run_id=dag_run.run_id, map_index=map_index)
+        ti = TaskInstance.from_task(task, run_id=dag_run.run_id, map_index=map_index)
         ti.dag_run = dag_run
     else:
         ti = ti_or_none

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -491,7 +491,7 @@ class AbstractOperator(Templater, DAGNode):
 
         for index in indexes_to_map:
             # TODO: Make more efficient with bulk_insert_mappings/bulk_save_mappings.
-            ti = TaskInstance(self, run_id=run_id, map_index=index, state=state)
+            ti = TaskInstance.from_task(self, run_id=run_id, map_index=index, state=state)
             self.log.debug("Expanding TIs upserted %s", ti)
             task_instance_mutation_hook(ti)
             ti = session.merge(ti)

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1278,7 +1278,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
                     )
                     .one()
                 )
-                ti = TaskInstance(self, run_id=dag_run.run_id)
+                ti = TaskInstance.from_task(self, run_id=dag_run.run_id)
             except NoResultFound:
                 # This is _mostly_ only used in tests
                 dr = DagRun(
@@ -1288,7 +1288,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
                     execution_date=info.logical_date,
                     data_interval=info.data_interval,
                 )
-                ti = TaskInstance(self, run_id=dr.run_id)
+                ti = TaskInstance.from_task(self, run_id=dr.run_id)
                 ti.dag_run = dr
                 session.add(dr)
                 session.flush()

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1069,7 +1069,7 @@ class DagRun(Base, LoggingMixin):
 
             def create_ti(task: Operator, indexes: Iterable[int]) -> Iterator[TI]:
                 for map_index in indexes:
-                    ti = TI(task, run_id=self.run_id, map_index=map_index)
+                    ti = TI.from_task(task, run_id=self.run_id, map_index=map_index)
                     ti_mutation_hook(ti)
                     created_counts[ti.operator] += 1
                     yield ti
@@ -1185,7 +1185,7 @@ class DagRun(Base, LoggingMixin):
         for index in range(total_length):
             if index in existing_indexes:
                 continue
-            ti = TI(task, run_id=self.run_id, map_index=index, state=None)
+            ti = TI.from_task(task, run_id=self.run_id, map_index=index, state=None)
             self.log.debug("Expanding TIs upserted %s", ti)
             task_instance_mutation_hook(ti)
             ti = session.merge(ti)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -604,6 +604,9 @@ class TaskInstance(Base, LoggingMixin):
             ti_dict.pop(field, None)
         return ti_dict
 
+    def to_dict(self) -> dict[str, Any]:
+        return self.serialize()
+
     @staticmethod
     def insert_mapping(run_id: str, task: Operator, map_index: int) -> dict[str, Any]:
         """:meta private:"""

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -488,7 +488,6 @@ class TaskInstance(Base, LoggingMixin):
         ti.dag_id = task.dag_id
         ti.task_id = task.task_id
         ti.map_index = map_index
-        ti.run_id = run_id
         ti.refresh_from_task(task)
         # init_on_load will config the log
         ti.init_on_load()
@@ -527,6 +526,8 @@ class TaskInstance(Base, LoggingMixin):
                         f"DagRun for {ti.dag_id!r} with date {execution_date} not found"
                     ) from None
 
+        ti.run_id = run_id
+
         ti.try_number = 0
         ti.max_tries = ti.task.retries
         ti.unixname = getuser()
@@ -552,6 +553,8 @@ class TaskInstance(Base, LoggingMixin):
         ti_dict = self.__dict__.copy()
         ti_dict.pop("_log", None)
         ti_dict.pop("test_mode", None)
+        ti_dict.pop("dag_run", None)
+        ti_dict.pop("_sa_instance_state", None)
         return ti_dict
 
     @staticmethod

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -489,9 +489,6 @@ class TaskInstance(Base, LoggingMixin):
 
         Deprecated, prefer to use "from_task" or "deserialize" static methods.
         """
-        if ti_dict is not None:
-            # Should only be used by deserialize method.
-            return
         if task is not None:
             self._init_from_task(task, execution_date, run_id, state, map_index)
             return
@@ -592,7 +589,10 @@ class TaskInstance(Base, LoggingMixin):
     def deserialize(ti_dict: dict[str, Any], version: int) -> TaskInstance:
         """Deserialize TaskInstance from dictionary."""
         if version > TaskInstance.__version__:
-            raise TypeError("version too big, dont know hot to deserialize")
+            raise TypeError(
+                f"""Version "{version}" is too big, don't know how to deserialize.
+              Latest supported version: {TaskInstance.__version}"""
+            )
         ti = TaskInstance()
         ti.__dict__ = ti_dict.copy()
         ti.init_on_load()

--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -52,7 +52,7 @@ class ExternalDagLink(BaseOperatorLink):
     name = "External DAG"
 
     def get_link(self, operator, dttm):
-        ti = TaskInstance(task=operator, execution_date=dttm)
+        ti = TaskInstance.from_task(task=operator, execution_date=dttm)
         operator.render_template_fields(ti.get_template_context())
         query = {"dag_id": operator.external_dag_id, "execution_date": dttm.isoformat()}
         return build_airflow_url_with_query(query)

--- a/airflow/serialization/enums.py
+++ b/airflow/serialization/enums.py
@@ -51,3 +51,4 @@ class DagAttributeTypes(str, Enum):
     XCOM_REF = "xcomref"
     DATASET = "dataset"
     SIMPLE_TASK_INSTANCE = "simple_task_instance"
+    TASK_INSTANCE = "task_instance"

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -449,7 +449,9 @@ class BaseSerialization:
         elif isinstance(var, SimpleTaskInstance):
             return cls._encode(cls.serialize(var.__dict__, strict=strict), type_=DAT.SIMPLE_TASK_INSTANCE)
         elif isinstance(var, TaskInstance):
-            return cls._encode(cls.serialize(var.serialize(), strict=strict), type_=DAT.TASK_INSTANCE)
+            # FIXME: We can't use var.serialize() there due to problems in test
+            # test_recursive_serialize_calls_must_forward_kwargs
+            return cls._encode(cls.serialize(var=var.to_dict(), strict=strict), type_=DAT.TASK_INSTANCE)
         else:
             log.debug("Cast type %s to str in serialization.", type(var))
             if strict:

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -44,7 +44,7 @@ from airflow.models.expandinput import EXPAND_INPUT_EMPTY, ExpandInput, create_e
 from airflow.models.mappedoperator import MappedOperator
 from airflow.models.operator import Operator
 from airflow.models.param import Param, ParamsDict
-from airflow.models.taskinstance import SimpleTaskInstance
+from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance
 from airflow.models.taskmixin import DAGNode
 from airflow.models.xcom_arg import XComArg, deserialize_xcom_arg, serialize_xcom_arg
 from airflow.providers_manager import ProvidersManager
@@ -448,6 +448,8 @@ class BaseSerialization:
             return cls._encode(dict(uri=var.uri, extra=var.extra), type_=DAT.DATASET)
         elif isinstance(var, SimpleTaskInstance):
             return cls._encode(cls.serialize(var.__dict__, strict=strict), type_=DAT.SIMPLE_TASK_INSTANCE)
+        elif isinstance(var, TaskInstance):
+            return cls._encode(cls.serialize(var.to_dict(), strict=strict), type_=DAT.TASK_INSTANCE)
         else:
             log.debug("Cast type %s to str in serialization.", type(var))
             if strict:
@@ -502,6 +504,8 @@ class BaseSerialization:
             return Dataset(**var)
         elif type_ == DAT.SIMPLE_TASK_INSTANCE:
             return SimpleTaskInstance(**cls.deserialize(var))
+        elif type_ == DAT.TASK_INSTANCE:
+            return TaskInstance.from_dict(cls.deserialize(var))
         else:
             raise TypeError(f"Invalid type {type_!s} in deserialization.")
 

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -449,7 +449,7 @@ class BaseSerialization:
         elif isinstance(var, SimpleTaskInstance):
             return cls._encode(cls.serialize(var.__dict__, strict=strict), type_=DAT.SIMPLE_TASK_INSTANCE)
         elif isinstance(var, TaskInstance):
-            return cls._encode(cls.serialize(var.to_dict(), strict=strict), type_=DAT.TASK_INSTANCE)
+            return cls._encode(cls.serialize(var.serialize(), strict=strict), type_=DAT.TASK_INSTANCE)
         else:
             log.debug("Cast type %s to str in serialization.", type(var))
             if strict:
@@ -505,7 +505,7 @@ class BaseSerialization:
         elif type_ == DAT.SIMPLE_TASK_INSTANCE:
             return SimpleTaskInstance(**cls.deserialize(var))
         elif type_ == DAT.TASK_INSTANCE:
-            return TaskInstance.from_dict(cls.deserialize(var))
+            return TaskInstance.deserialize(cls.deserialize(var))
         else:
             raise TypeError(f"Invalid type {type_!s} in deserialization.")
 

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -505,7 +505,7 @@ class BaseSerialization:
         elif type_ == DAT.SIMPLE_TASK_INSTANCE:
             return SimpleTaskInstance(**cls.deserialize(var))
         elif type_ == DAT.TASK_INSTANCE:
-            return TaskInstance.deserialize(cls.deserialize(var))
+            return TaskInstance.deserialize(ti_dict=cls.deserialize(var), version=1)
         else:
             raise TypeError(f"Invalid type {type_!s} in deserialization.")
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1343,7 +1343,7 @@ class Airflow(AirflowBaseView):
             # make sense in this situation, but "works" prior to AIP-39. This
             # "fakes" a temporary DagRun-TaskInstance association (not saved to
             # database) for presentation only.
-            ti = TaskInstance(raw_task, map_index=map_index)
+            ti = TaskInstance.from_task(raw_task, map_index=map_index)
             ti.dag_run = DagRun(dag_id=dag_id, execution_date=dttm)
         else:
             ti = dag_run.get_task_instance(task_id=task_id, map_index=map_index, session=session)

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -57,7 +57,7 @@ def create_context(task) -> Context:
         execution_date=execution_date,
         run_id=DagRun.generate_run_id(DagRunType.MANUAL, execution_date),
     )
-    task_instance = TaskInstance(task=task)
+    task_instance = TaskInstance.from_task(task=task)
     task_instance.dag_run = dag_run
     task_instance.dag_id = dag.dag_id
     task_instance.xcom_push = mock.Mock()  # type: ignore

--- a/tests/api/common/test_delete_dag.py
+++ b/tests/api/common/test_delete_dag.py
@@ -81,7 +81,7 @@ class TestDeleteDAGSuccessfulDelete:
         with create_session() as session:
             session.add(DM(dag_id=self.key, fileloc=self.dag_file_path, is_subdag=for_sub_dag))
             dr = DR(dag_id=self.key, run_type=DagRunType.MANUAL, run_id="test", execution_date=test_date)
-            ti = TI(task=task, state=State.SUCCESS)
+            ti = TI.from_task(task=task, state=State.SUCCESS)
             ti.dag_run = dr
             session.add_all((dr, ti))
             # flush to ensure task instance if written before

--- a/tests/api_connexion/endpoints/test_mapped_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_mapped_task_instance_endpoint.py
@@ -120,17 +120,23 @@ class TestMappedTaskInstanceEndpoint:
 
             index = 0
             for i in range(dags[dag_id]["success"]):
-                ti = TaskInstance(mapped, run_id=dr.run_id, map_index=index, state=TaskInstanceState.SUCCESS)
+                ti = TaskInstance.from_task(
+                    mapped, run_id=dr.run_id, map_index=index, state=TaskInstanceState.SUCCESS
+                )
                 setattr(ti, "start_date", DEFAULT_DATETIME_1)
                 session.add(ti)
                 index += 1
             for i in range(dags[dag_id]["failed"]):
-                ti = TaskInstance(mapped, run_id=dr.run_id, map_index=index, state=TaskInstanceState.FAILED)
+                ti = TaskInstance.from_task(
+                    mapped, run_id=dr.run_id, map_index=index, state=TaskInstanceState.FAILED
+                )
                 setattr(ti, "start_date", DEFAULT_DATETIME_1)
                 session.add(ti)
                 index += 1
             for i in range(dags[dag_id]["running"]):
-                ti = TaskInstance(mapped, run_id=dr.run_id, map_index=index, state=TaskInstanceState.RUNNING)
+                ti = TaskInstance.from_task(
+                    mapped, run_id=dr.run_id, map_index=index, state=TaskInstanceState.RUNNING
+                )
                 setattr(ti, "start_date", DEFAULT_DATETIME_1)
                 session.add(ti)
                 index += 1

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -159,7 +159,7 @@ class TestTaskInstanceEndpoint:
                     state=dag_run_state,
                 )
                 session.add(dr)
-            ti = TaskInstance(task=tasks[i], **self.ti_init)
+            ti = TaskInstance.from_task(task=tasks[i], **self.ti_init)
             ti.dag_run = dr
             ti.note = "placeholder-note"
 
@@ -385,7 +385,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
         tis = self.create_task_instances(session)
         old_ti = tis[0]
         for idx in (1, 2):
-            ti = TaskInstance(task=old_ti.task, run_id=old_ti.run_id, map_index=idx)
+            ti = TaskInstance.from_task(task=old_ti.task, run_id=old_ti.run_id, map_index=idx)
             ti.rendered_task_instance_fields = RTIF(ti, render_templates=False)
             for attr in ["duration", "end_date", "pid", "start_date", "state", "queue", "note"]:
                 setattr(ti, attr, getattr(old_ti, attr))
@@ -1697,7 +1697,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         NEW_STATE = "failed"
         map_index = 1
         tis = self.create_task_instances(session)
-        ti = TaskInstance(task=tis[0].task, run_id=tis[0].run_id, map_index=map_index)
+        ti = TaskInstance.from_task(task=tis[0].task, run_id=tis[0].run_id, map_index=map_index)
         ti.rendered_task_instance_fields = RTIF(ti, render_templates=False)
         session.add(ti)
         session.commit()
@@ -1871,7 +1871,7 @@ class TestSetTaskInstanceNote(TestTaskInstanceEndpoint):
         tis = self.create_task_instances(session)
         old_ti = tis[0]
         for idx in (1, 2):
-            ti = TaskInstance(task=old_ti.task, run_id=old_ti.run_id, map_index=idx)
+            ti = TaskInstance.from_task(task=old_ti.task, run_id=old_ti.run_id, map_index=idx)
             ti.rendered_task_instance_fields = RTIF(ti, render_templates=False)
             for attr in ["duration", "end_date", "pid", "start_date", "state", "queue", "note"]:
                 setattr(ti, attr, getattr(old_ti, attr))

--- a/tests/api_connexion/endpoints/test_xcom_endpoint.py
+++ b/tests/api_connexion/endpoints/test_xcom_endpoint.py
@@ -171,7 +171,7 @@ class TestGetXComEntry(TestXComEndpoint):
                 run_type=DagRunType.MANUAL,
             )
             session.add(dagrun)
-            ti = TaskInstance(EmptyOperator(task_id=task_id), run_id=run_id)
+            ti = TaskInstance.from_task(EmptyOperator(task_id=task_id), run_id=run_id)
             ti.dag_id = dag_id
             session.add(ti)
         backend.set(
@@ -365,7 +365,7 @@ class TestGetXComEntries(TestXComEndpoint):
                 run_type=DagRunType.MANUAL,
             )
             session.add(dagrun)
-            ti = TaskInstance(EmptyOperator(task_id=task_id), run_id=run_id)
+            ti = TaskInstance.from_task(EmptyOperator(task_id=task_id), run_id=run_id)
             ti.dag_id = dag_id
             session.add(ti)
 
@@ -401,7 +401,7 @@ class TestGetXComEntries(TestXComEndpoint):
                 run_type=DagRunType.MANUAL,
             )
             session.add(dagrun1)
-            ti = TaskInstance(EmptyOperator(task_id="invalid_task"), run_id="not_this_run_id")
+            ti = TaskInstance.from_task(EmptyOperator(task_id="invalid_task"), run_id="not_this_run_id")
             ti.dag_id = "invalid_dag"
             session.add(ti)
         for i in [1, 2]:
@@ -486,7 +486,7 @@ class TestPaginationGetXComEntries(TestXComEndpoint):
                 run_type=DagRunType.MANUAL,
             )
             session.add(dagrun)
-            ti = TaskInstance(EmptyOperator(task_id=self.task_id), run_id=self.run_id)
+            ti = TaskInstance.from_task(EmptyOperator(task_id=self.task_id), run_id=self.run_id)
             ti.dag_id = self.dag_id
             session.add(ti)
 

--- a/tests/api_connexion/schemas/test_task_instance_schema.py
+++ b/tests/api_connexion/schemas/test_task_instance_schema.py
@@ -63,7 +63,7 @@ class TestTaskInstanceSchema:
         session.rollback()
 
     def test_task_instance_schema_without_sla_and_rendered(self, session):
-        ti = TI(task=self.task, **self.default_ti_init)
+        ti = TI.from_task(task=self.task, **self.default_ti_init)
         for key, value in self.default_ti_extras.items():
             setattr(ti, key, value)
         serialized_ti = task_instance_schema.dump((ti, None, None))
@@ -105,7 +105,7 @@ class TestTaskInstanceSchema:
         )
         session.add(sla_miss)
         session.flush()
-        ti = TI(task=self.task, **self.default_ti_init)
+        ti = TI.from_task(task=self.task, **self.default_ti_init)
         for key, value in self.default_ti_extras.items():
             setattr(ti, key, value)
         self.task.template_fields = ["partitions"]

--- a/tests/callbacks/test_callback_requests.py
+++ b/tests/callbacks/test_callback_requests.py
@@ -32,7 +32,7 @@ from airflow.operators.bash import BashOperator
 from airflow.utils import timezone
 from airflow.utils.state import State
 
-TI = TaskInstance(
+TI = TaskInstance.from_task(
     task=BashOperator(task_id="test", bash_command="true", dag=DAG(dag_id="id"), start_date=datetime.now()),
     run_id="fake_run",
     state=State.RUNNING,
@@ -105,7 +105,7 @@ class TestCallbackRequest:
 
         test_pod = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="hello", namespace="ns"))
         op = BashOperator(task_id="hi", executor_config={"pod_override": test_pod}, bash_command="hi")
-        ti = TaskInstance(task=op)
+        ti = TaskInstance.from_task(task=op)
         s = SimpleTaskInstance.from_ti(ti)
         data = TaskCallbackRequest("hi", s).to_json()
         actual = TaskCallbackRequest.from_json(data).simple_task_instance.executor_config["pod_override"]
@@ -121,7 +121,7 @@ class TestCallbackRequest:
         from airflow.operators.bash import BashOperator
 
         op = BashOperator(task_id="hi", bash_command="hi")
-        ti = TaskInstance(task=op)
+        ti = TaskInstance.from_task(task=op)
         ti.set_state("SUCCESS", session=MagicMock())
         start_date = ti.start_date
         end_date = ti.end_date

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -498,7 +498,7 @@ class TestCliTasks:
             run_type=DagRunType.MANUAL,
             external_trigger=True,
         )
-        ti2 = TaskInstance(task2, dagrun.execution_date)
+        ti2 = TaskInstance.from_task(task2, dagrun.execution_date)
         ti2.set_state(State.SUCCESS)
         ti_start = ti2.start_date
         ti_end = ti2.end_date

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -134,7 +134,7 @@ class TestCore:
         )
         task.run(start_date=execution_date, end_date=execution_date)
 
-        ti = TI(task=task, execution_date=execution_date)
+        ti = TI.from_task(task=task, execution_date=execution_date)
         context = ti.get_template_context()
 
         # next_ds should be the execution date for manually triggered runs
@@ -166,8 +166,8 @@ class TestCore:
         )
         task1.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
         task2.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        ti1 = TI(task=task1, execution_date=DEFAULT_DATE)
-        ti2 = TI(task=task2, execution_date=DEFAULT_DATE)
+        ti1 = TI.from_task(task=task1, execution_date=DEFAULT_DATE)
+        ti2 = TI.from_task(task=task2, execution_date=DEFAULT_DATE)
         context1 = ti1.get_template_context()
         context2 = ti2.get_template_context()
 

--- a/tests/core/test_impersonation_tests.py
+++ b/tests/core/test_impersonation_tests.py
@@ -114,7 +114,7 @@ class BaseImpersonationTest:
 
         BackfillJob(dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE).run()
         run_id = DagRun.generate_run_id(DagRunType.BACKFILL_JOB, execution_date=DEFAULT_DATE)
-        ti = TaskInstance(task=dag.get_task(task_id), run_id=run_id)
+        ti = TaskInstance.from_task(task=dag.get_task(task_id), run_id=run_id)
         ti.refresh_from_db()
 
         assert ti.state == State.SUCCESS

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -122,7 +122,7 @@ class TestDagFileProcessor:
             default_args={"start_date": test_start_date, "sla": datetime.timedelta()},
         )
 
-        session.merge(TaskInstance(task=task, execution_date=test_start_date, state="success"))
+        session.merge(TaskInstance.from_task(task=task, execution_date=test_start_date, state="success"))
         session.merge(SlaMiss(task_id="dummy", dag_id="test_sla_miss", execution_date=test_start_date))
 
         mock_dagbag = mock.Mock()
@@ -154,7 +154,7 @@ class TestDagFileProcessor:
             default_args={"start_date": test_start_date, "sla": None},
         )
 
-        session.merge(TaskInstance(task=task, execution_date=test_start_date, state="success"))
+        session.merge(TaskInstance.from_task(task=task, execution_date=test_start_date, state="success"))
         session.merge(SlaMiss(task_id="dummy", dag_id="test_sla_miss", execution_date=test_start_date))
 
         mock_dagbag = mock.Mock()
@@ -186,7 +186,7 @@ class TestDagFileProcessor:
         )
 
         # Create a TaskInstance for two days ago
-        session.merge(TaskInstance(task=task, execution_date=test_start_date, state="success"))
+        session.merge(TaskInstance.from_task(task=task, execution_date=test_start_date, state="success"))
 
         # Create an SlaMiss where notification was sent, but email was not
         session.merge(
@@ -230,7 +230,7 @@ class TestDagFileProcessor:
         dag_maker.create_dagrun(execution_date=test_start_date, state=State.SUCCESS)
 
         # Create a TaskInstance for two days ago
-        ti = TaskInstance(task=task, execution_date=test_start_date, state="success")
+        ti = TaskInstance.from_task(task=task, execution_date=test_start_date, state="success")
         session.merge(ti)
         session.flush()
 
@@ -280,7 +280,7 @@ class TestDagFileProcessor:
 
         dag_maker.create_dagrun(execution_date=test_start_date, state=State.SUCCESS)
 
-        session.merge(TaskInstance(task=task, execution_date=test_start_date, state="success"))
+        session.merge(TaskInstance.from_task(task=task, execution_date=test_start_date, state="success"))
         session.merge(
             SlaMiss(task_id=task.task_id, dag_id=dag.dag_id, execution_date=now - datetime.timedelta(days=2))
         )
@@ -331,7 +331,7 @@ class TestDagFileProcessor:
             )
             mock_stats_incr.reset_mock()
 
-            session.merge(TaskInstance(task=task, execution_date=test_start_date, state="Success"))
+            session.merge(TaskInstance.from_task(task=task, execution_date=test_start_date, state="Success"))
 
             # Create an SlaMiss where notification was sent, but email was not
             session.merge(
@@ -373,7 +373,7 @@ class TestDagFileProcessor:
             default_args={"start_date": test_start_date, "sla": datetime.timedelta(hours=1)},
         )
 
-        session.merge(TaskInstance(task=task, execution_date=test_start_date, state="Success"))
+        session.merge(TaskInstance.from_task(task=task, execution_date=test_start_date, state="Success"))
 
         email2 = "test2@test.com"
         EmptyOperator(task_id="sla_not_missed", dag=dag, owner="airflow", email=email2)
@@ -417,7 +417,7 @@ class TestDagFileProcessor:
         )
         mock_stats_incr.reset_mock()
 
-        session.merge(TaskInstance(task=task, execution_date=test_start_date, state="Success"))
+        session.merge(TaskInstance.from_task(task=task, execution_date=test_start_date, state="Success"))
 
         # Create an SlaMiss where notification was sent, but email was not
         session.merge(SlaMiss(task_id="dummy", dag_id="test_sla_miss", execution_date=test_start_date))
@@ -452,7 +452,7 @@ class TestDagFileProcessor:
             default_args={"start_date": test_start_date, "sla": datetime.timedelta(hours=1)},
         )
 
-        session.merge(TaskInstance(task=task, execution_date=test_start_date, state="Success"))
+        session.merge(TaskInstance.from_task(task=task, execution_date=test_start_date, state="Success"))
 
         # Create an SlaMiss where notification was sent, but email was not
         session.merge(
@@ -481,7 +481,7 @@ class TestDagFileProcessor:
                 session=session,
             )
             task = dag.get_task(task_id="run_this_first")
-            ti = TaskInstance(task, run_id=dagrun.run_id, state=State.RUNNING)
+            ti = TaskInstance.from_task(task, run_id=dagrun.run_id, state=State.RUNNING)
             session.add(ti)
 
         requests = [
@@ -514,7 +514,7 @@ class TestDagFileProcessor:
                 session=session,
             )
             task = dag.get_task(task_id="run_this_first")
-            ti = TaskInstance(task, run_id=dagrun.run_id, state=State.QUEUED)
+            ti = TaskInstance.from_task(task, run_id=dagrun.run_id, state=State.QUEUED)
             session.add(ti)
 
             if has_serialized_dag:
@@ -547,7 +547,7 @@ class TestDagFileProcessor:
                 run_type=DagRunType.SCHEDULED,
                 session=session,
             )
-            ti = TaskInstance(task, run_id=dagrun.run_id, state=State.RUNNING)
+            ti = TaskInstance.from_task(task, run_id=dagrun.run_id, state=State.RUNNING)
             ti.hostname = "test_hostname"
             session.add(ti)
 

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -266,7 +266,7 @@ class TestAirflowTaskDecorator(BasePythonTest):
             ret = arg_task(4, date(2019, 1, 1), "dag {{dag.dag_id}} ran on {{ds}}.", named_tuple)
 
         dr = self.create_dag_run()
-        ti = TaskInstance(task=ret.operator, run_id=dr.run_id)
+        ti = TaskInstance.from_task(task=ret.operator, run_id=dr.run_id)
         rendered_op_args = ti.render_templates().op_args
         assert len(rendered_op_args) == 4
         assert rendered_op_args[0] == 4
@@ -287,7 +287,7 @@ class TestAirflowTaskDecorator(BasePythonTest):
             )
 
         dr = self.create_dag_run()
-        ti = TaskInstance(task=ret.operator, run_id=dr.run_id)
+        ti = TaskInstance.from_task(task=ret.operator, run_id=dr.run_id)
         rendered_op_kwargs = ti.render_templates().op_kwargs
         assert rendered_op_kwargs["an_int"] == 4
         assert rendered_op_kwargs["a_date"] == date(2019, 1, 1)

--- a/tests/executors/test_base_executor.py
+++ b/tests/executors/test_base_executor.py
@@ -50,7 +50,7 @@ def test_is_single_threaded_default_value():
 
 def test_get_task_log():
     executor = BaseExecutor()
-    ti = TaskInstance(task=BaseOperator(task_id="dummy"))
+    ti = TaskInstance.from_task(task=BaseOperator(task_id="dummy"))
     assert executor.get_task_log(ti=ti) == ([], [])
 
 

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -172,7 +172,7 @@ class TestCeleryExecutor:
         with DAG("test_try_adopt_task_instances_none"):
             task_1 = BaseOperator(task_id="task_1", start_date=start_date)
 
-        key1 = TaskInstance(task=task_1, run_id=None)
+        key1 = TaskInstance.from_task(task=task_1, run_id=None)
         tis = [key1]
         executor = celery_executor.CeleryExecutor()
 
@@ -189,10 +189,10 @@ class TestCeleryExecutor:
             task_1 = BaseOperator(task_id="task_1", start_date=start_date)
             task_2 = BaseOperator(task_id="task_2", start_date=start_date)
 
-        ti1 = TaskInstance(task=task_1, run_id=None)
+        ti1 = TaskInstance.from_task(task=task_1, run_id=None)
         ti1.external_executor_id = "231"
         ti1.state = State.QUEUED
-        ti2 = TaskInstance(task=task_2, run_id=None)
+        ti2 = TaskInstance.from_task(task=task_2, run_id=None)
         ti2.external_executor_id = "232"
         ti2.state = State.QUEUED
 
@@ -295,10 +295,10 @@ class TestCeleryExecutor:
             task_1 = BaseOperator(task_id="task_1", start_date=start_date)
             task_2 = BaseOperator(task_id="task_2", start_date=start_date)
 
-        ti1 = TaskInstance(task=task_1, run_id=None)
+        ti1 = TaskInstance.from_task(task=task_1, run_id=None)
         ti1.external_executor_id = "231"
         ti1.state = State.QUEUED
-        ti2 = TaskInstance(task=task_2, run_id=None)
+        ti2 = TaskInstance.from_task(task=task_2, run_id=None)
         ti2.external_executor_id = "232"
         ti2.state = State.QUEUED
 
@@ -324,10 +324,10 @@ class TestCeleryExecutor:
             task_1 = BaseOperator(task_id="task_1", start_date=start_date)
             task_2 = BaseOperator(task_id="task_2", start_date=start_date)
 
-        ti1 = TaskInstance(task=task_1, run_id=None)
+        ti1 = TaskInstance.from_task(task=task_1, run_id=None)
         ti1.external_executor_id = "231"
         ti1.state = State.QUEUED
-        ti2 = TaskInstance(task=task_2, run_id=None)
+        ti2 = TaskInstance.from_task(task=task_2, run_id=None)
         ti2.external_executor_id = "232"
         ti2.state = State.QUEUED
 

--- a/tests/integration/executors/test_celery_executor.py
+++ b/tests/integration/executors/test_celery_executor.py
@@ -177,7 +177,7 @@ class TestCeleryExecutor:
                 "command",
                 1,
                 None,
-                SimpleTaskInstance.from_ti(ti=TaskInstance(task=task, run_id=None)),
+                SimpleTaskInstance.from_ti(ti=TaskInstance.from_task(task=task, run_id=None)),
             )
             key = ("fail", "fake_simple_ti", when, 0)
             executor.queued_tasks[key] = value_tuple
@@ -207,7 +207,7 @@ class TestCeleryExecutor:
                 "command",
                 1,
                 None,
-                SimpleTaskInstance.from_ti(ti=TaskInstance(task=task, run_id=None)),
+                SimpleTaskInstance.from_ti(ti=TaskInstance.from_task(task=task, run_id=None)),
             )
             key = ("fail", "fake_simple_ti", when, 0)
             executor.queued_tasks[key] = value_tuple

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -510,7 +510,7 @@ class TestSchedulerJob:
 
         dr1 = dag_maker.create_dagrun(run_type=DagRunType.BACKFILL_JOB)
 
-        ti1 = TaskInstance(task1, run_id=dr1.run_id)
+        ti1 = TaskInstance.from_task(task1, run_id=dr1.run_id)
         ti1.refresh_from_db()
         ti1.state = State.SCHEDULED
         session.merge(ti1)
@@ -944,8 +944,8 @@ class TestSchedulerJob:
         dr2 = dag_maker.create_dagrun_after(dr1, run_type=DagRunType.SCHEDULED)
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
-        ti1 = TaskInstance(task1, run_id=dr1.run_id)
-        ti2 = TaskInstance(task1, run_id=dr2.run_id)
+        ti1 = TaskInstance.from_task(task1, run_id=dr1.run_id)
+        ti2 = TaskInstance.from_task(task1, run_id=dr2.run_id)
         ti1.state = State.SCHEDULED
         ti2.state = State.SCHEDULED
         session.merge(ti1)
@@ -3887,7 +3887,7 @@ class TestSchedulerJob:
         self.scheduler_job.executor = MockExecutor(do_update=False)
         self.scheduler_job.processor_agent = mock.MagicMock(spec=DagFileProcessorAgent)
 
-        ti = TaskInstance(task=task1, execution_date=DEFAULT_DATE)
+        ti = TaskInstance.from_task(task=task1, execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
         ti.state = State.SUCCESS
         session.merge(ti)
@@ -4190,7 +4190,7 @@ class TestSchedulerJob:
 
             for task_id in tasks_to_setup:
                 task = dag.get_task(task_id=task_id)
-                ti = TaskInstance(task, run_id=dag_run.run_id, state=State.RUNNING)
+                ti = TaskInstance.from_task(task, run_id=dag_run.run_id, state=State.RUNNING)
                 ti.queued_by_job_id = 999
 
                 local_job = LocalTaskJob(ti)
@@ -4253,7 +4253,7 @@ class TestSchedulerJob:
 
             for task_id in tasks_to_setup:
                 task = dag.get_task(task_id=task_id)
-                ti = TaskInstance(task, run_id=dag_run.run_id, state=State.RUNNING)
+                ti = TaskInstance.from_task(task, run_id=dag_run.run_id, state=State.RUNNING)
                 ti.queued_by_job_id = 999
 
                 local_job = LocalTaskJob(ti)
@@ -4314,7 +4314,7 @@ class TestSchedulerJob:
             )
             task = dag.get_task(task_id="run_this_last")
 
-            ti = TaskInstance(task, run_id=dag_run.run_id, state=State.RUNNING)
+            ti = TaskInstance.from_task(task, run_id=dag_run.run_id, state=State.RUNNING)
             local_job = LocalTaskJob(ti)
             local_job.state = State.SHUTDOWN
             session.add(local_job)

--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -262,7 +262,9 @@ def test_trigger_create_race_condition_18392(session, tmp_path):
 
     dag = DagModel(dag_id="test-dag")
     dag_run = DagRun(dag.dag_id, run_id="abc", run_type="none")
-    ti = TaskInstance(PythonOperator(task_id="dummy-task", python_callable=print), run_id=dag_run.run_id)
+    ti = TaskInstance.from_task(
+        PythonOperator(task_id="dummy-task", python_callable=print), run_id=dag_run.run_id
+    )
     ti.dag_id = dag.dag_id
     ti.trigger_id = 1
     session.add(dag)

--- a/tests/lineage/test_lineage.py
+++ b/tests/lineage/test_lineage.py
@@ -75,10 +75,10 @@ class TestLineage:
         dag.clear()
         dag_run = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
 
-        ctx1 = Context({"ti": TI(task=op1, run_id=dag_run.run_id), "ds": DEFAULT_DATE})
-        ctx2 = Context({"ti": TI(task=op2, run_id=dag_run.run_id), "ds": DEFAULT_DATE})
-        ctx3 = Context({"ti": TI(task=op3, run_id=dag_run.run_id), "ds": DEFAULT_DATE})
-        ctx5 = Context({"ti": TI(task=op5, run_id=dag_run.run_id), "ds": DEFAULT_DATE})
+        ctx1 = Context({"ti": TI.from_task(task=op1, run_id=dag_run.run_id), "ds": DEFAULT_DATE})
+        ctx2 = Context({"ti": TI.from_task(task=op2, run_id=dag_run.run_id), "ds": DEFAULT_DATE})
+        ctx3 = Context({"ti": TI.from_task(task=op3, run_id=dag_run.run_id), "ds": DEFAULT_DATE})
+        ctx5 = Context({"ti": TI.from_task(task=op5, run_id=dag_run.run_id), "ds": DEFAULT_DATE})
 
         # prepare with manual inlets and outlets
         op1.pre_execute(ctx1)
@@ -124,7 +124,7 @@ class TestLineage:
         op1.outlets.append(file1)
 
         # execution_date is set in the context in order to avoid creating task instances
-        ctx1 = Context({"ti": TI(task=op1, run_id=dag_run.run_id), "ds": DEFAULT_DATE})
+        ctx1 = Context({"ti": TI.from_task(task=op1, run_id=dag_run.run_id), "ds": DEFAULT_DATE})
 
         op1.pre_execute(ctx1)
         assert op1.inlets[0].url == f1s.format(DEFAULT_DATE)
@@ -147,8 +147,8 @@ class TestLineage:
 
         dag_run = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
 
-        ctx1 = Context({"ti": TI(task=op1, run_id=dag_run.run_id), "ds": DEFAULT_DATE})
-        ctx2 = Context({"ti": TI(task=op2, run_id=dag_run.run_id), "ds": DEFAULT_DATE})
+        ctx1 = Context({"ti": TI.from_task(task=op1, run_id=dag_run.run_id), "ds": DEFAULT_DATE})
+        ctx2 = Context({"ti": TI.from_task(task=op2, run_id=dag_run.run_id), "ds": DEFAULT_DATE})
 
         # prepare with manual inlets and outlets
         op1.pre_execute(ctx1)

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -440,13 +440,13 @@ class TestDag:
             state=None, run_id="test4", execution_date=DEFAULT_DATE + datetime.timedelta(days=3)
         )
 
-        ti1 = TI(task=test_task, run_id=dr1.run_id)
+        ti1 = TI.from_task(task=test_task, run_id=dr1.run_id)
         ti1.state = None
-        ti2 = TI(task=test_task, run_id=dr2.run_id)
+        ti2 = TI.from_task(task=test_task, run_id=dr2.run_id)
         ti2.state = State.RUNNING
-        ti3 = TI(task=test_task, run_id=dr3.run_id)
+        ti3 = TI.from_task(task=test_task, run_id=dr3.run_id)
         ti3.state = State.QUEUED
-        ti4 = TI(task=test_task, run_id=dr4.run_id)
+        ti4 = TI.from_task(task=test_task, run_id=dr4.run_id)
         ti4.state = State.RUNNING
         session = settings.Session()
         session.merge(ti1)
@@ -1592,7 +1592,7 @@ class TestDag:
         )
         session.merge(dagrun_1)
 
-        task_instance_1 = TI(t_1, execution_date=DEFAULT_DATE, state=State.RUNNING)
+        task_instance_1 = TI.from_task(t_1, execution_date=DEFAULT_DATE, state=State.RUNNING)
         session.merge(task_instance_1)
         session.commit()
 
@@ -1792,8 +1792,8 @@ my_postgres_conn:
             execution_date=DEFAULT_DATE,
             session=session,
         )
-        task_instance_1 = TI(t_1, execution_date=DEFAULT_DATE, state=State.RUNNING)
-        task_instance_2 = TI(t_2, execution_date=DEFAULT_DATE, state=State.RUNNING)
+        task_instance_1 = TI.from_task(t_1, execution_date=DEFAULT_DATE, state=State.RUNNING)
+        task_instance_2 = TI.from_task(t_2, execution_date=DEFAULT_DATE, state=State.RUNNING)
         session.merge(task_instance_1)
         session.merge(task_instance_2)
 
@@ -1875,7 +1875,7 @@ my_postgres_conn:
         )
         session.merge(dagrun_1)
 
-        task_instance_1 = TI(t_1, execution_date=DEFAULT_DATE, state=ti_state_begin)
+        task_instance_1 = TI.from_task(t_1, execution_date=DEFAULT_DATE, state=ti_state_begin)
         task_instance_1.job_id = 123
         session.merge(task_instance_1)
         session.commit()

--- a/tests/models/test_mappedoperator.py
+++ b/tests/models/test_mappedoperator.py
@@ -212,7 +212,9 @@ def test_expand_mapped_task_instance(dag_maker, session, num_existing_tis, expec
 
     for index in range(num_existing_tis):
         # Give the existing TIs a state to make sure we don't change them
-        ti = TaskInstance(mapped, run_id=dr.run_id, map_index=index, state=TaskInstanceState.SUCCESS)
+        ti = TaskInstance.from_task(
+            mapped, run_id=dr.run_id, map_index=index, state=TaskInstanceState.SUCCESS
+        )
         session.add(ti)
     session.flush()
 
@@ -254,7 +256,9 @@ def test_expand_mapped_task_failed_state_in_db(dag_maker, session):
 
     for index in range(2):
         # Give the existing TIs a state to make sure we don't change them
-        ti = TaskInstance(mapped, run_id=dr.run_id, map_index=index, state=TaskInstanceState.SUCCESS)
+        ti = TaskInstance.from_task(
+            mapped, run_id=dr.run_id, map_index=index, state=TaskInstanceState.SUCCESS
+        )
         session.add(ti)
     session.flush()
 
@@ -461,7 +465,9 @@ def test_expand_kwargs_mapped_task_instance(dag_maker, session, num_existing_tis
 
     for index in range(num_existing_tis):
         # Give the existing TIs a state to make sure we don't change them
-        ti = TaskInstance(mapped, run_id=dr.run_id, map_index=index, state=TaskInstanceState.SUCCESS)
+        ti = TaskInstance.from_task(
+            mapped, run_id=dr.run_id, map_index=index, state=TaskInstanceState.SUCCESS
+        )
         session.add(ti)
     session.flush()
 

--- a/tests/models/test_pool.py
+++ b/tests/models/test_pool.py
@@ -72,8 +72,8 @@ class TestPool:
             op1 = EmptyOperator(task_id="dummy1", pool="test_pool")
             op2 = EmptyOperator(task_id="dummy2", pool="test_pool")
         dag_maker.create_dagrun()
-        ti1 = TI(task=op1, execution_date=DEFAULT_DATE)
-        ti2 = TI(task=op2, execution_date=DEFAULT_DATE)
+        ti1 = TI.from_task(task=op1, execution_date=DEFAULT_DATE)
+        ti2 = TI.from_task(task=op2, execution_date=DEFAULT_DATE)
         ti1.state = State.RUNNING
         ti2.state = State.QUEUED
 
@@ -111,8 +111,8 @@ class TestPool:
             op1 = EmptyOperator(task_id="dummy1", pool="test_pool")
             op2 = EmptyOperator(task_id="dummy2", pool="test_pool")
         dag_maker.create_dagrun()
-        ti1 = TI(task=op1, execution_date=DEFAULT_DATE)
-        ti2 = TI(task=op2, execution_date=DEFAULT_DATE)
+        ti1 = TI.from_task(task=op1, execution_date=DEFAULT_DATE)
+        ti2 = TI.from_task(task=op2, execution_date=DEFAULT_DATE)
         ti1.state = State.RUNNING
         ti2.state = State.QUEUED
 
@@ -152,8 +152,8 @@ class TestPool:
             op1 = EmptyOperator(task_id="dummy1")
             op2 = EmptyOperator(task_id="dummy2", pool_slots=2)
         dag_maker.create_dagrun()
-        ti1 = TI(task=op1, execution_date=DEFAULT_DATE)
-        ti2 = TI(task=op2, execution_date=DEFAULT_DATE)
+        ti1 = TI.from_task(task=op1, execution_date=DEFAULT_DATE)
+        ti2 = TI.from_task(task=op2, execution_date=DEFAULT_DATE)
         ti1.state = State.RUNNING
         ti2.state = State.QUEUED
 

--- a/tests/models/test_skipmixin.py
+++ b/tests/models/test_skipmixin.py
@@ -119,9 +119,9 @@ class TestSkipMixin:
             task1 >> [task2, task3]
         dag_maker.create_dagrun()
 
-        ti1 = TI(task1, execution_date=DEFAULT_DATE)
-        ti2 = TI(task2, execution_date=DEFAULT_DATE)
-        ti3 = TI(task3, execution_date=DEFAULT_DATE)
+        ti1 = TI.from_task(task1, execution_date=DEFAULT_DATE)
+        ti2 = TI.from_task(task2, execution_date=DEFAULT_DATE)
+        ti3 = TI.from_task(task3, execution_date=DEFAULT_DATE)
 
         SkipMixin().skip_all_except(ti=ti1, branch_task_ids=branch_task_ids)
 
@@ -137,7 +137,7 @@ class TestSkipMixin:
         with dag_maker("dag_test_skip_all_except_wrong_type"):
             task = EmptyOperator(task_id="task")
         dag_maker.create_dagrun()
-        ti1 = TI(task, execution_date=DEFAULT_DATE)
+        ti1 = TI.from_task(task, execution_date=DEFAULT_DATE)
         error_message = (
             r"'branch_task_ids' must be either None, a task ID, or an Iterable of IDs, but got 'int'\."
         )
@@ -148,7 +148,7 @@ class TestSkipMixin:
         with dag_maker("dag_test_skip_all_except_wrong_type"):
             task = EmptyOperator(task_id="task")
         dag_maker.create_dagrun()
-        ti1 = TI(task, execution_date=DEFAULT_DATE)
+        ti1 = TI.from_task(task, execution_date=DEFAULT_DATE)
         error_message = (
             r"'branch_task_ids' expected all task IDs are strings. "
             r"Invalid tasks found: \{\(42, 'int'\)\}\."
@@ -173,7 +173,7 @@ class TestSkipMixin:
             task1 >> [task2, task3]
         dag_maker.create_dagrun()
 
-        ti1 = TI(task1, execution_date=DEFAULT_DATE)
+        ti1 = TI.from_task(task1, execution_date=DEFAULT_DATE)
 
         error_message = r"'branch_task_ids' must contain only valid task_ids. Invalid tasks found: .*"
         with pytest.raises(AirflowException, match=error_message):

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -26,7 +26,7 @@ import signal
 import sys
 import urllib
 from traceback import format_exception
-from typing import cast
+from typing import Callable, cast
 from unittest import mock
 from unittest.mock import call, mock_open, patch
 from uuid import uuid4
@@ -259,6 +259,47 @@ class TestTaskInstance:
         # ensure log is correctly created for ORM ti
         assert ti.log.name == "airflow.task"
         assert not ti.test_mode
+
+    def test_serialize_dict(self, create_task_instance: Callable[[], TaskInstance]):
+        expected_fields = [
+            "_try_number",
+            "dag_id",
+            "duration",
+            "end_date",
+            "executor_config",
+            "external_executor_id",
+            "hostname",
+            "job_id",
+            "map_index",
+            "max_tries",
+            "next_kwargs",
+            "next_method",
+            "operator",
+            "pid",
+            "pool_slots",
+            "pool",
+            "priority_weight",
+            "queue",
+            "queued_by_job_id",
+            "queued_dttm",
+            "rendered_task_instance_fields",
+            "run_as_user",
+            "run_id",
+            "start_date",
+            "state",
+            "task_id",
+            "task",
+            "trigger_id",
+            "trigger_timeout",
+            "unixname",
+            "updated_at",
+        ]
+        ti = create_task_instance()
+        # ensure log is correctly created for ORM ti
+        serialized_dict = ti.serialize()
+        print(serialized_dict.keys())
+        for key in serialized_dict:
+            assert key in expected_fields
 
     @patch.object(DAG, "get_concurrency_reached")
     def test_requeue_over_dag_concurrency(self, mock_concurrency_reached, create_task_instance):

--- a/tests/models/test_timestamp.py
+++ b/tests/models/test_timestamp.py
@@ -40,7 +40,7 @@ def add_log(execdate, session, dag_maker, timezone_override=None):
     with dag_maker(dag_id="logging", default_args={"start_date": execdate}):
         task = EmptyOperator(task_id="dummy")
     dag_maker.create_dagrun()
-    task_instance = TaskInstance(task=task, execution_date=execdate, state="success")
+    task_instance = TaskInstance.from_task(task=task, execution_date=execdate, state="success")
     session.merge(task_instance)
     log = Log(State.RUNNING, task_instance)
     if timezone_override:

--- a/tests/models/test_trigger.py
+++ b/tests/models/test_trigger.py
@@ -72,7 +72,7 @@ def test_clean_unused(session, create_task_instance):
     task_instance.trigger_id = trigger1.id
     session.add(task_instance)
     fake_task = EmptyOperator(task_id="fake2", dag=task_instance.task.dag)
-    task_instance = TaskInstance(task=fake_task, run_id=task_instance.run_id)
+    task_instance = TaskInstance.from_task(task=fake_task, run_id=task_instance.run_id)
     task_instance.state = State.SUCCESS
     task_instance.trigger_id = trigger2.id
     session.add(task_instance)

--- a/tests/models/test_xcom.py
+++ b/tests/models/test_xcom.py
@@ -59,7 +59,7 @@ def task_instance_factory(request, session: Session):
             execution_date=execution_date,
         )
         session.add(run)
-        ti = TaskInstance(EmptyOperator(task_id=task_id), run_id=run_id)
+        ti = TaskInstance.from_task(EmptyOperator(task_id=task_id), run_id=run_id)
         ti.dag_id = dag_id
         session.add(ti)
         session.commit()
@@ -86,7 +86,7 @@ def task_instance(task_instance_factory):
 
 @pytest.fixture()
 def task_instances(session, task_instance):
-    ti2 = TaskInstance(EmptyOperator(task_id="task_2"), run_id=task_instance.run_id)
+    ti2 = TaskInstance.from_task(EmptyOperator(task_id="task_2"), run_id=task_instance.run_id)
     ti2.dag_id = task_instance.dag_id
     session.add(ti2)
     session.commit()

--- a/tests/operators/test_subdag_operator.py
+++ b/tests/operators/test_subdag_operator.py
@@ -329,7 +329,7 @@ class TestSubDagOperator:
         subdag_task._get_dagrun = Mock(return_value=self.dag_run_success)
 
         mock_get_task_instance.side_effect = [
-            TaskInstance(task=task, run_id=dag_run.run_id, state=state)
+            TaskInstance.from_task(task=task, run_id=dag_run.run_id, state=state)
             for task, state in zip(dummy_subdag_tasks, states)
         ]
 

--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -73,7 +73,7 @@ class TestCloudwatchTaskHandler:
             session.commit()
             session.refresh(dag_run)
 
-        self.ti = TaskInstance(task=task, run_id=dag_run.run_id)
+        self.ti = TaskInstance.from_task(task=task, run_id=dag_run.run_id)
         self.ti.dag_run = dag_run
         self.ti.try_number = 1
         self.ti.state = State.RUNNING

--- a/tests/providers/amazon/aws/log/test_s3_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_s3_task_handler.py
@@ -65,7 +65,7 @@ class TestS3TaskHandler:
             session.commit()
             session.refresh(dag_run)
 
-        self.ti = TaskInstance(task=task, run_id=dag_run.run_id)
+        self.ti = TaskInstance.from_task(task=task, run_id=dag_run.run_id)
         self.ti.dag_run = dag_run
         self.ti.try_number = 1
         self.ti.state = State.RUNNING

--- a/tests/providers/amazon/aws/operators/test_athena.py
+++ b/tests/providers/amazon/aws/operators/test_athena.py
@@ -209,7 +209,7 @@ class TestAthenaOperator:
     def test_return_value(self, mock_conn, mock_run_query, mock_check_query_status):
         """Test we return the right value -- that will get put in to XCom by the execution engine"""
         dag_run = DagRun(dag_id=self.dag.dag_id, execution_date=timezone.utcnow(), run_id="test")
-        ti = TaskInstance(task=self.athena)
+        ti = TaskInstance.from_task(task=self.athena)
         ti.dag_run = dag_run
 
         assert self.athena.execute(ti.get_template_context()) == ATHENA_QUERY_ID

--- a/tests/providers/amazon/aws/operators/test_datasync.py
+++ b/tests/providers/amazon/aws/operators/test_datasync.py
@@ -312,7 +312,7 @@ class TestDataSyncOperatorCreate(DataSyncTestCaseBase):
 
         self.set_up_operator()
         dag_run = DagRun(dag_id=self.dag.dag_id, execution_date=timezone.utcnow(), run_id="test")
-        ti = TaskInstance(task=self.datasync)
+        ti = TaskInstance.from_task(task=self.datasync)
         ti.dag_run = dag_run
         assert self.datasync.execute(ti.get_template_context()) is not None
         # ### Check mocks:
@@ -504,7 +504,7 @@ class TestDataSyncOperatorGetTasks(DataSyncTestCaseBase):
 
         self.set_up_operator()
         dag_run = DagRun(dag_id=self.dag.dag_id, execution_date=timezone.utcnow(), run_id="test")
-        ti = TaskInstance(task=self.datasync)
+        ti = TaskInstance.from_task(task=self.datasync)
         ti.dag_run = dag_run
         result = self.datasync.execute(ti.get_template_context())
         assert result["TaskArn"] == self.task_arn
@@ -602,7 +602,7 @@ class TestDataSyncOperatorUpdate(DataSyncTestCaseBase):
 
         self.set_up_operator()
         dag_run = DagRun(dag_id=self.dag.dag_id, execution_date=timezone.utcnow(), run_id="test")
-        ti = TaskInstance(task=self.datasync)
+        ti = TaskInstance.from_task(task=self.datasync)
         ti.dag_run = dag_run
         result = self.datasync.execute(ti.get_template_context())
         assert result["TaskArn"] == self.task_arn
@@ -772,7 +772,7 @@ class TestDataSyncOperator(DataSyncTestCaseBase):
 
         self.set_up_operator()
         dag_run = DagRun(dag_id=self.dag.dag_id, execution_date=timezone.utcnow(), run_id="test")
-        ti = TaskInstance(task=self.datasync)
+        ti = TaskInstance.from_task(task=self.datasync)
         ti.dag_run = dag_run
         assert self.datasync.execute(ti.get_template_context()) is not None
         # ### Check mocks:
@@ -866,7 +866,7 @@ class TestDataSyncOperatorDelete(DataSyncTestCaseBase):
 
         self.set_up_operator()
         dag_run = DagRun(dag_id=self.dag.dag_id, execution_date=timezone.utcnow(), run_id="test")
-        ti = TaskInstance(task=self.datasync)
+        ti = TaskInstance.from_task(task=self.datasync)
         ti.dag_run = dag_run
         result = self.datasync.execute(ti.get_template_context())
         assert result["TaskArn"] == self.task_arn

--- a/tests/providers/amazon/aws/operators/test_dms_describe_tasks.py
+++ b/tests/providers/amazon/aws/operators/test_dms_describe_tasks.py
@@ -86,7 +86,7 @@ class TestDmsDescribeTasksOperator:
         )
 
         dag_run = DagRun(dag_id=self.dag.dag_id, execution_date=timezone.utcnow(), run_id="test")
-        ti = TaskInstance(task=describe_task)
+        ti = TaskInstance.from_task(task=describe_task)
         ti.dag_run = dag_run
         marker, response = describe_task.execute(ti.get_template_context())
 

--- a/tests/providers/amazon/aws/operators/test_emr_add_steps.py
+++ b/tests/providers/amazon/aws/operators/test_emr_add_steps.py
@@ -96,7 +96,7 @@ class TestEmrAddStepsOperator:
 
     def test_render_template(self):
         dag_run = DagRun(dag_id=self.operator.dag.dag_id, execution_date=DEFAULT_DATE, run_id="test")
-        ti = TaskInstance(task=self.operator)
+        ti = TaskInstance.from_task(task=self.operator)
         ti.dag_run = dag_run
         ti.render_templates()
 
@@ -144,7 +144,7 @@ class TestEmrAddStepsOperator:
             do_xcom_push=False,
         )
         dag_run = DagRun(dag_id=dag.dag_id, execution_date=timezone.utcnow(), run_id="test")
-        ti = TaskInstance(task=test_task)
+        ti = TaskInstance.from_task(task=test_task)
         ti.dag_run = dag_run
         ti.render_templates()
 

--- a/tests/providers/amazon/aws/operators/test_emr_create_job_flow.py
+++ b/tests/providers/amazon/aws/operators/test_emr_create_job_flow.py
@@ -85,7 +85,7 @@ class TestEmrCreateJobFlowOperator:
     def test_render_template(self):
         self.operator.job_flow_overrides = self._config
         dag_run = DagRun(dag_id=self.operator.dag_id, execution_date=DEFAULT_DATE, run_id="test")
-        ti = TaskInstance(task=self.operator)
+        ti = TaskInstance.from_task(task=self.operator)
         ti.dag_run = dag_run
         ti.render_templates()
 
@@ -115,7 +115,7 @@ class TestEmrCreateJobFlowOperator:
         self.operator.params = {"releaseLabel": "5.11.0"}
 
         dag_run = DagRun(dag_id=self.operator.dag_id, execution_date=DEFAULT_DATE, run_id="test")
-        ti = TaskInstance(task=self.operator)
+        ti = TaskInstance.from_task(task=self.operator)
         ti.dag_run = dag_run
         ti.render_templates()
 

--- a/tests/providers/amazon/aws/operators/test_sagemaker_base.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_base.py
@@ -66,7 +66,7 @@ class TestSageMakerExperimentOperator:
             dag=dag,
         )
         dag_run = DagRun(dag_id=dag.dag_id, execution_date=execution_date, run_id="test")
-        ti = TaskInstance(task=op)
+        ti = TaskInstance.from_task(task=op)
         ti.dag_run = dag_run
         context = ti.get_template_context()
         ti.render_templates(context)

--- a/tests/providers/amazon/aws/sensors/test_s3_key.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_key.py
@@ -118,7 +118,7 @@ class TestS3KeySensor:
         )
 
         dag_run = DagRun(dag_id=dag.dag_id, execution_date=execution_date, run_id="test")
-        ti = TaskInstance(task=op)
+        ti = TaskInstance.from_task(task=op)
         ti.dag_run = dag_run
         context = ti.get_template_context()
         ti.render_templates(context)
@@ -144,7 +144,7 @@ class TestS3KeySensor:
         )
 
         dag_run = DagRun(dag_id=dag.dag_id, execution_date=execution_date, run_id="test")
-        ti = TaskInstance(task=op)
+        ti = TaskInstance.from_task(task=op)
         ti.dag_run = dag_run
         context = ti.get_template_context()
         ti.render_templates(context)

--- a/tests/providers/amazon/aws/transfers/test_mongo_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_mongo_to_s3.py
@@ -77,7 +77,7 @@ class TestMongoToS3Operator:
 
     def test_render_template(self):
         dag_run = DagRun(dag_id=self.mock_operator.dag_id, execution_date=DEFAULT_DATE, run_id="test")
-        ti = TaskInstance(task=self.mock_operator)
+        ti = TaskInstance.from_task(task=self.mock_operator)
         ti.dag_run = dag_run
         ti.render_templates()
 

--- a/tests/providers/apache/hive/operators/test_hive.py
+++ b/tests/providers/apache/hive/operators/test_hive.py
@@ -83,7 +83,7 @@ class HiveOperatorTest(TestHiveEnvironment):
 
         fake_run_id = "test_mapred_job_name"
         fake_execution_date = timezone.datetime(2018, 6, 19)
-        fake_ti = TaskInstance(task=op)
+        fake_ti = TaskInstance.from_task(task=op)
         fake_ti.dag_run = DagRun(run_id=fake_run_id, execution_date=fake_execution_date)
         fake_ti.hostname = "fake_hostname"
         fake_context = {"ti": fake_ti}

--- a/tests/providers/apache/kylin/operators/test_kylin_cube.py
+++ b/tests/providers/apache/kylin/operators/test_kylin_cube.py
@@ -166,7 +166,7 @@ class TestKylinCubeOperator:
                 "end_time": "1483286400000",
             },
         )
-        ti = TaskInstance(operator, run_id="kylin_test")
+        ti = TaskInstance.from_task(operator, run_id="kylin_test")
         ti.dag_run = DagRun(dag_id=self.dag.dag_id, run_id="kylin_test", execution_date=DEFAULT_DATE)
         ti.render_templates()
         assert "learn_kylin" == getattr(operator, "project")

--- a/tests/providers/apache/spark/operators/test_spark_submit.py
+++ b/tests/providers/apache/spark/operators/test_spark_submit.py
@@ -146,7 +146,7 @@ class TestSparkSubmitOperator:
     def test_render_template(self):
         # Given
         operator = SparkSubmitOperator(task_id="spark_submit_job", dag=self.dag, **self._config)
-        ti = TaskInstance(operator, run_id="spark_test")
+        ti = TaskInstance.from_task(operator, run_id="spark_test")
         ti.dag_run = DagRun(dag_id=self.dag.dag_id, run_id="spark_test", execution_date=DEFAULT_DATE)
 
         # When

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -77,7 +77,7 @@ def create_context(task, persist_to_db=False, map_index=None):
         run_type=DagRunType.MANUAL,
         dag_id=dag.dag_id,
     )
-    task_instance = TaskInstance(task=task, run_id=dag_run.run_id)
+    task_instance = TaskInstance.from_task(task=task, run_id=dag_run.run_id)
     task_instance.dag_run = dag_run
     if map_index is not None:
         task_instance.map_index = map_index

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -1187,7 +1187,7 @@ def create_context(task):
         execution_date=logical_date,
         run_id=DagRun.generate_run_id(DagRunType.MANUAL, logical_date),
     )
-    task_instance = TaskInstance(task=task)
+    task_instance = TaskInstance.from_task(task=task)
     task_instance.dag_run = dag_run
     task_instance.dag_id = dag.dag_id
     task_instance.xcom_push = mock.Mock()

--- a/tests/providers/google/cloud/operators/test_cloud_build.py
+++ b/tests/providers/google/cloud/operators/test_cloud_build.py
@@ -498,7 +498,7 @@ def create_context(task):
         execution_date=logical_date,
         run_id=DagRun.generate_run_id(DagRunType.MANUAL, logical_date),
     )
-    task_instance = TaskInstance(task=task)
+    task_instance = TaskInstance.from_task(task=task)
     task_instance.dag_run = dag_run
     task_instance.dag_id = dag.dag_id
     task_instance.xcom_push = mock.Mock()

--- a/tests/providers/google/cloud/operators/test_mlengine.py
+++ b/tests/providers/google/cloud/operators/test_mlengine.py
@@ -1048,7 +1048,7 @@ def create_context(task):
         execution_date=logical_date,
         run_id=DagRun.generate_run_id(DagRunType.MANUAL, logical_date),
     )
-    task_instance = TaskInstance(task=task)
+    task_instance = TaskInstance.from_task(task=task)
     task_instance.dag_run = dag_run
     task_instance.dag_id = dag.dag_id
     task_instance.xcom_push = MagicMock()

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -1542,7 +1542,7 @@ class TestAsyncGCSToBigQueryOperator(unittest.TestCase):
             execution_date=logical_date,
             run_id=DagRun.generate_run_id(DagRunType.MANUAL, logical_date),
         )
-        task_instance = TaskInstance(task=task)
+        task_instance = TaskInstance.from_task(task=task)
         task_instance.dag_run = dag_run
         task_instance.dag_id = dag.dag_id
         task_instance.xcom_push = mock.Mock()

--- a/tests/providers/oracle/operators/test_oracle.py
+++ b/tests/providers/oracle/operators/test_oracle.py
@@ -98,7 +98,7 @@ class TestOracleStoredProcedureOperator:
                 procedure=procedure, oracle_conn_id=oracle_conn_id, parameters=parameters, task_id=task_id
             )
         dr = dag_maker.create_dagrun(run_id=task_id)
-        ti = TaskInstance(task=task, run_id=dr.run_id)
+        ti = TaskInstance.from_task(task=task, run_id=dr.run_id)
         with pytest.raises(oracledb.DatabaseError, match=re.escape(error)):
             ti.run()
         assert ti.xcom_pull(task_ids=task.task_id, key="ORA") == ora_exit_code

--- a/tests/providers/ssh/operators/test_ssh.py
+++ b/tests/providers/ssh/operators/test_ssh.py
@@ -222,7 +222,7 @@ class TestSSHOperator:
         with dag_maker(dag_id=f"dag_{request.node.name}"):
             task = SSHOperator(task_id="push_xcom", ssh_hook=self.hook, command=command)
         dr = dag_maker.create_dagrun(run_id="push_xcom")
-        ti = TaskInstance(task=task, run_id=dr.run_id)
+        ti = TaskInstance.from_task(task=task, run_id=dr.run_id)
         with pytest.raises(AirflowException, match=f"SSH operator error: exit status = {ssh_exit_code}"):
             ti.run()
         assert ti.xcom_pull(task_ids=task.task_id, key="ssh_exit") == ssh_exit_code

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -108,7 +108,7 @@ class TestExternalTaskSensor:
             SerializedDagModel.write_dag(dag)
 
         for idx, task in enumerate(task_group):
-            ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
+            ti = TaskInstance.from_task(task=task, execution_date=DEFAULT_DATE)
             ti.run(ignore_ti_state=True, mark_success=True)
             ti.set_state(target_states[idx])
 
@@ -1250,7 +1250,7 @@ def test_clear_overlapping_external_task_marker(dag_bag_head_tail, session):
         )
         session.add(dagrun)
         for task in dag.tasks:
-            ti = TaskInstance(task=task)
+            ti = TaskInstance.from_task(task=task)
             dagrun.task_instances.append(ti)
             ti.state = TaskInstanceState.SUCCESS
     session.flush()
@@ -1335,11 +1335,11 @@ def test_clear_overlapping_external_task_marker_mapped_tasks(dag_bag_head_tail_m
         for task in dag.tasks:
             if task.task_id == "dummy_task":
                 for map_index in range(5):
-                    ti = TaskInstance(task=task, run_id=dagrun.run_id, map_index=map_index)
+                    ti = TaskInstance.from_task(task=task, run_id=dagrun.run_id, map_index=map_index)
                     ti.state = TaskInstanceState.SUCCESS
                     dagrun.task_instances.append(ti)
             else:
-                ti = TaskInstance(task=task, run_id=dagrun.run_id)
+                ti = TaskInstance.from_task(task=task, run_id=dagrun.run_id)
                 ti.state = TaskInstanceState.SUCCESS
                 dagrun.task_instances.append(ti)
     session.flush()

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -147,7 +147,7 @@ class TestStandardTaskRunner:
             state=State.RUNNING,
             start_date=DEFAULT_DATE,
         )
-        ti = TaskInstance(task=task, run_id="test")
+        ti = TaskInstance.from_task(task=task, run_id="test")
         job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True)
         runner = StandardTaskRunner(job1)
         runner.start()
@@ -315,7 +315,7 @@ class TestStandardTaskRunner:
             state=State.RUNNING,
             start_date=DEFAULT_DATE,
         )
-        ti = TaskInstance(task=task, run_id="test")
+        ti = TaskInstance.from_task(task=task, run_id="test")
         job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True)
         runner = StandardTaskRunner(job1)
         runner.start()
@@ -373,7 +373,7 @@ class TestStandardTaskRunner:
             state=State.RUNNING,
             start_date=DEFAULT_DATE,
         )
-        ti = TaskInstance(task=task, run_id="test")
+        ti = TaskInstance.from_task(task=task, run_id="test")
         job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True)
         runner = StandardTaskRunner(job1)
         runner.start()

--- a/tests/ti_deps/deps/test_dag_ti_slots_available_dep.py
+++ b/tests/ti_deps/deps/test_dag_ti_slots_available_dep.py
@@ -30,7 +30,7 @@ class TestDagTISlotsAvailableDep:
         """
         dag = Mock(concurrency=1, get_concurrency_reached=Mock(return_value=True))
         task = Mock(dag=dag, pool_slots=1)
-        ti = TaskInstance(task, execution_date=None)
+        ti = TaskInstance.from_task(task, execution_date=None)
 
         assert not DagTISlotsAvailableDep().is_met(ti=ti)
 
@@ -40,6 +40,6 @@ class TestDagTISlotsAvailableDep:
         """
         dag = Mock(concurrency=1, get_concurrency_reached=Mock(return_value=False))
         task = Mock(dag=dag, pool_slots=1)
-        ti = TaskInstance(task, execution_date=None)
+        ti = TaskInstance.from_task(task, execution_date=None)
 
         assert DagTISlotsAvailableDep().is_met(ti=ti)

--- a/tests/ti_deps/deps/test_dag_unpaused_dep.py
+++ b/tests/ti_deps/deps/test_dag_unpaused_dep.py
@@ -30,7 +30,7 @@ class TestDagUnpausedDep:
         """
         dag = Mock(**{"get_is_paused.return_value": True})
         task = Mock(dag=dag)
-        ti = TaskInstance(task=task, execution_date=None)
+        ti = TaskInstance.from_task(task=task, execution_date=None)
 
         assert not DagUnpausedDep().is_met(ti=ti)
 
@@ -40,6 +40,6 @@ class TestDagUnpausedDep:
         """
         dag = Mock(**{"get_is_paused.return_value": False})
         task = Mock(dag=dag)
-        ti = TaskInstance(task=task, execution_date=None)
+        ti = TaskInstance.from_task(task=task, execution_date=None)
 
         assert DagUnpausedDep().is_met(ti=ti)

--- a/tests/ti_deps/deps/test_not_in_retry_period_dep.py
+++ b/tests/ti_deps/deps/test_not_in_retry_period_dep.py
@@ -31,7 +31,7 @@ from airflow.utils.timezone import datetime
 class TestNotInRetryPeriodDep:
     def _get_task_instance(self, state, end_date=None, retry_delay=timedelta(minutes=15)):
         task = Mock(retry_delay=retry_delay, retry_exponential_backoff=False)
-        ti = TaskInstance(task=task, state=state, execution_date=None)
+        ti = TaskInstance.from_task(task=task, state=state, execution_date=None)
         ti.end_date = end_date
         return ti
 

--- a/tests/ti_deps/deps/test_ready_to_reschedule_dep.py
+++ b/tests/ti_deps/deps/test_ready_to_reschedule_dep.py
@@ -31,7 +31,7 @@ class TestNotInReschedulePeriodDep:
     def _get_task_instance(self, state):
         dag = DAG("test_dag")
         task = Mock(dag=dag, reschedule=True, is_mapped=False)
-        ti = TaskInstance(task=task, state=state, run_id=None)
+        ti = TaskInstance.from_task(task=task, state=state, run_id=None)
         return ti
 
     def _get_task_reschedule(self, reschedule_date):
@@ -49,7 +49,7 @@ class TestNotInReschedulePeriodDep:
     def _get_mapped_task_instance(self, state):
         dag = DAG("test_dag")
         task = Mock(dag=dag, reschedule=True, is_mapped=True)
-        ti = TaskInstance(task=task, state=state, run_id=None)
+        ti = TaskInstance.from_task(task=task, state=state, run_id=None)
         return ti
 
     def _get_mapped_task_reschedule(self, reschedule_date):

--- a/tests/ti_deps/deps/test_trigger_rule_dep.py
+++ b/tests/ti_deps/deps/test_trigger_rule_dep.py
@@ -97,7 +97,7 @@ def get_mapped_task_dagrun(session, dag_maker):
         ti = dr.get_task_instance("do_something_else", session=session)
         ti.map_index = 0
         for map_index in range(1, 5):
-            ti = TaskInstance(ti.task, run_id=dr.run_id, map_index=map_index)
+            ti = TaskInstance.from_task(ti.task, run_id=dr.run_id, map_index=map_index)
             ti.dag_run = dr
             session.add(ti)
         session.flush()

--- a/tests/triggers/test_external_task.py
+++ b/tests/triggers/test_external_task.py
@@ -51,7 +51,7 @@ class TestTaskStateTrigger:
         session.commit()
 
         external_task = EmptyOperator(task_id=self.TASK_ID, dag=dag)
-        instance = TaskInstance(external_task, timezone.datetime(2022, 1, 1))
+        instance = TaskInstance.from_task(external_task, timezone.datetime(2022, 1, 1))
         session.add(instance)
         session.commit()
 

--- a/tests/utils/test_db_cleanup.py
+++ b/tests/utils/test_db_cleanup.py
@@ -513,7 +513,7 @@ def create_tis(base_date, num_tis, external_trigger=False):
                 start_date=start_date,
                 external_trigger=external_trigger,
             )
-            ti = TaskInstance(
+            ti = TaskInstance.from_task(
                 PythonOperator(task_id="dummy-task", python_callable=print), run_id=dag_run.run_id
             )
             ti.dag_id = dag.dag_id

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -92,7 +92,7 @@ class TestFileTaskLogHandler:
             dag=dag,
             python_callable=task_callable,
         )
-        ti = TaskInstance(task=task, run_id=dagrun.run_id)
+        ti = TaskInstance.from_task(task=task, run_id=dagrun.run_id)
 
         logger = ti.log
         ti.log.disabled = False
@@ -144,7 +144,7 @@ class TestFileTaskLogHandler:
             dag=dag,
             python_callable=task_callable,
         )
-        ti = TaskInstance(task=task, run_id=dagrun.run_id)
+        ti = TaskInstance.from_task(task=task, run_id=dagrun.run_id)
 
         logger = ti.log
         ti.log.disabled = False
@@ -198,7 +198,7 @@ class TestFileTaskLogHandler:
             state=State.RUNNING,
             execution_date=DEFAULT_DATE,
         )
-        ti = TaskInstance(task=task, run_id=dagrun.run_id)
+        ti = TaskInstance.from_task(task=task, run_id=dagrun.run_id)
 
         ti.try_number = 2
         ti.state = State.RUNNING
@@ -347,7 +347,7 @@ class TestFileTaskLogHandler:
             state=State.RUNNING,
             execution_date=DEFAULT_DATE,
         )
-        ti = TaskInstance(task=task, run_id=dagrun.run_id)
+        ti = TaskInstance.from_task(task=task, run_id=dagrun.run_id)
         ti.try_number = 3
 
         logger = ti.log

--- a/tests/utils/test_task_handler_with_custom_formatter.py
+++ b/tests/utils/test_task_handler_with_custom_formatter.py
@@ -59,7 +59,7 @@ def task_instance():
     dag = DAG(DAG_ID, start_date=DEFAULT_DATE)
     task = EmptyOperator(task_id=TASK_ID, dag=dag)
     dagrun = dag.create_dagrun(DagRunState.RUNNING, execution_date=DEFAULT_DATE, run_type=DagRunType.MANUAL)
-    ti = TaskInstance(task=task, run_id=dagrun.run_id)
+    ti = TaskInstance.from_task(task=task, run_id=dagrun.run_id)
     ti.log.disabled = False
     yield ti
     clear_db_runs()

--- a/tests/www/views/test_views_dagrun.py
+++ b/tests/www/views/test_views_dagrun.py
@@ -118,8 +118,8 @@ def running_dag_run(session):
     )
     session.add(dr)
     tis = [
-        TaskInstance(dag.get_task("runme_0"), run_id=dr.run_id, state="success"),
-        TaskInstance(dag.get_task("runme_1"), run_id=dr.run_id, state="failed"),
+        TaskInstance.from_task(dag.get_task("runme_0"), run_id=dr.run_id, state="success"),
+        TaskInstance.from_task(dag.get_task("runme_1"), run_id=dr.run_id, state="failed"),
     ]
     session.bulk_save_objects(tis)
     session.commit()
@@ -139,12 +139,12 @@ def completed_dag_run_with_missing_task(session):
     )
     session.add(dr)
     tis = [
-        TaskInstance(dag.get_task("runme_0"), run_id=dr.run_id, state="success"),
-        TaskInstance(dag.get_task("runme_1"), run_id=dr.run_id, state="success"),
-        TaskInstance(dag.get_task("also_run_this"), run_id=dr.run_id, state="success"),
-        TaskInstance(dag.get_task("run_after_loop"), run_id=dr.run_id, state="success"),
-        TaskInstance(dag.get_task("this_will_skip"), run_id=dr.run_id, state="success"),
-        TaskInstance(dag.get_task("run_this_last"), run_id=dr.run_id, state="success"),
+        TaskInstance.from_task(dag.get_task("runme_0"), run_id=dr.run_id, state="success"),
+        TaskInstance.from_task(dag.get_task("runme_1"), run_id=dr.run_id, state="success"),
+        TaskInstance.from_task(dag.get_task("also_run_this"), run_id=dr.run_id, state="success"),
+        TaskInstance.from_task(dag.get_task("run_after_loop"), run_id=dr.run_id, state="success"),
+        TaskInstance.from_task(dag.get_task("this_will_skip"), run_id=dr.run_id, state="success"),
+        TaskInstance.from_task(dag.get_task("run_this_last"), run_id=dr.run_id, state="success"),
     ]
     session.bulk_save_objects(tis)
     session.commit()


### PR DESCRIPTION
In AIP-44 we need to send the TaskInstance object to worker for execution. Currently this object type doesn't  support serialization(only SimpleTaskInstance does). 

This change is mainly about new way to construct TaskInstance  `from_dict` - which requires changing the constructor into `from_task` and refactoring all usages.

Note that deserialized TaskInstance will not have ORM state (so will not be able to refresh state automatically from DB etc), but this should be fine as it will be used on client side of Internal API.

related: #29320

