### PR TITLE
Revert "Quarantine `test_cli_internal_api_background`"

### DIFF
--- a/tests/cli/commands/test_internal_api_command.py
+++ b/tests/cli/commands/test_internal_api_command.py
@@ -131,7 +131,6 @@ class TestCliInternalAPi:
                     raise
                 time.sleep(1)
 
-    @pytest.mark.quarantined
     @pytest.mark.execution_timeout(210)
     def test_cli_internal_api_background(self):
         with tempfile.TemporaryDirectory(prefix="gunicorn") as tmpdir:


### PR DESCRIPTION
Reverts apache/airflow#29665

Seems like https://github.com/apache/airflow/pull/29681 would fix https://github.com/apache/airflow/issues/29679