### PR TITLE
Change permissions of config/password files created by airflow

### DIFF
--- a/airflow/cli/commands/standalone_command.py
+++ b/airflow/cli/commands/standalone_command.py
@@ -27,7 +27,7 @@ from collections import deque
 
 from termcolor import colored
 
-from airflow.configuration import AIRFLOW_HOME, conf
+from airflow.configuration import AIRFLOW_HOME, conf, make_group_other_inaccessible
 from airflow.executors import executor_constants
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.scheduler_job import SchedulerJob
@@ -195,6 +195,7 @@ class StandaloneCommand:
             )
             with open(password_path, "w") as file:
                 file.write(password)
+            make_group_other_inaccessible(password_path)
             appbuilder.sm.add_user("admin", "Admin", "User", "admin@example.com", role, password)
             self.print_output("standalone", "Created admin user")
         # If the user does exist and we know its password, read the password


### PR DESCRIPTION
The permissions for files created by airflow when creating config and standalone files are now only limited to the owner.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
