### PR TITLE
Migrate breeze unit tests to pytest.

### DIFF
--- a/dev/breeze/tests/test_run_utils.py
+++ b/dev/breeze/tests/test_run_utils.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import os
 import stat
 from pathlib import Path
-from unittest import TestCase
 
 from airflow_breeze.utils.run_utils import (
     change_directory_permission,
@@ -51,4 +50,4 @@ def test_filter_out_none():
     dict_input_with_none = {"sample": None, "sample1": "One", "sample2": "Two", "samplen": None}
     expected_dict_output = {"sample1": "One", "sample2": "Two"}
     output_dict = filter_out_none(**dict_input_with_none)
-    TestCase().assertDictEqual(output_dict, expected_dict_output)
+    assert output_dict == expected_dict_output


### PR DESCRIPTION
As a part of #29305, this PR removes a unittest.TestCase dependency from breeze package. The only remaining unittest dependency of this unittest.mock which is anyways used by pytest-mock and is not in plans for removal according to https://github.com/apache/airflow/issues/29305#issuecomment-1435711841



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
