### PR TITLE
Use waiters in ECS Operators instead of inner sensors

### DIFF
--- a/airflow/providers/amazon/aws/hooks/ecs.py
+++ b/airflow/providers/amazon/aws/hooks/ecs.py
@@ -70,6 +70,7 @@ class EcsTaskDefinitionStates(str, Enum):
 
     ACTIVE = "ACTIVE"
     INACTIVE = "INACTIVE"
+    DELETE_IN_PROGRESS = "DELETE_IN_PROGRESS"
 
 
 class EcsTaskStates(str, Enum):

--- a/airflow/providers/amazon/aws/hooks/ecs.py
+++ b/airflow/providers/amazon/aws/hooks/ecs.py
@@ -55,7 +55,7 @@ def should_retry_eni(exception: Exception):
     return False
 
 
-class EcsClusterStates(Enum):
+class EcsClusterStates(str, Enum):
     """Contains the possible State values of an ECS Cluster."""
 
     ACTIVE = "ACTIVE"
@@ -65,14 +65,14 @@ class EcsClusterStates(Enum):
     INACTIVE = "INACTIVE"
 
 
-class EcsTaskDefinitionStates(Enum):
+class EcsTaskDefinitionStates(str, Enum):
     """Contains the possible State values of an ECS Task Definition."""
 
     ACTIVE = "ACTIVE"
     INACTIVE = "INACTIVE"
 
 
-class EcsTaskStates(Enum):
+class EcsTaskStates(str, Enum):
     """Contains the possible State values of an ECS Task."""
 
     PROVISIONING = "PROVISIONING"

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -119,7 +119,7 @@ class EcsCreateClusterOperator(EcsBaseOperator):
         cluster_state = cluster_details.get("status")
 
         if cluster_state == EcsClusterStates.ACTIVE:
-            # In some circumstances the ECS Cluster is deleted immediately,
+            # In some circumstances the ECS Cluster is created immediately,
             # and there is no reason to wait for completion.
             self.log.info("Cluster %r in state: %r.", self.cluster_name, cluster_state)
         elif self.wait_for_completion:

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -96,7 +96,7 @@ class EcsCreateClusterOperator(EcsBaseOperator):
         *,
         cluster_name: str,
         create_cluster_kwargs: dict | None = None,
-        wait_for_completion: bool = False,
+        wait_for_completion: bool = True,
         waiter_delay: int | None = None,
         waiter_max_attempts: int | None = None,
         **kwargs,

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -39,7 +39,7 @@ from airflow.providers.amazon.aws.hooks.ecs import (
     EcsTaskDefinitionStates,
     should_retry_eni,
 )
-from airflow.providers.amazon.aws.sensors.ecs import EcsClusterStateSensor, EcsTaskDefinitionStateSensor
+from airflow.utils.helpers import prune_dict
 from airflow.utils.session import provide_session
 
 if TYPE_CHECKING:
@@ -83,6 +83,10 @@ class EcsCreateClusterOperator(EcsBaseOperator):
         cluster, you create a cluster that's named default.
     :param create_cluster_kwargs: Extra arguments for Cluster Creation.
     :param wait_for_completion: If True, waits for creation of the cluster to complete. (default: True)
