### PR TITLE
Fix sftp sensor with pattern

### DIFF
--- a/airflow/providers/sftp/sensors/sftp.py
+++ b/airflow/providers/sftp/sensors/sftp.py
@@ -18,6 +18,7 @@
 """This module contains SFTP sensor."""
 from __future__ import annotations
 
+import os
 from datetime import datetime
 from typing import TYPE_CHECKING, Sequence
 
@@ -69,7 +70,7 @@ class SFTPSensor(BaseSensorOperator):
         if self.file_pattern:
             file_from_pattern = self.hook.get_file_by_pattern(self.path, self.file_pattern)
             if file_from_pattern:
-                actual_file_to_check = file_from_pattern
+                actual_file_to_check = os.path.join(self.path, file_from_pattern)
             else:
                 return False
         else:

--- a/tests/providers/sftp/sensors/test_sftp.py
+++ b/tests/providers/sftp/sensors/test_sftp.py
@@ -99,15 +99,6 @@ class TestSFTPSensor:
         assert not output
 
     @patch("airflow.providers.sftp.sensors.sftp.SFTPHook")
-    def test_file_with_pattern_parameter_call(self, sftp_hook_mock):
-        sftp_hook_mock.return_value.get_mod_time.return_value = "19700101000000"
-        sftp_sensor = SFTPSensor(task_id="unit_test", path="/path/to/file/", file_pattern="*.txt")
-        context = {"ds": "1970-01-01"}
-        output = sftp_sensor.poke(context)
-        sftp_hook_mock.return_value.get_file_by_pattern.assert_called_once_with("/path/to/file/", "*.txt")
-        assert output
-
-    @patch("airflow.providers.sftp.sensors.sftp.SFTPHook")
     def test_file_present_with_pattern(self, sftp_hook_mock):
         sftp_hook_mock.return_value.get_mod_time.return_value = "19700101000000"
         sftp_hook_mock.return_value.get_file_by_pattern.return_value = "text_file.txt"

--- a/tests/providers/sftp/sensors/test_sftp.py
+++ b/tests/providers/sftp/sensors/test_sftp.py
@@ -110,7 +110,7 @@ class TestSFTPSensor:
     @patch("airflow.providers.sftp.sensors.sftp.SFTPHook")
     def test_file_present_with_pattern(self, sftp_hook_mock):
         sftp_hook_mock.return_value.get_mod_time.return_value = "19700101000000"
-        sftp_hook_mock.return_value.get_file_by_pattern.return_value = "/path/to/file/text_file.txt"
+        sftp_hook_mock.return_value.get_file_by_pattern.return_value = "text_file.txt"
         sftp_sensor = SFTPSensor(task_id="unit_test", path="/path/to/file/", file_pattern="*.txt")
         context = {"ds": "1970-01-01"}
         output = sftp_sensor.poke(context)


### PR DESCRIPTION
This PR will solve the issue registered by @RishuGuru in #28121.
It also takes into account the request from @potiuk in #28123 to add/fix the unit tests.

In summary, the SFTP Sensor was not finding the files when the `file_pattern` argument was used.
This was due to an incorrect assumption that  the SFTP Hook function `get_file_by_pattern` would return the full path, where actually it only returns the file name (corrected in e08a702b508e01c8437e4a45eaa726bb39e4f47f).

The unit test that was checking that also made this assumption (corrected in 018f316f96ed5f6361eea59987996454ced73bc7).

Also the unit test `test_file_with_pattern_parameter_call` seemed to become redundant, and I removed it (full explanation in faa5a73d5b353a3c2c83a90b5040966158b97979).

closes: #28121
