### PR TITLE
Return error when group is not defined in breeze configuration

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/setup_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/setup_commands.py
@@ -492,7 +492,7 @@ def find_options_in_options_list(option: str, option_list: list[list[str]]) -> i
     return None
 
 
-def check_params(command: str, subcommand: str | None, command_dict: dict[str, Any]) -> bool:
+def errors_detected_in_params(command: str, subcommand: str | None, command_dict: dict[str, Any]) -> bool:
     import rich_click
 
     get_console().print(
@@ -508,7 +508,7 @@ def check_params(command: str, subcommand: str | None, command_dict: dict[str, A
             f"defined in rich click configuration."
         )
         get_console().print(f"[warning]Please add it to the `{command_path_config(command)}`.")
-        return False
+        return True
     rich_click_param_groups = options[rich_click_key]
     defined_param_names = [
         param["opts"] for param in command_dict["params"] if param["param_type_name"] == "option"
@@ -567,10 +567,10 @@ def check_that_all_params_are_in_groups(commands: tuple[str, ...]) -> int:
         if "commands" in current_command_dict:
             subcommands = current_command_dict["commands"]
             for subcommand in sorted(subcommands.keys()):
-                if check_params(command, subcommand, subcommands[subcommand]):
+                if errors_detected_in_params(command, subcommand, subcommands[subcommand]):
                     errors_detected = True
         else:
-            if check_params(command, None, current_command_dict):
+            if errors_detected_in_params(command, None, current_command_dict):
                 errors_detected = True
     return 1 if errors_detected else 0
 


### PR DESCRIPTION
When group was not found in Breeze configuration, we printed error but did not return error code - thus we missed the fact that some groups were not defined in breeze configuration.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
