### PR TITLE
Add `_on_failure_fail_dagrun` attribute for teardown tasks

### DIFF
--- a/airflow/decorators/setup_teardown.py
+++ b/airflow/decorators/setup_teardown.py
@@ -37,14 +37,19 @@ def setup_task(python_callable: Callable) -> Callable:
     return wrapper
 
 
-def teardown_task(python_callable: Callable) -> Callable:
-    # Using FunctionType here since _TaskDecorator is also a callable
-    if isinstance(python_callable, types.FunctionType):
-        python_callable = python_task(python_callable)
+def teardown_task(_func=None, *, on_failure_fail_dagrun: bool | None = None) -> Callable:
+    def teardown(python_callable: Callable) -> Callable:
+        # Using FunctionType here since _TaskDecorator is also a callable
+        if isinstance(python_callable, types.FunctionType):
+            python_callable = python_task(python_callable)
 
-    @functools.wraps(python_callable)
-    def wrapper(*args, **kwargs) -> Callable:
-        with SetupTeardownContext.teardown():
-            return python_callable(*args, **kwargs)
+        @functools.wraps(python_callable)
+        def wrapper(*args, **kwargs) -> Callable:
+            with SetupTeardownContext.teardown(on_failure_fail_dagrun):
+                return python_callable(*args, **kwargs)
 
-    return wrapper
+        return wrapper
+
+    if _func is None:
+        return teardown
+    return teardown(_func)

--- a/airflow/decorators/setup_teardown.py
+++ b/airflow/decorators/setup_teardown.py
@@ -45,7 +45,7 @@ def teardown_task(_func=None, *, on_failure_fail_dagrun: bool | None = None) -> 
 
         @functools.wraps(python_callable)
         def wrapper(*args, **kwargs) -> Callable:
-            with SetupTeardownContext.teardown(on_failure_fail_dagrun):
+            with SetupTeardownContext.teardown(on_failure_fail_dagrun=on_failure_fail_dagrun):
                 return python_callable(*args, **kwargs)
 
         return wrapper

--- a/airflow/decorators/task_group.py
+++ b/airflow/decorators/task_group.py
@@ -184,6 +184,7 @@ def task_group(
     add_suffix_on_collision: bool = False,
     setup: bool = False,
     teardown: bool = False,
+    on_failure_fail_dagrun: bool = False,
 ) -> Callable[[Callable[FParams, FReturn]], _TaskGroupFactory[FParams, FReturn]]:
     ...
 

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -931,7 +931,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         from airflow.utils.setup_teardown import SetupTeardownContext
 
         on_failure_fail_dagrun = kwargs.pop("on_failure_fail_dagrun", False)
-        with SetupTeardownContext.teardown(on_failure_fail_dagrun):
+        with SetupTeardownContext.teardown(on_failure_fail_dagrun=on_failure_fail_dagrun):
             return cls(*args, **kwargs)
 
     def __eq__(self, other):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -929,7 +929,8 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     def as_teardown(cls, *args, **kwargs):
         from airflow.utils.setup_teardown import SetupTeardownContext
 
-        with SetupTeardownContext.teardown():
+        on_failure_fail_dagrun = kwargs.pop("on_failure_fail_dagrun", False)
+        with SetupTeardownContext.teardown(on_failure_fail_dagrun):
             return cls(*args, **kwargs)
 
     def __eq__(self, other):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -688,6 +688,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
 
     _is_setup = False
     _is_teardown = False
+    _on_failure_fail_dagrun = False
 
     def __init__(
         self,
@@ -1478,6 +1479,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
                     "params",
                     "_is_setup",
                     "_is_teardown",
+                    "_on_failure_fail_dagrun",
                 }
             )
             DagContext.pop_context_managed_dag()

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -43,7 +43,7 @@ class SetupTeardownContext:
 
     @classmethod
     @contextmanager
-    def teardown(cls):
+    def teardown(cls, on_failure_fail_dagrun=None):
         if cls.is_setup or cls.is_teardown:
             raise AirflowException(
                 "A teardown task or taskgroup cannot be nested inside another"
@@ -51,7 +51,11 @@ class SetupTeardownContext:
             )
 
         cls.is_teardown = True
+        if on_failure_fail_dagrun:
+            setattr(cls, "on_failure_fail_dagrun", on_failure_fail_dagrun)
         try:
             yield
         finally:
             cls.is_teardown = False
+            if on_failure_fail_dagrun:
+                delattr(cls, "on_failure_fail_dagrun")

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -44,7 +44,7 @@ class SetupTeardownContext:
 
     @classmethod
     @contextmanager
