### PR TITLE
Move sqlalchemy.ext.declarative imports to orm

### DIFF
--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -22,8 +22,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Collection, Iterable, Iterator, NamedTuple
 
 from sqlalchemy import or_
-from sqlalchemy.orm import lazyload
-from sqlalchemy.orm.session import Session as SASession
+from sqlalchemy.orm import Session as SASession, lazyload
 
 from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun

--- a/airflow/api_connexion/endpoints/log_endpoint.py
+++ b/airflow/api_connexion/endpoints/log_endpoint.py
@@ -21,8 +21,7 @@ from typing import Any
 from flask import Response, request
 from itsdangerous.exc import BadSignature
 from itsdangerous.url_safe import URLSafeSerializer
-from sqlalchemy.orm import joinedload
-from sqlalchemy.orm.session import Session
+from sqlalchemy.orm import Session, joinedload
 
 from airflow.api_connexion import security
 from airflow.api_connexion.exceptions import BadRequest, NotFound

--- a/airflow/models/base.py
+++ b/airflow/models/base.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from typing import Any
 
 from sqlalchemy import MetaData, String
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from airflow.configuration import conf
 

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -24,8 +24,7 @@ from json import JSONDecodeError
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit
 
 from sqlalchemy import Boolean, Column, Integer, String, Text
-from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy.orm import reconstructor, synonym
+from sqlalchemy.orm import declared_attr, reconstructor, synonym
 
 from airflow.configuration import ensure_secrets_loaded
 from airflow.exceptions import AirflowException, AirflowNotFoundException, RemovedInAirflow3Warning

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -43,9 +43,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy.orm import joinedload, relationship, synonym
-from sqlalchemy.orm.session import Session
+from sqlalchemy.orm import Session, declared_attr, joinedload, relationship, synonym
 from sqlalchemy.sql.expression import false, select, true
 
 from airflow import settings

--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -23,8 +23,7 @@ from typing import Any
 
 from sqlalchemy import Boolean, Column, Integer, String, Text
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
-from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy.orm import Session, reconstructor, synonym
+from sqlalchemy.orm import Session, declared_attr, reconstructor, synonym
 
 from airflow.api_internal.internal_api_call import internal_api_call
 from airflow.configuration import ensure_secrets_loaded

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -31,8 +31,7 @@ import pluggy
 import sqlalchemy
 from sqlalchemy import create_engine, exc
 from sqlalchemy.engine import Engine
-from sqlalchemy.orm import scoped_session, sessionmaker
-from sqlalchemy.orm.session import Session as SASession
+from sqlalchemy.orm import Session as SASession, scoped_session, sessionmaker
 from sqlalchemy.pool import NullPool
 
 from airflow import policies

--- a/airflow/www/fab_security/sqla/models.py
+++ b/airflow/www/fab_security/sqla/models.py
@@ -38,8 +38,7 @@ from sqlalchemy import (
     event,
     func,
 )
-from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy.orm import backref, relationship
+from sqlalchemy.orm import backref, declared_attr, relationship
 
 from airflow.models.base import Base
 


### PR DESCRIPTION
These imports are being moved to sqlalchemy.orm, and are also available there in 1.4 (which we use), so let's move them to ease the eventual migration to 2.0.

See https://docs.sqlalchemy.org/en/20/changelog/migration_20.html