### PR TITLE
Exclude v1.58 of `PyGithub` package in GitHub provider

### DIFF
--- a/airflow/providers/github/provider.yaml
+++ b/airflow/providers/github/provider.yaml
@@ -24,7 +24,9 @@ description: |
 
 dependencies:
   - apache-airflow>=2.3.0
-  - pygithub
+  # There was a change introduced in version 1.58 which breaks `pickle` serialization out of the box.
+  # See https://github.com/PyGithub/PyGithub/issues/2436.
+  - PyGithub!=1.58
 
 versions:
   - 2.2.0

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -316,8 +316,8 @@
   },
   "github": {
     "deps": [
-      "apache-airflow>=2.3.0",
-      "pygithub"
+      "PyGithub!=1.58",
+      "apache-airflow>=2.3.0"
     ],
     "cross-providers-deps": []
   },


### PR DESCRIPTION
Related: https://github.com/PyGithub/PyGithub/issues/2436

Starting with v1.58 of `PyGithub`, serialization with `pickle` of `Repository`, `NamedUser`, `Issue`, and other `github.Github.GithubObject`s is no longer possible out of the box. Users won't be able to pass these objects in XCom if desired.