### PR TITLE
Make sure DOCKER_BUILDKIT=1 variable is set for all builds

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -464,9 +464,9 @@ def run_build_ci_image(
             output=output,
         )
     else:
+        env = os.environ.copy()
+        env["DOCKER_BUILDKIT"] = "1"
         if ci_image_params.empty_image:
-            env = os.environ.copy()
-            env["DOCKER_BUILDKIT"] = "1"
             get_console(output=output).print(
                 f"\n[info]Building empty CI Image for Python {ci_image_params.python}\n"
             )
@@ -502,6 +502,7 @@ def run_build_ci_image(
                 cwd=AIRFLOW_SOURCES_ROOT,
                 text=True,
                 check=False,
+                env=env,
                 output=output,
             )
             if build_command_result.returncode != 0 and not ci_image_params.upgrade_to_newer_dependencies:
@@ -515,6 +516,7 @@ def run_build_ci_image(
                             image_params=ci_image_params,
                         ),
                         cwd=AIRFLOW_SOURCES_ROOT,
+                        env=env,
                         text=True,
                         check=False,
                         output=output,

--- a/dev/breeze/src/airflow_breeze/commands/production_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/production_image_commands.py
@@ -482,9 +482,9 @@ def run_build_production_image(
     if prod_image_params.prepare_buildx_cache:
         build_command_result = build_cache(image_params=prod_image_params, output=output)
     else:
+        env = os.environ.copy()
+        env["DOCKER_BUILDKIT"] = "1"
         if prod_image_params.empty_image:
-            env = os.environ.copy()
-            env["DOCKER_BUILDKIT"] = "1"
             get_console(output=output).print(
                 f"\n[info]Building empty PROD Image for Python {prod_image_params.python}\n"
             )
@@ -504,6 +504,7 @@ def run_build_production_image(
                 ),
                 cwd=AIRFLOW_SOURCES_ROOT,
                 check=False,
+                env=env,
                 text=True,
                 output=output,
             )
@@ -523,6 +524,7 @@ def run_build_production_image(
                     cwd=AIRFLOW_SOURCES_ROOT,
                     check=False,
                     text=True,
+                    env=env,
                     output=output,
                 )
             if build_command_result.returncode == 0:


### PR DESCRIPTION
The DOCKER_BUILDKIT=1 was only set in some specific cases, but since our images are using buildkit features, we should always use buildkit when building the images.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
