### PR TITLE
Replace blockquote + Note: with RST note in docs

### DIFF
--- a/docs/apache-airflow/authoring-and-scheduling/serializers.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/serializers.rst
@@ -47,9 +47,9 @@ but its keys need to be of primitive form. In case you are implementing a regist
 not to have circular imports. Typically, this can be avoided by using ``str`` for populating the list of serializers.
 Like so: ``serializers = ["my.company.Foo"]`` instead of ``serializers = [Foo]``.
 
-::
+.. note::
 
-  Note: Serialization and deserialization is dependent on speed. Use built-in functions like ``dict`` as much as you can and stay away from using classes and other complex structures.
+  Serialization and deserialization is dependent on speed. Use built-in functions like ``dict`` as much as you can and stay away from using classes and other complex structures.
 
 Airflow Object
 --------------

--- a/docs/apache-airflow/core-concepts/taskflow.rst
+++ b/docs/apache-airflow/core-concepts/taskflow.rst
@@ -179,9 +179,9 @@ It is good practice to version the objects that will be used in serialization. T
 so that a version 2 is able to deserialize a version 1. In case you need custom logic
 for deserialization ensure that ``deserialize(data: dict, version: int)`` is specified.
 
-::
+.. note::
 
-  Note: Typing of ``__version__`` is required and needs to be ``ClassVar[int]``
+  Typing of ``__version__`` is required and needs to be ``ClassVar[int]``
 
 
 Sensors and the TaskFlow API

--- a/docs/apache-airflow/core-concepts/xcoms.rst
+++ b/docs/apache-airflow/core-concepts/xcoms.rst
@@ -38,9 +38,9 @@ You can also use XComs in :ref:`templates <concepts:jinja-templating>`::
 
 XComs are a relative of :doc:`variables`, with the main difference being that XComs are per-task-instance and designed for communication within a DAG run, while Variables are global and designed for overall configuration and value sharing.
 
-::
+.. note::
 
-  Note: If the first task run is not succeeded then on every retry task XComs will be cleared to make the task run idempotent.
+  If the first task run is not succeeded then on every retry task XComs will be cleared to make the task run idempotent.
 
 Custom XCom Backends
 --------------------


### PR DESCRIPTION
As a follow to #29678 replacing other places containing a blockquote `::` + explicit "Note" in text with the RST `.. note::` for the better styling and consistency. In the case of the TaskFlow page it's also fixing a minor bug, since the code blocks inside the blockquote weren't interpreted correctly.

There are also places across the documentation containing just "Note: " without being blockquoted. They are to be addressed separately.

### Before

<img width="1122" alt="Screenshot 2023-02-22 at 22 36 49" src="https://user-images.githubusercontent.com/38596482/220777405-1dcf23c7-7db4-49ba-953c-8717b4e3bbb5.png">

<img width="1125" alt="Screenshot 2023-02-22 at 22 37 24" src="https://user-images.githubusercontent.com/38596482/220777402-97e688d2-04c9-45cc-8f3e-08f052f21b2d.png">

*Note: `is not` seems to be interpreted as code above, this is why it's bold*.

### After 
<img width="1102" alt="Screenshot 2023-02-22 at 22 36 02" src="https://user-images.githubusercontent.com/38596482/220777409-55b8d32a-3430-41bd-97c4-e5e39c5e7b0d.png">
<img width="1102" alt="Screenshot 2023-02-22 at 22 35 17" src="https://user-images.githubusercontent.com/38596482/220777410-cf72735e-437f-4949-8353-71a05cf0bdcb.png">
<img width="1116" alt="Screenshot 2023-02-22 at 22 34 17" src="https://user-images.githubusercontent.com/38596482/220777413-8476eca2-6ad7-45fc-a985-7cee716b9f8b.png">
