### PR TITLE
Make permissions for FileTaskHandler group-writeable and configurable

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1135,7 +1135,7 @@ ARG AIRFLOW_CONSTRAINTS_LOCATION=""
 ARG DEFAULT_CONSTRAINTS_BRANCH="constraints-main"
 # By changing the epoch we can force reinstalling Airflow and pip all dependencies
 # It can also be overwritten manually by setting the AIRFLOW_CI_BUILD_EPOCH environment variable.
-ARG AIRFLOW_CI_BUILD_EPOCH="4"
+ARG AIRFLOW_CI_BUILD_EPOCH="4"0
 ARG AIRFLOW_PRE_CACHED_PIP_PACKAGES="true"
 # By default in the image, we are installing all providers when installing from sources
 ARG INSTALL_PROVIDERS_FROM_SOURCES="true"

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -806,6 +806,36 @@ logging:
       type: string
       example: path.to.my_func
       default: ~
+    file_task_handler_new_folder_permissions:
+      description: |
+        Permissions in the form or of octal string as understood by chmod. The permissions are important
+        when you use impersonation, when logs are written by a different user than airflow. The most secure
+        way of configuring it in this case is to add both users to the same group and make it the default
+        group of both users. Group-writeable logs are default in airflow, but you might decide that you are
+        OK with having the logs other-writeable, in which case you should set it to `0o777`. You might
+        decide to add more security if you do not use impersonation and change it to `0o755` to make it
+        only owner-writeable. You can also make it just readable only for owner by changing it to `0o700` if
+        all the access (read/write) for your logs happens from the same user.
+      version_added: 2.6.0
+      type: string
+      example: "0o775"
+      default: "0o775"
+    file_task_handler_new_file_permissions:
+      description: |
+        Permissions in the form or of octal string as understood by chmod. The permissions are important
+        when you use impersonation, when logs are written by a different user than airflow. The most secure
+        way of configuring it in this case is to add both users to the same group and make it the default
+        group of both users. Group-writeable logs are default in airflow, but you might decide that you are
+        OK with having the logs other-writeable, in which case you should set it to `0o666`. You might
+        decide to add more security if you do not use impersonation and change it to `0o644` to make it
+        only owner-writeable. You can also make it just readable only for owner by changing it to `0o600` if
+        all the access (read/write) for your logs happens from the same user.
+      version_added: 2.6.0
+      type: string
+      example: "0o664"
+      default: "0o664"
+
+
 metrics:
   description: |
     StatsD (https://github.com/etsy/statsd) integration settings.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -445,6 +445,28 @@ trigger_log_server_port = 8794
 # Example: interleave_timestamp_parser = path.to.my_func
 # interleave_timestamp_parser =
 
+# Permissions in the form or of octal string as understood by chmod. The permissions are important
+# when you use impersonation, when logs are written by a different user than airflow. The most secure
+# way of configuring it in this case is to add both users to the same group and make it the default
+# group of both users. Group-writeable logs are default in airflow, but you might decide that you are
+# OK with having the logs other-writeable, in which case you should set it to `0o777`. You might
+# decide to add more security if you do not use impersonation and change it to `0o755` to make it
+# only owner-writeable. You can also make it just readable only for owner by changing it to `0o700` if
+# all the access (read/write) for your logs happens from the same user.
+# Example: file_task_handler_new_folder_permissions = 0o775
+file_task_handler_new_folder_permissions = 0o775
+
+# Permissions in the form or of octal string as understood by chmod. The permissions are important
+# when you use impersonation, when logs are written by a different user than airflow. The most secure
+# way of configuring it in this case is to add both users to the same group and make it the default
+# group of both users. Group-writeable logs are default in airflow, but you might decide that you are
+# OK with having the logs other-writeable, in which case you should set it to `0o666`. You might
+# decide to add more security if you do not use impersonation and change it to `0o644` to make it
+# only owner-writeable. You can also make it just readable only for owner by changing it to `0o600` if
+# all the access (read/write) for your logs happens from the same user.
+# Example: file_task_handler_new_file_permissions = 0o664
+file_task_handler_new_file_permissions = 0o664
+
 [metrics]
 
 # StatsD (https://github.com/etsy/statsd) integration settings.

--- a/newsfragments/29506.significant.rst
+++ b/newsfragments/29506.significant.rst
@@ -1,0 +1,6 @@
+Default permissions of file task handler log directories and files has been changed to "owner + group" writeable.
+
+Default setting handles case where impersonation is needed and both users (airflow and the impersonated user)
+have the same group set as main group. Previously the default was also other-writeable and the user might choose
+to use the other-writeable setting if they wish by configuring ``file_task_handler_new_folder_permissions``
+and ``file_task_handler_new_file_permissions`` in ``logging`` section.


### PR DESCRIPTION
File Task Handler should apply different permissions to log files generated by Airflow in order to handle impersonation. This change exposes mechanism to bettet control the extend of permissions granted depending on individual preferences of the users. Default permissions are set to "group-writeable" allowing for impersonation use case, but it can be more relaxed or more limited by configuration.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
