### PR TITLE
Merge GCSObjectExistenceAsyncSensor logic to GCSObjectExistenceSensor

### DIFF
--- a/airflow/providers/google/cloud/sensors/gcs.py
+++ b/airflow/providers/google/cloud/sensors/gcs.py
@@ -104,7 +104,7 @@ class GCSObjectExistenceSensor(BaseSensorOperator):
 
     def execute(self, context: Context) -> None:
         """Airflow runs this method on the worker and defers using the trigger."""
-        if self.deferrable is False:
+        if not self.deferrable:
             super().execute(context)
         else:
             self.defer(

--- a/airflow/providers/google/cloud/sensors/gcs.py
+++ b/airflow/providers/google/cloud/sensors/gcs.py
@@ -22,7 +22,7 @@ import os
 import textwrap
 import warnings
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Callable, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 from google.api_core.retry import Retry
 from google.cloud.storage.retry import DEFAULT_RETRY
@@ -75,6 +75,7 @@ class GCSObjectExistenceSensor(BaseSensorOperator):
         delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         retry: Retry = DEFAULT_RETRY,
+        deferrable: bool = False,
         **kwargs,
     ) -> None:
 
@@ -90,6 +91,8 @@ class GCSObjectExistenceSensor(BaseSensorOperator):
         self.impersonation_chain = impersonation_chain
         self.retry = retry
 
+        self.deferrable = deferrable
+
     def poke(self, context: Context) -> bool:
         self.log.info("Sensor checks existence of : %s, %s", self.bucket, self.object)
         hook = GCSHook(
@@ -99,10 +102,43 @@ class GCSObjectExistenceSensor(BaseSensorOperator):
         )
         return hook.exists(self.bucket, self.object, self.retry)
 
+    def execute(self, context: Context) -> None:
+        """Airflow runs this method on the worker and defers using the trigger."""
+        if self.deferrable is False:
+            super().execute(context)
+        else:
+            self.defer(
+                timeout=timedelta(seconds=self.timeout),
+                trigger=GCSBlobTrigger(
+                    bucket=self.bucket,
+                    object_name=self.object,
+                    poke_interval=self.poke_interval,
+                    google_cloud_conn_id=self.google_cloud_conn_id,
+                    hook_params={
+                        "delegate_to": self.delegate_to,
+                        "impersonation_chain": self.impersonation_chain,
+                    },
+                ),
+                method_name="execute_complete",
+            )
+
+    def execute_complete(self, context: Context, event: dict[str, str]) -> str:
+        """
+        Callback for when the trigger fires - returns immediately.
+        Relies on trigger to throw an exception, otherwise it assumes execution was
+        successful.
+        """
+        if event["status"] == "error":
+            raise AirflowException(event["message"])
+        self.log.info("File %s was found in bucket %s.", self.object, self.bucket)
+        return event["message"]
+
 
 class GCSObjectExistenceAsyncSensor(GCSObjectExistenceSensor):
     """
-    Checks for the existence of a file in Google Cloud Storage .
+    Checks for the existence of a file in Google Cloud Storage.
+    Class `GCSObjectExistenceAsyncSensor` is deprecated and will be removed in a future release.
+    Please use `GCSObjectExistenceSensor` and set `deferrable` attribute to `True` instead
 
     :param bucket: The Google Cloud Storage bucket where the object is.
     :param object: The name of the object to check in the Google cloud storage bucket.
@@ -120,33 +156,13 @@ class GCSObjectExistenceAsyncSensor(GCSObjectExistenceSensor):
         account from the list granting this role to the originating account (templated).
     """
 
