### PR TITLE
Upgrade FAB to 4.3.0

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1600,6 +1600,20 @@ webserver:
       type: boolean
       example: ~
       default: "False"
+    auth_rate_limited:
+      description: |
+        Boolean for enabling rate limiting on authentication endpoints.
+      version_added: 2.6.0
+      type: boolean
+      example: ~
+      default: "True"
+    auth_rate_limit:
+      description: |
+          Rate limit for authentication endpoints.
+      version_added: 2.6.0
+      type: string
+      example: ~
+      default: "5 per 40 second"
 
 email:
   description: |

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -824,6 +824,12 @@ enable_swagger_ui = True
 # Boolean for running Internal API in the webserver.
 run_internal_api = False
 
+# Boolean for enabling rate limiting on authentication endpoints.
+auth_rate_limited = True
+
+# Rate limit for authentication endpoints.
+auth_rate_limit = 5 per 40 second
+
 [email]
 
 # Configuration email backend and whether to

--- a/docs/apache-airflow/administration-and-deployment/security/webserver.rst
+++ b/docs/apache-airflow/administration-and-deployment/security/webserver.rst
@@ -263,3 +263,24 @@ certs and keys.
     ssl_key = <path to key>
     ssl_cert = <path to cert>
     ssl_cacert = <path to cacert>
+
+Rate limiting
+-------------
+
+Airflow can be configured to limit the number of authentication requests in a given time window. We are using
+`Flask-Limiter <https://flask-limiter.readthedocs.io/en/stable/>`_ to achieve that and by default Airflow
+uses per-webserver default limit of 5 requests per 40 second fixed window. By default no common storage for
+rate limits is used between the gunicorn processes you run so rate-limit is applied separately for each process,
+so assuming random distribution of the requests by gunicorn with single webserver instance and default 4
+gunicorn workers, the effective rate limit is 5 x 4 = 20 requests per 40 second window (more or less).
+However you can configure the rate limit to be shared between the processes by using rate limit storage via
+setting the ``RATELIMIT_*`` configuration settings in ``webserver_config.py``.
+For example, to use Redis as a rate limit storage you can use the following configuration (you need
+to set ``redis_host`` to your Redis instance)
+
+```
+RATELIMIT_STORAGE_URI = 'redis://redis_host:6379/0
+```
+
+You can also configure other rate limit settings in ``webserver_config.py`` - for more details, see the
+`Flask Limiter rate limit configuration <https://flask-limiter.readthedocs.io/en/stable/configuration.html>`_.

--- a/docs/apache-airflow/howto/set-config.rst
+++ b/docs/apache-airflow/howto/set-config.rst
@@ -130,3 +130,15 @@ the example below.
     generated using the secret key has a short expiry time though - make sure that time on ALL the machines
     that you run airflow components on is synchronized (for example using ntpd) otherwise you might get
     "forbidden" errors when the logs are accessed.
+
+
+Configuring Flask Application for Airflow Webserver
+===================================================
+
+Airflow uses Flask to render the web UI. When you initialize the Airflow webserver, predefined configuration
+is used, based on the ``webserver`` section of the ``airflow.cfg`` file. You can override these settings
+and add any extra settings however by adding flask configuration to ``webserver_config.py`` file in your
+``$AIRFLOW_HOME`` directory. This file is automatically loaded by the webserver.
+
+For example if you would like to change rate limit strategy to "moving window", you can set the
+``RATELIMIT_STRATEGY`` to ``moving-window``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,7 +93,7 @@ install_requires =
     # `airflow/www/fab_security` with their upstream counterparts. In particular, make sure any breaking changes,
     # for example any new methods, are accounted for.
     # NOTE! When you change the value here, you also have to update flask-appbuilder[oauth] in setup.py
-    flask-appbuilder==4.1.4
+    flask-appbuilder==4.3.0
     flask-caching>=1.5.0
     flask-login>=0.6.2
     flask-session>=0.4.0

