### PR TITLE
Scheduler, make stale DAG deactivation threshold configurable instead of using dag processing timeout

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2112,7 +2112,7 @@ scheduler:
       default: "60"
     stale_dag_threshold:
       description: |
-        How long (in seconds) to wait after we have reparsed a DAG file before deactivating stale
+        How long (in seconds) to wait after we have re-parsed a DAG file before deactivating stale
         DAGs (DAGs which are no longer present in the expected files). The reason why we need
         this threshold is to account for the time between when the file is parsed and when the
         DAG is loaded. The absolute maximum that this could take is `dag_file_processor_timeout`,

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2121,7 +2121,7 @@ scheduler:
       version_added: 2.6.0
       type: integer
       example: ~
-      default: "30"
+      default: "50"
     dag_dir_list_interval:
       description: |
         How often (in seconds) to scan the DAGs directory for new files. Default to 5 minutes.

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2110,6 +2110,18 @@ scheduler:
       type: integer
       example: ~
       default: "60"
+    stale_dag_threshold:
+      description: |
+        How long (in seconds) to wait after we've reparsed a DAG file before deactivating stale
+        DAGs (DAGs which are no longer present in the expected files). The reason why we need
+        this threshold is to account for the time between when the file is parsed and when the
+        DAG is loaded. The absolute maximum that this could take is `dag_file_processor_timeout`,
+        but when you have a long timeout configured, it results in a significant delay in the
+        deactivation of stale dags.
+      version_added: 2.6.0
+      type: integer
+      example: ~
+      default: "30"
     dag_dir_list_interval:
       description: |
         How often (in seconds) to scan the DAGs directory for new files. Default to 5 minutes.

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2112,7 +2112,7 @@ scheduler:
       default: "60"
     stale_dag_threshold:
       description: |
-        How long (in seconds) to wait after we've reparsed a DAG file before deactivating stale
+        How long (in seconds) to wait after we have reparsed a DAG file before deactivating stale
         DAGs (DAGs which are no longer present in the expected files). The reason why we need
         this threshold is to account for the time between when the file is parsed and when the
         DAG is loaded. The absolute maximum that this could take is `dag_file_processor_timeout`,

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1083,7 +1083,7 @@ min_file_process_interval = 30
 # referenced and should be marked as orphaned.
 parsing_cleanup_interval = 60
 
-# How long (in seconds) to wait after we've reparsed a DAG file before deactivating stale
+# How long (in seconds) to wait after we have reparsed a DAG file before deactivating stale
 # DAGs (DAGs which are no longer present in the expected files). The reason why we need
 # this threshold is to account for the time between when the file is parsed and when the
 # DAG is loaded. The absolute maximum that this could take is `dag_file_processor_timeout`,

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1083,6 +1083,14 @@ min_file_process_interval = 30
 # referenced and should be marked as orphaned.
 parsing_cleanup_interval = 60
 
+# How long (in seconds) to wait after we've reparsed a DAG file before deactivating stale
+# DAGs (DAGs which are no longer present in the expected files). The reason why we need
+# this threshold is to account for the time between when the file is parsed and when the
+# DAG is loaded. The absolute maximum that this could take is `dag_file_processor_timeout`,
+# but when you have a long timeout configured, it results in a significant delay in the
+# deactivation of stale dags.
+stale_dag_threshold = 30
+
 # How often (in seconds) to scan the DAGs directory for new files. Default to 5 minutes.
 dag_dir_list_interval = 300
 

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1083,7 +1083,7 @@ min_file_process_interval = 30
 # referenced and should be marked as orphaned.
 parsing_cleanup_interval = 60
 
-# How long (in seconds) to wait after we have reparsed a DAG file before deactivating stale
+# How long (in seconds) to wait after we have re-parsed a DAG file before deactivating stale
 # DAGs (DAGs which are no longer present in the expected files). The reason why we need
 # this threshold is to account for the time between when the file is parsed and when the
 # DAG is loaded. The absolute maximum that this could take is `dag_file_processor_timeout`,

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1089,7 +1089,7 @@ parsing_cleanup_interval = 60
 # DAG is loaded. The absolute maximum that this could take is `dag_file_processor_timeout`,
 # but when you have a long timeout configured, it results in a significant delay in the
 # deactivation of stale dags.
-stale_dag_threshold = 30
+stale_dag_threshold = 50
 
 # How often (in seconds) to scan the DAGs directory for new files. Default to 5 minutes.
 dag_dir_list_interval = 300

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -524,9 +524,6 @@ class DagFileProcessorManager(LoggingMixin):
             query = query.filter(DagModel.processor_subdir == dag_directory)
         dags_parsed = query.all()
 
-        processor_timeout_seconds: int = conf.getint("core", "dag_file_processor_timeout")
-
-
         for dag in dags_parsed:
             # The largest valid difference between a DagFileStat's last_finished_time and a DAG's
             # last_parsed_time is the processor_timeout. Longer than that indicates that the DAG is

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -432,7 +432,7 @@ class DagFileProcessorManager(LoggingMixin):
         self.last_deactivate_stale_dags_time = timezone.make_aware(datetime.fromtimestamp(0))
         # How often to check for DAGs which are no longer in files
         self.parsing_cleanup_interval = conf.getint("scheduler", "parsing_cleanup_interval")
-        # How long to wait for a DAG to be reparsed after it's file has been parsed before disabling
+        # How long to wait for a DAG to be reparsed after its file has been parsed before disabling
         self.stale_dag_threshold = conf.getboolean("scheduler", "stale_dag_threshold")
         # How long to wait before timing out a process to parse a DAG file
         self._processor_timeout = processor_timeout
