### PR TITLE
Update sftp_to_s3.rst

### DIFF
--- a/docs/apache-airflow-providers-amazon/operators/transfer/sftp_to_s3.rst
+++ b/docs/apache-airflow-providers-amazon/operators/transfer/sftp_to_s3.rst
@@ -20,7 +20,7 @@ SFTP to Amazon S3
 =================
 
 Use the ``SFTPToS3Operator`` transfer to copy the data from a SFTP server to an Amazon Simple Storage Service (S3) file.
-For more information about the service visits `Amazon Transfer for SFTP API documentation <https://docs.aws.amazon.com/whitepapers/latest/architecting-hipaa-security-and-compliance-on-aws/aws-transfer-for-sftp.html>`_.
+
 
 Prerequisite Tasks
 ------------------


### PR DESCRIPTION
This operator does not use AWS transfer family. I just connects to SFTP, copies the file locally and puts it on S3. See: https://airflow.apache.org/docs/apache-airflow/1.10.3/_modules/airflow/contrib/operators/sftp_to_s3_operator.html

