### PR TITLE
Add deferrable `AzureDataFactoryPipelineRunStatusSensor`

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -1092,15 +1092,17 @@ class AzureDataFactoryAsyncHook(AzureDataFactoryHook):
     :param azure_data_factory_conn_id: The :ref:`Azure Data Factory connection id<howto/connection:adf>`.
     """
 
-    def __init__(self, azure_data_factory_conn_id: str):
+    default_conn_name: str = "azure_data_factory_default"
+
+    def __init__(self, azure_data_factory_conn_id: str = default_conn_name):
         self._async_conn: AsyncDataFactoryManagementClient = None
         self.conn_id = azure_data_factory_conn_id
         super().__init__(azure_data_factory_conn_id=azure_data_factory_conn_id)
 
     async def get_async_conn(self) -> AsyncDataFactoryManagementClient:
         """Get async connection and connect to azure data factory"""
-        if self._conn is not None:
-            return self._conn
+        if self._async_conn is not None:
+            return self._async_conn
 
         conn = await sync_to_async(self.get_connection)(self.conn_id)
         extras = conn.extra_dejson
@@ -1141,6 +1143,7 @@ class AzureDataFactoryAsyncHook(AzureDataFactoryHook):
         :param run_id: The pipeline run identifier.
         :param resource_group_name: The resource group name.
         :param factory_name: The factory name.
+        :param config: Extra parameters for the ADF client.
         """
         async with await self.get_async_conn() as client:
             try:

--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -33,11 +33,17 @@ from __future__ import annotations
 import inspect
 import time
 from functools import wraps
-from typing import Any, Callable, Union
+from typing import Any, Callable, TypeVar, Union, cast
 
+from asgiref.sync import sync_to_async
 from azure.core.polling import LROPoller
 from azure.identity import ClientSecretCredential, DefaultAzureCredential
+from azure.identity.aio import (
+    ClientSecretCredential as AsyncClientSecretCredential,
+    DefaultAzureCredential as AsyncDefaultAzureCredential,
+)
 from azure.mgmt.datafactory import DataFactoryManagementClient
