### PR TITLE
added warning log for max page limit exceeding api calls

### DIFF
--- a/airflow/api_connexion/parameters.py
+++ b/airflow/api_connexion/parameters.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from functools import wraps
 from typing import Any, Callable, Container, TypeVar, cast
@@ -27,6 +28,8 @@ from sqlalchemy.orm.query import Query
 from airflow.api_connexion.exceptions import BadRequest
 from airflow.configuration import conf
 from airflow.utils import timezone
+
+log = logging.getLogger(__name__)
 
 
 def validate_istimezone(value: datetime) -> None:
@@ -64,6 +67,11 @@ def check_limit(value: int) -> int:
     fallback = conf.getint("api", "fallback_page_limit")
 
     if value > max_val:
+        log.warning(
+            "The limit param value %s passed in API exceeds the configured maximum page limit %s",
+            value,
+            max_val,
+        )
         return max_val
     if value == 0:
         return fallback


### PR DESCRIPTION
added a warning log message in case the limit set in API requests exceeds the maximum page limit configured in airflow cfg file.
related: #27425
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
