### PR TITLE
Explicitly handle exceptions raised by config parsing in AWS provider

### DIFF
--- a/airflow/providers/amazon/aws/utils/connection_wrapper.py
+++ b/airflow/providers/amazon/aws/utils/connection_wrapper.py
@@ -443,10 +443,13 @@ def _parse_s3_config(
     import configparser
 
     config = configparser.ConfigParser()
-    if config.read(config_file_name):  # pragma: no cover
-        sections = config.sections()
-    else:
-        raise AirflowException(f"Couldn't read {config_file_name}")
+    try:
+        if config.read(config_file_name):  # pragma: no cover
+            sections = config.sections()
+        else:
+            raise AirflowException(f"Couldn't read {config_file_name}")
+    except Exception as e:
+        raise AirflowException("Exception when parsing %s: %s", config_file_name, e.__class__.__name__)
     # Setting option names depending on file format
     if config_format is None:
         config_format = "boto"


### PR DESCRIPTION
This PR handles all the exceptions that are raised by config parser when reading AWS configuration file and turns them into AirflowException

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
