### PR TITLE
GCSToGCSOperator: Fix 'NoneType' object is not subscriptable.

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -374,7 +374,7 @@ class GCSToGCSOperator(BaseOperator):
 
     def _copy_file(self, hook, source_object):
         destination_object = self.destination_object or source_object
-        if self.destination_object[-1] == "/":
+        if self.destination_object and self.destination_object[-1] == "/":
             file_name = source_object.split("/")[-1]
             destination_object += file_name
         self._copy_single_object(


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This change is to prevent this error.
---
When `move_files` is False and destination_object is not provided operator fails with following traceback: 
```
{taskinstance.py:1853} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/opt/python3.8/lib/python3.8/site-packages/airflow/providers/google/cloud/transfers/gcs_to_gcs.py", line 268, in execute
    self._copy_source_without_wildcard(hook=hook, prefix=prefix)
  File "/opt/python3.8/lib/python3.8/site-packages/airflow/providers/google/cloud/transfers/gcs_to_gcs.py", line 371, in _copy_source_without_wildcard
    self._copy_file(hook=hook, source_object=objects[0])
  File "/opt/python3.8/lib/python3.8/site-packages/airflow/providers/google/cloud/transfers/gcs_to_gcs.py", line 377, in _copy_file
    if self.destination_object[-1] == "/":
TypeError: 'NoneType' object is not subscriptable
```

Current workaround is to set `destination_object` to '/' 