### PR TITLE
Migrating from unittest to pytest tests callbacks

### DIFF
--- a/tests/callbacks/test_callback_requests.py
+++ b/tests/callbacks/test_callback_requests.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from parameterized import parameterized
+import pytest
 
 from airflow.callbacks.callback_requests import (
     CallbackRequest,
@@ -40,7 +40,8 @@ TI = TaskInstance(
 
 
 class TestCallbackRequest:
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "input,request_class",
         [
             (CallbackRequest(full_filepath="filepath", msg="task_failure"), CallbackRequest),
             (

--- a/tests/cli/commands/test_pool_command.py
+++ b/tests/cli/commands/test_pool_command.py
@@ -41,7 +41,6 @@ class TestCliPools:
         cls.session = Session
         cls._cleanup()
 
-
     def tearDown(self):
         self._cleanup()
 

--- a/tests/cli/commands/test_pool_command.py
+++ b/tests/cli/commands/test_pool_command.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import io
 import json
 import os
-import unittest
 from contextlib import redirect_stdout
 
 import pytest
@@ -33,17 +32,15 @@ from airflow.settings import Session
 from airflow.utils.db import add_default_pool_if_not_exists
 
 
-class TestCliPools(unittest.TestCase):
+class TestCliPools:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.dagbag = models.DagBag(include_examples=True)
         cls.parser = cli_parser.get_parser()
-
-    def setUp(self):
-        super().setUp()
         settings.configure_orm()
-        self.session = Session
-        self._cleanup()
+        cls.session = Session
+        cls._cleanup()
+
 
     def tearDown(self):
         self._cleanup()

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -33,7 +33,6 @@ from unittest.mock import sentinel
 
 import pendulum
 import pytest
-from parameterized import parameterized
 
 from airflow import DAG
 from airflow.cli import cli_parser

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -336,12 +336,13 @@ class TestCliTasks:
         assert "foo=bar" in output
         assert "AIRFLOW_TEST_MODE=True" in output
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "option",
         [
-            ("--ignore-all-dependencies",),
-            ("--ignore-depends-on-past",),
-            ("--ignore-dependencies",),
-            ("--force",),
+            "--ignore-all-dependencies",
+            "--ignore-depends-on-past",
+            "--ignore-dependencies",
+            "--force",
         ],
     )
     def test_cli_run_invalid_raw_option(self, option: str):


### PR DESCRIPTION
Migrated callbacks unittest to pytest

![image](https://user-images.githubusercontent.com/120032754/216772446-ef4352d2-c726-4c44-b9af-9e135ead16a2.png)

related: https://github.com/apache/airflow/issues/29305