### PR TITLE
Add setup/teardown tasks to parsing

### DIFF
--- a/airflow/decorators/__init__.py
+++ b/airflow/decorators/__init__.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 
 from airflow.decorators.base import TaskDecorator
 from airflow.decorators.branch_python import branch_task
@@ -24,6 +24,7 @@ from airflow.decorators.external_python import external_python_task
 from airflow.decorators.python import python_task
 from airflow.decorators.python_virtualenv import virtualenv_task
 from airflow.decorators.sensor import sensor_task
+from airflow.decorators.setup_teardown import setup_task, teardown_task
 from airflow.decorators.short_circuit import short_circuit_task
 from airflow.decorators.task_group import task_group
 from airflow.models.dag import dag
@@ -42,6 +43,8 @@ __all__ = [
     "branch_task",
     "short_circuit_task",
     "sensor_task",
+    "setup",
+    "teardown",
 ]
 
 
@@ -68,3 +71,5 @@ class TaskDecoratorCollection:
 
 
 task = TaskDecoratorCollection()
+setup: Callable = setup_task
+teardown: Callable = teardown_task

--- a/airflow/decorators/__init__.pyi
+++ b/airflow/decorators/__init__.pyi
@@ -31,7 +31,6 @@ from airflow.decorators.external_python import external_python_task
 from airflow.decorators.python import python_task
 from airflow.decorators.python_virtualenv import virtualenv_task
 from airflow.decorators.sensor import sensor_task
-from airflow.decorators.setup_teardown import setup_task, teardown_task
 from airflow.decorators.short_circuit import short_circuit_task
 from airflow.decorators.task_group import task_group
 from airflow.kubernetes.secret import Secret
@@ -457,5 +456,5 @@ class TaskDecoratorCollection:
     def sensor(self, python_callable: FParams | FReturn | None = None) -> Task[FParams, FReturn]: ...
 
 task: TaskDecoratorCollection
-setup: setup_task
-teardown: teardown_task
+setup: Callable
+teardown: Callable

--- a/airflow/decorators/__init__.pyi
+++ b/airflow/decorators/__init__.pyi
@@ -31,6 +31,7 @@ from airflow.decorators.external_python import external_python_task
 from airflow.decorators.python import python_task
 from airflow.decorators.python_virtualenv import virtualenv_task
 from airflow.decorators.sensor import sensor_task
+from airflow.decorators.setup_teardown import setup_task, teardown_task
 from airflow.decorators.short_circuit import short_circuit_task
 from airflow.decorators.task_group import task_group
 from airflow.kubernetes.secret import Secret
@@ -49,6 +50,8 @@ __all__ = [
     "branch_task",
     "short_circuit_task",
     "sensor_task",
+    "setup",
+    "teardown",
 ]
 
 class TaskDecoratorCollection:
@@ -454,3 +457,5 @@ class TaskDecoratorCollection:
     def sensor(self, python_callable: FParams | FReturn | None = None) -> Task[FParams, FReturn]: ...
 
 task: TaskDecoratorCollection
+setup: setup_task
+teardown: teardown_task

--- a/airflow/decorators/setup_teardown.py
+++ b/airflow/decorators/setup_teardown.py
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import functools
+import types
+from typing import Callable
+
+from airflow.decorators import python_task
+from airflow.utils.setup_teardown import SetupTeardownContext
+
+
+def setup_task(python_callable: Callable) -> Callable:
+    # Using FunctionType here since _TaskDecorator is also a callable
+    if isinstance(python_callable, types.FunctionType):
+        python_callable = python_task(python_callable)
+
+    @functools.wraps(python_callable)
+    def wrapper(*args, **kwargs):
+        with SetupTeardownContext.setup():
+            return python_callable(*args, **kwargs)
+
+    return wrapper
+
+
+def teardown_task(python_callable: Callable) -> Callable:
+    # Using FunctionType here since _TaskDecorator is also a callable
+    if isinstance(python_callable, types.FunctionType):
+        python_callable = python_task(python_callable)
+
+    @functools.wraps(python_callable)
+    def wrapper(*args, **kwargs) -> Callable:
+        with SetupTeardownContext.teardown():
+            return python_callable(*args, **kwargs)
+
+    return wrapper

