### PR TITLE
Make cncf.kubernetes required for flink provider

### DIFF
--- a/airflow/providers/apache/flink/provider.yaml
+++ b/airflow/providers/apache/flink/provider.yaml
@@ -27,15 +27,7 @@ versions:
 dependencies:
   - apache-airflow>=2.3.0
   - cryptography>=2.0.0
-  # The Kubernetes API is known to introduce problems when upgraded to a MAJOR version. Airflow Core
-  # Uses Kubernetes for Kubernetes executor, and we also know that Kubernetes Python client follows SemVer
-  # (https://github.com/kubernetes-client/python#compatibility). This is a crucial component of Airflow
-  # So we should limit it to the next MAJOR version and only deliberately bump the version when we
-  # tested it, and we know it can be bumped. Bumping this version should also be connected with
-  # limiting minimum airflow version supported in cncf.kubernetes provider, due to the
-  # potential breaking changes in Airflow Core as well (kubernetes is added as extra, so Airflow
-  # core is not hard-limited via install-requirements, only by extra).
-  - kubernetes>=21.7.0,<24
+  - apache-airflow-providers-cncf-kubernetes>=5.1.0
 
 integrations:
   - integration-name: Apache Flink
@@ -54,8 +46,3 @@ sensors:
   - integration-name: Apache Flink
     python-modules:
       - airflow.providers.apache.flink.sensors.flink_kubernetes
-
-additional-extras:
-  - name: cncf.kubernetes
-    dependencies:
-      - apache-airflow-providers-cncf-kubernetes>=5.1.0

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -80,9 +80,9 @@
   },
   "apache.flink": {
     "deps": [
+      "apache-airflow-providers-cncf-kubernetes>=5.1.0",
       "apache-airflow>=2.3.0",
-      "cryptography>=2.0.0",
-      "kubernetes>=21.7.0,<24"
+      "cryptography>=2.0.0"
     ],
     "cross-providers-deps": [
       "cncf.kubernetes"


### PR DESCRIPTION
The #29707 added version to optional cncf.kubernetes dependency, but in fact the kubernetes provider is a required dependency so we need to change it to be so.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
