### PR TITLE
Support `CloudDataTransferServiceJobStatusSensor` without specifying a `project_id`

### DIFF
--- a/airflow/providers/google/cloud/sensors/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/sensors/cloud_storage_transfer_service.py
@@ -93,7 +93,7 @@ class CloudDataTransferServiceJobStatusSensor(BaseSensorOperator):
             impersonation_chain=self.impersonation_chain,
         )
         operations = hook.list_transfer_operations(
-            request_filter={"project_id": self.project_id, "job_names": [self.job_name]}
+            request_filter={"project_id": self.project_id or hook.project_id, "job_names": [self.job_name]}
         )
 
         for operation in operations:

--- a/tests/providers/google/cloud/sensors/test_cloud_storage_transfer_service.py
+++ b/tests/providers/google/cloud/sensors/test_cloud_storage_transfer_service.py
@@ -72,8 +72,41 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor:
     @mock.patch(
         "airflow.providers.google.cloud.sensors.cloud_storage_transfer_service.CloudDataTransferServiceHook"
     )
-    def test_wait_for_status_success_default_expected_status(self, mock_tool):
+    def test_wait_for_status_success_without_project_id(self, mock_tool):
+        operations = [
+            {
+                "name": TEST_NAME,
+                "metadata": {
+                    "status": GcpTransferOperationStatus.SUCCESS,
+                    "counters": TEST_COUNTERS,
+                },
+            }
+        ]
+        mock_tool.return_value.list_transfer_operations.return_value = operations
+        mock_tool.operations_contain_expected_statuses.return_value = True
+        mock_tool.return_value.project_id = "project-id"
 
+        op = CloudDataTransferServiceJobStatusSensor(
+            task_id="task-id",
+            job_name=JOB_NAME,
+            expected_statuses=GcpTransferOperationStatus.SUCCESS,
+        )
+
+        context = {"ti": (mock.Mock(**{"xcom_push.return_value": None}))}
+        result = op.poke(context)
+
+        mock_tool.return_value.list_transfer_operations.assert_called_once_with(
+            request_filter={"project_id": "project-id", "job_names": [JOB_NAME]}
+        )
+        mock_tool.operations_contain_expected_statuses.assert_called_once_with(
+            operations=operations, expected_statuses={GcpTransferOperationStatus.SUCCESS}
+        )
+        assert result
+
+    @mock.patch(
+        "airflow.providers.google.cloud.sensors.cloud_storage_transfer_service.CloudDataTransferServiceHook"
+    )
+    def test_wait_for_status_success_default_expected_status(self, mock_tool):
         op = CloudDataTransferServiceJobStatusSensor(
             task_id="task-id",
             job_name=JOB_NAME,


### PR DESCRIPTION

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---

The document is written as follows

> project_id: (Optional) the ID of the project that owns the Transfer
        Job. If set to None or missing, the default project_id from the Google Cloud
        connection is used.

However, when omitted my `project_id`, the following error occurred. I'm certain that `project_id` is set in the extra field of the `google_cloud_default` connection because I can retrieve my `project_id` using `hook.project_id`

```
[2023-03-09, 02:31:24 UTC] {taskinstance.py:1774} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/sensors/base.py", line 236, in execute
    while not self.poke(context):
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/providers/google/cloud/sensors/cloud_storage_transfer_service.py", line 91, in poke
    operations = hook.list_transfer_operations(
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py", line 380, in list_transfer_operations
    request_filter = self._inject_project_id(request_filter, FILTER, FILTER_PROJECT_ID)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py", line 459, in _inject_project_id
    raise AirflowException(
airflow.exceptions.AirflowException: The project id must be passed either as `project_id` key in `filter` parameter or as project_id extra in Google Cloud connection definition. Both are not set!
```

It appears like`project_id` is required as part of the `request_filter`


**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
