### PR TITLE
Remove section check from get-value command

### DIFF
--- a/airflow/cli/commands/config_command.py
+++ b/airflow/cli/commands/config_command.py
@@ -38,10 +38,6 @@ def show_config(args):
 
 
 def get_value(args):
-    """Get one value from configuration."""
-    if not conf.has_section(args.section):
-        raise SystemExit(f"The section [{args.section}] is not found in config.")
-
     if not conf.has_option(args.section, args.option):
         raise SystemExit(f"The option [{args.section}/{args.option}] is not found in config.")
 

--- a/airflow/cli/commands/config_command.py
+++ b/airflow/cli/commands/config_command.py
@@ -38,6 +38,7 @@ def show_config(args):
 
 
 def get_value(args):
+    """Get one value from configuration."""
     if not conf.has_option(args.section, args.option):
         raise SystemExit(f"The option [{args.section}/{args.option}] is not found in config.")
 

--- a/tests/cli/commands/test_config_command.py
+++ b/tests/cli/commands/test_config_command.py
@@ -71,15 +71,15 @@ class TestCliConfigGetValue:
         assert "test_value" == temp_stdout.getvalue().strip()
 
     @mock.patch("airflow.cli.commands.config_command.conf")
-    def test_should_raise_exception_when_section_is_missing(self, mock_conf):
+    def test_should_not_raise_exception_when_section_for_config_with_value_defined_elsewhere_is_missing(
+        self, mock_conf
+    ):
+        # no section in config
         mock_conf.has_section.return_value = False
+        # pretend that the option is defined by other means
         mock_conf.has_option.return_value = True
 
-        with pytest.raises(SystemExit) as ctx:
-            config_command.get_value(
-                self.parser.parse_args(["config", "get-value", "missing-section", "dags_folder"])
-            )
-        assert "The section [missing-section] is not found in config." == str(ctx.value)
+        config_command.get_value(self.parser.parse_args(["config", "get-value", "some_section", "value"]))
 
     @mock.patch("airflow.cli.commands.config_command.conf")
     def test_should_raise_exception_when_option_is_missing(self, mock_conf):


### PR DESCRIPTION
The section check is not really needed and harmful. There should be no problems if sections are missing from the configuration file.

Running this check might lead to a problem that if someone stripds down the config file to bare minimum and moves the crucial configuration to env variables the 'get-value' command might fail, even if the configuration is perfectly sound for Airflow.

Fixes: #29537

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
