### PR TITLE
Quarantine `test_cli_internal_api_background`

### DIFF
--- a/tests/cli/commands/test_internal_api_command.py
+++ b/tests/cli/commands/test_internal_api_command.py
@@ -131,6 +131,7 @@ class TestCliInternalAPi:
                     raise
                 time.sleep(1)
 
+    @pytest.mark.quarantined
     @pytest.mark.execution_timeout(210)
     def test_cli_internal_api_background(self):
         with tempfile.TemporaryDirectory(prefix="gunicorn") as tmpdir:


### PR DESCRIPTION
This tests failed due to timeout (3.5 minutes) in main, temporary quarantine it