+from azure.mgmt.datafactory.aio import DataFactoryManagementClient as AsyncDataFactoryManagementClient
 from azure.mgmt.datafactory.models import (
     CreateRunResponse,
     DataFlow,
@@ -54,6 +60,9 @@ from airflow.hooks.base import BaseHook
 from airflow.typing_compat import TypedDict
 
 Credentials = Union[ClientSecretCredential, DefaultAzureCredential]
+AsyncCredentials = Union[AsyncClientSecretCredential, AsyncDefaultAzureCredential]
+
+T = TypeVar("T", bound=Any)
 
 
 def provide_targeted_factory(func: Callable) -> Callable:
@@ -1039,3 +1048,120 @@ class AzureDataFactoryHook(BaseHook):
             return success
         except Exception as e:
             return False, str(e)
+
+
+def provide_targeted_factory_async(func: T) -> T:
+    """
+    Provide the targeted factory to the async decorated function in case it isn't specified.
+
+    If ``resource_group_name`` or ``factory_name`` is not provided it defaults to the value specified in
+    the connection extras.
+    """
+    signature = inspect.signature(func)
+
+    @wraps(func)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        bound_args = signature.bind(*args, **kwargs)
+
+        async def bind_argument(arg: Any, default_key: str) -> None:
+            # Check if arg was not included in the function signature or, if it is, the value is not provided.
+            if arg not in bound_args.arguments or bound_args.arguments[arg] is None:
+                self = args[0]
+                conn = await sync_to_async(self.get_connection)(self.conn_id)
+                default_value = conn.extra_dejson.get(default_key)
+                if not default_value:
+                    raise AirflowException("Could not determine the targeted data factory.")
+
+                bound_args.arguments[arg] = conn.extra_dejson[default_key]
+
+        await bind_argument("resource_group_name", "extra__azure_data_factory__resource_group_name")
+        await bind_argument("factory_name", "extra__azure_data_factory__factory_name")
+
+        return await func(*bound_args.args, **bound_args.kwargs)
+
+    return cast(T, wrapper)
+
+
+class AzureDataFactoryAsyncHook(AzureDataFactoryHook):
+    """
+    An Async Hook that connects to Azure DataFactory to perform pipeline operations
+
+    :param azure_data_factory_conn_id: The :ref:`Azure Data Factory connection id<howto/connection:adf>`.
+    """
+
+    def __init__(self, azure_data_factory_conn_id: str):
+        self._async_conn: AsyncDataFactoryManagementClient = None
+        self.conn_id = azure_data_factory_conn_id
+        super().__init__(azure_data_factory_conn_id=azure_data_factory_conn_id)
+
+    async def get_async_conn(self) -> AsyncDataFactoryManagementClient:
+        """Get async connection and connect to azure data factory"""
+        if self._conn is not None:
+            return self._conn
+
+        conn = await sync_to_async(self.get_connection)(self.conn_id)
+        tenant = conn.extra_dejson.get("extra__azure_data_factory__tenantId")
+
+        try:
+            subscription_id = conn.extra_dejson["extra__azure_data_factory__subscriptionId"]
+        except KeyError:
+            raise ValueError("A Subscription ID is required to connect to Azure Data Factory.")
+
+        credential: AsyncCredentials
+        if conn.login is not None and conn.password is not None:
+            if not tenant:
+                raise ValueError("A Tenant ID is required when authenticating with Client ID and Secret.")
+
+            credential = AsyncClientSecretCredential(
+                client_id=conn.login, client_secret=conn.password, tenant_id=tenant
+            )
+        else:
+            credential = AsyncDefaultAzureCredential()
+
+        return AsyncDataFactoryManagementClient(
+            credential=credential,
+            subscription_id=subscription_id,
+        )
+
+    @provide_targeted_factory_async
+    async def get_pipeline_run(
+        self,
+        run_id: str,
+        resource_group_name: str | None = None,
+        factory_name: str | None = None,
+        **config: Any,
+    ) -> PipelineRun:
+        """
+        Connects to Azure Data Factory asynchronously to get the pipeline run details by run id
+
+        :param run_id: The pipeline run identifier.
+        :param resource_group_name: The resource group name.
+        :param factory_name: The factory name.
+        """
+        async with await self.get_async_conn() as client:
+            try:
+                pipeline_run = await client.pipeline_runs.get(resource_group_name, factory_name, run_id)
+                return pipeline_run
+            except Exception as e:
+                raise AirflowException(e)
+
+    async def get_adf_pipeline_run_status(
+        self, run_id: str, resource_group_name: str | None = None, factory_name: str | None = None
+    ) -> str:
+        """
+        Connects to Azure Data Factory asynchronously and gets the pipeline status by run_id
+
+        :param run_id: The pipeline run identifier.
+        :param resource_group_name: The resource group name.
+        :param factory_name: The factory name.
+        """
+        try:
+            pipeline_run = await self.get_pipeline_run(
+                run_id=run_id,
+                factory_name=factory_name,
+                resource_group_name=resource_group_name,
+            )
+            status: str = pipeline_run.status
+            return status
+        except Exception as e:
+            raise AirflowException(e)

--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -1140,7 +1140,9 @@ class AzureDataFactoryAsyncHook(AzureDataFactoryHook):
         """
         async with await self.get_async_conn() as client:
             try:
+                print("I am here1")
                 pipeline_run = await client.pipeline_runs.get(resource_group_name, factory_name, run_id)
+                print("I am here2")
                 return pipeline_run
             except Exception as e:
                 raise AirflowException(e)

--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -1140,9 +1140,7 @@ class AzureDataFactoryAsyncHook(AzureDataFactoryHook):
         """
         async with await self.get_async_conn() as client:
             try:
-                print("I am here1")
                 pipeline_run = await client.pipeline_runs.get(resource_group_name, factory_name, run_id)
-                print("I am here2")
                 return pipeline_run
             except Exception as e:
                 raise AirflowException(e)

--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -1124,10 +1124,12 @@ class AzureDataFactoryAsyncHook(AzureDataFactoryHook):
         else:
             credential = AsyncDefaultAzureCredential()
 
-        return AsyncDataFactoryManagementClient(
+        self._async_conn = AsyncDataFactoryManagementClient(
             credential=credential,
             subscription_id=subscription_id,
         )
+
+        return self._async_conn
 
     @provide_targeted_factory_async
     async def get_pipeline_run(

--- a/airflow/providers/microsoft/azure/sensors/data_factory.py
+++ b/airflow/providers/microsoft/azure/sensors/data_factory.py
@@ -93,7 +93,7 @@ class AzureDataFactoryPipelineRunStatusAsyncSensor(AzureDataFactoryPipelineRunSt
     :param run_id: The pipeline run identifier.
     :param resource_group_name: The resource group name.
     :param factory_name: The data factory name.
-    :param poll_interval: polling period in seconds to check for the status
+    :param poke_interval: polling period in seconds to check for the status
     """
 
     def __init__(

--- a/airflow/providers/microsoft/azure/sensors/data_factory.py
+++ b/airflow/providers/microsoft/azure/sensors/data_factory.py
@@ -16,12 +16,18 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+import warnings
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any, Sequence
 
+from airflow import AirflowException
 from airflow.providers.microsoft.azure.hooks.data_factory import (
     AzureDataFactoryHook,
     AzureDataFactoryPipelineRunException,
     AzureDataFactoryPipelineRunStatus,
+)
+from airflow.providers.microsoft.azure.triggers.data_factory import (
+    ADFPipelineRunStatusSensorTrigger,
 )
 from airflow.sensors.base import BaseSensorOperator
 
@@ -78,3 +84,60 @@ class AzureDataFactoryPipelineRunStatusSensor(BaseSensorOperator):
             raise AzureDataFactoryPipelineRunException(f"Pipeline run {self.run_id} has been cancelled.")
 
         return pipeline_run_status == AzureDataFactoryPipelineRunStatus.SUCCEEDED
+
+
+class AzureDataFactoryPipelineRunStatusAsyncSensor(AzureDataFactoryPipelineRunStatusSensor):
+    """
+    Checks the status of a pipeline run asynchronously.
+
+    :param azure_data_factory_conn_id: The connection identifier for connecting to Azure Data Factory.
+    :param run_id: The pipeline run identifier.
+    :param resource_group_name: The resource group name.
+    :param factory_name: The data factory name.
+    :param poll_interval: polling period in seconds to check for the status
+    """
+
+    def __init__(
+        self,
+        *,
+        poll_interval: float = 5,
+        **kwargs: Any,
+    ):
+        # TODO: Remove once deprecated
+        if poll_interval:
+            self.poke_interval = poll_interval
+            warnings.warn(
+                "Argument `poll_interval` is deprecated and will be removed "
+                "in a future release.  Please use  `poke_interval` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        super().__init__(**kwargs)
+
+    def execute(self, context: Context) -> None:
+        """Defers trigger class to poll for state of the job run until
+        it reaches a failure state or success state
+        """
+        self.defer(
+            timeout=timedelta(seconds=self.timeout),
+            trigger=ADFPipelineRunStatusSensorTrigger(
+                run_id=self.run_id,
+                azure_data_factory_conn_id=self.azure_data_factory_conn_id,
+                resource_group_name=self.resource_group_name,
+                factory_name=self.factory_name,
+                poke_interval=self.poke_interval,
+            ),
+            method_name="execute_complete",
+        )
+
+    def execute_complete(self, context: Context, event: dict[str, str]) -> None:
+        """
+        Callback for when the trigger fires - returns immediately.
+        Relies on trigger to throw an exception, otherwise it assumes execution was
+        successful.
+        """
+        if event:
+            if event["status"] == "error":
+                raise AirflowException(event["message"])
+            self.log.info(event["message"])
+        return None

--- a/airflow/providers/microsoft/azure/sensors/data_factory.py
+++ b/airflow/providers/microsoft/azure/sensors/data_factory.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Sequence
 
@@ -100,18 +99,10 @@ class AzureDataFactoryPipelineRunStatusAsyncSensor(AzureDataFactoryPipelineRunSt
     def __init__(
         self,
         *,
-        poll_interval: float = 5,
+        poke_interval: float = 60,
         **kwargs: Any,
     ):
-        # TODO: Remove once deprecated
-        if poll_interval:
-            self.poke_interval = poll_interval
-            warnings.warn(
-                "Argument `poll_interval` is deprecated and will be removed "
-                "in a future release.  Please use  `poke_interval` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+        self.poke_interval = poke_interval
         super().__init__(**kwargs)
 
     def execute(self, context: Context) -> None:

--- a/airflow/providers/microsoft/azure/triggers/__init__.py
+++ b/airflow/providers/microsoft/azure/triggers/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/microsoft/azure/triggers/data_factory.py
+++ b/airflow/providers/microsoft/azure/triggers/data_factory.py
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncIterator
+
+from airflow.providers.microsoft.azure.hooks.data_factory import (
+    AzureDataFactoryAsyncHook,
+    AzureDataFactoryPipelineRunStatus,
+)
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+
+class ADFPipelineRunStatusSensorTrigger(BaseTrigger):
+    """
+    ADFPipelineRunStatusSensorTrigger is fired as deferred class with params to run the
+    task in trigger worker, when ADF Pipeline is running
+
+    :param run_id: The pipeline run identifier.
+    :param azure_data_factory_conn_id: The connection identifier for connecting to Azure Data Factory.
+    :param poke_interval:  polling period in seconds to check for the status
+    :param resource_group_name: The resource group name.
+    :param factory_name: The data factory name.
+    """
+
+    def __init__(
+        self,
+        run_id: str,
+        azure_data_factory_conn_id: str,
+        poke_interval: float,
+        resource_group_name: str | None = None,
+        factory_name: str | None = None,
+    ):
+        super().__init__()
+        self.run_id = run_id
+        self.azure_data_factory_conn_id = azure_data_factory_conn_id
+        self.resource_group_name = resource_group_name
+        self.factory_name = factory_name
+        self.poke_interval = poke_interval
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        """Serializes ADFPipelineRunStatusSensorTrigger arguments and classpath."""
+        return (
+            "airflow.providers.microsoft.azure.triggers.data_factory.ADFPipelineRunStatusSensorTrigger",
+            {
+                "run_id": self.run_id,
+                "azure_data_factory_conn_id": self.azure_data_factory_conn_id,
+                "resource_group_name": self.resource_group_name,
+                "factory_name": self.factory_name,
+                "poke_interval": self.poke_interval,
+            },
+        )
+
+    async def run(self) -> AsyncIterator["TriggerEvent"]:
+        """Make async connection to Azure Data Factory, polls for the pipeline run status"""
+        hook = AzureDataFactoryAsyncHook(azure_data_factory_conn_id=self.azure_data_factory_conn_id)
+        try:
+            while True:
+                pipeline_status = await hook.get_adf_pipeline_run_status(
+                    run_id=self.run_id,
+                    resource_group_name=self.resource_group_name,
+                    factory_name=self.factory_name,
+                )
+                if pipeline_status == AzureDataFactoryPipelineRunStatus.FAILED:
+                    yield TriggerEvent(
+                        {"status": "error", "message": f"Pipeline run {self.run_id} has Failed."}
+                    )
+                elif pipeline_status == AzureDataFactoryPipelineRunStatus.CANCELLED:
+                    msg = f"Pipeline run {self.run_id} has been Cancelled."
+                    yield TriggerEvent({"status": "error", "message": msg})
+                elif pipeline_status == AzureDataFactoryPipelineRunStatus.SUCCEEDED:
+                    msg = f"Pipeline run {self.run_id} has been Succeeded."
+                    yield TriggerEvent({"status": "success", "message": msg})
+                await asyncio.sleep(self.poke_interval)
+        except Exception as e:
+            yield TriggerEvent({"status": "error", "message": str(e)})

--- a/docs/apache-airflow-providers-microsoft-azure/operators/adf_run_pipeline.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/operators/adf_run_pipeline.rst
@@ -27,7 +27,7 @@ AzureDataFactoryRunPipelineOperator
 -----------------------------------
 Use the :class:`~airflow.providers.microsoft.azure.operators.data_factory.AzureDataFactoryRunPipelineOperator` to execute a pipeline within a data factory.
 By default, the operator will periodically check on the status of the executed pipeline to terminate with a "Succeeded" status.
-This functionality can be disabled for an asynchronous wait -- typically with the :class:`~airflow.providers.microsoft.azure.sensors.data_factory.AzureDataFactoryPipelineRunSensor` -- by setting ``wait_for_termination`` to False.
+This functionality can be disabled for an asynchronous wait -- typically with the :class:`~airflow.providers.microsoft.azure.sensors.data_factory.AzureDataFactoryPipelineRunStatusSensor` -- by setting ``wait_for_termination`` to False.
 
 Below is an example of using this operator to execute an Azure Data Factory pipeline.
 
@@ -37,13 +37,29 @@ Below is an example of using this operator to execute an Azure Data Factory pipe
       :start-after: [START howto_operator_adf_run_pipeline]
       :end-before: [END howto_operator_adf_run_pipeline]
 
-Here is a different example of using this operator to execute a pipeline but coupled with the :class:`~airflow.providers.microsoft.azure.sensors.data_factory.AzureDataFactoryPipelineRunSensor` to perform an asynchronous wait.
+Here is a different example of using this operator to execute a pipeline but coupled with the :class:`~airflow.providers.microsoft.azure.sensors.data_factory.AzureDataFactoryPipelineRunStatusSensor` to perform an asynchronous wait.
 
     .. exampleinclude:: /../../tests/system/providers/microsoft/azure/example_adf_run_pipeline.py
         :language: python
         :dedent: 0
         :start-after: [START howto_operator_adf_run_pipeline_async]
         :end-before: [END howto_operator_adf_run_pipeline_async]
+
+Poll for status of a datafactory pipeline run asynchronously
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the :class:`~airflow.providers.microsoft.azure.sensors.data_factory.AzureDataFactoryPipelineRunStatusAsyncSensor`
+(deferrable version) to periodically retrieve the
+status of a datafactory pipeline run asynchronously. This sensor will free up the worker slots since
+polling for job status happens on the Airflow triggerer, leading to efficient utilization
+of resources within Airflow.
+
+.. exampleinclude:: /../../tests/system/providers/microsoft/azure/example_adf_run_pipeline.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_adf_run_pipeline_async]
+    :end-before: [END howto_operator_adf_run_pipeline_async]
+
 
 Reference
 ---------

--- a/docs/apache-airflow-providers-microsoft-azure/operators/adf_run_pipeline.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/operators/adf_run_pipeline.rst
@@ -45,12 +45,12 @@ Here is a different example of using this operator to execute a pipeline but cou
         :start-after: [START howto_operator_adf_run_pipeline_async]
         :end-before: [END howto_operator_adf_run_pipeline_async]
 
-Poll for status of a datafactory pipeline run asynchronously
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Poll for status of a data factory pipeline run asynchronously
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use the :class:`~airflow.providers.microsoft.azure.sensors.data_factory.AzureDataFactoryPipelineRunStatusAsyncSensor`
 (deferrable version) to periodically retrieve the
-status of a datafactory pipeline run asynchronously. This sensor will free up the worker slots since
+status of a data factory pipeline run asynchronously. This sensor will free up the worker slots since
 polling for job status happens on the Airflow triggerer, leading to efficient utilization
 of resources within Airflow.
 

--- a/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
@@ -883,8 +883,8 @@ class TestAzureDataFactoryAsyncHook:
         ],
     )
     @async_mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_connection")
-    async def test_get_async_conn_key_error_tenantId(self, mock_connection, mock_connection_params):
-        """Test get_async_conn function with raising key error"""
+    async def test_get_async_conn_key_error_subscription_id(self, mock_connection, mock_connection_params):
+        """Test get_async_conn function when subscription_id is missing in the connection"""
         mock_conn = Connection(
             conn_id=DEFAULT_CONNECTION_CLIENT_SECRET,
             conn_type="azure_data_factory",
@@ -909,8 +909,8 @@ class TestAzureDataFactoryAsyncHook:
         ],
     )
     @async_mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_connection")
-    async def test_get_async_conn_key_error_subscriptionId(self, mock_connection, mock_connection_params):
-        """Test get_async_conn function with raising key error"""
+    async def test_get_async_conn_key_error_tenant_id(self, mock_connection, mock_connection_params):
+        """Test get_async_conn function when tenant id is missing in the connection"""
         mock_conn = Connection(
             conn_id=DEFAULT_CONNECTION_CLIENT_SECRET,
             conn_type="azure_data_factory",

--- a/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
@@ -18,16 +18,19 @@ from __future__ import annotations
 
 import json
 import os
+from unittest import mock
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from azure.identity import ClientSecretCredential, DefaultAzureCredential
+from azure.mgmt.datafactory.aio import DataFactoryManagementClient
 from azure.mgmt.datafactory.models import FactoryListResponse
 from pytest import fixture, param
 
-from airflow.exceptions import AirflowException
+from airflow import AirflowException
 from airflow.models.connection import Connection
 from airflow.providers.microsoft.azure.hooks.data_factory import (
+    AzureDataFactoryAsyncHook,
     AzureDataFactoryHook,
     AzureDataFactoryPipelineRunException,
     AzureDataFactoryPipelineRunStatus,
@@ -36,12 +39,18 @@ from airflow.providers.microsoft.azure.hooks.data_factory import (
 from airflow.utils import db
 
 DEFAULT_RESOURCE_GROUP = "defaultResourceGroup"
-RESOURCE_GROUP = "testResourceGroup"
+AZURE_DATA_FACTORY_CONN_ID = "azure_data_factory_default"
+RESOURCE_GROUP_NAME = "team_provider_resource_group_test"
+DATAFACTORY_NAME = "ADFProvidersTeamDataFactory"
+TASK_ID = "test_adf_pipeline_run_status_sensor"
+RUN_ID = "7f8c6c72-c093-11ec-a83d-0242ac120007"
+DEFAULT_CONNECTION_CLIENT_SECRET = "azure_data_factory_test_client_secret"
+MODULE = "astronomer.providers.microsoft.azure"
 
+RESOURCE_GROUP = "testResourceGroup"
 DEFAULT_FACTORY = "defaultFactory"
 FACTORY = "testFactory"
 
-DEFAULT_CONNECTION_CLIENT_SECRET = "azure_data_factory_test_client_secret"
 DEFAULT_CONNECTION_DEFAULT_CREDENTIAL = "azure_data_factory_test_default_credential"
 
 MODEL = object()
@@ -708,3 +717,172 @@ def test_backcompat_prefix_both_prefers_short(mock_connect):
         hook = AzureDataFactoryHook("my_conn")
         hook.delete_factory(factory_name="n/a")
         mock_connect.return_value.factories.delete.assert_called_with("non-prefixed", "n/a")
+
+
+class TestAzureDataFactoryAsyncHook:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_status",
+        ["Queued", "InProgress", "Succeeded", "Failed", "Cancelled"],
+    )
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn")
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_pipeline_run")
+    async def test_get_adf_pipeline_run_status(self, mock_get_pipeline_run, mock_conn, mock_status):
+        """Test get_adf_pipeline_run_status function with mocked status"""
+        mock_get_pipeline_run.return_value.status = mock_status
+        hook = AzureDataFactoryAsyncHook(AZURE_DATA_FACTORY_CONN_ID)
+        response = await hook.get_adf_pipeline_run_status(RUN_ID, RESOURCE_GROUP_NAME, DATAFACTORY_NAME)
+        assert response == mock_status
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn")
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_pipeline_run")
+    async def test_get_adf_pipeline_run_status_exception(self, mock_get_pipeline_run, mock_conn):
+        """Test get_adf_pipeline_run_status function with exception"""
+        mock_get_pipeline_run.side_effect = Exception("Test exception")
+        hook = AzureDataFactoryAsyncHook(AZURE_DATA_FACTORY_CONN_ID)
+        with pytest.raises(AirflowException):
+            await hook.get_adf_pipeline_run_status(RUN_ID, RESOURCE_GROUP_NAME, DATAFACTORY_NAME)
+
+    @pytest.mark.asyncio
+    @mock.patch("azure.mgmt.datafactory.models._models_py3.PipelineRun")
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn")
+    async def test_get_pipeline_run(self, mock_async_connection, mock_pipeline_run):
+        """Test get_pipeline_run run function"""
+        mock_async_connection.return_value.__aenter__.return_value.pipeline_runs.get.return_value = (
+            mock_pipeline_run
+        )
+        hook = AzureDataFactoryAsyncHook(AZURE_DATA_FACTORY_CONN_ID)
+        response = await hook.get_pipeline_run(RUN_ID, RESOURCE_GROUP_NAME, DATAFACTORY_NAME)
+        assert response == mock_pipeline_run
+
+    @pytest.mark.asyncio
+    @mock.patch("azure.mgmt.datafactory.models._models_py3.PipelineRun")
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_connection")
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn")
+    async def test_get_pipeline_run_without_resource_name(
+        self, mock_async_connection, mock_get_connection, mock_pipeline_run
+    ):
+        """Test get_pipeline_run run function without passing the resource name
+        to check the decorator function"""
+        mock_connection = Connection(
+            extra=json.dumps(
+                {
+                    "extra__azure_data_factory__resource_group_name": RESOURCE_GROUP_NAME,
+                    "extra__azure_data_factory__factory_name": DATAFACTORY_NAME,
+                }
+            )
+        )
+        mock_get_connection.return_value = mock_connection
+        mock_async_connection.return_value.__aenter__.return_value.pipeline_runs.get.return_value = (
+            mock_pipeline_run
+        )
+        hook = AzureDataFactoryAsyncHook(AZURE_DATA_FACTORY_CONN_ID)
+        response = await hook.get_pipeline_run(RUN_ID, None, DATAFACTORY_NAME)
+        assert response == mock_pipeline_run
+
+    @pytest.mark.asyncio
+    @mock.patch("azure.mgmt.datafactory.models._models_py3.PipelineRun")
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_connection")
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn")
+    async def test_get_pipeline_run_exception_without_resource(
+        self, mock_conn, mock_get_connection, mock_pipeline_run
+    ):
+        """
+        Test get_pipeline_run function without passing the resource name to check the decorator function and
+        raise exception
+        """
+        mock_connection = Connection(
+            extra=json.dumps({"extra__azure_data_factory__factory_name": DATAFACTORY_NAME})
+        )
+        mock_get_connection.return_value = mock_connection
+        mock_conn.return_value.__aenter__.return_value.pipeline_runs.get.return_value = mock_pipeline_run
+        hook = AzureDataFactoryAsyncHook(AZURE_DATA_FACTORY_CONN_ID)
+        with pytest.raises(AirflowException):
+            await hook.get_pipeline_run(RUN_ID, None, DATAFACTORY_NAME)
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn")
+    async def test_get_pipeline_run_exception(self, mock_conn):
+        """Test get_pipeline_run function with exception"""
+        mock_conn.return_value.__aenter__.return_value.pipeline_runs.get.side_effect = Exception(
+            "Test exception"
+        )
+        hook = AzureDataFactoryAsyncHook(AZURE_DATA_FACTORY_CONN_ID)
+        with pytest.raises(AirflowException):
+            await hook.get_pipeline_run(RUN_ID, RESOURCE_GROUP_NAME, DATAFACTORY_NAME)
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_connection")
+    async def test_get_async_conn(self, mock_connection):
+        """"""
+        mock_conn = Connection(
+            conn_id=DEFAULT_CONNECTION_CLIENT_SECRET,
+            conn_type="azure_data_factory",
+            login="clientId",
+            password="clientSecret",
+            extra=json.dumps(
+                {
+                    "extra__azure_data_factory__tenantId": "tenantId",
+                    "extra__azure_data_factory__subscriptionId": "subscriptionId",
+                    "extra__azure_data_factory__resource_group_name": RESOURCE_GROUP_NAME,
+                    "extra__azure_data_factory__factory_name": DATAFACTORY_NAME,
+                }
+            ),
+        )
+        mock_connection.return_value = mock_conn
+        hook = AzureDataFactoryAsyncHook(AZURE_DATA_FACTORY_CONN_ID)
+        response = await hook.get_async_conn()
+        assert isinstance(response, DataFactoryManagementClient)
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_connection")
+    async def test_get_async_conn_without_login_id(self, mock_connection):
+        """Test get_async_conn function without login id"""
+        mock_conn = Connection(
+            conn_id=DEFAULT_CONNECTION_CLIENT_SECRET,
+            conn_type="azure_data_factory",
+            extra=json.dumps(
+                {
+                    "extra__azure_data_factory__tenantId": "tenantId",
+                    "extra__azure_data_factory__subscriptionId": "subscriptionId",
+                    "extra__azure_data_factory__resource_group_name": RESOURCE_GROUP_NAME,
+                    "extra__azure_data_factory__factory_name": DATAFACTORY_NAME,
+                }
+            ),
+        )
+        mock_connection.return_value = mock_conn
+        hook = AzureDataFactoryAsyncHook(AZURE_DATA_FACTORY_CONN_ID)
+        response = await hook.get_async_conn()
+        assert isinstance(response, DataFactoryManagementClient)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_connection_params",
+        [
+            {
+                "extra__azure_data_factory__tenantId": "tenantId",
+                "extra__azure_data_factory__resource_group_name": RESOURCE_GROUP_NAME,
+                "extra__azure_data_factory__factory_name": DATAFACTORY_NAME,
+            },
+            {
+                "extra__azure_data_factory__subscriptionId": "subscriptionId",
+                "extra__azure_data_factory__resource_group_name": RESOURCE_GROUP_NAME,
+                "extra__azure_data_factory__factory_name": DATAFACTORY_NAME,
+            },
+        ],
+    )
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_connection")
+    async def test_get_async_conn_key_error(self, mock_connection, mock_connection_params):
+        """Test get_async_conn function with raising key error"""
+        mock_conn = Connection(
+            conn_id=DEFAULT_CONNECTION_CLIENT_SECRET,
+            conn_type="azure_data_factory",
+            login="clientId",
+            password="clientSecret",
+            extra=json.dumps(mock_connection_params),
+        )
+        mock_connection.return_value = mock_conn
+        hook = AzureDataFactoryAsyncHook(AZURE_DATA_FACTORY_CONN_ID)
+        with pytest.raises(ValueError):
+            await hook.get_async_conn()

--- a/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
@@ -45,7 +45,7 @@ DATAFACTORY_NAME = "ADFProvidersTeamDataFactory"
 TASK_ID = "test_adf_pipeline_run_status_sensor"
 RUN_ID = "7f8c6c72-c093-11ec-a83d-0242ac120007"
 DEFAULT_CONNECTION_CLIENT_SECRET = "azure_data_factory_test_client_secret"
-MODULE = "astronomer.providers.microsoft.azure"
+MODULE = "airflow.providers.microsoft.azure"
 
 RESOURCE_GROUP = "testResourceGroup"
 DEFAULT_FACTORY = "defaultFactory"

--- a/tests/providers/microsoft/azure/sensors/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/sensors/test_azure_data_factory.py
@@ -16,16 +16,22 @@
 # under the License.
 from __future__ import annotations
 
+from unittest import mock
 from unittest.mock import patch
 
 import pytest
 
+from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.providers.microsoft.azure.hooks.data_factory import (
     AzureDataFactoryHook,
     AzureDataFactoryPipelineRunException,
     AzureDataFactoryPipelineRunStatus,
 )
-from airflow.providers.microsoft.azure.sensors.data_factory import AzureDataFactoryPipelineRunStatusSensor
+from airflow.providers.microsoft.azure.sensors.data_factory import (
+    AzureDataFactoryPipelineRunStatusAsyncSensor,
+    AzureDataFactoryPipelineRunStatusSensor,
+)
+from airflow.providers.microsoft.azure.triggers.data_factory import ADFPipelineRunStatusSensorTrigger
 
 
 class TestPipelineRunStatusSensor:
@@ -74,3 +80,43 @@ class TestPipelineRunStatusSensor:
 
             with pytest.raises(AzureDataFactoryPipelineRunException, match=error_message):
                 self.sensor.poke({})
+
+
+class TestAzureDataFactoryPipelineRunStatusAsyncSensor:
+    RUN_ID = "7f8c6c72-c093-11ec-a83d-0242ac120007"
+    SENSOR = AzureDataFactoryPipelineRunStatusAsyncSensor(
+        task_id="pipeline_run_sensor_async",
+        run_id=RUN_ID,
+    )
+
+    def test_adf_pipeline_status_sensor_async(self):
+        """Assert execute method defer for Azure Data factory pipeline run status sensor"""
+
+        with pytest.raises(TaskDeferred) as exc:
+            self.SENSOR.execute({})
+        assert isinstance(
+            exc.value.trigger, ADFPipelineRunStatusSensorTrigger
+        ), "Trigger is not a ADFPipelineRunStatusSensorTrigger"
+
+    def test_adf_pipeline_status_sensor_execute_complete_success(self):
+        """Assert execute_complete log success message when trigger fire with target status"""
+
+        msg = f"Pipeline run {self.RUN_ID} has been succeeded."
+        with mock.patch.object(self.SENSOR.log, "info") as mock_log_info:
+            self.SENSOR.execute_complete(context={}, event={"status": "success", "message": msg})
+        mock_log_info.assert_called_with(msg)
+
+    def test_adf_pipeline_status_sensor_execute_complete_failure(self):
+        """Assert execute_complete method fail"""
+
+        with pytest.raises(AirflowException):
+            self.SENSOR.execute_complete(context={}, event={"status": "error", "message": ""})
+
+    def test_poll_interval_deprecation_warning(self):
+        """Test DeprecationWarning for AzureDataFactoryPipelineRunStatusAsyncSensor
+        by setting param poll_interval"""
+        # TODO: Remove once deprecated
+        with pytest.warns(expected_warning=DeprecationWarning):
+            AzureDataFactoryPipelineRunStatusAsyncSensor(
+                task_id="pipeline_run_sensor_async", run_id=self.RUN_ID, poll_interval=5.0
+            )

--- a/tests/providers/microsoft/azure/sensors/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/sensors/test_azure_data_factory.py
@@ -111,12 +111,3 @@ class TestAzureDataFactoryPipelineRunStatusAsyncSensor:
 
         with pytest.raises(AirflowException):
             self.SENSOR.execute_complete(context={}, event={"status": "error", "message": ""})
-
-    def test_poll_interval_deprecation_warning(self):
-        """Test DeprecationWarning for AzureDataFactoryPipelineRunStatusAsyncSensor
-        by setting param poll_interval"""
-        # TODO: Remove once deprecated
-        with pytest.warns(expected_warning=DeprecationWarning):
-            AzureDataFactoryPipelineRunStatusAsyncSensor(
-                task_id="pipeline_run_sensor_async", run_id=self.RUN_ID, poll_interval=5.0
-            )

--- a/tests/providers/microsoft/azure/triggers/__init__.py
+++ b/tests/providers/microsoft/azure/triggers/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/microsoft/azure/triggers/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/triggers/test_azure_data_factory.py
@@ -1,0 +1,138 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+
+import pytest
+
+from airflow.providers.microsoft.azure.triggers.data_factory import (
+    ADFPipelineRunStatusSensorTrigger,
+)
+from airflow.triggers.base import TriggerEvent
+
+if sys.version_info < (3, 8):
+    # For compatibility with Python 3.7
+    from asynctest import mock as async_mock
+else:
+    from unittest import mock as async_mock
+
+RESOURCE_GROUP_NAME = "team_provider_resource_group_test"
+DATAFACTORY_NAME = "ADFProvidersTeamDataFactory"
+AZURE_DATA_FACTORY_CONN_ID = "azure_data_factory_default"
+RUN_ID = "7f8c6c72-c093-11ec-a83d-0242ac120007"
+POKE_INTERVAL = 5
+AZ_PIPELINE_RUN_ID = "123"
+AZ_RESOURCE_GROUP_NAME = "test-rg"
+AZ_FACTORY_NAME = "test-factory"
+AZ_DATA_FACTORY_CONN_ID = "test-conn"
+AZ_PIPELINE_END_TIME = time.time() + 60 * 60 * 24 * 7
+MODULE = "airflow.providers.microsoft.azure"
+
+
+class TestADFPipelineRunStatusSensorTrigger:
+    TRIGGER = ADFPipelineRunStatusSensorTrigger(
+        run_id=RUN_ID,
+        azure_data_factory_conn_id=AZURE_DATA_FACTORY_CONN_ID,
+        resource_group_name=RESOURCE_GROUP_NAME,
+        factory_name=DATAFACTORY_NAME,
+        poke_interval=POKE_INTERVAL,
+    )
+
+    def test_adf_pipeline_run_status_sensors_trigger_serialization(self):
+        """
+        Asserts that the TaskStateTrigger correctly serializes its arguments
+        and classpath.
+        """
+
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert classpath == f"{MODULE}.triggers.data_factory.ADFPipelineRunStatusSensorTrigger"
+        assert kwargs == {
+            "run_id": RUN_ID,
+            "azure_data_factory_conn_id": AZURE_DATA_FACTORY_CONN_ID,
+            "resource_group_name": RESOURCE_GROUP_NAME,
+            "factory_name": DATAFACTORY_NAME,
+            "poke_interval": POKE_INTERVAL,
+        }
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_status",
+        [
+            "Queued",
+            "InProgress",
+        ],
+    )
+    @async_mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_adf_pipeline_run_status")
+    async def test_adf_pipeline_run_status_sensors_trigger_run(self, mock_data_factory, mock_status):
+        """
+        Test if the task is run is in trigger successfully.
+        """
+        mock_data_factory.return_value = mock_status
+
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        # TriggerEvent was not returned
+        assert task.done() is False
+        asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_status",
+        ["Succeeded"],
+    )
+    @async_mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_adf_pipeline_run_status")
+    async def test_adf_pipeline_run_status_sensors_trigger_completed(self, mock_data_factory, mock_status):
+        """Test if the task pipeline status is in succeeded status."""
+        mock_data_factory.return_value = mock_status
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        msg = f"Pipeline run {RUN_ID} has been Succeeded."
+        assert TriggerEvent({"status": "success", "message": msg}) == actual
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_status, mock_message",
+        [
+            ("Failed", f"Pipeline run {RUN_ID} has Failed."),
+            ("Cancelled", f"Pipeline run {RUN_ID} has been Cancelled."),
+        ],
+    )
+    @async_mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_adf_pipeline_run_status")
+    async def test_adf_pipeline_run_status_sensors_trigger_failure_status(
+        self, mock_data_factory, mock_status, mock_message
+    ):
+        """Test if the task is run is in trigger failure status."""
+        mock_data_factory.return_value = mock_status
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "error", "message": mock_message}) == actual
+
+    @pytest.mark.asyncio
+    @async_mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_adf_pipeline_run_status")
+    async def test_adf_pipeline_run_status_sensors_trigger_exception(self, mock_data_factory):
+        """Test EMR container sensors with raise exception"""
+        mock_data_factory.side_effect = Exception("Test exception")
+
+        task = [i async for i in self.TRIGGER.run()]
+        assert len(task) == 1
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) in task


### PR DESCRIPTION
This PR donates the `AzureDataFactoryPipelineRunStatusAsyncSensor` from [astronomer-providers](https://github.com/astronomer/astronomer-providers) repo to OSS

cc @josh-fell @kaxil 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
