### PR TITLE
Fix single threaded executor compat regression from recent refactoring

### DIFF
--- a/airflow/executors/executor_loader.py
+++ b/airflow/executors/executor_loader.py
@@ -170,7 +170,8 @@ class ExecutorLoader:
         initialized) because loading the executor class is heavy work we want to
         avoid unless needed.
         """
-        if not executor.is_single_threaded:
+        if executor.is_single_threaded:
+            # Single threaded executors can run with any backend
             return
 
         # This is set in tests when we want to be able to use the SequentialExecutor.
@@ -179,6 +180,7 @@ class ExecutorLoader:
 
         from airflow.settings import engine
 
+        # SQLite only works with single threaded executors
         if engine.dialect.name == "sqlite":
             raise AirflowConfigException(f"error: cannot use SQLite with the {executor.__name__}")
 

--- a/tests/executors/test_executor_loader.py
+++ b/tests/executors/test_executor_loader.py
@@ -120,9 +120,9 @@ class TestExecutorLoader:
     @pytest.mark.parametrize(
         ["executor", "expectation"],
         [
-            (FakeExecutor, nullcontext()),
+            (FakeSingleThreadedExecutor, nullcontext()),
             (
-                FakeSingleThreadedExecutor,
+                FakeExecutor,
                 pytest.raises(AirflowConfigException, match=r"^error: cannot use SQLite with the .+"),
             ),
         ],


### PR DESCRIPTION
The refactor in #29569 accidentally swapped the conditions for sqlite compatibility in executor loading. 
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
