### PR TITLE
Remove <2.0.0 limit on google-cloud-bigtable

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigtable.py
+++ b/airflow/providers/google/cloud/hooks/bigtable.py
@@ -22,12 +22,11 @@ import enum
 import warnings
 from typing import Sequence
 
-from google.cloud.bigtable import Client
+from google.cloud.bigtable import Client, enums
 from google.cloud.bigtable.cluster import Cluster
 from google.cloud.bigtable.column_family import ColumnFamily, GarbageCollectionRule
 from google.cloud.bigtable.instance import Instance
 from google.cloud.bigtable.table import ClusterState, Table
-from google.cloud.bigtable import enums
 
 from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
@@ -56,9 +55,9 @@ class BigtableHook(GoogleBaseHook):
             delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
-        self._client = None
+        self._client: Client | None = None
 
-    def _get_client(self, project_id: str):
+    def _get_client(self, project_id: str) -> Client:
         if not self._client:
             self._client = Client(
                 project=project_id,
@@ -69,7 +68,7 @@ class BigtableHook(GoogleBaseHook):
         return self._client
 
     @GoogleBaseHook.fallback_to_default_project_id
-    def get_instance(self, instance_id: str, project_id: str) -> Instance:
+    def get_instance(self, instance_id: str, project_id: str) -> Instance | None:
         """
         Retrieves and returns the specified Cloud Bigtable instance if it exists.
         Otherwise, returns None.
@@ -113,10 +112,10 @@ class BigtableHook(GoogleBaseHook):
         project_id: str,
         replica_clusters: list[dict[str, str]] | None = None,
         instance_display_name: str | None = None,
-        instance_type: enums.Instance.Type = enums.Instance.Type.UNSPECIFIED,
+        instance_type: enums.Instance.Type = enums.Instance.Type.UNSPECIFIED,  # type: ignore[assignment]
         instance_labels: dict | None = None,
         cluster_nodes: int | None = None,
-        cluster_storage_type: enums.StorageType = enums.StorageType.UNSPECIFIED,
+        cluster_storage_type: enums.StorageType = enums.StorageType.UNSPECIFIED,  # type: ignore[assignment]
         timeout: float | None = None,
     ) -> Instance:
         """
@@ -142,7 +141,6 @@ class BigtableHook(GoogleBaseHook):
         :param timeout: (optional) timeout (in seconds) for instance creation.
                         If None is not specified, Operator will wait indefinitely.
         """
-
         instance = Instance(
             instance_id,
             self._get_client(project_id=project_id),
@@ -198,7 +196,6 @@ class BigtableHook(GoogleBaseHook):
         :param timeout: (optional) timeout (in seconds) for instance update.
             If None is not specified, Operator will wait indefinitely.
         """
-
         instance = Instance(
             instance_id=instance_id,
             client=self._get_client(project_id=project_id),
@@ -250,7 +247,10 @@ class BigtableHook(GoogleBaseHook):
             BigTable exists. If set to None or missing,
             the default project_id from the Google Cloud connection is used.
         """
-        table = self.get_instance(instance_id=instance_id, project_id=project_id).table(table_id=table_id)
+        instance = self.get_instance(instance_id=instance_id, project_id=project_id)
+        if instance is None:
+            raise RuntimeError("Instance %s did not exist; unable to delete table %s" % instance_id, table_id)
+        table = instance.table(table_id=table_id)
         table.delete()
 
     @staticmethod

--- a/airflow/providers/google/cloud/hooks/bigtable.py
+++ b/airflow/providers/google/cloud/hooks/bigtable.py
@@ -142,8 +142,6 @@ class BigtableHook(GoogleBaseHook):
         :param timeout: (optional) timeout (in seconds) for instance creation.
                         If None is not specified, Operator will wait indefinitely.
         """
-        cluster_storage_type = enums.StorageType(cluster_storage_type)
-        instance_type = enums.Instance.Type(instance_type)
 
         instance = Instance(
             instance_id,
@@ -200,7 +198,6 @@ class BigtableHook(GoogleBaseHook):
         :param timeout: (optional) timeout (in seconds) for instance update.
             If None is not specified, Operator will wait indefinitely.
         """
-        instance_type = enums.Instance.Type(instance_type)
 
         instance = Instance(
             instance_id=instance_id,

--- a/airflow/providers/google/cloud/hooks/bigtable.py
+++ b/airflow/providers/google/cloud/hooks/bigtable.py
@@ -27,7 +27,7 @@ from google.cloud.bigtable.cluster import Cluster
 from google.cloud.bigtable.column_family import ColumnFamily, GarbageCollectionRule
 from google.cloud.bigtable.instance import Instance
 from google.cloud.bigtable.table import ClusterState, Table
-from google.cloud.bigtable_admin_v2 import enums
+from google.cloud.bigtable import enums
 
 from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
@@ -113,10 +113,10 @@ class BigtableHook(GoogleBaseHook):
         project_id: str,
         replica_clusters: list[dict[str, str]] | None = None,
         instance_display_name: str | None = None,
-        instance_type: enums.Instance.Type = enums.Instance.Type.TYPE_UNSPECIFIED,
+        instance_type: enums.Instance.Type = enums.Instance.Type.UNSPECIFIED,
         instance_labels: dict | None = None,
         cluster_nodes: int | None = None,
-        cluster_storage_type: enums.StorageType = enums.StorageType.STORAGE_TYPE_UNSPECIFIED,
+        cluster_storage_type: enums.StorageType = enums.StorageType.UNSPECIFIED,
         timeout: float | None = None,
     ) -> Instance:
         """

--- a/airflow/providers/google/cloud/operators/bigtable.py
+++ b/airflow/providers/google/cloud/operators/bigtable.py
@@ -22,8 +22,8 @@ import enum
 from typing import TYPE_CHECKING, Iterable, Sequence
 
 import google.api_core.exceptions
-from google.cloud.bigtable.column_family import GarbageCollectionRule
 from google.cloud.bigtable import enums
+from google.cloud.bigtable.column_family import GarbageCollectionRule
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator

--- a/airflow/providers/google/cloud/operators/bigtable.py
+++ b/airflow/providers/google/cloud/operators/bigtable.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Iterable, Sequence
 
 import google.api_core.exceptions
 from google.cloud.bigtable.column_family import GarbageCollectionRule
-from google.cloud.bigtable_admin_v2 import enums
+from google.cloud.bigtable import enums
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator

--- a/airflow/providers/google/cloud/sensors/bigtable.py
+++ b/airflow/providers/google/cloud/sensors/bigtable.py
@@ -21,8 +21,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Sequence
 
 import google.api_core.exceptions
-from google.cloud.bigtable.table import ClusterState
 from google.cloud.bigtable import enums
+from google.cloud.bigtable.table import ClusterState
 
 from airflow.providers.google.cloud.hooks.bigtable import BigtableHook
 from airflow.providers.google.cloud.links.bigtable import BigtableTablesLink
@@ -103,7 +103,7 @@ class BigtableTableReplicationCompletedSensor(BaseSensorOperator, BigtableValida
             )
             return False
 
-        ready_state = ClusterState(enums.Table.ClusterState.ReplicationState.READY)
+        ready_state = ClusterState(enums.Table.ReplicationState.READY)
 
         is_table_replicated = True
         for cluster_id in cluster_states.keys():

--- a/airflow/providers/google/cloud/sensors/bigtable.py
+++ b/airflow/providers/google/cloud/sensors/bigtable.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Sequence
 
 import google.api_core.exceptions
 from google.cloud.bigtable.table import ClusterState
-from google.cloud.bigtable_admin_v2 import enums
+from google.cloud.bigtable import enums
 
 from airflow.providers.google.cloud.hooks.bigtable import BigtableHook
 from airflow.providers.google.cloud.links.bigtable import BigtableTablesLink

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -83,7 +83,7 @@ dependencies:
   - google-cloud-aiplatform>=1.7.1,<2.0.0
   - google-cloud-automl>=2.1.0
   - google-cloud-bigquery-datatransfer>=3.0.0
-  - google-cloud-bigtable>=1.0.0,<3.0.0
+  - google-cloud-bigtable>=2.0.0,<3.0.0
   - google-cloud-build>=3.0.0
   - google-cloud-compute>=0.1.0,<2.0.0
   - google-cloud-container>=2.2.0,<3.0.0

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -83,7 +83,7 @@ dependencies:
   - google-cloud-aiplatform>=1.7.1,<2.0.0
   - google-cloud-automl>=2.1.0
   - google-cloud-bigquery-datatransfer>=3.0.0
-  - google-cloud-bigtable>=1.0.0,<2.0.0
+  - google-cloud-bigtable>=1.0.0,<3.0.0
   - google-cloud-build>=3.0.0
   - google-cloud-compute>=0.1.0,<2.0.0
   - google-cloud-container>=2.2.0,<3.0.0
@@ -127,9 +127,6 @@ dependencies:
   # A transient dependency of google-cloud-bigquery-datatransfer, but we
   # further constrain it since older versions are buggy.
   - proto-plus>=1.19.6
-  # Google bigtable client require protobuf <= 3.20.0. We can remove the limitation
-  # when this limitation is removed
-  - protobuf<=3.20.0
 
 integrations:
   - integration-name: Google Analytics360

--- a/docs/apache-airflow-providers-google/index.rst
+++ b/docs/apache-airflow-providers-google/index.rst
@@ -112,7 +112,7 @@ PIP package                              Version required
 ``google-cloud-aiplatform``              ``>=1.7.1,<2.0.0``
 ``google-cloud-automl``                  ``>=2.1.0``
 ``google-cloud-bigquery-datatransfer``   ``>=3.0.0``
-``google-cloud-bigtable``                ``>=1.0.0,<2.0.0``
+``google-cloud-bigtable``                ``>=1.0.0,<3.0.0``
 ``google-cloud-build``                   ``>=3.0.0``
 ``google-cloud-compute``                 ``>=0.1.0,<2.0.0``
 ``google-cloud-container``               ``>=2.2.0,<3.0.0``

--- a/docs/apache-airflow-providers-google/index.rst
+++ b/docs/apache-airflow-providers-google/index.rst
@@ -112,7 +112,7 @@ PIP package                              Version required
 ``google-cloud-aiplatform``              ``>=1.7.1,<2.0.0``
 ``google-cloud-automl``                  ``>=2.1.0``
 ``google-cloud-bigquery-datatransfer``   ``>=3.0.0``
-``google-cloud-bigtable``                ``>=1.0.0,<3.0.0``
+``google-cloud-bigtable``                ``>=2.0.0,<3.0.0``
 ``google-cloud-build``                   ``>=3.0.0``
 ``google-cloud-compute``                 ``>=0.1.0,<2.0.0``
 ``google-cloud-container``               ``>=2.2.0,<3.0.0``

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -336,7 +336,7 @@
       "google-cloud-aiplatform>=1.7.1,<2.0.0",
       "google-cloud-automl>=2.1.0",
       "google-cloud-bigquery-datatransfer>=3.0.0",
-      "google-cloud-bigtable>=1.0.0,<2.0.0",
+      "google-cloud-bigtable>=1.0.0,<3.0.0",
       "google-cloud-build>=3.0.0",
       "google-cloud-compute>=0.1.0,<2.0.0",
       "google-cloud-container>=2.2.0,<3.0.0",
@@ -373,7 +373,6 @@
       "pandas-gbq",
       "pandas>=0.17.1",
       "proto-plus>=1.19.6",
-      "protobuf<=3.20.0",
       "sqlalchemy-bigquery>=1.2.1"
     ],
     "cross-providers-deps": [

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -336,7 +336,7 @@
       "google-cloud-aiplatform>=1.7.1,<2.0.0",
       "google-cloud-automl>=2.1.0",
       "google-cloud-bigquery-datatransfer>=3.0.0",
-      "google-cloud-bigtable>=1.0.0,<3.0.0",
+      "google-cloud-bigtable>=2.0.0,<3.0.0",
       "google-cloud-build>=3.0.0",
       "google-cloud-compute>=0.1.0,<2.0.0",
       "google-cloud-container>=2.2.0,<3.0.0",

--- a/tests/providers/google/cloud/hooks/test_bigtable.py
+++ b/tests/providers/google/cloud/hooks/test_bigtable.py
@@ -21,9 +21,8 @@ from unittest import mock
 from unittest.mock import PropertyMock
 
 import google
-from google.cloud.bigtable import Client
+from google.cloud.bigtable import Client, enums
 from google.cloud.bigtable.instance import Instance
-from google.cloud.bigtable import enums
 
 from airflow.providers.google.cloud.hooks.bigtable import BigtableHook
 from airflow.providers.google.common.consts import CLIENT_INFO

--- a/tests/providers/google/cloud/hooks/test_bigtable.py
+++ b/tests/providers/google/cloud/hooks/test_bigtable.py
@@ -23,7 +23,7 @@ from unittest.mock import PropertyMock
 import google
 from google.cloud.bigtable import Client
 from google.cloud.bigtable.instance import Instance
-from google.cloud.bigtable_admin_v2 import enums
+from google.cloud.bigtable import enums
 
 from airflow.providers.google.cloud.hooks.bigtable import BigtableHook
 from airflow.providers.google.common.consts import CLIENT_INFO

--- a/tests/providers/google/cloud/operators/test_bigtable.py
+++ b/tests/providers/google/cloud/operators/test_bigtable.py
@@ -23,7 +23,7 @@ import google.api_core.exceptions
 import pytest
 from google.cloud.bigtable.column_family import MaxVersionsGCRule
 from google.cloud.bigtable.instance import Instance
-from google.cloud.bigtable_admin_v2 import enums
+from google.cloud.bigtable import enums
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.operators.bigtable import (

--- a/tests/providers/google/cloud/operators/test_bigtable.py
+++ b/tests/providers/google/cloud/operators/test_bigtable.py
@@ -21,9 +21,9 @@ from unittest import mock
 
 import google.api_core.exceptions
 import pytest
+from google.cloud.bigtable import enums
 from google.cloud.bigtable.column_family import MaxVersionsGCRule
 from google.cloud.bigtable.instance import Instance
-from google.cloud.bigtable import enums
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.operators.bigtable import (


### PR DESCRIPTION
related: #27292 
related: #26922

## What this does
* Removes <2.0.0 limit on google-cloud-bigtable and corresponding protobuf limit
    * google-cloud-bigtable [no longer requires](https://github.com/googleapis/python-bigtable/blob/main/setup.py#L45) <= 3.2.0 on protobuf

## Why 
* python 3.11 support
* the corresponding protobuf limit restricted multiple other packages from later versions
    * Of interest to me it limited `google-cloud-aiplatform` to `1.13.1`
    * which limited `google-cloud-bigquery` to `>=1.15.0,<3.0.0dev`
* Only 1 non-significant breaking change in `google-cloud-bigtable` [2.0+](https://github.com/googleapis/python-bigtable/releases/tag/v2.0.0)
    * [Microgenerator changes which removes support for python <= 3.5](https://github.com/googleapis/python-bigtable/pull/203)
    * No other breaking changes in release notes

## Update
* Updated pr to account for Enum import path moving slightly and type changes
