### PR TITLE
Impovements for RedshiftDataOperator

### DIFF
--- a/airflow/providers/amazon/aws/hooks/redshift_data.py
+++ b/airflow/providers/amazon/aws/hooks/redshift_data.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+from pprint import pformat
 from time import sleep
 from typing import TYPE_CHECKING, Any, Iterable
 
@@ -109,8 +110,8 @@ class RedshiftDataHook(AwsGenericHook["RedshiftDataAPIServiceClient"]):
                 return status
             elif status == "FAILED" or status == "ABORTED":
                 raise ValueError(
-                    f"Statement {statement_id!r} terminated with status {status}, "
-                    f"error msg: {resp.get('Error')}"
+                    f"Statement {statement_id!r} terminated with status {status}. "
+                    f"Response details: {pformat(resp)}"
                 )
             else:
                 self.log.info("Query %s", status)


### PR DESCRIPTION
I added two improvements to the `RedshiftDataOperator`:
1. Better error reporting. Before my changes, all you get in case of an error is just a status (`FAILURE`). It's not very helpful. I added the whole response in the exception, so it will be printed in the logs and it will give a possibility to troubleshoot problems easily.
2. I added a `return_sql_result` optional parameter. By default it's `False`, so it's a backward-compatible change. If it's `True` operator will return a result of a SQL query from the `execute` method. It means that this result will be available through xcom variables. It may be handy if you need to get some small portions of data (or metadata) from Redshift. For example, I'm running `show table` query to get a DDL of some table and create a temporary copy of it.