### PR TITLE
Improve grid view height calculations

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -19,7 +19,7 @@
 
 body {
   position: relative;
-  padding: 70px 0 100px;
+  padding: 70px 0;
   min-height: 100vh;
   overflow-y: scroll;
   background-color: #fff;

--- a/airflow/www/static/js/dag/Main.tsx
+++ b/airflow/www/static/js/dag/Main.tsx
@@ -46,11 +46,13 @@ const minPanelWidth = 300;
 const gridWidthKey = 'grid-width';
 const saveWidth = debounce((w) => localStorage.setItem(gridWidthKey, w), hoverDelay);
 
+const footerHeight = parseInt(getComputedStyle(document.getElementsByTagName('body')[0]).paddingBottom.replace('px', ''), 10) || 0;
+const headerHeight = parseInt(getComputedStyle(document.getElementsByTagName('body')[0]).paddingTop.replace('px', ''), 10) || 0;
+
 const Main = () => {
   const { data: { groups }, isLoading } = useGridData();
   const resizeRef = useRef<HTMLDivElement>(null);
   const gridRef = useRef<HTMLDivElement>(null);
-  const detailsRef = useRef<HTMLDivElement>(null);
   const isPanelOpen = localStorage.getItem(detailsPanelKey) !== 'true';
   const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: isPanelOpen });
   const { clearSelection } = useSelection();
