### PR TITLE
Fix the missing pytest fixture aioresponse for non_existent_endpoint

### DIFF
--- a/tests/providers/http/hooks/test_http.py
+++ b/tests/providers/http/hooks/test_http.py
@@ -428,6 +428,7 @@ async def test_do_api_call_async_retryable_error(caplog, aioresponse):
     """Test api call asynchronously with retryable error."""
     caplog.set_level(logging.WARNING, logger="airflow.providers.http.hooks.http")
     hook = HttpAsyncHook(method="GET")
+    aioresponse.get("http://httpbin.org/non_existent_endpoint", status=500, repeat=True)
 
     with pytest.raises(AirflowException) as exc, mock.patch.dict(
         "os.environ",


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
It looks like `test_do_api_call_async_retryable_error` at tests/providers/http/hooks/test_http.py:436 was committed with a failing test. The test is missing a non-existent endpoint for `aioresponse` pytest fixture

This PR is related to previous PR https://github.com/apache/airflow/pull/29038
cc: @syun64

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
