### PR TITLE
Introduce testing a connection via Airflow CLI

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -836,7 +836,7 @@ ARG_ENV_VARS = Arg(
 )
 
 # connections
-ARG_CONN_ID = Arg(("conn_id",), help="Connection id, required to get/add/delete a connection", type=str)
+ARG_CONN_ID = Arg(("conn_id",), help="Connection ID, required to get/add/delete/test a connection", type=str)
 ARG_CONN_ID_FILTER = Arg(
     ("--conn-id",), help="If passed, only items with the specified connection ID will be displayed", type=str
 )
@@ -1708,6 +1708,12 @@ CONNECTIONS_COMMANDS = (
             ARG_CONN_OVERWRITE,
             ARG_VERBOSE,
         ),
+    ),
+    ActionCommand(
+        name="test",
+        help="Test a connection",
+        func=lazy_load_command("airflow.cli.commands.connection_command.connections_test"),
+        args=(ARG_CONN_ID, ARG_VERBOSE),
     ),
 )
 PROVIDERS_COMMANDS = (

--- a/airflow/cli/commands/connection_command.py
+++ b/airflow/cli/commands/connection_command.py
@@ -325,3 +325,23 @@ def _import_helper(file_path: str, overwrite: bool) -> None:
             session.merge(conn)
             session.commit()
             print(f"Imported connection {conn_id}")
+
+
+@suppress_logs_and_warning
+def connections_test(args) -> None:
+    """Test an Airflow connection."""
+    console = AirflowConsole()
+
+    print(f"Retrieving connection: {args.conn_id!r}")
+    try:
+        conn = BaseHook.get_connection(args.conn_id)
+    except AirflowNotFoundException:
+        console.print("[bold yellow]\nConnection not found.\n")
+        raise SystemExit(1)
+
+    print("\nTesting...")
+    status, message = conn.test_connection()
+    if status is True:
+        console.print("[bold green]\nConnection success!\n")
+    else:
+        console.print(f"[bold][red]\nConnection failed![/bold]\n{message}\n")

--- a/docs/apache-airflow/howto/connection.rst
+++ b/docs/apache-airflow/howto/connection.rst
@@ -191,19 +191,30 @@ Passwords cannot be manipulated or read without the key. For information on conf
 Testing Connections
 ^^^^^^^^^^^^^^^^^^^
 
-Airflow Web UI & API allows to test connections. The test connection feature can be used from
-:ref:`create <creating_connection_ui>` or :ref:`edit <editing_connection_ui>` connection page, or through calling
-:doc:`Connections REST API </stable-rest-api-ref/>`.
+Airflow Web UI, REST API, and CLI allow you to test connections. The test connection feature can be used from
+:ref:`create <creating_connection_ui>` or :ref:`edit <editing_connection_ui>` connection page in the UI, through calling
+:doc:`Connections REST API </stable-rest-api-ref/>`, or running the ``airflow connections test`` :ref:`CLI command <cli>`.
 
-To test a connection Airflow calls out the ``test_connection`` method from the associated hook class and reports the
-results of it. It may happen that the connection type does not have any associated hook or the hook doesn't have the
-``test_connection`` method implementation, in either case the error message will throw the proper error message.
+.. warning::
 
-One important point to note is that the connections will be tested from the webserver only, so this feature is
-subject to network egress rules setup for your webserver. Also, if webserver & worker machines have different libs or
-provider packages installed then the test results might differ.
+    This feature won't be available for the connections residing in external secrets backends when using the
+    Airflow UI or REST API.
 
-Last caveat is that this feature won't be available for the connections coming out of the secrets backends.
+To test a connection, Airflow calls the ``test_connection`` method from the associated hook class and reports the
+results. It may happen that the connection type does not have any associated hook or the hook doesn't have the
+``test_connection`` method implementation, in either case an error message will be displayed or functionality
+will be disabled (if you are testing in the UI).
+
+.. note::
+
+    When testing in the Airflow UI, the test executes from the webserver so this feature is subject to network
+    egress rules setup for your webserver.
+
+.. note::
+
+    If webserver & worker machines (if testing via the Airflow UI) or machines/pods (if testing via the
+    Airflow CLI) have different libs or provider packages installed, test results *might* differ.
+
 
 Custom connection types
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/cli/commands/test_connection_command.py
+++ b/tests/cli/commands/test_connection_command.py
@@ -919,3 +919,37 @@ class TestCliImportConnections:
 
         # The existing connection should have been overwritten
         assert current_conns_as_dicts["new3"] == expected_connections["new3"]
+
+
+class TestCliTestConnections:
+    parser = cli_parser.get_parser()
+
+    def setup_class(self):
+        clear_db_connections()
+
+    @mock.patch("airflow.providers.http.hooks.http.HttpHook.test_connection")
+    def test_cli_connections_test_success(self, mock_test_conn):
+        """Check that successful connection test result is displayed properly."""
+        conn_id = "http_default"
+        mock_test_conn.return_value = True, None
+        with redirect_stdout(io.StringIO()) as stdout:
+            connection_command.connections_test(self.parser.parse_args(["connections", "test", conn_id]))
+
+            assert "Connection success!" in stdout.getvalue()
+
+    @mock.patch("airflow.providers.http.hooks.http.HttpHook.test_connection")
+    def test_cli_connections_test_fail(self, mock_test_conn):
+        """Check that failed connection test result is displayed properly."""
+        conn_id = "http_default"
+        mock_test_conn.return_value = False, "Failed."
+        with redirect_stdout(io.StringIO()) as stdout:
+            connection_command.connections_test(self.parser.parse_args(["connections", "test", conn_id]))
+
+            assert "Connection failed!\nFailed.\n\n" in stdout.getvalue()
+
+    def test_cli_connections_test_missing_conn(self):
+        """Check a connection test on a non-existent connection raises a "Connection not found" message."""
+        with redirect_stdout(io.StringIO()) as stdout, pytest.raises(SystemExit):
+            connection_command.connections_test(self.parser.parse_args(["connections", "test", "missing"]))
+
+            assert "Connection not found.\n\n" in stdout.getvalue()


### PR DESCRIPTION
Closes: #29875

This PR adds a new Airflow CLI command -- `airflow connections test <conn_id>` -- to test a single, predefined Airflow connection.

_Help_
```
root@066b5575260e:/opt/airflow# airflow connections test --help
Usage: airflow connections test [-h] [-v] conn_id

Test a connection

Positional Arguments:
  conn_id        Connection ID, required to get/add/delete/test a connection

Optional Arguments:
  -h, --help     show this help message and exit
  -v, --verbose  Make logging output more verbose
```

_Successful test_
<img width="517" alt="image" src="https://user-images.githubusercontent.com/48934154/222923391-271c0102-8132-48f7-97a2-ded2aab0e32c.png">


_Failed tests_
<img width="533" alt="image" src="https://user-images.githubusercontent.com/48934154/222923406-8a022d44-e4ba-40e0-8d36-2cfe01927f25.png">

<img width="509" alt="image" src="https://user-images.githubusercontent.com/48934154/222923492-eb4a04a2-dee4-4d33-a56f-df75268a1a4c.png">

_Missing connection_
<img width="500" alt="image" src="https://user-images.githubusercontent.com/48934154/222923434-2317773c-ec5f-4f9a-9bc0-46daeb4ea67e.png">



_TODO:_
- [x] Add tests (unironically)