### PR TITLE
Make Liveness/Readiness Probe timeouts configurable for PgBouncer Exporter

### DIFF
--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -165,15 +165,17 @@ spec:
               command:
                 - pgbouncer_exporter
                 - health
-            initialDelaySeconds: 10
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.pgbouncer.metricsExporterSidecar.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.pgbouncer.metricsExporterSidecar.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.pgbouncer.metricsExporterSidecar.livenessProbe.timeoutSeconds }}
           readinessProbe:
             exec:
               command:
                 - pgbouncer_exporter
                 - health
-            initialDelaySeconds: 10
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.pgbouncer.metricsExporterSidecar.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.pgbouncer.metricsExporterSidecar.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.pgbouncer.metricsExporterSidecar.readinessProbe.timeoutSeconds }}
       volumes:
         - name: pgbouncer-config
           secret:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4596,19 +4596,16 @@
                             "properties": {
                                 "initialDelaySeconds": {
                                     "description": "Metrics Exporter liveness probe initial delay",
-                                    "format": "int32",
                                     "type": "integer",
                                     "default": 10
                                 },
                                 "periodSeconds": {
                                     "description": "Metrics Exporter liveness probe frequency",
-                                    "format": "int32",
                                     "type": "integer",
                                     "default": 10
                                 },
                                 "timeoutSeconds": {
                                     "description": "Metrics Exporter liveness probe command timeout",
-                                    "format": "int32",
                                     "type": "integer",
                                     "default": 1
                                 }
@@ -4621,19 +4618,16 @@
                             "properties": {
                                 "initialDelaySeconds": {
                                     "description": "Metrics Exporter readiness probe initial delay",
-                                    "format": "int32",
                                     "type": "integer",
                                     "default": 10
                                 },
                                 "periodSeconds": {
                                     "description": "Metrics Exporter readiness probe frequency",
-                                    "format": "int32",
                                     "type": "integer",
                                     "default": 10
                                 },
                                 "timeoutSeconds": {
                                     "description": "Metrics Exporter readiness probe command timeout",
-                                    "format": "int32",
                                     "type": "integer",
                                     "default": 1
                                 }

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4588,6 +4588,56 @@
                                 "verify-full"
                             ],
                             "default": "disable"
+                        },
+                        "livenessProbe": {
+                            "description": "LivenessProbe configurations for ``metricsExporterSidecar``",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "initialDelaySeconds": {
+                                    "description": "Metrics Exporter liveness probe initial delay",
+                                    "format": "int32",
+                                    "type": "integer",
+                                    "default": 10
+                                },
+                                "periodSeconds": {
+                                    "description": "Metrics Exporter liveness probe frequency",
+                                    "format": "int32",
+                                    "type": "integer",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "description": "Metrics Exporter liveness probe command timeout",
+                                    "format": "int32",
+                                    "type": "integer",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "readinessProbe": {
+                            "description": "ReadinessProbe configurations for ``metricsExporterSidecar``",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "initialDelaySeconds": {
+                                    "description": "Metrics Exporter readiness probe initial delay",
+                                    "format": "int32",
+                                    "type": "integer",
+                                    "default": 10
+                                },
+                                "periodSeconds": {
+                                    "description": "Metrics Exporter readiness probe frequency",
+                                    "format": "int32",
+                                    "type": "integer",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "description": "Metrics Exporter readiness probe command timeout",
+                                    "format": "int32",
+                                    "type": "integer",
+                                    "default": 1
+                                }
+                            }
                         }
                     }
                 }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1585,6 +1585,16 @@ pgbouncer:
     #   memory: 128Mi
     sslmode: "disable"
 
+    livenessProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 1
+
+    readinessProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 1
+
 # Configuration for the redis provisioned by the chart
 redis:
   enabled: true


### PR DESCRIPTION
Closes: #28891

The Pull Request makes Timeouts of Liveness and Readiness Probes for PgBouncer Metrics Exporter configurable. This change allows to provide more stability because it may be necessary to adjust these timeouts in slow environments where it takes more time to execute probes and avoid unnecessary container restarts and failures of Airflow tasks due to the unreachable PgBouncer.