### PR TITLE
Do not crash when a version fails to parse

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/find_newer_dependencies.py
+++ b/dev/breeze/src/airflow_breeze/utils/find_newer_dependencies.py
@@ -109,7 +109,10 @@ def get_releases_and_upload_times(package, min_date, current_version, tz) -> lis
     releases: list[tuple[Any, Any]] = []
     for release_version, release_info in package_info["releases"].items():
         if release_info and not release_info[0]["yanked"]:
-            parsed_version = version.parse(release_version)
+            try:
+                parsed_version = version.parse(release_version)
+            except version.InvalidVersion:
+                continue
             if (
                 parsed_version.is_prerelease
                 or parsed_version.is_devrelease


### PR DESCRIPTION
Old files on PyPI may contain version numbers that are non-standard and can't be properly parsed. Those are no longer allowed for new versions, so we can safely ignore those versions since they must be ancient.

The error is hit by #29644