### PR TITLE
Handle `github_method_args` in GithubOperator when not provided

### DIFF
--- a/airflow/providers/github/operators/github.py
+++ b/airflow/providers/github/operators/github.py
@@ -38,10 +38,10 @@ class GithubOperator(BaseOperator):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:GithubOperator`
 
-    :param github_conn_id: reference to a pre-defined GitHub Connection
-    :param github_method: method name from GitHub Python SDK to be called
-    :param github_method_args: required method parameters for the github_method. (templated)
-    :param result_processor: function to further process the response from GitHub API
+    :param github_conn_id: Reference to a pre-defined GitHub Connection
+    :param github_method: Method name from GitHub Python SDK to be called
+    :param github_method_args: Method parameters for the github_method. (templated)
+    :param result_processor: Function to further process the response from GitHub API
     """
 
     template_fields = ("github_method_args",)
@@ -58,7 +58,7 @@ class GithubOperator(BaseOperator):
         super().__init__(**kwargs)
         self.github_conn_id = github_conn_id
         self.method_name = github_method
-        self.github_method_args = github_method_args
+        self.github_method_args = github_method_args or {}
         self.result_processor = result_processor
 
     def execute(self, context: Context) -> Any:

--- a/tests/providers/github/operators/test_github.py
+++ b/tests/providers/github/operators/test_github.py
@@ -42,6 +42,15 @@ class TestGithubOperator:
             )
         )
 
+    def test_operator_init_with_optional_args(self):
+        github_operator = GithubOperator(
+            task_id="github_list_repos",
+            github_method="get_user",
+        )
+
+        assert github_operator.github_method_args == {}
+        assert github_operator.result_processor is None
+
     @patch(
         "airflow.providers.github.hooks.github.GithubClient", autospec=True, return_value=github_client_mock
     )

--- a/tests/system/providers/github/example_github.py
+++ b/tests/system/providers/github/example_github.py
@@ -82,7 +82,6 @@ with DAG(
     github_list_repos = GithubOperator(
         task_id="github_list_repos",
         github_method="get_user",
-        github_method_args={},
         result_processor=lambda user: logging.info(list(user.get_repos())),
     )
 


### PR DESCRIPTION
The `github_method_args` is an optional parameter for GithubOperator; however, if an arg value is not passed the GithubOperator task fails because `github_method_args` is always expected to be a mapping. It should be possible for users to not need to pass `github_method_args` in GithubOperator when it's not needed.