### PR TITLE
Mark Airflow directory in container as safe for git commands

### DIFF
--- a/scripts/in_container/run_prepare_airflow_packages.sh
+++ b/scripts/in_container/run_prepare_airflow_packages.sh
@@ -78,7 +78,14 @@ function prepare_airflow_packages() {
     echo "${COLOR_BLUE}===================================================================================${COLOR_RESET}"
 }
 
+function mark_directory_as_safe() {
+    git config --global --unset-all safe.directory || true
+    git config --global --add safe.directory /opt/airflow
+}
+
 install_supported_pip_version
+
+mark_directory_as_safe
 
 prepare_airflow_packages
 


### PR DESCRIPTION
There is a new setting/version of git in GitHub Actions that started checking the ownership of the Git repository. Since in case of the provider commands we run them inside docker image as root user (this is in order to isolate the provider package building from the main CI environment), the owner of such directory is different (runner user) than the user that runs the git command (root).

This change marks the current git directory for such commands as safe, regardles from the discrepancy.

This config is global and run inside the image, so it is safe to leave it after methods complete as containers are torn-down after completing package preparation.

This PR also improves diagnostics. Previously the `git remote add` output was redirected to dev null as there was no way it could fail, but this turned to be false - the output of the `git remote add` commnd is now also printed for diagnostics.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
