### PR TITLE
Lazy load Task Instance logs in UI

### DIFF
--- a/airflow/www/static/js/ti_log.js
+++ b/airflow/www/static/js/ti_log.js
@@ -183,22 +183,19 @@ function setDownloadUrl(tryNumber) {
 }
 
 $(document).ready(() => {
-  // Lazily load all past task instance logs.
-  // TODO: We only need to have recursive queries for
-  // latest running task instances. Currently it does not
-  // work well with ElasticSearch because ES query only
-  // returns at most 10k documents. We want the ability
-  // to display all logs in the front-end.
-  // An optimization here is to render from latest attempt.
-  for (let i = TOTAL_ATTEMPTS; i >= 1; i -= 1) {
-    // Only autoTailing the page when streaming the latest attempt.
-    const autoTailing = i === TOTAL_ATTEMPTS;
-    autoTailingLog(i, null, autoTailing);
-  }
+  // Automatically load logs for the latest attempt
+  autoTailingLog(TOTAL_ATTEMPTS, null, true);
 
   setDownloadUrl();
   $("#ti_log_try_number_list a").click(function () {
     const tryNumber = $(this).data("try-number");
+
+    // Load logs if not yet loaded for a given attempt
+    if (tryNumber !== TOTAL_ATTEMPTS && !$(this).data("loaded")) {
+      $(this).data("loaded", true);
+      autoTailingLog(tryNumber, null, false);
+    }
+
     setDownloadUrl(tryNumber);
   });
 });


### PR DESCRIPTION
Task instance logs were previously eagerly loaded, which I believe wasn't done intentionally. This commit chages the behaviour - now TI's previous attempts logs are loaded lazily only after clicking on their tab.

related: https://github.com/apache/airflow/discussions/29727

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
