### PR TITLE
`RedshiftDataOperator` replace `await_result` with `wait_for_completion`

### DIFF
--- a/airflow/providers/amazon/aws/operators/redshift_data.py
+++ b/airflow/providers/amazon/aws/operators/redshift_data.py
@@ -44,7 +44,7 @@ class RedshiftDataOperator(BaseOperator):
     :param secret_arn: the name or ARN of the secret that enables db access
     :param statement_name: the name of the SQL statement
     :param with_event: indicates whether to send an event to EventBridge
-    :param await_result: indicates whether to wait for a result, if True wait, if False don't wait
+    :param wait_for_completion: indicates whether to wait for a result, if True wait, if False don't wait
     :param poll_interval: how often in seconds to check the query status
     :param aws_conn_id: aws connection to use
     :param region: aws region to use
@@ -73,10 +73,11 @@ class RedshiftDataOperator(BaseOperator):
         secret_arn: str | None = None,
         statement_name: str | None = None,
         with_event: bool = False,
-        await_result: bool = True,
+        await_result: bool | None = None,
         poll_interval: int = 10,
         aws_conn_id: str = "aws_default",
         region: str | None = None,
+        wait_for_completion: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -89,6 +90,15 @@ class RedshiftDataOperator(BaseOperator):
         self.statement_name = statement_name
         self.with_event = with_event
         self.await_result = await_result
+        self.wait_for_completion = wait_for_completion
+        if await_result:
+            warnings.warn(
+                f"Parameter `{self.__class__.__name__}.await_result` is deprecated and will be removed "
+                "in a future release. Please use method `wait_for_completion` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.wait_for_completion = await_result
         if poll_interval > 0:
             self.poll_interval = poll_interval
         else:
@@ -121,7 +131,7 @@ class RedshiftDataOperator(BaseOperator):
             secret_arn=self.secret_arn,
             statement_name=self.statement_name,
             with_event=self.with_event,
-            wait_for_completion=self.await_result,
+            wait_for_completion=self.wait_for_completion,
             poll_interval=self.poll_interval,
         )
         return self.statement_id
@@ -142,7 +152,7 @@ class RedshiftDataOperator(BaseOperator):
             secret_arn=self.secret_arn,
             statement_name=self.statement_name,
             with_event=self.with_event,
-            wait_for_completion=self.await_result,
+            wait_for_completion=self.wait_for_completion,
             poll_interval=self.poll_interval,
         )
         return self.statement_id
@@ -169,7 +179,7 @@ class RedshiftDataOperator(BaseOperator):
             secret_arn=self.secret_arn,
             statement_name=self.statement_name,
             with_event=self.with_event,
-            wait_for_completion=self.await_result,
+            wait_for_completion=self.wait_for_completion,
             poll_interval=self.poll_interval,
         )
 

--- a/airflow/providers/amazon/aws/operators/redshift_data.py
+++ b/airflow/providers/amazon/aws/operators/redshift_data.py
@@ -73,11 +73,11 @@ class RedshiftDataOperator(BaseOperator):
         secret_arn: str | None = None,
         statement_name: str | None = None,
         with_event: bool = False,
-        await_result: bool | None = None,
+        wait_for_completion: bool = True,
         poll_interval: int = 10,
         aws_conn_id: str = "aws_default",
         region: str | None = None,
-        wait_for_completion: bool = True,
+        await_result: bool | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)

--- a/tests/system/providers/amazon/aws/example_redshift.py
+++ b/tests/system/providers/amazon/aws/example_redshift.py
@@ -202,7 +202,7 @@ with DAG(
             );
         """,
         poll_interval=POLL_INTERVAL,
-        await_result=True,
+        wait_for_completion=True,
     )
     # [END howto_operator_redshift_data]
 
@@ -220,7 +220,7 @@ with DAG(
             INSERT INTO fruit VALUES ( 6, 'Strawberry', 'Red');
         """,
         poll_interval=POLL_INTERVAL,
-        await_result=True,
+        wait_for_completion=True,
     )
 
     # [START howto_operator_redshift_sql]


### PR DESCRIPTION
Followup of https://github.com/apache/airflow/pull/27947#discussion_r1096353052

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
