### PR TITLE
Don't use importlib.metadata to get Version for speed

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -52,7 +52,7 @@ from airflow import settings
 
 __all__ = ["__version__", "login", "DAG", "PY36", "PY37", "PY38", "PY39", "PY310", "XComArg"]
 
-__version__ = "2.6.0dev0"
+__version__ = "2.6.0.dev0"
 
 # Make `airflow` an namespace package, supporting installing
 # airflow.providers.* in different locations (i.e. one in site, and one in user

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -52,6 +52,8 @@ from airflow import settings
 
 __all__ = ["__version__", "login", "DAG", "PY36", "PY37", "PY38", "PY39", "PY310", "XComArg"]
 
+__version__ = "2.6.0dev0"
+
 # Make `airflow` an namespace package, supporting installing
 # airflow.providers.* in different locations (i.e. one in site, and one in user
 # lib.)
@@ -78,7 +80,6 @@ __lazy_imports: dict[str, tuple[str, str]] = {
     "XComArg": (".models.xcom_arg", "XComArg"),
     "AirflowException": (".exceptions", "AirflowException"),
     "version": (".version", ""),
-    "__version__": (".version", "version"),
 }
 
 

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -41,7 +41,6 @@ from airflow.utils.context import Context, context_copy_partial, context_merge
 from airflow.utils.operator_helpers import KeywordParameters
 from airflow.utils.process_utils import execute_in_subprocess
 from airflow.utils.python_virtualenv import prepare_virtualenv, write_python_script
-from airflow.version import version as airflow_version
 
 
 def task(python_callable: Callable | None = None, multiple_outputs: bool | None = None, **kwargs):
@@ -690,9 +689,11 @@ class ExternalPythonOperator(_BasePythonVirtualenvOperator):
             return False
 
     def _get_airflow_version_from_target_env(self) -> str | None:
+        from airflow import __version__ as airflow_version
+
         try:
             result = subprocess.check_output(
-                [self.python, "-c", "from airflow import version; print(version.version)"], text=True
+                [self.python, "-c", "from airflow import __version__; print(__version__)"], text=True
             )
             target_airflow_version = result.strip()
             if target_airflow_version != airflow_version:

--- a/airflow/version.py
+++ b/airflow/version.py
@@ -17,20 +17,5 @@
 # under the License.
 from __future__ import annotations
 
-__all__ = ["version"]
-
-try:
-    import importlib_metadata as metadata
-except ImportError:
-    from importlib import metadata  # type: ignore[no-redef]
-
-try:
-    version = metadata.version("apache-airflow")
-except metadata.PackageNotFoundError:
-    import logging
-
-    log = logging.getLogger(__name__)
-    log.warning("Package metadata could not be found. Overriding it with version found in setup.py")
-    from setup import version
-
-del metadata
+# Compat -- somethings access `airflow.version.version` directly
+from airflow import __version__ as version  # noqa: F401

--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,6 @@
 from __future__ import annotations
 
 # Compat -- somethings access `airflow.version.version` directly
