### PR TITLE
FIx formatting of Dataset inlet/outlet note in TaskFlow concepts

### DIFF
--- a/docs/apache-airflow/core-concepts/taskflow.rst
+++ b/docs/apache-airflow/core-concepts/taskflow.rst
@@ -91,9 +91,10 @@ need to be able to be serialized. Airflow out of the box supports all built-in t
 supports objects that are decorated with ``@dataclass`` or ``@attr.define``. The following example shows the use of
 a ``Dataset``, which is ``@attr.define`` decorated, together with TaskFlow.
 
-::
+.. note::
 
-  Note: An additional benefit of using ``Dataset`` is that it automatically registers as an ``inlet`` in case it is used as an input argument. It also auto registers as an ``outlet`` if the return value of your task is a ``dataset`` or a ``list[Dataset]]``.
+    An additional benefit of using ``Dataset`` is that it automatically registers as an ``inlet`` in case it is used as an input argument. It also auto registers as an ``outlet`` if the return value of your task is a ``dataset`` or a ``list[Dataset]]``.
+
 
 .. code-block:: python
 


### PR DESCRIPTION
**Before**
<img width="932" alt="image" src="https://user-images.githubusercontent.com/48934154/220452755-2f674ada-b405-4bc7-ab12-77215c8bcfd7.png">

**After**
<img width="936" alt="image" src="https://user-images.githubusercontent.com/48934154/220452840-69c8d89c-406b-4781-8006-7cc12818b485.png">
