### PR TITLE
[WIP] Deprecate `execution_date` in the Airflow REST API

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -4228,21 +4228,44 @@ components:
 
             The value can be repeated to retrieve multiple matching values (OR condition).
 
-        execution_date_gte:
+        logical_date_gte:
           type: string
           format: date-time
           description: |
             Returns objects greater or equal to the specified date.
 
+            This can be combined with logical_date_lte key to receive only the selected period.
+
+        logical_date_lte:
+          type: string
+          format: date-time
+          deprecated: true
+          description: |
+            Returns objects less than or equal to the specified date.
+
+            This can be combined with logical_date_gte key to receive only the selected period.
+
+        execution_date_gte:
+          type: string
+          format: date-time
+          deprecated: true
+          description: |
+            Returns objects greater or equal to the specified date.
+
             This can be combined with execution_date_lte key to receive only the selected period.
+
+            *Deprecated since version 2.6.0*&#58; Use 'logical_date_gte' instead.
 
         execution_date_lte:
           type: string
           format: date-time
+          deprecated: true
           description: |
             Returns objects less than or equal to the specified date.
 
             This can be combined with execution_date_gte key to receive only the selected period.
+
+            *Deprecated since version 2.6.0*&#58; Use 'logical_date_lte' instead.
 
         start_date_gte:
           type: string

--- a/airflow/api_connexion/parameters.py
+++ b/airflow/api_connexion/parameters.py
@@ -105,6 +105,8 @@ def apply_sorting(
 ) -> Query:
     """Apply sorting to query."""
     lstriped_orderby = order_by.lstrip("-")
+    if lstriped_orderby == "logical_date":
+        lstriped_orderby = "execution_date"
     if allowed_attrs and lstriped_orderby not in allowed_attrs:
         raise BadRequest(
             detail=f"Ordering with '{lstriped_orderby}' is disallowed or "
@@ -117,3 +119,16 @@ def apply_sorting(
     else:
         order_by = f"{lstriped_orderby} asc"
     return query.order_by(text(order_by))
+
+
+def get_logical_date(logical_date, execution_date, default_value=None):
+    if not logical_date and not execution_date:  # Both missing.
+        return default_value
+    elif not logical_date:  # Only logical_date missing.
+        return execution_date
+    elif logical_date != execution_date:  # Both provided but don't match.
+        raise BadRequest(
+            "logical_date conflicts with execution_date",
+            detail=f"{logical_date!r} != {execution_date!r}",
+        )
+    return logical_date

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1876,14 +1876,35 @@ export interface components {
        * Format: date-time
        * @description Returns objects greater or equal to the specified date.
        *
+       * This can be combined with logical_date_lte key to receive only the selected period.
+       */
+      logical_date_gte?: string;
+      /**
+       * Format: date-time
+       * @deprecated
+       * @description Returns objects less than or equal to the specified date.
+       *
+       * This can be combined with logical_date_gte key to receive only the selected period.
+       */
+      logical_date_lte?: string;
+      /**
+       * Format: date-time
+       * @deprecated
+       * @description Returns objects greater or equal to the specified date.
+       *
        * This can be combined with execution_date_lte key to receive only the selected period.
+       *
+       * *Deprecated since version 2.6.0*&#58; Use 'logical_date_gte' instead.
        */
       execution_date_gte?: string;
       /**
        * Format: date-time
+       * @deprecated
        * @description Returns objects less than or equal to the specified date.
        *
        * This can be combined with execution_date_gte key to receive only the selected period.
+       *
+       * *Deprecated since version 2.6.0*&#58; Use 'logical_date_lte' instead.
        */
       execution_date_lte?: string;
       /**

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -349,7 +349,7 @@ class TestGetDagRuns(TestDagRunEndpoint):
         result = session.query(DagRun).all()
         assert len(result) == 2
         response = self.client.get(
-            "api/v1/dags/TEST_DAG_ID/dagRuns?order_by=-execution_date",
+            "api/v1/dags/TEST_DAG_ID/dagRuns?order_by=-logical_date",
             environ_overrides={"REMOTE_USER": "test"},
         )
 


### PR DESCRIPTION
closes: #29745 

---
Deprecate `execution_date` in the Airflow REST API and support logical date in all the endpoints.