### PR TITLE
Delay ConnectionModelView init until it's accessed

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -51,7 +51,6 @@ from airflow.www.extensions.init_views import (
     init_api_experimental,
     init_api_internal,
     init_appbuilder_views,
-    init_connection_form,
     init_error_handlers,
     init_flash_views,
     init_plugins,
@@ -150,7 +149,6 @@ def create_app(config=None, testing=False):
         init_appbuilder_views(flask_app)
         init_appbuilder_links(flask_app)
         init_plugins(flask_app)
-        init_connection_form()
         init_error_handlers(flask_app)
         init_api_connexion(flask_app)
         if conf.getboolean("webserver", "run_internal_api", fallback=False):

--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -150,13 +150,6 @@ def init_plugins(app):
         app.register_blueprint(blue_print["blueprint"])
 
 
-def init_connection_form():
-    """Initializes connection form"""
-    from airflow.www.views import lazy_add_provider_discovered_options_to_connection_form
-
-    lazy_add_provider_discovered_options_to_connection_form()
-
-
 def init_error_handlers(app: Flask):
     """Add custom errors handlers"""
     from airflow.www import views

--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -18,7 +18,9 @@
 from __future__ import annotations
 
 import json
+import operator
 from datetime import datetime as dt
+from typing import Iterator
 
 import pendulum
 from flask_appbuilder.fieldwidgets import (
@@ -34,7 +36,9 @@ from wtforms import widgets
 from wtforms.fields import Field, IntegerField, PasswordField, SelectField, StringField, TextAreaField
 from wtforms.validators import InputRequired, Optional
 
+from airflow.compat.functools import cache
 from airflow.configuration import conf
+from airflow.providers_manager import ProvidersManager
 from airflow.utils import timezone
 from airflow.utils.types import DagRunType
 from airflow.www.widgets import (
@@ -176,17 +180,56 @@ class TaskInstanceEditForm(DynamicForm):
     note = TextAreaField(lazy_gettext("User Note"), widget=BS3TextAreaFieldWidget())
 
 
-class ConnectionForm(DynamicForm):
-    """Form for editing and adding Connection"""
+@cache
+def create_connection_form_class() -> type[DynamicForm]:
+    """Create a form class for editing and adding Connection.
 
-    conn_id = StringField(
-        lazy_gettext("Connection Id"), validators=[InputRequired()], widget=BS3TextFieldWidget()
-    )
-    # conn_type is added later via lazy_add_provider_discovered_options_to_connection_form
-    description = StringField(lazy_gettext("Description"), widget=BS3TextAreaFieldWidget())
-    host = StringField(lazy_gettext("Host"), widget=BS3TextFieldWidget())
-    schema = StringField(lazy_gettext("Schema"), widget=BS3TextFieldWidget())
-    login = StringField(lazy_gettext("Login"), widget=BS3TextFieldWidget())
-    password = PasswordField(lazy_gettext("Password"), widget=BS3PasswordFieldWidget())
-    port = IntegerField(lazy_gettext("Port"), validators=[Optional()], widget=BS3TextFieldWidget())
-    extra = TextAreaField(lazy_gettext("Extra"), widget=BS3TextAreaFieldWidget())
+    This class is created dynamically because it relies heavily on run-time
+    provider discovery, which slows down webserver startup a lot.
+    By creating the class at runtime, we can delay loading the providers until
+    when the connection form is first used, which may as well be never for a
+    short-lived server.
+    """
+    providers_manager = ProvidersManager()
+
+    def _iter_connection_types() -> Iterator[tuple[str, str]]:
+        """List available connection types."""
+        yield ("email", "Email")
+        yield ("fs", "File (path)")
+        yield ("generic", "Generic")
+        yield ("mesos_framework-id", "Mesos Framework ID")
+        for connection_type, provider_info in providers_manager.hooks.items():
+            if provider_info:
+                yield (connection_type, provider_info.hook_name)
+
+    class ConnectionForm(DynamicForm):
+        conn_id = StringField(
+            lazy_gettext("Connection Id"),
+            validators=[InputRequired()],
+            widget=BS3TextFieldWidget(),
+        )
+        conn_type = SelectField(
+            lazy_gettext("Connection Type"),
+            choices=sorted(_iter_connection_types(), key=operator.itemgetter(1)),
+            widget=Select2Widget(),
+            validators=[InputRequired()],
+            description=(
+                "Connection Type missing? Make sure you've installed the "
+                "corresponding Airflow Provider Package."
+            ),
+        )
+        description = StringField(lazy_gettext("Description"), widget=BS3TextAreaFieldWidget())
+        host = StringField(lazy_gettext("Host"), widget=BS3TextFieldWidget())
+        schema = StringField(lazy_gettext("Schema"), widget=BS3TextFieldWidget())
+        login = StringField(lazy_gettext("Login"), widget=BS3TextFieldWidget())
+        password = PasswordField(lazy_gettext("Password"), widget=BS3PasswordFieldWidget())
+        port = IntegerField(lazy_gettext("Port"), validators=[Optional()], widget=BS3TextFieldWidget())
+        extra = TextAreaField(lazy_gettext("Extra"), widget=BS3TextAreaFieldWidget())
+
+        def iter_extra_field_names(self) -> Iterator[tuple[str, str]]:
+            return ((k, v.field_name) for k, v in providers_manager.connection_form_widgets.items())
+
+    for key, value in providers_manager.connection_form_widgets.items():
+        setattr(ConnectionForm, key, value.field)
+
+    return ConnectionForm

--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -226,9 +226,6 @@ def create_connection_form_class() -> type[DynamicForm]:
         port = IntegerField(lazy_gettext("Port"), validators=[Optional()], widget=BS3TextFieldWidget())
         extra = TextAreaField(lazy_gettext("Extra"), widget=BS3TextAreaFieldWidget())
 
-        def iter_extra_field_names(self) -> Iterator[tuple[str, str]]:
-            return ((k, v.field_name) for k, v in providers_manager.connection_form_widgets.items())
-
     for key, value in providers_manager.connection_form_widgets.items():
         setattr(ConnectionForm, key, value.field)
 

--- a/tests/test_utils/decorators.py
+++ b/tests/test_utils/decorators.py
@@ -36,7 +36,6 @@ def dont_initialize_flask_app_submodules(_func=None, *, skip_all_except=None):
             "init_appbuilder_links",
             "init_appbuilder_views",
             "init_plugins",
-            "init_connection_form",
             "init_error_handlers",
             "init_api_connexion",
             "init_api_internal",

--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -27,7 +27,6 @@ from pytest import param
 
 from airflow.models import Connection
 from airflow.utils.session import create_session
-from airflow.www.extensions import init_views
 from airflow.www.views import ConnectionFormWidget, ConnectionModelView
 from tests.test_utils.www import _check_last_log, _check_last_log_masked_connection, check_content_in_response
 
@@ -53,20 +52,19 @@ def clear_connections():
 
 
 def test_create_connection(admin_client, session):
-    init_views.init_connection_form()
     resp = admin_client.post("/connection/add", data=CONNECTION, follow_redirects=True)
     check_content_in_response("Added Row", resp)
     _check_last_log(session, dag_id=None, event="connection.create", execution_date=None)
 
 
 def test_action_logging_connection_masked_secrets(session, admin_client):
-    init_views.init_connection_form()
     admin_client.post("/connection/add", data=conn_with_extra(), follow_redirects=True)
     _check_last_log_masked_connection(session, dag_id=None, event="connection.create", execution_date=None)
 
 
 def test_prefill_form_null_extra():
     mock_form = mock.Mock()
+    mock_form.iter_extra_field_names.return_value = ()
     mock_form.data = {"conn_id": "test", "extra": None, "conn_type": "test"}
 
     cmv = ConnectionModelView()
@@ -93,13 +91,10 @@ def test_prefill_form_backcompat(extras, expected):
     Either way, the field is known internally to the model view as the prefixed value.
     """
     mock_form = mock.Mock()
+    mock_form.iter_extra_field_names.return_value = [("extra__test__my_param", "my_param")]
     mock_form.data = {"conn_id": "test", "extra": json.dumps(extras), "conn_type": "test"}
+
     cmv = ConnectionModelView()
-    cmv.extra_fields = ["extra__test__my_param"]
-
-    # this is set by `lazy_add_provider_discovered_options_to_connection_form`
-    cmv.extra_field_name_mapping["extra__test__my_param"] = "my_param"
-
     cmv.prefill_form(form=mock_form, pk=1)
     assert mock_form.extra__test__my_param.data == expected
 
@@ -118,6 +113,7 @@ def test_process_form_extras_both(mock_pm_hooks, mock_import_str, field_name):
 
     # Testing parameters set in both `Extra` and custom fields.
     mock_form = mock.Mock()
+    mock_form.iter_extra_field_names.return_value = [("extra__test__custom_field", field_name)]
     mock_form.data = {
         "conn_type": "test",
         "conn_id": "extras_test",
@@ -127,12 +123,7 @@ def test_process_form_extras_both(mock_pm_hooks, mock_import_str, field_name):
     }
 
     cmv = ConnectionModelView()
-
-    # this is set by `lazy_add_provider_discovered_options_to_connection_form`
-    cmv.extra_field_name_mapping["extra__test__custom_field"] = field_name
-    cmv.extra_fields = ["extra__test__custom_field"]  # Custom field
     cmv.process_form(form=mock_form, is_created=True)
-
     assert json.loads(mock_form.extra.data) == {
         field_name: "custom_field_val",
         "param1": "param1_val",
@@ -150,6 +141,7 @@ def test_process_form_extras_extra_only(mock_pm_hooks, mock_import_str):
     """
     # Testing parameters set in `Extra` field only.
     mock_form = mock.Mock()
+    mock_form.iter_extra_field_names.return_value = ()
     mock_form.data = {
         "conn_type": "test2",
         "conn_id": "extras_test2",
@@ -157,9 +149,7 @@ def test_process_form_extras_extra_only(mock_pm_hooks, mock_import_str):
     }
 
     cmv = ConnectionModelView()
-
     cmv.process_form(form=mock_form, is_created=True)
-
     assert json.loads(mock_form.extra.data) == {"param2": "param2_val"}
 
 
@@ -176,6 +166,10 @@ def test_process_form_extras_custom_only(mock_pm_hooks, mock_import_str, field_n
 
     # Testing parameters set in custom fields only.
     mock_form = mock.Mock()
+    mock_form.iter_extra_field_names.return_value = [
+        ("extra__test3__custom_field", field_name),
+        ("extra__test3__custom_bool_field", False),
+    ]
     mock_form.data = {
         "conn_type": "test3",
         "conn_id": "extras_test3",
@@ -184,12 +178,7 @@ def test_process_form_extras_custom_only(mock_pm_hooks, mock_import_str, field_n
     }
 
     cmv = ConnectionModelView()
-    cmv.extra_fields = ["extra__test3__custom_field", "extra__test3__custom_bool_field"]  # Custom fields
-
-    # this is set by `lazy_add_provider_discovered_options_to_connection_form`
-    cmv.extra_field_name_mapping["extra__test3__custom_field"] = field_name
     cmv.process_form(form=mock_form, is_created=True)
-
     assert json.loads(mock_form.extra.data) == {field_name: False}
 
 
@@ -206,6 +195,7 @@ def test_process_form_extras_updates(mock_pm_hooks, mock_import_str, field_name)
 
     # Testing parameters set in both extra and custom fields (connection updates).
     mock_form = mock.Mock()
+    mock_form.iter_extra_field_names.return_value = [("extra__test4__custom_field", field_name)]
     mock_form.data = {
         "conn_type": "test4",
         "conn_id": "extras_test4",
@@ -214,11 +204,6 @@ def test_process_form_extras_updates(mock_pm_hooks, mock_import_str, field_name)
     }
 
     cmv = ConnectionModelView()
-    cmv.extra_fields = ["extra__test4__custom_field"]  # Custom field
-
-    # this is set by `lazy_add_provider_discovered_options_to_connection_form`
-    cmv.extra_field_name_mapping["extra__test4__custom_field"] = field_name
-
     cmv.process_form(form=mock_form, is_created=True)
 
     if field_name == "custom_field":
@@ -343,10 +328,6 @@ def test_process_form_invalid_extra_removed(admin_client):
     Test that when an invalid json `extra` is passed in the form, it is removed and _not_
     saved over the existing extras.
     """
-    from airflow.www.views import lazy_add_provider_discovered_options_to_connection_form
-
-    lazy_add_provider_discovered_options_to_connection_form()
-
     conn_details = {"conn_id": "test_conn", "conn_type": "http"}
     conn = Connection(**conn_details, extra='{"foo": "bar"}')
     conn.id = 1

--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -64,10 +64,10 @@ def test_action_logging_connection_masked_secrets(session, admin_client):
 
 def test_prefill_form_null_extra():
     mock_form = mock.Mock()
-    mock_form.iter_extra_field_names.return_value = ()
     mock_form.data = {"conn_id": "test", "extra": None, "conn_type": "test"}
 
     cmv = ConnectionModelView()
+    cmv._iter_extra_field_names = mock.Mock(return_value=())
     cmv.prefill_form(form=mock_form, pk=1)
 
 
@@ -91,10 +91,10 @@ def test_prefill_form_backcompat(extras, expected):
     Either way, the field is known internally to the model view as the prefixed value.
     """
     mock_form = mock.Mock()
-    mock_form.iter_extra_field_names.return_value = [("extra__test__my_param", "my_param")]
     mock_form.data = {"conn_id": "test", "extra": json.dumps(extras), "conn_type": "test"}
 
     cmv = ConnectionModelView()
+    cmv._iter_extra_field_names = mock.Mock(return_value=[("extra__test__my_param", "my_param")])
     cmv.prefill_form(form=mock_form, pk=1)
     assert mock_form.extra__test__my_param.data == expected
 
@@ -113,7 +113,6 @@ def test_process_form_extras_both(mock_pm_hooks, mock_import_str, field_name):
 
     # Testing parameters set in both `Extra` and custom fields.
     mock_form = mock.Mock()
-    mock_form.iter_extra_field_names.return_value = [("extra__test__custom_field", field_name)]
     mock_form.data = {
         "conn_type": "test",
         "conn_id": "extras_test",
@@ -123,6 +122,7 @@ def test_process_form_extras_both(mock_pm_hooks, mock_import_str, field_name):
     }
 
     cmv = ConnectionModelView()
+    cmv._iter_extra_field_names = mock.Mock(return_value=[("extra__test__custom_field", field_name)])
     cmv.process_form(form=mock_form, is_created=True)
     assert json.loads(mock_form.extra.data) == {
         field_name: "custom_field_val",
@@ -141,7 +141,6 @@ def test_process_form_extras_extra_only(mock_pm_hooks, mock_import_str):
     """
     # Testing parameters set in `Extra` field only.
     mock_form = mock.Mock()
-    mock_form.iter_extra_field_names.return_value = ()
     mock_form.data = {
         "conn_type": "test2",
         "conn_id": "extras_test2",
@@ -149,6 +148,7 @@ def test_process_form_extras_extra_only(mock_pm_hooks, mock_import_str):
     }
 
     cmv = ConnectionModelView()
+    cmv._iter_extra_field_names = mock.Mock(return_value=())
     cmv.process_form(form=mock_form, is_created=True)
     assert json.loads(mock_form.extra.data) == {"param2": "param2_val"}
 
@@ -166,10 +166,6 @@ def test_process_form_extras_custom_only(mock_pm_hooks, mock_import_str, field_n
 
     # Testing parameters set in custom fields only.
     mock_form = mock.Mock()
-    mock_form.iter_extra_field_names.return_value = [
-        ("extra__test3__custom_field", field_name),
-        ("extra__test3__custom_bool_field", False),
-    ]
     mock_form.data = {
         "conn_type": "test3",
         "conn_id": "extras_test3",
@@ -178,6 +174,12 @@ def test_process_form_extras_custom_only(mock_pm_hooks, mock_import_str, field_n
     }
 
     cmv = ConnectionModelView()
+    cmv._iter_extra_field_names = mock.Mock(
+        return_value=[
+            ("extra__test3__custom_field", field_name),
+            ("extra__test3__custom_bool_field", False),
+        ],
+    )
     cmv.process_form(form=mock_form, is_created=True)
     assert json.loads(mock_form.extra.data) == {field_name: False}
 
@@ -195,7 +197,6 @@ def test_process_form_extras_updates(mock_pm_hooks, mock_import_str, field_name)
 
     # Testing parameters set in both extra and custom fields (connection updates).
     mock_form = mock.Mock()
-    mock_form.iter_extra_field_names.return_value = [("extra__test4__custom_field", field_name)]
     mock_form.data = {
         "conn_type": "test4",
         "conn_id": "extras_test4",
@@ -204,6 +205,7 @@ def test_process_form_extras_updates(mock_pm_hooks, mock_import_str, field_name)
     }
 
     cmv = ConnectionModelView()
+    cmv._iter_extra_field_names = mock.Mock(return_value=[("extra__test4__custom_field", field_name)])
     cmv.process_form(form=mock_form, is_created=True)
 
     if field_name == "custom_field":


### PR DESCRIPTION
This removed the "lazy" initialization of ConnectionModelView (and ConnectionForm used by it) that happens when the webserver first launches, and moves the corresponding logic to until the view is actually being accessed.

This further delays the provider manager from loading connection form widgets until the last possible moment and speeds up the webserver's startup sequence.

While this does make the connection form view a bit slower (only the first time since the result is cached), the slowdown should not be as noticeable since the provider manager should generally be partially loaded into memory at that point.