### PR TITLE
Store grid tabs in url params

### DIFF
--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect } from "react";
 import {
   Flex,
   Divider,
@@ -28,12 +28,14 @@ import {
   Tab,
   Text,
 } from "@chakra-ui/react";
+import { useSearchParams } from "react-router-dom";
 
 import useSelection from "src/dag/useSelection";
 import { getTask, getMetaValue } from "src/utils";
 import { useGridData, useTaskInstance } from "src/api";
 import { MdDetails, MdAccountTree, MdReorder } from "react-icons/md";
 import { BiBracket } from "react-icons/bi";
+import URLSearchParamsWrapper from "src/utils/URLSearchParamWrapper";
 
 import Header from "./Header";
 import TaskInstanceContent from "./taskInstance";
@@ -51,6 +53,39 @@ interface Props {
   onToggleGroups: (groupIds: string[]) => void;
 }
 
+const tabToIndex = (tab?: string) => {
+  switch (tab) {
+    case "graph":
+      return 1;
+    case "logs":
+    case "mapped_tasks":
+      return 2;
+    case "details":
+    default:
+      return 0;
+  }
+};
+
+const indexToTab = (
+  index: number,
+  showLogs: boolean,
+  showMappedTasks: boolean
+) => {
+  switch (index) {
+    case 1:
+      return "graph";
+    case 2:
+      if (showMappedTasks) return "mapped_tasks";
+      if (showLogs) return "logs";
+      return undefined;
+    case 0:
+    default:
+      return undefined;
+  }
+};
+
+const TAB_PARAM = "tab";
+
 const Details = ({ openGroupIds, onToggleGroups }: Props) => {
   const {
     selected: { runId, taskId, mapIndex },
@@ -59,7 +94,6 @@ const Details = ({ openGroupIds, onToggleGroups }: Props) => {
   const isDag = !runId && !taskId;
   const isDagRun = runId && !taskId;
   const isTaskInstance = taskId && runId;
-  const [tabIndex, setTabIndex] = useState(0);
 
   const {
     data: { dagRuns, groups },
@@ -74,11 +108,26 @@ const Details = ({ openGroupIds, onToggleGroups }: Props) => {
   const showLogs = !!(isTaskInstance && !isGroupOrMappedTaskSummary);
   const showMappedTasks = !!(isTaskInstance && isMappedTaskSummary && !isGroup);
 
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab = searchParams.get(TAB_PARAM) || undefined;
+  const tabIndex = tabToIndex(tab);
+
+  const onChangeTab = useCallback(
+    (index: number) => {
+      const params = new URLSearchParamsWrapper(searchParams);
+      const newTab = indexToTab(index, showLogs, showMappedTasks);
+      if (newTab) params.set(TAB_PARAM, newTab);
+      else params.delete(TAB_PARAM);
+      setSearchParams(params);
+    },
+    [setSearchParams, searchParams, showLogs, showMappedTasks]
+  );
+
   useEffect(() => {
     if ((!taskId || isGroup) && tabIndex > 1) {
-      setTabIndex(1);
+      onChangeTab(1);
     }
-  }, [runId, taskId, tabIndex, setTabIndex, isGroup]);
+  }, [runId, taskId, tabIndex, isGroup, onChangeTab]);
 
   const run = dagRuns.find((r) => r.runId === runId);
   const { data: mappedTaskInstance } = useTaskInstance({
@@ -103,7 +152,7 @@ const Details = ({ openGroupIds, onToggleGroups }: Props) => {
         isLazy
         height="100%"
         index={tabIndex}
-        onChange={setTabIndex}
+        onChange={onChangeTab}
       >
         <TabList>
           <Tab>

--- a/airflow/www/static/js/dag/useSelection.ts
+++ b/airflow/www/static/js/dag/useSelection.ts
@@ -41,6 +41,7 @@ const useSelection = () => {
   };
 
   const onSelect = ({ runId, taskId, mapIndex }: SelectionProps) => {
+    // Check the window, in case params have changed since this hook was loaded
     const params = new URLSearchParams(window.location.search);
 
     if (runId) params.set(RUN_ID, runId);

--- a/airflow/www/static/js/dag/useSelection.ts
+++ b/airflow/www/static/js/dag/useSelection.ts
@@ -18,7 +18,6 @@
  */
 
 import { useSearchParams } from "react-router-dom";
-import URLSearchParamsWrapper from "src/utils/URLSearchParamWrapper";
 
 const RUN_ID = "dag_run_id";
 const TASK_ID = "task_id";
@@ -42,7 +41,7 @@ const useSelection = () => {
   };
 
   const onSelect = ({ runId, taskId, mapIndex }: SelectionProps) => {
-    const params = new URLSearchParamsWrapper(searchParams);
+    const params = new URLSearchParams(window.location.search);
 
     if (runId) params.set(RUN_ID, runId);
     else params.delete(RUN_ID);


### PR DESCRIPTION
Allow people to link directly to the graph, logs or mapped tasks tabs on grid view by adding it to the url params. Later we can build redirects to these pages when we deprecate /logs and /graph

Related: #29852, #29856

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
