### PR TITLE
Standardize AWS lambda naming

### DIFF
--- a/airflow/providers/amazon/aws/operators/lambda_function.py
+++ b/airflow/providers/amazon/aws/operators/lambda_function.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from airflow.compat.functools import cached_property
@@ -118,7 +119,7 @@ class LambdaCreateFunctionOperator(BaseOperator):
         return response.get("FunctionArn")
 
 
-class AwsLambdaInvokeFunctionOperator(BaseOperator):
+class LambdaInvokeFunctionOperator(BaseOperator):
     """
     Invokes an AWS Lambda function. You can invoke a function synchronously (and wait for the response),
     or asynchronously.
@@ -127,7 +128,7 @@ class AwsLambdaInvokeFunctionOperator(BaseOperator):
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:AwsLambdaInvokeFunctionOperator`
+        :ref:`howto/operator:LambdaInvokeFunctionOperator`
 
     :param function_name: The name of the AWS Lambda function, version, or alias.
     :param log_type: Set to Tail to include the execution log in the response. Otherwise, set to "None".
@@ -194,3 +195,21 @@ class AwsLambdaInvokeFunctionOperator(BaseOperator):
             )
         self.log.info("Lambda function invocation succeeded: %r", response.get("ResponseMetadata"))
         return payload
+
+
+class AwsLambdaInvokeFunctionOperator(LambdaInvokeFunctionOperator):
+    """
+    This class is deprecated.
+    Please use
+    :class:`airflow.providers.amazon.aws.operators.lambda_function.LambdaInvokeFunctionOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This class is deprecated."
+            "Please use"
+            "`airflow.providers.amazon.aws.operators.lambda_function.LambdaInvokeFunctionOperator`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/docs/apache-airflow-providers-amazon/operators/lambda.rst
+++ b/docs/apache-airflow-providers-amazon/operators/lambda.rst
@@ -47,13 +47,13 @@ To create an AWS lambda function you can use
     :start-after: [START howto_operator_create_lambda_function]
     :end-before: [END howto_operator_create_lambda_function]
 
-.. _howto/operator:AwsLambdaInvokeFunctionOperator:
+.. _howto/operator:LambdaInvokeFunctionOperator:
 
 Invoke an AWS Lambda function
 =============================
 
 To invoke an AWS lambda function you can use
-:class:`~airflow.providers.amazon.aws.operators.lambda_function.AwsLambdaInvokeFunctionOperator`.
+:class:`~airflow.providers.amazon.aws.operators.lambda_function.LambdaInvokeFunctionOperator`.
 
 .. exampleinclude:: /../../tests/system/providers/amazon/aws/example_lambda.py
     :language: python

--- a/tests/always/test_project_structure.py
+++ b/tests/always/test_project_structure.py
@@ -403,6 +403,10 @@ class TestAmazonProviderProjectStructure(ExampleCoverageTest):
         "airflow.providers.amazon.aws.sensors.emr.EmrStepSensor",
     }
 
+    DEPRECATED_CLASSES = {
+        "airflow.providers.amazon.aws.operators.lambda_function.AwsLambdaInvokeFunctionOperator",
+    }
+
 
 class TestElasticsearchProviderProjectStructure(ExampleCoverageTest):
     PROVIDER = "elasticsearch"

--- a/tests/providers/amazon/aws/operators/test_lambda_function.py
+++ b/tests/providers/amazon/aws/operators/test_lambda_function.py
@@ -25,8 +25,8 @@ import pytest
 
 from airflow.providers.amazon.aws.hooks.lambda_function import LambdaHook
 from airflow.providers.amazon.aws.operators.lambda_function import (
-    AwsLambdaInvokeFunctionOperator,
     LambdaCreateFunctionOperator,
+    LambdaInvokeFunctionOperator,
 )
 
 FUNCTION_NAME = "function_name"
@@ -69,9 +69,9 @@ class TestLambdaCreateFunctionOperator:
         mock_hook_conn.get_waiter.assert_called_once_with("function_active_v2")
 
 
-class TestAwsLambdaInvokeFunctionOperator:
+class TestLambdaInvokeFunctionOperator:
     def test_init(self):
-        lambda_operator = AwsLambdaInvokeFunctionOperator(
+        lambda_operator = LambdaInvokeFunctionOperator(
             task_id="test",
             function_name="test",
             payload=json.dumps({"TestInput": "Testdata"}),
@@ -84,9 +84,9 @@ class TestAwsLambdaInvokeFunctionOperator:
         assert lambda_operator.log_type == "None"
         assert lambda_operator.aws_conn_id == "aws_conn_test"
 
-    @patch.object(AwsLambdaInvokeFunctionOperator, "hook", new_callable=mock.PropertyMock)
+    @patch.object(LambdaInvokeFunctionOperator, "hook", new_callable=mock.PropertyMock)
     def test_invoke_lambda(self, hook_mock):
-        operator = AwsLambdaInvokeFunctionOperator(
+        operator = LambdaInvokeFunctionOperator(
             task_id="task_test",
             function_name="a",
             invocation_type="b",
@@ -115,9 +115,9 @@ class TestAwsLambdaInvokeFunctionOperator:
             qualifier="f",
         )
 
-    @patch.object(AwsLambdaInvokeFunctionOperator, "hook", new_callable=mock.PropertyMock)
+    @patch.object(LambdaInvokeFunctionOperator, "hook", new_callable=mock.PropertyMock)
     def test_invoke_lambda_bad_http_code(self, hook_mock):
-        operator = AwsLambdaInvokeFunctionOperator(
+        operator = LambdaInvokeFunctionOperator(
             task_id="task_test",
             function_name="a",
         )
@@ -126,9 +126,9 @@ class TestAwsLambdaInvokeFunctionOperator:
         with pytest.raises(ValueError):
             operator.execute(None)
 
-    @patch.object(AwsLambdaInvokeFunctionOperator, "hook", new_callable=mock.PropertyMock)
+    @patch.object(LambdaInvokeFunctionOperator, "hook", new_callable=mock.PropertyMock)
     def test_invoke_lambda_function_error(self, hook_mock):
-        operator = AwsLambdaInvokeFunctionOperator(
+        operator = LambdaInvokeFunctionOperator(
             task_id="task_test",
             function_name="a",
         )

--- a/tests/system/providers/amazon/aws/example_lambda.py
+++ b/tests/system/providers/amazon/aws/example_lambda.py
@@ -27,8 +27,8 @@ from airflow import models
 from airflow.decorators import task
 from airflow.models.baseoperator import chain
 from airflow.providers.amazon.aws.operators.lambda_function import (
-    AwsLambdaInvokeFunctionOperator,
     LambdaCreateFunctionOperator,
+    LambdaInvokeFunctionOperator,
 )
 from airflow.providers.amazon.aws.sensors.lambda_function import LambdaFunctionStateSensor
 from airflow.utils.trigger_rule import TriggerRule
@@ -100,7 +100,7 @@ with models.DAG(
     wait_lambda_function_state.poke_interval = 1
 
     # [START howto_operator_invoke_lambda_function]
-    invoke_lambda_function = AwsLambdaInvokeFunctionOperator(
+    invoke_lambda_function = LambdaInvokeFunctionOperator(
         task_id="invoke_lambda_function",
         function_name=lambda_function_name,
         payload=json.dumps({"SampleEvent": {"SampleData": {"Name": "XYZ", "DoB": "1993-01-01"}}}),


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/29677

I didn't change file names `lambda_funciton.py` to `lambda.py` as I think the current naming is fine (at least it does not contradict AIP-21)  and lambda is a reserved word in Python so I think it's best not to create confusion around it.

cc @vincbeck 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
