### PR TITLE
Make serde lazy-load dependent modules

### DIFF
--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -280,6 +280,12 @@ _AIRFLOW_SERIALIZERS = {
         "datetime": "airflow.serialization.serializers.datetime",
         "timedelta": "airflow.serialization.serializers.datetime",
     },
+    "kubernetes": {
+        "client.models.v1_resource_requirements.V1ResourceRequirements": (
+            "airflow.serialization.serializers.kubernetes"
+        ),
+        "client.models.v1_pod.V1Pod": "airflow.serialization.serializers.kubernetes",
+    },
     "numpy": {
         "bool_": "airflow.serialization.serializers.numpy",
         "complex64": "airflow.serialization.serializers.numpy",
@@ -310,12 +316,6 @@ _AIRFLOW_DESERIALIZERS = {
         "date": "airflow.serialization.serializers.datetime",
         "datetime": "airflow.serialization.serializers.datetime",
         "timedelta": "airflow.serialization.serializers.datetime",
-    },
-    "kubernetes": {
-        "client.models.v1_resource_requirements.V1ResourceRequirements": (
-            "airflow.serialization.serializers.kubernetes"
-        ),
-        "client.models.v1_pod.V1Pod": "airflow.serialization.serializers.kubernetes",
     },
     "numpy": {
         "bool_": "airflow.serialization.serializers.numpy",

--- a/airflow/serialization/serializers/bignum.py
+++ b/airflow/serialization/serializers/bignum.py
@@ -25,10 +25,6 @@ from airflow.utils.module_loading import qualname
 if TYPE_CHECKING:
     from airflow.serialization.serde import U
 
-
-serializers = [Decimal]
-deserializers = serializers
-
 __version__ = 1
 
 

--- a/airflow/serialization/serializers/datetime.py
+++ b/airflow/serialization/serializers/datetime.py
@@ -31,9 +31,6 @@ if TYPE_CHECKING:
 
 __version__ = 1
 
-serializers = [date, datetime, timedelta, DateTime]
-deserializers = serializers
-
 TIMESTAMP = "timestamp"
 TIMEZONE = "tz"
 

--- a/airflow/serialization/serializers/kubernetes.py
+++ b/airflow/serialization/serializers/kubernetes.py
@@ -22,22 +22,16 @@ from typing import TYPE_CHECKING
 
 from airflow.utils.module_loading import qualname
 
-serializers = []
-
 try:
     from kubernetes.client import models as k8s
-
-    serializers = [k8s.v1_pod.V1Pod, k8s.V1ResourceRequirements]
 except ImportError:
-    k8s = None
+    k8s = None  # type: ignore[assignment]
 
 if TYPE_CHECKING:
     from airflow.serialization.serde import U
 
-
 __version__ = 1
 
-deserializers: list[type[object]] = []
 log = logging.getLogger(__name__)
 
 

--- a/airflow/serialization/serializers/numpy.py
+++ b/airflow/serialization/serializers/numpy.py
@@ -49,7 +49,7 @@ try:
         )
     }
 except ImportError:
-    np = None  # type: ignore
+    np = None  # type: ignore[assignment]
     _deserializers = {}
 
 

--- a/airflow/serialization/serializers/timezone.py
+++ b/airflow/serialization/serializers/timezone.py
@@ -27,10 +27,6 @@ from airflow.utils.module_loading import qualname
 if TYPE_CHECKING:
     from airflow.serialization.serde import U
 
-
-serializers = [FixedTimezone, Timezone]
-deserializers = serializers
-
 __version__ = 1
 
 

--- a/airflow/utils/module_loading.py
+++ b/airflow/utils/module_loading.py
@@ -17,9 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-import pkgutil
 from importlib import import_module
-from types import ModuleType
 from typing import Callable
 
 
@@ -58,7 +56,3 @@ def qualname(o: object | Callable) -> str:
         return f"{module}.{name}"
 
     return name
-
-
-def iter_namespace(ns: ModuleType):
-    return pkgutil.iter_modules(ns.__path__, ns.__name__ + ".")


### PR DESCRIPTION
Currently serde loads all possible classes on initialization, including any possible modules. This includes numpy and kubernetes, which are notoriously slow, even if they are never used.

Instead of relying on actually loading modules, this new mechanism only initializes a collection of strings at startup, and only loads relevant serialization modules when needed. This should greatly improve startup time.