### PR TITLE
Clear ExecutorLoader cache in tests

### DIFF
--- a/airflow/executors/executor_loader.py
+++ b/airflow/executors/executor_loader.py
@@ -170,11 +170,11 @@ class ExecutorLoader:
         initialized) because loading the executor class is heavy work we want to
         avoid unless needed.
         """
+        # Single threaded executors can run with any backend.
         if executor.is_single_threaded:
-            # Single threaded executors can run with any backend
             return
 
-        # This is set in tests when we want to be able to use the SequentialExecutor.
+        # This is set in tests when we want to be able to use SQLite.
         if os.environ.get("_AIRFLOW__SKIP_DATABASE_EXECUTOR_COMPATIBILITY_CHECK") == "1":
             return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -892,7 +892,9 @@ def _clear_db(request):
 
 
 @pytest.fixture(autouse=True)
-def _clear_entry_point_cache():
+def clear_lru_cache():
+    from airflow.executors.executor_loader import ExecutorLoader
     from airflow.utils.entry_points import _get_grouped_entry_points
 
+    ExecutorLoader.validate_database_executor_compatibility.cache_clear()
     _get_grouped_entry_points.cache_clear()

--- a/tests/executors/test_executor_loader.py
+++ b/tests/executors/test_executor_loader.py
@@ -120,10 +120,11 @@ class TestExecutorLoader:
     @pytest.mark.parametrize(
         ["executor", "expectation"],
         [
-            (FakeSingleThreadedExecutor, nullcontext()),
-            (
+            pytest.param(FakeSingleThreadedExecutor, nullcontext(), id="single-threaded"),
+            pytest.param(
                 FakeExecutor,
                 pytest.raises(AirflowConfigException, match=r"^error: cannot use SQLite with the .+"),
+                id="multi-threaded",
             ),
         ],
     )


### PR DESCRIPTION
This allows us to properly test the validator function's behavior against various executors.