### PR TITLE
Workaround documentation prooblems for Boto3

### DIFF
--- a/docs/exts/docs_build/third_party_inventories.py
+++ b/docs/exts/docs_build/third_party_inventories.py
@@ -17,7 +17,10 @@
 from __future__ import annotations
 
 THIRD_PARTY_INDEXES = {
-    "boto3": "https://boto3.amazonaws.com/v1/documentation/api/latest",
+    # Temporary set to the latest version of boto3 inventory which has all the methods
+    # This should be changed back to "latest" once the inventory is fixed
+    # See https://github.com/boto/boto3/issues/3610 for details
+    "boto3": "https://boto3.amazonaws.com/v1/documentation/api/1.26.80",
     "celery": "https://docs.celeryq.dev/en/stable/",
     "docker": "https://docker-py.readthedocs.io/en/stable",
     "hdfs": "https://hdfscli.readthedocs.io/en/latest",


### PR DESCRIPTION
Boto3 interspinx repository got broken as of 1.26.81 and it is being tracked in https://github.com/boto/boto3/issues/3610

This PR fixes the version of the inventory to 1.26.80 which is the latest known correct inventory version.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
