### PR TITLE
Fixing broken filter in /taskinstance/list view

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -139,6 +139,8 @@ if TYPE_CHECKING:
     from airflow.models.operator import Operator
     from airflow.utils.task_group import MappedTaskGroup, TaskGroup
 
+    # This is a workaround because mypy doesn't work with hybrid_property
+    # TODO: remove this hack and move hybrid_property back to main import block
     hybrid_property = property
 else:
     from sqlalchemy.ext.hybrid import hybrid_property

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -141,6 +141,7 @@ if TYPE_CHECKING:
 
     # This is a workaround because mypy doesn't work with hybrid_property
     # TODO: remove this hack and move hybrid_property back to main import block
+    # See https://github.com/python/mypy/issues/4430
     hybrid_property = property
 else:
     from sqlalchemy.ext.hybrid import hybrid_property

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -58,6 +58,7 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.ext.associationproxy import association_proxy
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import reconstructor, relationship
 from sqlalchemy.orm.attributes import NO_VALUE, set_committed_value
@@ -561,7 +562,7 @@ class TaskInstance(Base, LoggingMixin):
         self._log = logging.getLogger("airflow.task")
         self.test_mode = False  # can be changed when calling 'run'
 
-    @property
+    @hybrid_property
     def try_number(self):
         """
         Return the try number that this task number will be when it is actually

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -58,7 +58,6 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import reconstructor, relationship
 from sqlalchemy.orm.attributes import NO_VALUE, set_committed_value
@@ -139,6 +138,10 @@ if TYPE_CHECKING:
     from airflow.models.dataset import DatasetEvent
     from airflow.models.operator import Operator
     from airflow.utils.task_group import MappedTaskGroup, TaskGroup
+
+    hybrid_property = property
+else:
+    from sqlalchemy.ext.hybrid import hybrid_property
 
 
 PAST_DEPENDS_MET = "past_depends_met"

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -147,6 +147,19 @@ def test_task_start_date_filter(admin_client, url, content):
 
 
 @pytest.mark.parametrize(
+    "url",
+    [
+        "/taskinstance/list/?_flt_1_try_number=0", # greater than
+        "/taskinstance/list/?_flt_2_try_number=5", # less than
+    ]
+)
+def test_try_number_filter(admin_client, url):
+    resp = admin_client.get(url)
+    # Ensure that the taskInstance view can filter on gt / lt try_number
+    check_content_in_response("List Task Instance", resp)
+
+
+@pytest.mark.parametrize(
     "url, content",
     [
         (

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -149,9 +149,9 @@ def test_task_start_date_filter(admin_client, url, content):
 @pytest.mark.parametrize(
     "url",
     [
-        "/taskinstance/list/?_flt_1_try_number=0", # greater than
-        "/taskinstance/list/?_flt_2_try_number=5", # less than
-    ]
+        "/taskinstance/list/?_flt_1_try_number=0",  # greater than
+        "/taskinstance/list/?_flt_2_try_number=5",  # less than
+    ],
 )
 def test_try_number_filter(admin_client, url):
     resp = admin_client.get(url)


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/29843

Because the column and column in the DB are both called `try_number`, flask-appbuilder ends up trying to build a filter using the `try_number` property, which doesn't work.

I think that we _could_ get around this by renaming the property, but that would be a huge refactor. Instead, we can just use the `@hybrid_property` decorator which will enable different behaviour at the class vs. instance-level.

([more on sqlalchemy hybrid properties here](https://docs.sqlalchemy.org/en/14/orm/extensions/hybrid.html))

Tested this in breeze and can confirm it works:
<img width="1882" alt="image" src="https://user-images.githubusercontent.com/16950874/222294346-4eb9d7f5-1efa-4771-a475-3db9927b42a5.png">

Will wait for the full tests to run before I claim that this doesn't break anything else 🤞 