### PR TITLE
Support setup and teardown taskflow taskgroups

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1375,10 +1375,15 @@ class TaskGroupSerialization(BaseSerialization):
             return task
 
         group.setup_children = {
-            label: set_ref(task_dict[val]) for label, (_type, val) in encoded_group["setup_children"].items()
+            label: set_ref(task_dict[val])
+            if _type == DAT.OP
+            else cls.deserialize_task_group(val, group, task_dict, dag=dag)
+            for label, (_type, val) in encoded_group["setup_children"].items()
         }
         group.teardown_children = {
             label: set_ref(task_dict[val])
+            if _type == DAT.OP
+            else cls.deserialize_task_group(val, group, task_dict, dag=dag)
             for label, (_type, val) in encoded_group["teardown_children"].items()
         }
         group.children = {

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1378,7 +1378,7 @@ class TestStringifiedDAGs:
 
             @setup
             @task_group
-            def setup():
+            def setup_group():
                 @task_group
                 def sub_setup():
                     EmptyOperator(task_id="setup2")
@@ -1388,12 +1388,12 @@ class TestStringifiedDAGs:
 
             @teardown
             @task_group
-            def teardown():
+            def teardown_group():
                 EmptyOperator(task_id="teardown1")
 
-            setup()
+            setup_group()
             EmptyOperator(task_id="sometask")
-            teardown()
+            teardown_group()
 
         dag_dict = SerializedDAG.to_dict(dag)
         SerializedDAG.validate_schema(dag_dict)

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1415,37 +1415,37 @@ class TestStringifiedDAGs:
             assert list(dag_task_group.teardown_children.keys()) == expected_teardown
 
         _check_taskgroup_children(
-            serialized_dag.task_group, dag.task_group, ["setup"], ["sometask"], ["teardown"]
+            serialized_dag.task_group, dag.task_group, ["setup_group"], ["sometask"], ["teardown_group"]
         )
 
-        se_setup_group = serialized_dag.task_group.setup_children["setup"]
-        dag_setup_group = dag.task_group.setup_children["setup"]
+        se_setup_group = serialized_dag.task_group.setup_children["setup_group"]
+        dag_setup_group = dag.task_group.setup_children["setup_group"]
         _check_taskgroup_children(
             se_setup_group,
             dag_setup_group,
-            ["setup.setup1", "setup.sub_setup"],
+            ["setup_group.setup1", "setup_group.sub_setup"],
             [],
             [],
         )
 
-        se_sub_setup_group = se_setup_group.setup_children["setup.sub_setup"]
-        dag_sub_setup_group = dag_setup_group.setup_children["setup.sub_setup"]
+        se_sub_setup_group = se_setup_group.setup_children["setup_group.sub_setup"]
+        dag_sub_setup_group = dag_setup_group.setup_children["setup_group.sub_setup"]
         _check_taskgroup_children(
             se_sub_setup_group,
             dag_sub_setup_group,
-            ["setup.sub_setup.setup2"],
+            ["setup_group.sub_setup.setup2"],
             [],
             [],
         )
 
-        se_teardown_group = serialized_dag.task_group.teardown_children["teardown"]
-        dag_teardown_group = dag.task_group.teardown_children["teardown"]
+        se_teardown_group = serialized_dag.task_group.teardown_children["teardown_group"]
+        dag_teardown_group = dag.task_group.teardown_children["teardown_group"]
         _check_taskgroup_children(
             se_teardown_group,
             dag_teardown_group,
             [],
             [],
-            ["teardown.teardown1"],
+            ["teardown_group.teardown1"],
         )
 
     def test_deps_sorted(self):

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1304,7 +1304,7 @@ class TestStringifiedDAGs:
 
     def test_task_group_setup_teardown_tasks(self):
         """
-        Test TaskGroup setup and teardown serialization/deserialization.
+        Test TaskGroup setup and teardown task serialization/deserialization.
         """
         from airflow.operators.empty import EmptyOperator
 
@@ -1364,6 +1364,88 @@ class TestStringifiedDAGs:
             ["group1.group2.setup2"],
             ["group1.group2.task2"],
             ["group1.group2.teardown2"],
+        )
+
+    def test_task_group_setup_teardown_taskgroups(self):
+        """
+        Test TaskGroup setup and teardown taskgroup serialization/deserialization.
+        """
+        from airflow.decorators import setup, task_group, teardown
+        from airflow.operators.empty import EmptyOperator
+
+        execution_date = datetime(2020, 1, 1)
+        with DAG("test_task_group_setup_teardown_task_groups", start_date=execution_date) as dag:
+
+            @setup
+            @task_group
+            def setup():
+                @task_group
+                def sub_setup():
+                    EmptyOperator(task_id="setup2")
+
+                EmptyOperator(task_id="setup1")
+                sub_setup()
+
+            @teardown
+            @task_group
+            def teardown():
+                EmptyOperator(task_id="teardown1")
+
+            setup()
+            EmptyOperator(task_id="sometask")
+            teardown()
+
+        dag_dict = SerializedDAG.to_dict(dag)
+        SerializedDAG.validate_schema(dag_dict)
+        json_dag = SerializedDAG.from_json(SerializedDAG.to_json(dag))
+        self.validate_deserialized_dag(json_dag, dag)
+
+        serialized_dag = SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(dag))
+
+        def _check_taskgroup_children(
+            se_task_group, dag_task_group, expected_setup, expected_children, expected_teardown
+        ):
+            assert list(se_task_group.children.keys()) == expected_children
+            assert list(dag_task_group.children.keys()) == expected_children
+
+            assert list(se_task_group.setup_children.keys()) == expected_setup
+            assert list(dag_task_group.setup_children.keys()) == expected_setup
+
+            assert list(se_task_group.teardown_children.keys()) == expected_teardown
+            assert list(dag_task_group.teardown_children.keys()) == expected_teardown
+
+        _check_taskgroup_children(
+            serialized_dag.task_group, dag.task_group, ["setup"], ["sometask"], ["teardown"]
+        )
+
+        se_setup_group = serialized_dag.task_group.setup_children["setup"]
+        dag_setup_group = dag.task_group.setup_children["setup"]
+        _check_taskgroup_children(
+            se_setup_group,
+            dag_setup_group,
+            ["setup.setup1", "setup.sub_setup"],
+            [],
+            [],
+        )
+
+        se_sub_setup_group = se_setup_group.setup_children["setup.sub_setup"]
+        dag_sub_setup_group = dag_setup_group.setup_children["setup.sub_setup"]
+        _check_taskgroup_children(
+            se_sub_setup_group,
+            dag_sub_setup_group,
+            ["setup.sub_setup.setup2"],
+            [],
+            [],
+        )
+
+        se_teardown_group = serialized_dag.task_group.teardown_children["teardown"]
+        dag_teardown_group = dag.task_group.teardown_children["teardown"]
+        _check_taskgroup_children(
+            se_teardown_group,
+            dag_teardown_group,
+            [],
+            [],
+            ["teardown.teardown1"],
         )
 
     def test_deps_sorted(self):