+    :param waiter_delay: The amount of time in seconds to wait between attempts,
+        if not set then default waiter value will use.
+    :param waiter_max_attempts: The maximum number of attempts to be made,
+        if not set then default waiter value will use.
     """
 
     template_fields: Sequence[str] = ("cluster_name", "create_cluster_kwargs", "wait_for_completion")
@@ -92,32 +96,45 @@ class EcsCreateClusterOperator(EcsBaseOperator):
         *,
         cluster_name: str,
         create_cluster_kwargs: dict | None = None,
-        wait_for_completion: bool = True,
+        wait_for_completion: bool = False,
+        waiter_delay: int | None = None,
+        waiter_max_attempts: int | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.cluster_name = cluster_name
         self.create_cluster_kwargs = create_cluster_kwargs or {}
         self.wait_for_completion = wait_for_completion
+        self.waiter_delay = waiter_delay
+        self.waiter_max_attempts = waiter_max_attempts
 
     def execute(self, context: Context):
         self.log.info(
-            "Creating cluster %s using the following values: %s",
+            "Creating cluster %r using the following values: %s",
             self.cluster_name,
             self.create_cluster_kwargs,
         )
         result = self.client.create_cluster(clusterName=self.cluster_name, **self.create_cluster_kwargs)
+        cluster_details = result["cluster"]
+        cluster_state = cluster_details.get("status")
 
-        if self.wait_for_completion:
-            while not EcsClusterStateSensor(
-                task_id="await_cluster",
-                cluster_name=self.cluster_name,
-            ).poke(context):
-                # The sensor has a built-in delay and will try again until
-                # the cluster is ready or has reached a failed state.
-                pass
+        if cluster_state == EcsClusterStates.ACTIVE:
+            # In some circumstances ECS Cluster deleted immediately,
+            # and there is no reason wait for completion.
+            self.log.info("Cluster %r in state: %r.", self.cluster_name, cluster_state)
+        elif self.wait_for_completion:
+            waiter = self.hook.get_waiter("cluster_active")
+            waiter.wait(
+                clusters=[cluster_details["clusterArn"]],
+                WaiterConfig=prune_dict(
+                    {
+                        "Delay": self.waiter_delay,
+                        "MaxAttempts": self.waiter_max_attempts,
+                    }
+                ),
+            )
 
-        return result["cluster"]
+        return cluster_details
 
 
 class EcsDeleteClusterOperator(EcsBaseOperator):
@@ -130,6 +147,10 @@ class EcsDeleteClusterOperator(EcsBaseOperator):
 
     :param cluster_name: The short name or full Amazon Resource Name (ARN) of the cluster to delete.
     :param wait_for_completion: If True, waits for creation of the cluster to complete. (default: True)
+    :param waiter_delay: The amount of time in seconds to wait between attempts,
+        if not set then default waiter value will use.
+    :param waiter_max_attempts: The maximum number of attempts to be made,
+        if not set then default waiter value will use.
     """
 
     template_fields: Sequence[str] = ("cluster_name", "wait_for_completion")
@@ -139,28 +160,39 @@ class EcsDeleteClusterOperator(EcsBaseOperator):
         *,
         cluster_name: str,
         wait_for_completion: bool = True,
+        waiter_delay: int | None = None,
+        waiter_max_attempts: int | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.cluster_name = cluster_name
         self.wait_for_completion = wait_for_completion
+        self.waiter_delay = waiter_delay
+        self.waiter_max_attempts = waiter_max_attempts
 
     def execute(self, context: Context):
-        self.log.info("Deleting cluster %s.", self.cluster_name)
+        self.log.info("Deleting cluster %r.", self.cluster_name)
         result = self.client.delete_cluster(cluster=self.cluster_name)
+        cluster_details = result["cluster"]
+        cluster_state = cluster_details.get("status")
 
-        if self.wait_for_completion:
-            while not EcsClusterStateSensor(
-                task_id="await_cluster_delete",
-                cluster_name=self.cluster_name,
-                target_state=EcsClusterStates.INACTIVE,
-                failure_states={EcsClusterStates.FAILED},
-            ).poke(context):
-                # The sensor has a built-in delay and will try again until
-                # the cluster is deleted or reaches a failed state.
-                pass
+        if cluster_state == EcsClusterStates.INACTIVE:
+            # In some circumstances ECS Cluster deleted immediately,
+            # and there is no reason wait for completion.
+            self.log.info("Cluster %r in state: %r.", self.cluster_name, cluster_state)
+        elif self.wait_for_completion:
+            waiter = self.hook.get_waiter("cluster_inactive")
+            waiter.wait(
+                clusters=[cluster_details["clusterArn"]],
+                WaiterConfig=prune_dict(
+                    {
+                        "Delay": self.waiter_delay,
+                        "MaxAttempts": self.waiter_max_attempts,
+                    }
+                ),
+            )
 
