### PR TITLE
detect if 'docker-compose' existing

### DIFF
--- a/docs/apache-airflow/howto/docker-compose/airflow.sh
+++ b/docs/apache-airflow/howto/docker-compose/airflow.sh
@@ -24,9 +24,16 @@ PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 set -euo pipefail
 
+# check is there a docker-compose command, if not, use "docker compose" instead.
+if [ -x "$(command -v docker-compose)" ]; then
+    dc=docker-compose
+else
+    dc="docker compose"
+fi
+
 export COMPOSE_FILE="${PROJECT_DIR}/docker-compose.yaml"
 if [ $# -gt 0 ]; then
-    exec docker-compose run --rm airflow-cli "${@}"
+    exec $dc run --rm airflow-cli "${@}"
 else
-    exec docker-compose run --rm airflow-cli
+    exec $dc run --rm airflow-cli
 fi


### PR DESCRIPTION
use "docker compose" instead of "docker-compose" if the latter doesn't there.

related: #29542 