### PR TITLE
Track number of tasks in executor as metric in scheduler job

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -447,6 +447,9 @@ class SchedulerJob(BaseJob):
                     starved_dags.add(dag_id)
                     continue
 
+                if self.executor.has_task(task_instance):
+                    num_tasks_in_executor += 1
+
                 if task_instance.dag_model.has_task_concurrency_limits:
                     # Many dags don't have a task_concurrency, so where we can avoid loading the full
                     # serialized DAG the better.


### PR DESCRIPTION
This ensures that the stats gauge for scheduler.tasks.running isn't always 0.

closes: #29578

I was unclear of how to set things up in a test to test this behavior, so any advice there would be welcome. This is based on the old behavior of how this worked before the incrementing of `num_tasks_in_executor` was deleted, but if there is a better way to do this I'm happy to update.
