### PR TITLE
Fix some new graph bugs

### DIFF
--- a/airflow/www/static/js/dag/details/graph/Node.tsx
+++ b/airflow/www/static/js/dag/details/graph/Node.tsx
@@ -131,7 +131,12 @@ const Node = ({
             }
           }}
         >
-          <Flex justifyContent="space-between" width={width} p={2}>
+          <Flex
+            justifyContent="space-between"
+            width={width}
+            p={2}
+            flexWrap="wrap"
+          >
             <Flex flexDirection="column">
               <Text noOfLines={1} maxWidth={`calc(${width}px - 8px)`}>
                 {taskName}

--- a/airflow/www/static/js/dag/details/graph/utils.ts
+++ b/airflow/www/static/js/dag/details/graph/utils.ts
@@ -151,15 +151,24 @@ export const buildEdges = ({
       const targetIds = e.target.split(".");
       const isSelected =
         selectedTaskId &&
-        (e.source === selectedTaskId || e.target === selectedTaskId);
+        (e.source.includes(selectedTaskId) ||
+          e.target.includes(selectedTaskId));
 
       if (
         sourceIds.length === targetIds.length &&
         sourceIds[0] === targetIds[0]
       ) {
-        const parentIds =
+        let parentIds =
           sourceIds.length > targetIds.length ? sourceIds : targetIds;
-        parentIds.pop();
+
+        if (e.target.includes("_join_id") && e.source.includes("_join_id")) {
+          /** edges between join ids are positioned absolutely,
+           * other edges are positioned relative to their parent */
+          parentIds = [];
+        } else {
+          // remove the last node
+          parentIds.pop();
+        }
         let parentX = 0;
         let parentY = 0;
 

--- a/airflow/www/static/js/dag/details/graph/utils.ts
+++ b/airflow/www/static/js/dag/details/graph/utils.ts
@@ -161,7 +161,7 @@ export const buildEdges = ({
         let parentIds =
           sourceIds.length > targetIds.length ? sourceIds : targetIds;
 
-        if (e.target.includes("_join_id") && e.source.includes("_join_id")) {
+        if (e.target.endsWith("_join_id") && e.source.endsWith("_join_id")) {
           /** edges between join ids are positioned absolutely,
            * other edges are positioned relative to their parent */
           parentIds = [];


### PR DESCRIPTION
1. Edges between two different join nodes we're being positioned incorrectly. Edges inside of groups are positioned relative to the group as a whole, but between groups are positioned absolutely.

2. Wrap task group text to prevent overflow.

3. Highlight all edges related to a task group when a group is selected


| Before  | After |
| ------------- | ------------- |
| <img width="285" alt="Screenshot 2023-03-02 at 3 51 58 PM" src="https://user-images.githubusercontent.com/4600967/223462095-f2bdebdc-0105-40b5-8632-1632ae29a01e.png">  | <img width="365" alt="Screenshot 2023-03-02 at 3 52 05 PM" src="https://user-images.githubusercontent.com/4600967/223462131-a8e0b616-f964-4e5c-a123-9f78bc9adf06.png">  |
| <img width="869" alt="Screenshot 2023-03-07 at 10 09 50 AM" src="https://user-images.githubusercontent.com/4600967/223463160-a9f4dd95-3d35-41b7-8cf2-0b528c3237ae.png"> | <img width="995" alt="Screenshot 2023-03-07 at 10 09 33 AM" src="https://user-images.githubusercontent.com/4600967/223463200-012ebe13-5744-45d5-9ef2-46d2d8c7c576.png"> |





---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
