### PR TITLE
Remove unused key_id variable

### DIFF
--- a/airflow/providers/hashicorp/hooks/vault.py
+++ b/airflow/providers/hashicorp/hooks/vault.py
@@ -186,10 +186,6 @@ class VaultHook(BaseHook):
             else (None, None)
         )
 
-        key_id = self.connection.extra_dejson.get("key_id")
-        if not key_id:
-            key_id = self.connection.login
-
         if self.connection.conn_type == "vault":
             conn_protocol = "http"
         elif self.connection.conn_type == "vaults":


### PR DESCRIPTION
The variable `key_id` loaded from connection extra is not used, we pass directly the connection login to the client, and since we already deprecated `role_id` and we asked the users to use connection login, I think we can just remove this code instead of replacing `key_id=self.connection.login` by `key_id=key_id` and add a deprecation warning.