@@ -106,11 +108,18 @@ const Main = () => {
   }, [resize, isLoading, isOpen]);
 
   return (
-    <Box flex={1}>
+    <Box
+      flex={1}
+      height={`calc(100vh - ${footerHeight + headerHeight}px)`}
+      maxHeight={`calc(100vh - ${footerHeight + headerHeight}px)`}
+      minHeight="750px"
+      overflow="hidden"
+      position="relative"
+    >
       <FilterBar />
       <LegendRow onStatusHover={onStatusHover} onStatusLeave={onStatusLeave} />
       <Divider mb={5} borderBottomWidth={2} />
-      <Flex>
+      <Flex height="100%">
         {isLoading || isEmpty(groups)
           ? (<Spinner />)
           : (
@@ -143,7 +152,6 @@ const Main = () => {
                     zIndex={1}
                     bg="white"
                     height="100%"
-                    ref={detailsRef}
                   >
                     <Details />
                   </Box>

--- a/airflow/www/static/js/dag/details/Dag.tsx
+++ b/airflow/www/static/js/dag/details/Dag.tsx
@@ -33,7 +33,9 @@ import {
 import { mean } from 'lodash';
 
 import { getDuration, formatDuration } from 'src/datetime_utils';
-import { finalStatesMap, getMetaValue, getTaskSummary } from 'src/utils';
+import {
+  finalStatesMap, getMetaValue, getTaskSummary, useOffsetTop,
+} from 'src/utils';
 import { useGridData } from 'src/api';
 import Time from 'src/components/Time';
 import type { TaskState } from 'src/types';
@@ -45,6 +47,7 @@ const dagDetailsUrl = getMetaValue('dag_details_url');
 const Dag = () => {
   const { data: { dagRuns, groups } } = useGridData();
   const detailsRef = useRef<HTMLDivElement>(null);
+  const offsetTop = useOffsetTop(detailsRef);
 
   const taskSummary = getTaskSummary({ task: groups });
   const numMap = finalStatesMap();
@@ -93,6 +96,7 @@ const Dag = () => {
       </Button>
       <Box
         height="100%"
+        maxHeight={`calc(100% - ${offsetTop}px)`}
         ref={detailsRef}
         overflowY="auto"
       >

--- a/airflow/www/static/js/dag/details/dagRun/index.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/index.tsx
@@ -36,14 +36,13 @@ import { MdOutlineAccountTree } from 'react-icons/md';
 import ReactJson from 'react-json-view';
 
 import { useGridData } from 'src/api';
-import { appendSearchParams, getMetaValue } from 'src/utils';
+import { appendSearchParams, getMetaValue, useOffsetTop } from 'src/utils';
 import type { DagRun as DagRunType } from 'src/types';
 import { SimpleStatus } from 'src/dag/StatusBox';
 import { ClipboardText } from 'src/components/Clipboard';
 import { formatDuration, getDuration } from 'src/datetime_utils';
 import Time from 'src/components/Time';
 import RunTypeIcon from 'src/components/RunTypeIcon';
-
 import URLSearchParamsWrapper from 'src/utils/URLSearchParamWrapper';
 import NotesAccordion from 'src/dag/details/NotesAccordion';
 
@@ -63,6 +62,8 @@ interface Props {
 const DagRun = ({ runId }: Props) => {
   const { data: { dagRuns } } = useGridData();
   const detailsRef = useRef<HTMLDivElement>(null);
+  const offsetTop = useOffsetTop(detailsRef);
+
   const run = dagRuns.find((dr) => dr.runId === runId);
   const { onCopy, hasCopied } = useClipboard(run?.conf || '');
   if (!run) return null;
@@ -105,7 +106,7 @@ const DagRun = ({ runId }: Props) => {
         <Divider my={3} />
       </Box>
       <Box
-        height="100%"
+        maxHeight={`calc(100% - ${offsetTop}px)`}
         ref={detailsRef}
         overflowY="auto"
         pb={4}

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
@@ -23,8 +23,7 @@ import React, {
 import {
   Code,
 } from '@chakra-ui/react';
-
-import useOffsetHeight from 'src/utils/useOffsetHeight';
+import { useOffsetTop } from 'src/utils';
 
 interface Props {
   parsedLogs: string;
@@ -38,11 +37,10 @@ const LogBlock = ({
   tryNumber,
 }: Props) => {
   const [autoScroll, setAutoScroll] = useState(true);
+
   const logBoxRef = useRef<HTMLPreElement>(null);
-
-  const maxHeight = useOffsetHeight(logBoxRef, parsedLogs, 500);
-
   const codeBlockBottomDiv = useRef<HTMLDivElement>(null);
+  const offsetTop = useOffsetTop(logBoxRef);
 
   const scrollToBottom = () => {
     codeBlockBottomDiv.current?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
@@ -70,8 +68,7 @@ const LogBlock = ({
     <Code
       ref={logBoxRef}
       onScroll={onScroll}
-      height="100%"
-      maxHeight={maxHeight}
+      maxHeight={`calc(100% - ${offsetTop}px)`}
       overflowY="auto"
       p={3}
       pb={0}

--- a/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
@@ -18,11 +18,10 @@
  */
 
 import React, {
-  useState, useMemo,
+  useState, useMemo, useRef,
 } from 'react';
 import {
   Flex,
-  Text,
   Box,
 } from '@chakra-ui/react';
 import { snakeCase } from 'lodash';
@@ -33,6 +32,7 @@ import { useMappedInstances } from 'src/api';
 import { StatusWithNotes } from 'src/dag/StatusBox';
 import { Table } from 'src/components/Table';
 import Time from 'src/components/Time';
+import { useOffsetTop } from 'src/utils';
 
 interface Props {
   dagId: string;
@@ -44,6 +44,8 @@ interface Props {
 const MappedInstances = ({
   dagId, runId, taskId, onRowClicked,
 }: Props) => {
+  const mappedTasksRef = useRef<HTMLDivElement>(null);
+  const offsetTop = useOffsetTop(mappedTasksRef);
   const limit = 25;
   const [offset, setOffset] = useState(0);
   const [sortBy, setSortBy] = useState<SortingRule<object>[]>([]);
@@ -106,9 +108,11 @@ const MappedInstances = ({
   );
 
   return (
-    <Box>
-      <br />
-      <Text as="strong">Mapped Instances</Text>
+    <Box
+      ref={mappedTasksRef}
+      maxHeight={`calc(100% - ${offsetTop}px)`}
+      overflowY="auto"
+    >
       <Table
         data={data}
         columns={columns}

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -31,7 +31,7 @@ import {
 } from '@chakra-ui/react';
 
 import { useGridData, useTaskInstance } from 'src/api';
-import { getMetaValue, getTask } from 'src/utils';
+import { getMetaValue, getTask, useOffsetTop } from 'src/utils';
 import type { DagRun, TaskInstance as TaskInstanceType } from 'src/types';
 import type { SelectionProps } from 'src/dag/useSelection';
 import NotesAccordion from 'src/dag/details/NotesAccordion';
@@ -58,10 +58,11 @@ interface Props {
 const TaskInstance = ({
   taskId, runId, mapIndex, onSelect,
 }: Props) => {
+  const taskInstancesRef = useRef<HTMLDivElement>(null);
+  const offsetTop = useOffsetTop(taskInstancesRef);
   const isMapIndexDefined = !(mapIndex === undefined);
   const actionsMapIndexes = isMapIndexDefined ? [mapIndex] : [];
   const { data: { dagRuns, groups } } = useGridData();
-  const detailsRef = useRef<HTMLDivElement>(null);
   const storageTabIndex = parseInt(localStorage.getItem(detailsPanelActiveTabIndex) || '0', 10);
   const [preferedTabIndex, setPreferedTabIndex] = useState(storageTabIndex);
 
@@ -114,7 +115,7 @@ const TaskInstance = ({
   }
 
   return (
-    <Box py="4px" height="100%">
+    <Box pt={2} height="100%">
       {!isGroup && (
         <TaskNav
           taskId={taskId}
@@ -153,15 +154,14 @@ const TaskInstance = ({
           onClick={() => onSelect({ runId, taskId })}
         />
 
-        <TabPanels>
+        <TabPanels height="100%">
           {/* Details Tab */}
           <TabPanel
             pt={isMapIndexDefined ? '0px' : undefined}
-            height="100%"
-            ref={detailsRef}
+            ref={taskInstancesRef}
+            maxHeight={`calc(100% - ${offsetTop}px)`}
             overflowY="auto"
-            py="4px"
-            pb={4}
+            pb={0}
           >
             <Box py="4px">
               {!isGroupOrMappedTaskSummary && (
@@ -199,7 +199,7 @@ const TaskInstance = ({
 
           {/* Logs Tab */}
           {!isGroupOrMappedTaskSummary && (
-            <TabPanel pt={isMapIndexDefined ? '0px' : undefined}>
+            <TabPanel pt={isMapIndexDefined ? '0px' : undefined} height="100%">
               <Logs
                 dagId={dagId}
                 dagRunId={runId}
@@ -215,7 +215,7 @@ const TaskInstance = ({
           {/* Mapped Task Instances Tab */}
           {
             isMappedTaskSummary && !isGroup && (
-              <TabPanel>
+              <TabPanel height="100%" pb={0}>
                 <MappedInstances
                   dagId={dagId}
                   runId={runId}

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -130,7 +130,6 @@ const TaskInstance = ({
         size="lg"
         index={selectedTabIndex}
         onChange={handleTabsChange}
-        isLazy
         height="100%"
       >
         <TabList>

--- a/airflow/www/static/js/dag/grid/index.tsx
+++ b/airflow/www/static/js/dag/grid/index.tsx
@@ -31,8 +31,7 @@ import {
 import { MdDoubleArrow } from 'react-icons/md';
 
 import { useGridData } from 'src/api';
-import { getMetaValue } from 'src/utils';
-import useOffsetHeight from 'src/utils/useOffsetHeight';
+import { getMetaValue, useOffsetTop } from 'src/utils';
 
 import renderTaskRows from './renderTaskRows';
 import DagRuns from './dagRuns';
@@ -52,8 +51,7 @@ const Grid = ({
 }: Props) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const tableRef = useRef<HTMLTableSectionElement>(null);
-  const gridRef = useRef<HTMLDivElement>(null);
-  const offsetHeight = useOffsetHeight(scrollRef, undefined, 750);
+  const offsetTop = useOffsetTop(scrollRef);
 
   const { data: { groups, dagRuns } } = useGridData();
   const dagRunIds = dagRuns.map((dr) => dr.runId);
@@ -95,9 +93,7 @@ const Grid = ({
     <Box
       p={3}
       pt={0}
-      mt={0}
       height="100%"
-      ref={gridRef}
       position="relative"
     >
       <IconButton
@@ -117,13 +113,11 @@ const Grid = ({
         top="30px"
       />
       <Box
-        height="100%"
-        maxHeight={offsetHeight}
+        maxHeight={`calc(100% - ${offsetTop}px)`}
         ref={scrollRef}
         overflow="auto"
         position="relative"
         pr={4}
-        pb={4}
       >
         <Table pr="10px">
           <Thead>

--- a/airflow/www/static/js/utils/index.ts
+++ b/airflow/www/static/js/utils/index.ts
@@ -18,7 +18,10 @@
  */
 
 import Color from 'color';
+
 import type { DagRun, RunOrdering, Task } from 'src/types';
+
+import useOffsetTop from './useOffsetTop';
 
 // Delay in ms for various hover actions
 const hoverDelay = 200;
@@ -140,4 +143,5 @@ export {
   getTaskSummary,
   getDagRunLabel,
   getStatusBackgroundColor,
+  useOffsetTop,
 };

--- a/airflow/www/static/js/utils/useOffsetTop.ts
+++ b/airflow/www/static/js/utils/useOffsetTop.ts
@@ -17,40 +17,27 @@
  * under the License.
  */
 
-/* global document, window */
-
 import { debounce } from 'lodash';
 import React, { useEffect, useState } from 'react';
 
-const footerHeight = parseInt(getComputedStyle(document.getElementsByTagName('body')[0]).paddingBottom.replace('px', ''), 10) || 0;
-
 // For an html element, keep it within view height by calculating the top offset and footer height
-const useOffsetHeight = (
-  contentRef: React.RefObject<HTMLDivElement | HTMLPreElement>,
-  dataToWatch?: any, // recalculate height if this changes
-  minHeight: number = 300,
-) => {
-  const [height, setHeight] = useState(0);
+const useOffsetTop = (contentRef: React.RefObject<HTMLElement>) => {
+  const [top, setTop] = useState(0);
 
   useEffect(() => {
     const calculateHeight = debounce(() => {
-      if (contentRef.current) {
-        const topOffset = contentRef.current.offsetTop;
-        const newHeight = (window.innerHeight - (topOffset + footerHeight)) * 2;
-        setHeight(newHeight > minHeight ? newHeight : minHeight);
-      }
+      const offset = contentRef.current?.getBoundingClientRect().top || 0;
+
+      // Note: offsetParent() will get the highest level parent with position: static;
+      const parentOffset = contentRef.current?.offsetParent?.getBoundingClientRect().top || 0;
+      const childOffset = offset - parentOffset;
+      if (childOffset) setTop(childOffset);
     }, 25);
     // set height on load
     calculateHeight();
+  }, [contentRef]);
 
-    // set height on window resize
-    window.addEventListener('resize', calculateHeight);
-    return () => {
-      window.removeEventListener('resize', calculateHeight);
-    };
-  }, [contentRef, minHeight, dataToWatch]);
-
-  return height;
+  return top;
 };
 
-export default useOffsetHeight;
+export default useOffsetTop;


### PR DESCRIPTION
In https://github.com/apache/airflow/pull/29367 I address the issue of the grid view heights being too short simply by doubling the minimum height. This PR tries to come up with a better solution. Instead of calculating the window height and a top/bottom offset, we simply sit a maxHeight for the parent component of the entire grid view and then subtract the topOffset of each component that needs a scroll overflow.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
