### PR TITLE
Fix failing multiple-output-inference tests for Python 3.8+

### DIFF
--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Dict, Tuple
 
 import pytest
 
+from airflow import PY38
 from airflow.decorators import task as task_decorator
 from airflow.decorators.base import DecoratedMappedOperator
 from airflow.exceptions import AirflowException
@@ -118,7 +119,7 @@ class TestAirflowTaskDecorator(BasePythonTest):
             ) -> "UnresolveableName[int, int]":
                 ...
 
-            line = sys._getframe().f_lineno - 3
+            line = sys._getframe().f_lineno - 6 if PY38 else sys._getframe().f_lineno - 3
 
         warn = recwarn[0]
         assert warn.filename == __file__


### PR DESCRIPTION
The #29445 introduced a test for generated warnings that tested line number of the generated warning. However the number of line had changed in Python 3.8 because the stack trace of the error is a bit different.

The #29445 tests passed when merging as they were only run for Python 3.7, however our Canary builds caught it and failed in main.

Adding conditionals to handle it for other Python versions as well.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
