### PR TITLE
Git clean should work if root owned files are in the working tree

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
@@ -63,7 +63,8 @@ def git_tag(version):
 
 def git_clean():
     if confirm_action("Clean git repo?"):
-        run_command(["sudo", "git", "clean", "-fxd"], dry_run_override=DRY_RUN, check=True)
+        run_command(["breeze", "ci", "fix-ownership"], dry_run_override=DRY_RUN, check=True)
+        run_command(["git", "clean", "-fxd"], dry_run_override=DRY_RUN, check=True)
         console_print("Git repo cleaned")
 
 

--- a/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
@@ -63,7 +63,7 @@ def git_tag(version):
 
 def git_clean():
     if confirm_action("Clean git repo?"):
-        run_command(["git", "clean", "-fxd"], dry_run_override=DRY_RUN, check=True)
+        run_command(["sudo", "git", "clean", "-fxd"], dry_run_override=DRY_RUN, check=True)
         console_print("Git repo cleaned")
 
 

--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -74,6 +74,8 @@ function in_container_fix_ownership() {
             "${AIRFLOW_SOURCES}/dags"
             "${AIRFLOW_SOURCES}/airflow/"
             "${AIRFLOW_SOURCES}/images/"
+            "${AIRFLOW_SOURCES}/.mypy_cache/"
+            "${AIRFLOW_SOURCES}/dev/"
         )
         count_matching=$(find "${DIRECTORIES_TO_FIX[@]}" -mindepth 1 -user root -printf . 2>/dev/null | wc -m || true)
         if [[ ${count_matching=} != "0" && ${count_matching=} != "" ]]; then


### PR DESCRIPTION
```
breeze release-management start-rc-process --version ${VERSION} --previous-version 2.5.1
```

Can fail if there are root owned files in the working tree. This can happen especially in the `.logs` folder.

edit: ~This runs the `git clean` as root to not fail with a 'PermissionError' and make sure that all files are actually deleted before going further.~ Run `fix_ownership` before cleaning the git repo