### PR TITLE
Ssh connection docs: Fix wrong escaping of the newline

### DIFF
--- a/docs/apache-airflow-providers-ssh/connections/ssh.rst
+++ b/docs/apache-airflow-providers-ssh/connections/ssh.rst
@@ -99,7 +99,7 @@ Extra (optional)
 
     .. code-block:: bash
 
-       python -c 'import re, sys; print(re.sub("\r\n", "\\\\n", sys.stdin.read()))' < /path/to/your/key
+       python -c 'import re, sys; print(re.sub("\n", "\\\\n", sys.stdin.read()))' < /path/to/your/key
 
     You can then provide the result in the extras JSON as:
 


### PR DESCRIPTION
Fix replacing of `\n`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
