### PR TITLE
Update docker image python version to 3.7 in entrypoint.rst

### DIFF
--- a/docs/docker-stack/entrypoint.rst
+++ b/docs/docker-stack/entrypoint.rst
@@ -132,7 +132,7 @@ if you specify extra arguments. For example:
 
 .. code-block:: bash
 
-  docker run -it apache/airflow:2.6.0.dev0-python3.6 bash -c "ls -la"
+  docker run -it apache/airflow:2.6.0.dev0-python3.7 bash -c "ls -la"
   total 16
   drwxr-xr-x 4 airflow root 4096 Jun  5 18:12 .
   drwxr-xr-x 1 root    root 4096 Jun  5 18:12 ..
@@ -144,7 +144,7 @@ you pass extra parameters. For example:
 
 .. code-block:: bash
 
-  > docker run -it apache/airflow:2.6.0.dev0-python3.6 python -c "print('test')"
+  > docker run -it apache/airflow:2.6.0.dev0-python3.7 python -c "print('test')"
   test
 
 If first argument equals to "airflow" - the rest of the arguments is treated as an airflow command
@@ -152,13 +152,13 @@ to execute. Example:
 
 .. code-block:: bash
 
-   docker run -it apache/airflow:2.6.0.dev0-python3.6 airflow webserver
+   docker run -it apache/airflow:2.6.0.dev0-python3.7 airflow webserver
 
 If there are any other arguments - they are simply passed to the "airflow" command
 
 .. code-block:: bash
 
-  > docker run -it apache/airflow:2.6.0.dev0-python3.6 help
+  > docker run -it apache/airflow:2.6.0.dev0-python3.7 help
     usage: airflow [-h] GROUP_OR_COMMAND ...
 
     positional arguments:


### PR DESCRIPTION
Python 3.6 support was dropped a while ago.

This update the container images used in the `entrypoint.rst` doc. Without this, we reference images that do not exist such as:
![image](https://user-images.githubusercontent.com/14861206/223553793-88607390-c177-450f-83f4-83891b4cb267.png)
