### PR TITLE
Use MariaDB client binaries in arm64 image for support MySQL backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -917,6 +917,9 @@ jobs:
         uses: ./.github/actions/migration_tests
       - name: "Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.test-types}}"
         run: breeze testing tests --run-in-parallel
+      - name: "Tests ARM Pytest collection: ${{matrix.python-version}}"
+        if: env.MYSQL_VERSION != '5.7'
+        run: breeze shell "python /opt/airflow/scripts/in_container/test_pytest_collection.py" arm
       - name: "Post Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.test-types}}"
         uses: ./.github/actions/post_tests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -180,8 +180,12 @@ declare -a packages
 
 MYSQL_VERSION="8.0"
 readonly MYSQL_VERSION
+MARIADB_VERSION="10.5"
+readonly MARIADB_VERSION
 
 COLOR_BLUE=$'\e[34m'
+readonly COLOR_BLUE
+COLOR_YELLOW=$'\e[1;33m'
 readonly COLOR_BLUE
 COLOR_RESET=$'\e[0m'
 readonly COLOR_RESET
@@ -227,13 +231,34 @@ install_mysql_client() {
     apt-get clean && rm -rf /var/lib/apt/lists/*
 }
 
-if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
-    # disable MYSQL for ARM64
-    INSTALL_MYSQL_CLIENT="false"
-fi
+install_mariadb_client() {
+    if [[ "${1}" == "dev" ]]; then
+        packages=("libmariadb-dev" "mariadb-client-core-${MARIADB_VERSION}")
+    elif [[ "${1}" == "prod" ]]; then
+        packages=("mariadb-client-core-${MARIADB_VERSION}")
+    else
+        echo
+        echo "Specify either prod or dev"
+        echo
+        exit 1
+    fi
+
+    echo
+    echo "${COLOR_BLUE}Installing MariaDB client version ${MARIADB_VERSION}: ${1}${COLOR_RESET}"
+    echo "${COLOR_YELLOW}MariaDB client binary compatible with MySQL client.${COLOR_RESET}"
+    echo
+    apt-get update
+    apt-get install --no-install-recommends -y "${packages[@]}"
+    apt-get autoremove -yqq --purge
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+}
 
 if [[ ${INSTALL_MYSQL_CLIENT:="true"} == "true" ]]; then
-    install_mysql_client "${@}"
+    if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
+        install_mariadb_client "${@}"
+    else
+        install_mysql_client "${@}"
+    fi
 fi
 EOF
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -186,7 +186,7 @@ readonly MARIADB_VERSION
 COLOR_BLUE=$'\e[34m'
 readonly COLOR_BLUE
 COLOR_YELLOW=$'\e[1;33m'
-readonly COLOR_BLUE
+readonly COLOR_YELLOW
 COLOR_RESET=$'\e[0m'
 readonly COLOR_RESET
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -146,7 +146,7 @@ readonly MARIADB_VERSION
 COLOR_BLUE=$'\e[34m'
 readonly COLOR_BLUE
 COLOR_YELLOW=$'\e[1;33m'
-readonly COLOR_BLUE
+readonly COLOR_YELLOW
 COLOR_RESET=$'\e[0m'
 readonly COLOR_RESET
 
@@ -662,7 +662,7 @@ If it does not complete soon, you might want to stop it and remove file lock:
 if [[ ${SKIP_ENVIRONMENT_INITIALIZATION=} != "true" ]]; then
 
     if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
-        if [[ ${BACKEND} == "mssql" ]]; then
+        if [[ ${BACKEND:=} == "mssql" ]]; then
             echo "${COLOR_RED}ARM platform is not supported for ${BACKEND} backend. Exiting.${COLOR_RESET}"
             exit 1
         fi

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -140,8 +140,12 @@ declare -a packages
 
 MYSQL_VERSION="8.0"
 readonly MYSQL_VERSION
+MARIADB_VERSION="10.5"
+readonly MARIADB_VERSION
 
 COLOR_BLUE=$'\e[34m'
+readonly COLOR_BLUE
+COLOR_YELLOW=$'\e[1;33m'
 readonly COLOR_BLUE
 COLOR_RESET=$'\e[0m'
 readonly COLOR_RESET
@@ -187,13 +191,34 @@ install_mysql_client() {
     apt-get clean && rm -rf /var/lib/apt/lists/*
 }
 
-if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
-    # disable MYSQL for ARM64
-    INSTALL_MYSQL_CLIENT="false"
-fi
+install_mariadb_client() {
+    if [[ "${1}" == "dev" ]]; then
+        packages=("libmariadb-dev" "mariadb-client-core-${MARIADB_VERSION}")
+    elif [[ "${1}" == "prod" ]]; then
+        packages=("mariadb-client-core-${MARIADB_VERSION}")
+    else
+        echo
+        echo "Specify either prod or dev"
+        echo
+        exit 1
+    fi
+
+    echo
+    echo "${COLOR_BLUE}Installing MariaDB client version ${MARIADB_VERSION}: ${1}${COLOR_RESET}"
+    echo "${COLOR_YELLOW}MariaDB client binary compatible with MySQL client.${COLOR_RESET}"
+    echo
+    apt-get update
+    apt-get install --no-install-recommends -y "${packages[@]}"
+    apt-get autoremove -yqq --purge
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+}
 
 if [[ ${INSTALL_MYSQL_CLIENT:="true"} == "true" ]]; then
-    install_mysql_client "${@}"
+    if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
+        install_mariadb_client "${@}"
+    else
+        install_mysql_client "${@}"
+    fi
 fi
 EOF
 
@@ -637,7 +662,7 @@ If it does not complete soon, you might want to stop it and remove file lock:
 if [[ ${SKIP_ENVIRONMENT_INITIALIZATION=} != "true" ]]; then
 
     if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
-        if [[ ${BACKEND:=} == "mysql" || ${BACKEND} == "mssql" ]]; then
+        if [[ ${BACKEND} == "mssql" ]]; then
             echo "${COLOR_RED}ARM platform is not supported for ${BACKEND} backend. Exiting.${COLOR_RESET}"
             exit 1
         fi

--- a/airflow/providers/mysql/provider.yaml
+++ b/airflow/providers/mysql/provider.yaml
@@ -45,8 +45,8 @@ versions:
 dependencies:
   - apache-airflow>=2.3.0
   - apache-airflow-providers-common-sql>=1.3.1
-  - mysql-connector-python>=8.0.11; platform_machine != "aarch64"
-  - mysqlclient>=1.3.6; platform_machine != "aarch64"
+  - mysql-connector-python>=8.0.11
+  - mysqlclient>=1.3.6
 
 integrations:
   - integration-name: MySQL

--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -554,8 +554,14 @@ def enter_shell(**kwargs) -> RunCommandResult:
         cmd.extend(["-c", cmd_added])
     if "arm64" in DOCKER_DEFAULT_PLATFORM:
         if shell_params.backend == "mysql":
-            get_console().print("\n[error]MySQL is not supported on ARM architecture.[/]\n")
-            sys.exit(1)
+            if shell_params.mysql_version == "8":
+                get_console().print("\n[warn]MySQL use MariaDB client binaries on ARM architecture.[/]\n")
+            else:
+                get_console().print(
+                    f"\n[error]Only MySQL 8.0 is supported on ARM architecture, "
+                    f"but got {shell_params.mysql_version}[/]\n"
+                )
+                sys.exit(1)
         if shell_params.backend == "mssql":
             get_console().print("\n[error]MSSQL is not supported on ARM architecture[/]\n")
             sys.exit(1)

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -513,8 +513,8 @@
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
-      "mysql-connector-python>=8.0.11; platform_machine != \"aarch64\"",
-      "mysqlclient>=1.3.6; platform_machine != \"aarch64\""
+      "mysql-connector-python>=8.0.11",
+      "mysqlclient>=1.3.6"
     ],
     "cross-providers-deps": [
       "amazon",

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -86,7 +86,7 @@ If it does not complete soon, you might want to stop it and remove file lock:
 if [[ ${SKIP_ENVIRONMENT_INITIALIZATION=} != "true" ]]; then
 
     if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
-        if [[ ${BACKEND} == "mssql" ]]; then
+        if [[ ${BACKEND:=} == "mssql" ]]; then
             echo "${COLOR_RED}ARM platform is not supported for ${BACKEND} backend. Exiting.${COLOR_RESET}"
             exit 1
         fi

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -86,7 +86,7 @@ If it does not complete soon, you might want to stop it and remove file lock:
 if [[ ${SKIP_ENVIRONMENT_INITIALIZATION=} != "true" ]]; then
 
     if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
-        if [[ ${BACKEND:=} == "mysql" || ${BACKEND} == "mssql" ]]; then
+        if [[ ${BACKEND} == "mssql" ]]; then
             echo "${COLOR_RED}ARM platform is not supported for ${BACKEND} backend. Exiting.${COLOR_RESET}"
             exit 1
         fi

--- a/scripts/docker/install_mysql.sh
+++ b/scripts/docker/install_mysql.sh
@@ -26,7 +26,7 @@ readonly MARIADB_VERSION
 COLOR_BLUE=$'\e[34m'
 readonly COLOR_BLUE
 COLOR_YELLOW=$'\e[1;33m'
-readonly COLOR_BLUE
+readonly COLOR_YELLOW
 COLOR_RESET=$'\e[0m'
 readonly COLOR_RESET
 

--- a/scripts/docker/install_mysql.sh
+++ b/scripts/docker/install_mysql.sh
@@ -20,8 +20,12 @@ declare -a packages
 
 MYSQL_VERSION="8.0"
 readonly MYSQL_VERSION
+MARIADB_VERSION="10.5"
+readonly MARIADB_VERSION
 
 COLOR_BLUE=$'\e[34m'
+readonly COLOR_BLUE
+COLOR_YELLOW=$'\e[1;33m'
 readonly COLOR_BLUE
 COLOR_RESET=$'\e[0m'
 readonly COLOR_RESET
@@ -67,13 +71,36 @@ install_mysql_client() {
     apt-get clean && rm -rf /var/lib/apt/lists/*
 }
 
-if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
-    # disable MYSQL for ARM64
-    INSTALL_MYSQL_CLIENT="false"
-fi
+install_mariadb_client() {
+    if [[ "${1}" == "dev" ]]; then
+        packages=("libmariadb-dev" "mariadb-client-core-${MARIADB_VERSION}")
+    elif [[ "${1}" == "prod" ]]; then
+        packages=("mariadb-client-core-${MARIADB_VERSION}")
+    else
+        echo
+        echo "Specify either prod or dev"
+        echo
+        exit 1
+    fi
 
-# Install MySQL client from Oracle repositories (Debian installs mariadb)
-# But only if it is not disabled
+    echo
+    echo "${COLOR_BLUE}Installing MariaDB client version ${MARIADB_VERSION}: ${1}${COLOR_RESET}"
+    echo "${COLOR_YELLOW}MariaDB client binary compatible with MySQL client.${COLOR_RESET}"
+    echo
+    apt-get update
+    apt-get install --no-install-recommends -y "${packages[@]}"
+    apt-get autoremove -yqq --purge
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+}
+
+# Install MySQL client only if it is not disabled.
+# For amd64 (x86_64) install MySQL client from Oracle repositories.
+# For arm64 install MariaDB client from Debian repository, see:
+# https://mariadb.com/kb/en/mariadb-clientserver-tcp-protocol/
 if [[ ${INSTALL_MYSQL_CLIENT:="true"} == "true" ]]; then
-    install_mysql_client "${@}"
+    if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
+        install_mariadb_client "${@}"
+    else
+        install_mysql_client "${@}"
+    fi
 fi

--- a/scripts/in_container/run_provider_yaml_files_check.py
+++ b/scripts/in_container/run_provider_yaml_files_check.py
@@ -164,13 +164,6 @@ def check_if_object_exist(object_name: str, resource_type: str, yaml_file_path: 
         else:
             raise RuntimeError(f"Wrong enum {object_type}???")
     except Exception as e:
-        if architecture == Architecture.ARM:
-            if "MySQLdb" in str(e):
-                console.print(
-                    f"[yellow]The imports fail on ARM: {object_name} in {resource_type} {e}, "
-                    f"but it is expected.[/]"
-                )
-                return
         errors.append(
             f"The `{object_name}` object in {resource_type} list in {yaml_file_path} does not exist "
             f"or is not a class: {e}"


### PR DESCRIPTION
According to https://mariadb.com/kb/en/mariadb-clientserver-tcp-protocol/ MariaDB client use the same protocol as use MySQL.

This PoC use binaries which included in standard Debian repository only for ARM64 images, AMD64/x86_64 still use Oracle MySQL repository, see [all supported options](https://www.mysql.com/support/supportedplatforms/database.html)

Airflow starts almost fine in breeze with MySQL 8.0 backend, except:
- There is not native ARM image for 5.7, so disable it in breeze. Yeah it is still an option with emulation AMD64, but personally I do not think it is make sense to add support for something which almost EOL.
- I have a DAG with start date in 1900, due to the fact we use TIMESTAMP for MySQL as result there is no possible to run DAG with start date lower than 1970-01-01. It is probably something new for me, rather than actual problem.

Some additionals:
- Potentially I could miss some part which also need to be changed.
- This PR create "chicken or egg" problem, users can't install provider in old Airflow Image without extend/build own image with MariaDB client as well as need install python packages manually if use old provider.
- **This changes do not add support MariaDB as backend**