### PR TITLE
Enhance `SparkKubernetesOperator`

### DIFF
--- a/tests/providers/apache/flink/operators/test_flink_kubernetes.py
+++ b/tests/providers/apache/flink/operators/test_flink_kubernetes.py
@@ -197,11 +197,8 @@ class TestFlinkKubernetesOperator:
         args = {"owner": "airflow", "start_date": timezone.datetime(2020, 2, 1)}
         self.dag = DAG("test_dag_id", default_args=args)
 
-    @patch("kubernetes.client.api.custom_objects_api.CustomObjectsApi.delete_namespaced_custom_object")
     @patch("kubernetes.client.api.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object")
-    def test_create_application_from_yaml(
-        self, mock_create_namespaced_crd, mock_delete_namespaced_crd, mock_kubernetes_hook
-    ):
+    def test_create_application_from_yaml(self, mock_create_namespaced_crd, mock_kubernetes_hook):
         op = FlinkKubernetesOperator(
             application_file=TEST_VALID_APPLICATION_YAML,
             dag=self.dag,
@@ -210,13 +207,7 @@ class TestFlinkKubernetesOperator:
         )
         op.execute(None)
         mock_kubernetes_hook.assert_called_once_with()
-        mock_delete_namespaced_crd.assert_called_once_with(
-            group="flink.apache.org",
-            namespace="default",
-            plural="flinkdeployments",
-            version="v1beta1",
-            name=TEST_APPLICATION_DICT["metadata"]["name"],
-        )
+
         mock_create_namespaced_crd.assert_called_with(
             body=TEST_APPLICATION_DICT,
             group="flink.apache.org",
@@ -225,11 +216,8 @@ class TestFlinkKubernetesOperator:
             version="v1beta1",
         )
 
-    @patch("kubernetes.client.api.custom_objects_api.CustomObjectsApi.delete_namespaced_custom_object")
     @patch("kubernetes.client.api.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object")
-    def test_create_application_from_json(
-        self, mock_create_namespaced_crd, mock_delete_namespaced_crd, mock_kubernetes_hook
-    ):
+    def test_create_application_from_json(self, mock_create_namespaced_crd, mock_kubernetes_hook):
         op = FlinkKubernetesOperator(
             application_file=TEST_VALID_APPLICATION_JSON,
             dag=self.dag,
@@ -238,13 +226,7 @@ class TestFlinkKubernetesOperator:
         )
         op.execute(None)
         mock_kubernetes_hook.assert_called_once_with()
-        mock_delete_namespaced_crd.assert_called_once_with(
-            group="flink.apache.org",
-            namespace="default",
-            plural="flinkdeployments",
-            version="v1beta1",
-            name=TEST_APPLICATION_DICT["metadata"]["name"],
-        )
+
         mock_create_namespaced_crd.assert_called_with(
             body=TEST_APPLICATION_DICT,
             group="flink.apache.org",
@@ -253,10 +235,9 @@ class TestFlinkKubernetesOperator:
             version="v1beta1",
         )
 
-    @patch("kubernetes.client.api.custom_objects_api.CustomObjectsApi.delete_namespaced_custom_object")
     @patch("kubernetes.client.api.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object")
     def test_create_application_from_json_with_api_group_and_version(
-        self, mock_create_namespaced_crd, mock_delete_namespaced_crd, mock_kubernetes_hook
+        self, mock_create_namespaced_crd, mock_kubernetes_hook
     ):
         api_group = "flink.apache.org"
         api_version = "v1beta1"
@@ -270,13 +251,7 @@ class TestFlinkKubernetesOperator:
         )
         op.execute(None)
         mock_kubernetes_hook.assert_called_once_with()
-        mock_delete_namespaced_crd.assert_called_once_with(
-            group=api_group,
-            namespace="default",
-            plural="flinkdeployments",
-            version=api_version,
-            name=TEST_APPLICATION_DICT["metadata"]["name"],
-        )
+
         mock_create_namespaced_crd.assert_called_with(
             body=TEST_APPLICATION_DICT,
             group=api_group,
@@ -285,11 +260,8 @@ class TestFlinkKubernetesOperator:
             version=api_version,
         )
 
