### PR TITLE
Update set-up-database.rst

### DIFF
--- a/docs/apache-airflow/howto/set-up-database.rst
+++ b/docs/apache-airflow/howto/set-up-database.rst
@@ -167,6 +167,9 @@ In the example below, a database ``airflow_db`` and user  with username ``airflo
    CREATE DATABASE airflow_db;
    CREATE USER airflow_user WITH PASSWORD 'airflow_pass';
    GRANT ALL PRIVILEGES ON DATABASE airflow_db TO airflow_user;
+   -- PostgreSQL 15 requires additional privileges:
+   USE airflow_db;
+   GRANT ALL ON SCHEMA public TO airflow_user;
 
 .. note::
 


### PR DESCRIPTION
In the [documentation](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-up-database.html#choosing-database-backend) we state that we support Postgres 15.
There's a [breaking change](https://www.postgresql.org/docs/release/15.0/) in Postgres 15:

> Remove PUBLIC creation permission on the [public schema](https://www.postgresql.org/docs/15/ddl-schemas.html#DDL-SCHEMAS-PUBLIC)

The two additional steps are required in order to run `airflow db init`.
More info in [SO](https://stackoverflow.com/questions/75647987/init-a-new-postgres-15-db-as-airflows-backend/75682570#75682570)