### PR TITLE
Template extra volumes in helm chart

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -73,7 +73,7 @@ spec:
           {{- toYaml .Values.volumeMounts | nindent 8 }}
         {{- end }}
         {{- if .Values.workers.extraVolumeMounts }}
-          {{- toYaml .Values.workers.extraVolumeMounts | nindent 8 }}
+          {{- tpl (toYaml .Values.workers.extraVolumeMounts) . | nindent 8 }}
         {{- end }}
     {{- if .Values.workers.extraContainers }}
       {{- toYaml .Values.workers.extraContainers | nindent 4 }}
@@ -119,5 +119,5 @@ spec:
     {{- toYaml .Values.volumes | nindent 2 }}
   {{- end }}
   {{- if .Values.workers.extraVolumes }}
-    {{- toYaml .Values.workers.extraVolumes | nindent 2 }}
+    {{- tpl (toYaml .Values.workers.extraVolumes) . | nindent 2 }}
   {{- end }}

--- a/chart/templates/jobs/migrate-database-job.yaml
+++ b/chart/templates/jobs/migrate-database-job.yaml
@@ -106,7 +106,7 @@ spec:
             {{- toYaml .Values.volumeMounts | nindent 12 }}
             {{- end }}
             {{- if .Values.migrateDatabaseJob.extraVolumeMounts }}
-              {{ toYaml .Values.migrateDatabaseJob.extraVolumeMounts | nindent 12 }}
+              {{ tpl (toYaml .Values.migrateDatabaseJob.extraVolumeMounts) . | nindent 12 }}
             {{- end }}
         {{- if .Values.migrateDatabaseJob.extraContainers }}
           {{- toYaml .Values.migrateDatabaseJob.extraContainers | nindent 8 }}
@@ -119,6 +119,6 @@ spec:
           {{- toYaml .Values.volumes | nindent 8 }}
         {{- end }}
         {{- if .Values.migrateDatabaseJob.extraVolumes }}
-          {{- toYaml .Values.migrateDatabaseJob.extraVolumes | nindent 8 }}
+          {{- tpl (toYaml .Values.migrateDatabaseJob.extraVolumes) . | nindent 8 }}
         {{- end }}
 {{- end }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -244,7 +244,7 @@ spec:
               {{- toYaml .Values.volumeMounts | nindent 12 }}
             {{- end }}
             {{- if .Values.scheduler.extraVolumeMounts }}
-              {{- toYaml .Values.scheduler.extraVolumeMounts | nindent 12 }}
+              {{- tpl (toYaml .Values.scheduler.extraVolumeMounts) . | nindent 12 }}
             {{- end }}
             {{- if or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName }}
               {{- include "airflow_webserver_config_mount" . | nindent 12 }}
@@ -279,7 +279,7 @@ spec:
           {{- toYaml .Values.volumes | nindent 8 }}
         {{- end }}
         {{- if .Values.scheduler.extraVolumes }}
-          {{- toYaml .Values.scheduler.extraVolumes | nindent 8 }}
+          {{- tpl (toYaml .Values.scheduler.extraVolumes) . | nindent 8 }}
         {{- end }}
   {{- if .Values.logs.persistence.enabled }}
         - name: logs

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -189,7 +189,7 @@ spec:
               {{- toYaml .Values.volumeMounts | nindent 12 }}
             {{- end }}
             {{- if .Values.webserver.extraVolumeMounts }}
-              {{- toYaml .Values.webserver.extraVolumeMounts | nindent 12 }}
+              {{- tpl (toYaml .Values.webserver.extraVolumeMounts) . | nindent 12 }}
             {{- end }}
           ports:
             - name: airflow-ui
@@ -264,5 +264,5 @@ spec:
           {{- toYaml .Values.volumes | nindent 8 }}
         {{- end }}
         {{- if .Values.webserver.extraVolumes }}
-          {{- toYaml .Values.webserver.extraVolumes | nindent 8 }}
+          {{- tpl (toYaml .Values.webserver.extraVolumes) . | nindent 8 }}
         {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -574,7 +574,18 @@ workers:
   # Add additional init containers into workers.
   extraInitContainers: []
 
-  # Mount additional volumes into worker.
+  # Mount additional volumes into worker. It can be templated like in the following example:
+  #   extraVolumes:
+  #     - name: my-templated-extra-volume
+  #       secret:
+  #          secretName: '{{ include "my_secret_template" . }}'
+  #          defaultMode: 0640
+  #          optional: true
+  #
+  #   extraVolumeMounts:
+  #     - name: my-templated-extra-volume
+  #       mountPath: "{{ .Values.my_custom_path }}"
+  #       readOnly: true
   extraVolumes: []
   extraVolumeMounts: []
 
@@ -713,7 +724,18 @@ scheduler:
   # Add additional init containers into scheduler.
   extraInitContainers: []
 
-  # Mount additional volumes into scheduler.
+  # Mount additional volumes into scheduler. It can be templated like in the following example:
+  #   extraVolumes:
+  #     - name: my-templated-extra-volume
+  #       secret:
+  #          secretName: '{{ include "my_secret_template" . }}'
+  #          defaultMode: 0640
+  #          optional: true
+  #
+  #   extraVolumeMounts:
+  #     - name: my-templated-extra-volume
+  #       mountPath: "{{ .Values.my_custom_path }}"
+  #       readOnly: true
   extraVolumes: []
   extraVolumeMounts: []
 
@@ -894,7 +916,18 @@ migrateDatabaseJob:
   # Launch additional containers into database migration job
   extraContainers: []
 
-  # Mount additional volumes into database migration job
+  # Mount additional volumes into database migration job. It can be templated like in the following example:
+  #   extraVolumes:
+  #     - name: my-templated-extra-volume
+  #       secret:
+  #          secretName: '{{ include "my_secret_template" . }}'
+  #          defaultMode: 0640
+  #          optional: true
+  #
+  #   extraVolumeMounts:
+  #     - name: my-templated-extra-volume
+  #       mountPath: "{{ .Values.my_custom_path }}"
+  #       readOnly: true
   extraVolumes: []
   extraVolumeMounts: []
 
@@ -1003,7 +1036,18 @@ webserver:
   # Add additional init containers into webserver.
   extraInitContainers: []
 
-  # Mount additional volumes into webserver.
+  # Mount additional volumes into webserver. It can be templated like in the following example:
+  #   extraVolumes:
+  #     - name: my-templated-extra-volume
+  #       secret:
+  #          secretName: '{{ include "my_secret_template" . }}'
+  #          defaultMode: 0640
+  #          optional: true
+  #
+  #   extraVolumeMounts:
+  #     - name: my-templated-extra-volume
+  #       mountPath: "{{ .Values.my_custom_path }}"
+  #       readOnly: true
   extraVolumes: []
   extraVolumeMounts: []
 


### PR DESCRIPTION
This adds the possibility to define dynamic names (defined in custom helm template functions) for volumes and volumeMounts definitions such as secret names, config map names, mount paths etc.

I did not find a way to add tests in which I could define custom template functions, but I ran the chart tests successfully so it brings no regressions and I already use this in production, which works fine so far.

