### PR TITLE
Update description of dag_processing.last_duration

### DIFF
--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
@@ -161,7 +161,7 @@ Name                                                Description
 =================================================== ========================================================================
 ``dagrun.dependency-check.<dag_id>``                Milliseconds taken to check DAG dependencies
 ``dag.<dag_id>.<task_id>.duration``                 Milliseconds taken to finish a task
-``dag_processing.last_duration.<dag_file>``         Milliseconds taken to load the given DAG file
+``dag_processing.last_duration.<dag_file>``         Seconds taken to load the given DAG file
 ``dagrun.duration.success.<dag_id>``                Seconds taken for a DagRun to reach success state
 ``dagrun.duration.failed.<dag_id>``                 Milliseconds taken for a DagRun to reach failed state
 ``dagrun.schedule_delay.<dag_id>``                  Seconds of delay between the scheduled DagRun


### PR DESCRIPTION
Time metric reports dag_processing.last_duration.<dag_file> report seconds and not milliseconds according to https://github.com/apache/airflow/blob/2.4.3/airflow/dag_processing/manager.py#L874