--- a/tests/utils/test_setup_teardown.py
+++ b/tests/utils/test_setup_teardown.py
@@ -1,0 +1,125 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.exceptions import AirflowException
+from airflow.utils.setup_teardown import SetupTeardownContext
+
+
+class TestSetupTearDownContext:
+    def test_setup(self):
+        assert SetupTeardownContext.is_setup is False
+        assert SetupTeardownContext.is_teardown is False
+
+        with SetupTeardownContext.setup():
+            assert SetupTeardownContext.is_setup is True
+            assert SetupTeardownContext.is_teardown is False
+
+        assert SetupTeardownContext.is_setup is False
+        assert SetupTeardownContext.is_teardown is False
+
+    def test_teardown(self):
+        assert SetupTeardownContext.is_setup is False
+        assert SetupTeardownContext.is_teardown is False
+
+        with SetupTeardownContext.setup():
+            assert SetupTeardownContext.is_setup is True
+            assert SetupTeardownContext.is_teardown is False
+
+        assert SetupTeardownContext.is_setup is False
+        assert SetupTeardownContext.is_teardown is False
+
+    def test_setup_exception(self):
+        """Ensure context is reset even if an exception happens"""
+        with pytest.raises(Exception, match="Hello"):
+            with SetupTeardownContext.setup():
+                raise Exception("Hello")
+
+        assert SetupTeardownContext.is_setup is False
+        assert SetupTeardownContext.is_teardown is False
+
+    def test_teardown_exception(self):
+        """Ensure context is reset even if an exception happens"""
+        with pytest.raises(Exception, match="Hello"):
+            with SetupTeardownContext.teardown():
+                raise Exception("Hello")
+
+        assert SetupTeardownContext.is_setup is False
+        assert SetupTeardownContext.is_teardown is False
+
+    def test_setup_block_nested(self):
+        with SetupTeardownContext.setup():
+            with pytest.raises(
+                AirflowException,
+                match=(
+                    "A setup task or taskgroup cannot be nested inside another"
+                    " setup/teardown task or taskgroup"
+                ),
+            ):
+                with SetupTeardownContext.setup():
+                    raise Exception("This should not be reached")
+
+        assert SetupTeardownContext.is_setup is False
+        assert SetupTeardownContext.is_teardown is False
+
+    def test_teardown_block_nested(self):
+        with SetupTeardownContext.teardown():
+            with pytest.raises(
+                AirflowException,
+                match=(
+                    "A teardown task or taskgroup cannot be nested inside another"
+                    " setup/teardown task or taskgroup"
+                ),
+            ):
+                with SetupTeardownContext.teardown():
+                    raise Exception("This should not be reached")
+
+        assert SetupTeardownContext.is_setup is False
+        assert SetupTeardownContext.is_teardown is False
+
+    def test_teardown_nested_in_setup_blocked(self):
+        with SetupTeardownContext.setup():
+            with pytest.raises(
+                AirflowException,
+                match=(
+                    "A teardown task or taskgroup cannot be nested inside another"
+                    " setup/teardown task or taskgroup"
+                ),
+            ):
+                with SetupTeardownContext.teardown():
+                    raise Exception("This should not be reached")
+
+        assert SetupTeardownContext.is_setup is False
+        assert SetupTeardownContext.is_teardown is False
+
+    def test_setup_nested_in_teardown_blocked(self):
+        with SetupTeardownContext.teardown():
+            with pytest.raises(
+                AirflowException,
+                match=(
+                    "A setup task or taskgroup cannot be nested inside another"
+                    " setup/teardown task or taskgroup"
+                ),
+            ):
+                with SetupTeardownContext.setup():
+                    raise Exception("This should not be reached")
+
+        assert SetupTeardownContext.is_setup is False
+        assert SetupTeardownContext.is_teardown is False


### PR DESCRIPTION
This adds support for marking whole taskflow taskgroups as "setup" or "teardown" in a DAG. This provides DAG authors more flexibility, and allows easier reuse of the existing Airflow ecosystem (e.g. not everything becomes hook invocations in a single task).

This also adds some validation to make sure setup and teardown taskflow task groups can't themselves contain explicity marked setup or teardown tasks. All tasks in a setup or teardown taskflow task group are already implicitly either setup or teardown.

Support for classic style taskgroups will be handled later.


