### PR TITLE
Limit tenacity due to mypy problems

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -133,7 +133,9 @@ install_requires =
     sqlalchemy>=1.4,<2.0
     sqlalchemy_jsonfield>=1.0
     tabulate>=0.7.5
-    tenacity>=6.2.0
+    # The 8.2.0 release of tenacity has a mypy error that breaks our CI
+    # The upper-bound limit can be removed after https://github.com/jd/tenacity/issues/389 is resolved
+    tenacity>=6.2.0,<8.2.0
     termcolor>=1.1.0
     typing-extensions>=4.0.0
     unicodecsv>=0.14.1


### PR DESCRIPTION
The 8.2.0 version of tenacity, implemented a change that breaks mypy checks for clients using `@retry` decorated functions.

The issue is tracked in https://github.com/jd/tenacity/issues/389

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
