### PR TITLE
Reuse mock import from util module

### DIFF
--- a/tests/providers/google/cloud/triggers/test_gcs.py
+++ b/tests/providers/google/cloud/triggers/test_gcs.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import asyncio
-import sys
 
 import pytest
 from gcloud.aio.storage import Bucket, Storage
@@ -26,13 +25,7 @@ from gcloud.aio.storage import Bucket, Storage
 from airflow.providers.google.cloud.hooks.gcs import GCSAsyncHook
 from airflow.providers.google.cloud.triggers.gcs import GCSBlobTrigger
 from airflow.triggers.base import TriggerEvent
-
-if sys.version_info < (3, 8):
-    from asynctest import mock
-    from asynctest.mock import CoroutineMock as AsyncMock
-else:
-    from unittest import mock
-    from unittest.mock import AsyncMock
+from tests.providers.google.cloud.utils.compat import AsyncMock, async_mock
 
 TEST_BUCKET = "TEST_BUCKET"
 TEST_OBJECT = "TEST_OBJECT"
@@ -66,7 +59,7 @@ def test_gcs_blob_trigger_serialization():
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.triggers.gcs.GCSBlobTrigger._object_exists")
+@async_mock.patch("airflow.providers.google.cloud.triggers.gcs.GCSBlobTrigger._object_exists")
 async def test_gcs_blob_trigger_success(mock_object_exists):
     """
     Tests that the GCSBlobTrigger is success case
@@ -87,7 +80,7 @@ async def test_gcs_blob_trigger_success(mock_object_exists):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.triggers.gcs.GCSBlobTrigger._object_exists")
+@async_mock.patch("airflow.providers.google.cloud.triggers.gcs.GCSBlobTrigger._object_exists")
 async def test_gcs_blob_trigger_pending(mock_object_exists):
     """
     Test that GCSBlobTrigger is in loop if file isn't found.
@@ -110,7 +103,7 @@ async def test_gcs_blob_trigger_pending(mock_object_exists):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.triggers.gcs.GCSBlobTrigger._object_exists")
+@async_mock.patch("airflow.providers.google.cloud.triggers.gcs.GCSBlobTrigger._object_exists")
 async def test_gcs_blob_trigger_exception(mock_object_exists):
     """
     Tests the GCSBlobTrigger does fire if there is an exception.


### PR DESCRIPTION
Reuse the mock module import from utils to avoid redundant code.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
