### PR TITLE
Replace deprecated k8s registry references

### DIFF
--- a/airflow/kubernetes/pod_template_file_examples/git_sync_template.yaml
+++ b/airflow/kubernetes/pod_template_file_examples/git_sync_template.yaml
@@ -26,7 +26,7 @@ metadata:
 spec:
   initContainers:
     - name: git-sync
-      image: "k8s.gcr.io/git-sync/git-sync:v3.6.3"
+      image: "registry.k8s.io/git-sync/git-sync:v3.6.3"
       env:
         - name: GIT_SYNC_BRANCH
           value: "v2-2-stable"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -675,7 +675,7 @@
                         "repository": {
                             "description": "The gitSync image repository.",
                             "type": "string",
-                            "default": "k8s.gcr.io/git-sync/git-sync"
+                            "default": "registry.k8s.io/git-sync/git-sync"
                         },
                         "tag": {
                             "description": "The gitSync image tag.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -96,7 +96,7 @@ images:
     tag: airflow-pgbouncer-exporter-2023.02.21-0.14.0
     pullPolicy: IfNotPresent
   gitSync:
-    repository: k8s.gcr.io/git-sync/git-sync
+    repository: registry.k8s.io/git-sync/git-sync
     tag: v3.6.3
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
`k8s.gcr.io` image registry will be frozen from the 3rd of April 2023 according to this [announcement](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/), and it was replaced by `registry.k8s.io` which contains already all the images.
