### PR TITLE
fix template_fields in the decorator `task.docker`

### DIFF
--- a/airflow/providers/docker/decorators/docker.py
+++ b/airflow/providers/docker/decorators/docker.py
@@ -77,7 +77,7 @@ class _DockerDecoratedOperator(DecoratedOperator, DockerOperator):
 
     custom_operator_name = "@task.docker"
 
-    template_fields: Sequence[str] = ("op_args", "op_kwargs")
+    template_fields: Sequence[str] = ("op_args", "op_kwargs") + DockerOperator.template_fields
 
     # since we won't mutate the arguments, we should just do the shallow copy
     # there are some cases we can't deepcopy the objects (e.g protobuf).

--- a/airflow/providers/docker/decorators/docker.py
+++ b/airflow/providers/docker/decorators/docker.py
@@ -77,7 +77,7 @@ class _DockerDecoratedOperator(DecoratedOperator, DockerOperator):
 
     custom_operator_name = "@task.docker"
 
-    template_fields: Sequence[str] = tuple({"op_args", "op_kwargs"} | set(DockerOperator.template_fields))
+    template_fields: Sequence[str] = (*DockerOperator.template_fields, "op_args", "op_kwargs")
 
     # since we won't mutate the arguments, we should just do the shallow copy
     # there are some cases we can't deepcopy the objects (e.g protobuf).

--- a/airflow/providers/docker/decorators/docker.py
+++ b/airflow/providers/docker/decorators/docker.py
@@ -77,7 +77,7 @@ class _DockerDecoratedOperator(DecoratedOperator, DockerOperator):
 
     custom_operator_name = "@task.docker"
 
-    template_fields: Sequence[str] = ("op_args", "op_kwargs") + DockerOperator.template_fields
+    template_fields: Sequence[str] = tuple({"op_args", "op_kwargs"} | set(DockerOperator.template_fields))
 
     # since we won't mutate the arguments, we should just do the shallow copy
     # there are some cases we can't deepcopy the objects (e.g protobuf).

--- a/tests/providers/docker/decorators/test_docker.py
+++ b/tests/providers/docker/decorators/test_docker.py
@@ -73,7 +73,7 @@ class TestDockerDecorator:
         ti = TaskInstance(task=ret.operator, run_id=dr.run_id)
         rendered = ti.render_templates()
         assert rendered.container_name == f"python_{dr.dag_id}"
-        
+
     def test_basic_docker_operator_multiple_output(self, dag_maker):
         @task.docker(image="python:3.9-slim", multiple_outputs=True, auto_remove="force")
         def return_dict(number: int):

--- a/tests/providers/docker/decorators/test_docker.py
+++ b/tests/providers/docker/decorators/test_docker.py
@@ -20,10 +20,10 @@ import pytest
 
 from airflow.decorators import task
 from airflow.exceptions import AirflowException
+from airflow.models import TaskInstance
 from airflow.models.dag import DAG
 from airflow.utils import timezone
 from airflow.utils.state import TaskInstanceState
-from airflow.models import TaskInstance
 
 DEFAULT_DATE = timezone.datetime(2021, 9, 1)
 
@@ -64,7 +64,7 @@ class TestDockerDecorator:
     def test_basic_docker_operator_with_template_fields(self, dag_maker):
         @task.docker(image="python:3.9-slim", container_name="python_{{dag_run.dag_id}}", auto_remove="force")
         def f():
-            raise RuntimeError("Should not executed") 
+            raise RuntimeError("Should not executed")
 
         with dag_maker():
             ret = f()

--- a/tests/providers/docker/decorators/test_docker.py
+++ b/tests/providers/docker/decorators/test_docker.py
@@ -64,9 +64,7 @@ class TestDockerDecorator:
         , dag_maker):
         @task.docker(image="python:3.9-slim", container_name='python_{{dag_run.dag_id}}', auto_remove="force")
         def f():
-            import random
-
-            return [random.random() for _ in range(100)]
+            raise RuntimeError("Should not executed") 
 
         with dag_maker():
             ret = f()

--- a/tests/providers/docker/decorators/test_docker.py
+++ b/tests/providers/docker/decorators/test_docker.py
@@ -62,7 +62,7 @@ class TestDockerDecorator:
 
     def test_basic_docker_operator_with_template_fields(
         , dag_maker):
-        @task.docker(image="python:3.9-slim", container_name='python_{{dag_run.dag_id}}')
+        @task.docker(image="python:3.9-slim", container_name='python_{{dag_run.dag_id}}', auto_remove="force")
         def f():
             import random
 
@@ -72,11 +72,9 @@ class TestDockerDecorator:
             ret = f()
 
         dr = dag_maker.create_dagrun()
-        ret.operator.run(start_date=dr.execution_date, end_date=dr.execution_date)
         ti = dr.get_task_instances()[0]
         rendered_op_kwargs = ti.render_templates().op_kwargs
         assert rendered_op_kwargs["container_name"] == f"python_{dr.dag_id}"
-        assert len(ti.xcom_pull()) == 100
 
         
     def test_basic_docker_operator_multiple_output(self, dag_maker):

--- a/tests/providers/docker/decorators/test_docker.py
+++ b/tests/providers/docker/decorators/test_docker.py
@@ -62,7 +62,7 @@ class TestDockerDecorator:
         assert len(result) == 50
 
     def test_basic_docker_operator_with_template_fields(self, dag_maker):
-        @task.docker(image="python:3.9-slim", container_name='python_{{dag_run.dag_id}}', auto_remove="force")
+        @task.docker(image="python:3.9-slim", container_name="python_{{dag_run.dag_id}}", auto_remove="force")
         def f():
             raise RuntimeError("Should not executed") 
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:


How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #29585

Add back the template fields that exists under `DockerOperator` to `task.docker`

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
