### PR TITLE
Fix SQL syntax for files parameter in CopyFromExternalStageToSnowflakeOperator

### DIFF
--- a/airflow/providers/snowflake/transfers/copy_into_snowflake.py
+++ b/airflow/providers/snowflake/transfers/copy_into_snowflake.py
@@ -132,7 +132,7 @@ class CopyFromExternalStageToSnowflakeOperator(BaseOperator):
         sql = f"""
         COPY INTO {into}
              FROM  @{self.stage}/{self.prefix or ""}
-        {"FILES=" + ",".join(map(enclose_param ,self.files)) if self.files else ""}
+        {"FILES=(" + ",".join(map(enclose_param, self.files)) + ")" if self.files else ""}
         {"PATTERN=" + enclose_param(self.pattern) if self.pattern else ""}
         FILE_FORMAT={self.file_format}
         {self.copy_options or ""}

--- a/tests/providers/snowflake/transfers/test_copy_into_snowflake.py
+++ b/tests/providers/snowflake/transfers/test_copy_into_snowflake.py
@@ -55,7 +55,7 @@ class TestCopyFromExternalStageToSnowflake:
         sql = """
         COPY INTO schema.table(col1, col2)
              FROM  @stage/prefix
-        FILES='file1.csv','file2.csv'
+        FILES=('file1.csv','file2.csv')
         PATTERN='*.csv'
         FILE_FORMAT=CSV
         copy_options


### PR DESCRIPTION
Currently, `CopyFromExternalStageToSnowflakeOperator` will return a SQL compilation error if a file list is specified. The [optional FILES parameter](https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#optional-parameters) for Snowflake's COPY INTO command requires the file list to be surrounded by parentheses.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