-    def teardown(cls, on_failure_fail_dagrun=False):
+    def teardown(cls, *, on_failure_fail_dagrun=False):
         if cls.is_setup or cls.is_teardown:
             raise AirflowException(
                 "A teardown task or taskgroup cannot be nested inside another"

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -26,6 +26,7 @@ class SetupTeardownContext:
 
     is_setup: bool = False
     is_teardown: bool = False
+    on_failure_fail_dagrun: bool = False
 
     @classmethod
     @contextmanager
@@ -43,7 +44,7 @@ class SetupTeardownContext:
 
     @classmethod
     @contextmanager
-    def teardown(cls, on_failure_fail_dagrun=None):
+    def teardown(cls, on_failure_fail_dagrun=False):
         if cls.is_setup or cls.is_teardown:
             raise AirflowException(
                 "A teardown task or taskgroup cannot be nested inside another"
@@ -51,11 +52,9 @@ class SetupTeardownContext:
             )
 
         cls.is_teardown = True
-        if on_failure_fail_dagrun:
-            setattr(cls, "on_failure_fail_dagrun", on_failure_fail_dagrun)
+        cls.on_failure_fail_dagrun = on_failure_fail_dagrun
         try:
             yield
         finally:
             cls.is_teardown = False
-            if on_failure_fail_dagrun:
-                delattr(cls, "on_failure_fail_dagrun")
+            cls.on_failure_fail_dagrun = False

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -246,6 +246,8 @@ class TaskGroup(DAGNode):
         elif SetupTeardownContext.is_teardown or is_teardown:
             if isinstance(task, AbstractOperator):
                 setattr(task, "_is_teardown", True)
+                if getattr(SetupTeardownContext, "on_failure_fail_dagrun", False):
+                    setattr(task, "_on_failure_fail_dagrun", True)
 
         self.children[key] = task
 

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -250,10 +250,7 @@ class TaskGroup(DAGNode):
         elif SetupTeardownContext.is_teardown or is_teardown:
             if isinstance(task, AbstractOperator):
                 setattr(task, "_is_teardown", True)
-                if (
-                    getattr(SetupTeardownContext, "on_failure_fail_dagrun", False)
-                    or self.on_failure_fail_dagrun
-                ):
+                if SetupTeardownContext.on_failure_fail_dagrun or self.on_failure_fail_dagrun:
                     setattr(task, "_on_failure_fail_dagrun", True)
 
         self.children[key] = task

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -94,16 +94,20 @@ class TaskGroup(DAGNode):
         add_suffix_on_collision: bool = False,
         setup: bool = False,
         teardown: bool = False,
+        on_failure_fail_dagrun: bool = False,
     ):
         from airflow.models.dag import DagContext
 
         if setup and teardown:
             raise AirflowException("Cannot set both setup and teardown to True")
+        if on_failure_fail_dagrun and not teardown:
+            raise AirflowException("on_failure_fail_dagrun can only be set to True if teardown is True")
 
         self.prefix_group_id = prefix_group_id
         self.default_args = copy.deepcopy(default_args or {})
         self.setup = setup
         self.teardown = teardown
+        self.on_failure_fail_dagrun = on_failure_fail_dagrun
 
         dag = dag or DagContext.get_current_dag()
 
@@ -246,7 +250,10 @@ class TaskGroup(DAGNode):
         elif SetupTeardownContext.is_teardown or is_teardown:
             if isinstance(task, AbstractOperator):
                 setattr(task, "_is_teardown", True)
-                if getattr(SetupTeardownContext, "on_failure_fail_dagrun", False):
+                if (
+                    getattr(SetupTeardownContext, "on_failure_fail_dagrun", False)
+                    or self.on_failure_fail_dagrun
+                ):
                     setattr(task, "_on_failure_fail_dagrun", True)
 
         self.children[key] = task

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -475,8 +475,7 @@ class TestSetupTearDownTask:
             mytask()
         teardown_task = dag.task_group.children["mytask"]
         assert teardown_task._is_teardown
-        if on_failure_fail_dagrun:
-            assert teardown_task._on_failure_fail_dagrun is True
+        assert teardown_task._on_failure_fail_dagrun is on_failure_fail_dagrun
         assert len(dag.task_group.children) == 1
 
     @pytest.mark.parametrize("on_failure_fail_dagrun", [True, False])
@@ -490,8 +489,7 @@ class TestSetupTearDownTask:
 
         teardown_task = dag.task_group.children["mytask"]
         assert teardown_task._is_teardown
-        if on_failure_fail_dagrun:
-            assert teardown_task._on_failure_fail_dagrun is True
+        assert teardown_task._on_failure_fail_dagrun is on_failure_fail_dagrun
         assert len(dag.task_group.children) == 1
 
     @pytest.mark.parametrize("on_failure_fail_dagrun", [True, False])


### PR DESCRIPTION
This adds basic implementation of on_failure_fail_dagrun params to teardown tasks

Part of https://github.com/orgs/apache/projects/207?pane=issue&itemId=18760456

Related: #29125