### PR TITLE
Update issue triage policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/airflow_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_bug_report.yml
@@ -1,7 +1,7 @@
 ---
 name: Airflow Bug report
 description: Problems and issues with code in Apache Airflow core
-labels: ["kind:bug", "area:core"]
+labels: ["kind:bug", "area:core", "needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/airflow_doc_issue_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_doc_issue_report.yml
@@ -1,7 +1,7 @@
 ---
 name: Airflow Doc issue report
 description: Problems and issues with Apache Airflow documentation
-labels: ["kind:bug", "kind:documentation"]
+labels: ["kind:bug", "kind:documentation", "needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/airflow_helmchart_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_helmchart_bug_report.yml
@@ -1,7 +1,7 @@
 ---
 name: Airflow Helm Chart Bug report
 description: Problems and issues with the Apache Airflow Official Helm Chart
-labels: ["kind:bug", "area:helm-chart"]
+labels: ["kind:bug", "area:helm-chart", "needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/airflow_providers_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_providers_bug_report.yml
@@ -1,7 +1,7 @@
 ---
 name: Airflow Providers Bug report
 description: Problems and issues with code in Apache Airflow Providers
-labels: ["kind:bug", "area:providers"]
+labels: ["kind:bug", "area:providers", "needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 ---
 name: Airflow feature request
 description: Suggest an idea for this project
-labels: ["kind:feature"]
+labels: ["kind:feature", "needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -47,3 +47,22 @@ jobs:
             activity occurs from the issue author.
           close-issue-message: >
             This issue has been closed because it has not received response from the issue author.
+  recheck-old-bug-report:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/stale@v7
+        with:
+          only-issue-labels: 'kind:bug'
+          stale-issue-label: 'Stale Bug Report'
+          days-before-issue-stale: 365
+          days-before-issue-close: 30
+          remove-stale-when-updated: true
+          labels-to-add-when-unstale: 'needs-triage'
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has been open for 365 days
+            without any activity. There has been several Airflow releases since last activity on this issue.
+            Kindly asking to recheck the report against latest Airflow version and let us know
+            if the issue is reproducible. The issue will be closed in next 30 days if no further activity
+            occurs from the issue author.
+          close-issue-message: >
+            This issue has been closed because it has not received response from the issue author.

--- a/ISSUE_TRIAGE_PROCESS.rst
+++ b/ISSUE_TRIAGE_PROCESS.rst
@@ -251,9 +251,14 @@ the label ``pending-response``.
 Also, during this stage, additional labels may be added to the issue to help
 classification and triage, such as ``affected_version`` and ``area``.
 
-Some issues may need a detailed review by one of the core committers of the project
-and this could be tagged with a ``needs:triage`` label.
-
+New issues are automatically assigned with ``needs-triage`` label. This labels goal
+is to help us detect issues that are waiting for initial triage. The label will be removed by the triager
+once the issue is accepted (and assigned with relevant kind and area labels). This sometimes can take a while as we might
+ask for other members of the community for consultation or ask for further information from the issue author.
+Removing the ``needs-triage`` label means that the issue has been accepted and awaits implementation (no further triage action required),
+as long as the ``needs-triage`` label remains the triage team will keep an eye on the issue and check periodically
+if it needs to be accepted or closed/converted to Github Discussion.
+``needs-triage`` label may also be applied manually by committers if they think a further action from the triage team is required.
 
 **Good First Issue**
 
@@ -307,3 +312,14 @@ we normally convert such issues to discussions in the Ideas category.
 Issues that seems more like support requests are also converted to discussions in the Q&A category.
 We use judgment about which Issues to convert to discussions, it's best to always clarify with a comment why the issue is being converted.
 Note that we can always convert discussions back to issues.
+
+
+**Stale Policy **
+
+As time passes bug reports that have been accepted may be out dated.
+Bot will scan older bug reports and if the report is inactive it will comment
+and ask the author to recheck if the bug is still reproducible on latest version.
+If the issue is reconfirmed triage team will check if labels needs to be updated (for example: ``reported_version`` label)
+If no one respond after some time, we will consider the issue as resolved (may have already been fixed) and bot will resolve the issue.
+The exact timeframes for each one of the actions is subject to change from time to time.
+The updated values can be checked in ``.github/workflow`` where we define the bots policy.


### PR DESCRIPTION
Following mailing list thread [[Discussion] Set further policies for triaging issues](https://lists.apache.org/thread/k8sv9cgqjzsgqm7x0h3ysmkkcq4m1owq) as we agreed on the high level concept we can now discuss the details as review to this PR.

My proposal is as written in the policy doc as well as the implementation of the bot.
Please share your thoughts/concerns.



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
