### PR TITLE
Remove replicas if KEDA is enabled

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -19,6 +19,7 @@
 ## Airflow Worker Deployment
 #################################
 {{- $persistence := .Values.workers.persistence.enabled }}
+{{- $keda := .Values.workers.keda.enabled }}
 {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
 {{- $nodeSelector := or .Values.workers.nodeSelector .Values.nodeSelector }}
 {{- $affinity := or .Values.workers.affinity .Values.affinity }}
@@ -44,10 +45,12 @@ metadata:
     {{- toYaml .Values.workers.annotations | nindent 4 }}
 {{- end }}
 spec:
-{{- if $persistence }}
+  {{- if $persistence }}
   serviceName: {{ .Release.Name }}-worker
-{{- end }}
+  {{- end }}
+  {{- if not $keda }}
   replicas: {{ .Values.workers.replicas }}
+  {{- end }}
   {{- if $revisionHistoryLimit }}
   revisionHistoryLimit: {{ $revisionHistoryLimit }}
   {{- end }}

--- a/tests/charts/test_worker.py
+++ b/tests/charts/test_worker.py
@@ -608,6 +608,19 @@ class TestWorkerKedaAutoScaler:
         assert "test_label" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
 
+    def test_should_remove_replicas_field(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "workers": {
+                    "keda": {"enabled": True},
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        assert "replicas" not in jmespath.search("spec", docs[0])
+
 
 class TestWorkerNetworkPolicy:
     def test_should_add_component_specific_labels(self):


### PR DESCRIPTION
Remove `replicas` field in workers Deployment/StatefulSet if KEDA is enabled
---

GitOps operators (e.g. ArgoCD) complain when the manifest is changed due to KEDA/HPA auto-scaling. The good practice is to remove `replicas` field when auto-scaling is used.

Reference:
https://argo-cd.readthedocs.io/en/stable/user-guide/best_practices/#leaving-room-for-imperativeness