--- a/airflow/example_dags/example_setup_teardown.py
+++ b/airflow/example_dags/example_setup_teardown.py
@@ -1,0 +1,58 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Example DAG demonstrating the usage of setup and teardown tasks."""
+from __future__ import annotations
+
+import pendulum
+
+from airflow.decorators import setup, task, teardown
+from airflow.models.dag import DAG
+from airflow.operators.bash import BashOperator
+from airflow.utils.task_group import TaskGroup
+
+with DAG(
+    dag_id="example_setup_teardown",
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+    catchup=False,
+    tags=["example"],
+) as dag:
+    BashOperator.as_setup(task_id="root_setup", bash_command="echo 'Hello from root_setup'")
+    normal = BashOperator(task_id="normal", bash_command="echo 'I am just a normal task'")
+    BashOperator.as_teardown(task_id="root_teardown", bash_command="echo 'Goodbye from root_teardown'")
+
+    with TaskGroup("section_1", tooltip="Tasks for section_1") as section_1:
+
+        @setup
+        @task
+        def my_setup():
+            print("I set up")
+
+        @task
+        def hello():
+            print("I say hello")
+
+        @teardown
+        @task
+        def my_teardown():
+            print("I tear down")
+
+        my_setup()
+        hello()
+        my_teardown()
+
+    normal >> section_1

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -915,6 +915,20 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
             )
             self.template_fields = [self.template_fields]
 
+    @classmethod
+    def as_setup(cls, *args, **kwargs):
+        from airflow.utils.setup_teardown import SetupTeardownContext
+
+        with SetupTeardownContext.setup():
+            return cls(*args, **kwargs)
+
+    @classmethod
+    def as_teardown(cls, *args, **kwargs):
+        from airflow.utils.setup_teardown import SetupTeardownContext
+
+        with SetupTeardownContext.teardown():
+            return cls(*args, **kwargs)
+
     def __eq__(self, other):
         if type(self) is type(other):
             # Use getattr() instead of __dict__ as __dict__ doesn't return

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -284,6 +284,8 @@
         "is_mapped": { "type": "boolean" },
         "prefix_group_id": { "type": "boolean" },
         "children":  { "$ref": "#/definitions/dict" },
+        "setup_children":  { "$ref": "#/definitions/dict" },
+        "teardown_children":  { "$ref": "#/definitions/dict" },
         "tooltip": { "type": "string" },
         "ui_color": { "type": "string" },
         "ui_fgcolor": { "type": "string" },

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+
+class SetupTeardownContext:
+    """Track whether the next added task is a setup or teardown task"""
+
+    is_setup: bool = False
+    is_teardown: bool = False
+
+    @classmethod
+    @contextmanager
+    def setup(cls):
+        cls.is_setup = True
+        yield
+        cls.is_setup = False
+
+    @classmethod
+    @contextmanager
+    def teardown(cls):
+        cls.is_teardown = True
+        yield
+        cls.is_teardown = False

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -1,0 +1,103 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.decorators import setup, task, teardown
+
+
+class TestSetupTearDownTask:
+    def test_marking_functions_as_setup_task(self, dag_maker):
+        @setup
+        def mytask():
+            print("I am a setup task")
+
+        with dag_maker() as dag:
+            mytask()
+        setup_task = dag.task_group.setup_children["mytask"]
+        assert setup_task._is_setup
+        assert len(dag.task_group.setup_children) == 1
+        assert len(dag.task_group.children) == 0
+        assert len(dag.task_group.teardown_children) == 0
+
+    def test_marking_functions_as_teardown_task(self, dag_maker):
+        @teardown
+        def mytask():
+            print("I am a teardown task")
+
+        with dag_maker() as dag:
+            mytask()
+
+        teardown_task = dag.task_group.teardown_children["mytask"]
+        assert teardown_task._is_teardown
+        assert len(dag.task_group.setup_children) == 0
+        assert len(dag.task_group.children) == 0
+        assert len(dag.task_group.teardown_children) == 1
+
+    def test_marking_decorated_functions_as_setup_task(self, dag_maker):
+        @setup
+        @task
+        def mytask():
+            print("I am a setup task")
+
+        with dag_maker() as dag:
+            mytask()
+
+        setup_task = dag.task_group.setup_children["mytask"]
+        assert setup_task._is_setup
+        assert len(dag.task_group.setup_children) == 1
+        assert len(dag.task_group.children) == 0
+        assert len(dag.task_group.teardown_children) == 0
+
+    def test_marking_operator_as_setup_task(self, dag_maker):
+        from airflow.operators.bash import BashOperator
+
+        with dag_maker() as dag:
+            BashOperator.as_setup(task_id="mytask", bash_command='echo "I am a setup task"')
+
+        setup_task = dag.task_group.setup_children["mytask"]
+        assert setup_task._is_setup
+        assert len(dag.task_group.setup_children) == 1
+        assert len(dag.task_group.children) == 0
+        assert len(dag.task_group.teardown_children) == 0
+
+    def test_marking_decorated_functions_as_teardown_task(self, dag_maker):
+        @teardown
+        @task
+        def mytask():
+            print("I am a teardown task")
+
+        with dag_maker() as dag:
+            mytask()
+
+        teardown_task = dag.task_group.teardown_children["mytask"]
+        assert teardown_task._is_teardown
+        assert len(dag.task_group.setup_children) == 0
+        assert len(dag.task_group.children) == 0
+        assert len(dag.task_group.teardown_children) == 1
+
+    def test_marking_operator_as_teardown_task(self, dag_maker):
+        from airflow.operators.bash import BashOperator
+
+        with dag_maker() as dag:
+            BashOperator.as_teardown(task_id="mytask", bash_command='echo "I am a setup task"')
+
+        teardown_task = dag.task_group.teardown_children["mytask"]
+        assert teardown_task._is_teardown
+        assert len(dag.task_group.setup_children) == 0
+        assert len(dag.task_group.children) == 0
+        assert len(dag.task_group.teardown_children) == 1


### PR DESCRIPTION
This adds support for setup and teardown tasks during DAG parsing. This puts those tasks in new `setup_children` and `teardown_children` lists in task groups. We also set `_is_setup` and `_is_teardown` attrs on the tasks.

There is much left to do to harden these pieces, but this covers the basics.

Closes: #29124
Closes: #29326