### PR TITLE
Small Extension Fix of Internal API Configuration Path in init_views.py

### DIFF
--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -232,7 +232,7 @@ def init_api_internal(app: Flask, standalone_api: bool = False) -> None:
     if not standalone_api and not conf.getboolean("webserver", "run_internal_api", fallback=False):
         return
 
-    with open(path.join(ROOT_APP_DIR, "api_internal", "openapi", "internal_api_v1.yml")) as f:
+    with open(path.join(ROOT_APP_DIR, "api_internal", "openapi", "internal_api_v1.yaml")) as f:
         specification = safe_load(f)
     api_bp = FlaskApi(
         specification=specification,


### PR DESCRIPTION
It is just a tiny extension change for the configuration path.

**Context:**
While working on [BaseJob.heartbeat to InternalAPI#29315](https://github.com/apache/airflow/issues/29315), I realised that the `Webserver` wasn't taking the configuration correctly for the Internal API. This was preventing the `Webserver` from booting up due to `FileNotFoundError` when trying to run with `[webserver] run_internal_api = True`