### PR TITLE
Add missing snowflake in `scripts/ci/installed_providers.txt`

### DIFF
--- a/scripts/ci/installed_providers.txt
+++ b/scripts/ci/installed_providers.txt
@@ -18,5 +18,6 @@ redis
 sendgrid
 sftp
 slack
+snowflake
 sqlite
 ssh


### PR DESCRIPTION
fix test docker_tests.test_prod_image.TestPythonPackages.test_required_providers_are_installed which failed in `main`
