### PR TITLE
Can't configure Kubernetes and Celery workers in Helm Chart

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -20,9 +20,9 @@
 #################################
 {{- $persistence := .Values.workers.persistence.enabled }}
 {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
-{{- $nodeSelector := or .Values.workers.nodeSelector .Values.nodeSelector }}
-{{- $affinity := or .Values.workers.affinity .Values.affinity }}
-{{- $tolerations := or .Values.workers.tolerations .Values.tolerations }}
+{{- $nodeSelector := or .Values.workers.celeryWorkers.resources .Values.nodeSelector }}
+{{- $affinity := or .Values.workers.celeryWorkers.affinity .Values.affinity }}
+{{- $tolerations := or .Values.workers.celeryWorkers.tolerations .Values.tolerations }}
 {{- $topologySpreadConstraints := or .Values.workers.topologySpreadConstraints .Values.topologySpreadConstraints }}
 {{- $revisionHistoryLimit := or .Values.workers.revisionHistoryLimit .Values.revisionHistoryLimit }}
 {{- $securityContext := include "airflowSecurityContext" (list . .Values.workers) }}
@@ -130,7 +130,7 @@ spec:
       {{- if and $persistence .Values.workers.persistence.fixPermissions }}
         - name: volume-permissions
           resources:
-{{ toYaml .Values.workers.resources | indent 12 }}
+{{ toYaml .Values.workers.celeryWorkers.resources | indent 12 }}
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           command:
@@ -146,7 +146,7 @@ spec:
       {{- end }}
         - name: wait-for-airflow-migrations
           resources:
-{{ toYaml .Values.workers.resources | indent 12 }}
+{{ toYaml .Values.workers.celeryWorkers.resources | indent 12 }}
           image: {{ template "airflow_image_for_migrations" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           volumeMounts:
@@ -187,7 +187,7 @@ spec:
           args: {{ tpl (toYaml .Values.workers.args) . | nindent 12 }}
           {{- end }}
           resources:
-{{ toYaml .Values.workers.resources | indent 12 }}
+{{ toYaml .Values.workers.celeryWorkers.resources | indent 12 }}
           {{- if .Values.workers.livenessProbe.enabled }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.workers.livenessProbe.initialDelaySeconds }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1177,6 +1177,60 @@
             "x-docsSection": "Workers",
             "additionalProperties": false,
             "properties": {
+                "kubernetesWorkers": {
+                    "description": "Properties specific to kubernetes workers",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {}
+                },
+                "celeryWorkers": {
+                    "description": "Properties specific to celery workers",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "resources": {
+                            "description": "Resources for celery worker pods",
+                            "type": "object",
+                            "default": {},
+                            "examples": [
+                                {
+                                    "limits": {
+                                        "cpu": "100m",
+                                        "memory": "128Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "100m",
+                                        "memory": "128Mi"
+                                    }
+                                }
+                            ],
+                            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
+                        },
+                        "nodeSelector": {
+                            "description": "Select certain nodes for worker pods.",
+                            "type": "object",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "affinity": {
+                            "description": "Specify scheduling constraints for worker pods.",
+                            "type": "object",
+                            "default": "See values.yaml",
+                            "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
+                        },
+                        "tolerations": {
+                            "description": "Specify Tolerations for worker pods.",
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "type": "object",
+                                "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
+                            }
+                        }
+                    }
+                },
                 "replicas": {
                     "description": "Number of Airflow Celery workers in StatefulSet.",
                     "type": "integer",
@@ -1436,24 +1490,6 @@
                         }
                     }
                 },
-                "resources": {
-                    "description": "Resources on workers",
-                    "type": "object",
-                    "default": {},
-                    "examples": [
-                        {
-                            "limits": {
-                                "cpu": "100m",
-                                "memory": "128Mi"
-                            },
-                            "requests": {
-                                "cpu": "100m",
-                                "memory": "128Mi"
-                            }
-                        }
-                    ],
-                    "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
-                },
                 "terminationGracePeriodSeconds": {
                     "description": "Grace period for tasks to finish after SIGTERM is sent from Kubernetes.",
                     "type": "integer",
@@ -1496,14 +1532,6 @@
                         "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
                     }
                 },
-                "nodeSelector": {
-                    "description": "Select certain nodes for worker pods.",
-                    "type": "object",
-                    "default": {},
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
                 "priorityClassName": {
                     "description": "Specify priority for worker pods.",
                     "type": [
@@ -1511,21 +1539,6 @@
                         "null"
                     ],
                     "default": null
-                },
-                "affinity": {
-                    "description": "Specify scheduling constraints for worker pods.",
-                    "type": "object",
-                    "default": "See values.yaml",
-                    "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
-                },
-                "tolerations": {
-                    "description": "Specify Tolerations for worker pods.",
-                    "type": "array",
-                    "default": [],
-                    "items": {
-                        "type": "object",
-                        "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
-                    }
                 },
                 "topologySpreadConstraints": {
                     "description": "Specify topology spread constraints for worker pods.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -446,6 +446,28 @@ kerberos:
 
 # Airflow Worker Config
 workers:
+  kubernetesWorkers: {}
+  celeryWorkers:
+    resources: {}
+    #  limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    #  requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # Select certain nodes for airflow worker pods.
+    nodeSelector: {}
+    affinity: {}
+    # default worker affinity is:
+    #  podAntiAffinity:
+    #    preferredDuringSchedulingIgnoredDuringExecution:
+    #    - podAffinityTerm:
+    #        labelSelector:
+    #          matchLabels:
+    #            component: worker
+    #        topologyKey: kubernetes.io/hostname
+    #      weight: 100
+    tolerations: []
   # Number of airflow celery workers in StatefulSet
   replicas: 1
   # Max number of old replicasets to retain
@@ -552,14 +574,6 @@ workers:
     #   cpu: 100m
     #   memory: 128Mi
 
-  resources: {}
-  #  limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  #  requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
   # Grace period for tasks to finish after SIGTERM is sent from kubernetes
   terminationGracePeriodSeconds: 600
 
@@ -578,20 +592,7 @@ workers:
   extraVolumes: []
   extraVolumeMounts: []
 
-  # Select certain nodes for airflow worker pods.
-  nodeSelector: {}
   priorityClassName: ~
-  affinity: {}
-  # default worker affinity is:
-  #  podAntiAffinity:
-  #    preferredDuringSchedulingIgnoredDuringExecution:
-  #    - podAffinityTerm:
-  #        labelSelector:
-  #          matchLabels:
-  #            component: worker
-  #        topologyKey: kubernetes.io/hostname
-  #      weight: 100
-  tolerations: []
   topologySpreadConstraints: []
   # hostAliases to use in worker pods.
   # See:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:


related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The "workers" section in the values.yaml is only used to configure the celery executor and celerykubernetes executors. We should split the common section of the workers section into celery vs kubernetes so that configuration is easier.

closes: #28880 
Fixes #28880

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