-    def execute(self, context: Context) -> None:
-        """Airflow runs this method on the worker and defers using the trigger."""
-        self.defer(
-            timeout=timedelta(seconds=self.timeout),
-            trigger=GCSBlobTrigger(
-                bucket=self.bucket,
-                object_name=self.object,
-                poke_interval=self.poke_interval,
-                google_cloud_conn_id=self.google_cloud_conn_id,
-                hook_params={
-                    "delegate_to": self.delegate_to,
-                    "impersonation_chain": self.impersonation_chain,
-                },
-            ),
-            method_name="execute_complete",
+    def __init__(self, **kwargs: Any) -> None:
+        warnings.warn(
+            "Class `GCSObjectExistenceAsyncSensor` is deprecated and will be removed in a future release. "
+            "Please use `GCSObjectExistenceSensor` and set `deferrable` attribute to `True` instead",
+            DeprecationWarning,
         )
-
-    def execute_complete(self, context: Context, event: dict[str, str]) -> str:
-        """
-        Callback for when the trigger fires - returns immediately.
-        Relies on trigger to throw an exception, otherwise it assumes execution was
-        successful.
-        """
-        if event["status"] == "error":
-            raise AirflowException(event["message"])
-        self.log.info("File %s was found in bucket %s.", self.object, self.bucket)
-        return event["message"]
+        super().__init__(deferrable=True, **kwargs)
 
 
 def ts_function(context):

--- a/docs/apache-airflow-providers-google/operators/cloud/gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/gcs.rst
@@ -164,14 +164,20 @@ Use the :class:`~airflow.providers.google.cloud.sensors.gcs.GCSObjectExistenceSe
     :start-after: [START howto_sensor_object_exists_task]
     :end-before: [END howto_sensor_object_exists_task]
 
+Also you can use deferrable mode in this operator if you would like to free up the worker slots while the sensor is running.
+
+.. exampleinclude:: /../../tests/system/providers/google/cloud/gcs/example_gcs_sensor.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_sensor_object_exists_task_defered]
+    :end-before: [END howto_sensor_object_exists_task_defered]
 
 .. _howto/sensor:GCSObjectExistenceAsyncSensor:
 
 GCSObjectExistenceAsyncSensor
 -----------------------------
 
-Use the :class:`~airflow.providers.google.cloud.sensors.gcs.GCSObjectExistenceAsyncSensor`
-(deferrable version) if you would like to free up the worker slots while the sensor is running.
+:class:`~airflow.providers.google.cloud.sensors.gcs.GCSObjectExistenceAsyncSensor` is deprecated and will be removed in a future release. Please use :class:`~airflow.providers.google.cloud.sensors.gcs.GCSObjectExistenceSensor` and use the deferrable mode in that operator.
 
 .. exampleinclude:: /../../tests/system/providers/google/cloud/gcs/example_gcs_sensor.py
     :language: python

--- a/tests/system/providers/google/cloud/gcs/example_gcs_sensor.py
+++ b/tests/system/providers/google/cloud/gcs/example_gcs_sensor.py
@@ -124,6 +124,12 @@ with models.DAG(
     )
     # [END howto_sensor_object_exists_task_async]
 
+    # [START howto_sensor_object_exists_task_defered]
+    gcs_object_exists_defered = GCSObjectExistenceSensor(
+        bucket=BUCKET_NAME, object=FILE_NAME, task_id="gcs_object_exists_defered", deferrable=True
+    )
+    # [END howto_sensor_object_exists_task_defered]
+
     # [START howto_sensor_object_with_prefix_exists_task]
     gcs_object_with_prefix_exists = GCSObjectsWithPrefixExistenceSensor(
         bucket=BUCKET_NAME,
@@ -144,7 +150,12 @@ with models.DAG(
         sleep,
         upload_file,
         # TEST BODY
-        [gcs_object_exists, gcs_object_exists_async, gcs_object_with_prefix_exists],
+        [
+            gcs_object_exists,
+            gcs_object_exists_defered,
+            gcs_object_exists_async,
+            gcs_object_with_prefix_exists,
+        ],
         # TEST TEARDOWN
         delete_bucket,
     )


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---

### Why making this change?
apache-airflow-providers-google treats the deferred execution of its operators and sensors in a different way which might cause confusion. For example, [BigQueryCheckOperator](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/operators/bigquery.py#L200) uses the [deferrable](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/operators/bigquery.py#L200) parameter to toggle deferred execution while we need to use another sensor for [GCSObjectExistenceSensor](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/sensors/gcs.py#L39) (i.e., [GCSObjectExistenceAsyncSensor](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/sensors/gcs.py#L103)) to achieve the same thing.

### What's changed?
In this pull request, I move the deferred logic from [GCSObjectExistenceAsyncSensor](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/sensors/gcs.py#L103) to [GCSObjectExistenceSensor](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/sensors/gcs.py#L39) so that we can keep the consistency and reduce maintenance effort. Instead of removing [GCSObjectExistenceAsyncSensor](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/sensors/gcs.py#L103), I add a deprecation warning in case there're users using it.

---

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
