### PR TITLE
Bump stale bot version

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,7 +29,7 @@ jobs:
   stale:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v7
         with:
           stale-pr-message: >
             This pull request has been automatically marked as stale because it has not had


### PR DESCRIPTION
stale workflow shows warning message:
```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
https://github.com/apache/airflow/actions/runs/4153778955

lets try to update to latest version and see if it's resolved.

I went though the [change log](https://github.com/actions/stale/blob/main/CHANGELOG.md) and looks like we can just update the version without changing anything else. They added `close-issue-reason` but the default value of not `not_planned` seems OK.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
