### PR TITLE
 Migrate tests in google/cloud/operators from unittest to pytest

### DIFF
--- a/tests/providers/google/cloud/operators/test_automl.py
+++ b/tests/providers/google/cloud/operators/test_automl.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import copy
-import unittest
 from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
@@ -67,7 +66,7 @@ MASK = {"field": "mask"}
 extract_object_id = CloudAutoMLHook.extract_object_id
 
 
-class TestAutoMLTrainModelOperator(unittest.TestCase):
+class TestAutoMLTrainModelOperator:
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
     def test_execute(self, mock_hook):
         mock_hook.return_value.create_model.return_value.result.return_value = Model(name=MODEL_PATH)
@@ -89,7 +88,7 @@ class TestAutoMLTrainModelOperator(unittest.TestCase):
         )
 
 
-class TestAutoMLBatchPredictOperator(unittest.TestCase):
+class TestAutoMLBatchPredictOperator:
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
     def test_execute(self, mock_hook):
         mock_hook.return_value.batch_predict.return_value.result.return_value = BatchPredictResult()
@@ -118,7 +117,7 @@ class TestAutoMLBatchPredictOperator(unittest.TestCase):
         )
 
 
-class TestAutoMLPredictOperator(unittest.TestCase):
+class TestAutoMLPredictOperator:
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
     def test_execute(self, mock_hook):
         mock_hook.return_value.predict.return_value = PredictResponse()
@@ -144,7 +143,7 @@ class TestAutoMLPredictOperator(unittest.TestCase):
         )
 
 
-class TestAutoMLCreateImportOperator(unittest.TestCase):
+class TestAutoMLCreateImportOperator:
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
     def test_execute(self, mock_hook):
         mock_hook.return_value.create_dataset.return_value = Dataset(name=DATASET_PATH)
@@ -167,7 +166,7 @@ class TestAutoMLCreateImportOperator(unittest.TestCase):
         )
 
 
-class TestAutoMLListColumnsSpecsOperator(unittest.TestCase):
+class TestAutoMLListColumnsSpecsOperator:
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
     def test_execute(self, mock_hook):
         table_spec = "table_spec_id"
@@ -199,7 +198,7 @@ class TestAutoMLListColumnsSpecsOperator(unittest.TestCase):
         )
 
 
-class TestAutoMLUpdateDatasetOperator(unittest.TestCase):
+class TestAutoMLUpdateDatasetOperator:
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
     def test_execute(self, mock_hook):
         mock_hook.return_value.update_dataset.return_value = Dataset(name=DATASET_PATH)
@@ -223,7 +222,7 @@ class TestAutoMLUpdateDatasetOperator(unittest.TestCase):
         )
 
 
-class TestAutoMLGetModelOperator(unittest.TestCase):
+class TestAutoMLGetModelOperator:
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
     def test_execute(self, mock_hook):
         mock_hook.return_value.get_model.return_value = Model(name=MODEL_PATH)
@@ -246,7 +245,7 @@ class TestAutoMLGetModelOperator(unittest.TestCase):
         )
 
 
-class TestAutoMLDeleteModelOperator(unittest.TestCase):
+class TestAutoMLDeleteModelOperator:
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
     def test_execute(self, mock_hook):
         op = AutoMLDeleteModelOperator(
@@ -266,7 +265,7 @@ class TestAutoMLDeleteModelOperator(unittest.TestCase):
         )
 
 
-class TestAutoMLDeployModelOperator(unittest.TestCase):
+class TestAutoMLDeployModelOperator:
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
     def test_execute(self, mock_hook):
         image_detection_metadata = {}
@@ -289,7 +288,7 @@ class TestAutoMLDeployModelOperator(unittest.TestCase):
         )
 
 
-class TestAutoMLDatasetImportOperator(unittest.TestCase):
+class TestAutoMLDatasetImportOperator:
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
     def test_execute(self, mock_hook):
         op = AutoMLImportDataOperator(
@@ -311,7 +310,7 @@ class TestAutoMLDatasetImportOperator(unittest.TestCase):
         )
 
 
-class TestAutoMLTablesListTableSpecsOperator(unittest.TestCase):
+class TestAutoMLTablesListTableSpecsOperator:
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
     def test_execute(self, mock_hook):
         filter_ = "filter"
@@ -338,7 +337,7 @@ class TestAutoMLTablesListTableSpecsOperator(unittest.TestCase):
         )
 
 
-class TestAutoMLDatasetListOperator(unittest.TestCase):
+class TestAutoMLDatasetListOperator:
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
     def test_execute(self, mock_hook):
         op = AutoMLListDatasetOperator(location=GCP_LOCATION, project_id=GCP_PROJECT_ID, task_id=TASK_ID)
@@ -352,7 +351,7 @@ class TestAutoMLDatasetListOperator(unittest.TestCase):
         )
 
 
-class TestAutoMLDatasetDeleteOperator(unittest.TestCase):
+class TestAutoMLDatasetDeleteOperator:
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
     def test_execute(self, mock_hook):
         op = AutoMLDeleteDatasetOperator(

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -89,7 +88,7 @@ MATERIALIZED_VIEW_DEFINITION = {
 TEST_TABLE = "test-table"
 
 
-class TestBigQueryCreateEmptyTableOperator(unittest.TestCase):
+class TestBigQueryCreateEmptyTableOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
     def test_execute(self, mock_hook):
         operator = BigQueryCreateEmptyTableOperator(
@@ -287,7 +286,7 @@ class TestBigQueryCreateExternalTableOperator(unittest.TestCase):
         )
 
 
-class TestBigQueryDeleteDatasetOperator(unittest.TestCase):
+class TestBigQueryDeleteDatasetOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
     def test_execute(self, mock_hook):
         operator = BigQueryDeleteDatasetOperator(
@@ -303,7 +302,7 @@ class TestBigQueryDeleteDatasetOperator(unittest.TestCase):
         )
 
 
-class TestBigQueryCreateEmptyDatasetOperator(unittest.TestCase):
+class TestBigQueryCreateEmptyDatasetOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
     def test_execute(self, mock_hook):
         operator = BigQueryCreateEmptyDatasetOperator(
@@ -370,7 +369,7 @@ class TestBigQueryGetDatasetOperator(unittest.TestCase):
         )
 
 
-class TestBigQueryUpdateTableOperator(unittest.TestCase):
+class TestBigQueryUpdateTableOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
     def test_execute(self, mock_hook):
         table_resource = {"friendlyName": "Test TB"}
@@ -392,7 +391,7 @@ class TestBigQueryUpdateTableOperator(unittest.TestCase):
         )
 
 
-class TestBigQueryUpdateTableSchemaOperator(unittest.TestCase):
+class TestBigQueryUpdateTableSchemaOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
     def test_execute(self, mock_hook):
 
@@ -422,7 +421,7 @@ class TestBigQueryUpdateTableSchemaOperator(unittest.TestCase):
         )
 
 
-class TestBigQueryPatchDatasetOperator(unittest.TestCase):
+class TestBigQueryPatchDatasetOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
     def test_execute(self, mock_hook):
         dataset_resource = {"friendlyName": "Test DS"}
@@ -439,7 +438,7 @@ class TestBigQueryPatchDatasetOperator(unittest.TestCase):
         )
 
 
-class TestBigQueryUpdateDatasetOperator(unittest.TestCase):
+class TestBigQueryUpdateDatasetOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
     def test_execute(self, mock_hook):
         dataset_resource = {"friendlyName": "Test DS"}
@@ -792,7 +791,7 @@ class TestBigQueryOperator:
         )
 
 
-class TestBigQueryGetDataOperator(unittest.TestCase):
+class TestBigQueryGetDataOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
     def test_execute(self, mock_hook):
 
@@ -818,7 +817,7 @@ class TestBigQueryGetDataOperator(unittest.TestCase):
         )
 
 
-class TestBigQueryTableDeleteOperator(unittest.TestCase):
+class TestBigQueryTableDeleteOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
     def test_execute(self, mock_hook):
         ignore_if_missing = True
@@ -836,7 +835,7 @@ class TestBigQueryTableDeleteOperator(unittest.TestCase):
         )
 
 
