### PR TITLE
Update scripts to make our pgbouncer-related scripts multiplatform

### DIFF
--- a/chart/dockerfiles/pgbouncer-exporter/build_and_push.sh
+++ b/chart/dockerfiles/pgbouncer-exporter/build_and_push.sh
@@ -45,8 +45,18 @@ cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
 
 center_text "Building image"
 
-docker build . \
+# Note, you need buildx and qemu installed for your docker. They come pre-installed with docker-desktop, but
+# as described in:
+# * https://docs.docker.com/build/install-buildx/
+# * https://docs.docker.com/build/building/multi-platform/
+# You can also install them easily on all docker-based systems
+# You might also need to create a different builder to build multi-platform images
+# For example by running `docker buildx create --use`
+
+docker buildx build . \
+    --platform linux/amd64,linux/arm64 \
     --pull \
+    --push \
     --build-arg "PGBOUNCER_EXPORTER_VERSION=${PGBOUNCER_EXPORTER_VERSION}" \
     --build-arg "AIRFLOW_PGBOUNCER_EXPORTER_VERSION=${AIRFLOW_PGBOUNCER_EXPORTER_VERSION}"\
     --build-arg "COMMIT_SHA=${COMMIT_SHA}" \
@@ -56,10 +66,3 @@ docker build . \
 center_text "Checking image"
 
 docker run --rm "${TAG}" --version
-
-echo Image labels:
-docker inspect "${TAG}" --format '{{ json .ContainerConfig.Labels }}' | python3 -m json.tool
-
-center_text "Pushing image"
-
-docker push "${TAG}"

--- a/chart/dockerfiles/pgbouncer/build_and_push.sh
+++ b/chart/dockerfiles/pgbouncer/build_and_push.sh
@@ -46,8 +46,18 @@ cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
 
 center_text "Building image"
 
-docker build . \
+# Note, you need buildx and qemu installed for your docker. They come pre-installed with docker-desktop, but
+# as described in:
+# * https://docs.docker.com/build/install-buildx/
+# * https://docs.docker.com/build/building/multi-platform/
+# You can also install them easily on all docker-based systems
+# You might also need to create a different builder to build multi-platform images
+# For example by running `docker buildx create --use`
+
+docker buildx build . \
+    --platform linux/amd64,linux/arm64 \
     --pull \
+    --push \
     --build-arg "PGBOUNCER_VERSION=${PGBOUNCER_VERSION}" \
     --build-arg "AIRFLOW_PGBOUNCER_VERSION=${AIRFLOW_PGBOUNCER_VERSION}"\
     --build-arg "PGBOUNCER_SHA256=${PGBOUNCER_SHA256}"\
@@ -57,9 +67,3 @@ docker build . \
 center_text "Checking image"
 
 docker run --rm "${TAG}" pgbouncer --version
-
-echo Image labels:
-docker inspect "${TAG}" --format '{{ json .ContainerConfig.Labels }}' | python3 -m json.tool
-
-center_text "Pushing image"
-docker push "${TAG}"

--- a/chart/newsfragments/30054.significant.rst
+++ b/chart/newsfragments/30054.significant.rst
@@ -1,0 +1,4 @@
+The pgbouncer and pgbouncer-images are based on newer software/os. They are also multi-platform AMD/ARM images:
+
+* pgbouncer: 1.16.1 based on alpine 3.14 (airflow-pgbouncer-2023.02.24-1.16.1)
+* pgbouncer-exporter: 0.14.0 based on alpine 3.17 (apache/airflow:airflow-pgbouncer-exporter-2023.02.21-0.14.0)


### PR DESCRIPTION
The images were traditionally amd-only and they are used by the Helm Chart, however this means that if someone uses the chart on ARM, they have an emulated performance (16x slower or so).

This change switches our scripts to use the buildx and qemu (by default installed with Docker Desktop) to build and push multiplatform images.

Fixes: #29967

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