-from airflow import __version__ as version  # noqa: F401
+from airflow import __version__ as version
+
+__all__ = ["version"]

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -246,7 +246,7 @@ The Release Candidate artifacts we vote upon should be the exact ones we vote ag
     git reset --hard origin/v${VERSION_BRANCH}-test
     ```
 
-- Set your version in `setup.py` and `airflow/api_connexion/openapi/v1.yaml` (without the RC tag).
+- Set your version in `airflow/__init__.py` and `airflow/api_connexion/openapi/v1.yaml` (without the RC tag).
 - Add supported Airflow version to `./scripts/ci/pre_commit/pre_commit_supported_versions.py` and let pre-commit do the job.
 - Replace the version in `README.md` and verify that installation instructions work fine.
 - Build the release notes:

--- a/scripts/ci/pre_commit/common_precommit_utils.py
+++ b/scripts/ci/pre_commit/common_precommit_utils.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import ast
 import hashlib
 import os
 import re
@@ -23,6 +24,18 @@ from pathlib import Path
 
 AIRFLOW_SOURCES_ROOT_PATH = Path(__file__).parents[3].resolve()
 AIRFLOW_BREEZE_SOURCES_PATH = AIRFLOW_SOURCES_ROOT_PATH / "dev" / "breeze"
+
+
+def read_airflow_version() -> str:
+    ast_obj = ast.parse((AIRFLOW_SOURCES_ROOT_PATH / "airflow" / "__init__.py").read_text())
+    for node in ast_obj.body:
+        if not isinstance(node, ast.Assign):
+            continue
+
+        if node.targets[0].id == "__version__":  # type: ignore[attr-defined]
+            return ast.literal_eval(node.value)
+
+    raise RuntimeError("Couldn't find __version__ in AST")
 
 
 def filter_out_providers_on_non_main_branch(files: list[str]) -> list[str]:

--- a/scripts/ci/pre_commit/pre_commit_version_heads_map.py
+++ b/scripts/ci/pre_commit/pre_commit_version_heads_map.py
@@ -28,7 +28,9 @@ PROJECT_SOURCE_ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
 
 DB_FILE = PROJECT_SOURCE_ROOT_DIR / "airflow" / "utils" / "db.py"
 
-AIRFLOW_INIT_FILE = PROJECT_SOURCE_ROOT_DIR / "airflow" / "__init__.py"
+sys.path.insert(0, str(Path(__file__).parent.resolve()))  # make sure common_precommit_utils is importable
+
+from common_precommit_utils import read_airflow_version  # noqa: E402
 
 
 def read_revision_heads_map():
@@ -45,21 +47,8 @@ def read_revision_heads_map():
     return revision_heads_map.keys()
 
 
-def read_current_airflow_version():
-
-    ast_obj = ast.parse(open(AIRFLOW_INIT_FILE).read())
-    for node in ast_obj.body:
-        if not isinstance(node, ast.Assign):
-            continue
-
-        if node.targets[0].id == "__version__":
-            return Version(ast.literal_eval(node.value))
-
-    raise RuntimeError("Couldn't find __version__ in AST")
-
-
 if __name__ == "__main__":
-    airflow_version = read_current_airflow_version()
+    airflow_version = Version(read_airflow_version())
     if airflow_version.is_devrelease or "b" in (airflow_version.pre or ()):
         exit(0)
     versions = read_revision_heads_map()

--- a/scripts/in_container/run_migration_reference.py
+++ b/scripts/in_container/run_migration_reference.py
@@ -30,13 +30,13 @@ from typing import TYPE_CHECKING, Iterable
 from alembic.script import ScriptDirectory
 from tabulate import tabulate
 
+from airflow import __version__ as airflow_version
 from airflow.utils.db import _get_alembic_config
-from setup import version as _airflow_version
 
 if TYPE_CHECKING:
     from alembic.script import Script
 
-airflow_version = re.match(r"(\d+\.\d+\.\d+).*", _airflow_version).group(1)  # type: ignore
+airflow_version = re.match(r"(\d+\.\d+\.\d+).*", airflow_version).group(1)  # type: ignore
 project_root = Path(__file__).parents[2].resolve()
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ summary = Programmatically author, schedule and monitor data pipelines
 author = Apache Software Foundation
 author_email = dev@airflow.apache.org
 url = https://airflow.apache.org/
+version = attr: airflow.__version__
 long_description = file: README.md
 long_description_content_type = text/markdown
 license = Apache License 2.0
@@ -43,6 +44,7 @@ classifiers =
     Framework :: Apache Airflow
 project_urls =
     Documentation=https://airflow.apache.org/docs/
+    Downloads=https://archive.apache.org/dist/airflow/
     Bug Tracker=https://github.com/apache/airflow/issues
     Source Code=https://github.com/apache/airflow
     Slack Chat=https://s.apache.org/airflow-slack

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,6 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = "2.6.0.dev0"
-
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 PROVIDERS_ROOT = AIRFLOW_SOURCES_ROOT / "airflow" / "providers"
 
@@ -162,7 +160,7 @@ class ListExtras(Command):
         print("\n".join(wrap(", ".join(EXTRAS_DEPENDENCIES.keys()), 100)))
 
 
-def git_version(version_: str) -> str:
+def git_version() -> str:
     """
     Return a version to identify the state of the underlying git repo. The version will
     indicate whether the head of the current git-backed working directory is tied to a
@@ -171,7 +169,6 @@ def git_version(version_: str) -> str:
     branch head. Finally, a "dirty" suffix is appended to indicate that uncommitted
     changes are present.
 
-    :param str version_: Semver version
     :return: Found Airflow version in Git repo
     """
     try:
@@ -193,7 +190,7 @@ def git_version(version_: str) -> str:
         if repo.is_dirty():
             return f".dev0+{sha}.dirty"
         # commit is clean
-        return f".release:{version_}+{sha}"
+        return f".release:{sha}"
     return "no_git_version"
 
 
@@ -203,7 +200,7 @@ def write_version(filename: str = str(AIRFLOW_SOURCES_ROOT / "airflow" / "git_ve
 
     :param str filename: Destination file to write.
     """
-    text = f"{git_version(version)}"
+    text = git_version()
     with open(filename, "w") as file:
         file.write(text)
 
@@ -907,9 +904,7 @@ def do_setup() -> None:
     write_version()
     setup(
         distclass=AirflowDistribution,
-        version=version,
         extras_require=EXTRAS_DEPENDENCIES,
-        download_url=("https://archive.apache.org/dist/airflow/" + version),
         cmdclass={
             "extra_clean": CleanCommand,
             "compile_assets": CompileAssets,


### PR DESCRIPTION
As discovered by @uranusjr in other PRs, loading the Metadata info at runtime is surprisingly expensive.

Recent versions of setuptools (including the one we already say we depend upon in pyproject.toml) have the ability to pull the version from an attribute using an "ast-eval" method so this keeps the property of there being a single source of truth for the Airflow version, it just moves that places to airflow/__init__.py.

You might wonder why this particular case matters at runtime? In the grand scheme of things it likely doesn't, except that the airflow/operators/python.py imports this at the top level (or did before this PR) which made me look in to it and discover a quick win here.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
