### PR TITLE
Add database check_migrations config

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -566,7 +566,14 @@ database:
       type: integer
       example: ~
       default: "3"
-
+    check_migrations:
+      description: |
+        Whether to run alembic migrations during Airflow start up. Sometimes this operation can be expensive,
+        and the users can assert the correct version through other means (e.g. through a Helm chart).
+      version_added: 2.6.0
+      type: boolean
+      example: ~
+      default: "True"
 logging:
   description: ~
   options:

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -570,8 +570,9 @@ database:
       description: |
         Whether to run alembic migrations during Airflow start up. Sometimes this operation can be expensive,
         and the users can assert the correct version through other means (e.g. through a Helm chart).
+        Accepts "True" or "False".
       version_added: 2.6.0
-      type: boolean
+      type: string
       example: ~
       default: "True"
 logging:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -323,6 +323,10 @@ load_default_connections = True
 # Currently it is only used in ``DagFileProcessor.process_file`` to retry ``dagbag.sync_to_db``.
 max_db_retries = 3
 
+# Whether to run alembic migrations during Airflow start up. Sometimes this operation can be expensive,
+# and the users can assert the correct version through other means (e.g. through a Helm chart).
+check_migrations = True
+
 [logging]
 # The folder where airflow should store its log files.
 # This path must be absolute.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -325,6 +325,7 @@ max_db_retries = 3
 
 # Whether to run alembic migrations during Airflow start up. Sometimes this operation can be expensive,
 # and the users can assert the correct version through other means (e.g. through a Helm chart).
+# Accepts "True" or "False".
 check_migrations = True
 
 [logging]

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -102,8 +102,9 @@ def action_cli(func=None, check_db=True):
                 # Check and run migrations if necessary
                 if check_db:
                     from airflow.utils.db import check_and_run_migrations, synchronize_log_template
-
-                    check_and_run_migrations()
+                    from airflow.configuration import conf
+                    if conf.get("database", "CHECK_MIGRATIONS"):
+                        check_and_run_migrations()
                     synchronize_log_template()
                 return f(*args, **kwargs)
             except Exception as e:

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -101,8 +101,8 @@ def action_cli(func=None, check_db=True):
             try:
                 # Check and run migrations if necessary
                 if check_db:
-                    from airflow.utils.db import check_and_run_migrations, synchronize_log_template
                     from airflow.configuration import conf
+                    from airflow.utils.db import check_and_run_migrations, synchronize_log_template
 
                     if conf.getboolean("database", "check_migrations"):
                         check_and_run_migrations()

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -103,7 +103,8 @@ def action_cli(func=None, check_db=True):
                 if check_db:
                     from airflow.utils.db import check_and_run_migrations, synchronize_log_template
                     from airflow.configuration import conf
-                    if conf.get("database", "CHECK_MIGRATIONS"):
+
+                    if conf.getboolean("database", "check_migrations"):
                         check_and_run_migrations()
                     synchronize_log_template()
                 return f(*args, **kwargs)

--- a/tests/cli/commands/test_scheduler_command.py
+++ b/tests/cli/commands/test_scheduler_command.py
@@ -73,6 +73,23 @@ class TestSchedulerCommand:
             scheduler_command.scheduler(args)
             with pytest.raises(AssertionError):
                 mock_process.assert_has_calls([mock.call(target=serve_logs)])
+    @mock.patch.dict(
+        "os.environ",
+        {
+            "AIRFLOW__DATABASE__CHECK_MIGRATIONS": "False",
+        },
+    )
+    @mock.patch("airflow.utils.db.check_and_run_migrations")
+    @mock.patch("airflow.utils.db.synchronize_log_template")
+    @mock.patch("airflow.cli.commands.scheduler_command.SchedulerJob")
+    @mock.patch("airflow.cli.commands.scheduler_command.Process")
+    @pytest.mark.parametrize("executor", ["LocalExecutor"])
+    def test_check_migrations_is_false(self, mock_process, mock_scheduler_job, mock_log, mock_run_migration, executor):
+        args = self.parser.parse_args(["scheduler"])
+        with conf_vars({("core", "executor"): "SequentialExecutor", ("database", "check_migrations"): "False"}):
+            scheduler_command.scheduler(args)
+            assert mock_run_migration.assert_not_called()
+            assert mock_log.assert_called_once()
 
     @mock.patch("airflow.cli.commands.scheduler_command.SchedulerJob")
     @mock.patch("airflow.cli.commands.scheduler_command.Process")

--- a/tests/cli/commands/test_scheduler_command.py
+++ b/tests/cli/commands/test_scheduler_command.py
@@ -88,8 +88,8 @@ class TestSchedulerCommand:
         args = self.parser.parse_args(["scheduler"])
         with conf_vars({("core", "executor"): "SequentialExecutor", ("database", "check_migrations"): "False"}):
             scheduler_command.scheduler(args)
-            assert mock_run_migration.assert_not_called()
-            assert mock_log.assert_called_once()
+            mock_run_migration.assert_not_called()
+            mock_log.assert_called_once()
 
     @mock.patch("airflow.cli.commands.scheduler_command.SchedulerJob")
     @mock.patch("airflow.cli.commands.scheduler_command.Process")

--- a/tests/cli/commands/test_scheduler_command.py
+++ b/tests/cli/commands/test_scheduler_command.py
@@ -78,14 +78,9 @@ class TestSchedulerCommand:
     @mock.patch("airflow.utils.db.synchronize_log_template")
     @mock.patch("airflow.cli.commands.scheduler_command.SchedulerJob")
     @mock.patch("airflow.cli.commands.scheduler_command.Process")
-    @pytest.mark.parametrize("executor", ["LocalExecutor"])
-    def test_check_migrations_is_false(
-        self, mock_process, mock_scheduler_job, mock_log, mock_run_migration, executor
-    ):
+    def test_check_migrations_is_false(self, mock_process, mock_scheduler_job, mock_log, mock_run_migration):
         args = self.parser.parse_args(["scheduler"])
-        with conf_vars(
-            {("core", "executor"): "SequentialExecutor", ("database", "check_migrations"): "False"}
-        ):
+        with conf_vars({("database", "check_migrations"): "False"}):
             scheduler_command.scheduler(args)
             mock_run_migration.assert_not_called()
             mock_log.assert_called_once()
@@ -94,14 +89,9 @@ class TestSchedulerCommand:
     @mock.patch("airflow.utils.db.synchronize_log_template")
     @mock.patch("airflow.cli.commands.scheduler_command.SchedulerJob")
     @mock.patch("airflow.cli.commands.scheduler_command.Process")
-    @pytest.mark.parametrize("executor", ["LocalExecutor"])
-    def test_check_migrations_is_true(
-        self, mock_process, mock_scheduler_job, mock_log, mock_run_migration, executor
-    ):
+    def test_check_migrations_is_true(self, mock_process, mock_scheduler_job, mock_log, mock_run_migration):
         args = self.parser.parse_args(["scheduler"])
-        with conf_vars(
-            {("core", "executor"): "SequentialExecutor", ("database", "check_migrations"): "True"}
-        ):
+        with conf_vars({("database", "check_migrations"): "True"}):
             scheduler_command.scheduler(args)
             mock_run_migration.assert_called_once()
             mock_log.assert_called_once()


### PR DESCRIPTION
To enable/disable run alembic migrations during Airflow start-up. Sometimes this operation can be expensive. Other parts of the deployment (e.g. Helm chart) can assert that the Airflow metadata database is up-to-date.