### PR TITLE
Fix bitnami/postgresql default username and password

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -5236,7 +5236,7 @@
                                 "string",
                                 "null"
                             ],
-                            "default": null
+                            "default": ""
                         },
                         "password": {
                             "description": "Password for the custom user to create.",
@@ -5244,7 +5244,7 @@
                                 "string",
                                 "null"
                             ],
-                            "default": null
+                            "default": ""
                         }
                     }
                 }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1707,8 +1707,8 @@ postgresql:
   auth:
     enablePostgresUser: true
     postgresPassword: postgres
-    username: ~
-    password: ~
+    username: ""
+    password: ""
 
 # Config settings to go into the mounted airflow.cfg
 #


### PR DESCRIPTION
The PR changes default `username` and `password` values used by bitnami/postgresql subchart, because current `null` values don't allow to install simple Airflow deployment using Argo CD.
BTW, [bitnami/postgresql](https://artifacthub.io/packages/helm/bitnami/postgresql/12.1.9) chart uses empty strings `""` for `auth.username` and `auth.password` by default.

### How to reproduce
Install Argo CD
```
helm install argocd argo/argo-cd --set applicationSet.enabled=false --version 5.20.3
```
Create Application file `airflow.yaml`
```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: airflow
spec:
  project: default
  source:
    repoURL: https://github.com/apache/airflow.git
    targetRevision: 7ee1a5624497fc457af239e93e4c1af94972bbe6
    path: chart
    helm:
      version: v3
      valueFiles:
        - values.yaml
      values: |
        pgbouncer:
          enabled: true
        workers:
          persistence:
            enabled: false
        createUserJob:
          useHelmHooks: false
          applyCustomEnv: false
        migrateDatabaseJob:
          useHelmHooks: false
          applyCustomEnv: false
          jobAnnotations:
            "argocd.argoproj.io/hook": Sync
  destination:
    server: https://kubernetes.default.svc
    namespace: airflow
  syncPolicy:
    automated:
      prune: true
      selfHeal: true
    syncOptions:
      - CreateNamespace=true
```
Create Airflow Application
```
kubectl apply -f airflow.yaml
```
Check that `airflow-postgresql-0` pod cannot start. Both `livenessProbe` and `readinessProbe` are broken: username is empty in command scripts, i.e. `-U ""`
```
apiVersion: v1
kind: Pod
metadata:
  name: airflow-postgresql-0
  namespace: airflow
spec:
  containers:
    - name: postgresql
      livenessProbe:
        exec:
          command:
            - /bin/sh
            - '-c'
            - exec pg_isready -U "" -h 127.0.0.1 -p 5432
      readinessProbe:
        exec:
          command:
            - /bin/sh
            - '-c'
            - '-e'
            - >
              exec pg_isready -U "" -h 127.0.0.1 -p 5432
              [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
```

### How to test
Use the following Application definition which points to fixed helm chart
```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: airflow
spec:
  project: default
  source:
    repoURL: https://github.com/dnskr/airflow.git
    targetRevision: dee81abf62369ef4fa1c2001f62fe8f395746cf3
    path: chart
    helm:
      version: v3
      valueFiles:
        - values.yaml
      values: |
        pgbouncer:
          enabled: true
        workers:
          persistence:
            enabled: false
        createUserJob:
          useHelmHooks: false
          applyCustomEnv: false
        migrateDatabaseJob:
          useHelmHooks: false
          applyCustomEnv: false
          jobAnnotations:
            "argocd.argoproj.io/hook": Sync
  destination:
    server: https://kubernetes.default.svc
    namespace: airflow
  syncPolicy:
    automated:
      prune: true
      selfHeal: true
    syncOptions:
      - CreateNamespace=true
```