### PR TITLE
Don't display empty rendered attrs in Task Instance Details page

### DIFF
--- a/airflow/www/templates/airflow/task.html
+++ b/airflow/www/templates/airflow/task.html
@@ -40,8 +40,10 @@
   </table>
   <div>
     {% for attr, value in special_attrs_rendered.items() %}
-      <h5>Attribute: {{ attr }}</h5>
-      {{ value }}
+      {% if value %}
+        <h5>Attribute: {{ attr }}</h5>
+        {{ value }}
+      {% endif %}
     {% endfor %}
     {% if ti_attrs is none %}
       <h5>No Task Instance Available</h5>


### PR DESCRIPTION
Closes: #29515

The Task Instance Details page was displaying attributes which did not have a value. Mainly these were the docs attributes (i.e. `doc`, `doc_json`, `doc_md`, `doc_rst`, and `doc_yaml`). This clutters the page with less useful information for the task instance.

This PR changes the attributes displayed on the page only if they have non-emptyvalues generally.

**Current Task Instance Details with no doc attribute provided**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/48934154/218872133-c4c57c1b-ae96-4914-bbdb-691fbb029880.png">

**New Task Instance Details with no doc or other special rendered attributes**
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/48934154/218871741-db43f3dd-b43f-4aed-8194-c0f74c04fe09.png">

**Current Task Instance Details with `bash_command` and only `doc_md` provided**
There are other special-rendered like `sql` and `hql` but let's use a `BashOperator` as an example.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/48934154/218872490-474aea51-4f79-4d9e-b11e-68682d307c64.png">


**New Task Instance Details with `bash_command` and only `doc_md` provided**
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/48934154/218872364-4e58a754-9687-488c-85ae-e787ad215999.png">


