### PR TITLE
Move libjars parameter in Sqoop Hook to Hook parameter

### DIFF
--- a/airflow/providers/apache/sqoop/hooks/sqoop.py
+++ b/airflow/providers/apache/sqoop/hooks/sqoop.py
@@ -36,7 +36,6 @@ class SqoopHook(BaseHook):
 
         * ``job_tracker``: Job tracker local|jobtracker:port.
         * ``namenode``: Namenode.
-        * ``lib_jars``: Comma separated jar files to include in the classpath.
         * ``files``: Comma separated files to be copied to the map reduce cluster.
         * ``archives``: Comma separated archives to be unarchived on the compute
             machines.
@@ -46,6 +45,7 @@ class SqoopHook(BaseHook):
     :param verbose: Set sqoop to verbose.
     :param num_mappers: Number of map tasks to import in parallel.
     :param properties: Properties to set via the -D argument
+    :param libjars: Optional Comma separated jar files to include in the classpath.
     """
 
     conn_name_attr = "conn_id"
@@ -61,6 +61,7 @@ class SqoopHook(BaseHook):
         hcatalog_database: str | None = None,
         hcatalog_table: str | None = None,
         properties: dict[str, Any] | None = None,
+        libjars: str | None = None,
     ) -> None:
         # No mutable types in the default parameters
         super().__init__()
@@ -68,7 +69,7 @@ class SqoopHook(BaseHook):
         connection_parameters = self.conn.extra_dejson
         self.job_tracker = connection_parameters.get("job_tracker", None)
         self.namenode = connection_parameters.get("namenode", None)
-        self.libjars = connection_parameters.get("libjars", None)
+        self.libjars = libjars
         self.files = connection_parameters.get("files", None)
         self.archives = connection_parameters.get("archives", None)
         self.password_file = connection_parameters.get("password_file", None)

--- a/airflow/providers/apache/sqoop/operators/sqoop.py
+++ b/airflow/providers/apache/sqoop/operators/sqoop.py
@@ -82,6 +82,7 @@ class SqoopOperator(BaseOperator):
     :param extra_export_options: Extra export options to pass as dict.
         If a key doesn't have a value, just pass an empty string to it.
         Don't include prefix of -- for sqoop options.
+    :param libjars: Optional Comma separated jar files to include in the classpath.
     """
 
     template_fields: Sequence[str] = (
@@ -150,6 +151,7 @@ class SqoopOperator(BaseOperator):
         extra_import_options: dict[str, Any] | None = None,
         extra_export_options: dict[str, Any] | None = None,
         schema: str | None = None,
+        libjars: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -187,6 +189,7 @@ class SqoopOperator(BaseOperator):
         self.extra_export_options = extra_export_options or {}
         self.hook: SqoopHook | None = None
         self.schema = schema
+        self.libjars = libjars
 
     def execute(self, context: Context) -> None:
         """Execute sqoop job"""
@@ -265,4 +268,5 @@ class SqoopOperator(BaseOperator):
             hcatalog_database=self.hcatalog_database,
             hcatalog_table=self.hcatalog_table,
             properties=self.properties,
+            libjars=self.libjars,
         )

--- a/tests/providers/apache/sqoop/hooks/test_sqoop.py
+++ b/tests/providers/apache/sqoop/hooks/test_sqoop.py
@@ -76,7 +76,6 @@ class TestSqoopHook:
     _config_json = {
         "namenode": "http://0.0.0.0:50070/",
         "job_tracker": "http://0.0.0.0:50030/",
-        "libjars": "/path/to/jars",
         "files": "/path/to/files",
         "archives": "/path/to/archives",
     }
@@ -117,7 +116,7 @@ class TestSqoopHook:
         mock_popen.return_value.__enter__.return_value = mock_proc
 
         # When
-        hook = SqoopHook(conn_id="sqoop_test")
+        hook = SqoopHook(conn_id="sqoop_test", libjars="/path/to/jars")
         hook.export_table(**self._config_export)
 
         # Then
@@ -130,7 +129,7 @@ class TestSqoopHook:
                 "-jt",
                 self._config_json["job_tracker"],
                 "-libjars",
-                self._config_json["libjars"],
+                "/path/to/jars",
                 "-files",
                 self._config_json["files"],
                 "-archives",
@@ -199,9 +198,6 @@ class TestSqoopHook:
 
         if self._config_json["job_tracker"]:
             assert f"-jt {self._config_json['job_tracker']}" in cmd
-
-        if self._config_json["libjars"]:
-            assert f"-libjars {self._config_json['libjars']}" in cmd
 
         if self._config_json["files"]:
             assert f"-files {self._config_json['files']}" in cmd


### PR DESCRIPTION
The libjars parameter is not needed to be configured in configuration, it should be implemented in Hook (and Operator transitively).

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
