### PR TITLE
Decouple production executor warning in dags UI

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -109,14 +109,15 @@ class BaseExecutor(LoggingMixin):
     supports_pickling: bool = True
     supports_sentry: bool = False
 
-    job_id: None | int | str = None
-    callback_sink: BaseCallbackSink | None = None
-
     is_local: bool = False
     is_single_threaded: bool = False
-    change_sensor_mode_to_reschedule: bool = False
+    is_production: bool = True
 
+    change_sensor_mode_to_reschedule: bool = False
     serve_logs: bool = False
+
+    job_id: None | int | str = None
+    callback_sink: BaseCallbackSink | None = None
 
     def __init__(self, parallelism: int = PARALLELISM):
         super().__init__()

--- a/airflow/executors/celery_kubernetes_executor.py
+++ b/airflow/executors/celery_kubernetes_executor.py
@@ -41,10 +41,13 @@ class CeleryKubernetesExecutor(LoggingMixin):
     supports_ad_hoc_ti_run: bool = True
     supports_pickling: bool = True
     supports_sentry: bool = False
-    change_sensor_mode_to_reschedule: bool = False
-    is_single_threaded: bool = False
+
     is_local: bool = False
+    is_single_threaded: bool = False
+    is_production: bool = True
+
     serve_logs: bool = False
+    change_sensor_mode_to_reschedule: bool = False
 
     callback_sink: BaseCallbackSink | None = None
 

--- a/airflow/executors/debug_executor.py
+++ b/airflow/executors/debug_executor.py
@@ -43,8 +43,11 @@ class DebugExecutor(BaseExecutor):
     """
 
     _terminated = threading.Event()
-    change_sensor_mode_to_reschedule: bool = True
+
     is_single_threaded: bool = True
+    is_production: bool = False
+
+    change_sensor_mode_to_reschedule: bool = True
 
     def __init__(self):
         super().__init__()

--- a/airflow/executors/local_kubernetes_executor.py
+++ b/airflow/executors/local_kubernetes_executor.py
@@ -41,10 +41,13 @@ class LocalKubernetesExecutor(LoggingMixin):
     supports_ad_hoc_ti_run: bool = True
     supports_pickling: bool = False
     supports_sentry: bool = False
-    change_sensor_mode_to_reschedule: bool = False
-    is_single_threaded: bool = False
+
     is_local: bool = False
+    is_single_threaded: bool = False
+    is_production: bool = True
+
     serve_logs: bool = True
+    change_sensor_mode_to_reschedule: bool = False
 
     callback_sink: BaseCallbackSink | None = None
 

--- a/airflow/executors/sequential_executor.py
+++ b/airflow/executors/sequential_executor.py
@@ -45,8 +45,11 @@ class SequentialExecutor(BaseExecutor):
     """
 
     supports_pickling: bool = False
+
     is_local: bool = True
     is_single_threaded: bool = True
+    is_production: bool = False
+
     serve_logs: bool = True
 
     def __init__(self):

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -113,9 +113,9 @@
       <a href={{ get_docs_url("howto/set-up-database.html") }}><b>Click here</b></a> for more information.
     {% endcall %}
   {% endif %}
-  {% if sequential_executor_warning | default(false) %}
+  {% if production_executor_warning | default(false) %}
     {% call show_message(category='warning', dismissible=false) %}
-      Do not use <b>SequentialExecutor</b> in production.
+      Do not use the <b>{{ production_executor_warning }}</b> in production.
       <a href={{ get_docs_url("executor/index.html") }}><b>Click here</b></a> for more information.
     {% endcall %}
   {% endif %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -89,6 +89,7 @@ from airflow.compat.functools import cached_property
 from airflow.configuration import AIRFLOW_CONFIG, conf
 from airflow.datasets import Dataset
 from airflow.exceptions import AirflowException, ParamValidationError, RemovedInAirflow3Warning
+from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job import BaseJob
 from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.jobs.triggerer_job import TriggererJob
@@ -623,8 +624,10 @@ class AirflowBaseView(BaseView):
     }
 
     if not conf.getboolean("core", "unit_test_mode"):
+        executor, _ = ExecutorLoader.import_default_executor_cls()
         extra_args["sqlite_warning"] = settings.engine.dialect.name == "sqlite"
-        extra_args["sequential_executor_warning"] = conf.get("core", "executor") == "SequentialExecutor"
+        if not executor.is_production:
+            extra_args["production_executor_warning"] = executor.__name__
 
     line_chart_attr = {
         "legend.maxKeyLength": 200,

--- a/tests/executors/test_base_executor.py
+++ b/tests/executors/test_base_executor.py
@@ -48,6 +48,10 @@ def test_is_single_threaded_default_value():
     assert not BaseExecutor.is_single_threaded
 
 
+def test_is_production_default_value():
+    assert BaseExecutor.is_production
+
+
 def test_get_task_log():
     executor = BaseExecutor()
     ti = TaskInstance(task=BaseOperator(task_id="dummy"))

--- a/tests/executors/test_celery_kubernetes_executor.py
+++ b/tests/executors/test_celery_kubernetes_executor.py
@@ -40,6 +40,9 @@ class TestCeleryKubernetesExecutor:
     def test_is_local_default_value(self):
         assert not CeleryKubernetesExecutor.is_local
 
+    def test_is_production_default_value(self):
+        assert CeleryKubernetesExecutor.is_production
+
     def test_serve_logs_default_value(self):
         assert not CeleryKubernetesExecutor.serve_logs
 

--- a/tests/executors/test_debug_executor.py
+++ b/tests/executors/test_debug_executor.py
@@ -121,3 +121,6 @@ class TestDebugExecutor:
 
     def test_is_single_threaded(self):
         assert DebugExecutor.is_single_threaded
+
+    def test_is_production_default_value(self):
+        assert not DebugExecutor.is_production

--- a/tests/executors/test_local_kubernetes_executor.py
+++ b/tests/executors/test_local_kubernetes_executor.py
@@ -35,6 +35,9 @@ class TestLocalKubernetesExecutor:
     def test_is_local_default_value(self):
         assert not LocalKubernetesExecutor.is_local
 
+    def test_is_production_default_value(self):
+        assert LocalKubernetesExecutor.is_production
+
     def test_serve_logs_default_value(self):
         assert LocalKubernetesExecutor.serve_logs
 

--- a/tests/executors/test_sequential_executor.py
+++ b/tests/executors/test_sequential_executor.py
@@ -32,6 +32,9 @@ class TestSequentialExecutor:
     def test_is_local_default_value(self):
         assert SequentialExecutor.is_local
 
+    def test_is_production_default_value(self):
+        assert not SequentialExecutor.is_production
+
     def test_serve_logs_default_value(self):
         assert SequentialExecutor.serve_logs
 


### PR DESCRIPTION
Previously the views code was hardcoded to look out for the SequentialExecutor and warn to not use it in production. This change makes that generalized to any non-production executor.

Some screenshots below:

![Screenshot from 2023-03-03 12-37-51](https://user-images.githubusercontent.com/65743084/222824456-6beeeac2-e327-4e59-8297-c4414f96fd1a.png)
![Screenshot from 2023-03-03 12-36-03](https://user-images.githubusercontent.com/65743084/222824506-18e10e27-ce73-4a85-bbd9-a4be2d0e4cc2.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
