### PR TITLE
Fix validation of date-time field in API and Parameter schemas

### DIFF
--- a/airflow/example_dags/example_params_ui_tutorial.py
+++ b/airflow/example_dags/example_params_ui_tutorial.py
@@ -80,7 +80,7 @@ with DAG(
         ),
         # Dates and Times are also supported
         "date_time": Param(
-            f"{datetime.date.today()} {datetime.time(hour=12, minute=17, second=00)}",
+            f"{datetime.date.today()}T{datetime.time(hour=12, minute=17, second=00)}+00:00",
             type="string",
             format="date-time",
             title="Date-Time Picker",

--- a/airflow/models/param.py
+++ b/airflow/models/param.py
@@ -18,12 +18,16 @@ from __future__ import annotations
 
 import contextlib
 import copy
+import datetime
 import json
 import logging
 import warnings
 from typing import TYPE_CHECKING, Any, ClassVar, ItemsView, Iterable, MutableMapping, ValuesView
 
+from pendulum.parsing import parse_iso8601
+
 from airflow.exceptions import AirflowException, ParamValidationError, RemovedInAirflow3Warning
+from airflow.utils import timezone
 from airflow.utils.context import Context
 from airflow.utils.mixins import ResolveMixin
 from airflow.utils.types import NOTSET, ArgNotSet
@@ -72,6 +76,27 @@ class Param:
                 RemovedInAirflow3Warning,
             )
 
