### PR TITLE
reorient grid buttons

### DIFF
--- a/airflow/www/static/js/components/AutoRefresh.tsx
+++ b/airflow/www/static/js/components/AutoRefresh.tsx
@@ -31,7 +31,7 @@ const AutoRefresh = () => {
   const { isRefreshOn, toggleRefresh, isPaused } = useAutoRefresh();
 
   return (
-    <FormControl display="flex" width="auto" mr={2}>
+    <FormControl display="flex" width="auto" mr={2} alignItems="center">
       <Spinner color="blue.500" speed="1s" mr="4px" visibility={isRefreshOn ? 'visible' : 'hidden'} />
       <FormLabel
         htmlFor="auto-refresh"

--- a/airflow/www/static/js/dag/grid/dagRuns/index.tsx
+++ b/airflow/www/static/js/dag/grid/dagRuns/index.tsx
@@ -32,9 +32,10 @@ import {
 import { useGridData } from 'src/api';
 import { getDuration, formatDuration } from 'src/datetime_utils';
 import useSelection from 'src/dag/useSelection';
-import type { DagRun } from 'src/types';
+import type { DagRun, Task } from 'src/types';
 
 import DagRunBar from './Bar';
+import ToggleGroups from '../ToggleGroups';
 
 const DurationAxis = (props: BoxProps) => (
   <Box position="absolute" borderBottomWidth={1} zIndex={0} opacity={0.7} width="100%" {...props} />
@@ -54,7 +55,15 @@ export interface RunWithDuration extends DagRun {
   duration: number;
 }
 
-const DagRuns = () => {
+interface Props {
+  groups?: Task;
+  openGroupIds?: string[];
+  onToggleGroups?: (groupIds: string[]) => void;
+}
+
+const DagRuns = ({
+  groups, openGroupIds, onToggleGroups,
+}: Props) => {
   const { data: { dagRuns } } = useGridData();
   const { selected, onSelect } = useSelection();
   const durations: number[] = [];
@@ -73,9 +82,16 @@ const DagRuns = () => {
   return (
     <Tr>
       <Th left={0} zIndex={2}>
-        <Box borderBottomWidth={3} position="relative" height="100%" width="100%">
+        <Flex borderBottomWidth={3} position="relative" height="100%" width="100%" flexDirection="column-reverse" pb={2}>
           {!!runs.length && (
           <>
+            {!!(groups && openGroupIds && onToggleGroups) && (
+              <ToggleGroups
+                groups={groups}
+                openGroupIds={openGroupIds}
+                onToggleGroups={onToggleGroups}
+              />
+            )}
             <DurationTick bottom="120px">Duration</DurationTick>
             <DurationTick bottom="96px">
               {formatDuration(max)}
@@ -88,7 +104,7 @@ const DagRuns = () => {
             </DurationTick>
           </>
           )}
-        </Box>
+        </Flex>
       </Th>
       <Th align="right" verticalAlign="bottom">
         <Flex justifyContent="flex-end" borderBottomWidth={3} position="relative">

--- a/airflow/www/static/js/dag/grid/index.tsx
+++ b/airflow/www/static/js/dag/grid/index.tsx
@@ -25,21 +25,17 @@ import {
   Tbody,
   Box,
   Thead,
-  Flex,
   IconButton,
 } from '@chakra-ui/react';
 
-import { MdReadMore } from 'react-icons/md';
+import { MdDoubleArrow } from 'react-icons/md';
 
 import { useGridData } from 'src/api';
 import { getMetaValue } from 'src/utils';
-import AutoRefresh from 'src/components/AutoRefresh';
 import useOffsetHeight from 'src/utils/useOffsetHeight';
 
 import renderTaskRows from './renderTaskRows';
-import ResetRoot from './ResetRoot';
 import DagRuns from './dagRuns';
-import ToggleGroups from './ToggleGroups';
 
 const dagId = getMetaValue('dag_id');
 
@@ -56,6 +52,7 @@ const Grid = ({
 }: Props) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const tableRef = useRef<HTMLTableSectionElement>(null);
+  const gridRef = useRef<HTMLDivElement>(null);
   const offsetHeight = useOffsetHeight(scrollRef, undefined, 750);
 
   const { data: { groups, dagRuns } } = useGridData();
@@ -96,36 +93,29 @@ const Grid = ({
 
   return (
     <Box
-      m={3}
+      p={3}
+      pt={0}
       mt={0}
       height="100%"
+      ref={gridRef}
+      position="relative"
     >
-      <Flex
-        alignItems="center"
-        justifyContent="space-between"
-        p={1}
-        pb={2}
-        backgroundColor="white"
-      >
-        <Flex alignItems="center">
-          <AutoRefresh />
-          <ToggleGroups
-            groups={groups}
-            openGroupIds={openGroupIds}
-            onToggleGroups={onToggleGroups}
-          />
-          <ResetRoot />
-        </Flex>
-        <IconButton
-          fontSize="2xl"
-          onClick={onPanelToggle}
-          title={`${isPanelOpen ? 'Hide ' : 'Show '} Details Panel`}
-          aria-label={isPanelOpen ? 'Show Details' : 'Hide Details'}
-          icon={<MdReadMore />}
-          transform={!isPanelOpen ? 'rotateZ(180deg)' : undefined}
-          transitionProperty="none"
-        />
-      </Flex>
+      <IconButton
+        fontSize="2xl"
+        variant="ghost"
+        color="gray.400"
+        size="sm"
+        onClick={onPanelToggle}
+        title={`${isPanelOpen ? 'Hide ' : 'Show '} Details Panel`}
+        aria-label={isPanelOpen ? 'Show Details' : 'Hide Details'}
+        icon={<MdDoubleArrow />}
+        transform={!isPanelOpen ? 'rotateZ(180deg)' : undefined}
+        transitionProperty="none"
+        position="absolute"
+        right={0}
+        zIndex={2}
+        top="30px"
+      />
       <Box
         height="100%"
         maxHeight={offsetHeight}
@@ -137,7 +127,11 @@ const Grid = ({
       >
         <Table pr="10px">
           <Thead>
-            <DagRuns />
+            <DagRuns
+              groups={groups}
+              openGroupIds={openGroupIds}
+              onToggleGroups={onToggleGroups}
+            />
           </Thead>
           <Tbody ref={tableRef}>
             {renderTaskRows({

--- a/airflow/www/static/js/dag/nav/FilterBar.tsx
+++ b/airflow/www/static/js/dag/nav/FilterBar.tsx
@@ -28,10 +28,12 @@ import {
 } from '@chakra-ui/react';
 import React from 'react';
 import type { DagRun, RunState, TaskState } from 'src/types';
+import AutoRefresh from 'src/components/AutoRefresh';
 
 import { useTimezone } from 'src/context/timezone';
 import { isoFormatWithoutTZ } from 'src/datetime_utils';
 import useFilters from '../useFilters';
+import ResetRoot from '../grid/ResetRoot';
 
 declare const filtersOptions: {
   dagStates: RunState[],
@@ -57,64 +59,70 @@ const FilterBar = () => {
   const inputStyles = { backgroundColor: 'white', size: 'lg' };
 
   return (
-    <Flex backgroundColor="#f0f0f0" mt={4} p={4}>
-      <Box px={2}>
-        <Input
-          {...inputStyles}
-          type="datetime-local"
-          value={formattedTime || ''}
-          onChange={(e) => onBaseDateChange(e.target.value)}
-        />
-      </Box>
-      <Box px={2}>
-        <Select
-          {...inputStyles}
-          placeholder="Runs"
-          value={filters.numRuns || ''}
-          onChange={(e) => onNumRunsChange(e.target.value)}
-        >
-          {filtersOptions.numRuns.map((value) => (
-            <option value={value} key={value}>{value}</option>
-          ))}
-        </Select>
-      </Box>
-      <Box px={2}>
-        <Select
-          {...inputStyles}
-          value={filters.runType || ''}
-          onChange={(e) => onRunTypeChange(e.target.value)}
-        >
-          <option value="" key="all">All Run Types</option>
-          {filtersOptions.runTypes.map((value) => (
-            <option value={value.toString()} key={value}>{value}</option>
-          ))}
-        </Select>
-      </Box>
-      <Box />
-      <Box px={2}>
-        <Select
-          {...inputStyles}
-          value={filters.runState || ''}
-          onChange={(e) => onRunStateChange(e.target.value)}
-        >
-          <option value="" key="all">All Run States</option>
-          {filtersOptions.dagStates.map((value) => (
-            <option value={value} key={value}>{value}</option>
-          ))}
-        </Select>
-      </Box>
-      <Box px={2}>
-        <Button
-          colorScheme="cyan"
-          aria-label="Reset filters"
-          background="white"
-          variant="outline"
-          onClick={clearFilters}
-          size="lg"
-        >
-          Clear Filters
-        </Button>
-      </Box>
+    <Flex backgroundColor="#f0f0f0" mt={4} p={4} justifyContent="space-between">
+      <Flex>
+        <Box px={2}>
+          <Input
+            {...inputStyles}
+            type="datetime-local"
+            value={formattedTime || ''}
+            onChange={(e) => onBaseDateChange(e.target.value)}
+          />
+        </Box>
+        <Box px={2}>
+          <Select
+            {...inputStyles}
+            placeholder="Runs"
+            value={filters.numRuns || ''}
+            onChange={(e) => onNumRunsChange(e.target.value)}
+          >
+            {filtersOptions.numRuns.map((value) => (
+              <option value={value} key={value}>{value}</option>
+            ))}
+          </Select>
+        </Box>
+        <Box px={2}>
+          <Select
+            {...inputStyles}
+            value={filters.runType || ''}
+            onChange={(e) => onRunTypeChange(e.target.value)}
+          >
+            <option value="" key="all">All Run Types</option>
+            {filtersOptions.runTypes.map((value) => (
+              <option value={value.toString()} key={value}>{value}</option>
+            ))}
+          </Select>
+        </Box>
+        <Box />
+        <Box px={2}>
+          <Select
+            {...inputStyles}
+            value={filters.runState || ''}
+            onChange={(e) => onRunStateChange(e.target.value)}
+          >
+            <option value="" key="all">All Run States</option>
+            {filtersOptions.dagStates.map((value) => (
+              <option value={value} key={value}>{value}</option>
+            ))}
+          </Select>
+        </Box>
+        <Box px={2}>
+          <Button
+            colorScheme="cyan"
+            aria-label="Reset filters"
+            background="white"
+            variant="outline"
+            onClick={clearFilters}
+            size="lg"
+          >
+            Clear Filters
+          </Button>
+        </Box>
+      </Flex>
+      <Flex>
+        <AutoRefresh />
+        <ResetRoot />
+      </Flex>
     </Flex>
   );
 };


### PR DESCRIPTION
Save some vertical space in the grid view by moving the nav bar above the dag run bar chart.
- Auto refresh goes inside of the main grid nav, to the top right.
- Task group expand/collapse goes closer the task name list
- Opening/closing the details panel: icon is changed, remove button background, and absolute positioning,

Old:
<img width="895" alt="old" src="https://user-images.githubusercontent.com/4600967/219244836-09af3cdd-df2c-4e19-9c0f-c812f55dba61.png">

New:
<img width="994" alt="new" src="https://user-images.githubusercontent.com/4600967/219245221-e34138e8-5e38-471e-8caa-8a279300eedf.png">



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