-        return result["cluster"]
+        return cluster_details
 
 
 class EcsDeregisterTaskDefinitionOperator(EcsBaseOperator):
@@ -174,30 +206,53 @@ class EcsDeregisterTaskDefinitionOperator(EcsBaseOperator):
     :param task_definition: The family and revision (family:revision) or full Amazon Resource Name (ARN)
         of the task definition to deregister. If you use a family name, you must specify a revision.
     :param wait_for_completion: If True, waits for creation of the cluster to complete. (default: True)
+    :param waiter_delay: The amount of time in seconds to wait between attempts,
+        if not set then default waiter value will use.
+    :param waiter_max_attempts: The maximum number of attempts to be made,
+        if not set then default waiter value will use.
     """
 
     template_fields: Sequence[str] = ("task_definition", "wait_for_completion")
 
-    def __init__(self, *, task_definition: str, wait_for_completion: bool = True, **kwargs):
+    def __init__(
+        self,
+        *,
+        task_definition: str,
+        wait_for_completion: bool = True,
+        waiter_delay: int | None = None,
+        waiter_max_attempts: int | None = None,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self.task_definition = task_definition
         self.wait_for_completion = wait_for_completion
+        self.waiter_delay = waiter_delay
+        self.waiter_max_attempts = waiter_max_attempts
 
     def execute(self, context: Context):
         self.log.info("Deregistering task definition %s.", self.task_definition)
         result = self.client.deregister_task_definition(taskDefinition=self.task_definition)
+        task_definition_details = result["taskDefinition"]
+        task_definition_arn = task_definition_details["taskDefinitionArn"]
+        task_definition_state = task_definition_details.get("status")
 
-        if self.wait_for_completion:
-            while not EcsTaskDefinitionStateSensor(
-                task_id="await_deregister_task_definition",
-                task_definition=self.task_definition,
-                target_state=EcsTaskDefinitionStates.INACTIVE,
-            ).poke(context):
-                # The sensor has a built-in delay and will try again until the
-                # task definition is deregistered or reaches a failed state.
-                pass
+        if task_definition_state == EcsTaskDefinitionStates.INACTIVE:
+            # In some circumstances ECS Task Definition deleted immediately,
+            # and there is no reason wait for completion.
+            self.log.info("Task Definition %r in state: %r.", task_definition_arn, task_definition_state)
+        elif self.wait_for_completion:
+            waiter = self.hook.get_waiter("task_definition_inactive")
+            waiter.wait(
+                taskDefinition=task_definition_arn,
+                WaiterConfig=prune_dict(
+                    {
+                        "Delay": self.waiter_delay,
+                        "MaxAttempts": self.waiter_max_attempts,
+                    }
+                ),
+            )
 
-        return result["taskDefinition"]["taskDefinitionArn"]
+        return task_definition_arn
 
 
 class EcsRegisterTaskDefinitionOperator(EcsBaseOperator):
@@ -213,6 +268,10 @@ class EcsRegisterTaskDefinitionOperator(EcsBaseOperator):
         the different containers that make up your task.
     :param register_task_kwargs: Extra arguments for Register Task Definition.
     :param wait_for_completion: If True, waits for creation of the cluster to complete. (default: True)
+    :param waiter_delay: The amount of time in seconds to wait between attempts,
+        if not set then default waiter value will use.
+    :param waiter_max_attempts: The maximum number of attempts to be made,
+        if not set then default waiter value will use.
     """
 
     template_fields: Sequence[str] = (
@@ -229,6 +288,8 @@ class EcsRegisterTaskDefinitionOperator(EcsBaseOperator):
         container_definitions: list[dict],
         register_task_kwargs: dict | None = None,
         wait_for_completion: bool = True,
+        waiter_delay: int | None = None,
+        waiter_max_attempts: int | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -236,6 +297,8 @@ class EcsRegisterTaskDefinitionOperator(EcsBaseOperator):
         self.container_definitions = container_definitions
         self.register_task_kwargs = register_task_kwargs or {}
         self.wait_for_completion = wait_for_completion
+        self.waiter_delay = waiter_delay
+        self.waiter_max_attempts = waiter_max_attempts
 
     def execute(self, context: Context):
         self.log.info(
@@ -249,18 +312,28 @@ class EcsRegisterTaskDefinitionOperator(EcsBaseOperator):
             containerDefinitions=self.container_definitions,
             **self.register_task_kwargs,
         )
-        task_arn = response["taskDefinition"]["taskDefinitionArn"]
+        task_definition_details = response["taskDefinition"]
+        task_definition_arn = task_definition_details["taskDefinitionArn"]
+        task_definition_state = task_definition_details.get("status")
 
-        if self.wait_for_completion:
-            while not EcsTaskDefinitionStateSensor(
-                task_id="await_register_task_definition", task_definition=task_arn
-            ).poke(context):
-                # The sensor has a built-in delay and will try again until
-                # the task definition is registered or reaches a failed state.
-                pass
+        if task_definition_state == EcsTaskDefinitionStates.ACTIVE:
+            # In some circumstances ECS Task Definition created immediately,
+            # and there is no reason wait for completion.
+            self.log.info("Task Definition %r in state: %r.", task_definition_arn, task_definition_state)
+        elif self.wait_for_completion:
+            waiter = self.hook.get_waiter("task_definition_active")
+            waiter.wait(
+                taskDefinition=task_definition_arn,
+                WaiterConfig=prune_dict(
+                    {
+                        "Delay": self.waiter_delay,
+                        "MaxAttempts": self.waiter_max_attempts,
+                    }
+                ),
+            )
 
-        context["ti"].xcom_push(key="task_definition_arn", value=task_arn)
-        return task_arn
+        context["ti"].xcom_push(key="task_definition_arn", value=task_definition_arn)
+        return task_definition_arn
 
 
 class EcsRunTaskOperator(EcsBaseOperator):

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -84,9 +84,9 @@ class EcsCreateClusterOperator(EcsBaseOperator):
     :param create_cluster_kwargs: Extra arguments for Cluster Creation.
     :param wait_for_completion: If True, waits for creation of the cluster to complete. (default: True)
     :param waiter_delay: The amount of time in seconds to wait between attempts,
-        if not set then default waiter value will use.
+        if not set then the default waiter value will be used.
     :param waiter_max_attempts: The maximum number of attempts to be made,
-        if not set then default waiter value will use.
+        if not set then the default waiter value will be used.
     """
 
     template_fields: Sequence[str] = ("cluster_name", "create_cluster_kwargs", "wait_for_completion")
@@ -119,8 +119,8 @@ class EcsCreateClusterOperator(EcsBaseOperator):
         cluster_state = cluster_details.get("status")
 
         if cluster_state == EcsClusterStates.ACTIVE:
-            # In some circumstances ECS Cluster deleted immediately,
-            # and there is no reason wait for completion.
+            # In some circumstances the ECS Cluster is deleted immediately,
+            # and there is no reason to wait for completion.
             self.log.info("Cluster %r in state: %r.", self.cluster_name, cluster_state)
         elif self.wait_for_completion:
             waiter = self.hook.get_waiter("cluster_active")
@@ -148,9 +148,9 @@ class EcsDeleteClusterOperator(EcsBaseOperator):
     :param cluster_name: The short name or full Amazon Resource Name (ARN) of the cluster to delete.
     :param wait_for_completion: If True, waits for creation of the cluster to complete. (default: True)
     :param waiter_delay: The amount of time in seconds to wait between attempts,
-        if not set then default waiter value will use.
+        if not set then the default waiter value will be used.
     :param waiter_max_attempts: The maximum number of attempts to be made,
-        if not set then default waiter value will use.
+        if not set then the default waiter value will be used.
     """
 
     template_fields: Sequence[str] = ("cluster_name", "wait_for_completion")
@@ -177,8 +177,8 @@ class EcsDeleteClusterOperator(EcsBaseOperator):
         cluster_state = cluster_details.get("status")
 
         if cluster_state == EcsClusterStates.INACTIVE:
-            # In some circumstances ECS Cluster deleted immediately,
-            # and there is no reason wait for completion.
+            # In some circumstances the ECS Cluster is deleted immediately,
+            # so there is no reason to wait for completion.
             self.log.info("Cluster %r in state: %r.", self.cluster_name, cluster_state)
         elif self.wait_for_completion:
             waiter = self.hook.get_waiter("cluster_inactive")
@@ -207,9 +207,9 @@ class EcsDeregisterTaskDefinitionOperator(EcsBaseOperator):
         of the task definition to deregister. If you use a family name, you must specify a revision.
     :param wait_for_completion: If True, waits for creation of the cluster to complete. (default: True)
     :param waiter_delay: The amount of time in seconds to wait between attempts,
-        if not set then default waiter value will use.
+        if not set then the default waiter value will be used.
     :param waiter_max_attempts: The maximum number of attempts to be made,
-        if not set then default waiter value will use.
+        if not set then the default waiter value will be used.
     """
 
     template_fields: Sequence[str] = ("task_definition", "wait_for_completion")
@@ -237,8 +237,8 @@ class EcsDeregisterTaskDefinitionOperator(EcsBaseOperator):
         task_definition_state = task_definition_details.get("status")
 
         if task_definition_state == EcsTaskDefinitionStates.INACTIVE:
-            # In some circumstances ECS Task Definition deleted immediately,
-            # and there is no reason wait for completion.
+            # In some circumstances the ECS Task Definition is deleted immediately,
+            # so there is no reason to wait for completion.
             self.log.info("Task Definition %r in state: %r.", task_definition_arn, task_definition_state)
         elif self.wait_for_completion:
             waiter = self.hook.get_waiter("task_definition_inactive")
@@ -269,9 +269,9 @@ class EcsRegisterTaskDefinitionOperator(EcsBaseOperator):
     :param register_task_kwargs: Extra arguments for Register Task Definition.
     :param wait_for_completion: If True, waits for creation of the cluster to complete. (default: True)
     :param waiter_delay: The amount of time in seconds to wait between attempts,
-        if not set then default waiter value will use.
+        if not set then the default waiter value will be used.
     :param waiter_max_attempts: The maximum number of attempts to be made,
-        if not set then default waiter value will use.
+        if not set then the default waiter value will be used.
     """
 
     template_fields: Sequence[str] = (
@@ -317,8 +317,8 @@ class EcsRegisterTaskDefinitionOperator(EcsBaseOperator):
         task_definition_state = task_definition_details.get("status")
 
         if task_definition_state == EcsTaskDefinitionStates.ACTIVE:
-            # In some circumstances ECS Task Definition created immediately,
-            # and there is no reason wait for completion.
+            # In some circumstances the ECS Task Definition is created immediately,
+            # so there is no reason to wait for completion.
             self.log.info("Task Definition %r in state: %r.", task_definition_arn, task_definition_state)
         elif self.wait_for_completion:
             waiter = self.hook.get_waiter("task_definition_active")

--- a/airflow/providers/amazon/aws/waiters/ecs.json
+++ b/airflow/providers/amazon/aws/waiters/ecs.json
@@ -1,0 +1,81 @@
+{
+    "version": 2,
+    "waiters": {
+        "cluster_active": {
+            "operation": "DescribeClusters",
+            "delay": 15,
+            "maxAttempts": 60,
+            "acceptors": [
+                {
+                    "expected": "ACTIVE",
+                    "matcher": "pathAny",
+                    "state": "success",
+                    "argument": "clusters[].status"
+                },
+                {
+                    "expected": "FAILED",
+                    "matcher": "pathAny",
+                    "state": "failure",
+                    "argument": "clusters[].status"
+                },
+                {
+                    "expected": "INACTIVE",
+                    "matcher": "pathAny",
+                    "state": "failure",
+                    "argument": "clusters[].status"
+                },
+                {
+                  "expected": "MISSING",
+                  "matcher": "pathAny",
+                  "state": "failure",
+                  "argument": "failures[].reason"
+                }
+            ]
+        },
+        "cluster_inactive": {
+            "operation": "DescribeClusters",
+            "delay": 15,
+            "maxAttempts": 60,
+            "acceptors": [
+                {
+                    "expected": "INACTIVE",
+                    "matcher": "pathAny",
+                    "state": "success",
+                    "argument": "clusters[].status"
+                },
+                {
+                  "expected": "MISSING",
+                  "matcher": "pathAny",
+                  "state": "success",
+                  "argument": "failures[].reason"
+                }
+            ]
+        },
+        "task_definition_active": {
+            "operation": "DescribeTaskDefinition",
+            "delay": 15,
+            "maxAttempts": 60,
+            "acceptors": [
+                {
+                    "expected": "ACTIVE",
+                    "matcher": "path",
+                    "state": "success",
+                    "argument": "taskDefinition.status"
+                }
+            ]
+        },
+        "task_definition_inactive": {
+            "operation": "DescribeTaskDefinition",
+            "delay": 15,
+            "maxAttempts": 60,
+            "acceptors": [
+                {
+                    "expected": "INACTIVE",
+                    "matcher": "path",
+                    "state": "success",
+                    "argument": "taskDefinition.status"
+                }
+            ]
+        }
+    }
+}

--- a/airflow/providers/amazon/aws/waiters/ecs.json
+++ b/airflow/providers/amazon/aws/waiters/ecs.json
@@ -61,6 +61,12 @@
                     "matcher": "path",
                     "state": "success",
                     "argument": "taskDefinition.status"
+                },
+                {
+                    "expected": "DELETE_IN_PROGRESS",
+                    "matcher": "path",
+                    "state": "failure",
+                    "argument": "taskDefinition.status"
                 }
             ]
         },