-class TestBigQueryGetDatasetTablesOperator(unittest.TestCase):
+class TestBigQueryGetDatasetTablesOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
     def test_execute(self, mock_hook):
         operator = BigQueryGetDatasetTablesOperator(
@@ -872,7 +871,7 @@ class TestBigQueryCheckOperators:
         mock_get_db_hook.assert_called_once()
 
 
-class TestBigQueryUpsertTableOperator(unittest.TestCase):
+class TestBigQueryUpsertTableOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
     def test_execute(self, mock_hook):
         operator = BigQueryUpsertTableOperator(

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -235,7 +235,7 @@ def test_create_existing_table(mock_hook, caplog, if_exists, is_conflict, expect
         assert log_msg in caplog.text
 
 
-class TestBigQueryCreateExternalTableOperator(unittest.TestCase):
+class TestBigQueryCreateExternalTableOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
     def test_execute(self, mock_hook):
         operator = BigQueryCreateExternalTableOperator(
@@ -356,7 +356,7 @@ def test_create_empty_dataset(mock_hook, caplog, if_exists, is_conflict, expecte
         assert log_msg in caplog.text
 
 
-class TestBigQueryGetDatasetOperator(unittest.TestCase):
+class TestBigQueryGetDatasetOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
     def test_execute(self, mock_hook):
         operator = BigQueryGetDatasetOperator(

--- a/tests/providers/google/cloud/operators/test_bigquery_dts.py
+++ b/tests/providers/google/cloud/operators/test_bigquery_dts.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
@@ -51,7 +50,7 @@ transfer_config = TransferConfig(
 )
 
 
-class BigQueryCreateDataTransferOperatorTestCase(unittest.TestCase):
+class BigQueryCreateDataTransferOperatorTestCase:
     @mock.patch(
         "airflow.providers.google.cloud.operators.bigquery_dts.BiqQueryDataTransferServiceHook",
         **{"return_value.create_transfer_config.return_value": transfer_config},
@@ -78,7 +77,7 @@ class BigQueryCreateDataTransferOperatorTestCase(unittest.TestCase):
         assert "access_key_id" not in return_value.get("params", {})
 
 
-class BigQueryDeleteDataTransferConfigOperatorTestCase(unittest.TestCase):
+class BigQueryDeleteDataTransferConfigOperatorTestCase:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery_dts.BiqQueryDataTransferServiceHook")
     def test_execute(self, mock_hook):
         op = BigQueryDeleteDataTransferConfigOperator(
@@ -94,7 +93,7 @@ class BigQueryDeleteDataTransferConfigOperatorTestCase(unittest.TestCase):
         )
 
 
-class BigQueryDataTransferServiceStartTransferRunsOperatorTestCase(unittest.TestCase):
+class BigQueryDataTransferServiceStartTransferRunsOperatorTestCase:
     OPERATOR_MODULE_PATH = "airflow.providers.google.cloud.operators.bigquery_dts"
 
     @mock.patch(

--- a/tests/providers/google/cloud/operators/test_bigquery_dts.py
+++ b/tests/providers/google/cloud/operators/test_bigquery_dts.py
@@ -50,7 +50,7 @@ transfer_config = TransferConfig(
 )
 
 
-class BigQueryCreateDataTransferOperatorTestCase:
+class TestBigQueryCreateDataTransferOperator:
     @mock.patch(
         "airflow.providers.google.cloud.operators.bigquery_dts.BiqQueryDataTransferServiceHook",
         **{"return_value.create_transfer_config.return_value": transfer_config},
@@ -77,7 +77,7 @@ class BigQueryCreateDataTransferOperatorTestCase:
         assert "access_key_id" not in return_value.get("params", {})
 
 
-class BigQueryDeleteDataTransferConfigOperatorTestCase:
+class TestBigQueryDeleteDataTransferConfigOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery_dts.BiqQueryDataTransferServiceHook")
     def test_execute(self, mock_hook):
         op = BigQueryDeleteDataTransferConfigOperator(
@@ -93,7 +93,7 @@ class BigQueryDeleteDataTransferConfigOperatorTestCase:
         )
 
 
-class BigQueryDataTransferServiceStartTransferRunsOperatorTestCase:
+class TestBigQueryDataTransferServiceStartTransferRunsOperator:
     OPERATOR_MODULE_PATH = "airflow.providers.google.cloud.operators.bigquery_dts"
 
     @mock.patch(

--- a/tests/providers/google/cloud/operators/test_cloud_build.py
+++ b/tests/providers/google/cloud/operators/test_cloud_build.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import json
 import tempfile
 from copy import deepcopy
-from unittest import TestCase, mock
+from unittest import mock
 
 import pytest
 from google.api_core.gapic_v1.method import DEFAULT
@@ -103,7 +103,7 @@ TEST_BUILD_INSTANCE = dict(
 )
 
 
-class TestCloudBuildOperator(TestCase):
+class TestCloudBuildOperator:
     @mock.patch(CLOUD_BUILD_HOOK_PATH)
     def test_cancel_build(self, mock_hook):
         mock_hook.return_value.cancel_build.return_value = Build()
@@ -299,7 +299,7 @@ class TestCloudBuildOperator(TestCase):
         )
 
 
-class TestBuildProcessor(TestCase):
+class TestBuildProcessor:
     def test_verify_source(self):
         error_message = r"The source could not be determined."
         with pytest.raises(AirflowException, match=error_message):

--- a/tests/providers/google/cloud/operators/test_cloud_memorystore.py
+++ b/tests/providers/google/cloud/operators/test_cloud_memorystore.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
 from google.cloud.memcache_v1beta2.types import cloud_memcache
@@ -65,7 +65,7 @@ TEST_NAME = "test-name"
 TEST_UPDATE_INSTANCE_NAME = "projects/{project_id}/locations/{location}/instances/{instance_id}"
 
 
-class TestCloudMemorystoreCreateInstanceOperator(TestCase):
+class TestCloudMemorystoreCreateInstanceOperator:
     @mock.patch("airflow.providers.google.cloud.operators.cloud_memorystore.CloudMemorystoreHook")
     def test_assert_valid_hook_call(self, mock_hook):
         task = CloudMemorystoreCreateInstanceOperator(
@@ -97,7 +97,7 @@ class TestCloudMemorystoreCreateInstanceOperator(TestCase):
         )
 
 
-class TestCloudMemorystoreDeleteInstanceOperator(TestCase):
+class TestCloudMemorystoreDeleteInstanceOperator:
     @mock.patch("airflow.providers.google.cloud.operators.cloud_memorystore.CloudMemorystoreHook")
     def test_assert_valid_hook_call(self, mock_hook):
         task = CloudMemorystoreDeleteInstanceOperator(
@@ -126,7 +126,7 @@ class TestCloudMemorystoreDeleteInstanceOperator(TestCase):
         )
 
 
-class TestCloudMemorystoreExportInstanceOperator(TestCase):
+class TestCloudMemorystoreExportInstanceOperator:
     @mock.patch("airflow.providers.google.cloud.operators.cloud_memorystore.CloudMemorystoreHook")
     def test_assert_valid_hook_call(self, mock_hook):
         task = CloudMemorystoreExportInstanceOperator(
@@ -157,7 +157,7 @@ class TestCloudMemorystoreExportInstanceOperator(TestCase):
         )
 
 
-class TestCloudMemorystoreFailoverInstanceOperator(TestCase):
+class TestCloudMemorystoreFailoverInstanceOperator:
     @mock.patch("airflow.providers.google.cloud.operators.cloud_memorystore.CloudMemorystoreHook")
     def test_assert_valid_hook_call(self, mock_hook):
         task = CloudMemorystoreFailoverInstanceOperator(
@@ -188,7 +188,7 @@ class TestCloudMemorystoreFailoverInstanceOperator(TestCase):
         )
 
 
-class TestCloudMemorystoreGetInstanceOperator(TestCase):
+class TestCloudMemorystoreGetInstanceOperator:
     @mock.patch("airflow.providers.google.cloud.operators.cloud_memorystore.CloudMemorystoreHook")
     def test_assert_valid_hook_call(self, mock_hook):
         task = CloudMemorystoreGetInstanceOperator(
@@ -218,7 +218,7 @@ class TestCloudMemorystoreGetInstanceOperator(TestCase):
         )
 
 
-class TestCloudMemorystoreImportOperator(TestCase):
+class TestCloudMemorystoreImportOperator:
     @mock.patch("airflow.providers.google.cloud.operators.cloud_memorystore.CloudMemorystoreHook")
     def test_assert_valid_hook_call(self, mock_hook):
         task = CloudMemorystoreImportOperator(
@@ -249,7 +249,7 @@ class TestCloudMemorystoreImportOperator(TestCase):
         )
 
 
-class TestCloudMemorystoreListInstancesOperator(TestCase):
+class TestCloudMemorystoreListInstancesOperator:
     @mock.patch("airflow.providers.google.cloud.operators.cloud_memorystore.CloudMemorystoreHook")
     def test_assert_valid_hook_call(self, mock_hook):
         task = CloudMemorystoreListInstancesOperator(
@@ -278,7 +278,7 @@ class TestCloudMemorystoreListInstancesOperator(TestCase):
         )
 
 
-class TestCloudMemorystoreUpdateInstanceOperator(TestCase):
+class TestCloudMemorystoreUpdateInstanceOperator:
     @mock.patch("airflow.providers.google.cloud.operators.cloud_memorystore.CloudMemorystoreHook")
     def test_assert_valid_hook_call(self, mock_hook):
         mock_hook.return_value.update_instance.return_value.name = TEST_UPDATE_INSTANCE_NAME.format(
@@ -316,7 +316,7 @@ class TestCloudMemorystoreUpdateInstanceOperator(TestCase):
         )
 
 
-class TestCloudMemorystoreScaleInstanceOperator(TestCase):
+class TestCloudMemorystoreScaleInstanceOperator:
     @mock.patch("airflow.providers.google.cloud.operators.cloud_memorystore.CloudMemorystoreHook")
     def test_assert_valid_hook_call(self, mock_hook):
         mock_hook.return_value.update_instance.return_value.name = TEST_UPDATE_INSTANCE_NAME.format(
@@ -353,7 +353,7 @@ class TestCloudMemorystoreScaleInstanceOperator(TestCase):
         )
 
 
-class TestCloudMemorystoreCreateInstanceAndImportOperatorOperator(TestCase):
+class TestCloudMemorystoreCreateInstanceAndImportOperatorOperator:
     @mock.patch("airflow.providers.google.cloud.operators.cloud_memorystore.CloudMemorystoreHook")
     def test_assert_valid_hook_call(self, mock_hook):
         task = CloudMemorystoreCreateInstanceAndImportOperator(
@@ -398,7 +398,7 @@ class TestCloudMemorystoreCreateInstanceAndImportOperatorOperator(TestCase):
         )
 
 
-class TestCloudMemorystoreMemcachedCreateInstanceOperator(TestCase):
+class TestCloudMemorystoreMemcachedCreateInstanceOperator:
     @mock.patch("airflow.providers.google.cloud.operators.cloud_memorystore.CloudMemorystoreMemcachedHook")
     def test_assert_valid_hook_call(self, mock_hook):
         mock_hook.return_value.create_instance.return_value = cloud_memcache.Instance()
@@ -426,7 +426,7 @@ class TestCloudMemorystoreMemcachedCreateInstanceOperator(TestCase):
         )
 
 
-class TestCloudMemorystoreMemcachedDeleteInstanceOperator(TestCase):
+class TestCloudMemorystoreMemcachedDeleteInstanceOperator:
     @mock.patch("airflow.providers.google.cloud.operators.cloud_memorystore.CloudMemorystoreMemcachedHook")
     def test_assert_valid_hook_call(self, mock_hook):
         task = CloudMemorystoreMemcachedDeleteInstanceOperator(
@@ -451,7 +451,7 @@ class TestCloudMemorystoreMemcachedDeleteInstanceOperator(TestCase):
         )
 
 
-class TestCloudMemorystoreMemcachedGetInstanceOperator(TestCase):
+class TestCloudMemorystoreMemcachedGetInstanceOperator:
     @mock.patch("airflow.providers.google.cloud.operators.cloud_memorystore.CloudMemorystoreMemcachedHook")
     def test_assert_valid_hook_call(self, mock_hook):
         mock_hook.return_value.get_instance.return_value = cloud_memcache.Instance()
@@ -481,7 +481,7 @@ class TestCloudMemorystoreMemcachedGetInstanceOperator(TestCase):
         )
 
 
-class TestCloudMemorystoreMemcachedListInstancesOperator(TestCase):
+class TestCloudMemorystoreMemcachedListInstancesOperator:
     @mock.patch("airflow.providers.google.cloud.operators.cloud_memorystore.CloudMemorystoreMemcachedHook")
     def test_assert_valid_hook_call(self, mock_hook):
         task = CloudMemorystoreMemcachedListInstancesOperator(
@@ -508,7 +508,7 @@ class TestCloudMemorystoreMemcachedListInstancesOperator(TestCase):
         )
 
 
-class TestCloudMemorystoreMemcachedUpdateInstanceOperator(TestCase):
+class TestCloudMemorystoreMemcachedUpdateInstanceOperator:
     @mock.patch("airflow.providers.google.cloud.operators.cloud_memorystore.CloudMemorystoreMemcachedHook")
     def test_assert_valid_hook_call(self, mock_hook):
         mock_hook.return_value.update_instance.return_value.name = TEST_UPDATE_INSTANCE_NAME.format(

--- a/tests/providers/google/cloud/operators/test_cloud_sql.py
+++ b/tests/providers/google/cloud/operators/test_cloud_sql.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import os
-import unittest
 from unittest import mock
 
 import pytest
@@ -149,7 +148,7 @@ IMPORT_BODY = {
 }
 
 
-class TestCloudSql(unittest.TestCase):
+class TestCloudSql:
     @mock.patch(
         "airflow.providers.google.cloud.operators.cloud_sql"
         ".CloudSQLCreateInstanceOperator._check_if_instance_exists"
@@ -673,7 +672,7 @@ class TestCloudSql(unittest.TestCase):
         assert result
 
 
-class TestCloudSqlQueryValidation(unittest.TestCase):
+class TestCloudSqlQueryValidation:
     @staticmethod
     def _setup_connections(get_connection, uri):
         gcp_connection = mock.MagicMock()

--- a/tests/providers/google/cloud/operators/test_cloud_storage_transfer_service.py
+++ b/tests/providers/google/cloud/operators/test_cloud_storage_transfer_service.py
@@ -155,7 +155,7 @@ class TestTransferJobPreprocessor:
         TransferJobPreprocessor(body=body).process_body()
         assert body == {}
 
-    @unittest.skipIf(boto3 is None, "Skipping test because boto3 is not available")
+    @pytest.mark.skipif(boto3 is None, reason="Skipping test because boto3 is not available")
     @mock.patch("airflow.providers.google.cloud.operators.cloud_storage_transfer_service.AwsBaseHook")
     def test_should_inject_aws_credentials(self, mock_hook):
         mock_hook.return_value.get_credentials.return_value = Credentials(

--- a/tests/providers/google/cloud/operators/test_cloud_storage_transfer_service.py
+++ b/tests/providers/google/cloud/operators/test_cloud_storage_transfer_service.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import itertools
-import unittest
 from copy import deepcopy
 from datetime import date, time
 from unittest import mock
@@ -150,7 +149,7 @@ VALID_TRANSFER_JOB_AWS_RAW[TRANSFER_SPEC][AWS_S3_DATA_SOURCE][AWS_ACCESS_KEY] = 
 VALID_OPERATION = {NAME: "operation-name"}
 
 
-class TestTransferJobPreprocessor(unittest.TestCase):
+class TestTransferJobPreprocessor:
     def test_should_do_nothing_on_empty(self):
         body = {}
         TransferJobPreprocessor(body=body).process_body()
@@ -201,7 +200,7 @@ class TestTransferJobPreprocessor(unittest.TestCase):
         }
 
 
-class TestTransferJobValidator(unittest.TestCase):
+class TestTransferJobValidator:
     def test_should_raise_exception_when_encounters_aws_credentials(self):
         body = {"transferSpec": {"awsS3DataSource": {"awsAccessKey": TEST_AWS_ACCESS_KEY}}}
         with pytest.raises(AirflowException) as ctx:

--- a/tests/providers/google/cloud/operators/test_datacatalog.py
+++ b/tests/providers/google/cloud/operators/test_datacatalog.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from typing import Sequence
-from unittest import TestCase, mock
+from unittest import mock
 
 from google.api_core.exceptions import AlreadyExists
 from google.api_core.gapic_v1.method import _MethodDefault
@@ -124,7 +124,7 @@ TEST_TAG_TEMPLATE_FIELD_LINK = "projects/{project_id}/locations/{location}/tagTe
     /fields/{tag_template_field_id}"
 
 
-class TestCloudDataCatalogCreateEntryOperator(TestCase):
+class TestCloudDataCatalogCreateEntryOperator:
     @mock.patch(
         "airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook",
         **{"return_value.create_entry.return_value": TEST_ENTRY},
@@ -228,7 +228,7 @@ class TestCloudDataCatalogCreateEntryOperator(TestCase):
         assert TEST_ENTRY_DICT == result
 
 
-class TestCloudDataCatalogCreateEntryGroupOperator(TestCase):
+class TestCloudDataCatalogCreateEntryGroupOperator:
     @mock.patch(
         "airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook",
         **{"return_value.create_entry_group.return_value": TEST_ENTRY_GROUP},
@@ -274,7 +274,7 @@ class TestCloudDataCatalogCreateEntryGroupOperator(TestCase):
         assert result == TEST_ENTRY_GROUP_DICT
 
 
-class TestCloudDataCatalogCreateTagOperator(TestCase):
+class TestCloudDataCatalogCreateTagOperator:
     @mock.patch(
         "airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook",
         **{"return_value.create_tag.return_value": TEST_TAG},
@@ -325,7 +325,7 @@ class TestCloudDataCatalogCreateTagOperator(TestCase):
         assert TEST_TAG_DICT == result
 
 
-class TestCloudDataCatalogCreateTagTemplateOperator(TestCase):
+class TestCloudDataCatalogCreateTagTemplateOperator:
     @mock.patch(
         "airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook",
         **{"return_value.create_tag_template.return_value": TEST_TAG_TEMPLATE},
@@ -371,7 +371,7 @@ class TestCloudDataCatalogCreateTagTemplateOperator(TestCase):
         assert TEST_TAG_TEMPLATE_DICT == result
 
 
-class TestCloudDataCatalogCreateTagTemplateFieldOperator(TestCase):
+class TestCloudDataCatalogCreateTagTemplateFieldOperator:
     @mock.patch(
         "airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook",
         **{"return_value.create_tag_template_field.return_value": TEST_TAG_TEMPLATE_FIELD},  # type: ignore
@@ -419,7 +419,7 @@ class TestCloudDataCatalogCreateTagTemplateFieldOperator(TestCase):
         assert TEST_TAG_TEMPLATE_FIELD_DICT == result
 
 
-class TestCloudDataCatalogDeleteEntryOperator(TestCase):
+class TestCloudDataCatalogDeleteEntryOperator:
     @mock.patch("airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook")
     def test_assert_valid_hook_call(self, mock_hook) -> None:
         task = CloudDataCatalogDeleteEntryOperator(
@@ -450,7 +450,7 @@ class TestCloudDataCatalogDeleteEntryOperator(TestCase):
         )
 
 
-class TestCloudDataCatalogDeleteEntryGroupOperator(TestCase):
+class TestCloudDataCatalogDeleteEntryGroupOperator:
     @mock.patch("airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook")
     def test_assert_valid_hook_call(self, mock_hook) -> None:
         task = CloudDataCatalogDeleteEntryGroupOperator(
@@ -479,7 +479,7 @@ class TestCloudDataCatalogDeleteEntryGroupOperator(TestCase):
         )
 
 
-class TestCloudDataCatalogDeleteTagOperator(TestCase):
+class TestCloudDataCatalogDeleteTagOperator:
     @mock.patch("airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook")
     def test_assert_valid_hook_call(self, mock_hook) -> None:
         task = CloudDataCatalogDeleteTagOperator(
@@ -512,7 +512,7 @@ class TestCloudDataCatalogDeleteTagOperator(TestCase):
         )
 
 
-class TestCloudDataCatalogDeleteTagTemplateOperator(TestCase):
+class TestCloudDataCatalogDeleteTagTemplateOperator:
     @mock.patch("airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook")
     def test_assert_valid_hook_call(self, mock_hook) -> None:
         task = CloudDataCatalogDeleteTagTemplateOperator(
@@ -543,7 +543,7 @@ class TestCloudDataCatalogDeleteTagTemplateOperator(TestCase):
         )
 
 
-class TestCloudDataCatalogDeleteTagTemplateFieldOperator(TestCase):
+class TestCloudDataCatalogDeleteTagTemplateFieldOperator:
     @mock.patch("airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook")
     def test_assert_valid_hook_call(self, mock_hook) -> None:
         task = CloudDataCatalogDeleteTagTemplateFieldOperator(
@@ -576,7 +576,7 @@ class TestCloudDataCatalogDeleteTagTemplateFieldOperator(TestCase):
         )
 
 
-class TestCloudDataCatalogGetEntryOperator(TestCase):
+class TestCloudDataCatalogGetEntryOperator:
     @mock.patch(
         "airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook",
         **{"return_value.get_entry.return_value": TEST_ENTRY},  # type: ignore
@@ -610,7 +610,7 @@ class TestCloudDataCatalogGetEntryOperator(TestCase):
         )
 
 
-class TestCloudDataCatalogGetEntryGroupOperator(TestCase):
+class TestCloudDataCatalogGetEntryGroupOperator:
     @mock.patch(
         "airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook",
         **{"return_value.get_entry_group.return_value": TEST_ENTRY_GROUP},  # type: ignore
@@ -644,7 +644,7 @@ class TestCloudDataCatalogGetEntryGroupOperator(TestCase):
         )
 
 
-class TestCloudDataCatalogGetTagTemplateOperator(TestCase):
+class TestCloudDataCatalogGetTagTemplateOperator:
     @mock.patch(
         "airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook",
         **{"return_value.get_tag_template.return_value": TEST_TAG_TEMPLATE},  # type: ignore
@@ -676,7 +676,7 @@ class TestCloudDataCatalogGetTagTemplateOperator(TestCase):
         )
 
 
-class TestCloudDataCatalogListTagsOperator(TestCase):
+class TestCloudDataCatalogListTagsOperator:
     @mock.patch(
         "airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook",
         return_value=mock.MagicMock(list_tags=mock.MagicMock(return_value=[TEST_TAG])),
@@ -712,7 +712,7 @@ class TestCloudDataCatalogListTagsOperator(TestCase):
         )
 
 
-class TestCloudDataCatalogLookupEntryOperator(TestCase):
+class TestCloudDataCatalogLookupEntryOperator:
     @mock.patch(
         "airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook",
         **{"return_value.lookup_entry.return_value": TEST_ENTRY},  # type: ignore
@@ -742,7 +742,7 @@ class TestCloudDataCatalogLookupEntryOperator(TestCase):
         )
 
 
-class TestCloudDataCatalogRenameTagTemplateFieldOperator(TestCase):
+class TestCloudDataCatalogRenameTagTemplateFieldOperator:
     @mock.patch("airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook")
     def test_assert_valid_hook_call(self, mock_hook) -> None:
         task = CloudDataCatalogRenameTagTemplateFieldOperator(
@@ -775,7 +775,7 @@ class TestCloudDataCatalogRenameTagTemplateFieldOperator(TestCase):
         )
 
 
-class TestCloudDataCatalogSearchCatalogOperator(TestCase):
+class TestCloudDataCatalogSearchCatalogOperator:
     @mock.patch("airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook")
     def test_assert_valid_hook_call(self, mock_hook) -> None:
         task = CloudDataCatalogSearchCatalogOperator(
@@ -806,7 +806,7 @@ class TestCloudDataCatalogSearchCatalogOperator(TestCase):
         )
 
 
-class TestCloudDataCatalogUpdateEntryOperator(TestCase):
+class TestCloudDataCatalogUpdateEntryOperator:
     @mock.patch("airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook")
     def test_assert_valid_hook_call(self, mock_hook) -> None:
         mock_hook.return_value.update_entry.return_value.name = TEST_ENTRY_LINK.format(
@@ -847,7 +847,7 @@ class TestCloudDataCatalogUpdateEntryOperator(TestCase):
         )
 
 
-class TestCloudDataCatalogUpdateTagOperator(TestCase):
+class TestCloudDataCatalogUpdateTagOperator:
     @mock.patch("airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook")
     def test_assert_valid_hook_call(self, mock_hook) -> None:
         mock_hook.return_value.update_tag.return_value.name = TEST_ENTRY_LINK.format(
@@ -890,7 +890,7 @@ class TestCloudDataCatalogUpdateTagOperator(TestCase):
         )
 
 
-class TestCloudDataCatalogUpdateTagTemplateOperator(TestCase):
+class TestCloudDataCatalogUpdateTagTemplateOperator:
     @mock.patch("airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook")
     def test_assert_valid_hook_call(self, mock_hook) -> None:
         mock_hook.return_value.update_tag_template.return_value.name = TEST_TAG_TEMPLATE_LINK.format(
@@ -928,7 +928,7 @@ class TestCloudDataCatalogUpdateTagTemplateOperator(TestCase):
         )
 
 
-class TestCloudDataCatalogUpdateTagTemplateFieldOperator(TestCase):
+class TestCloudDataCatalogUpdateTagTemplateFieldOperator:
     @mock.patch("airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook")
     def test_assert_valid_hook_call(self, mock_hook) -> None:
         mock_hook.return_value.update_tag_template_field.return_value.name = (

--- a/tests/providers/google/cloud/operators/test_dataflow.py
+++ b/tests/providers/google/cloud/operators/test_dataflow.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import copy
-import unittest
 from copy import deepcopy
 from unittest import mock
 
@@ -101,8 +100,8 @@ IMPERSONATION_CHAIN = ["impersonate", "this"]
 CANCEL_TIMEOUT = 10 * 420
 
 
-class TestDataflowPythonOperator(unittest.TestCase):
-    def setUp(self):
+class TestDataflowPythonOperator:
+    def setup_method(self):
         self.dataflow = DataflowCreatePythonJobOperator(
             task_id=TASK_ID,
             py_file=PY_FILE,
@@ -182,8 +181,8 @@ class TestDataflowPythonOperator(unittest.TestCase):
         provide_gcloud_mock.assert_called_once_with()
 
 
-class TestDataflowJavaOperator(unittest.TestCase):
-    def setUp(self):
+class TestDataflowJavaOperator:
+    def setup_method(self):
         self.dataflow = DataflowCreateJavaJobOperator(
             task_id=TASK_ID,
             jar=JAR_FILE,
@@ -389,8 +388,8 @@ class TestDataflowJavaOperator(unittest.TestCase):
         )
 
 
-class TestDataflowJavaOperatorWithLocal(unittest.TestCase):
-    def setUp(self):
+class TestDataflowJavaOperatorWithLocal:
+    def setup_method(self):
         self.dataflow = DataflowCreateJavaJobOperator(
             task_id=TASK_ID,
             jar=LOCAL_JAR_FILE,
@@ -615,7 +614,7 @@ class TestDataflowStartFlexTemplateOperator:
         mock_defer_method.assert_called_once()
 
 
-class TestDataflowSqlOperator(unittest.TestCase):
+class TestDataflowSqlOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dataflow.DataflowHook")
     def test_execute(self, mock_hook):
         start_sql = DataflowStartSqlJobOperator(
@@ -649,7 +648,7 @@ class TestDataflowSqlOperator(unittest.TestCase):
         )
 
 
-class TestDataflowStopJobOperator(unittest.TestCase):
+class TestDataflowStopJobOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dataflow.DataflowHook")
     def test_exec_job_id(self, dataflow_mock):
         self.dataflow = DataflowStopJobOperator(

--- a/tests/providers/google/cloud/operators/test_dataflow.py
+++ b/tests/providers/google/cloud/operators/test_dataflow.py
@@ -142,7 +142,7 @@ class TestDataflowPythonOperator:
         job_name = dataflow_hook_mock.return_value.build_dataflow_job_name.return_value
         self.dataflow.execute(None)
         beam_hook_mock.assert_called_once_with(runner="DataflowRunner")
-        self.assertTrue(self.dataflow.py_file.startswith("/tmp/dataflow"))
+        assert self.dataflow.py_file.startswith("/tmp/dataflow")
         gcs_provide_file.assert_called_once_with(object_url=PY_FILE)
         mock_callback_on_job_id.assert_called_once_with(on_new_job_id_callback=mock.ANY)
         dataflow_hook_mock.assert_called_once_with(
@@ -267,7 +267,7 @@ class TestDataflowJavaOperator:
 
         self.dataflow.execute(None)
 
-        self.assertTrue(dataflow_mock.called)
+        assert dataflow_mock.called
         start_java_hook.assert_not_called()
         gcs_provide_file.assert_called_once()
         variables = {
@@ -317,7 +317,7 @@ class TestDataflowJavaOperator:
             "output": "gs://test/output",
             "labels": {"foo": "bar", "airflow-version": self.expected_airflow_version},
         }
-        self.assertEqual(expected_variables, is_job_dataflow_running_variables)
+        assert expected_variables == is_job_dataflow_running_variables
         job_name = dataflow_hook_mock.return_value.build_dataflow_job_name.return_value
         expected_variables["jobName"] = job_name
         start_java_mock.assert_called_once_with(
@@ -371,7 +371,7 @@ class TestDataflowJavaOperator:
             "output": "gs://test/output",
             "labels": {"foo": "bar", "airflow-version": self.expected_airflow_version},
         }
-        self.assertEqual(expected_variables, is_job_dataflow_running_variables)
+        assert expected_variables == is_job_dataflow_running_variables
         job_name = dataflow_hook_mock.return_value.build_dataflow_job_name.return_value
         expected_variables["jobName"] = job_name
         start_java_mock.assert_called_once_with(
@@ -433,7 +433,7 @@ class TestDataflowJavaOperatorWithLocal:
             "output": "gs://test/output",
             "labels": {"foo": "bar", "airflow-version": self.expected_airflow_version},
         }
-        self.assertEqual(expected_variables, is_job_dataflow_running_variables)
+        assert expected_variables == is_job_dataflow_running_variables
         job_name = dataflow_hook_mock.return_value.build_dataflow_job_name.return_value
         expected_variables["jobName"] = job_name
         start_java_mock.assert_called_once_with(

--- a/tests/providers/google/cloud/operators/test_dataform.py
+++ b/tests/providers/google/cloud/operators/test_dataform.py
@@ -16,8 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-from unittest import TestCase, mock
+from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
 
@@ -71,7 +70,7 @@ WORKFLOW_INVOCATION = {
 WORKFLOW_INVOCATION_ID = "test_workflow_invocation"
 
 
-class TestDataformCreateCompilationResult(unittest.TestCase):
+class TestDataformCreateCompilationResult:
     @mock.patch(HOOK_STR)
     @mock.patch(COMPILATION_RESULT_STR)
     def test_execute(self, compilation_result_mock, hook_mock):
@@ -99,7 +98,7 @@ class TestDataformCreateCompilationResult(unittest.TestCase):
         )
 
 
-class TestDataformGetCompilationResultOperator(TestCase):
+class TestDataformGetCompilationResultOperator:
     @mock.patch(HOOK_STR)
     @mock.patch(COMPILATION_RESULT_STR)
     def test_execute(self, compilation_result_mock, hook_mock):
@@ -123,7 +122,7 @@ class TestDataformGetCompilationResultOperator(TestCase):
         )
 
 
-class TestDataformCreateWorkflowInvocationOperator(TestCase):
+class TestDataformCreateWorkflowInvocationOperator:
     @mock.patch(HOOK_STR)
     @mock.patch(WORKFLOW_INVOCATION_STR)
     def test_execute(self, workflow_invocation_str, hook_mock):
@@ -148,7 +147,7 @@ class TestDataformCreateWorkflowInvocationOperator(TestCase):
         )
 
 
-class TestDataformGetWorkflowInvocationOperator(TestCase):
+class TestDataformGetWorkflowInvocationOperator:
     @mock.patch(HOOK_STR)
     @mock.patch(WORKFLOW_INVOCATION_STR)
     def test_execute(self, workflow_invocation_str, hook_mock):
@@ -174,7 +173,7 @@ class TestDataformGetWorkflowInvocationOperator(TestCase):
         )
 
 
-class TestDataformCancelWorkflowInvocationOperator(TestCase):
+class TestDataformCancelWorkflowInvocationOperator:
     @mock.patch(HOOK_STR)
     def test_execute(self, hook_mock):
         op = DataformCancelWorkflowInvocationOperator(
@@ -196,7 +195,7 @@ class TestDataformCancelWorkflowInvocationOperator(TestCase):
         )
 
 
-class TestDataformCreateRepositoryOperator(TestCase):
+class TestDataformCreateRepositoryOperator:
     @mock.patch(HOOK_STR)
     @mock.patch(REPOSITORY_STR)
     def test_execute(self, _, hook_mock):
@@ -217,7 +216,7 @@ class TestDataformCreateRepositoryOperator(TestCase):
         )
 
 
-class TestDataformDeleteRepositoryOperator(TestCase):
+class TestDataformDeleteRepositoryOperator:
     @mock.patch(HOOK_STR)
     def test_execute(self, hook_mock):
         force = True
@@ -241,7 +240,7 @@ class TestDataformDeleteRepositoryOperator(TestCase):
         )
 
 
-class TestDataformCreateWorkspaceOperator(TestCase):
+class TestDataformCreateWorkspaceOperator:
     @mock.patch(HOOK_STR)
     @mock.patch(WORKSPACE_STR)
     def test_execute(self, _, hook_mock):
@@ -265,7 +264,7 @@ class TestDataformCreateWorkspaceOperator(TestCase):
         )
 
 
-class TestDataformDeleteWorkspaceOperator(TestCase):
+class TestDataformDeleteWorkspaceOperator:
     @mock.patch(HOOK_STR)
     def test_execute(self, hook_mock):
         op = DataformDeleteWorkspaceOperator(
@@ -288,7 +287,7 @@ class TestDataformDeleteWorkspaceOperator(TestCase):
         )
 
 
-class TestDataformWriteFileOperator(TestCase):
+class TestDataformWriteFileOperator:
     @mock.patch(HOOK_STR)
     @mock.patch(WRITE_FILE_RESPONSE_STR)
     def test_execute(self, _, hook_mock):
@@ -316,7 +315,7 @@ class TestDataformWriteFileOperator(TestCase):
         )
 
 
-class TestDataformMakeDirectoryOperator(TestCase):
+class TestDataformMakeDirectoryOperator:
     @mock.patch(HOOK_STR)
     @mock.patch(MAKE_DIRECTORY_RESPONSE_STR)
     def test_execute(self, _, hook_mock):
@@ -342,7 +341,7 @@ class TestDataformMakeDirectoryOperator(TestCase):
         )
 
 
-class TestDataformRemoveFileOperator(TestCase):
+class TestDataformRemoveFileOperator:
     @mock.patch(HOOK_STR)
     def test_execute(self, hook_mock):
         op = DataformRemoveFileOperator(
@@ -367,7 +366,7 @@ class TestDataformRemoveFileOperator(TestCase):
         )
 
 
-class TestDataformRemoveDirectoryOperator(TestCase):
+class TestDataformRemoveDirectoryOperator:
     @mock.patch(HOOK_STR)
     def test_execute(self, hook_mock):
         op = DataformRemoveDirectoryOperator(
@@ -392,7 +391,7 @@ class TestDataformRemoveDirectoryOperator(TestCase):
         )
 
 
-class TestDataformInstallNpmPackagesOperator(TestCase):
+class TestDataformInstallNpmPackagesOperator:
     @mock.patch(HOOK_STR)
     @mock.patch(INSTALL_NPM_PACKAGES_RESPONSE_STR)
     def test_execute(self, _, hook_mock):

--- a/tests/providers/google/cloud/operators/test_dataplex.py
+++ b/tests/providers/google/cloud/operators/test_dataplex.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
 
@@ -51,7 +51,7 @@ API_VERSION = "v1"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
-class TestDataplexCreateTaskOperator(TestCase):
+class TestDataplexCreateTaskOperator:
     @mock.patch(HOOK_STR)
     @mock.patch(TASK_STR)
     def test_execute(self, task_mock, hook_mock):
@@ -90,7 +90,7 @@ class TestDataplexCreateTaskOperator(TestCase):
         )
 
 
-class TestDataplexDeleteTaskOperator(TestCase):
+class TestDataplexDeleteTaskOperator:
     @mock.patch(HOOK_STR)
     def test_execute(self, hook_mock):
         op = DataplexDeleteTaskOperator(
@@ -122,7 +122,7 @@ class TestDataplexDeleteTaskOperator(TestCase):
         )
 
 
-class TestDataplexListTasksOperator(TestCase):
+class TestDataplexListTasksOperator:
     @mock.patch(HOOK_STR)
     def test_execute(self, hook_mock):
         op = DataplexListTasksOperator(
@@ -156,7 +156,7 @@ class TestDataplexListTasksOperator(TestCase):
         )
 
 
-class TestDataplexGetTaskOperator(TestCase):
+class TestDataplexGetTaskOperator:
     @mock.patch(HOOK_STR)
     @mock.patch(TASK_STR)
     def test_execute(self, task_mock, hook_mock):
@@ -191,7 +191,7 @@ class TestDataplexGetTaskOperator(TestCase):
         )
 
 
-class TestDataplexDeleteLakeOperator(TestCase):
+class TestDataplexDeleteLakeOperator:
     @mock.patch(HOOK_STR)
     def test_execute(self, hook_mock):
         op = DataplexDeleteLakeOperator(
@@ -221,7 +221,7 @@ class TestDataplexDeleteLakeOperator(TestCase):
         )
 
 
-class TestDataplexCreateLakeOperator(TestCase):
+class TestDataplexCreateLakeOperator:
     @mock.patch(HOOK_STR)
     @mock.patch(LAKE_STR)
     def test_execute(self, lake_mock, hook_mock):

--- a/tests/providers/google/cloud/operators/test_dataproc.py
+++ b/tests/providers/google/cloud/operators/test_dataproc.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import inspect
-import unittest
 from unittest import mock
 from unittest.mock import MagicMock, Mock, call
 
@@ -263,13 +262,13 @@ def assert_warning(msg: str, warnings):
     assert any(msg in str(w) for w in warnings)
 
 
-class DataprocTestBase(unittest.TestCase):
+class DataprocTestBase:
     @classmethod
     def setUpClass(cls):
         cls.dagbag = DagBag(dag_folder="/dev/null", include_examples=False)
         cls.dag = DAG(TEST_DAG_ID, default_args={"owner": "airflow", "start_date": DEFAULT_DATE})
 
-    def setUp(self):
+    def setup_method(self):
         self.mock_ti = MagicMock()
         self.mock_context = {"ti": self.mock_ti}
         self.extra_links_manager_mock = Mock()
@@ -306,7 +305,7 @@ class DataprocClusterTestBase(DataprocTestBase):
         ]
 
 
-class TestsClusterGenerator(unittest.TestCase):
+class TestsClusterGenerator:
     def test_image_version(self):
         with pytest.raises(ValueError) as ctx:
             ClusterGenerator(
@@ -850,7 +849,7 @@ def test_scale_cluster_operator_extra_links(dag_maker, create_task_instance_of_o
     assert ti.task.get_extra_links(ti, DataprocLink.name) == DATAPROC_CLUSTER_LINK_EXPECTED
 
 
-class TestDataprocClusterDeleteOperator(unittest.TestCase):
+class TestDataprocClusterDeleteOperator:
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_execute(self, mock_hook):
         op = DataprocDeleteClusterOperator(
@@ -1331,7 +1330,7 @@ def test_update_cluster_operator_extra_links(dag_maker, create_task_instance_of_
     assert ti.task.get_extra_links(ti, DataprocLink.name) == DATAPROC_CLUSTER_LINK_EXPECTED
 
 
-class TestDataprocWorkflowTemplateInstantiateOperator(unittest.TestCase):
+class TestDataprocWorkflowTemplateInstantiateOperator:
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_execute(self, mock_hook):
         version = 6
@@ -1437,7 +1436,7 @@ def test_instantiate_workflow_operator_extra_links(mock_hook, dag_maker, create_
     assert ti.task.get_extra_links(ti, DataprocLink.name) == DATAPROC_WORKFLOW_LINK_EXPECTED
 
 
-class TestDataprocWorkflowTemplateInstantiateInlineOperator(unittest.TestCase):
+class TestDataprocWorkflowTemplateInstantiateInlineOperator:
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_execute(self, mock_hook):
         template = {}
@@ -1510,7 +1509,7 @@ def test_instantiate_inline_workflow_operator_extra_links(
     assert ti.task.get_extra_links(ti, DataprocLink.name) == DATAPROC_WORKFLOW_LINK_EXPECTED
 
 
-class TestDataProcHiveOperator(unittest.TestCase):
+class TestDataProcHiveOperator:
     query = "define sin HiveUDF('sin');"
     variables = {"key": "value"}
     job_id = "uuid_id"
@@ -1572,7 +1571,7 @@ class TestDataProcHiveOperator(unittest.TestCase):
         assert self.job == job
 
 
-class TestDataProcPigOperator(unittest.TestCase):
+class TestDataProcPigOperator:
     query = "define sin HiveUDF('sin');"
     variables = {"key": "value"}
     job_id = "uuid_id"
@@ -1634,7 +1633,7 @@ class TestDataProcPigOperator(unittest.TestCase):
         assert self.job == job
 
 
-class TestDataProcSparkSqlOperator(unittest.TestCase):
+class TestDataProcSparkSqlOperator:
     query = "SHOW DATABASES;"
     variables = {"key": "value"}
     job_name = "simple"
@@ -1824,7 +1823,7 @@ def test_submit_spark_job_operator_extra_links(mock_hook, dag_maker, create_task
     assert link == DATAPROC_JOB_LINK_EXPECTED
 
 
-class TestDataProcHadoopOperator(unittest.TestCase):
+class TestDataProcHadoopOperator:
     args = ["wordcount", "gs://pub/shakespeare/rose.txt"]
     jar = "file:///usr/lib/spark/examples/jars/spark-examples.jar"
     job_name = "simple"
@@ -1863,7 +1862,7 @@ class TestDataProcHadoopOperator(unittest.TestCase):
         assert self.job == job
 
 
-class TestDataProcPySparkOperator(unittest.TestCase):
+class TestDataProcPySparkOperator:
     uri = "gs://{}/{}"
     job_id = "uuid_id"
     job_name = "simple"

--- a/tests/providers/google/cloud/operators/test_dataproc.py
+++ b/tests/providers/google/cloud/operators/test_dataproc.py
@@ -948,9 +948,11 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
 
         # Test whether xcom push occurs before polling for job
-        assert self.extra_links_manager_mock.mock_calls.index(xcom_push_call) < \
-               self.extra_links_manager_mock.mock_calls.index(wait_for_job_call), \
-               "Xcom push for Job Link has to be done before polling for job status"
+        assert self.extra_links_manager_mock.mock_calls.index(
+            xcom_push_call
+        ) < self.extra_links_manager_mock.mock_calls.index(
+            wait_for_job_call
+        ), "Xcom push for Job Link has to be done before polling for job status"
 
         mock_hook.return_value.submit_job.assert_called_once_with(
             project_id=GCP_PROJECT,

--- a/tests/providers/google/cloud/operators/test_dataproc_metastore.py
+++ b/tests/providers/google/cloud/operators/test_dataproc_metastore.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from google.api_core.gapic_v1.method import _MethodDefault
 from google.api_core.retry import Retry
@@ -70,7 +70,7 @@ TEST_UPDATE_MASK: FieldMask = FieldMask(paths=["labels"])
 TEST_DESTINATION_GCS_FOLDER: str = "gs://bucket_name/path_inside_bucket"
 
 
-class TestDataprocMetastoreCreateBackupOperator(TestCase):
+class TestDataprocMetastoreCreateBackupOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dataproc_metastore.DataprocMetastoreHook")
     @mock.patch("airflow.providers.google.cloud.operators.dataproc_metastore.Backup")
     def test_assert_valid_hook_call(self, mock_backup, mock_hook) -> None:
@@ -104,7 +104,7 @@ class TestDataprocMetastoreCreateBackupOperator(TestCase):
         )
 
 
-class TestDataprocMetastoreCreateMetadataImportOperator(TestCase):
+class TestDataprocMetastoreCreateMetadataImportOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dataproc_metastore.DataprocMetastoreHook")
     @mock.patch("airflow.providers.google.cloud.operators.dataproc_metastore.MetadataImport")
     def test_assert_valid_hook_call(self, mock_metadata_import, mock_hook) -> None:
@@ -138,7 +138,7 @@ class TestDataprocMetastoreCreateMetadataImportOperator(TestCase):
         )
 
 
-class TestDataprocMetastoreCreateServiceOperator(TestCase):
+class TestDataprocMetastoreCreateServiceOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dataproc_metastore.DataprocMetastoreHook")
     @mock.patch("airflow.providers.google.cloud.operators.dataproc_metastore.Service")
     def test_execute(self, mock_service, mock_hook) -> None:
@@ -171,7 +171,7 @@ class TestDataprocMetastoreCreateServiceOperator(TestCase):
         )
 
 
-class TestDataprocMetastoreDeleteBackupOperator(TestCase):
+class TestDataprocMetastoreDeleteBackupOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dataproc_metastore.DataprocMetastoreHook")
     def test_assert_valid_hook_call(self, mock_hook) -> None:
         task = DataprocMetastoreDeleteBackupOperator(
@@ -201,7 +201,7 @@ class TestDataprocMetastoreDeleteBackupOperator(TestCase):
         )
 
 
-class TestDataprocMetastoreDeleteServiceOperator(TestCase):
+class TestDataprocMetastoreDeleteServiceOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dataproc_metastore.DataprocMetastoreHook")
     def test_execute(self, mock_hook) -> None:
         task = DataprocMetastoreDeleteServiceOperator(
@@ -228,7 +228,7 @@ class TestDataprocMetastoreDeleteServiceOperator(TestCase):
         )
 
 
-class TestDataprocMetastoreExportMetadataOperator(TestCase):
+class TestDataprocMetastoreExportMetadataOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dataproc_metastore.DataprocMetastoreHook")
     @mock.patch("airflow.providers.google.cloud.operators.dataproc_metastore.MetadataExport")
     @mock.patch(
@@ -265,7 +265,7 @@ class TestDataprocMetastoreExportMetadataOperator(TestCase):
         )
 
 
-class TestDataprocMetastoreGetServiceOperator(TestCase):
+class TestDataprocMetastoreGetServiceOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dataproc_metastore.DataprocMetastoreHook")
     @mock.patch("airflow.providers.google.cloud.operators.dataproc_metastore.Service")
     def test_execute(self, mock_service, mock_hook) -> None:
@@ -294,7 +294,7 @@ class TestDataprocMetastoreGetServiceOperator(TestCase):
         )
 
 
-class TestDataprocMetastoreListBackupsOperator(TestCase):
+class TestDataprocMetastoreListBackupsOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dataproc_metastore.DataprocMetastoreHook")
     @mock.patch("airflow.providers.google.cloud.operators.dataproc_metastore.Backup")
     def test_assert_valid_hook_call(self, mock_backup, mock_hook) -> None:
@@ -327,7 +327,7 @@ class TestDataprocMetastoreListBackupsOperator(TestCase):
         )
 
 
-class TestDataprocMetastoreRestoreServiceOperator(TestCase):
+class TestDataprocMetastoreRestoreServiceOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dataproc_metastore.DataprocMetastoreHook")
     @mock.patch(
         "airflow.providers.google.cloud.operators.dataproc_metastore"
@@ -368,7 +368,7 @@ class TestDataprocMetastoreRestoreServiceOperator(TestCase):
         )
 
 
-class TestDataprocMetastoreUpdateServiceOperator(TestCase):
+class TestDataprocMetastoreUpdateServiceOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dataproc_metastore.DataprocMetastoreHook")
     def test_assert_valid_hook_call(self, mock_hook) -> None:
         task = DataprocMetastoreUpdateServiceOperator(

--- a/tests/providers/google/cloud/operators/test_dlp.py
+++ b/tests/providers/google/cloud/operators/test_dlp.py
@@ -20,7 +20,6 @@ This module contains various unit tests for Google Cloud DLP Operators
 """
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
@@ -81,7 +80,7 @@ DLP_JOB_PATH = f"projects/{PROJECT_ID}/dlpJobs/{DLP_JOB_ID}"
 DLP_JOB_TRIGGER_PATH = f"projects/{PROJECT_ID}/jobTriggers/{TRIGGER_ID}"
 
 
-class TestCloudDLPCancelDLPJobOperator(unittest.TestCase):
+class TestCloudDLPCancelDLPJobOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_cancel_dlp_job(self, mock_hook):
         mock_hook.return_value.cancel_dlp_job.return_value = mock.MagicMock()
@@ -100,7 +99,7 @@ class TestCloudDLPCancelDLPJobOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPCreateDeidentifyTemplateOperator(unittest.TestCase):
+class TestCloudDLPCreateDeidentifyTemplateOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_create_deidentify_template(self, mock_hook):
         mock_hook.return_value.create_deidentify_template.return_value = mock.MagicMock()
@@ -122,7 +121,7 @@ class TestCloudDLPCreateDeidentifyTemplateOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPCreateDLPJobOperator(unittest.TestCase):
+class TestCloudDLPCreateDLPJobOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_create_dlp_job(self, mock_hook):
         mock_hook.return_value.create_dlp_job.return_value = DlpJob(
@@ -147,7 +146,7 @@ class TestCloudDLPCreateDLPJobOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPCreateInspectTemplateOperator(unittest.TestCase):
+class TestCloudDLPCreateInspectTemplateOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_create_inspect_template(self, mock_hook):
         mock_hook.return_value.create_inspect_template.return_value = InspectTemplate(name=DLP_JOB_PATH)
@@ -168,7 +167,7 @@ class TestCloudDLPCreateInspectTemplateOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPCreateJobTriggerOperator(unittest.TestCase):
+class TestCloudDLPCreateJobTriggerOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_create_job_trigger(self, mock_hook):
         mock_hook.return_value.create_job_trigger.return_value = JobTrigger(name=DLP_JOB_TRIGGER_PATH)
@@ -188,7 +187,7 @@ class TestCloudDLPCreateJobTriggerOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPCreateStoredInfoTypeOperator(unittest.TestCase):
+class TestCloudDLPCreateStoredInfoTypeOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_create_stored_info_type(self, mock_hook):
         mock_hook.return_value.create_stored_info_type.return_value = StoredInfoType(name=DLP_JOB_PATH)
@@ -209,7 +208,7 @@ class TestCloudDLPCreateStoredInfoTypeOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPDeidentifyContentOperator(unittest.TestCase):
+class TestCloudDLPDeidentifyContentOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_deidentify_content(self, mock_hook):
         mock_hook.return_value.deidentify_content.return_value = DeidentifyContentResponse()
@@ -232,7 +231,7 @@ class TestCloudDLPDeidentifyContentOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPDeleteDeidentifyTemplateOperator(unittest.TestCase):
+class TestCloudDLPDeleteDeidentifyTemplateOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_delete_deidentify_template(self, mock_hook):
         mock_hook.return_value.delete_deidentify_template.return_value = mock.MagicMock()
@@ -254,7 +253,7 @@ class TestCloudDLPDeleteDeidentifyTemplateOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPDeleteDlpJobOperator(unittest.TestCase):
+class TestCloudDLPDeleteDlpJobOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_delete_dlp_job(self, mock_hook):
         mock_hook.return_value.delete_dlp_job.return_value = mock.MagicMock()
@@ -273,7 +272,7 @@ class TestCloudDLPDeleteDlpJobOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPDeleteInspectTemplateOperator(unittest.TestCase):
+class TestCloudDLPDeleteInspectTemplateOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_delete_inspect_template(self, mock_hook):
         mock_hook.return_value.delete_inspect_template.return_value = mock.MagicMock()
@@ -295,7 +294,7 @@ class TestCloudDLPDeleteInspectTemplateOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPDeleteJobTriggerOperator(unittest.TestCase):
+class TestCloudDLPDeleteJobTriggerOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_delete_job_trigger(self, mock_hook):
         mock_hook.return_value.delete_job_trigger.return_value = mock.MagicMock()
@@ -316,7 +315,7 @@ class TestCloudDLPDeleteJobTriggerOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPDeleteStoredInfoTypeOperator(unittest.TestCase):
+class TestCloudDLPDeleteStoredInfoTypeOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_delete_stored_info_type(self, mock_hook):
         mock_hook.return_value.delete_stored_info_type.return_value = mock.MagicMock()
@@ -340,7 +339,7 @@ class TestCloudDLPDeleteStoredInfoTypeOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPGetDeidentifyTemplateOperator(unittest.TestCase):
+class TestCloudDLPGetDeidentifyTemplateOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_get_deidentify_template(self, mock_hook):
         mock_hook.return_value.get_deidentify_template.return_value = DeidentifyTemplate()
@@ -362,7 +361,7 @@ class TestCloudDLPGetDeidentifyTemplateOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPGetDlpJobOperator(unittest.TestCase):
+class TestCloudDLPGetDlpJobOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_get_dlp_job(self, mock_hook):
         mock_hook.return_value.get_dlp_job.return_value = DlpJob()
@@ -381,7 +380,7 @@ class TestCloudDLPGetDlpJobOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPGetInspectTemplateOperator(unittest.TestCase):
+class TestCloudDLPGetInspectTemplateOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_get_inspect_template(self, mock_hook):
         mock_hook.return_value.get_inspect_template.return_value = InspectTemplate()
@@ -403,7 +402,7 @@ class TestCloudDLPGetInspectTemplateOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPGetJobTripperOperator(unittest.TestCase):
+class TestCloudDLPGetJobTripperOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_get_job_trigger(self, mock_hook):
         mock_hook.return_value.get_job_trigger.return_value = JobTrigger()
@@ -424,7 +423,7 @@ class TestCloudDLPGetJobTripperOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPGetStoredInfoTypeOperator(unittest.TestCase):
+class TestCloudDLPGetStoredInfoTypeOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_get_stored_info_type(self, mock_hook):
         mock_hook.return_value.get_stored_info_type.return_value = StoredInfoType()
@@ -448,7 +447,7 @@ class TestCloudDLPGetStoredInfoTypeOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPInspectContentOperator(unittest.TestCase):
+class TestCloudDLPInspectContentOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_inspect_content(self, mock_hook):
         inspect_template_name = "inspect_template_name/name"
@@ -472,7 +471,7 @@ class TestCloudDLPInspectContentOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPListDeidentifyTemplatesOperator(unittest.TestCase):
+class TestCloudDLPListDeidentifyTemplatesOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_list_deidentify_templates(self, mock_hook):
         mock_hook.return_value.list_deidentify_templates.return_value = mock.MagicMock()
@@ -493,7 +492,7 @@ class TestCloudDLPListDeidentifyTemplatesOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPListDlpJobsOperator(unittest.TestCase):
+class TestCloudDLPListDlpJobsOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_list_dlp_jobs(self, mock_hook):
         mock_hook.return_value.list_dlp_jobs.return_value = mock.MagicMock()
@@ -515,7 +514,7 @@ class TestCloudDLPListDlpJobsOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPListInfoTypesOperator(unittest.TestCase):
+class TestCloudDLPListInfoTypesOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_list_info_types(self, mock_hook):
         mock_hook.return_value.list_info_types.return_value = ListInfoTypesResponse()
@@ -534,7 +533,7 @@ class TestCloudDLPListInfoTypesOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPListInspectTemplatesOperator(unittest.TestCase):
+class TestCloudDLPListInspectTemplatesOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_list_inspect_templates(self, mock_hook):
         mock_hook.return_value.list_inspect_templates.return_value = mock.MagicMock()
@@ -555,7 +554,7 @@ class TestCloudDLPListInspectTemplatesOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPListJobTriggersOperator(unittest.TestCase):
+class TestCloudDLPListJobTriggersOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_list_job_triggers(self, mock_hook):
         mock_hook.return_value.list_job_triggers.return_value = mock.MagicMock()
@@ -576,7 +575,7 @@ class TestCloudDLPListJobTriggersOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPListStoredInfoTypesOperator(unittest.TestCase):
+class TestCloudDLPListStoredInfoTypesOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_list_stored_info_types(self, mock_hook):
         mock_hook.return_value.list_stored_info_types.return_value = mock.MagicMock()
@@ -597,7 +596,7 @@ class TestCloudDLPListStoredInfoTypesOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPRedactImageOperator(unittest.TestCase):
+class TestCloudDLPRedactImageOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_redact_image(self, mock_hook):
         mock_hook.return_value.redact_image.return_value = RedactImageResponse()
@@ -619,7 +618,7 @@ class TestCloudDLPRedactImageOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPReidentifyContentOperator(unittest.TestCase):
+class TestCloudDLPReidentifyContentOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_reidentify_content(self, mock_hook):
         mock_hook.return_value.reidentify_content.return_value = ReidentifyContentResponse()
@@ -642,7 +641,7 @@ class TestCloudDLPReidentifyContentOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPUpdateDeidentifyTemplateOperator(unittest.TestCase):
+class TestCloudDLPUpdateDeidentifyTemplateOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_update_deidentify_template(self, mock_hook):
         mock_hook.return_value.update_deidentify_template.return_value = DeidentifyTemplate()
@@ -666,7 +665,7 @@ class TestCloudDLPUpdateDeidentifyTemplateOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPUpdateInspectTemplateOperator(unittest.TestCase):
+class TestCloudDLPUpdateInspectTemplateOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_update_inspect_template(self, mock_hook):
         mock_hook.return_value.update_inspect_template.return_value = InspectTemplate()
@@ -690,7 +689,7 @@ class TestCloudDLPUpdateInspectTemplateOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPUpdateJobTriggerOperator(unittest.TestCase):
+class TestCloudDLPUpdateJobTriggerOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_update_job_trigger(self, mock_hook):
         mock_hook.return_value.update_job_trigger.return_value = JobTrigger()
@@ -711,7 +710,7 @@ class TestCloudDLPUpdateJobTriggerOperator(unittest.TestCase):
         )
 
 
-class TestCloudDLPUpdateStoredInfoTypeOperator(unittest.TestCase):
+class TestCloudDLPUpdateStoredInfoTypeOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dlp.CloudDLPHook")
     def test_update_stored_info_type(self, mock_hook):
         mock_hook.return_value.update_stored_info_type.return_value = StoredInfoType()

--- a/tests/providers/google/cloud/operators/test_functions.py
+++ b/tests/providers/google/cloud/operators/test_functions.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from copy import deepcopy
 from unittest import mock
 
@@ -69,7 +68,7 @@ def _prepare_test_bodies():
     return body_values
 
 
-class TestGcfFunctionDeploy(unittest.TestCase):
+class TestGcfFunctionDeploy:
     @parameterized.expand(_prepare_test_bodies())
     @mock.patch("airflow.providers.google.cloud.operators.functions.CloudFunctionsHook")
     def test_body_empty_or_missing_fields(self, body, message, mock_hook):
@@ -579,7 +578,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         mock_hook.reset_mock()
 
 
-class TestGcfFunctionDelete(unittest.TestCase):
+class TestGcfFunctionDelete:
     _FUNCTION_NAME = "projects/project_name/locations/project_location/functions/function_name"
     _DELETE_FUNCTION_EXPECTED = {
         "@type": "type.googleapis.com/google.cloud.functions.v1.CloudFunction",
@@ -678,7 +677,7 @@ class TestGcfFunctionDelete(unittest.TestCase):
         )
 
 
-class TestGcfFunctionInvokeOperator(unittest.TestCase):
+class TestGcfFunctionInvokeOperator:
     @mock.patch("airflow.providers.google.cloud.operators.functions.GoogleCloudBaseOperator.xcom_push")
     @mock.patch("airflow.providers.google.cloud.operators.functions.CloudFunctionsHook")
     def test_execute(self, mock_gcf_hook, mock_xcom):

--- a/tests/providers/google/cloud/operators/test_gcs.py
+++ b/tests/providers/google/cloud/operators/test_gcs.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
@@ -45,7 +44,7 @@ LOCAL_FILE_PATH = "/home/airflow/gcp/test-object"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
-class TestGoogleCloudStorageCreateBucket(unittest.TestCase):
+class TestGoogleCloudStorageCreateBucket:
     @mock.patch("airflow.providers.google.cloud.operators.gcs.GCSHook")
     def test_execute(self, mock_hook):
         operator = GCSCreateBucketOperator(
@@ -69,7 +68,7 @@ class TestGoogleCloudStorageCreateBucket(unittest.TestCase):
         )
 
 
-class TestGoogleCloudStorageAcl(unittest.TestCase):
+class TestGoogleCloudStorageAcl:
     @mock.patch("airflow.providers.google.cloud.operators.gcs.GCSHook")
     def test_bucket_create_acl(self, mock_hook):
         operator = GCSBucketCreateAclEntryOperator(
@@ -109,7 +108,7 @@ class TestGoogleCloudStorageAcl(unittest.TestCase):
         )
 
 
-class TestGCSDeleteObjectsOperator(unittest.TestCase):
+class TestGCSDeleteObjectsOperator:
     @mock.patch("airflow.providers.google.cloud.operators.gcs.GCSHook")
     def test_delete_objects(self, mock_hook):
         operator = GCSDeleteObjectsOperator(task_id=TASK_ID, bucket_name=TEST_BUCKET, objects=MOCK_FILES[0:2])
@@ -157,7 +156,7 @@ class TestGCSDeleteObjectsOperator(unittest.TestCase):
         )
 
 
-class TestGoogleCloudStorageListOperator(unittest.TestCase):
+class TestGoogleCloudStorageListOperator:
     @mock.patch("airflow.providers.google.cloud.operators.gcs.GCSHook")
     def test_execute(self, mock_hook):
         mock_hook.return_value.list.return_value = MOCK_FILES
@@ -173,7 +172,7 @@ class TestGoogleCloudStorageListOperator(unittest.TestCase):
         assert sorted(files) == sorted(MOCK_FILES)
 
 
-class TestGCSFileTransformOperator(unittest.TestCase):
+class TestGCSFileTransformOperator:
     @mock.patch("airflow.providers.google.cloud.operators.gcs.NamedTemporaryFile")
     @mock.patch("airflow.providers.google.cloud.operators.gcs.subprocess")
     @mock.patch("airflow.providers.google.cloud.operators.gcs.GCSHook")
@@ -235,7 +234,7 @@ class TestGCSFileTransformOperator(unittest.TestCase):
         )
 
 
-class TestGCSTimeSpanFileTransformOperatorDateInterpolation(unittest.TestCase):
+class TestGCSTimeSpanFileTransformOperatorDateInterpolation:
     def test_execute(self):
         interp_dt = datetime(2015, 2, 1, 15, 16, 17, 345, tzinfo=timezone.utc)
 
@@ -266,7 +265,7 @@ class TestGCSTimeSpanFileTransformOperatorDateInterpolation(unittest.TestCase):
         )
 
 
-class TestGCSTimeSpanFileTransformOperator(unittest.TestCase):
+class TestGCSTimeSpanFileTransformOperator:
     @mock.patch("airflow.providers.google.cloud.operators.gcs.TemporaryDirectory")
     @mock.patch("airflow.providers.google.cloud.operators.gcs.subprocess")
     @mock.patch("airflow.providers.google.cloud.operators.gcs.GCSHook")
@@ -392,7 +391,7 @@ class TestGCSTimeSpanFileTransformOperator(unittest.TestCase):
         )
 
 
-class TestGCSDeleteBucketOperator(unittest.TestCase):
+class TestGCSDeleteBucketOperator:
     @mock.patch("airflow.providers.google.cloud.operators.gcs.GCSHook")
     def test_delete_bucket(self, mock_hook):
         operator = GCSDeleteBucketOperator(task_id=TASK_ID, bucket_name=TEST_BUCKET)
@@ -401,7 +400,7 @@ class TestGCSDeleteBucketOperator(unittest.TestCase):
         mock_hook.return_value.delete_bucket.assert_called_once_with(bucket_name=TEST_BUCKET, force=True)
 
 
-class TestGoogleCloudStorageSync(unittest.TestCase):
+class TestGoogleCloudStorageSync:
     @mock.patch("airflow.providers.google.cloud.operators.gcs.GCSHook")
     def test_execute(self, mock_hook):
         task = GCSSynchronizeBucketsOperator(

--- a/tests/providers/google/cloud/operators/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/operators/test_kubernetes_engine.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import json
 import os
-import unittest
 from unittest import mock
 from unittest.mock import PropertyMock
 
@@ -63,7 +62,7 @@ KUBE_ENV_VAR = "KUBECONFIG"
 FILE_NAME = "/tmp/mock_name"
 
 
-class TestGoogleCloudPlatformContainerOperator(unittest.TestCase):
+class TestGoogleCloudPlatformContainerOperator:
     @parameterized.expand(
         (body,)
         for body in [
@@ -216,8 +215,8 @@ class TestGoogleCloudPlatformContainerOperator(unittest.TestCase):
         mock_defer_method.assert_called_once()
 
 
-class TestGKEPodOperator(unittest.TestCase):
-    def setUp(self):
+class TestGKEPodOperator:
+    def setup_method(self):
         self.gke_op = GKEStartPodOperator(
             project_id=TEST_GCP_PROJECT_ID,
             location=PROJECT_LOCATION,

--- a/tests/providers/google/cloud/operators/test_life_sciences.py
+++ b/tests/providers/google/cloud/operators/test_life_sciences.py
@@ -18,7 +18,6 @@
 """Tests for Google Life Sciences Run Pipeline operator """
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.google.cloud.operators.life_sciences import LifeSciencesRunPipelineOperator
@@ -35,7 +34,7 @@ TEST_PROJECT_ID = "life-science-project-id"
 TEST_LOCATION = "test-location"
 
 
-class TestLifeSciencesRunPipelineOperator(unittest.TestCase):
+class TestLifeSciencesRunPipelineOperator:
     @mock.patch("airflow.providers.google.cloud.operators.life_sciences.LifeSciencesHook")
     def test_executes(self, mock_hook):
         mock_instance = mock_hook.return_value

--- a/tests/providers/google/cloud/operators/test_looker.py
+++ b/tests/providers/google/cloud/operators/test_looker.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -40,13 +39,13 @@ DEFAULT_DATE = datetime(2020, 1, 1)
 TEST_JOB_ID = "123"
 
 
-class LookerTestBase(unittest.TestCase):
+class LookerTestBase:
     @classmethod
     def setUpClass(cls):
         cls.dagbag = DagBag(dag_folder="/dev/null", include_examples=False)
         cls.dag = DAG(TEST_DAG_ID, default_args={"owner": "airflow", "start_date": DEFAULT_DATE})
 
-    def setUp(self):
+    def setup_method(self):
         self.mock_ti = MagicMock()
         self.mock_context = {"ti": self.mock_ti}
 

--- a/tests/providers/google/cloud/operators/test_mlengine.py
+++ b/tests/providers/google/cloud/operators/test_mlengine.py
@@ -97,7 +97,6 @@ class TestMLEngineBatchPredictionOperator:
     }
 
     def setup_method(self):
-        super().setUp()
         self.dag = DAG(
             "test_dag",
             default_args={

--- a/tests/providers/google/cloud/operators/test_mlengine.py
+++ b/tests/providers/google/cloud/operators/test_mlengine.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import copy
-import unittest
 from unittest import mock
 from unittest.mock import ANY, MagicMock, patch
 
@@ -68,7 +67,7 @@ TEST_VERSION = {
 MLENGINE_AI_PATH = "airflow.providers.google.cloud.operators.mlengine.{}"
 
 
-class TestMLEngineBatchPredictionOperator(unittest.TestCase):
+class TestMLEngineBatchPredictionOperator:
     INPUT_MISSING_ORIGIN = {
         "dataFormat": "TEXT",
         "inputPaths": ["gs://legal-bucket/fake-input-path/*"],
@@ -97,7 +96,7 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
         "task_id": "test-prediction",
     }
 
-    def setUp(self):
+    def setup_method(self):
         super().setUp()
         self.dag = DAG(
             "test_dag",
@@ -315,7 +314,7 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
         assert "A failure message" == str(ctx.value)
 
 
-class TestMLEngineTrainingCancelJobOperator(unittest.TestCase):
+class TestMLEngineTrainingCancelJobOperator:
 
     TRAINING_DEFAULT_ARGS = {
         "project_id": "test-project",
@@ -368,7 +367,7 @@ class TestMLEngineTrainingCancelJobOperator(unittest.TestCase):
         assert http_error_code == ctx.value.resp.status
 
 
-class TestMLEngineModelOperator(unittest.TestCase):
+class TestMLEngineModelOperator:
     @patch(MLENGINE_AI_PATH.format("MLEngineHook"))
     def test_success_create_model(self, mock_hook):
         task = MLEngineManageModelOperator(
@@ -430,7 +429,7 @@ class TestMLEngineModelOperator(unittest.TestCase):
             task.execute(None)
 
 
-class TestMLEngineCreateModelOperator(unittest.TestCase):
+class TestMLEngineCreateModelOperator:
     @patch(MLENGINE_AI_PATH.format("MLEngineHook"))
     def test_success_create_model(self, mock_hook):
         task = MLEngineCreateModelOperator(
@@ -454,7 +453,7 @@ class TestMLEngineCreateModelOperator(unittest.TestCase):
         )
 
 
-class TestMLEngineGetModelOperator(unittest.TestCase):
+class TestMLEngineGetModelOperator:
     @patch(MLENGINE_AI_PATH.format("MLEngineHook"))
     def test_success_get_model(self, mock_hook):
         task = MLEngineGetModelOperator(
@@ -479,7 +478,7 @@ class TestMLEngineGetModelOperator(unittest.TestCase):
         assert mock_hook.return_value.get_model.return_value == result
 
 
-class TestMLEngineDeleteModelOperator(unittest.TestCase):
+class TestMLEngineDeleteModelOperator:
     @patch(MLENGINE_AI_PATH.format("MLEngineHook"))
     def test_success_delete_model(self, mock_hook):
         task = MLEngineDeleteModelOperator(
@@ -504,7 +503,7 @@ class TestMLEngineDeleteModelOperator(unittest.TestCase):
         )
 
 
-class TestMLEngineVersionOperator(unittest.TestCase):
+class TestMLEngineVersionOperator:
     VERSION_DEFAULT_ARGS = {
         "project_id": "test-project",
         "model_name": "test-model",
@@ -532,7 +531,7 @@ class TestMLEngineVersionOperator(unittest.TestCase):
         )
 
 
-class TestMLEngineCreateVersion(unittest.TestCase):
+class TestMLEngineCreateVersion:
     @patch(MLENGINE_AI_PATH.format("MLEngineHook"))
     def test_success(self, mock_hook):
         task = MLEngineCreateVersionOperator(
@@ -579,7 +578,7 @@ class TestMLEngineCreateVersion(unittest.TestCase):
             )
 
 
-class TestMLEngineSetDefaultVersion(unittest.TestCase):
+class TestMLEngineSetDefaultVersion:
     @patch(MLENGINE_AI_PATH.format("MLEngineHook"))
     def test_success(self, mock_hook):
         task = MLEngineSetDefaultVersionOperator(
@@ -626,7 +625,7 @@ class TestMLEngineSetDefaultVersion(unittest.TestCase):
             )
 
 
-class TestMLEngineListVersions(unittest.TestCase):
+class TestMLEngineListVersions:
     @patch(MLENGINE_AI_PATH.format("MLEngineHook"))
     def test_success(self, mock_hook):
         task = MLEngineListVersionsOperator(
@@ -661,7 +660,7 @@ class TestMLEngineListVersions(unittest.TestCase):
             )
 
 
-class TestMLEngineDeleteVersion(unittest.TestCase):
+class TestMLEngineDeleteVersion:
     @patch(MLENGINE_AI_PATH.format("MLEngineHook"))
     def test_success(self, mock_hook):
         task = MLEngineDeleteVersionOperator(

--- a/tests/providers/google/cloud/operators/test_natural_language.py
+++ b/tests/providers/google/cloud/operators/test_natural_language.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import patch
 
 from google.cloud.language_v1.proto.language_service_pb2 import (
@@ -47,7 +46,7 @@ ANALYZE_SENTIMENT_RESPONSE = AnalyzeSentimentResponse()
 ENCODING_TYPE = "UTF32"
 
 
-class TestCloudLanguageAnalyzeEntitiesOperator(unittest.TestCase):
+class TestCloudLanguageAnalyzeEntitiesOperator:
     @patch("airflow.providers.google.cloud.operators.natural_language.CloudNaturalLanguageHook")
     def test_minimal_green_path(self, hook_mock):
         hook_mock.return_value.analyze_entities.return_value = ANALYZE_ENTITIES_RESPONSE
@@ -56,7 +55,7 @@ class TestCloudLanguageAnalyzeEntitiesOperator(unittest.TestCase):
         assert resp == {}
 
 
-class TestCloudLanguageAnalyzeEntitySentimentOperator(unittest.TestCase):
+class TestCloudLanguageAnalyzeEntitySentimentOperator:
     @patch("airflow.providers.google.cloud.operators.natural_language.CloudNaturalLanguageHook")
     def test_minimal_green_path(self, hook_mock):
         hook_mock.return_value.analyze_entity_sentiment.return_value = ANALYZE_ENTITY_SENTIMENT_RESPONSE
@@ -65,7 +64,7 @@ class TestCloudLanguageAnalyzeEntitySentimentOperator(unittest.TestCase):
         assert resp == {}
 
 
-class TestCloudLanguageAnalyzeSentimentOperator(unittest.TestCase):
+class TestCloudLanguageAnalyzeSentimentOperator:
     @patch("airflow.providers.google.cloud.operators.natural_language.CloudNaturalLanguageHook")
     def test_minimal_green_path(self, hook_mock):
         hook_mock.return_value.analyze_sentiment.return_value = ANALYZE_SENTIMENT_RESPONSE
@@ -74,7 +73,7 @@ class TestCloudLanguageAnalyzeSentimentOperator(unittest.TestCase):
         assert resp == {}
 
 
-class TestCloudLanguageClassifyTextOperator(unittest.TestCase):
+class TestCloudLanguageClassifyTextOperator:
     @patch("airflow.providers.google.cloud.operators.natural_language.CloudNaturalLanguageHook")
     def test_minimal_green_path(self, hook_mock):
         hook_mock.return_value.classify_text.return_value = CLASSIFY_TEXT_RESPONSE

--- a/tests/providers/google/cloud/operators/test_pubsub.py
+++ b/tests/providers/google/cloud/operators/test_pubsub.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from typing import Any
 from unittest import mock
 
@@ -44,7 +43,7 @@ TEST_MESSAGES = [
 ]
 
 
-class TestPubSubTopicCreateOperator(unittest.TestCase):
+class TestPubSubTopicCreateOperator:
     @mock.patch("airflow.providers.google.cloud.operators.pubsub.PubSubHook")
     def test_failifexists(self, mock_hook):
         operator = PubSubCreateTopicOperator(
@@ -86,7 +85,7 @@ class TestPubSubTopicCreateOperator(unittest.TestCase):
         )
 
 
-class TestPubSubTopicDeleteOperator(unittest.TestCase):
+class TestPubSubTopicDeleteOperator:
     @mock.patch("airflow.providers.google.cloud.operators.pubsub.PubSubHook")
     def test_execute(self, mock_hook):
         operator = PubSubDeleteTopicOperator(task_id=TASK_ID, project_id=TEST_PROJECT, topic=TEST_TOPIC)
@@ -102,7 +101,7 @@ class TestPubSubTopicDeleteOperator(unittest.TestCase):
         )
 
 
-class TestPubSubSubscriptionCreateOperator(unittest.TestCase):
+class TestPubSubSubscriptionCreateOperator:
     @mock.patch("airflow.providers.google.cloud.operators.pubsub.PubSubHook")
     def test_execute(self, mock_hook):
         operator = PubSubCreateSubscriptionOperator(
@@ -199,7 +198,7 @@ class TestPubSubSubscriptionCreateOperator(unittest.TestCase):
         assert response == TEST_SUBSCRIPTION
 
 
-class TestPubSubSubscriptionDeleteOperator(unittest.TestCase):
+class TestPubSubSubscriptionDeleteOperator:
     @mock.patch("airflow.providers.google.cloud.operators.pubsub.PubSubHook")
     def test_execute(self, mock_hook):
         operator = PubSubDeleteSubscriptionOperator(
@@ -217,7 +216,7 @@ class TestPubSubSubscriptionDeleteOperator(unittest.TestCase):
         )
 
 
-class TestPubSubPublishOperator(unittest.TestCase):
+class TestPubSubPublishOperator:
     @mock.patch("airflow.providers.google.cloud.operators.pubsub.PubSubHook")
     def test_publish(self, mock_hook):
         operator = PubSubPublishMessageOperator(
@@ -233,7 +232,7 @@ class TestPubSubPublishOperator(unittest.TestCase):
         )
 
 
-class TestPubSubPullOperator(unittest.TestCase):
+class TestPubSubPullOperator:
     def _generate_messages(self, count):
         return [
             ReceivedMessage(

--- a/tests/providers/google/cloud/operators/test_spanner.py
+++ b/tests/providers/google/cloud/operators/test_spanner.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -46,7 +45,7 @@ CREATE_QUERY_2 = "CREATE TABLE my_table2 (id INT64, name STRING(100))"
 DDL_STATEMENTS = [CREATE_QUERY, CREATE_QUERY_2]
 
 
-class TestCloudSpanner(unittest.TestCase):
+class TestCloudSpanner:
     @mock.patch("airflow.providers.google.cloud.operators.spanner.SpannerHook")
     def test_instance_create(self, mock_hook):
         mock_hook.return_value.get_instance.return_value = None

--- a/tests/providers/google/cloud/operators/test_speech_to_text.py
+++ b/tests/providers/google/cloud/operators/test_speech_to_text.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -33,7 +32,7 @@ CONFIG = {"encoding": "LINEAR16"}
 AUDIO = {"uri": "gs://bucket/object"}
 
 
-class TestCloudSql(unittest.TestCase):
+class TestCloudSql:
     @patch("airflow.providers.google.cloud.operators.speech_to_text.CloudSpeechToTextHook")
     def test_recognize_speech_green_path(self, mock_hook):
         mock_hook.return_value.recognize_speech.return_value = MagicMock()

--- a/tests/providers/google/cloud/operators/test_stackdriver.py
+++ b/tests/providers/google/cloud/operators/test_stackdriver.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import json
-import unittest
 from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
@@ -90,7 +89,7 @@ TEST_NOTIFICATION_CHANNEL_2 = {
 }
 
 
-class TestStackdriverListAlertPoliciesOperator(unittest.TestCase):
+class TestStackdriverListAlertPoliciesOperator:
     @mock.patch("airflow.providers.google.cloud.operators.stackdriver.StackdriverHook")
     def test_execute(self, mock_hook):
         operator = StackdriverListAlertPoliciesOperator(task_id=TEST_TASK_ID, filter_=TEST_FILTER)
@@ -118,7 +117,7 @@ class TestStackdriverListAlertPoliciesOperator(unittest.TestCase):
         ] == result
 
 
-class TestStackdriverEnableAlertPoliciesOperator(unittest.TestCase):
+class TestStackdriverEnableAlertPoliciesOperator:
     @mock.patch("airflow.providers.google.cloud.operators.stackdriver.StackdriverHook")
     def test_execute(self, mock_hook):
         operator = StackdriverEnableAlertPoliciesOperator(task_id=TEST_TASK_ID, filter_=TEST_FILTER)
@@ -128,7 +127,7 @@ class TestStackdriverEnableAlertPoliciesOperator(unittest.TestCase):
         )
 
 
-class TestStackdriverDisableAlertPoliciesOperator(unittest.TestCase):
+class TestStackdriverDisableAlertPoliciesOperator:
     @mock.patch("airflow.providers.google.cloud.operators.stackdriver.StackdriverHook")
     def test_execute(self, mock_hook):
         operator = StackdriverDisableAlertPoliciesOperator(task_id=TEST_TASK_ID, filter_=TEST_FILTER)
@@ -138,7 +137,7 @@ class TestStackdriverDisableAlertPoliciesOperator(unittest.TestCase):
         )
 
 
-class TestStackdriverUpsertAlertsOperator(unittest.TestCase):
+class TestStackdriverUpsertAlertsOperator:
     @mock.patch("airflow.providers.google.cloud.operators.stackdriver.StackdriverHook")
     def test_execute(self, mock_hook):
         operator = StackdriverUpsertAlertOperator(
@@ -154,7 +153,7 @@ class TestStackdriverUpsertAlertsOperator(unittest.TestCase):
         )
 
 
-class TestStackdriverDeleteAlertOperator(unittest.TestCase):
+class TestStackdriverDeleteAlertOperator:
     @mock.patch("airflow.providers.google.cloud.operators.stackdriver.StackdriverHook")
     def test_execute(self, mock_hook):
         operator = StackdriverDeleteAlertOperator(
@@ -167,7 +166,7 @@ class TestStackdriverDeleteAlertOperator(unittest.TestCase):
         )
 
 
-class TestStackdriverListNotificationChannelsOperator(unittest.TestCase):
+class TestStackdriverListNotificationChannelsOperator:
     @mock.patch("airflow.providers.google.cloud.operators.stackdriver.StackdriverHook")
     def test_execute(self, mock_hook):
         operator = StackdriverListNotificationChannelsOperator(task_id=TEST_TASK_ID, filter_=TEST_FILTER)
@@ -215,7 +214,7 @@ class TestStackdriverListNotificationChannelsOperator(unittest.TestCase):
         ]
 
 
-class TestStackdriverEnableNotificationChannelsOperator(unittest.TestCase):
+class TestStackdriverEnableNotificationChannelsOperator:
     @mock.patch("airflow.providers.google.cloud.operators.stackdriver.StackdriverHook")
     def test_execute(self, mock_hook):
         operator = StackdriverEnableNotificationChannelsOperator(task_id=TEST_TASK_ID, filter_=TEST_FILTER)
@@ -225,7 +224,7 @@ class TestStackdriverEnableNotificationChannelsOperator(unittest.TestCase):
         )
 
 
-class TestStackdriverDisableNotificationChannelsOperator(unittest.TestCase):
+class TestStackdriverDisableNotificationChannelsOperator:
     @mock.patch("airflow.providers.google.cloud.operators.stackdriver.StackdriverHook")
     def test_execute(self, mock_hook):
         operator = StackdriverDisableNotificationChannelsOperator(task_id=TEST_TASK_ID, filter_=TEST_FILTER)
@@ -235,7 +234,7 @@ class TestStackdriverDisableNotificationChannelsOperator(unittest.TestCase):
         )
 
 
-class TestStackdriverUpsertChannelOperator(unittest.TestCase):
+class TestStackdriverUpsertChannelOperator:
     @mock.patch("airflow.providers.google.cloud.operators.stackdriver.StackdriverHook")
     def test_execute(self, mock_hook):
         operator = StackdriverUpsertNotificationChannelOperator(
@@ -252,7 +251,7 @@ class TestStackdriverUpsertChannelOperator(unittest.TestCase):
         )
 
 
-class TestStackdriverDeleteNotificationChannelOperator(unittest.TestCase):
+class TestStackdriverDeleteNotificationChannelOperator:
     @mock.patch("airflow.providers.google.cloud.operators.stackdriver.StackdriverHook")
     def test_execute(self, mock_hook):
         operator = StackdriverDeleteNotificationChannelOperator(

--- a/tests/providers/google/cloud/operators/test_tasks.py
+++ b/tests/providers/google/cloud/operators/test_tasks.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
@@ -51,7 +50,7 @@ TEST_QUEUE = Queue(name=FULL_QUEUE_PATH)
 TEST_TASK = Task(app_engine_http_request={})
 
 
-class TestCloudTasksQueueCreate(unittest.TestCase):
+class TestCloudTasksQueueCreate:
     @mock.patch("airflow.providers.google.cloud.operators.tasks.CloudTasksHook")
     def test_create_queue(self, mock_hook):
         mock_hook.return_value.create_queue.return_value = TEST_QUEUE
@@ -75,7 +74,7 @@ class TestCloudTasksQueueCreate(unittest.TestCase):
         )
 
 
-class TestCloudTasksQueueUpdate(unittest.TestCase):
+class TestCloudTasksQueueUpdate:
     @mock.patch("airflow.providers.google.cloud.operators.tasks.CloudTasksHook")
     def test_update_queue(self, mock_hook):
         mock_hook.return_value.update_queue.return_value = TEST_QUEUE
@@ -100,7 +99,7 @@ class TestCloudTasksQueueUpdate(unittest.TestCase):
         )
 
 
-class TestCloudTasksQueueGet(unittest.TestCase):
+class TestCloudTasksQueueGet:
     @mock.patch("airflow.providers.google.cloud.operators.tasks.CloudTasksHook")
     def test_get_queue(self, mock_hook):
         mock_hook.return_value.get_queue.return_value = TEST_QUEUE
@@ -123,7 +122,7 @@ class TestCloudTasksQueueGet(unittest.TestCase):
         )
 
 
-class TestCloudTasksQueuesList(unittest.TestCase):
+class TestCloudTasksQueuesList:
     @mock.patch("airflow.providers.google.cloud.operators.tasks.CloudTasksHook")
     def test_list_queues(self, mock_hook):
         mock_hook.return_value.list_queues.return_value = [TEST_QUEUE]
@@ -147,7 +146,7 @@ class TestCloudTasksQueuesList(unittest.TestCase):
         )
 
 
-class TestCloudTasksQueueDelete(unittest.TestCase):
+class TestCloudTasksQueueDelete:
     @mock.patch("airflow.providers.google.cloud.operators.tasks.CloudTasksHook")
     def test_delete_queue(self, mock_hook):
         mock_hook.return_value.delete_queue.return_value = None
@@ -169,7 +168,7 @@ class TestCloudTasksQueueDelete(unittest.TestCase):
         )
 
 
-class TestCloudTasksQueuePurge(unittest.TestCase):
+class TestCloudTasksQueuePurge:
     @mock.patch("airflow.providers.google.cloud.operators.tasks.CloudTasksHook")
     def test_delete_queue(self, mock_hook):
         mock_hook.return_value.purge_queue.return_value = TEST_QUEUE
@@ -192,7 +191,7 @@ class TestCloudTasksQueuePurge(unittest.TestCase):
         )
 
 
-class TestCloudTasksQueuePause(unittest.TestCase):
+class TestCloudTasksQueuePause:
     @mock.patch("airflow.providers.google.cloud.operators.tasks.CloudTasksHook")
     def test_pause_queue(self, mock_hook):
         mock_hook.return_value.pause_queue.return_value = TEST_QUEUE
@@ -215,7 +214,7 @@ class TestCloudTasksQueuePause(unittest.TestCase):
         )
 
 
-class TestCloudTasksQueueResume(unittest.TestCase):
+class TestCloudTasksQueueResume:
     @mock.patch("airflow.providers.google.cloud.operators.tasks.CloudTasksHook")
     def test_resume_queue(self, mock_hook):
         mock_hook.return_value.resume_queue.return_value = TEST_QUEUE
@@ -238,7 +237,7 @@ class TestCloudTasksQueueResume(unittest.TestCase):
         )
 
 
-class TestCloudTasksTaskCreate(unittest.TestCase):
+class TestCloudTasksTaskCreate:
     @mock.patch("airflow.providers.google.cloud.operators.tasks.CloudTasksHook")
     def test_create_task(self, mock_hook):
         mock_hook.return_value.create_task.return_value = TEST_TASK
@@ -272,7 +271,7 @@ class TestCloudTasksTaskCreate(unittest.TestCase):
         )
 
 
-class TestCloudTasksTaskGet(unittest.TestCase):
+class TestCloudTasksTaskGet:
     @mock.patch("airflow.providers.google.cloud.operators.tasks.CloudTasksHook")
     def test_get_task(self, mock_hook):
         mock_hook.return_value.get_task.return_value = TEST_TASK
@@ -305,7 +304,7 @@ class TestCloudTasksTaskGet(unittest.TestCase):
         )
 
 
-class TestCloudTasksTasksList(unittest.TestCase):
+class TestCloudTasksTasksList:
     @mock.patch("airflow.providers.google.cloud.operators.tasks.CloudTasksHook")
     def test_list_tasks(self, mock_hook):
         mock_hook.return_value.list_tasks.return_value = [TEST_TASK]
@@ -343,7 +342,7 @@ class TestCloudTasksTasksList(unittest.TestCase):
         )
 
 
-class TestCloudTasksTaskDelete(unittest.TestCase):
+class TestCloudTasksTaskDelete:
     @mock.patch("airflow.providers.google.cloud.operators.tasks.CloudTasksHook")
     def test_delete_task(self, mock_hook):
         mock_hook.return_value.delete_task.return_value = None
@@ -368,7 +367,7 @@ class TestCloudTasksTaskDelete(unittest.TestCase):
         )
 
 
-class TestCloudTasksTaskRun(unittest.TestCase):
+class TestCloudTasksTaskRun:
     @mock.patch("airflow.providers.google.cloud.operators.tasks.CloudTasksHook")
     def test_run_task(self, mock_hook):
         mock_hook.return_value.run_task.return_value = TEST_TASK

--- a/tests/providers/google/cloud/operators/test_text_to_speech.py
+++ b/tests/providers/google/cloud/operators/test_text_to_speech.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import ANY, MagicMock, Mock, PropertyMock, patch
 
 import pytest
@@ -37,7 +36,7 @@ TARGET_BUCKET_NAME = "target_bucket_name"
 TARGET_FILENAME = "target_filename"
 
 
-class TestGcpTextToSpeech(unittest.TestCase):
+class TestGcpTextToSpeech:
     @patch("airflow.providers.google.cloud.operators.text_to_speech.GCSHook")
     @patch("airflow.providers.google.cloud.operators.text_to_speech.CloudTextToSpeechHook")
     def test_synthesize_text_green_path(self, mock_text_to_speech_hook, mock_gcp_hook):

--- a/tests/providers/google/cloud/operators/test_translate.py
+++ b/tests/providers/google/cloud/operators/test_translate.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.google.cloud.operators.translate import CloudTranslateTextOperator
@@ -26,7 +25,7 @@ GCP_CONN_ID = "google_cloud_default"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
-class TestCloudTranslate(unittest.TestCase):
+class TestCloudTranslate:
     @mock.patch("airflow.providers.google.cloud.operators.translate.CloudTranslateHook")
     def test_minimal_green_path(self, mock_hook):
         mock_hook.return_value.translate.return_value = [

--- a/tests/providers/google/cloud/operators/test_translate_speech.py
+++ b/tests/providers/google/cloud/operators/test_translate_speech.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -34,7 +33,7 @@ GCP_CONN_ID = "google_cloud_default"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
-class TestCloudTranslateSpeech(unittest.TestCase):
+class TestCloudTranslateSpeech:
     @mock.patch("airflow.providers.google.cloud.operators.translate_speech.CloudSpeechToTextHook")
     @mock.patch("airflow.providers.google.cloud.operators.translate_speech.CloudTranslateHook")
     def test_minimal_green_path(self, mock_translate_hook, mock_speech_hook):

--- a/tests/providers/google/cloud/operators/test_video_intelligence.py
+++ b/tests/providers/google/cloud/operators/test_video_intelligence.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
@@ -39,7 +38,7 @@ AUDIO = {"uri": "gs://bucket/object"}
 INPUT_URI = "gs://test-bucket//test-video.mp4"
 
 
-class TestCloudVideoIntelligenceOperators(unittest.TestCase):
+class TestCloudVideoIntelligenceOperators:
     @mock.patch("airflow.providers.google.cloud.operators.video_intelligence.CloudVideoIntelligenceHook")
     def test_detect_video_labels_green_path(self, mock_hook):
 

--- a/tests/providers/google/cloud/operators/test_vision.py
+++ b/tests/providers/google/cloud/operators/test_vision.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from google.api_core.exceptions import AlreadyExists
@@ -60,7 +59,7 @@ GCP_CONN_ID = "google_cloud_default"
 DETECT_TEST_IMAGE = {"source": {"image_uri": "test_uri"}}
 
 
-class TestCloudVisionProductSetCreate(unittest.TestCase):
+class TestCloudVisionProductSetCreate:
     @mock.patch("airflow.providers.google.cloud.operators.vision.CloudVisionHook")
     def test_minimal_green_path(self, mock_hook):
         mock_hook.return_value.create_product_set.return_value = {}
@@ -97,7 +96,7 @@ class TestCloudVisionProductSetCreate(unittest.TestCase):
         assert PRODUCTSET_ID_TEST == result
 
 
-class TestCloudVisionProductSetUpdate(unittest.TestCase):
+class TestCloudVisionProductSetUpdate:
     @mock.patch("airflow.providers.google.cloud.operators.vision.CloudVisionHook")
     def test_minimal_green_path(self, mock_hook):
         mock_hook.return_value.update_product_set.return_value = {}
@@ -121,7 +120,7 @@ class TestCloudVisionProductSetUpdate(unittest.TestCase):
         )
 
 
-class TestCloudVisionProductSetGet(unittest.TestCase):
+class TestCloudVisionProductSetGet:
     @mock.patch("airflow.providers.google.cloud.operators.vision.CloudVisionHook")
     def test_minimal_green_path(self, mock_hook):
         mock_hook.return_value.get_product_set.return_value = {}
@@ -143,7 +142,7 @@ class TestCloudVisionProductSetGet(unittest.TestCase):
         )
 
 
-class TestCloudVisionProductSetDelete(unittest.TestCase):
+class TestCloudVisionProductSetDelete:
     @mock.patch("airflow.providers.google.cloud.operators.vision.CloudVisionHook")
     def test_minimal_green_path(self, mock_hook):
         mock_hook.return_value.delete_product_set.return_value = {}
@@ -165,7 +164,7 @@ class TestCloudVisionProductSetDelete(unittest.TestCase):
         )
 
 
-class TestCloudVisionProductCreate(unittest.TestCase):
+class TestCloudVisionProductCreate:
     @mock.patch("airflow.providers.google.cloud.operators.vision.CloudVisionHook")
     def test_minimal_green_path(self, mock_hook):
         mock_hook.return_value.create_product.return_value = {}
@@ -200,7 +199,7 @@ class TestCloudVisionProductCreate(unittest.TestCase):
         assert PRODUCT_ID_TEST == result
 
 
-class TestCloudVisionProductGet(unittest.TestCase):
+class TestCloudVisionProductGet:
     @mock.patch("airflow.providers.google.cloud.operators.vision.CloudVisionHook")
     def test_minimal_green_path(self, mock_hook):
         mock_hook.return_value.get_product.return_value = {}
@@ -220,7 +219,7 @@ class TestCloudVisionProductGet(unittest.TestCase):
         )
 
 
-class TestCloudVisionProductUpdate(unittest.TestCase):
+class TestCloudVisionProductUpdate:
     @mock.patch("airflow.providers.google.cloud.operators.vision.CloudVisionHook")
     def test_minimal_green_path(self, mock_hook):
         mock_hook.return_value.update_product.return_value = {}
@@ -242,7 +241,7 @@ class TestCloudVisionProductUpdate(unittest.TestCase):
         )
 
 
-class TestCloudVisionProductDelete(unittest.TestCase):
+class TestCloudVisionProductDelete:
     @mock.patch("airflow.providers.google.cloud.operators.vision.CloudVisionHook")
     def test_minimal_green_path(self, mock_hook):
         mock_hook.return_value.delete_product.return_value = {}
@@ -264,7 +263,7 @@ class TestCloudVisionProductDelete(unittest.TestCase):
         )
 
 
-class TestCloudVisionReferenceImageCreate(unittest.TestCase):
+class TestCloudVisionReferenceImageCreate:
     @mock.patch(
         "airflow.providers.google.cloud.operators.vision.CloudVisionHook",
     )
@@ -319,7 +318,7 @@ class TestCloudVisionReferenceImageCreate(unittest.TestCase):
         )
 
 
-class TestCloudVisionReferenceImageDelete(unittest.TestCase):
+class TestCloudVisionReferenceImageDelete:
     @mock.patch(
         "airflow.providers.google.cloud.operators.vision.CloudVisionHook",
     )
@@ -347,7 +346,7 @@ class TestCloudVisionReferenceImageDelete(unittest.TestCase):
         )
 
 
-class TestCloudVisionAddProductToProductSetOperator(unittest.TestCase):
+class TestCloudVisionAddProductToProductSetOperator:
     @mock.patch("airflow.providers.google.cloud.operators.vision.CloudVisionHook")
     def test_minimal_green_path(self, mock_hook):
         op = CloudVisionAddProductToProductSetOperator(
@@ -372,7 +371,7 @@ class TestCloudVisionAddProductToProductSetOperator(unittest.TestCase):
         )
 
 
-class TestCloudVisionRemoveProductFromProductSetOperator(unittest.TestCase):
+class TestCloudVisionRemoveProductFromProductSetOperator:
     @mock.patch("airflow.providers.google.cloud.operators.vision.CloudVisionHook")
     def test_minimal_green_path(self, mock_hook):
         op = CloudVisionRemoveProductFromProductSetOperator(
@@ -397,7 +396,7 @@ class TestCloudVisionRemoveProductFromProductSetOperator(unittest.TestCase):
         )
 
 
-class TestCloudVisionAnnotateImageOperator(unittest.TestCase):
+class TestCloudVisionAnnotateImageOperator:
     @mock.patch("airflow.providers.google.cloud.operators.vision.CloudVisionHook")
     def test_minimal_green_path_for_one_image(self, mock_hook):
         op = CloudVisionImageAnnotateOperator(request=ANNOTATE_REQUEST_TEST, task_id="id")
@@ -423,7 +422,7 @@ class TestCloudVisionAnnotateImageOperator(unittest.TestCase):
         )
 
 
-class TestCloudVisionDetectTextOperator(unittest.TestCase):
+class TestCloudVisionDetectTextOperator:
     @mock.patch("airflow.providers.google.cloud.operators.vision.CloudVisionHook")
     def test_minimal_green_path(self, mock_hook):
         op = CloudVisionDetectTextOperator(image=DETECT_TEST_IMAGE, task_id="id")
@@ -469,7 +468,7 @@ class TestCloudVisionDetectTextOperator(unittest.TestCase):
         )
 
 
-class TestCloudVisionDetectDocumentTextOperator(unittest.TestCase):
+class TestCloudVisionDetectDocumentTextOperator:
     @mock.patch("airflow.providers.google.cloud.operators.vision.CloudVisionHook")
     def test_minimal_green_path(self, mock_hook):
         op = CloudVisionTextDetectOperator(image=DETECT_TEST_IMAGE, task_id="id")
@@ -483,7 +482,7 @@ class TestCloudVisionDetectDocumentTextOperator(unittest.TestCase):
         )
 
 
-class TestCloudVisionDetectImageLabelsOperator(unittest.TestCase):
+class TestCloudVisionDetectImageLabelsOperator:
     @mock.patch("airflow.providers.google.cloud.operators.vision.CloudVisionHook")
     def test_minimal_green_path(self, mock_hook):
         op = CloudVisionDetectImageLabelsOperator(image=DETECT_TEST_IMAGE, task_id="id")
@@ -497,7 +496,7 @@ class TestCloudVisionDetectImageLabelsOperator(unittest.TestCase):
         )
 
 
-class TestCloudVisionDetectImageSafeSearchOperator(unittest.TestCase):
+class TestCloudVisionDetectImageSafeSearchOperator:
     @mock.patch("airflow.providers.google.cloud.operators.vision.CloudVisionHook")
     def test_minimal_green_path(self, mock_hook):
         op = CloudVisionDetectImageSafeSearchOperator(image=DETECT_TEST_IMAGE, task_id="id")


### PR DESCRIPTION
 Relates: #29305

This change moves the tests in google/cloud/operators provider package from unittest to pytest.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
