### PR TITLE
Fix compile www assets dev

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_compile_www_assets_dev.py
+++ b/scripts/ci/pre_commit/pre_commit_compile_www_assets_dev.py
@@ -35,6 +35,7 @@ WWW_ASSET_OUT_DEV_MODE_FILE = WWW_CACHE_DIR / "asset_compile_dev_mode.out"
 
 if __name__ == "__main__":
     www_directory = AIRFLOW_SOURCES_PATH / "airflow" / "www"
+    WWW_CACHE_DIR.mkdir(exist_ok=True)
     if WWW_HASH_FILE.exists():
         # cleanup hash of www so that next compile-assets recompiles them
         WWW_HASH_FILE.unlink()

--- a/scripts/ci/pre_commit/pre_commit_compile_www_assets_dev.py
+++ b/scripts/ci/pre_commit/pre_commit_compile_www_assets_dev.py
@@ -35,7 +35,7 @@ WWW_ASSET_OUT_DEV_MODE_FILE = WWW_CACHE_DIR / "asset_compile_dev_mode.out"
 
 if __name__ == "__main__":
     www_directory = AIRFLOW_SOURCES_PATH / "airflow" / "www"
-    WWW_CACHE_DIR.mkdir(exist_ok=True)
+    WWW_CACHE_DIR.mkdir(parents=True, exist_ok=True)
     if WWW_HASH_FILE.exists():
         # cleanup hash of www so that next compile-assets recompiles them
         WWW_HASH_FILE.unlink()


### PR DESCRIPTION
`.build/www` directory can be missing, and therefore asset compilation was not performed.

Ensure that this directory exists before redirecting the compilation output. (We do not have the issue for non-dev compilation because [this line](https://github.com/apache/airflow/blob/main/scripts/ci/pre_commit/pre_commit_compile_www_assets.py#L39) guarantee `www` existence)

To reproduce:
```
rm -rf .build
breeze start-airflow --backend postgres --python 3.8 --dev-mode
```

![image](https://user-images.githubusercontent.com/14861206/221379572-922a0091-9907-4c6e-9de6-a6eaaad38d6d.png)
