### PR TITLE
Refactor startup/teardown flag and storage

### DIFF
--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -30,6 +30,7 @@ from airflow.template.templater import Templater
 from airflow.utils.context import Context
 from airflow.utils.log.secrets_masker import redact
 from airflow.utils.session import NEW_SESSION, provide_session
+from airflow.utils.setup_teardown import SetupTeardown
 from airflow.utils.sqlalchemy import skip_locked, with_row_locks
 from airflow.utils.state import State, TaskInstanceState
 from airflow.utils.task_group import MappedTaskGroup
@@ -101,6 +102,12 @@ class AbstractOperator(Templater, DAGNode):
 
     outlets: list
     inlets: list
+
+    setup_teardown: SetupTeardown | None = None
+    """Indicate whether this is a setup or teadown task.
+
+    :meta private:
+    """
 
     HIDE_ATTRS_FROM_UI: ClassVar[frozenset[str]] = frozenset(
         (

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -270,7 +270,7 @@
       "required": [
         "_group_id",
         "prefix_group_id",
-        "children",
+        "all_children_by_kind",
         "tooltip",
         "ui_color",
         "ui_fgcolor",
@@ -283,9 +283,15 @@
         "_group_id": {"anyOf": [{"type": "null"}, { "type": "string" }]},
         "is_mapped": { "type": "boolean" },
         "prefix_group_id": { "type": "boolean" },
-        "children":  { "$ref": "#/definitions/dict" },
-        "setup_children":  { "$ref": "#/definitions/dict" },
-        "teardown_children":  { "$ref": "#/definitions/dict" },
+        "all_children_by_kind":  {
+          "type": "object",
+          "required": ["", "setup", "teardown"],
+          "properties": {
+            "": { "$ref": "#/definitions/dict" },
+            "setup": { "$ref": "#/definitions/dict" },
+            "teardown": { "$ref": "#/definitions/dict" }
+          }
+        },
         "tooltip": { "type": "string" },
         "ui_color": { "type": "string" },
         "ui_fgcolor": { "type": "string" },

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1327,7 +1327,7 @@ class TaskGroupSerialization(BaseSerialization):
                 serialize_kind(kind): {
                     label: child.serialize_for_task_group() for label, child in children.items()
                 }
-                for kind, children in task_group._all_children_by_kind.items()
+                for kind, children in task_group.all_children_by_kind.items()
             },
             "upstream_group_ids": cls.serialize(sorted(task_group.upstream_group_ids)),
             "downstream_group_ids": cls.serialize(sorted(task_group.downstream_group_ids)),
@@ -1384,7 +1384,7 @@ class TaskGroupSerialization(BaseSerialization):
                 return None
             return SetupTeardown(v)
 
-        group._all_children_by_kind = {
+        group.all_children_by_kind = {
             deserialize_kind(kind): {key: deserialize_child(typ, val) for key, (typ, val) in children.items()}
             for kind, children in encoded_group["all_children_by_kind"].items()
         }

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -32,10 +32,10 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             mytask()
 
-        setup_task = dag.task_group._all_children_by_kind[SetupTeardown.setup]["mytask"]
+        setup_task = dag.task_group.all_children_by_kind[SetupTeardown.setup]["mytask"]
         assert setup_task.setup_teardown == SetupTeardown.setup
 
-        counter = collections.Counter(dag.task_group._all_children_by_kind)
+        counter = collections.Counter(dag.task_group.all_children_by_kind)
         assert counter == collections.Counter({None: 0, SetupTeardown.setup: 1, SetupTeardown.teardown: 0})
 
     def test_marking_functions_as_teardown_task(self, dag_maker):
@@ -46,10 +46,10 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             mytask()
 
-        teardown_task = dag.task_group._all_children_by_kind[SetupTeardown.teardown]["mytask"]
+        teardown_task = dag.task_group.all_children_by_kind[SetupTeardown.teardown]["mytask"]
         assert teardown_task.setup_teardown == SetupTeardown.teardown
 
-        counter = collections.Counter(dag.task_group._all_children_by_kind)
+        counter = collections.Counter(dag.task_group.all_children_by_kind)
         assert counter == collections.Counter({None: 0, SetupTeardown.setup: 0, SetupTeardown.teardown: 1})
 
     def test_marking_decorated_functions_as_setup_task(self, dag_maker):
@@ -61,10 +61,10 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             mytask()
 
-        setup_task = dag.task_group._all_children_by_kind[SetupTeardown.setup]["mytask"]
+        setup_task = dag.task_group.all_children_by_kind[SetupTeardown.setup]["mytask"]
         assert setup_task.setup_teardown == SetupTeardown.setup
 
-        counter = collections.Counter(dag.task_group._all_children_by_kind)
+        counter = collections.Counter(dag.task_group.all_children_by_kind)
         assert counter == collections.Counter({None: 0, SetupTeardown.setup: 1, SetupTeardown.teardown: 0})
 
     def test_marking_operator_as_setup_task(self, dag_maker):
@@ -73,10 +73,10 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             BashOperator.as_setup(task_id="mytask", bash_command='echo "I am a setup task"')
 
-        setup_task = dag.task_group._all_children_by_kind[SetupTeardown.setup]["mytask"]
+        setup_task = dag.task_group.all_children_by_kind[SetupTeardown.setup]["mytask"]
         assert setup_task.setup_teardown == SetupTeardown.setup
 
-        counter = collections.Counter(dag.task_group._all_children_by_kind)
+        counter = collections.Counter(dag.task_group.all_children_by_kind)
         assert counter == collections.Counter({None: 0, SetupTeardown.setup: 1, SetupTeardown.teardown: 0})
 
     def test_marking_decorated_functions_as_teardown_task(self, dag_maker):
@@ -88,10 +88,10 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             mytask()
 
-        teardown_task = dag.task_group._all_children_by_kind[SetupTeardown.teardown]["mytask"]
+        teardown_task = dag.task_group.all_children_by_kind[SetupTeardown.teardown]["mytask"]
         assert teardown_task.setup_teardown == SetupTeardown.teardown
 
-        counter = collections.Counter(dag.task_group._all_children_by_kind)
+        counter = collections.Counter(dag.task_group.all_children_by_kind)
         assert counter == collections.Counter({None: 0, SetupTeardown.setup: 0, SetupTeardown.teardown: 1})
 
     def test_marking_operator_as_teardown_task(self, dag_maker):
@@ -100,10 +100,10 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             BashOperator.as_teardown(task_id="mytask", bash_command='echo "I am a setup task"')
 
-        teardown_task = dag.task_group._all_children_by_kind[SetupTeardown.teardown]["mytask"]
+        teardown_task = dag.task_group.all_children_by_kind[SetupTeardown.teardown]["mytask"]
         assert teardown_task.setup_teardown == SetupTeardown.teardown
 
-        counter = collections.Counter(dag.task_group._all_children_by_kind)
+        counter = collections.Counter(dag.task_group.all_children_by_kind)
         assert counter == collections.Counter({None: 0, SetupTeardown.setup: 0, SetupTeardown.teardown: 1})
 
     def test_setup_taskgroup(self, dag_maker):
@@ -119,14 +119,14 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             mygroup()
 
-        counter = collections.Counter(dag.task_group._all_children_by_kind)
+        counter = collections.Counter(dag.task_group.all_children_by_kind)
         assert counter == collections.Counter({None: 0, SetupTeardown.setup: 1, SetupTeardown.teardown: 0})
 
-        setup_task_group = dag.task_group._all_children_by_kind[SetupTeardown.setup]["mygroup"]
-        counter = collections.Counter(setup_task_group._all_children_by_kind)
+        setup_task_group = dag.task_group.all_children_by_kind[SetupTeardown.setup]["mygroup"]
+        counter = collections.Counter(setup_task_group.all_children_by_kind)
         assert counter == collections.Counter({None: 0, SetupTeardown.setup: 1, SetupTeardown.teardown: 0})
 
-        setup_task = setup_task_group._all_children_by_kind[SetupTeardown.setup]["mygroup.mytask"]
+        setup_task = setup_task_group.all_children_by_kind[SetupTeardown.setup]["mygroup.mytask"]
         assert setup_task.setup_teardown == SetupTeardown.setup
 
     def test_teardown_taskgroup(self, dag_maker):
@@ -142,12 +142,12 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             mygroup()
 
-        counter = collections.Counter(dag.task_group._all_children_by_kind)
+        counter = collections.Counter(dag.task_group.all_children_by_kind)
         assert counter == collections.Counter({None: 0, SetupTeardown.setup: 0, SetupTeardown.teardown: 1})
 
-        teardown_task_group = dag.task_group._all_children_by_kind[SetupTeardown.teardown]["mygroup"]
-        counter = collections.Counter(teardown_task_group._all_children_by_kind)
+        teardown_task_group = dag.task_group.all_children_by_kind[SetupTeardown.teardown]["mygroup"]
+        counter = collections.Counter(teardown_task_group.all_children_by_kind)
         assert counter == collections.Counter({None: 0, SetupTeardown.setup: 0, SetupTeardown.teardown: 1})
 
-        teardown_task = teardown_task_group._all_children_by_kind[SetupTeardown.teardown]["mygroup.mytask"]
+        teardown_task = teardown_task_group.all_children_by_kind[SetupTeardown.teardown]["mygroup.mytask"]
         assert teardown_task.setup_teardown == SetupTeardown.teardown

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -354,8 +354,8 @@ def _check_taskgroup_children(
     expected_children,
     expected_teardown,
 ):
-    se_children = {key: sorted(children) for key, children in se_task_group._all_children_by_kind.items()}
-    dag_children = {key: sorted(children) for key, children in dag_task_group._all_children_by_kind.items()}
+    se_children = {key: sorted(children) for key, children in se_task_group.all_children_by_kind.items()}
+    dag_children = {key: sorted(children) for key, children in dag_task_group.all_children_by_kind.items()}
     assert (
         se_children
         == dag_children
@@ -1420,8 +1420,8 @@ class TestStringifiedDAGs:
             serialized_dag.task_group, dag.task_group, ["setup_group"], ["sometask"], ["teardown_group"]
         )
 
-        se_setup_group = serialized_dag.task_group._all_children_by_kind[SetupTeardown.setup]["setup_group"]
-        dag_setup_group = dag.task_group._all_children_by_kind[SetupTeardown.setup]["setup_group"]
+        se_setup_group = serialized_dag.task_group.all_children_by_kind[SetupTeardown.setup]["setup_group"]
+        dag_setup_group = dag.task_group.all_children_by_kind[SetupTeardown.setup]["setup_group"]
         _check_taskgroup_children(
             se_setup_group,
             dag_setup_group,
@@ -1430,10 +1430,8 @@ class TestStringifiedDAGs:
             [],
         )
 
-        se_sub_setup_group = se_setup_group._all_children_by_kind[SetupTeardown.setup][
-            "setup_group.sub_setup"
-        ]
-        dag_sub_setup_group = dag_setup_group._all_children_by_kind[SetupTeardown.setup][
+        se_sub_setup_group = se_setup_group.all_children_by_kind[SetupTeardown.setup]["setup_group.sub_setup"]
+        dag_sub_setup_group = dag_setup_group.all_children_by_kind[SetupTeardown.setup][
             "setup_group.sub_setup"
         ]
         _check_taskgroup_children(
@@ -1444,10 +1442,10 @@ class TestStringifiedDAGs:
             [],
         )
 
-        se_teardown_group = serialized_dag.task_group._all_children_by_kind[SetupTeardown.teardown][
+        se_teardown_group = serialized_dag.task_group.all_children_by_kind[SetupTeardown.teardown][
             "teardown_group"
         ]
-        dag_teardown_group = dag.task_group._all_children_by_kind[SetupTeardown.teardown]["teardown_group"]
+        dag_teardown_group = dag.task_group.all_children_by_kind[SetupTeardown.teardown]["teardown_group"]
         _check_taskgroup_children(
             se_teardown_group,
             dag_teardown_group,

--- a/tests/utils/test_setup_teardown.py
+++ b/tests/utils/test_setup_teardown.py
@@ -20,31 +20,25 @@ from __future__ import annotations
 import pytest
 
 from airflow.exceptions import AirflowException
-from airflow.utils.setup_teardown import SetupTeardownContext
+from airflow.utils.setup_teardown import SetupTeardown, SetupTeardownContext
 
 
 class TestSetupTearDownContext:
     def test_setup(self):
-        assert SetupTeardownContext.is_setup is False
-        assert SetupTeardownContext.is_teardown is False
+        assert SetupTeardownContext.setup_teardown is None
 
         with SetupTeardownContext.setup():
-            assert SetupTeardownContext.is_setup is True
-            assert SetupTeardownContext.is_teardown is False
+            assert SetupTeardownContext.setup_teardown == SetupTeardown.setup
 
-        assert SetupTeardownContext.is_setup is False
-        assert SetupTeardownContext.is_teardown is False
+        assert SetupTeardownContext.setup_teardown is None
 
     def test_teardown(self):
-        assert SetupTeardownContext.is_setup is False
-        assert SetupTeardownContext.is_teardown is False
+        assert SetupTeardownContext.setup_teardown is None
 
-        with SetupTeardownContext.setup():
-            assert SetupTeardownContext.is_setup is True
-            assert SetupTeardownContext.is_teardown is False
+        with SetupTeardownContext.teardown():
+            assert SetupTeardownContext.setup_teardown == SetupTeardown.teardown
 
-        assert SetupTeardownContext.is_setup is False
-        assert SetupTeardownContext.is_teardown is False
+        assert SetupTeardownContext.setup_teardown is None
 
     def test_setup_exception(self):
         """Ensure context is reset even if an exception happens"""
@@ -52,8 +46,7 @@ class TestSetupTearDownContext:
             with SetupTeardownContext.setup():
                 raise Exception("Hello")
 
-        assert SetupTeardownContext.is_setup is False
-        assert SetupTeardownContext.is_teardown is False
+        assert SetupTeardownContext.setup_teardown is None
 
     def test_teardown_exception(self):
         """Ensure context is reset even if an exception happens"""
@@ -61,8 +54,7 @@ class TestSetupTearDownContext:
             with SetupTeardownContext.teardown():
                 raise Exception("Hello")
 
-        assert SetupTeardownContext.is_setup is False
-        assert SetupTeardownContext.is_teardown is False
+        assert SetupTeardownContext.setup_teardown is None
 
     def test_setup_block_nested(self):
         with SetupTeardownContext.setup():
@@ -76,8 +68,7 @@ class TestSetupTearDownContext:
                 with SetupTeardownContext.setup():
                     raise Exception("This should not be reached")
 
-        assert SetupTeardownContext.is_setup is False
-        assert SetupTeardownContext.is_teardown is False
+        assert SetupTeardownContext.setup_teardown is None
 
     def test_teardown_block_nested(self):
         with SetupTeardownContext.teardown():
@@ -91,8 +82,7 @@ class TestSetupTearDownContext:
                 with SetupTeardownContext.teardown():
                     raise Exception("This should not be reached")
 
-        assert SetupTeardownContext.is_setup is False
-        assert SetupTeardownContext.is_teardown is False
+        assert SetupTeardownContext.setup_teardown is None
 
     def test_teardown_nested_in_setup_blocked(self):
         with SetupTeardownContext.setup():
@@ -106,8 +96,7 @@ class TestSetupTearDownContext:
                 with SetupTeardownContext.teardown():
                     raise Exception("This should not be reached")
 
-        assert SetupTeardownContext.is_setup is False
-        assert SetupTeardownContext.is_teardown is False
+        assert SetupTeardownContext.setup_teardown is None
 
     def test_setup_nested_in_teardown_blocked(self):
         with SetupTeardownContext.teardown():
@@ -121,5 +110,4 @@ class TestSetupTearDownContext:
                 with SetupTeardownContext.setup():
                     raise Exception("This should not be reached")
 
-        assert SetupTeardownContext.is_setup is False
-        assert SetupTeardownContext.is_teardown is False
+        assert SetupTeardownContext.setup_teardown is None


### PR DESCRIPTION
A new enum is introduced so we can combine the is_setup/teardown flags into one attribute. The children/setup_children/teardown_children in TaskGroup is also refactored into one single dict that stores all tasks categorized by their "kind" (setup, teardown, or "normal").

Some minor typing changes are made to fix Mypy.