### PR TITLE
Improve spacing for extra links and grid scrollbar

### DIFF
--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -34,7 +34,7 @@ const Details = () => {
   } = useSelection();
 
   return (
-    <Flex flexDirection="column" pl={3} mr={3} height="100%">
+    <Flex flexDirection="column" pl={3} height="100%">
       <Header />
       <Divider my={2} />
       <Box height="100%">

--- a/airflow/www/static/js/dag/details/taskInstance/ExtraLinks.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/ExtraLinks.tsx
@@ -18,7 +18,7 @@
  */
 
 import React from "react";
-import { Button, Flex, Link, Divider } from "@chakra-ui/react";
+import { Button, Flex, Link, Box, Text, Divider } from "@chakra-ui/react";
 
 import { useExtraLinks } from "src/api";
 
@@ -29,25 +29,22 @@ interface Props {
   extraLinks: string[];
 }
 
-const ExtraLinks = ({
-  dagId,
-  taskId,
-  executionDate,
-  extraLinks = [],
-}: Props) => {
-  const { data: links = [] } = useExtraLinks({
+const ExtraLinks = ({ dagId, taskId, executionDate, extraLinks }: Props) => {
+  const { data: links } = useExtraLinks({
     dagId,
     taskId,
     executionDate,
     extraLinks,
   });
 
-  if (!links.length) return null;
+  if (!links?.length) return null;
+
   const isExternal = (url: string | null) =>
     url && /^(?:[a-z]+:)?\/\//.test(url);
 
   return (
-    <>
+    <Box mb={3}>
+      <Text as="strong">Extra Links</Text>
       <Divider my={2} />
       <Flex flexWrap="wrap">
         {links.map(({ name, url }) => (
@@ -58,12 +55,14 @@ const ExtraLinks = ({
             href={url}
             isDisabled={!url}
             target={isExternal(url) ? "_blank" : undefined}
+            mr={2}
           >
             {name}
           </Button>
         ))}
       </Flex>
-    </>
+      <Divider my={2} />
+    </Box>
   );
 };
 

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -182,7 +182,7 @@ const TaskInstance = ({ taskId, runId, mapIndex, onSelect }: Props) => {
                   key={dagId + runId + taskId + instance.mapIndex}
                 />
               )}
-              <Box mb={8}>
+              <Box mb={3}>
                 <TaskActions
                   title={taskActionsTitle}
                   runId={runId}
@@ -193,12 +193,12 @@ const TaskInstance = ({ taskId, runId, mapIndex, onSelect }: Props) => {
                   isGroup={isGroup}
                 />
               </Box>
-              {!isMapped && (
+              {!isMapped && group.extraLinks && (
                 <ExtraLinks
                   taskId={taskId}
                   dagId={dagId}
                   executionDate={executionDate}
-                  extraLinks={group?.extraLinks || []}
+                  extraLinks={group?.extraLinks}
                 />
               )}
               <Details instance={instance} group={group} dagId={dagId} />

--- a/airflow/www/static/js/dag/grid/index.tsx
+++ b/airflow/www/static/js/dag/grid/index.tsx
@@ -86,7 +86,7 @@ const Grid = ({
   }, [tableRef, isPanelOpen]);
 
   return (
-    <Box p={3} pt={0} height="100%" position="relative">
+    <Box height="100%" position="relative">
       <IconButton
         fontSize="2xl"
         variant="ghost"
@@ -101,7 +101,7 @@ const Grid = ({
         position="absolute"
         right={0}
         zIndex={2}
-        top="30px"
+        top={-8}
       />
       <Box
         maxHeight={`calc(100% - ${offsetTop}px)`}
@@ -109,6 +109,7 @@ const Grid = ({
         overflow="auto"
         position="relative"
         pr={4}
+        mt={8}
       >
         <Table pr="10px">
           <Thead>


### PR DESCRIPTION
Following up on #29703 and #29564. I found a few more things to improve. 

1. Make sure the toggle details panel button doesn't conflict with the scroll bar on the grid.
2. Improved presentation of extra links

| Before  | After |
| ------------- | ------------- |
| <img width="347" alt="Screenshot 2023-02-28 at 8 22 29 PM" src="https://user-images.githubusercontent.com/4600967/222021348-349f4fba-64bd-47af-b279-dbf34be9e656.png">  | <img width="585" alt="Screenshot 2023-02-28 at 8 16 05 PM" src="https://user-images.githubusercontent.com/4600967/222021340-4125e526-1f2f-4697-b19f-2cef5eb0d1ec.png">  |
| <img width="320" alt="Screenshot 2023-02-28 at 8 21 28 PM" src="https://user-images.githubusercontent.com/4600967/222021394-dbfb7a99-6255-4692-a9c6-a128c79f2732.png">  | <img width="506" alt="Screenshot 2023-02-28 at 8 21 12 PM" src="https://user-images.githubusercontent.com/4600967/222021421-5027c3ed-09b3-4b2c-9bb4-1ae354e2a683.png">  |

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