@@ -528,7 +528,7 @@ class DagFileProcessorManager(LoggingMixin):
 
         for dag in dags_parsed:
             # The largest valid difference between a DagFileStat's last_finished_time and a DAG's
-            # last_parsed_time is thg processor_timeout. Longer than that indicates that the DAG is
+            # last_parsed_time is the processor_timeout. Longer than that indicates that the DAG is
             # no longer present in the file. We have a stale_dag_threshold configured to prevent a
             # significant delay in deactivation of stale dags when a large timeout is configured
             if (

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -433,7 +433,7 @@ class DagFileProcessorManager(LoggingMixin):
         # How often to check for DAGs which are no longer in files
         self.parsing_cleanup_interval = conf.getint("scheduler", "parsing_cleanup_interval")
         # How long to wait for a DAG to be reparsed after its file has been parsed before disabling
-        self.stale_dag_threshold = conf.getboolean("scheduler", "stale_dag_threshold")
+        self.stale_dag_threshold = conf.getint("scheduler", "stale_dag_threshold")
         # How long to wait before timing out a process to parse a DAG file
         self._processor_timeout = processor_timeout
         # How often to scan the DAGs directory for new files. Default to 5 minutes.

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -432,6 +432,8 @@ class DagFileProcessorManager(LoggingMixin):
         self.last_deactivate_stale_dags_time = timezone.make_aware(datetime.fromtimestamp(0))
         # How often to check for DAGs which are no longer in files
         self.parsing_cleanup_interval = conf.getint("scheduler", "parsing_cleanup_interval")
+        # How long to wait for a DAG to be reparsed after it's file has been parsed before disabling
+        self.stale_dag_threshold = conf.getboolean("scheduler", "stale_dag_threshold")
         # How long to wait before timing out a process to parse a DAG file
         self._processor_timeout = processor_timeout
         # How often to scan the DAGs directory for new files. Default to 5 minutes.
@@ -495,7 +497,7 @@ class DagFileProcessorManager(LoggingMixin):
             DagFileProcessorManager.deactivate_stale_dags(
                 last_parsed=last_parsed,
                 dag_directory=self.get_dag_directory(),
-                processor_timeout=self._processor_timeout,
+                stale_dag_threshold=self.stale_dag_threshold,
             )
             self.last_deactivate_stale_dags_time = timezone.utcnow()
 
@@ -506,7 +508,7 @@ class DagFileProcessorManager(LoggingMixin):
         cls,
         last_parsed: dict[str, datetime | None],
         dag_directory: str,
-        processor_timeout: timedelta,
+        stale_dag_threshold: timedelta,
         session: Session = NEW_SESSION,
     ):
         """
@@ -522,13 +524,16 @@ class DagFileProcessorManager(LoggingMixin):
             query = query.filter(DagModel.processor_subdir == dag_directory)
         dags_parsed = query.all()
 
+
+
         for dag in dags_parsed:
             # The largest valid difference between a DagFileStat's last_finished_time and a DAG's
-            # last_parsed_time is _processor_timeout. Longer than that indicates that the DAG is
-            # no longer present in the file.
+            # last_parsed_time is thg processor_timeout. Longer than that indicates that the DAG is
+            # no longer present in the file. We have a stale_dag_threshold configured to prevent a
+            # significant delay in deactivation of stale dags when a large timeout is configured
             if (
                 dag.fileloc in last_parsed
-                and (dag.last_parsed_time + processor_timeout) < last_parsed[dag.fileloc]
+                and (dag.last_parsed_time + stale_dag_threshold) < last_parsed[dag.fileloc]
             ):
                 cls.logger().info("DAG %s is missing and will be deactivated.", dag.dag_id)
                 to_deactivate.add(dag.dag_id)

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -565,6 +565,7 @@ class TestDagFileProcessorManager:
         {
             ("core", "load_examples"): "False",
             ("scheduler", "standalone_dag_processor"): "True",
+            ("scheduler", "stale_dag_threshold"): 50,
         }
     )
     def test_scan_stale_dags_standalone_mode(self):

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -565,7 +565,7 @@ class TestDagFileProcessorManager:
         {
             ("core", "load_examples"): "False",
             ("scheduler", "standalone_dag_processor"): "True",
-            ("scheduler", "stale_dag_threshold"): 50,
+            ("scheduler", "stale_dag_threshold"): "50",
         }
     )
     def test_scan_stale_dags_standalone_mode(self):


### PR DESCRIPTION
When we deactivate stale DAGs, we add a buffer to the last parsed time of a DAG when comparing it to the last parsed time of its DAG file to account for DAG files that take a long time to process. 
```python

        for dag in dags_parsed:
            # The largest valid difference between a DagFileStat's last_finished_time and a DAG's
            # last_parsed_time is _processor_timeout. Longer than that indicates that the DAG is
            # no longer present in the file.
            if (
                dag.fileloc in last_parsed
                and (dag.last_parsed_time + processor_timeout) < last_parsed[dag.fileloc]
            ):
                cls.logger().info("DAG %s is missing and will be deactivated.", dag.dag_id)
                to_deactivate.add(dag.dag_id)

```
The upper bound on this delay is indeed the processor timeout, but practically speaking, this is unnecessary when we configure a long timeout. This can result in a large delay in stale DAG deactivation. I think this buffer should be configurable.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
