### PR TITLE
Avoid considering EmptyOperator in mini scheduler

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2651,7 +2651,11 @@ class TaskInstance(Base, LoggingMixin):
                 task_id for task_id in partial_dag.task_ids if task_id not in task.downstream_task_ids
             }
 
-            schedulable_tis = [ti for ti in info.schedulable_tis if ti.task_id not in skippable_task_ids]
+            schedulable_tis = [
+                ti
+                for ti in info.schedulable_tis
+                if ti.task_id not in skippable_task_ids and not ti.task.inherits_from_empty_operator
+            ]
             for schedulable_ti in schedulable_tis:
                 if not hasattr(schedulable_ti, "task"):
                     schedulable_ti.task = task.dag.get_task(schedulable_ti.task_id)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2654,7 +2654,13 @@ class TaskInstance(Base, LoggingMixin):
             schedulable_tis = [
                 ti
                 for ti in info.schedulable_tis
-                if ti.task_id not in skippable_task_ids and not ti.task.inherits_from_empty_operator
+                if ti.task_id not in skippable_task_ids
+                and not (
+                    ti.task.inherits_from_empty_operator
+                    and not ti.task.on_execute_callback
+                    and not ti.task.on_success_callback
+                    and not ti.task.outlets
+                )
             ]
             for schedulable_ti in schedulable_tis:
                 if not hasattr(schedulable_ti, "task"):

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -3897,9 +3897,9 @@ def test_empty_operator_is_not_considered_in_mini_scheduler(dag_maker, caplog, s
         second_task = dag_run.get_task_instance(task_id="second_task")
         third_task = dag_run.get_task_instance(task_id="third_task")
         forth_task = dag_run.get_task_instance(task_id="forth_task")
-        assert second_task.state != State.NONE
+        assert second_task.state == State.SCHEDULED
         assert third_task.state == State.NONE
-        assert forth_task.state != State.NONE
+        assert forth_task.state == State.SCHEDULED
         assert "2 downstream tasks scheduled from follow-on schedule" in caplog.text
 
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -3859,6 +3859,44 @@ def test_mapped_task_does_not_error_in_mini_scheduler_if_upstreams_are_not_done(
     assert "0 downstream tasks scheduled from follow-on schedule" in caplog.text
 
 
+def test_empty_operator_is_not_considered_in_mini_scheduler(dag_maker, caplog, session):
+    """
+    This tests verify that operators with inherits_from_empty_operator are not considered by mini scheduler.
+    Such operators should not run on workers thus the mini scheduler optimization should skip them and not
+    submit them directly to worker.
+    """
+    with dag_maker() as dag:
+
+        @dag.task
+        def first_task():
+            print(2)
+
+        @dag.task
+        def second_task():
+            print(2)
+
+        third_task = EmptyOperator(task_id="third_task")
+
+        first_task() >> [second_task(), third_task]
+        dag_run = dag_maker.create_dagrun()
+        first_ti = dag_run.get_task_instance(task_id="first_task")
+        second_ti = dag_run.get_task_instance(task_id="second_task")
+        third_ti = dag_run.get_task_instance(task_id="third_task")
+        first_ti.state = State.SUCCESS
+        second_ti.state = State.NONE
+        third_ti.state = State.NONE
+        session.merge(first_ti)
+        session.merge(second_ti)
+        session.merge(third_ti)
+        session.commit()
+        first_ti.schedule_downstream_tasks(session=session)
+        second_task = dag_run.get_task_instance(task_id="second_task")
+        third_task = dag_run.get_task_instance(task_id="third_task")
+        assert second_task.state != State.NONE
+        assert third_task.state == State.NONE
+        assert "1 downstream tasks scheduled from follow-on schedule" in caplog.text
+
+
 def test_mapped_task_expands_in_mini_scheduler_if_upstreams_are_done(dag_maker, caplog, session):
     """Test that mini scheduler expands mapped task"""
     with dag_maker() as dag:


### PR DESCRIPTION
EmptyOperator should not be executed on workers thus it should not be considered for the mini scheduler optimization. closes: https://github.com/apache/airflow/issues/29974


TODO:
- [x] add test

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
