### PR TITLE
added python 3.11 to classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: System :: Monitoring
     Framework :: Apache Airflow
 project_urls =


### PR DESCRIPTION
I want to declare python 3.11 support and add the support if not supported yet.

I am not 100% sure about the whole CI system of the project yet, but most probably updates in https://github.com/apache/airflow/blob/main/pyproject.toml#L19 and other places are also required, right? any pointer would be highly appreciated