### PR TITLE
Disable ordering DagRuns search result by note

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -5059,7 +5059,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         "queued_at",
         "start_date",
         "end_date",
-        "note",
+        # "note", # todo: maybe figure out how to re-enable this
         "external_trigger",
         "conf",
     ]


### PR DESCRIPTION
closes: #30041
related: #27849

---
After moving the notes to a new table, we removed `note` from the supported search and sort columns for all the APIs, and it seems we forgot disabling this one.  