### PR TITLE
fix clear dag run openapi spec responses by adding additional return type

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -890,6 +890,7 @@ paths:
           content:
             application/json:
               schema:
+                type: object
                 oneOf:
                   - $ref: '#/components/schemas/DAGRun'
                   - $ref: '#/components/schemas/TaskInstanceCollection'

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -890,8 +890,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                oneOf:
+                anyOf:
                   - $ref: '#/components/schemas/DAGRun'
                   - $ref: '#/components/schemas/TaskInstanceCollection'
         '400':

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -890,7 +890,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DAGRun'
+                oneOf:
+                  - $ref: '#/components/schemas/DAGRun'
+                  - $ref: '#/components/schemas/TaskInstanceCollection'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -3002,9 +3002,8 @@ export interface operations {
       /** Success. */
       200: {
         content: {
-          "application/json":
-            | components["schemas"]["DAGRun"]
-            | components["schemas"]["TaskInstanceCollection"];
+          "application/json": Partial<components["schemas"]["DAGRun"]> &
+            Partial<components["schemas"]["TaskInstanceCollection"]>;
         };
       };
       400: components["responses"]["BadRequest"];

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -3002,7 +3002,9 @@ export interface operations {
       /** Success. */
       200: {
         content: {
-          "application/json": components["schemas"]["DAGRun"];
+          "application/json":
+            | components["schemas"]["DAGRun"]
+            | components["schemas"]["TaskInstanceCollection"];
         };
       };
       400: components["responses"]["BadRequest"];


### PR DESCRIPTION
This Pr fixes the openapi documentation for the clearDagRun api. The api in question has two returns types depending on whether the dry_run param is true or false. Whilst it has no affect on the swagger ui at this time documenting these other return types helps when using code generation and will help us when openapi starts using the multiple return types in its ui.
