### PR TITLE
Fix SFTPSensor when using newer_than and there are multiple matched files

### DIFF
--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -391,3 +391,18 @@ class SFTPHook(SSHHook):
                 return file
 
         return ""
+
+    def get_files_by_pattern(self, path, fnmatch_pattern) -> list[str]:
+        """
+        Returning the list of matching files based on the given fnmatch type pattern
+
+        :param path: path to be checked
+        :param fnmatch_pattern: The pattern that will be matched with `fnmatch`
+        :return: list of string containing the found files, or an empty list if none matched
+        """
+        matched_files = []
+        for file in self.list_directory(path):
+            if fnmatch(file, fnmatch_pattern):
+                matched_files.append(file)
+
+        return matched_files

--- a/tests/providers/sftp/hooks/test_sftp.py
+++ b/tests/providers/sftp/hooks/test_sftp.py
@@ -423,6 +423,22 @@ class TestSFTPHook:
         output = self.hook.get_file_by_pattern(TMP_PATH, "*_file_*.txt")
         assert output == ANOTHER_FILE_FOR_TESTS
 
+    def test_get_none_matched_files(self):
+        output = self.hook.get_files_by_pattern(TMP_PATH, "*.text")
+        assert output == []
+
+    def test_get_matched_files_several_pattern(self):
+        output = self.hook.get_files_by_pattern(TMP_PATH, "*.log")
+        assert output == [LOG_FILE_FOR_TESTS]
+
+    def test_get_all_matched_files(self):
+        output = self.hook.get_files_by_pattern(TMP_PATH, "test_*.txt")
+        assert output == [TMP_FILE_FOR_TESTS, ANOTHER_FILE_FOR_TESTS]
+
+    def test_get_matched_files_with_different_pattern(self):
+        output = self.hook.get_files_by_pattern(TMP_PATH, "*_file_*.txt")
+        assert output == [ANOTHER_FILE_FOR_TESTS]
+
     def teardown_method(self):
         shutil.rmtree(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS))
         for file_name in [TMP_FILE_FOR_TESTS, ANOTHER_FILE_FOR_TESTS, LOG_FILE_FOR_TESTS]:


### PR DESCRIPTION
closes: #29781 

---
Currently when we provide `file_pattern` to `SFTPSensor`, it tries to get the first matched file and return `True` when it finds one. But it does the same thing when `newer_than` is provided, so instead of checking if there is at least one file newer than the provided date, it checks if the first matched file is newer than this date.

This PR fixes this bug by getting all the matched files, and returning `True` when there is at least one file newer than the provided date.