### PR TITLE
Add time to live for finished jobs in Kubernetes

### DIFF
--- a/chart/templates/jobs/create-user-job.yaml
+++ b/chart/templates/jobs/create-user-job.yaml
@@ -48,6 +48,9 @@ metadata:
     {{- $annotations | toYaml | nindent 4 }}
   {{- end }}
 spec:
+  {{- if semverCompare ">= 1.23.x" (include "kubeVersion" .) }}
+  ttlSecondsAfterFinished: {{ .Values.createUserJob.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/chart/templates/jobs/migrate-database-job.yaml
+++ b/chart/templates/jobs/migrate-database-job.yaml
@@ -48,6 +48,9 @@ metadata:
     {{- $annotations | toYaml | nindent 4 }}
   {{- end }}
 spec:
+  {{- if semverCompare ">= 1.23.x" (include "kubeVersion" .) }}
+  ttlSecondsAfterFinished: {{ .Values.migrateDatabaseJob.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2894,6 +2894,11 @@
                         }
                     }
                 },
+                "ttlSecondsAfterFinished": {
+                    "description": "Number of seconds to wait until the job is eligible for deletion (Kubernetes 1.23+)",
+                    "type": "integer",
+                    "default": 300
+                },
                 "extraContainers": {
                     "description": "Launch additional containers for the create user job pod",
                     "type": "array",
@@ -3111,6 +3116,11 @@
                             }
                         }
                     ]
+                },
+                "ttlSecondsAfterFinished": {
+                    "description": "Number of seconds to wait until the job is eligible for deletion (Kubernetes 1.23+)",
+                    "type": "integer",
+                    "default": 300
                 },
                 "extraContainers": {
                     "description": "Launch additional containers for the migrate database job pod",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -782,11 +782,12 @@ createUserJob:
     - "{{ .Values.webserver.defaultUser.lastName }}"
     - "-p"
     - "{{ .Values.webserver.defaultUser.password }}"
-
   # Annotations on the create user job pod
   annotations: {}
   # jobAnnotations are annotations on the create user job
   jobAnnotations: {}
+  # Number of seconds to wait until the job is eligible for deletion (Kubernetes 1.23+)
+  ttlSecondsAfterFinished: 300
 
   # Labels specific to createUserJob objects and pods
   labels: {}
@@ -869,6 +870,9 @@ migrateDatabaseJob:
 
     # Annotations to add to migrate database job kubernetes service account.
     annotations: {}
+
+  # Number of seconds to wait until the job is eligible for deletion (Kubernetes 1.23+)
+  ttlSecondsAfterFinished: 300
 
   resources: {}
   #  limits:


### PR DESCRIPTION
When you upgrade/change job in K8S that has been finished and not manually removed, this leads to "Field is immutable" error.

This is a known kubernetes issue:

https://github.com/kubernetes/kubernetes/issues/89657

And there are some workarounds (manually removing the job for example), but the only good solution is possible only in K8S 1.23+ with ttlSecondsAfterFinished set for the job, so that K8S can auto
 clean it.

This PR adds it conditionally for K8S >= 1.23

Fixes: https://github.com/apache/airflow/issues/27561

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
