### PR TITLE
Add `wait_for_completion` param in `RedshiftCreateClusterOperator`

### DIFF
--- a/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -138,7 +138,7 @@ class RedshiftCreateClusterOperator(BaseOperator):
         aws_conn_id: str = "aws_default",
         wait_for_completion: bool = False,
         max_attempt: int = 5,
-        poll_interval: int = 65,
+        poll_interval: int = 60,
         **kwargs,
     ):
         super().__init__(**kwargs)

--- a/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -84,6 +84,9 @@ class RedshiftCreateClusterOperator(BaseOperator):
     :param default_iam_role_arn: ARN for the IAM role.
     :param aws_conn_id: str = The Airflow connection used for AWS credentials.
         The default connection id is ``aws_default``.
+    :param wait_for_completion: Whether wait for the cluster to be in ``available`` state
+    :param max_attempt: The maximum number of attempts to be made. Default: 5
+    :param poll_interval: The amount of time in seconds to wait between attempts. Default: 60
     """
 
     template_fields: Sequence[str] = (
@@ -133,6 +136,9 @@ class RedshiftCreateClusterOperator(BaseOperator):
         aqua_configuration_status: str | None = None,
         default_iam_role_arn: str | None = None,
         aws_conn_id: str = "aws_default",
+        wait_for_completion: bool = False,
+        max_attempt: int = 5,
+        poll_interval: int = 65,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -170,6 +176,9 @@ class RedshiftCreateClusterOperator(BaseOperator):
         self.aqua_configuration_status = aqua_configuration_status
         self.default_iam_role_arn = default_iam_role_arn
         self.aws_conn_id = aws_conn_id
+        self.wait_for_completion = wait_for_completion
+        self.max_attempt = max_attempt
+        self.poll_interval = poll_interval
         self.kwargs = kwargs
 
     def execute(self, context: Context):
@@ -242,6 +251,15 @@ class RedshiftCreateClusterOperator(BaseOperator):
             self.master_user_password,
             params,
         )
+        if self.wait_for_completion:
+            redshift_hook.get_conn().get_waiter("cluster_available").wait(
+                ClusterIdentifier=self.cluster_identifier,
+                WaiterConfig={
+                    "Delay": self.poll_interval,
+                    "MaxAttempts": self.max_attempt,
+                },
+            )
+
         self.log.info("Created Redshift cluster %s", self.cluster_identifier)
         self.log.info(cluster)
 

--- a/tests/providers/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_cluster.py
@@ -57,6 +57,7 @@ class TestRedshiftCreateClusterOperator:
             master_username="adminuser",
             master_user_password="Test123$",
             cluster_type="single-node",
+            wait_for_completion=True,
         )
         redshift_operator.execute(None)
         params = {
@@ -74,6 +75,10 @@ class TestRedshiftCreateClusterOperator:
             MasterUsername="adminuser",
             MasterUserPassword="Test123$",
             **params,
+        )
+
+        mock_get_conn.return_value.get_waiter.return_value.wait.assert_called_once_with(
+            ClusterIdentifier="test-cluster", WaiterConfig={"Delay": 65, "MaxAttempts": 5}
         )
 
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.get_conn")

--- a/tests/providers/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_cluster.py
@@ -78,7 +78,7 @@ class TestRedshiftCreateClusterOperator:
         )
 
         mock_get_conn.return_value.get_waiter.return_value.wait.assert_called_once_with(
-            ClusterIdentifier="test-cluster", WaiterConfig={"Delay": 65, "MaxAttempts": 5}
+            ClusterIdentifier="test-cluster", WaiterConfig={"Delay": 60, "MaxAttempts": 5}
         )
 
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.get_conn")

--- a/tests/providers/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_cluster.py
@@ -77,6 +77,7 @@ class TestRedshiftCreateClusterOperator:
             **params,
         )
 
+        # wait_for_completion is True so check waiter is called
         mock_get_conn.return_value.get_waiter.return_value.wait.assert_called_once_with(
             ClusterIdentifier="test-cluster", WaiterConfig={"Delay": 60, "MaxAttempts": 5}
         )
@@ -110,6 +111,9 @@ class TestRedshiftCreateClusterOperator:
             MasterUserPassword="Test123$",
             **params,
         )
+
+        # wait_for_completion is False so check waiter is not called
+        mock_get_conn.return_value.get_waiter.assert_not_called()
 
 
 class TestRedshiftCreateClusterSnapshotOperator:


### PR DESCRIPTION
Add `wait_for_completion` param in RedshiftCreateClusterOperator this will enable me to use a single operator to make a cluster in the available state
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
