### PR TITLE
Make providing a reproducible case required in bug templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/airflow_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_bug_report.yml
@@ -58,6 +58,8 @@ body:
         as minimally and precisely as possible. Keep in mind we do not have access to your cluster or DAGs.
         Remember that non-reproducible issues will be closed! Opening a discussion is recommended as a
         first step.
+    validations:
+      required: true
   - type: input
     attributes:
       label: Operating System

--- a/.github/ISSUE_TEMPLATE/airflow_helmchart_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_helmchart_bug_report.yml
@@ -96,6 +96,8 @@ body:
         as minimally and precisely as possible. Keep in mind we do not have access to your cluster or DAGs.
         Remember that non-reproducible issues will be closed! Opening a discussion is recommended as a
         first step.
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Anything else

--- a/.github/ISSUE_TEMPLATE/airflow_providers_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_providers_bug_report.yml
@@ -175,6 +175,8 @@ body:
         as minimally and precisely as possible. Keep in mind we do not have access to your cluster or
         DAGs. Remember that non-reproducible issues will be closed! Opening a discussion is
         recommended as a first step.
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Anything else


### PR DESCRIPTION
There have been many occurrences in which the first response from a maintainer to a newly-opened bug report is something to the effect of "can you provide a DAG, code, some reproducible details for this please?". Enforcing this detail in the issue templates would stave off this initial delay in diving into an issue. Even if the issue _might_ be self-explanatory, more details are better than less/none when trying to review, triage, and fix bugs. Adding a reproducible case also helps when looking back at an issue, if needed, to get a sense of what scenario could yield the bug initially.
