### PR TITLE
Handling project location param on async BigQuery dts trigger

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery_dts.py
+++ b/airflow/providers/google/cloud/operators/bigquery_dts.py
@@ -306,6 +306,10 @@ class BigQueryDataTransferServiceStartTransferRunsOperator(GoogleCloudBaseOperat
 
     def execute(self, context: Context):
         self.log.info("Submitting manual transfer for %s", self.transfer_config_id)
+
+        if self.requested_run_time and isinstance(self.requested_run_time.get("seconds"), str):
+            self.requested_run_time["seconds"] = int(self.requested_run_time["seconds"])
+
         response = self.hook.start_manual_transfer_runs(
             transfer_config_id=self.transfer_config_id,
             requested_time_range=self.requested_time_range,

--- a/airflow/providers/google/cloud/triggers/bigquery_dts.py
+++ b/airflow/providers/google/cloud/triggers/bigquery_dts.py
@@ -101,6 +101,7 @@ class BigQueryDataTransferRunTrigger(BaseTrigger):
                     project_id=self.project_id,
                     config_id=self.config_id,
                     run_id=self.run_id,
+                    location=self.location,
                 )
                 state = transfer_run.state
                 self.log.info("Current state is %s", state)


### PR DESCRIPTION
BUG FIX FOR THE MR: https://github.com/apache/airflow/pull/27833

### 1) Handling project location param on async BigQuery dts trigger
Currently, async version of BigQuery dts operator with trigger cannot be used in other regions except us (default) region.
when I used it on another region, trigger task raise error like below.
```
airflow.exceptions.AirflowException: Trigger failed with exception: 404 The requested transfer config (projects/****/locations/us/transferConfigs/*****) was not found.
```

I added config param in order to cover all the gcp locations.

### 2) convert type of field `seconds` to int, if it was str
`requested_run_time` is in the `template_fields` of `BigQueryDataTransferServiceStartTransferRunsOperator`.
but google python sdk client needs it to be `int` type. so it must be converted to `int` type after task is executed.
```
TypeError: '1676991600' has type str, but expected one of: int
```
