### PR TITLE
Validate Hive Beeline parameters

### DIFF
--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -141,6 +141,7 @@ class HiveCliHook(BaseHook):
 
         if self.use_beeline:
             hive_bin = "beeline"
+            self._validate_beeline_parameters(conn)
             jdbc_url = f"jdbc:hive2://{conn.host}:{conn.port}/{conn.schema}"
             if conf.get("core", "security") == "kerberos":
                 template = conn.extra_dejson.get("principal", "hive/_HOST@EXAMPLE.COM")
@@ -164,6 +165,22 @@ class HiveCliHook(BaseHook):
         hive_params_list = self.hive_cli_params.split()
 
         return [hive_bin] + cmd_extra + hive_params_list
+
+    def _validate_beeline_parameters(self, conn):
+        if ":" in conn.host or "/" in conn.host or ";" in conn.host:
+            raise Exception(
+                f"The host used in beeline command ({conn.host}) should not contain ':/;' characters)"
+            )
+        try:
+            int_port = int(conn.port)
+            if int_port <= 0 or int_port > 65535:
+                raise Exception(f"The port used in beeline command ({conn.port}) should be in range 0-65535)")
+        except (ValueError, TypeError) as e:
+            raise Exception(f"The port used in beeline command ({conn.port}) should be a valid integer: {e})")
+        if ";" in conn.schema:
+            raise Exception(
+                f"The schema used in beeline command ({conn.schema}) should not contain ';' character)"
+            )
 
     @staticmethod
     def _prepare_hiveconf(d: dict[Any, Any]) -> list[Any]:

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -29,7 +29,7 @@ from hmsclient import HMSClient
 from airflow.exceptions import AirflowException
 from airflow.models.connection import Connection
 from airflow.models.dag import DAG
-from airflow.providers.apache.hive.hooks.hive import HiveMetastoreHook, HiveServer2Hook
+from airflow.providers.apache.hive.hooks.hive import HiveCliHook, HiveMetastoreHook, HiveServer2Hook
 from airflow.secrets.environment_variables import CONN_ENV_PREFIX
 from airflow.utils import timezone
 from airflow.utils.operator_helpers import AIRFLOW_VAR_NAME_FORMAT_MAPPING
@@ -640,6 +640,37 @@ class TestHiveServer2Hook:
                 password="conn_pass",
                 database="default",
             )
+
+    @pytest.mark.parametrize(
+        "host, port, schema, message",
+        [
+            ("localhost", "10000", "default", None),
+            ("localhost:", "10000", "default", "The host used in beeline command"),
+            (";ocalhost", "10000", "default", "The host used in beeline command"),
+            (";ocalho/", "10000", "default", "The host used in beeline command"),
+            ("localhost", "as", "default", "The port used in beeline command"),
+            ("localhost", "0;", "default", "The port used in beeline command"),
+            ("localhost", "10/", "default", "The port used in beeline command"),
+            ("localhost", ":", "default", "The port used in beeline command"),
+            ("localhost", "-1", "default", "The port used in beeline command"),
+            ("localhost", "655536", "default", "The port used in beeline command"),
+            ("localhost", "1234", "default;", "The schema used in beeline command"),
+        ],
+    )
+    def test_get_conn_with_wrong_connection_parameters(self, host, port, schema, message):
+        connection = Connection(
+            conn_id="test",
+            conn_type="hive",
+            host=host,
+            port=port,
+            schema=schema,
+        )
+        hook = HiveCliHook()
+        if message:
+            with pytest.raises(Exception, match=message):
+                hook._validate_beeline_parameters(connection)
+        else:
+            hook._validate_beeline_parameters(connection)
 
     def test_get_records(self):
         hook = MockHiveServer2Hook()


### PR DESCRIPTION
The parameters for Hive when beeline is used should be validated in order to avoid unnecessary jdbc calls when they are invalid.

This PR adds raising an exception early in cases the parameters are not correct.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
