### PR TITLE
Avoid including fallback message for S3TaskHandler if streaming logs

### DIFF
--- a/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -133,7 +133,7 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
             else:
                 log_prefix = "*** Falling back to local log\n"
             local_log, metadata = super()._read(ti, try_number, metadata)
-            return log + local_log, metadata
+            return f"{log_prefix}{local_log}", metadata
 
     def s3_log_exists(self, remote_log_location: str) -> bool:
         """

--- a/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -128,8 +128,12 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
         if logs:
             return "".join(f"*** {x}\n" for x in messages) + "\n".join(logs), {"end_of_log": True}
         else:
+            if metadata and "log_pos" in metadata and metadata["log_pos"] > 0:
+                log = ""
+            else:
+                log = "*** Falling back to local log\n"
             local_log, metadata = super()._read(ti, try_number, metadata)
-            return "*** Falling back to local log\n" + local_log, metadata
+            return log + local_log, metadata
 
     def s3_log_exists(self, remote_log_location: str) -> bool:
         """

--- a/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -128,10 +128,10 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
         if logs:
             return "".join(f"*** {x}\n" for x in messages) + "\n".join(logs), {"end_of_log": True}
         else:
-            if metadata and "log_pos" in metadata and metadata["log_pos"] > 0:
-                log = ""
+            if metadata and metadata.get("log_pos", 0) > 0:
+                log_prefix = ""
             else:
-                log = "*** Falling back to local log\n"
+                log_prefix = "*** Falling back to local log\n"
             local_log, metadata = super()._read(ti, try_number, metadata)
             return log + local_log, metadata
 

--- a/tests/providers/amazon/aws/log/test_s3_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_s3_task_handler.py
@@ -146,6 +146,33 @@ class TestS3TaskHandler:
         assert actual == expected
         assert {"end_of_log": True, "log_pos": 0} == metadata[0]
 
+    def test_read_when_s3_log_missing_and_log_pos_missing_pre_26(self):
+        ti = copy.copy(self.ti)
+        ti.state = TaskInstanceState.SUCCESS
+        # mock that super class has no _read_remote_logs method
+        with mock.patch("airflow.providers.amazon.aws.log.s3_task_handler.hasattr", return_value=False):
+            log, metadata = self.s3_task_handler.read(ti)
+        assert 1 == len(log)
+        assert log[0][0][-1].startswith("*** Falling back to local log")
+
+    def test_read_when_s3_log_missing_and_log_pos_zero_pre_26(self):
+        ti = copy.copy(self.ti)
+        ti.state = TaskInstanceState.SUCCESS
+        # mock that super class has no _read_remote_logs method
+        with mock.patch("airflow.providers.amazon.aws.log.s3_task_handler.hasattr", return_value=False):
+            log, metadata = self.s3_task_handler.read(ti, metadata={"log_pos": 0})
+        assert 1 == len(log)
+        assert log[0][0][-1].startswith("*** Falling back to local log")
+
+    def test_read_when_s3_log_missing_and_log_pos_over_zero_pre_26(self):
+        ti = copy.copy(self.ti)
+        ti.state = TaskInstanceState.SUCCESS
+        # mock that super class has no _read_remote_logs method
+        with mock.patch("airflow.providers.amazon.aws.log.s3_task_handler.hasattr", return_value=False):
+            log, metadata = self.s3_task_handler.read(ti, metadata={"log_pos": 1})
+        assert 1 == len(log)
+        assert not log[0][0][-1].startswith("*** Falling back to local log")
+
     def test_s3_read_when_log_missing(self):
         handler = self.s3_task_handler
         url = "s3://bucket/foo"


### PR DESCRIPTION
This checks the metadata for the log_pos and if it is present and greater than 1 it doesn't include the "Falling back to local log" message.

closes: #29393

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
