### PR TITLE
Move extra links position in grid view

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -185,7 +185,6 @@ const TaskInstance = ({
                   isGroup={isGroup}
                 />
               </Box>
-              <Details instance={instance} group={group} dagId={dagId} />
               {!isMapped && (
                 <ExtraLinks
                   taskId={taskId}
@@ -194,6 +193,7 @@ const TaskInstance = ({
                   extraLinks={group?.extraLinks || []}
                 />
               )}
+              <Details instance={instance} group={group} dagId={dagId} />
             </Box>
           </TabPanel>
 


### PR DESCRIPTION
Before, we were rendering extra links below all of the task instance details in the grid view. It was easy to forget about them. Instead, they should be more visible and above the table of task instance details.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
