### PR TITLE
Fix import cycle starting from airflow/__main__.py

### DIFF
--- a/airflow/__main__.py
+++ b/airflow/__main__.py
@@ -24,12 +24,21 @@ import os
 
 import argcomplete
 
+# The configuration module initializes and validates the conf object as a side effect the first
+# time it is imported. If it is not imported before importing the settings module, the conf
+# object will then be initted/validated as a side effect of it being imported in settings,
+# however this can cause issues since those modules are very tightly coupled and can
+# very easily cause import cycles in the conf init/validate code (since downstream code from
+# those functions likely import settings).
+# Therefore importing configuration early (as the first airflow import) avoids
+# any possible import cycles with settings downstream.
+from airflow import configuration
 from airflow.cli import cli_parser
-from airflow.configuration import conf
 
 
 def main():
     """Main executable function."""
+    conf = configuration.conf
     if conf.get("core", "security") == "kerberos":
         os.environ["KRB5CCNAME"] = conf.get("kerberos", "ccache")
         os.environ["KRB5_KTNAME"] = conf.get("kerberos", "keytab")


### PR DESCRIPTION
###  Please see see #29257 for more details (it is a similar fix for `__init__.py`), as it has a fuller explanation for how this fix works
This is a fix related to #29494, this fix stops the cycle at the source by importing configuration first before anything else so that the `conf` object can be built and validated outside the scope of `airflow.settings`.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