-    @patch("kubernetes.client.api.custom_objects_api.CustomObjectsApi.delete_namespaced_custom_object")
     @patch("kubernetes.client.api.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object")
-    def test_namespace_from_operator(
-        self, mock_create_namespaced_crd, mock_delete_namespaced_crd, mock_kubernetes_hook
-    ):
+    def test_namespace_from_operator(self, mock_create_namespaced_crd, mock_kubernetes_hook):
         op = FlinkKubernetesOperator(
             application_file=TEST_VALID_APPLICATION_JSON,
             dag=self.dag,
@@ -299,13 +271,7 @@ class TestFlinkKubernetesOperator:
         )
         op.execute(None)
         mock_kubernetes_hook.assert_called_once_with()
-        mock_delete_namespaced_crd.assert_called_once_with(
-            group="flink.apache.org",
-            namespace="operator_namespace",
-            plural="flinkdeployments",
-            version="v1beta1",
-            name=TEST_APPLICATION_DICT["metadata"]["name"],
-        )
+
         mock_create_namespaced_crd.assert_called_with(
             body=TEST_APPLICATION_DICT,
             group="flink.apache.org",
@@ -314,11 +280,8 @@ class TestFlinkKubernetesOperator:
             version="v1beta1",
         )
 
-    @patch("kubernetes.client.api.custom_objects_api.CustomObjectsApi.delete_namespaced_custom_object")
     @patch("kubernetes.client.api.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object")
-    def test_namespace_from_connection(
-        self, mock_create_namespaced_crd, mock_delete_namespaced_crd, mock_kubernetes_hook
-    ):
+    def test_namespace_from_connection(self, mock_create_namespaced_crd, mock_kubernetes_hook):
         op = FlinkKubernetesOperator(
             application_file=TEST_VALID_APPLICATION_JSON,
             dag=self.dag,
@@ -328,13 +291,7 @@ class TestFlinkKubernetesOperator:
         op.execute(None)
 
         mock_kubernetes_hook.assert_called_once_with()
-        mock_delete_namespaced_crd.assert_called_once_with(
-            group="flink.apache.org",
-            namespace="mock_namespace",
-            plural="flinkdeployments",
-            version="v1beta1",
-            name=TEST_APPLICATION_DICT["metadata"]["name"],
-        )
+
         mock_create_namespaced_crd.assert_called_with(
             body=TEST_APPLICATION_DICT,
             group="flink.apache.org",

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes_pod.py
@@ -358,6 +358,31 @@ class TestKubernetesHook:
             mock_get_client.assert_called_with(cluster_context="test")
             assert kubernetes_hook.get_namespace() == "test"
 
+    @patch("kubernetes.config.kube_config.KubeConfigLoader")
+    @patch("kubernetes.config.kube_config.KubeConfigMerger")
+    @patch(f"{HOOK_MODULE}.client.CustomObjectsApi")
+    def test_delete_custom_object(
+        self, mock_custom_object_api, mock_kube_config_merger, mock_kube_config_loader
+    ):
+        hook = KubernetesHook()
+        hook.delete_custom_object(
+            group="group",
+            version="version",
+            plural="plural",
+            name="name",
+            namespace="namespace",
+            _preload_content="_preload_content",
+        )
+
+        mock_custom_object_api.return_value.delete_namespaced_custom_object.assert_called_once_with(
+            group="group",
+            version="version",
+            plural="plural",
+            name="name",
+            namespace="namespace",
+            _preload_content="_preload_content",
+        )
+
 
 class TestKubernetesHookIncorrectConfiguration:
     @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:


How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Enhancement on `SparkKubernetesOperator`:

- log the spark driver output to the airflow
- provide `on_kill` method 
- re-write `SparkKubernetesOperator` tests in `pytest`
- generalise  and simplify `create_custom_object` and `get_custom_object` on `KubernetesHook`:
   - they are not only about `SparkApplication`
   - (In my opinion) deleting previous object is out of scope this method and airflow
   

closes: #21325