### PR TITLE
Ensure Serialized DAG is deleted

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -764,13 +764,9 @@ class DagFileProcessorManager(LoggingMixin):
                 else:
                     dag_filelocs.append(fileloc)
 
-            processor_subdir = None
-            if self.standalone_dag_processor:
-                processor_subdir = self.get_dag_directory()
-
             SerializedDagModel.remove_deleted_dags(
                 alive_dag_filelocs=dag_filelocs,
-                processor_subdir=processor_subdir,
+                processor_subdir=self.get_dag_directory(),
             )
             DagModel.deactivate_deleted_dags(self._file_paths)
 

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -764,9 +764,13 @@ class DagFileProcessorManager(LoggingMixin):
                 else:
                     dag_filelocs.append(fileloc)
 
+            processor_subdir = None
+            if self.standalone_dag_processor:
+                processor_subdir = self.get_dag_directory()
+
             SerializedDagModel.remove_deleted_dags(
                 alive_dag_filelocs=dag_filelocs,
-                processor_subdir=self.get_dag_directory(),
+                processor_subdir=processor_subdir,
             )
             DagModel.deactivate_deleted_dags(self._file_paths)
 

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -251,7 +251,7 @@ class SerializedDagModel(Base):
                     cls.fileloc_hash.notin_(alive_fileloc_hashes),
                     cls.fileloc.notin_(alive_dag_filelocs),
                     or_(
-                        cls.processor_subdir is None,
+                        cls.processor_subdir.is_(None),
                         cls.processor_subdir == processor_subdir,
                     ),
                 )

--- a/tests/models/test_serialized_dag.py
+++ b/tests/models/test_serialized_dag.py
@@ -169,7 +169,7 @@ class TestSerializedDagModel:
         # remove repeated files for those DAGs that define multiple dags in the same file (set comprehension)
         example_dag_files = list({dag.fileloc for dag in filtered_example_dags_list})
         example_dag_files.remove(dag_removed_by_file.fileloc)
-        SDM.remove_deleted_dags(example_dag_files)
+        SDM.remove_deleted_dags(example_dag_files, processor_subdir="/tmp/test")
         assert not SDM.has_dag(dag_removed_by_file.dag_id)
 
     def test_bulk_sync_to_db(self):


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/29323

### Bug and Fix explained
So when a DAG file is deleted, the now removed DAGs are deleted during DAG directory refreshing. The DagProcessorManager creates a list of "alive" dag files and then should disable DAGs and delete serialized_dag entries.

The `remove_deleted_dags` method should delete serialized dags with either no `processor_subdir` or a matching `processor_subdir`. 
```python
 session.execute(
            cls.__table__.delete().where(
                and_(
                    cls.fileloc_hash.notin_(alive_fileloc_hashes),
                    cls.fileloc.notin_(alive_dag_filelocs),
                    or_(
                        cls.processor_subdir is None,
                        cls.processor_subdir == processor_subdir,
                    ),
                )
            )
        )

```
However, I've found with MySQL and Sqlite, `  cls.processor_subdir is None` does not match serialized dags with null `processor_subdir`. Based on this: https://stackoverflow.com/questions/5602918/select-null-values-in-sqlalchemy/44679356#44679356, I was able to resolve this issue by using the `_is` method instead.


This was resulting in the webserver still showing deleted DAGs (from a DAG link), and the dataset and dependency graphs still showing deleted DAGs.




<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.




Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
