### PR TITLE
Cache Secrets lookup from Azure Key Vault

### DIFF
--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -184,7 +184,7 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
         return path.replace("_", sep)
 
     @lru_cache(maxsize=128)
-    def _get_secret(self, path_prefix: str, secret_id: str, ttl: int = round(time.time()/self.ttl)) -> str | None:
+    def _get_secret(self, path_prefix: str, secret_id: str, ttl_hash: int = round(time.time()/self.ttl)) -> str | None:
         """
         Get an Azure Key Vault secret value
 
@@ -192,7 +192,7 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
         :param secret_id: Secret Key
         :param ttl: time to live for the cache expiry in seconds
         """
-        del ttl #delete as value has already been used for caching
+        del ttl_hash #delete as value has already been used for caching
         name = self.build_path(path_prefix, secret_id, self.sep)
         try:
             secret = self.client.get_secret(name=name)


### PR DESCRIPTION

closes: #29486 

-->
Adding a simple lru caching mechanism. The default ttl has been set to 1, so this will not be a breaking change for anyone otherwise, and will need to be setup by the users explicitly while configuring their Secrets Backend.
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
