### PR TITLE
Including airflow/example_dags/sql/sample.sql in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -38,4 +38,5 @@ include airflow/customized_form_field_behaviours.schema.json
 include airflow/serialization/schema.json
 include airflow/utils/python_virtualenv_script.jinja2
 include airflow/utils/context.pyi
+include airflow/example_dags/sql/sample.sql
 include generated


### PR DESCRIPTION
I was debugging another issue and running the official helm chart in Kind, and when I tried to run the `example_python_operator` DAG it failed on the `log_sql_query` task with the following error:

```
  File "/home/airflow/.local/lib/python3.7/site-packages/jinja2/environment.py", line 969, in _load_template
    template = self.loader.load(self, name, self.make_globals(globals))
  File "/home/airflow/.local/lib/python3.7/site-packages/jinja2/loaders.py", line 126, in load
    source, filename, uptodate = self.get_source(environment, name)
  File "/home/airflow/.local/lib/python3.7/site-packages/jinja2/loaders.py", line 218, in get_source
    raise TemplateNotFound(template)
jinja2.exceptions.TemplateNotFound: sql/sample.sql
```

Which then causes all of the downstream tasks to fail.

This is because the template used in the example DAG isn't bundled into the build. I suspect this might work in `breeze` because the source directory is mounted, but when Airflow is installed from pip it won't include this file. 

Anyways, I think that this minor change should fix things.