### PR TITLE
Update content type validation regexp for go client

### DIFF
--- a/clients/gen/go.sh
+++ b/clients/gen/go.sh
@@ -43,4 +43,10 @@ gen_client go \
     --git-repo-id airflow-client-go/airflow \
     --additional-properties "${go_config[*]}"
 
+# fix client content type validation regexp:
+# https://github.com/OpenAPITools/openapi-generator/issues/4890
+sed -i "s/(?:vnd\\\.\[^;\]+\\\+)?json/(?:(?:vnd\\\.\[^;\]+\\\+)|(?:problem\\\+))?json/g" "${OUTPUT_DIR}/client.go"
+sed -i "s/(?i:(?:application|text)\/xml/(?i:(?:application|text)\/(?:problem\\\+)?xml/g" "${OUTPUT_DIR}/client.go"
+
 run_pre_commit
+echo "Generation successful"


### PR DESCRIPTION
solves: https://github.com/apache/airflow-client-go/issues/38

We can workaround without having this, but it would be nicer for people using the client to not have content type error for `problem+json` response.

See original issue:
https://github.com/OpenAPITools/openapi-generator/issues/4890

Update the go client content type validation regexp after generating the client.

The generation now gives:
![image](https://user-images.githubusercontent.com/14861206/218258764-0a566db1-2ad1-43a1-8211-272d5f1eb1e8.png)


This allows us in the client to have a relevant error objet when calling for instance:
```
    run, response, error := cli.DAGRunApi.GetDagRun(ctx, "fake", "fake_run").Execute()
```
with an error that will be ''404 NOT FOUND", and not "undefined response type"
