### PR TITLE
Migrate DagWarning.purge_inactive_dag_warnings and DagModel.deactivate_deleted_dags to Internal API

### DIFF
--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -26,6 +26,7 @@ from flask import Response
 
 from airflow.api_connexion.types import APIResponse
 from airflow.models import Variable, XCom
+from airflow.models.dagwarning import DagWarning
 from airflow.serialization.serialized_objects import BaseSerialization
 
 log = logging.getLogger(__name__)
@@ -41,8 +42,10 @@ def _initialize_map() -> dict[str, Callable]:
         DagFileProcessor.update_import_errors,
         DagFileProcessor.manage_slas,
         DagFileProcessorManager.deactivate_stale_dags,
+        DagModel.deactivate_deleted_dags,
         DagModel.get_paused_dag_ids,
         DagFileProcessorManager.clear_nonexistent_import_errors,
+        DagWarning.purge_inactive_dag_warnings,
         XCom.get_value,
         XCom.get_one,
         XCom.get_many,

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -3329,6 +3329,7 @@ class DagModel(Base):
         session.commit()
 
     @classmethod
+    @internal_api_call
     @provide_session
     def deactivate_deleted_dags(cls, alive_dag_filelocs: list[str], session=NEW_SESSION):
         """

--- a/airflow/models/dagwarning.py
+++ b/airflow/models/dagwarning.py
@@ -22,6 +22,7 @@ from enum import Enum
 from sqlalchemy import Column, ForeignKeyConstraint, String, Text, false
 from sqlalchemy.orm import Session
 
+from airflow.api_internal.internal_api_call import internal_api_call
 from airflow.models.base import Base, StringID
 from airflow.utils import timezone
 from airflow.utils.retries import retry_db_transaction
@@ -66,6 +67,7 @@ class DagWarning(Base):
         return hash((self.dag_id, self.warning_type))
 
     @classmethod
+    @internal_api_call
     @provide_session
     def purge_inactive_dag_warnings(cls, session: Session = NEW_SESSION) -> None:
         """


### PR DESCRIPTION
These methods are used in dag processign:
https://github.com/mhenc/airflow/blob/master/airflow/dag_processing/manager.py#L771
https://github.com/mhenc/airflow/blob/master/airflow/dag_processing/manager.py#L613

closes: #29532 #29533