### PR TITLE
Clarify `service_config` in AWS Connection

### DIFF
--- a/docs/apache-airflow-providers-amazon/connections/aws.rst
+++ b/docs/apache-airflow-providers-amazon/connections/aws.rst
@@ -325,7 +325,7 @@ Per service configuration
 S3 Bucket configurations
 """"""""""""""""""""""""
 
-For use S3 Bucket name per connection in :class:`~airflow.providers.amazon.aws.hooks.s3.S3Hook` methods
+To use S3 bucket name per connection in :class:`~airflow.providers.amazon.aws.hooks.s3.S3Hook` methods,
 provide selected options in Connection Extra.
 
 .. note:: ``bucket_name`` provided in hook methods will override this Connection settings.

--- a/docs/apache-airflow-providers-amazon/connections/aws.rst
+++ b/docs/apache-airflow-providers-amazon/connections/aws.rst
@@ -87,8 +87,6 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in AWS
     connection. All parameters are optional.
 
-    * ``service_config``: json used to specify configuration/parameters for different AWS services, such as S3 or STS.
-
     The following extra parameters used to create an initial :external:py:class:`boto3.session.Session`:
 
     * ``aws_access_key_id``: AWS access key ID used for the initial connection.
@@ -116,6 +114,11 @@ Extra (optional)
       `botocore.config.Config <https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html>`__.
     * ``endpoint_url``: Endpoint URL for the connection.
     * ``verify``: Whether or not to verify SSL certificates.
+
+    The following extra parameters used for specific AWS Service
+
+    * ``service_config``: json used to specify configuration/parameters per AWS Service / Amazon Provider Hook,
+      for more details please have a look :ref:`howto/connection:aws:per-service-configuration`.
 
 .. warning:: Extra parameters below are deprecated and will be removed in a future version of this provider.
 
@@ -290,24 +293,6 @@ This assumes all other Connection fields eg **AWS Access Key ID** or **AWS Secre
       "assume_role_kwargs": { "something":"something" }
     }
 
-5. Using **service_config** to specify configuration for services such as S3, STS, and EMR
-
-.. code-block:: json
-
-    {
-      "service_config": {
-        "s3": {
-          "bucket_name": "awesome-bucket"
-        },
-        "sts": {
-          "endpoint_url": "https://example.org"
-        },
-        "emr": {
-          "job_flow_overrides": {"Name": "PiCalc", "ReleaseLabel": "emr-6.7.0"},
-          "endpoint_url": "https://emr.example.org"
-        }
-    }
-
 The following settings may be used within the ``assume_role_with_saml`` container in Extra.
 
     * ``principal_arn``: The ARN of the SAML provider created in IAM that describes the identity provider.
@@ -330,6 +315,29 @@ The following settings may be used within the ``assume_role_with_saml`` containe
     - :class:`airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithsaml
     - https://pypi.org/project/requests-gssapi/
+
+
+.. _howto/connection:aws:per-service-configuration:
+
+Per service configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+S3 Bucket configurations
+""""""""""""""""""""""""
+
+For use S3 Bucket name per connection in :class:`~airflow.providers.amazon.aws.hooks.s3.S3Hook` methods
+provide selected options in Connection Extra.
+
+.. note:: ``bucket_name`` provided in hook methods will override this Connection settings.
+
+.. code-block:: json
+
+    {
+      "service_config": {
+        "s3": {
+          "bucket_name": "awesome-bucket"
+        }
+    }
 
 
 Avoid Throttling exceptions


### PR DESCRIPTION
We add information about potential future implementation in `service_config` Extra AWS Connection config.
The sample include information about S3, STS and EMR however we only implement bucket_name for S3.
