### PR TITLE
Fix grid logs for large logs

### DIFF
--- a/airflow/www/static/js/api/useTaskLog.ts
+++ b/airflow/www/static/js/api/useTaskLog.ts
@@ -32,7 +32,7 @@ interface Props extends API.GetLogVariables {
 }
 
 const useTaskLog = ({
-  dagId, dagRunId, taskId, taskTryNumber, mapIndex, fullContent, state,
+  dagId, dagRunId, taskId, taskTryNumber, mapIndex, fullContent = false, state,
 }: Props) => {
   let url: string = '';
   const [isPreviousStatePending, setPrevState] = useState(true);

--- a/airflow/www/static/js/api/useTaskLog.ts
+++ b/airflow/www/static/js/api/useTaskLog.ts
@@ -32,7 +32,7 @@ interface Props extends API.GetLogVariables {
 }
 
 const useTaskLog = ({
-  dagId, dagRunId, taskId, taskTryNumber, mapIndex, fullContent = false, state,
+  dagId, dagRunId, taskId, taskTryNumber, mapIndex, fullContent, state,
 }: Props) => {
   let url: string = '';
   const [isPreviousStatePending, setPrevState] = useState(true);

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.test.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.test.tsx
@@ -81,7 +81,6 @@ describe('Test Logs Component.', () => {
     expect(useTaskLogMock).toHaveBeenLastCalledWith({
       dagId: 'dummyDagId',
       dagRunId: 'dummyDagRunId',
-      fullContent: false,
       taskId: 'dummyTaskId',
       taskTryNumber: 2,
     });
@@ -141,7 +140,6 @@ describe('Test Logs Component.', () => {
     expect(useTaskLogMock).toHaveBeenLastCalledWith({
       dagId: 'dummyDagId',
       dagRunId: 'dummyDagRunId',
-      fullContent: false,
       mapIndex: 1,
       taskId: 'dummyTaskId',
       taskTryNumber: 2,
@@ -168,7 +166,6 @@ describe('Test Logs Component.', () => {
     expect(useTaskLogMock).toHaveBeenLastCalledWith({
       dagId: 'dummyDagId',
       dagRunId: 'dummyDagRunId',
-      fullContent: false,
       taskId: 'dummyTaskId',
       taskTryNumber: 2,
     });
@@ -179,40 +176,8 @@ describe('Test Logs Component.', () => {
     expect(useTaskLogMock).toHaveBeenLastCalledWith({
       dagId: 'dummyDagId',
       dagRunId: 'dummyDagRunId',
-      fullContent: false,
       taskId: 'dummyTaskId',
       taskTryNumber: 1,
-    });
-  });
-
-  test('Test Logs Full Content', () => {
-    const tryNumber = 2;
-    const { getByTestId } = render(
-      <Logs
-        dagId="dummyDagId"
-        dagRunId="dummyDagRunId"
-        taskId="dummyTaskId"
-        executionDate="2020:01:01T01:00+00:00"
-        tryNumber={tryNumber}
-      />,
-    );
-    expect(useTaskLogMock).toHaveBeenLastCalledWith({
-      dagId: 'dummyDagId',
-      dagRunId: 'dummyDagRunId',
-      fullContent: false,
-      taskId: 'dummyTaskId',
-      taskTryNumber: 2,
-    });
-    const fullContentCheckbox = getByTestId('full-content-checkbox');
-
-    fireEvent.click(fullContentCheckbox);
-
-    expect(useTaskLogMock).toHaveBeenLastCalledWith({
-      dagId: 'dummyDagId',
-      dagRunId: 'dummyDagRunId',
-      fullContent: true,
-      taskId: 'dummyTaskId',
-      taskTryNumber: 2,
     });
   });
 });

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -102,7 +102,6 @@ const Logs = ({
 }: Props) => {
   const [internalIndexes, externalIndexes] = getLinkIndexes(tryNumber);
   const [selectedTryNumber, setSelectedTryNumber] = useState<number | undefined>();
-  const [shouldRequestFullContent, setShouldRequestFullContent] = useState(false);
   const [wrap, setWrap] = useState(getMetaValue('default_wrap') === 'True');
   const [logLevelFilters, setLogLevelFilters] = useState<Array<LogLevelOption>>([]);
   const [fileSourceFilters, setFileSourceFilters] = useState<Array<FileSourceOption>>([]);
@@ -115,7 +114,6 @@ const Logs = ({
     taskId,
     mapIndex,
     taskTryNumber,
-    fullContent: shouldRequestFullContent,
     state,
   });
 
@@ -221,13 +219,6 @@ const Logs = ({
                   data-testid="wrap-checkbox"
                 >
                   <Text as="strong">Wrap</Text>
-                </Checkbox>
-                <Checkbox
-                  onChange={() => setShouldRequestFullContent((previousState) => !previousState)}
-                  px={4}
-                  data-testid="full-content-checkbox"
-                >
-                  <Text as="strong" whiteSpace="nowrap">Full Logs</Text>
                 </Checkbox>
                 <LogLink
                   dagId={dagId}

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -130,7 +130,11 @@ const Logs = ({
     params.append('map_index', mapIndex.toString());
   }
 
-  const { parsedLogs, fileSources = [], truncatedContent, errorParsingLogs } = useMemo(
+  const {
+    parsedLogs,
+    fileSources = [],
+    warning,
+  } = useMemo(
     () => parseLogs(
       data,
       timezone,
@@ -247,16 +251,11 @@ const Logs = ({
               </Flex>
             </Flex>
           </Box>
-          {(truncatedContent || errorParsingLogs) && (
+          {!!warning && (
             <Flex bg="yellow.200" borderRadius={2} borderColor="gray.400" alignItems="center" p={2}>
               <Icon as={MdWarning} color="yellow.500" mr={2} />
               <Text fontSize="sm">
-                {truncatedContent && (
-                  <>Large log file. Some lines have been truncated. Download logs in order to see everything.</>
-                )}
-                {errorParsingLogs && (
-                  <>Unable to show logs. There was an error parsing logs.</>
-                )}
+                {warning}
               </Text>
             </Flex>
           )}

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -104,7 +104,6 @@ const Logs = ({
 }: Props) => {
   const [internalIndexes, externalIndexes] = getLinkIndexes(tryNumber);
   const [selectedTryNumber, setSelectedTryNumber] = useState<number | undefined>();
-  const [shouldRequestFullContent, setShouldRequestFullContent] = useState(false);
   const [wrap, setWrap] = useState(getMetaValue('default_wrap') === 'True');
   const [logLevelFilters, setLogLevelFilters] = useState<Array<LogLevelOption>>([]);
   const [fileSourceFilters, setFileSourceFilters] = useState<Array<FileSourceOption>>([]);
@@ -117,7 +116,6 @@ const Logs = ({
     taskId,
     mapIndex,
     taskTryNumber,
-    fullContent: shouldRequestFullContent,
     state,
   });
 
@@ -227,13 +225,6 @@ const Logs = ({
                   data-testid="wrap-checkbox"
                 >
                   <Text as="strong">Wrap</Text>
-                </Checkbox>
-                <Checkbox
-                  onChange={() => setShouldRequestFullContent((previousState) => !previousState)}
-                  px={4}
-                  data-testid="full-content-checkbox"
-                >
-                  <Text as="strong" whiteSpace="nowrap">Full Logs</Text>
                 </Checkbox>
                 <LogLink
                   dagId={dagId}

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
@@ -53,7 +53,6 @@ export const parseLogs = (
   try {
     lines = data.split('\n');
   } catch (err) {
-    console.error(err);
     warning = 'Unable to show logs. There was an error parsing logs.';
     return { warning };
   }

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
@@ -47,12 +47,17 @@ export const parseLogs = (
     return {};
   }
   let lines;
+
+  let errorParsingLogs = false;
+
   try {
     lines = data.split('\n');
   } catch (err) {
     console.error(err);
-    return {};
+    return { errorParsingLogs };
   }
+
+  let truncatedContent = false;
 
   const parsedLines: Array<string> = [];
   const fileSources: Set<string> = new Set();
@@ -87,5 +92,17 @@ export const parseLogs = (
     }
   });
 
-  return { parsedLogs: parsedLines.map((l) => l.slice(0, 1000000)).join('\n'), fileSources: Array.from(fileSources).sort() };
+  return {
+    parsedLogs: parsedLines
+      .map((l) => {
+        if (l.length >= 1000000) {
+          truncatedContent = true;
+          return `${l.slice(0, 1000000)}...`;
+        }
+        return l;
+      })
+      .join('\n'),
+    fileSources: Array.from(fileSources).sort(),
+    truncatedContent,
+  };
 };

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
@@ -87,5 +87,5 @@ export const parseLogs = (
     }
   });
 
-  return { parsedLogs: parsedLines.join('\n'), fileSources: Array.from(fileSources).sort() };
+  return { parsedLogs: parsedLines.map((l) => l.slice(0, 1000000)).join('\n'), fileSources: Array.from(fileSources).sort() };
 };

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
@@ -48,16 +48,15 @@ export const parseLogs = (
   }
   let lines;
 
-  let errorParsingLogs = false;
+  let warning;
 
   try {
     lines = data.split('\n');
   } catch (err) {
     console.error(err);
-    return { errorParsingLogs };
+    warning = 'Unable to show logs. There was an error parsing logs.';
+    return { warning };
   }
-
-  let truncatedContent = false;
 
   const parsedLines: Array<string> = [];
   const fileSources: Set<string> = new Set();
@@ -96,13 +95,13 @@ export const parseLogs = (
     parsedLogs: parsedLines
       .map((l) => {
         if (l.length >= 1000000) {
-          truncatedContent = true;
+          warning = 'Large log file. Some lines have been truncated. Download logs in order to see everything.';
           return `${l.slice(0, 1000000)}...`;
         }
         return l;
       })
       .join('\n'),
     fileSources: Array.from(fileSources).sort(),
-    truncatedContent,
+    warning,
   };
 };


### PR DESCRIPTION
If a task instance an very large log file, the UI would have difficulty rendering it. This PR fixes this on the UI side but truncating lines in the logs to less than 1 million characters and including a warning to the user.

<img width="875" alt="Screenshot 2023-02-06 at 10 00 04 AM" src="https://user-images.githubusercontent.com/4600967/217012926-47b71c4b-3a0b-48b4-8aa7-81dfa7832149.png">


Example DAG:
```import re
import time
import pendulum

from airflow import DAG
from airflow.decorators import task

with DAG(
    dag_id="bad_dag",
    start_date=pendulum.datetime(2023, 1, 1, tz="UTC"),
    schedule=None,
):

    @task()
    def one():
        print("Hello DAG is starting")
        file_contents = """
        2022-08-29T07:19:55.933Z [LogLevel = Information] XXXXXX.SetGameState.SetGameStateFunction: Entering handler  
        [AwsRequestId = c4e55d4c-718e-41bc-857e-15cbdf07751b, Region = us-east-1, AmazonTraceId = 
        Root=1-630c689b-713bc72374fa8913774ea82e;Parent=00dea2e84ddcf28d;Sampled=0, ExecutionEnv = 
        AWS_Lambda_dotnetcore3.1, FunctionName = int-set-game-state, FunctionVersion = $LATEST, MemoryLimitInMB = 1024]
        2022-08-29T07:19:56.119Z [LogLevel = Information] XXXXXX.Serverless.Shared.Repositories.Dynamo.LowLevelDynamoClient: 
        Sending request "(attribute_not_exists(#N0)) OR (#N1 = :v0)" [{"#N0":"PK","#N1":"ActiveDeviceId"}] 
        [{":v0":{"BOOL":false,"IsBOOLSet":false,"BS":[],"L":[],"IsLSet":false,"M":{},"IsMSet":false,"NS":[],"NULL":false,
        "S":"cde4646da573124b61d843d2afe48b74","SS":[]}}]  
        [AwsRequestId = c4e55d4c-718e-41bc-857e-15cbdf07751b, Region = us-east-1, AmazonTraceId = 
        Root=1-630c689b-713bc72374fa8913774ea82e;Parent=00dea2e84ddcf28d;Sampled=0, ExecutionEnv = 
        AWS_Lambda_dotnetcore3.1, FunctionName = int-set-game-state, FunctionVersion = $LATEST, MemoryLimitInMB = 1024]
        2022-08-29T07:19:56.200Z [LogLevel = Information] XXXXXX.SetGameState.SetGameStateFunction: Operation complete  
        [AwsRequestId = c4e55d4c-718e-41bc-857e-15cbdf07751b, Region = us-east-1, AmazonTraceId = 
        Root=1-630c689b-713bc72374fa8913774ea82e;Parent=00dea2e84ddcf28d;Sampled=0, ExecutionEnv = 
        AWS_Lambda_dotnetcore3.1, FunctionName = int-set-game-state, FunctionVersion = $LATEST, MemoryLimitInMB = 1024]
        2022-08-29T07:19:56.202Z END RequestId: c4e55d4c-718e-41bc-857e-15cbdf07751b
        """ * 5000
        re_pattern = r"(\d{4}-\d{2}-\d{2}.*?)\s+?\n\s+?(\[.*?\])"
        all_records = re.findall(re_pattern, file_contents, flags=re.S)
        print(f"All records {all_records}")
        print(all_records)
        print("All Done!")
        return

    @task()
    def two():
        time.sleep(5)
        print("two")

    one() >> two()
```


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
