### PR TITLE
Missing timezone in next_dag_run in parameterized docs

### DIFF
--- a/docs/apache-airflow/howto/timetable.rst
+++ b/docs/apache-airflow/howto/timetable.rst
@@ -226,7 +226,7 @@ purpose, we'd want to do something like:
             end = start + timedelta(days=1)
             return DagRunInfo(
                 data_interval=DataInterval(start=start, end=end),
-                run_after=DateTime.combine(end.date(), self._schedule_at),
+                run_after=DateTime.combine(end.date(), self._schedule_at).replace(tzinfo=UTC),
             )
 
 However, since the timetable is a part of the DAG, we need to tell Airflow how


### PR DESCRIPTION
The missing timezone in the next_dag_run datetime causes that the dags importing the parameterized timetable do not get inserted into DDBB, and therefore not recognized by airflow webserver/scheduler.

Error:
```sh

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/local/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/dag_processing/processor.py", line 174, in _run_file_processor
    _handle_dag_file_processing()
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/dag_processing/processor.py", line 155, in _handle_dag_file_processing
    result: tuple[int, int] = dag_file_processor.process_file(
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/utils/session.py", line 75, in wrapper
    return func(*args, session=session, **kwargs)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/dag_processing/processor.py", line 768, in process_file
    dagbag.sync_to_db(processor_subdir=self._dag_directory, session=session)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/utils/session.py", line 72, in wrapper
    return func(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/dagbag.py", line 645, in sync_to_db
    for attempt in run_with_db_retries(logger=self.log):
  File "/home/airflow/.local/lib/python3.10/site-packages/tenacity/__init__.py", line 384, in __iter__
    do = self.iter(retry_state=retry_state)
  File "/home/airflow/.local/lib/python3.10/site-packages/tenacity/__init__.py", line 351, in iter
    return fut.result()
  File "/usr/local/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/usr/local/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/dagbag.py", line 659, in sync_to_db
    DAG.bulk_write_to_db(
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/utils/session.py", line 72, in wrapper
    return func(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/dag.py", line 2851, in bulk_write_to_db
    session.flush()  # this is required to ensure each dataset has its PK loaded
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 3444, in flush
    self._flush(objects)
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 3583, in _flush
    with util.safe_reraise():
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/util/langhelpers.py", line 70, in __exit__
    compat.raise_(
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 3544, in _flush
    flush_context.execute()
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/orm/unitofwork.py", line 456, in execute
    rec.execute(self)
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/orm/unitofwork.py", line 630, in execute
    util.preloaded.orm_persistence.save_obj(
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/orm/persistence.py", line 245, in save_obj
    _emit_insert_statements(
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/orm/persistence.py", line 1097, in _emit_insert_statements
    c = connection._execute_20(
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1705, in _execute_20
    return meth(self, args_10style, kwargs_10style, execution_options)
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/sql/elements.py", line 334, in _execute_on_connection
    return connection._execute_clauseelement(
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1572, in _execute_clauseelement
    ret = self._execute_context(
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1806, in _execute_context
    self._handle_dbapi_exception(
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 2124, in _handle_dbapi_exception
    util.raise_(
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1800, in _execute_context
    context = constructor(
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 1121, in _init_compiled
    param = {
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 1122, in <dictcomp>
    key: processors[key](compiled_params[key])
  File "/home/airflow/.local/lib/python3.10/site-packages/sqlalchemy/sql/type_api.py", line 1667, in process
    return process_param(value, dialect)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/utils/sqlalchemy.py", line 75, in process_bind_param
    raise ValueError("naive datetime is disallowed")
sqlalchemy.exc.StatementError: (builtins.ValueError) naive datetime is disallowed
[SQL: INSERT INTO dag (dag_id, root_dag_id, is_paused, is_subdag, is_active, last_parsed_time, last_pickled, last_expired, scheduler_lock, pickle_id, fileloc, processor_subdir, owners, description, default_view, schedule_interval, timetable_description, max_active_tasks, max_active_runs, has_task_concurrency_limits, has_import_errors, next_dagrun, next_dagrun_data_interval_start, next_dagrun_data_interval_end, next_dagrun_create_after) VALUES (%(dag_id)s, %(root_dag_id)s, %(is_paused)s, %(is_subdag)s, %(is_active)s, %(last_parsed_time)s, %(last_pickled)s, %(last_expired)s, %(scheduler_lock)s, %(pickle_id)s, %(fileloc)s, %(processor_subdir)s, %(owners)s, %(description)s, %(default_view)s, %(schedule_interval)s, %(timetable_description)s, %(max_active_tasks)s, %(max_active_runs)s, %(has_task_concurrency_limits)s, %(has_import_errors)s, %(next_dagrun)s, %(next_dagrun_data_interval_start)s, %(next_dagrun_data_interval_end)s, %(next_dagrun_create_after)s)]
[parameters: [{'dag_id': 'bday_timetable5', 'owners': 'airflow', 'last_parsed_time': datetime.datetime(2023, 2, 3, 18, 33, 9, 724014, tzinfo=Timezone('UTC')), 'is_ ... (647 characters truncated) ... le_description': '', 'description': None, 'last_expired': None, 'scheduler_lock': None, 'last_pickled': None, 'pickle_id': None, 'root_dag_id': None}]]
```