### PR TITLE
Correct link to best_practice(s) section

### DIFF
--- a/docs/apache-airflow/howto/dynamic-dag-generation.rst
+++ b/docs/apache-airflow/howto/dynamic-dag-generation.rst
@@ -40,7 +40,7 @@ If you want to use variables to configure your code, you should always use
 `environment variables <https://wiki.archlinux.org/title/environment_variables>`_ in your
 top-level code rather than :doc:`Airflow Variables </core-concepts/variables>`. Using Airflow Variables
 in top-level code creates a connection to the metadata DB of Airflow to fetch the value, which can slow
-down parsing and place extra load on the DB. See the `best practices on Airflow Variables <best_practices/airflow_variables>`_
+down parsing and place extra load on the DB. See the `best practices on Airflow Variables <best_practice:airflow_variables>`_
 to make the best use of Airflow Variables in your DAGs using Jinja templates.
 
 For example you could set ``DEPLOYMENT`` variable differently for your production and development


### PR DESCRIPTION
Logical link <best_practices/airflow_variables> fails. In similar file faq.rst, logical link `DAG writing best practices<best_practice:writing_a_dag>` (without "s" at practice) works.

I could not deploy and test; however based on similarity, the above should fix the broken link in:
https://airflow.apache.org/docs/apache-airflow/2.5.1/howto/dynamic-dag-generation.html#dynamic-dags-with-environment-variables