### PR TITLE
Fix CI workflow by forcing python 3.7.15

### DIFF
--- a/.github/actions/breeze/action.yml
+++ b/.github/actions/breeze/action.yml
@@ -28,7 +28,7 @@ runs:
     - name: "Setup python"
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.7.15
         cache: 'pip'
         cache-dependency-path: ./dev/breeze/setup*
     - name: Cache breeze

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -108,7 +108,7 @@ jobs:
       - name: "Setup python"
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.7.15
       - name: "Retrieve defaults from branch_defaults.py"
         # We cannot "execute" the branch_defaults.py python code here because that would be
         # a security problem (we cannot run any code that comes from the sources coming from the PR.


### PR DESCRIPTION
I compared between the Build Image workflows which fail and the last succeeded one, and I found that the difference is in the python version which was 3.7.15 and now 3.7.16, so I create this PR to check if it's the problem or just a coincidence. 