### PR TITLE
Fix tags selection in DAGs UI

### DIFF
--- a/airflow/www/static/js/dags.js
+++ b/airflow/www/static/js/dags.js
@@ -61,9 +61,10 @@ $("#tags_filter").select2({
 $("#tags_filter").on("change", (e) => {
   e.preventDefault();
   const query = new URLSearchParams(window.location.search);
-  if (e.val.length) {
+  const tags = $(e.target).select2("val");
+  if (tags.length) {
     if (query.has("tags")) query.delete("tags");
-    e.val.forEach((value) => {
+    tags.forEach((value) => {
       query.append("tags", value);
     });
   } else {


### PR DESCRIPTION
The tags selection doesn't work for me without the fix (select2 on change event doesn't contain `val`, so the tags cannot be read from there).

Google Chrome: Version 109.0.5414.119 (Official Build) (x86_64)
jQuery v3.6.0

### Before:

https://user-images.githubusercontent.com/38596482/223279273-bbae473a-7828-4134-bf48-eeda965c7a1c.mov

### After:

https://user-images.githubusercontent.com/38596482/223279443-965adda9-783c-4f20-ada6-1c99568092de.mov

