### PR TITLE
Add `EC2CreateInstanceOperator`, `EC2TerminateInstanceOperator`

### DIFF
--- a/airflow/providers/amazon/aws/operators/ec2.py
+++ b/airflow/providers/amazon/aws/operators/ec2.py
@@ -218,11 +218,11 @@ class EC2TerminateInstanceOperator(BaseOperator):
         in the `terminated` state before returning.
     """
 
-    template_fields: Sequence[str] = ("instance_id", "region_name", "aws_conn_id", "wait_for_completion")
+    template_fields: Sequence[str] = ("instance_ids", "region_name", "aws_conn_id", "wait_for_completion")
 
     def __init__(
         self,
-        instance_id: str | list[str],
+        instance_ids: str | list[str],
         aws_conn_id: str = "aws_default",
         region_name: str | None = None,
         poll_interval: int = 20,
@@ -231,7 +231,7 @@ class EC2TerminateInstanceOperator(BaseOperator):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.instance_ids = [*instance_id]
+        self.instance_ids = instance_ids
         self.aws_conn_id = aws_conn_id
         self.region_name = region_name
         self.poll_interval = poll_interval
@@ -239,6 +239,8 @@ class EC2TerminateInstanceOperator(BaseOperator):
         self.wait_for_completion = wait_for_completion
 
     def execute(self, context: Context):
+        if isinstance(self.instance_ids, str):
+            self.instance_ids = [self.instance_ids]
         ec2_hook = EC2Hook(aws_conn_id=self.aws_conn_id, region_name=self.region_name, api_type="client_type")
         ec2_hook.conn.terminate_instances(InstanceIds=self.instance_ids)
 

--- a/airflow/providers/amazon/aws/operators/ec2.py
+++ b/airflow/providers/amazon/aws/operators/ec2.py
@@ -120,7 +120,7 @@ class EC2StopInstanceOperator(BaseOperator):
 
 class EC2CreateInstanceOperator(BaseOperator):
     """
