### PR TITLE
Don't separate setup/teardowns from normal task

### DIFF
--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -284,8 +284,6 @@
         "is_mapped": { "type": "boolean" },
         "prefix_group_id": { "type": "boolean" },
         "children":  { "$ref": "#/definitions/dict" },
-        "setup_children":  { "$ref": "#/definitions/dict" },
-        "teardown_children":  { "$ref": "#/definitions/dict" },
         "tooltip": { "type": "string" },
         "ui_color": { "type": "string" },
         "ui_fgcolor": { "type": "string" },

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1323,13 +1323,6 @@ class TaskGroupSerialization(BaseSerialization):
             "tooltip": task_group.tooltip,
             "ui_color": task_group.ui_color,
             "ui_fgcolor": task_group.ui_fgcolor,
-            "setup_children": {
-                label: child.serialize_for_task_group() for label, child in task_group.setup_children.items()
-            },
-            "teardown_children": {
-                label: child.serialize_for_task_group()
-                for label, child in task_group.teardown_children.items()
-            },
             "children": {
                 label: child.serialize_for_task_group() for label, child in task_group.children.items()
             },
@@ -1380,18 +1373,6 @@ class TaskGroupSerialization(BaseSerialization):
             task.task_group = weakref.proxy(group)
             return task
 
