### PR TITLE
Add arg --yes to `db export-archived` command.

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1624,6 +1624,7 @@ DB_COMMANDS = (
             ARG_DB_OUTPUT_PATH,
             ARG_DB_DROP_ARCHIVES,
             ARG_DB_TABLES,
+            ARG_YES,
         ),
     ),
     ActionCommand(

--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -217,6 +217,7 @@ def export_archived(args):
         output_path=args.output_path,
         table_names=args.tables,
         drop_archives=args.drop_archives,
+        needs_confirm=not args.yes,
     )
 
 

--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -429,13 +429,18 @@ def run_cleanup(
 
 @provide_session
 def export_archived_records(
-    export_format, output_path, table_names=None, drop_archives=False, session: Session = NEW_SESSION
+    export_format,
+    output_path,
+    table_names=None,
+    drop_archives=False,
+    needs_confirm=True,
+    session: Session = NEW_SESSION,
 ):
     """Export archived data to the given output path in the given format."""
     archived_table_names = _get_archived_table_names(table_names, session)
     # If user chose to drop archives, check there are archive tables that exists
     # before asking for confirmation
-    if drop_archives and archived_table_names:
+    if drop_archives and archived_table_names and needs_confirm:
         _confirm_drop_archives(tables=sorted(archived_table_names))
     export_count = 0
     dropped_count = 0

--- a/tests/cli/commands/test_db_command.py
+++ b/tests/cli/commands/test_db_command.py
@@ -463,7 +463,7 @@ class TestCLIDBClean:
         db_command.export_archived(args)
 
         export_archived_mock.assert_called_once_with(
-            export_format="csv", output_path="path", table_names=None, drop_archives=False
+            export_format="csv", output_path="path", table_names=None, drop_archives=False, needs_confirm=True
         )
 
     @pytest.mark.parametrize(
@@ -485,7 +485,11 @@ class TestCLIDBClean:
         )
         db_command.export_archived(args)
         export_archived_mock.assert_called_once_with(
-            export_format="csv", output_path="path", table_names=expected, drop_archives=False
+            export_format="csv",
+            output_path="path",
+            table_names=expected,
+            drop_archives=False,
+            needs_confirm=True,
         )
 
     @pytest.mark.parametrize("extra_args, expected", [(["--drop-archives"], True), ([], False)])
@@ -505,7 +509,11 @@ class TestCLIDBClean:
         )
         db_command.export_archived(args)
         export_archived_mock.assert_called_once_with(
-            export_format="csv", output_path="path", table_names=None, drop_archives=expected
+            export_format="csv",
+            output_path="path",
+            table_names=None,
+            drop_archives=expected,
+            needs_confirm=True,
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
This was omitted in the command but I think it's necessary so one can choose to override the questions

