### PR TITLE
Update documentation for snowflake provider 4.0 breaking change

### DIFF
--- a/airflow/providers/snowflake/CHANGELOG.rst
+++ b/airflow/providers/snowflake/CHANGELOG.rst
@@ -73,6 +73,12 @@ However in this case the result returned by ``execute`` method is unchanged (it 
 rather than sequences and those dictionaries are pushed to XCom, so your DAGs relying on this behaviour
 should continue working without any change.
 
+UPDATE: One of the unmentioned, breaking changes in the operator in 4.0 line was to switch autocommit to
+False by default. While not very friendly to the users, it was a side effect of unifying the interface
+with other SQL operators and we released it to the users, so switching it back again would cause even more
+confusion. You should manually add autocommit=True to your SnowflakeOperator if you want to continue using
+it and expect autocommit to work, but even better, you should switch to SQLExecuteQueryOperator.
+
 In SnowflakeHook, if both ``extra__snowflake__foo`` and ``foo`` existed in connection extra
 dict, the prefixed version would be used; now, the non-prefixed version will be preferred.
 

--- a/airflow/providers/snowflake/operators/snowflake.py
+++ b/airflow/providers/snowflake/operators/snowflake.py
@@ -41,8 +41,6 @@ class SnowflakeOperator(SQLExecuteQueryOperator):
     :param sql: the SQL code to be executed as a single string, or
         a list of str (sql statements), or a reference to a template file.
         Template references are recognized by str ending in '.sql'
-    :param autocommit: if True, each command is automatically committed.
-        (default value: True)
     :param parameters: (optional) the parameters to render the SQL query with.
     :param warehouse: name of warehouse (will overwrite any warehouse
         defined in the connection's extra JSON)


### PR DESCRIPTION
The 4.0 version of Snowflake was breaking a little more than we described it originally, This PR adds explicit mentioning of the autocommit flag change.

Fixes: #30010

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