--- a/setup.py
+++ b/setup.py
@@ -278,7 +278,7 @@ doc_gen = [
 flask_appbuilder_oauth = [
     "authlib>=1.0.0",
     # The version here should be upgraded at the same time as flask-appbuilder in setup.cfg
-    "flask-appbuilder[oauth]==4.1.4",
+    "flask-appbuilder[oauth]==4.3.0",
 ]
 kerberos = [
     "pykerberos>=1.1.13",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -447,9 +447,12 @@ def frozen_sleep(monkeypatch):
 
 @pytest.fixture(scope="session")
 def app():
-    from airflow.www import app
+    from tests.test_utils.config import conf_vars
 
-    return app.create_app(testing=True)
+    with conf_vars({("webserver", "auth_rate_limited"): "False"}):
+        from airflow.www import app
+
+        yield app.create_app(testing=True)
 
 
 @pytest.fixture

--- a/tests/test_utils/www.py
+++ b/tests/test_utils/www.py
@@ -22,13 +22,13 @@ from unittest import mock
 from airflow.models import Log
 
 
-def client_with_login(app, **kwargs):
+def client_with_login(app, expected_response_code=302, **kwargs):
     patch_path = "airflow.www.fab_security.manager.check_password_hash"
     with mock.patch(patch_path) as check_password_hash:
         check_password_hash.return_value = True
         client = app.test_client()
         resp = client.post("/login/", data=kwargs)
-        assert resp.status_code == 302
+        assert resp.status_code == expected_response_code
     return client
 
 

--- a/tests/www/views/conftest.py
+++ b/tests/www/views/conftest.py
@@ -28,6 +28,7 @@ from airflow import settings
 from airflow.models import DagBag
 from airflow.www.app import create_app
 from tests.test_utils.api_connexion_utils import delete_user
+from tests.test_utils.config import conf_vars
 from tests.test_utils.decorators import dont_initialize_flask_app_submodules
 from tests.test_utils.www import client_with_login, client_without_login
 
@@ -62,7 +63,8 @@ def app(examples_dag_bag):
         ]
     )
     def factory():
-        return create_app(testing=True)
+        with conf_vars({("webserver", "auth_rate_limited"): "False"}):
+            return create_app(testing=True)
 
     app = factory()
     app.config["WTF_CSRF_ENABLED"] = False
@@ -110,6 +112,7 @@ def app(examples_dag_bag):
 
 @pytest.fixture()
 def admin_client(app):
+
     return client_with_login(app, username="test_admin", password="test_admin")
 
 

--- a/tests/www/views/test_views_log.py
+++ b/tests/www/views/test_views_log.py
@@ -73,7 +73,12 @@ def log_app(backup_modules, log_path):
             "init_api_connexion",
         ]
     )
-    @conf_vars({("logging", "logging_config_class"): "airflow_local_settings.LOGGING_CONFIG"})
+    @conf_vars(
+        {
+            ("logging", "logging_config_class"): "airflow_local_settings.LOGGING_CONFIG",
+            ("webserver", "auth_rate_limited"): "False",
+        }
+    )
     def factory():
         app = create_app(testing=True)
         app.config["WTF_CSRF_ENABLED"] = False

--- a/tests/www/views/test_views_rate_limit.py
+++ b/tests/www/views/test_views_rate_limit.py
@@ -1,0 +1,69 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.www.app import create_app
+from tests.test_utils.config import conf_vars
+from tests.test_utils.decorators import dont_initialize_flask_app_submodules
+from tests.test_utils.www import client_with_login
+
+
+@pytest.fixture()
+def app_with_rate_limit_one(examples_dag_bag):
+    @dont_initialize_flask_app_submodules(
+        skip_all_except=[
+            "init_api_connexion",
+            "init_appbuilder",
+            "init_appbuilder_links",
+            "init_appbuilder_views",
+            "init_flash_views",
+            "init_jinja_globals",
+            "init_plugins",
+            "init_airflow_session_interface",
+            "init_check_user_active",
+        ]
+    )
+    def factory():
+        with conf_vars(
+            {("webserver", "auth_rate_limited"): "True", ("webserver", "auth_rate_limit"): "1 per 20 second"}
+        ):
+            return create_app(testing=True)
+
+    app = factory()
+    app.config["WTF_CSRF_ENABLED"] = False
+    return app
+
+
+def test_rate_limit_one(app_with_rate_limit_one):
+    client_with_login(
+        app_with_rate_limit_one, expected_response_code=302, username="test_admin", password="test_admin"
+    )
+    client_with_login(
+        app_with_rate_limit_one, expected_response_code=429, username="test_admin", password="test_admin"
+    )
+    client_with_login(
+        app_with_rate_limit_one, expected_response_code=429, username="test_admin", password="test_admin"
+    )
+
+
+def test_rate_limit_disabled(app):
+    client_with_login(app, expected_response_code=302, username="test_admin", password="test_admin")
+    client_with_login(app, expected_response_code=302, username="test_admin", password="test_admin")
+    client_with_login(app, expected_response_code=302, username="test_admin", password="test_admin")


### PR DESCRIPTION
FAB 4.3.0 added rate limiting and we would like to upgrade to this version.

This requires to bring some of the changes from the PRs merged in Flask App Builder:

* https://github.com/dpgaspar/Flask-AppBuilder/pull/1976
* https://github.com/dpgaspar/Flask-AppBuilder/pull/1997
* https://github.com/dpgaspar/Flask-AppBuilder/pull/1999

While Flask App Builder disabled rate limitig by default, Airlfow is "end product" using it and we decided to enable it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
