### PR TITLE
docs: fix typo docs of remote logging

### DIFF
--- a/docs/apache-airflow-providers-amazon/logging/s3-task-handler.rst
+++ b/docs/apache-airflow-providers-amazon/logging/s3-task-handler.rst
@@ -129,7 +129,7 @@ With the above configurations, Webserver and Worker Pods can access Amazon S3 bu
 
 - Using Airflow CLI
 
-  ``airflow connections add aws_conn --conn-uri aws://@/?egion_name=eu-west-1``
+  ``airflow connections add aws_conn --conn-uri aws://@/?region_name=eu-west-1``
 
   Note that ``@`` used in ``-conn-uri`` parameter usually separates password and host but in this case it complies with uri validator used.
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

There's a typo in the Airflow remote logging documentation where "egion" is mistakenly used instead of "region." This error could cause confusion among readers, and it's important to correct it promptly.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
