### PR TITLE
fix dag docs toggle icon initial angle

### DIFF
--- a/airflow/www/templates/appbuilder/dag_docs.html
+++ b/airflow/www/templates/appbuilder/dag_docs.html
@@ -23,7 +23,7 @@
       <div class="panel panel-default">
         <div class="panel-heading" role="tab" id="headingOne">
           <h4 class="panel-title">
-            <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne" class="accordion-toggle">
+            <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne" class="accordion-toggle collapsed">
               <span class="material-icons" aria-hidden="true">info_outline</span>
               DAG Docs
               <span class="material-icons pull-right toggle-direction" aria-hidden="true">expand_less</span>


### PR DESCRIPTION

Dag docs toggle icon face upward when page loaded.
<img width="800" alt="Screenshot 2023-03-08 at 13 58 21" src="https://user-images.githubusercontent.com/62637758/223624114-7cc8c0ca-1fca-49e8-8f34-7bd9ad36cb71.png">

Fix toggle icons to face down by default
<img width="800" alt="Screenshot 2023-03-08 at 13 58 29" src="https://user-images.githubusercontent.com/62637758/223624118-5f09de9c-9883-4fe7-9d31-41dbc2f31d17.png">