### PR TITLE
Add more precise optional dependency to cncf.kubernetes from flink

### DIFF
--- a/airflow/providers/apache/flink/provider.yaml
+++ b/airflow/providers/apache/flink/provider.yaml
@@ -54,3 +54,8 @@ sensors:
   - integration-name: Apache Flink
     python-modules:
       - airflow.providers.apache.flink.sensors.flink_kubernetes
+
+additional-extras:
+  - name: cncf.kubernetes
+    dependencies:
+      - apache-airflow-providers-cncf-kubernetes>=5.1.0


### PR DESCRIPTION
The Flink provider has an optional cncf.kubernetes depedency that requires cncf.kubernetes at least in version 5.1.0 (some new features of the classes in cncf.kubernetes are used in Flink on Kubernetes.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
