### PR TITLE
Add note about workaround to potential error with argparse to hdfs

### DIFF
--- a/docs/apache-airflow-providers-apache-hdfs/index.rst
+++ b/docs/apache-airflow-providers-apache-hdfs/index.rst
@@ -53,6 +53,13 @@ Package apache-airflow-providers-apache-hdfs
 `Hadoop Distributed File System (HDFS) <https://hadoop.apache.org/docs/r1.2.1/hdfs_design.html>`__
 and `WebHDFS <https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/WebHDFS.html>`__.
 
+.. note::
+
+   The ``snakebite-py3`` used by the provider is an old package and it has an old version of ``argparse`` in
+   its dependencies and it might cause in some cases running airflow commands raises the error similar to
+   ``TypeError: __init__() got an unexpected keyword argument 'encoding'``. In this case make
+   sure to remove ``argparse`` with ``pip uninstall argparse`` command to get rid of this error.
+
 
 Release: 3.2.0
 


### PR DESCRIPTION
Instead of removing or reimplementing hdfs provider - in the event of a possibility to break argparse, we simply add a note in the provider documentation to remove argprase if such problem happens.

Fixes: #22689

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