--- a/tests/providers/amazon/aws/waiters/test_custom_waiters.py
+++ b/tests/providers/amazon/aws/waiters/test_custom_waiters.py
@@ -220,6 +220,15 @@ class TestCustomECSServiceWaiters:
         waiter = EcsHook(aws_conn_id=None).get_waiter("task_definition_active")
         waiter.wait(taskDefinition="spam-egg", WaiterConfig={"Delay": 0.01, "MaxAttempts": 3})
 
+    def test_task_definition_failure(self, mock_describe_task_definition):
+        """Test task definition reach delete in progress state during creation."""
+        mock_describe_task_definition.side_effect = [
+            self.describe_task_definition(EcsTaskDefinitionStates.DELETE_IN_PROGRESS),
+        ]
+        waiter = EcsHook(aws_conn_id=None).get_waiter("task_definition_active")
+        with pytest.raises(WaiterError, match='matched expected path: "DELETE_IN_PROGRESS"'):
+            waiter.wait(taskDefinition="spam-egg", WaiterConfig={"Delay": 0.01, "MaxAttempts": 1})
+
     def test_task_definition_inactive(self, mock_describe_task_definition):
         """Test task definition reach inactive state during deletion."""
         mock_describe_task_definition.side_effect = [

--- a/tests/providers/amazon/aws/waiters/test_custom_waiters.py
+++ b/tests/providers/amazon/aws/waiters/test_custom_waiters.py
@@ -18,11 +18,15 @@
 from __future__ import annotations
 
 import json
+from unittest import mock
 
 import boto3
+import pytest
+from botocore.exceptions import WaiterError
 from botocore.waiter import WaiterModel
 from moto import mock_eks
 
+from airflow.providers.amazon.aws.hooks.ecs import EcsClusterStates, EcsHook, EcsTaskDefinitionStates
 from airflow.providers.amazon.aws.hooks.eks import EksHook
 from airflow.providers.amazon.aws.waiters.base_waiter import BaseBotoWaiter
 
@@ -69,7 +73,7 @@ class TestBaseWaiter:
         assert waiter.client == client_name
 
 
-class TestServiceWaiters:
+class TestCustomEKSServiceWaiters:
     def test_service_waiters(self):
         hook = EksHook()
         with open(hook.waiter_path) as config_file:
@@ -98,3 +102,130 @@ class TestServiceWaiters:
             # so the best we can do it make sure the same attrs exist.
             assert hasattr(boto_waiter, attr)
             assert hasattr(client_waiter, attr)
+
+
+class TestCustomECSServiceWaiters:
+    """Test waiters from ``amazon/aws/waiters/ecs.json``."""
+
+    @pytest.fixture(autouse=True)
+    def setup_test_cases(self, monkeypatch):
+        self.client = boto3.client("ecs", region_name="eu-west-3")
+        monkeypatch.setattr(EcsHook, "conn", self.client)
+
+    @pytest.fixture
+    def mock_describe_clusters(self):
+        """Mock ``ECS.Client.describe_clusters`` method."""
+        with mock.patch.object(self.client, "describe_clusters") as m:
+            yield m
+
+    @pytest.fixture
+    def mock_describe_task_definition(self):
+        """Mock ``ECS.Client.describe_task_definition`` method."""
+        with mock.patch.object(self.client, "describe_task_definition") as m:
+            yield m
+
+    def test_service_waiters(self):
+        hook_waiters = EcsHook(aws_conn_id=None).list_waiters()
+        assert "cluster_active" in hook_waiters
+        assert "cluster_inactive" in hook_waiters
+        assert "task_definition_active" in hook_waiters
+        assert "task_definition_inactive" in hook_waiters
+
+    @staticmethod
+    def describe_clusters(status: str, cluster_name: str = "spam-egg", failures: dict | list | None = None):
+        """
+        Helper function for generate minimal DescribeClusters response for single job.
+        https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeClusters.html
+        """
+        assert status in EcsClusterStates.__members__.values()
+        failures = failures or []
+        if isinstance(failures, dict):
+            failures = [failures]
+
+        return {"clusters": [{"clusterName": cluster_name, "status": status}], "failures": failures}
+
+    def test_cluster_active(self, mock_describe_clusters):
+        """Test cluster reach Active state during creation."""
+        mock_describe_clusters.side_effect = [
+            self.describe_clusters(EcsClusterStates.DEPROVISIONING),
+            self.describe_clusters(EcsClusterStates.PROVISIONING),
+            self.describe_clusters(EcsClusterStates.ACTIVE),
+        ]
+        waiter = EcsHook(aws_conn_id=None).get_waiter("cluster_active")
+        waiter.wait(clusters=["spam-egg"], WaiterConfig={"Delay": 0.01, "MaxAttempts": 3})
+
+    @pytest.mark.parametrize("state", [EcsClusterStates.FAILED, EcsClusterStates.INACTIVE])
+    def test_cluster_active_failure_states(self, mock_describe_clusters, state):
+        """Test cluster reach inactive state during creation."""
+        mock_describe_clusters.side_effect = [
+            self.describe_clusters(EcsClusterStates.PROVISIONING),
+            self.describe_clusters(state),
+        ]
+        waiter = EcsHook(aws_conn_id=None).get_waiter("cluster_active")
+        with pytest.raises(WaiterError, match=f'matched expected path: "{state}"'):
+            waiter.wait(clusters=["spam-egg"], WaiterConfig={"Delay": 0.01, "MaxAttempts": 3})
+
+    def test_cluster_active_failure_reasons(self, mock_describe_clusters):
+        """Test cluster reach failure state during creation."""
+        mock_describe_clusters.side_effect = [
+            self.describe_clusters(EcsClusterStates.PROVISIONING),
+            self.describe_clusters(EcsClusterStates.PROVISIONING, failures={"reason": "MISSING"}),
+        ]
+        waiter = EcsHook(aws_conn_id=None).get_waiter("cluster_active")
+        with pytest.raises(WaiterError, match='matched expected path: "MISSING"'):
+            waiter.wait(clusters=["spam-egg"], WaiterConfig={"Delay": 0.01, "MaxAttempts": 3})
+
+    def test_cluster_inactive(self, mock_describe_clusters):
+        """Test cluster reach Inactive state during deletion."""
+        mock_describe_clusters.side_effect = [
+            self.describe_clusters(EcsClusterStates.ACTIVE),
+            self.describe_clusters(EcsClusterStates.ACTIVE),
+            self.describe_clusters(EcsClusterStates.INACTIVE),
+        ]
+        waiter = EcsHook(aws_conn_id=None).get_waiter("cluster_inactive")
+        waiter.wait(clusters=["spam-egg"], WaiterConfig={"Delay": 0.01, "MaxAttempts": 3})
+
+    def test_cluster_inactive_failure_reasons(self, mock_describe_clusters):
+        """Test cluster reach failure state during deletion."""
+        mock_describe_clusters.side_effect = [
+            self.describe_clusters(EcsClusterStates.ACTIVE),
+            self.describe_clusters(EcsClusterStates.DEPROVISIONING),
+            self.describe_clusters(EcsClusterStates.DEPROVISIONING, failures={"reason": "MISSING"}),
+        ]
+        waiter = EcsHook(aws_conn_id=None).get_waiter("cluster_inactive")
+        waiter.wait(clusters=["spam-egg"], WaiterConfig={"Delay": 0.01, "MaxAttempts": 3})
+
+    @staticmethod
+    def describe_task_definition(status: str, task_definition: str = "spam-egg"):
+        """
+        Helper function for generate minimal DescribeTaskDefinition response for single job.
+        https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTaskDefinition.html
+        """
+        return {
+            "taskDefinition": {
+                "taskDefinitionArn": (
+                    f"arn:aws:ecs:eu-west-3:123456789012:task-definition/{task_definition}:42"
+                ),
+                "status": status,
+            }
+        }
+
+    def test_task_definition_active(self, mock_describe_task_definition):
+        """Test task definition reach active state during creation."""
+        mock_describe_task_definition.side_effect = [
+            self.describe_task_definition(EcsTaskDefinitionStates.INACTIVE),
+            self.describe_task_definition(EcsTaskDefinitionStates.INACTIVE),
+            self.describe_task_definition(EcsTaskDefinitionStates.ACTIVE),
+        ]
+        waiter = EcsHook(aws_conn_id=None).get_waiter("task_definition_active")
+        waiter.wait(taskDefinition="spam-egg", WaiterConfig={"Delay": 0.01, "MaxAttempts": 3})
+
+    def test_task_definition_inactive(self, mock_describe_task_definition):
+        """Test task definition reach inactive state during deletion."""
+        mock_describe_task_definition.side_effect = [
+            self.describe_task_definition(EcsTaskDefinitionStates.ACTIVE),
+            self.describe_task_definition(EcsTaskDefinitionStates.ACTIVE),
+            self.describe_task_definition(EcsTaskDefinitionStates.INACTIVE),
+        ]
+        waiter = EcsHook(aws_conn_id=None).get_waiter("task_definition_inactive")
+        waiter.wait(taskDefinition="spam-egg", WaiterConfig={"Delay": 0.01, "MaxAttempts": 3})


### PR DESCRIPTION
closes: #29556

Use custom [botocore.Waiters](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html#waiters) instead of inner sensors in ECS Operators