+    @staticmethod
+    def _warn_if_not_rfc3339_dt(value):
+        """Fallback to iso8601 datetime validation if rfc3339 failed."""
+        try:
+            iso8601_value = parse_iso8601(value)
+        except Exception:
+            return None
+        if not isinstance(iso8601_value, datetime.datetime):
+            return None
+        warnings.warn(
+            f"The use of non-RFC3339 datetime: {value!r} is deprecated "
+            "and will be removed in a future release",
+            RemovedInAirflow3Warning,
+        )
+        if timezone.is_naive(iso8601_value):
+            warnings.warn(
+                "The use naive datetime is deprecated and will be removed in a future release",
+                RemovedInAirflow3Warning,
+            )
+        return value
+
     def resolve(self, value: Any = NOTSET, suppress_exception: bool = False) -> Any:
         """
         Runs the validations and returns the Param's final value.
@@ -98,6 +123,11 @@ class Param:
         try:
             jsonschema.validate(final_val, self.schema, format_checker=FormatChecker())
         except ValidationError as err:
+            if err.schema.get("format") == "date-time":
+                rfc3339_value = self._warn_if_not_rfc3339_dt(final_val)
+                if rfc3339_value:
+                    self.value = rfc3339_value
+                    return rfc3339_value
             if suppress_exception:
                 return None
             raise ParamValidationError(err) from None

--- a/airflow/www/static/js/main.js
+++ b/airflow/www/static/js/main.js
@@ -252,7 +252,7 @@ $(document).ready(() => {
   });
 
   $.fn.datetimepicker.defaults.sideBySide = true;
-  $('.datetimepicker').datetimepicker({ format: 'YYYY-MM-DD HH:mm:ssZ' });
+  $('.datetimepicker').datetimepicker({ format: 'YYYY-MM-DDTHH:mm:ssZ' });
   $('.datepicker').datetimepicker({ format: 'YYYY-MM-DD' });
   $('.timepicker').datetimepicker({ format: 'HH:mm:ss' });
 

--- a/newsfragments/29395.significant.rst
+++ b/newsfragments/29395.significant.rst
@@ -1,0 +1,8 @@
+The date-time fields passed as API parameters or Params should be RFC3339-compliant.
+
+In case of API calls, it was possible that "+" passed as part of the date-time fields were not URL-encoded, and
+such date-time fields could pass validation. Such date-time parameters should now be URL-encoded (as ``%2B``).
+
+In case of parameters, we still allow IS8601-compliant date-time (so for example it is possible that
+' ' was used instead of ``T`` separating date from time and no timezone was specified) but we raise
+deprecation warning.

--- a/setup.cfg
+++ b/setup.cfg
@@ -103,7 +103,7 @@ install_requires =
     importlib_resources>=5.2;python_version<"3.9"
     itsdangerous>=2.0
     jinja2>=3.0.0
-    jsonschema>=3.2.0
+    jsonschema>=4.0.0
     lazy-object-proxy
     linkify-it-py>=2.0.0
     lockfile>=0.12.2
@@ -123,6 +123,7 @@ install_requires =
     python-dateutil>=2.3
     python-nvd3>=0.15.0
     python-slugify>=5.0
+    rfc3339_validator>=0.1.4
     rich>=12.4.4
     setproctitle>=1.1.8
     # We use some deprecated features of sqlalchemy 2.0 and we should replace them before we can upgrade

--- a/tests/api_connexion/endpoints/test_mapped_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_mapped_task_instance_endpoint.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import datetime as dt
 import os
+import urllib
 
 import pytest
 
@@ -38,6 +39,8 @@ from tests.test_utils.mock_operators import MockOperator
 DEFAULT_DATETIME_1 = datetime(2020, 1, 1)
 DEFAULT_DATETIME_STR_1 = "2020-01-01T00:00:00+00:00"
 DEFAULT_DATETIME_STR_2 = "2020-01-02T00:00:00+00:00"
+QUOTED_DEFAULT_DATETIME_STR_1 = urllib.parse.quote(DEFAULT_DATETIME_STR_1)
+QUOTED_DEFAULT_DATETIME_STR_2 = urllib.parse.quote(DEFAULT_DATETIME_STR_2)
 
 
 @pytest.fixture(scope="module")
@@ -368,7 +371,7 @@ class TestGetMappedTaskInstances(TestMappedTaskInstanceEndpoint):
     def test_mapped_task_instances_with_date(self, one_task_with_mapped_tis, session):
         response = self.client.get(
             "/api/v1/dags/mapped_tis/dagRuns/run_mapped_tis/taskInstances/task_2/listMapped"
-            f"?start_date_gte={DEFAULT_DATETIME_STR_1}",
+            f"?start_date_gte={QUOTED_DEFAULT_DATETIME_STR_1}",
             environ_overrides={"REMOTE_USER": "test"},
         )
         assert response.status_code == 200
@@ -377,7 +380,7 @@ class TestGetMappedTaskInstances(TestMappedTaskInstanceEndpoint):
 
         response = self.client.get(
             "/api/v1/dags/mapped_tis/dagRuns/run_mapped_tis/taskInstances/task_2/listMapped"
-            f"?start_date_gte={DEFAULT_DATETIME_STR_2}",
+            f"?start_date_gte={QUOTED_DEFAULT_DATETIME_STR_2}",
             environ_overrides={"REMOTE_USER": "test"},
         )
         assert response.status_code == 200

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import urllib
 from unittest import mock
 
 import pendulum
@@ -38,6 +39,9 @@ from tests.test_utils.db import clear_db_runs, clear_db_sla_miss, clear_rendered
 DEFAULT_DATETIME_1 = datetime(2020, 1, 1)
 DEFAULT_DATETIME_STR_1 = "2020-01-01T00:00:00+00:00"
 DEFAULT_DATETIME_STR_2 = "2020-01-02T00:00:00+00:00"
+
+QUOTED_DEFAULT_DATETIME_STR_1 = urllib.parse.quote(DEFAULT_DATETIME_STR_1)
+QUOTED_DEFAULT_DATETIME_STR_2 = urllib.parse.quote(DEFAULT_DATETIME_STR_2)
 
 
 @pytest.fixture(scope="module")
@@ -480,7 +484,7 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                 False,
                 (
                     "/api/v1/dags/example_python_operator/dagRuns/~/"
-                    f"taskInstances?execution_date_lte={DEFAULT_DATETIME_STR_1}"
+                    f"taskInstances?execution_date_lte={QUOTED_DEFAULT_DATETIME_STR_1}"
                 ),
                 1,
                 id="test execution date filter",
@@ -494,7 +498,8 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                 True,
                 (
                     "/api/v1/dags/example_python_operator/dagRuns/~/taskInstances"
-                    f"?start_date_gte={DEFAULT_DATETIME_STR_1}&start_date_lte={DEFAULT_DATETIME_STR_2}"
+                    f"?start_date_gte={QUOTED_DEFAULT_DATETIME_STR_1}&"
+                    f"start_date_lte={QUOTED_DEFAULT_DATETIME_STR_2}"
                 ),
                 2,
                 id="test start date filter",
@@ -508,7 +513,8 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                 True,
                 (
                     "/api/v1/dags/example_python_operator/dagRuns/~/taskInstances?"
-                    f"end_date_gte={DEFAULT_DATETIME_STR_1}&end_date_lte={DEFAULT_DATETIME_STR_2}"
+                    f"end_date_gte={QUOTED_DEFAULT_DATETIME_STR_1}&"
+                    f"end_date_lte={QUOTED_DEFAULT_DATETIME_STR_2}"
                 ),
                 2,
                 id="test end date filter",
@@ -870,12 +876,12 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
     @pytest.mark.parametrize(
         "payload, expected",
         [
-            ({"end_date_lte": "2020-11-10T12:42:39.442973"}, "Naive datetime is disallowed"),
-            ({"end_date_gte": "2020-11-10T12:42:39.442973"}, "Naive datetime is disallowed"),
-            ({"start_date_lte": "2020-11-10T12:42:39.442973"}, "Naive datetime is disallowed"),
-            ({"start_date_gte": "2020-11-10T12:42:39.442973"}, "Naive datetime is disallowed"),
-            ({"execution_date_gte": "2020-11-10T12:42:39.442973"}, "Naive datetime is disallowed"),
-            ({"execution_date_lte": "2020-11-10T12:42:39.442973"}, "Naive datetime is disallowed"),
+            ({"end_date_lte": "2020-11-10T12:42:39.442973"}, "is not a 'date-time'"),
+            ({"end_date_gte": "2020-11-10T12:42:39.442973"}, "is not a 'date-time'"),
+            ({"start_date_lte": "2020-11-10T12:42:39.442973"}, "is not a 'date-time'"),
+            ({"start_date_gte": "2020-11-10T12:42:39.442973"}, "is not a 'date-time'"),
+            ({"execution_date_gte": "2020-11-10T12:42:39.442973"}, "is not a 'date-time'"),
+            ({"execution_date_lte": "2020-11-10T12:42:39.442973"}, "is not a 'date-time'"),
         ],
     )
     @provide_session
@@ -887,7 +893,7 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
             json=payload,
         )
         assert response.status_code == 400
-        assert response.json["detail"] == expected
+        assert expected in response.json["detail"]
 
 
 class TestPostClearTaskInstances(TestTaskInstanceEndpoint):


### PR DESCRIPTION
The open-api-schema-validator 0.4.3 made RFC3339  validation of the date-time fields mandatory and this revealed problems in our test URLs - the '+' was not url-encoded and it was replaced with space - thus the dates passed were not valid RFC3339 date-time specifications.

This however revealed one more problem. The rfc3339-validator package is automatically installed by the open-api-schema-validator, but when installed, it also adds validation to date-time fields validated by the Params of ours - for example naive date-time parameters are not supported any more (but they were in the past).

This might introduce breaking changes for users who use non-valid date-time parameters - however we should consider that as a bugfix, and accidental support, because the date-time schema should expect RFC3339 formatted date time.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
