### PR TITLE
fix do_xcom_push=False bug in SnowflakeOperator

### DIFF
--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -265,6 +265,8 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
             return_last=self.return_last,
             **extra_kwargs,
         )
+        if not self.do_xcom_push:
+            return None
         if return_single_query_results(self.sql, self.return_last, self.split_statements):
             # For simplicity, we pass always list as input to _process_output, regardless if
             # single query results are going to be returned, and we return the first element

--- a/tests/providers/common/sql/operators/test_sql.py
+++ b/tests/providers/common/sql/operators/test_sql.py
@@ -95,7 +95,6 @@ class TestSQLExecuteQueryOperator:
         mock_process_output.assert_not_called()
 
 
-
 class TestColumnCheckOperator:
 
     valid_column_mapping = {

--- a/tests/providers/common/sql/operators/test_sql.py
+++ b/tests/providers/common/sql/operators/test_sql.py
@@ -64,8 +64,9 @@ class TestSQLExecuteQueryOperator:
             dag=dag,
         )
 
+    @mock.patch.object(SQLExecuteQueryOperator, "_process_output")
     @mock.patch.object(SQLExecuteQueryOperator, "get_db_hook")
-    def test_do_xcom_push(self, mock_get_db_hook):
+    def test_do_xcom_push(self, mock_get_db_hook, mock_process_output):
         operator = self._construct_operator("SELECT 1;", do_xcom_push=True)
         operator.execute(context=MagicMock())
 
@@ -76,9 +77,11 @@ class TestSQLExecuteQueryOperator:
             parameters=None,
             return_last=True,
         )
+        mock_process_output.assert_called()
 
+    @mock.patch.object(SQLExecuteQueryOperator, "_process_output")
     @mock.patch.object(SQLExecuteQueryOperator, "get_db_hook")
-    def test_dont_xcom_push(self, mock_get_db_hook):
+    def test_dont_xcom_push(self, mock_get_db_hook, mock_process_output):
         operator = self._construct_operator("SELECT 1;", do_xcom_push=False)
         operator.execute(context=MagicMock())
 
@@ -89,6 +92,8 @@ class TestSQLExecuteQueryOperator:
             handler=None,
             return_last=True,
         )
+        mock_process_output.assert_not_called()
+
 
 
 class TestColumnCheckOperator:


### PR DESCRIPTION
closes: #29593

Adds a guard check to short-circuit out of `_process_output` in the event of no output (such as `do_xcom_push=False`)