### PR TITLE
Update docs re: template_fields typing and subclasses

### DIFF
--- a/docs/apache-airflow/core-concepts/operators.rst
+++ b/docs/apache-airflow/core-concepts/operators.rst
@@ -109,7 +109,8 @@ You can also use Jinja templating with nested fields, as long as these nested fi
     )
 
 
-.. note:: The ``template_fields`` property can equally be a class variable or an instance variable.
+.. note:: The ``template_fields`` property is a class variable and guaranteed to be of a ``Sequence[str]``
+    type (i.e. a list or tuple of strings).
 
 Deep nested fields can also be substituted, as long as all intermediate fields are marked as template fields:
 


### PR DESCRIPTION
Related: #22154

As a suggestion from [this issue comment](https://github.com/apache/airflow/issues/22154#issuecomment-1065394841), this PR adds some color on the expected typing `template_fields` in operators as well as how to add other fields via subclassing as a common use case how-to.