### PR TITLE
Disable unixodbc and related packages from Microsoft APT repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -267,6 +267,16 @@ function install_mssql_client() {
     curl --silent https://packages.microsoft.com/keys/microsoft.asc | apt-key add - >/dev/null 2>&1
     curl --silent "https://packages.microsoft.com/config/${distro}/${version}/prod.list" > \
         /etc/apt/sources.list.d/mssql-release.list
+
+    # Fix https://github.com/microsoft/linux-package-repositories/issues/36 for pyodbc<=4.0.32
+    # Deny upgrade unixodbc related packages from Microsoft repo
+    pin_packages=("libodbc1" "odbcinst1debian2" "odbcinst" "unixodbc-dev" "unixodbc")
+    for package in "${pin_packages[@]}"
+    do
+        printf "Package: %s\nPin: origin packages.microsoft.com\nPin-Priority: -1\n\n" "${package}" >> \
+            /etc/apt/preferences.d/99-deny-packages-from-ms-repo.pref
+    done
+
     apt-get update -yqq
     apt-get upgrade -yqq
     ACCEPT_EULA=Y apt-get -yqq install -y --no-install-recommends "${driver}"

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -227,6 +227,16 @@ function install_mssql_client() {
     curl --silent https://packages.microsoft.com/keys/microsoft.asc | apt-key add - >/dev/null 2>&1
     curl --silent "https://packages.microsoft.com/config/${distro}/${version}/prod.list" > \
         /etc/apt/sources.list.d/mssql-release.list
+
+    # Fix https://github.com/microsoft/linux-package-repositories/issues/36 for pyodbc<=4.0.32
+    # Deny upgrade unixodbc related packages from Microsoft repo
+    pin_packages=("libodbc1" "odbcinst1debian2" "odbcinst" "unixodbc-dev" "unixodbc")
+    for package in "${pin_packages[@]}"
+    do
+        printf "Package: %s\nPin: origin packages.microsoft.com\nPin-Priority: -1\n\n" "${package}" >> \
+            /etc/apt/preferences.d/99-deny-packages-from-ms-repo.pref
+    done
+
     apt-get update -yqq
     apt-get upgrade -yqq
     ACCEPT_EULA=Y apt-get -yqq install -y --no-install-recommends "${driver}"

--- a/scripts/docker/install_mssql.sh
+++ b/scripts/docker/install_mssql.sh
@@ -43,6 +43,16 @@ function install_mssql_client() {
     curl --silent https://packages.microsoft.com/keys/microsoft.asc | apt-key add - >/dev/null 2>&1
     curl --silent "https://packages.microsoft.com/config/${distro}/${version}/prod.list" > \
         /etc/apt/sources.list.d/mssql-release.list
+
+    # Fix https://github.com/microsoft/linux-package-repositories/issues/36 for pyodbc<=4.0.32
+    # Deny upgrade unixodbc related packages from Microsoft repo
+    pin_packages=("libodbc1" "odbcinst1debian2" "odbcinst" "unixodbc-dev" "unixodbc")
+    for package in "${pin_packages[@]}"
+    do
+        printf "Package: %s\nPin: origin packages.microsoft.com\nPin-Priority: -1\n\n" "${package}" >> \
+            /etc/apt/preferences.d/99-deny-packages-from-ms-repo.pref
+    done
+
     apt-get update -yqq
     apt-get upgrade -yqq
     ACCEPT_EULA=Y apt-get -yqq install -y --no-install-recommends "${driver}"


### PR DESCRIPTION
Disable `unixodbc` and related packages from https://packages.microsoft.com/ and use packages from Debian repo instead.

- https://github.com/microsoft/linux-package-repositories/issues/36#issuecomment-1430184884
- https://github.com/apache/airflow/pull/29519#issuecomment-1430499395

**Update**, forgot attach output from local built container

``` console
❯ docker run --rm -ti ghcr.io/apache/airflow/main/ci/python3.7:latest

...

root@95333f230202:/opt/airflow# apt update
Get:1 http://deb.debian.org/debian bullseye InRelease [116 kB]
Get:2 http://deb.debian.org/debian-security bullseye-security InRelease [48.4 kB]           
Get:3 http://deb.debian.org/debian bullseye-updates InRelease [44.1 kB]                                                 
Get:4 http://deb.debian.org/debian bullseye/main arm64 Packages [8072 kB]                                               
Get:5 https://apt.postgresql.org/pub/repos/apt bullseye-pgdg InRelease [91.7 kB]                                        
Get:6 https://packages.microsoft.com/debian/11/prod bullseye InRelease [10.5 kB]                                        
Get:7 https://apt.postgresql.org/pub/repos/apt bullseye-pgdg/main arm64 Packages [262 kB]               
Get:8 https://packages.microsoft.com/debian/11/prod bullseye/main arm64 Packages [26.8 kB]
Get:9 https://packages.microsoft.com/debian/11/prod bullseye/main armhf Packages [27.2 kB]                       
Get:10 https://packages.microsoft.com/debian/11/prod bullseye/main amd64 Packages [117 kB]                      
Get:11 http://deb.debian.org/debian-security bullseye-security/main arm64 Packages [224 kB]         
Get:12 http://deb.debian.org/debian bullseye-updates/main arm64 Packages [12.0 kB]        
Fetched 9051 kB in 4s (2334 kB/s)                                                             
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
1 package can be upgraded. Run 'apt list --upgradable' to see it.

root@95333f230202:/opt/airflow# apt list --upgradable
Listing... Done
postgresql-client-common/bullseye-pgdg 247.pgdg110+1 all [upgradable from: 225]
N: There is 1 additional version. Please use the '-a' switch to see it

root@95333f230202:/opt/airflow# apt-cache policy
Package files:
 100 /var/lib/dpkg/status
     release a=now
 500 https://apt.postgresql.org/pub/repos/apt bullseye-pgdg/main arm64 Packages
     release o=apt.postgresql.org,a=bullseye-pgdg,n=bullseye-pgdg,l=PostgreSQL for Debian/Ubuntu repository,c=main,b=arm64
     origin apt.postgresql.org
 500 https://packages.microsoft.com/debian/11/prod bullseye/main arm64 Packages
     release o=microsoft-debian-bullseye-prod bullseye,a=bullseye,n=bullseye,l=microsoft-debian-bullseye-prod bullseye,c=main,b=arm64
     origin packages.microsoft.com
 500 https://packages.microsoft.com/debian/11/prod bullseye/main armhf Packages
     release o=microsoft-debian-bullseye-prod bullseye,a=bullseye,n=bullseye,l=microsoft-debian-bullseye-prod bullseye,c=main,b=armhf
     origin packages.microsoft.com
 500 https://packages.microsoft.com/debian/11/prod bullseye/main amd64 Packages
     release o=microsoft-debian-bullseye-prod bullseye,a=bullseye,n=bullseye,l=microsoft-debian-bullseye-prod bullseye,c=main,b=amd64
     origin packages.microsoft.com
 500 http://deb.debian.org/debian bullseye-updates/main arm64 Packages
     release v=11-updates,o=Debian,a=stable-updates,n=bullseye-updates,l=Debian,c=main,b=arm64
     origin deb.debian.org
 500 http://deb.debian.org/debian-security bullseye-security/main arm64 Packages
     release v=11,o=Debian,a=stable-security,n=bullseye-security,l=Debian-Security,c=main,b=arm64
     origin deb.debian.org
 500 http://deb.debian.org/debian bullseye/main arm64 Packages
     release v=11.6,o=Debian,a=stable,n=bullseye,l=Debian,c=main,b=arm64
     origin deb.debian.org
Pinned packages:
     libodbc1 -> 2.3.11 with priority -1
     odbcinst -> 2.3.11 with priority -1
     odbcinst1debian2 -> 2.3.11 with priority -1
     unixodbc-dev -> 2.3.11 with priority -1
     unixodbc -> 2.3.11 with priority -1

root@95333f230202:/opt/airflow# apt-cache policy unixodbc-dev
unixodbc-dev:
  Installed: 2.3.6-0.1+b1
  Candidate: 2.3.6-0.1+b1
  Version table:
     2.3.11 -1
        500 https://packages.microsoft.com/debian/11/prod bullseye/main arm64 Packages
 *** 2.3.6-0.1+b1 500
        500 http://deb.debian.org/debian bullseye/main arm64 Packages
        100 /var/lib/dpkg/status

```