### PR TITLE
Limit importlib-metadata backport to < 5.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -101,7 +101,10 @@ install_requires =
     graphviz>=0.12
     gunicorn>=20.1.0
     httpx
-    importlib_metadata>=1.7;python_version<"3.9"
+    # Importlib-metadata 5 is breaking Celery import due to regression it introduced
+    # This was tracked and fixed in https://github.com/celery/celery/pull/7785 but it is not released yet
+    # We can remove the < 5.0.0 limitation hwne Celery 5.3.0 gets released and we bump celeryt o >= 5.3.0
+    importlib_metadata>=1.7,<5.0.0;python_version<"3.9"
     importlib_resources>=5.2;python_version<"3.9"
     itsdangerous>=2.0
     jinja2>=3.0.0


### PR DESCRIPTION
The Importlib-metadata 5 breaks importing Celery < 5.3.0. Until Celery 5.3.0 gets released (it is pre-release/beta now) we should workaround the problem by limiting importlib-metadata to < 5.0.0.

The fix in celery: https://github.com/celery/celery/pull/7785

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
