### PR TITLE
Propose to upgrade to newer dependencies in case build CI image fail

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -521,7 +521,7 @@ def run_build_ci_image(
                     )
                 else:
                     get_console().print(
-                        "[warning]Your image build failure. It could be caused by conflicting dependencies."
+                        "[warning]Your image build failed. It could be caused by conflicting dependencies."
                     )
                     get_console().print(
                         "[info]Run "

--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -504,24 +504,29 @@ def run_build_ci_image(
                 check=False,
                 output=output,
             )
-            if (
-                build_command_result.returncode != 0
-                and ci_image_params.upgrade_on_failure
-                and not ci_image_params.upgrade_to_newer_dependencies
-            ):
-                ci_image_params.upgrade_to_newer_dependencies = True
-                get_console().print(
-                    "[warning]Attempting to build with upgrade_to_newer_dependencies on failure"
-                )
-                build_command_result = run_command(
-                    prepare_docker_build_command(
-                        image_params=ci_image_params,
-                    ),
-                    cwd=AIRFLOW_SOURCES_ROOT,
-                    text=True,
-                    check=False,
-                    output=output,
-                )
+            if build_command_result.returncode != 0 and not ci_image_params.upgrade_to_newer_dependencies:
+                if ci_image_params.upgrade_on_failure:
+                    ci_image_params.upgrade_to_newer_dependencies = True
+                    get_console().print(
+                        "[warning]Attempting to build with upgrade_to_newer_dependencies on failure"
+                    )
+                    build_command_result = run_command(
+                        prepare_docker_build_command(
+                            image_params=ci_image_params,
+                        ),
+                        cwd=AIRFLOW_SOURCES_ROOT,
+                        text=True,
+                        check=False,
+                        output=output,
+                    )
+                else:
+                    get_console().print(
+                        "[warning]Your image build failure. It could be caused by conflicting dependencies."
+                    )
+                    get_console().print(
+                        "[info]Run "
+                        "`breeze ci-image build --upgrade-to-newer-dependencies` to upgrade them.\n."
+                    )
             if build_command_result.returncode == 0:
                 if ci_image_params.tag_as_latest:
                     build_command_result = tag_image_as_latest(image_params=ci_image_params, output=output)

--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -525,7 +525,7 @@ def run_build_ci_image(
                     )
                     get_console().print(
                         "[info]Run "
-                        "`breeze ci-image build --upgrade-to-newer-dependencies` to upgrade them.\n."
+                        "`breeze ci-image build --upgrade-to-newer-dependencies` to upgrade them.\n"
                     )
             if build_command_result.returncode == 0:
                 if ci_image_params.tag_as_latest:


### PR DESCRIPTION
When build image fails it might be because there might be conflicts with current constraints. In case this happens we propose to add `--upgrade-to-newer-dependencies` flag.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