-        group.setup_children = {
-            label: set_ref(task_dict[val])
-            if _type == DAT.OP
-            else cls.deserialize_task_group(val, group, task_dict, dag=dag)
-            for label, (_type, val) in encoded_group["setup_children"].items()
-        }
-        group.teardown_children = {
-            label: set_ref(task_dict[val])
-            if _type == DAT.OP
-            else cls.deserialize_task_group(val, group, task_dict, dag=dag)
-            for label, (_type, val) in encoded_group["teardown_children"].items()
-        }
         group.children = {
             label: set_ref(task_dict[val])
             if _type == DAT.OP

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -29,11 +29,9 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             mytask()
 
-        setup_task = dag.task_group.setup_children["mytask"]
+        assert len(dag.task_group.children) == 1
+        setup_task = dag.task_group.children["mytask"]
         assert setup_task._is_setup
-        assert len(dag.task_group.setup_children) == 1
-        assert len(dag.task_group.children) == 0
-        assert len(dag.task_group.teardown_children) == 0
 
     def test_marking_functions_as_teardown_task(self, dag_maker):
         @teardown
@@ -43,11 +41,9 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             mytask()
 
-        teardown_task = dag.task_group.teardown_children["mytask"]
+        assert len(dag.task_group.children) == 1
+        teardown_task = dag.task_group.children["mytask"]
         assert teardown_task._is_teardown
-        assert len(dag.task_group.setup_children) == 0
-        assert len(dag.task_group.children) == 0
-        assert len(dag.task_group.teardown_children) == 1
 
     def test_marking_decorated_functions_as_setup_task(self, dag_maker):
         @setup
@@ -58,11 +54,9 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             mytask()
 
-        setup_task = dag.task_group.setup_children["mytask"]
+        assert len(dag.task_group.children) == 1
+        setup_task = dag.task_group.children["mytask"]
         assert setup_task._is_setup
-        assert len(dag.task_group.setup_children) == 1
-        assert len(dag.task_group.children) == 0
-        assert len(dag.task_group.teardown_children) == 0
 
     def test_marking_operator_as_setup_task(self, dag_maker):
         from airflow.operators.bash import BashOperator
@@ -70,11 +64,9 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             BashOperator.as_setup(task_id="mytask", bash_command='echo "I am a setup task"')
 
-        setup_task = dag.task_group.setup_children["mytask"]
+        assert len(dag.task_group.children) == 1
+        setup_task = dag.task_group.children["mytask"]
         assert setup_task._is_setup
-        assert len(dag.task_group.setup_children) == 1
-        assert len(dag.task_group.children) == 0
-        assert len(dag.task_group.teardown_children) == 0
 
     def test_marking_decorated_functions_as_teardown_task(self, dag_maker):
         @teardown
@@ -85,11 +77,9 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             mytask()
 
-        teardown_task = dag.task_group.teardown_children["mytask"]
+        assert len(dag.task_group.children) == 1
+        teardown_task = dag.task_group.children["mytask"]
         assert teardown_task._is_teardown
-        assert len(dag.task_group.setup_children) == 0
-        assert len(dag.task_group.children) == 0
-        assert len(dag.task_group.teardown_children) == 1
 
     def test_marking_operator_as_teardown_task(self, dag_maker):
         from airflow.operators.bash import BashOperator
@@ -97,11 +87,9 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             BashOperator.as_teardown(task_id="mytask", bash_command='echo "I am a setup task"')
 
-        teardown_task = dag.task_group.teardown_children["mytask"]
+        assert len(dag.task_group.children) == 1
+        teardown_task = dag.task_group.children["mytask"]
         assert teardown_task._is_teardown
-        assert len(dag.task_group.setup_children) == 0
-        assert len(dag.task_group.children) == 0
-        assert len(dag.task_group.teardown_children) == 1
 
     def test_setup_taskgroup(self, dag_maker):
         @setup
@@ -116,14 +104,10 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             mygroup()
 
-        assert len(dag.task_group.setup_children) == 1
-        assert len(dag.task_group.children) == 0
-        assert len(dag.task_group.teardown_children) == 0
-        setup_task_group = dag.task_group.setup_children["mygroup"]
-        assert len(setup_task_group.setup_children) == 1
-        assert len(setup_task_group.children) == 0
-        assert len(setup_task_group.teardown_children) == 0
-        setup_task = setup_task_group.setup_children["mygroup.mytask"]
+        assert len(dag.task_group.children) == 1
+        setup_task_group = dag.task_group.children["mygroup"]
+        assert len(setup_task_group.children) == 1
+        setup_task = setup_task_group.children["mygroup.mytask"]
         assert setup_task._is_setup
 
     def test_teardown_taskgroup(self, dag_maker):
@@ -139,12 +123,8 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             mygroup()
 
-        assert len(dag.task_group.setup_children) == 0
-        assert len(dag.task_group.children) == 0
-        assert len(dag.task_group.teardown_children) == 1
-        teardown_task_group = dag.task_group.teardown_children["mygroup"]
-        assert len(teardown_task_group.setup_children) == 0
-        assert len(teardown_task_group.children) == 0
-        assert len(teardown_task_group.teardown_children) == 1
-        teardown_task = teardown_task_group.teardown_children["mygroup.mytask"]
+        assert len(dag.task_group.children) == 1
+        teardown_task_group = dag.task_group.children["mygroup"]
+        assert len(teardown_task_group.children) == 1
+        teardown_task = teardown_task_group.children["mygroup.mytask"]
         assert teardown_task._is_teardown

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -126,8 +126,6 @@ serialized_simple_dag_ground_truth = {
         "_task_group": {
             "_group_id": None,
             "prefix_group_id": True,
-            "setup_children": {},
-            "teardown_children": {},
             "children": {"bash_task": ("operator", "bash_task"), "custom_task": ("operator", "custom_task")},
             "tooltip": "",
             "ui_color": "CornflowerBlue",
@@ -1302,6 +1300,10 @@ class TestStringifiedDAGs:
 
         check_task_group(serialized_dag.task_group)
 
+    @staticmethod
+    def _check_taskgroup_children(se_task_group, dag_task_group, expected_children):
+        assert se_task_group.children.keys() == dag_task_group.children.keys() == expected_children
+
     def test_task_group_setup_teardown_tasks(self):
         """
         Test TaskGroup setup and teardown task serialization/deserialization.
@@ -1330,40 +1332,24 @@ class TestStringifiedDAGs:
 
         serialized_dag = SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(dag))
 
-        def _check_taskgroup_children(
-            se_task_group, dag_task_group, expected_setup, expected_children, expected_teardown
-        ):
-            assert list(se_task_group.children.keys()) == expected_children
-            assert list(dag_task_group.children.keys()) == expected_children
-
-            assert list(se_task_group.setup_children.keys()) == expected_setup
-            assert list(dag_task_group.setup_children.keys()) == expected_setup
-
-            assert list(se_task_group.teardown_children.keys()) == expected_teardown
-            assert list(dag_task_group.teardown_children.keys()) == expected_teardown
-
-        _check_taskgroup_children(
-            serialized_dag.task_group, dag.task_group, ["setup"], ["group1"], ["teardown"]
+        self._check_taskgroup_children(
+            serialized_dag.task_group, dag.task_group, {"setup", "teardown", "group1"}
         )
 
         se_first_group = serialized_dag.task_group.children["group1"]
         dag_first_group = dag.task_group.children["group1"]
-        _check_taskgroup_children(
+        self._check_taskgroup_children(
             se_first_group,
             dag_first_group,
-            ["group1.setup1"],
-            ["group1.task1", "group1.group2"],
-            ["group1.teardown1"],
+            {"group1.setup1", "group1.task1", "group1.group2", "group1.teardown1"},
         )
 
         se_second_group = se_first_group.children["group1.group2"]
         dag_second_group = dag_first_group.children["group1.group2"]
-        _check_taskgroup_children(
+        self._check_taskgroup_children(
             se_second_group,
             dag_second_group,
-            ["group1.group2.setup2"],
-            ["group1.group2.task2"],
-            ["group1.group2.teardown2"],
+            {"group1.group2.setup2", "group1.group2.task2", "group1.group2.teardown2"},
         )
 
     def test_task_group_setup_teardown_taskgroups(self):
@@ -1402,51 +1388,25 @@ class TestStringifiedDAGs:
 
         serialized_dag = SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(dag))
 
-        def _check_taskgroup_children(
-            se_task_group, dag_task_group, expected_setup, expected_children, expected_teardown
-        ):
-            assert list(se_task_group.children.keys()) == expected_children
-            assert list(dag_task_group.children.keys()) == expected_children
-
-            assert list(se_task_group.setup_children.keys()) == expected_setup
-            assert list(dag_task_group.setup_children.keys()) == expected_setup
-
-            assert list(se_task_group.teardown_children.keys()) == expected_teardown
-            assert list(dag_task_group.teardown_children.keys()) == expected_teardown
-
-        _check_taskgroup_children(
-            serialized_dag.task_group, dag.task_group, ["setup_group"], ["sometask"], ["teardown_group"]
+        self._check_taskgroup_children(
+            serialized_dag.task_group, dag.task_group, {"setup_group", "sometask", "teardown_group"}
         )
 
-        se_setup_group = serialized_dag.task_group.setup_children["setup_group"]
-        dag_setup_group = dag.task_group.setup_children["setup_group"]
-        _check_taskgroup_children(
-            se_setup_group,
-            dag_setup_group,
-            ["setup_group.setup1", "setup_group.sub_setup"],
-            [],
-            [],
+        se_setup_group = serialized_dag.task_group.children["setup_group"]
+        dag_setup_group = dag.task_group.children["setup_group"]
+        self._check_taskgroup_children(
+            se_setup_group, dag_setup_group, {"setup_group.setup1", "setup_group.sub_setup"}
         )
 
-        se_sub_setup_group = se_setup_group.setup_children["setup_group.sub_setup"]
-        dag_sub_setup_group = dag_setup_group.setup_children["setup_group.sub_setup"]
-        _check_taskgroup_children(
-            se_sub_setup_group,
-            dag_sub_setup_group,
-            ["setup_group.sub_setup.setup2"],
-            [],
-            [],
+        se_sub_setup_group = se_setup_group.children["setup_group.sub_setup"]
+        dag_sub_setup_group = dag_setup_group.children["setup_group.sub_setup"]
+        self._check_taskgroup_children(
+            se_sub_setup_group, dag_sub_setup_group, {"setup_group.sub_setup.setup2"}
         )
 
-        se_teardown_group = serialized_dag.task_group.teardown_children["teardown_group"]
-        dag_teardown_group = dag.task_group.teardown_children["teardown_group"]
-        _check_taskgroup_children(
-            se_teardown_group,
-            dag_teardown_group,
-            [],
-            [],
-            ["teardown_group.teardown1"],
-        )
+        se_teardown_group = serialized_dag.task_group.children["teardown_group"]
+        dag_teardown_group = dag.task_group.children["teardown_group"]
+        self._check_taskgroup_children(se_teardown_group, dag_teardown_group, {"teardown_group.teardown1"})
 
     def test_deps_sorted(self):
         """
@@ -2506,8 +2466,6 @@ def test_mapped_task_group_serde():
         "taskgroup",
         {
             "_group_id": "tg",
-            "setup_children": {},
-            "teardown_children": {},
             "children": {
                 "tg.op1": ("operator", "tg.op1"),
                 # "tg.op2": ("operator", "tg.op2"),

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1301,7 +1301,7 @@ class TestStringifiedDAGs:
         check_task_group(serialized_dag.task_group)
 
     @staticmethod
-    def _check_taskgroup_children(se_task_group, dag_task_group, expected_children):
+    def assert_taskgroup_children(se_task_group, dag_task_group, expected_children):
         assert se_task_group.children.keys() == dag_task_group.children.keys() == expected_children
 
     def test_task_group_setup_teardown_tasks(self):
@@ -1332,13 +1332,13 @@ class TestStringifiedDAGs:
 
         serialized_dag = SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(dag))
 
-        self._check_taskgroup_children(
+        self.assert_taskgroup_children(
             serialized_dag.task_group, dag.task_group, {"setup", "teardown", "group1"}
         )
 
         se_first_group = serialized_dag.task_group.children["group1"]
         dag_first_group = dag.task_group.children["group1"]
-        self._check_taskgroup_children(
+        self.assert_taskgroup_children(
             se_first_group,
             dag_first_group,
             {"group1.setup1", "group1.task1", "group1.group2", "group1.teardown1"},
@@ -1346,7 +1346,7 @@ class TestStringifiedDAGs:
 
         se_second_group = se_first_group.children["group1.group2"]
         dag_second_group = dag_first_group.children["group1.group2"]
-        self._check_taskgroup_children(
+        self.assert_taskgroup_children(
             se_second_group,
             dag_second_group,
             {"group1.group2.setup2", "group1.group2.task2", "group1.group2.teardown2"},
@@ -1388,25 +1388,25 @@ class TestStringifiedDAGs:
 
         serialized_dag = SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(dag))
 
-        self._check_taskgroup_children(
+        self.assert_taskgroup_children(
             serialized_dag.task_group, dag.task_group, {"setup_group", "sometask", "teardown_group"}
         )
 
         se_setup_group = serialized_dag.task_group.children["setup_group"]
         dag_setup_group = dag.task_group.children["setup_group"]
-        self._check_taskgroup_children(
+        self.assert_taskgroup_children(
             se_setup_group, dag_setup_group, {"setup_group.setup1", "setup_group.sub_setup"}
         )
 
         se_sub_setup_group = se_setup_group.children["setup_group.sub_setup"]
         dag_sub_setup_group = dag_setup_group.children["setup_group.sub_setup"]
-        self._check_taskgroup_children(
+        self.assert_taskgroup_children(
             se_sub_setup_group, dag_sub_setup_group, {"setup_group.sub_setup.setup2"}
         )
 
         se_teardown_group = serialized_dag.task_group.children["teardown_group"]
         dag_teardown_group = dag.task_group.children["teardown_group"]
-        self._check_taskgroup_children(se_teardown_group, dag_teardown_group, {"teardown_group.teardown1"})
+        self.assert_taskgroup_children(se_teardown_group, dag_teardown_group, {"teardown_group.teardown1"})
 
     def test_deps_sorted(self):
         """


### PR DESCRIPTION
Instead of keeping setup and teardown tasks separate from the normal task list in Task Groups, we will put them all into children together. Attributes on the tasks are all we need to support the setup/teardowns feature, and keeping them as normal-task-like as possible is desirable.