### PR TITLE
Fix BigQueryToGCSOperator by waiting insert_job result in normal mode

### DIFF
--- a/airflow/providers/google/cloud/transfers/bigquery_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_gcs.py
@@ -197,7 +197,7 @@ class BigQueryToGCSOperator(BaseOperator):
             job_id=job_id,
             timeout=self.result_timeout,
             retry=self.result_retry,
-            nowait=True,
+            nowait=self.deferrable,
         )
 
     def execute(self, context: Context):

--- a/tests/providers/google/cloud/transfers/test_bigquery_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_bigquery_to_gcs.py
@@ -87,7 +87,7 @@ class TestBigQueryToGCSOperator:
             location=None,
             timeout=None,
             retry=DEFAULT_RETRY,
-            nowait=True,
+            nowait=False,
         )
 
     @mock.patch("airflow.providers.google.cloud.transfers.bigquery_to_gcs.BigQueryHook")


### PR DESCRIPTION
closes: #29912 

---
In deferrable mode, we should not wait the job result in the worker, instead we create a trigger and we wait the end of the job in the triggerer, and this is what we do currently. But in the normal mode, we should wait it in the worker, otherwise the task finishes immediately with success state regardless the state of the job and its duration.