### PR TITLE
datasets, next_run_datasets, remove unnecessary timestamp filter

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3713,9 +3713,7 @@ class Airflow(AirflowBaseView):
                 )
                 .join(
                     DatasetEvent,
-                    and_(
-                        DatasetEvent.dataset_id == DatasetModel.id,
-                    ),
+                    DatasetEvent.dataset_id == DatasetModel.id,
                     isouter=True,
                 )
                 .filter(DagScheduleDatasetReference.dag_id == dag_id, ~DatasetModel.is_orphaned)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3715,7 +3715,6 @@ class Airflow(AirflowBaseView):
                     DatasetEvent,
                     and_(
                         DatasetEvent.dataset_id == DatasetModel.id,
-                        DatasetEvent.timestamp > DatasetDagRunQueue.created_at,
                     ),
                     isouter=True,
                 )


### PR DESCRIPTION
Closes: #26892
I'm not sure what the intention of this filter was:
`DatasetEvent.timestamp > DatasetDagRunQueue.created_at`
When a dataset is updated, 
1. A `DatasetEvent` is created (and saved)
2. And then, a `DatasetDagRunQueue` row is added for each dependant DAG.

I don't think we need this filter, and have confirmed that it prevents the last update from being shown.
By removing this filter, it resolves #26892


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
