### PR TITLE
Mask out non-access bits when comparing file modes

### DIFF
--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -440,7 +440,7 @@ class FileTaskHandler(logging.Handler):
             conf.get("logging", "file_task_handler_new_folder_permissions", fallback="0o775"), 8
         )
         directory.mkdir(mode=new_folder_permissions, parents=True, exist_ok=True)
-        if directory.stat().st_mode != new_folder_permissions:
+        if directory.stat().st_mode % 0o1000 != new_folder_permissions % 0o1000:
             print(f"Changing dir permission to {new_folder_permissions}")
             directory.chmod(new_folder_permissions)
 


### PR DESCRIPTION
While investigating https://github.com/apache/airflow/issues/29112 I found another issue in the way that the file task handler checks file access:

https://github.com/apache/airflow/blob/9745032fa7e05ea7e45266445db44d153c1adb11/airflow/utils/log/file_task_handler.py#L439-L445

The return value of `path.stat().st_mode` will include additional bits beyond the tailing 9 access bits (`-RWXRWXRWX`), which can lead to running `chmod` when it isn't required, as demonstrated here:
```python
>>> from pathlib import Path

>>> p = Path('/opt/airflow/logs/task/mytask')

>>> new_folder_permissions = 0o755

>>> p.mkdir(mode=new_folder_permissions, parents=True, exist_ok=True)

>>> p.stat().st_mode == new_folder_permissions   # Should return true, because we just created this directory
False

>>> format(p.stat().st_mode, 'o')   # Lets look at the full value of `std_mode`, oct-formatted
'42755'

>>> p.stat().st_mode % 0o1000 == new_folder_permissions   # selecting only the last 9 bits
True
```

I'm not sure if this is the main cause of https://github.com/apache/airflow/issues/29112, as there could be remaining issues around kubernetes security groups etc, but I think that this bug could definitely lead to unnecessarily chmod'ing directories without being the owner which could then throw the reported errors.