-    Create and start an EC2 Instance using boto3
+    Create and start a specified number of EC2 Instances using boto3
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
@@ -201,7 +201,7 @@ class EC2CreateInstanceOperator(BaseOperator):
 
 class EC2TerminateInstanceOperator(BaseOperator):
     """
-    Terminate an EC2 Instance using boto3
+    Terminate EC2 Instances using boto3
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:

--- a/airflow/providers/amazon/aws/operators/ec2.py
+++ b/airflow/providers/amazon/aws/operators/ec2.py
@@ -116,3 +116,116 @@ class EC2StopInstanceOperator(BaseOperator):
             target_state="stopped",
             check_interval=self.check_interval,
         )
+
+
+class EC2CreateInstanceOperator(BaseOperator):
+    """
+    Create and start an EC2 Instance using boto3
+
+    :param image_id: ID of the AMI used to create the instance.
+    :param max_count: Maximum number of instances to launch. Defaults to 1.
+    :param min_count: Minimum number of instances to launch. Defaults to 1.
+    :param aws_conn_id: AWS connection to use
+    :param region_name: AWS region name associated with the client.
+    :param poll_interval: Number of seconds to wait before attempting to
+        check state of instance. Only used if wait_for_completion is True. Default is 20.
+    :param max_attempts: Maximum number of attempts when checking state of instance.
+        Only used if wait_for_completion is True. Default is 20.
+    :param config: Dictionary for arbitrary parameters to the boto3 run_instances call.
+    :param wait_for_completion: If True, the operator will wait for the instance to be
+        in the `running` state before returning.
+    """
+
+    template_fields: Sequence[str] = ("image_id", "region_name", "config")
+
+    def __init__(
+        self,
+        image_id: str,
+        max_count: int = 1,
+        min_count: int = 1,
+        aws_conn_id: str = "aws_default",
+        region_name: str | None = None,
+        poll_interval: int = 20,
+        max_attempts: int = 20,
+        config: dict | None = None,
+        wait_for_completion: bool = False,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.image_id = image_id
+        self.max_count = max_count
+        self.min_count = min_count
+        self.aws_conn_id = aws_conn_id
+        self.region_name = region_name
+        self.poll_interval = poll_interval
+        self.max_attempts = max_attempts
+        self.config = config or {}
+        self.wait_for_completion = wait_for_completion
+
+    def execute(self, context: Context):
+        ec2_hook = EC2Hook(aws_conn_id=self.aws_conn_id, region_name=self.region_name, api_type="client_type")
+        instance_id = ec2_hook.conn.run_instances(
+            ImageId=self.image_id,
+            MinCount=self.min_count,
+            MaxCount=self.max_count,
+            **self.config,
+        )["Instances"][0]["InstanceId"]
+        self.log.info("Created EC2 instance %s", instance_id)
+        if self.wait_for_completion:
+            ec2_hook.get_waiter("instance_running").wait(
+                InstanceIds=[instance_id],
+                WaiterConfig={
+                    "Delay": self.poll_interval,
+                    "MaxAttempts": self.max_attempts,
+                },
+            )
+
+        return instance_id
+
+
+class EC2TerminateInstanceOperator(BaseOperator):
+    """
+    Terminate an EC2 Instance using boto3
+
+    :instance_id: ID of the instance to be terminated.
+    :param aws_conn_id: AWS connection to use
+    :param region_name: AWS region name associated with the client.
+    :param poll_interval: Number of seconds to wait before attempting to
+        check state of instance. Only used if wait_for_completion is True. Default is 20.
+    :param max_attempts: Maximum number of attempts when checking state of instance.
+        Only used if wait_for_completion is True. Default is 20.
+    """
+
+    template_fields: Sequence[str] = ("instance_id", "region_name")
+
+    def __init__(
+        self,
+        instance_id: str,
+        aws_conn_id: str = "aws_default",
+        region_name: str | None = None,
+        poll_interval: int = 20,
+        max_attempts: int = 20,
+        wait_for_completion: bool = False,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.instance_id = instance_id
+        self.aws_conn_id = aws_conn_id
+        self.region_name = region_name
+        self.poll_interval = poll_interval
+        self.max_attempts = max_attempts
+        self.wait_for_completion = wait_for_completion
+
+    def execute(self, context: Context):
+        ec2_hook = EC2Hook(aws_conn_id=self.aws_conn_id, region_name=self.region_name, api_type="client_type")
+        ec2_hook.conn.terminate_instances(InstanceIds=[self.instance_id])
+
+        self.log.info("Terminating EC2 instance %s", self.instance_id)
+        if self.wait_for_completion:
+            ec2_hook.get_waiter("instance_terminated").wait(
+                InstanceIds=[self.instance_id],
+                WaiterConfig={
+                    "Delay": self.poll_interval,
+                    "MaxAttempts": self.max_attempts,
+                },
+            )

--- a/airflow/providers/amazon/aws/operators/ec2.py
+++ b/airflow/providers/amazon/aws/operators/ec2.py
@@ -207,7 +207,7 @@ class EC2TerminateInstanceOperator(BaseOperator):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:EC2TerminateInstanceOperator`
 
-    :instance_id: ID of the instance to be terminated.
+    :param instance_id: ID of the instance to be terminated.
     :param aws_conn_id: AWS connection to use
     :param region_name: AWS region name associated with the client.
     :param poll_interval: Number of seconds to wait before attempting to

--- a/docs/apache-airflow-providers-amazon/operators/ec2.rst
+++ b/docs/apache-airflow-providers-amazon/operators/ec2.rst
@@ -85,6 +85,7 @@ To terminate an Amazon EC2 instance you can use
     :dedent: 4
     :start-after: [START howto_operator_ec2_terminate_instance]
     :end-before: [END howto_operator_ec2_terminate_instance]
+
 Sensors
 -------
 

--- a/docs/apache-airflow-providers-amazon/operators/ec2.rst
+++ b/docs/apache-airflow-providers-amazon/operators/ec2.rst
@@ -58,6 +58,7 @@ To stop an Amazon EC2 instance you can use
     :start-after: [START howto_operator_ec2_stop_instance]
     :end-before: [END howto_operator_ec2_stop_instance]
 
+.. _howto/operator:EC2CreateInstanceOperator:
 
 Create and start an Amazon EC2 instance
 =======================================
@@ -71,6 +72,7 @@ To create and start an Amazon EC2 instance you can use
     :start-after: [START howto_operator_ec2_create_instance]
     :end-before: [END howto_operator_ec2_create_instance]
 
+.. _howto/operator:EC2TerminateInstanceOperator:
 
 Terminate an Amazon EC2 instance
 ================================

--- a/docs/apache-airflow-providers-amazon/operators/ec2.rst
+++ b/docs/apache-airflow-providers-amazon/operators/ec2.rst
@@ -58,6 +58,31 @@ To stop an Amazon EC2 instance you can use
     :start-after: [START howto_operator_ec2_stop_instance]
     :end-before: [END howto_operator_ec2_stop_instance]
 
+
+Create and start an Amazon EC2 instance
+=======================================
+
+To create and start an Amazon EC2 instance you can use
+:class:`~airflow.providers.amazon.aws.operators.ec2.EC2CreateInstanceOperator`.
+
+.. exampleinclude:: /../../tests/system/providers/amazon/aws/example_ec2.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_ec2_create_instance]
+    :end-before: [END howto_operator_ec2_create_instance]
+
+
+Terminate an Amazon EC2 instance
+================================
+
+To terminate an Amazon EC2 instance you can use
+:class:`~airflow.providers.amazon.aws.operators.ec2.EC2TerminateInstanceOperator`.
+
+.. exampleinclude:: /../../tests/system/providers/amazon/aws/example_ec2.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_ec2_terminate_instance]
+    :end-before: [END howto_operator_ec2_terminate_instance]
 Sensors
 -------
 

--- a/tests/providers/amazon/aws/operators/test_ec2.py
+++ b/tests/providers/amazon/aws/operators/test_ec2.py
@@ -37,10 +37,11 @@ class BaseEc2TestClass:
             ec2_client = conn.meta.client
         except AttributeError:
             ec2_client = conn
-        
+
         # We need an existing AMI Image ID otherwise `moto` will raise DeprecationWarning.
         images = ec2_client.describe_images()["Images"]
         return images[0]["ImageId"]
+
 
 class TestEC2CreateInstanceOperator(BaseEc2TestClass):
     def test_init(self):
@@ -65,14 +66,14 @@ class TestEC2CreateInstanceOperator(BaseEc2TestClass):
         )
         instance_id = create_instance.execute(None)
 
-        assert ec2_hook.get_instance_state(instance_id=instance_id) == "running"
+        assert ec2_hook.get_instance_state(instance_id=instance_id[0]) == "running"
 
 
 class TestEC2TerminateInstanceOperator(BaseEc2TestClass):
     def test_init(self):
         ec2_operator = EC2TerminateInstanceOperator(
             task_id="test_terminate_instance",
-            instance_id="test_image_id",
+            instance_ids="test_image_id",
         )
 
         assert ec2_operator.task_id == "test_terminate_instance"
@@ -89,14 +90,14 @@ class TestEC2TerminateInstanceOperator(BaseEc2TestClass):
         )
         instance_id = create_instance.execute(None)
 
-        assert ec2_hook.get_instance_state(instance_id=instance_id) == "running"
+        assert ec2_hook.get_instance_state(instance_id=instance_id[0]) == "running"
 
         terminate_instance = EC2TerminateInstanceOperator(
-            task_id="test_terminate_instance", instance_id=instance_id
+            task_id="test_terminate_instance", instance_ids=instance_id
         )
         terminate_instance.execute(None)
 
-        assert ec2_hook.get_instance_state(instance_id=instance_id) == "terminated"
+        assert ec2_hook.get_instance_state(instance_id=instance_id[0]) == "terminated"
 
 
 class TestEC2StartInstanceOperator(BaseEc2TestClass):
@@ -127,11 +128,11 @@ class TestEC2StartInstanceOperator(BaseEc2TestClass):
         # start instance
         start_test = EC2StartInstanceOperator(
             task_id="start_test",
-            instance_id=instance_id,
+            instance_id=instance_id[0],
         )
         start_test.execute(None)
         # assert instance state is running
-        assert ec2_hook.get_instance_state(instance_id=instance_id) == "running"
+        assert ec2_hook.get_instance_state(instance_id=instance_id[0]) == "running"
 
 
 class TestEC2StopInstanceOperator(BaseEc2TestClass):
@@ -162,9 +163,8 @@ class TestEC2StopInstanceOperator(BaseEc2TestClass):
         # stop instance
         stop_test = EC2StopInstanceOperator(
             task_id="stop_test",
-            instance_id=instance_id,
+            instance_id=instance_id[0],
         )
         stop_test.execute(None)
         # assert instance state is running
-        assert ec2_hook.get_instance_state(instance_id=instance_id) == "stopped"
-
+        assert ec2_hook.get_instance_state(instance_id=instance_id[0]) == "stopped"

--- a/tests/system/providers/amazon/aws/example_ec2.py
+++ b/tests/system/providers/amazon/aws/example_ec2.py
@@ -39,7 +39,8 @@ DAG_ID = "example_ec2"
 sys_test_context_task = SystemTestContextBuilder().build()
 
 
-def _get_latest_ami_id():
+@task
+def get_latest_ami_id():
     """Returns the AMI ID of the most recently-created Amazon Linux image"""
 
     # Amazon is retiring AL2 in 2023 and replacing it with Amazon Linux 2022.
@@ -88,7 +89,7 @@ with DAG(
     env_id = test_context[ENV_ID_KEY]
     instance_name = f"{env_id}-instance"
     key_name = create_key_pair(key_name=f"{env_id}_key_pair")
-    image_id = _get_latest_ami_id()
+    image_id = get_latest_ami_id()
 
     config = {
         "InstanceType": "t2.micro",
@@ -150,6 +151,7 @@ with DAG(
         # TEST SETUP
         test_context,
         key_name,
+        image_id,
         # TEST BODY
         create_instance,
         instance_id,


### PR DESCRIPTION
This PR creates two new operators `EC2CreateInstanceOperator` and `EC2TerminateInstanceOperator` which will be used to create and terminate EC2 instances respectively. The system test has been updated to use the new operators.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
