### PR TITLE
Use non-deprecated method when unpause DAG in the UI

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2102,7 +2102,7 @@ class Airflow(AirflowBaseView):
                     recent_confs=recent_confs,
                 )
 
-        if unpause and dag.is_paused:
+        if unpause and dag.get_is_paused():
             models.DagModel.get_dagmodel(dag_id).set_is_paused(is_paused=False)
 
         try:


### PR DESCRIPTION
Use method instead of deprecated property in DAG object when unpause DAG in the UI

```console

/opt/airflow/airflow/www/views.py:2105 RemovedInAirflow3Warning: This attribute is deprecated. 
Please use `airflow.models.DAG.get_is_paused` method.
```
