### PR TITLE
Fix on_failure_callback when task receives a SIGTERM

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -29,6 +29,12 @@ if TYPE_CHECKING:
     from airflow.models import DagRun
 
 
+class AirflowKillSignal(Exception):
+    """Raise when there's kill signal"""
+
+    status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+
+
 class AirflowException(Exception):
     """
     Base class for all Airflow's errors.

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -29,8 +29,8 @@ if TYPE_CHECKING:
     from airflow.models import DagRun
 
 
-class AirflowKillSignal(Exception):
-    """Raise when there's kill signal"""
+class AirflowTermSignal(Exception):
+    """Raise when we receive a TERM signal"""
 
     status_code = HTTPStatus.INTERNAL_SERVER_ERROR
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -73,7 +73,6 @@ from airflow.datasets.manager import dataset_manager
 from airflow.exceptions import (
     AirflowException,
     AirflowFailException,
-    AirflowKillSignal,
     AirflowRescheduleException,
     AirflowSensorTimeout,
     AirflowSkipException,
@@ -1572,7 +1571,7 @@ class TaskInstance(Base, LoggingMixin):
                     result = self._execute_task(context, task_orig)
                     # Run post_execute callback
                     self.task.post_execute(context=context, result=result)
-                except AirflowKillSignal:
+                except AirflowTermSignal:
                     self.task.on_kill()
                     if self.task.on_failure_callback:
                         self._run_finished_callback(self.task.on_failure_callback, context, "on_failure")

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -73,6 +73,7 @@ from airflow.datasets.manager import dataset_manager
 from airflow.exceptions import (
     AirflowException,
     AirflowFailException,
+    AirflowKillSignal,
     AirflowRescheduleException,
     AirflowSensorTimeout,
     AirflowSkipException,
@@ -1527,8 +1528,7 @@ class TaskInstance(Base, LoggingMixin):
                 os._exit(1)
                 return
             self.log.error("Received SIGTERM. Terminating subprocesses.")
-            self.task.on_kill()
-            raise AirflowException("Task received SIGTERM signal")
+            raise AirflowKillSignal("Task received SIGTERM signal")
 
         signal.signal(signal.SIGTERM, signal_handler)
 
@@ -1567,10 +1567,15 @@ class TaskInstance(Base, LoggingMixin):
 
             # Execute the task
             with set_current_context(context):
-                result = self._execute_task(context, task_orig)
-
-            # Run post_execute callback
-            self.task.post_execute(context=context, result=result)
+                try:
+                    result = self._execute_task(context, task_orig)
+                    # Run post_execute callback
+                    self.task.post_execute(context=context, result=result)
+                except AirflowKillSignal:
+                    self.task.on_kill()
+                    if self.task.on_failure_callback:
+                        self._run_finished_callback(self.task.on_failure_callback, context, "on_failure")
+                    raise AirflowException("Task received SIGTERM signal")
 
         Stats.incr(f"operator_successes_{self.task.task_type}", 1, 1)
         Stats.incr(

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -78,6 +78,7 @@ from airflow.exceptions import (
     AirflowSensorTimeout,
     AirflowSkipException,
     AirflowTaskTimeout,
+    AirflowTermSignal,
     DagRunNotFound,
     RemovedInAirflow3Warning,
     TaskDeferralError,
@@ -1528,7 +1529,7 @@ class TaskInstance(Base, LoggingMixin):
                 os._exit(1)
                 return
             self.log.error("Received SIGTERM. Terminating subprocesses.")
-            raise AirflowKillSignal("Task received SIGTERM signal")
+            raise AirflowTermSignal("Task received SIGTERM signal")
 
         signal.signal(signal.SIGTERM, signal_handler)
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -472,6 +472,28 @@ class TestTaskInstance:
         ti.refresh_from_db()
         assert ti.state == State.UP_FOR_RETRY
 
+    def test_task_sigterm_calls_on_failure_callack(self, dag_maker, caplog):
+        """
+        Test that ensures that tasks call on_failure_callback when they receive sigterm
+        """
+
+        def task_function(ti):
+            os.kill(0, signal.SIGTERM)
+
+        with dag_maker():
+            task_ = PythonOperator(
+                task_id="test_on_failure",
+                python_callable=task_function,
+                on_failure_callback=lambda context: context["ti"].log.info("on_failure_callback called"),
+            )
+
+        dr = dag_maker.create_dagrun()
+        ti = dr.task_instances[0]
+        ti.task = task_
+        with pytest.raises(AirflowException):
+            ti.run()
+        assert "on_failure_callback called" in caplog.text
+
     @pytest.mark.parametrize("state", [State.SUCCESS, State.FAILED, State.SKIPPED])
     def test_task_sigterm_doesnt_change_state_of_finished_tasks(self, state, dag_maker):
         session = settings.Session()
@@ -2332,7 +2354,6 @@ class TestTaskInstance:
             assert context["dag_run"].dag_id == "test_dagrun_execute_callback"
 
         for i, callback_input in enumerate([[on_execute_callable], on_execute_callable]):
-
             ti = create_task_instance(
                 dag_id=f"test_execute_callback_{i}",
                 on_execute_callback=callback_input,
@@ -2369,7 +2390,6 @@ class TestTaskInstance:
             completed = True
 
         for i, callback_input in enumerate([[on_finish_callable], on_finish_callable]):
-
             ti = create_task_instance(
                 dag_id=f"test_finish_callback_{i}",
                 end_date=timezone.utcnow() + datetime.timedelta(days=10),

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -478,7 +478,7 @@ class TestTaskInstance:
         """
 
         def task_function(ti):
-            os.kill(0, signal.SIGTERM)
+            os.kill(ti.pid, signal.SIGTERM)
 
         with dag_maker():
             task_ = PythonOperator(


### PR DESCRIPTION
This fixes on_failure_callback when task receives a SIGTERM by raising a different exception in the handler and catching the exception during task execution so we can directly run the failure callback

closes: https://github.com/apache/airflow/issues/25297