### PR TITLE
Handle `jira_method_args` in JiraOperator when not provided

### DIFF
--- a/airflow/providers/atlassian/jira/operators/jira.py
+++ b/airflow/providers/atlassian/jira/operators/jira.py
@@ -31,12 +31,12 @@ class JiraOperator(BaseOperator):
     JiraOperator to interact and perform action on Jira issue tracking system.
     This operator is designed to use Atlassian Jira SDK: https://atlassian-python-api.readthedocs.io/jira.html
 
-    :param jira_conn_id: reference to a pre-defined Jira Connection
-    :param jira_method: method name from Atlassian Jira Python SDK to be called
-    :param jira_method_args: required method parameters for the jira_method. (templated)
-    :param result_processor: function to further process the response from Jira
-    :param get_jira_resource_method: function or operator to get jira resource
-                                    on which the provided jira_method will be executed
+    :param jira_conn_id: Reference to a pre-defined Jira Connection.
+    :param jira_method: Method name from Atlassian Jira Python SDK to be called.
+    :param jira_method_args: Method parameters for the jira_method. (templated)
+    :param result_processor: Function to further process the response from Jira.
+    :param get_jira_resource_method: Function or operator to get Jira resource on which the provided
+        jira_method will be executed.
     """
 
     template_fields: Sequence[str] = ("jira_method_args",)
@@ -54,7 +54,7 @@ class JiraOperator(BaseOperator):
         super().__init__(**kwargs)
         self.jira_conn_id = jira_conn_id
         self.method_name = jira_method
-        self.jira_method_args = jira_method_args
+        self.jira_method_args = jira_method_args or {}
         self.result_processor = result_processor
         self.get_jira_resource_method = get_jira_resource_method
 

--- a/tests/providers/atlassian/jira/operators/test_jira.py
+++ b/tests/providers/atlassian/jira/operators/test_jira.py
@@ -53,6 +53,13 @@ class TestJiraOperator:
             )
         )
 
+    def test_operator_init_with_optional_args(self):
+        jira_operator = JiraOperator(task_id="jira_list_issue_types", jira_method="issue_types")
+
+        assert jira_operator.jira_method_args == {}
+        assert jira_operator.result_processor is None
+        assert jira_operator.get_jira_resource_method is None
+
     @patch("airflow.providers.atlassian.jira.hooks.jira.Jira", autospec=True, return_value=jira_client_mock)
     def test_issue_search(self, jira_mock):
         jql_str = "issuekey=TEST-1226"


### PR DESCRIPTION
Related: #29699

The `jira_method_args` is an optional parameter for JiraOperator; however, if an arg value is not passed the JiraOperator task fails because `jira_method_args` is always expected to be a mapping. It should be possible for users to not need to pass `jira_method_args` in JiraOperator when it's not needed.