### PR TITLE
SLA callbacks no longer add files to the dag_processing manager queue

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -1187,7 +1187,7 @@ class DagFileProcessorManager(LoggingMixin):
 
         for file_path in files_paths_to_queue:
             self._file_stats.setdefault(file_path, DagFileProcessorManager.DEFAULT_FILE_STAT)
-        self._add_paths_to_queue(files_paths_to_queue)
+        self._add_paths_to_queue(files_paths_to_queue, False)
         Stats.incr("dag_processing.file_path_queue_update_count")
 
     def _kill_timed_out_processors(self):
@@ -1226,7 +1226,7 @@ class DagFileProcessorManager(LoggingMixin):
         for proc in processors_to_remove:
             self._processors.pop(proc)
 
-    def _add_paths_to_queue(self, file_paths_to_enqueue: list[str], add_at_front: bool = False):
+    def _add_paths_to_queue(self, file_paths_to_enqueue: list[str], add_at_front: bool):
         """Adds stuff to the back or front of the file queue, unless it's already present"""
         new_file_paths = list(p for p in file_paths_to_enqueue if p not in self._file_path_queue)
         if add_at_front:

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -366,6 +366,10 @@ class DagFileProcessorManager(LoggingMixin):
     :param async_mode: whether to start the manager in async mode
     """
 
+    DEFAULT_FILE_STAT = DagFileStat(
+        num_dags=0, import_errors=0, last_finish_time=None, last_duration=None, run_count=0
+    )
+
     def __init__(
         self,
         dag_directory: os.PathLike,
@@ -377,6 +381,7 @@ class DagFileProcessorManager(LoggingMixin):
         async_mode: bool = True,
     ):
         super().__init__()
+        # known files; this will be updated every `dag_dir_list_interval` and stuff added/removed accordingly
         self._file_paths: list[str] = []
         self._file_path_queue: collections.deque[str] = collections.deque()
         self._max_runs = max_runs
@@ -618,11 +623,14 @@ class DagFileProcessorManager(LoggingMixin):
 
             self._kill_timed_out_processors()
 
-            # Generate more file paths to process if we processed all the files
-            # already.
+            # Generate more file paths to process if we processed all the files already. Note for this
+            # to clear down, we must have cleared all files found from scanning the dags dir _and_ have
+            # cleared all files added as a result of callbacks
             if not self._file_path_queue:
                 self.emit_metrics()
                 self.prepare_file_path_queue()
+
+            # if new files found in dag dir, add them
             elif refreshed_dag_dir:
                 self.add_new_file_path_to_queue()
 
@@ -709,14 +717,19 @@ class DagFileProcessorManager(LoggingMixin):
                 self.log.debug("Skipping already queued SlaCallbackRequest")
                 return
 
-            # not already queued, queue the file _at the back_, and add the request to the file's callbacks
+            # not already queued, queue the callback
+            # do NOT add the file of this SLA to self._file_path_queue. SLAs can arrive so rapidly that
+            # they keep adding to the file queue and never letting it drain. This in turn prevents us from
+            # ever rescanning the dags folder for changes to existing dags. We simply store the callback, and
+            # periodically, when self._file_path_queue is drained, we rescan and re-queue all DAG files.
+            # The SLAs will be picked up then. It means a delay in reacting to the SLAs (as controlled by the
+            # min_file_process_interval config) but stops SLAs from DoS'ing the queue.
             self.log.debug("Queuing SlaCallbackRequest for %s", request.dag_id)
             self._callback_to_execute[request.full_filepath].append(request)
-            if request.full_filepath not in self._file_path_queue:
-                self._file_path_queue.append(request.full_filepath)
+            Stats.incr("dag_processing.sla_callback_count")
 
         # Other callbacks have a higher priority over DAG Run scheduling, so those callbacks gazump, even if
-        # already in the queue
+        # already in the file path queue
         else:
             self.log.debug("Queuing %s CallbackRequest: %s", type(request).__name__, request)
             self._callback_to_execute[request.full_filepath].append(request)
@@ -727,7 +740,8 @@ class DagFileProcessorManager(LoggingMixin):
                 self._file_path_queue = collections.deque(
                     file_path for file_path in self._file_path_queue if file_path != request.full_filepath
                 )
-            self._file_path_queue.appendleft(request.full_filepath)
+            self._add_paths_to_queue([request.full_filepath], True)
+            Stats.incr("dag_processing.other_callback_count")
 
     def _refresh_dag_dir(self):
         """Refresh file paths from dag dir if we haven't done it for too long."""
@@ -959,7 +973,15 @@ class DagFileProcessorManager(LoggingMixin):
         :return: None
         """
         self._file_paths = new_file_paths
+
+        # clean up the queues; remove anything queued which no longer in the list, including callbacks
         self._file_path_queue = collections.deque(x for x in self._file_path_queue if x in new_file_paths)
+        Stats.gauge("dag_processing.file_path_queue_size", len(self._file_path_queue))
+
+        callback_paths_to_del = list(x for x in self._callback_to_execute.keys() if x not in new_file_paths)
+        for path_to_del in callback_paths_to_del:
+            del self._callback_to_execute[path_to_del]
+
         # Stop processors that are working on deleted files
         filtered_processors = {}
         for file_path, processor in self._processors.items():
@@ -1066,18 +1088,22 @@ class DagFileProcessorManager(LoggingMixin):
             self._processors[file_path] = processor
             self.waitables[processor.waitable_handle] = processor
 
+            Stats.gauge("dag_processing.file_path_queue_size", len(self._file_path_queue))
+
     def add_new_file_path_to_queue(self):
         for file_path in self.file_paths:
             if file_path not in self._file_stats:
                 # We found new file after refreshing dir. add to parsing queue at start
                 self.log.info("Adding new file %s to parsing queue", file_path)
-                self._file_stats[file_path] = DagFileStat(
-                    num_dags=0, import_errors=0, last_finish_time=None, last_duration=None, run_count=0
-                )
+                self._file_stats[file_path] = DagFileProcessorManager.DEFAULT_FILE_STAT
                 self._file_path_queue.appendleft(file_path)
 
     def prepare_file_path_queue(self):
-        """Generate more file paths to process. Result are saved in _file_path_queue."""
+        """
+        Scan dags dir to generate more file paths to process.
+
+        Note this method is only called when the file path queue is empty
+        """
         self._parsing_start_time = time.perf_counter()
         # If the file path is already being processed, or if a file was
         # processed recently, wait until the next batch
@@ -1159,12 +1185,10 @@ class DagFileProcessorManager(LoggingMixin):
 
         self.log.debug("Queuing the following files for processing:\n\t%s", "\n\t".join(files_paths_to_queue))
 
-        default = DagFileStat(
-            num_dags=0, import_errors=0, last_finish_time=None, last_duration=None, run_count=0
-        )
         for file_path in files_paths_to_queue:
-            self._file_stats.setdefault(file_path, default)
-        self._file_path_queue.extend(files_paths_to_queue)
+            self._file_stats.setdefault(file_path, DagFileProcessorManager.DEFAULT_FILE_STAT)
+        self._add_paths_to_queue(files_paths_to_queue)
+        Stats.incr("dag_processing.file_path_queue_update_count")
 
     def _kill_timed_out_processors(self):
         """Kill any file processors that timeout to defend against process hangs."""
@@ -1201,6 +1225,15 @@ class DagFileProcessorManager(LoggingMixin):
         # Clean up `self._processors` after iterating over it
         for proc in processors_to_remove:
             self._processors.pop(proc)
+
+    def _add_paths_to_queue(self, file_paths_to_enqueue: list[str], add_at_front: bool = False):
+        """Adds stuff to the back or front of the file queue, unless it's already present"""
+        new_file_paths = list(p for p in file_paths_to_enqueue if p not in self._file_path_queue)
+        if add_at_front:
+            self._file_path_queue.extendleft(new_file_paths)
+        else:
+            self._file_path_queue.extend(new_file_paths)
+        Stats.gauge("dag_processing.file_path_queue_size", len(self._file_path_queue))
 
     def max_runs_reached(self):
         """:return: whether all file paths have been processed max_runs times."""

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -978,7 +978,7 @@ class DagFileProcessorManager(LoggingMixin):
         self._file_path_queue = collections.deque(x for x in self._file_path_queue if x in new_file_paths)
         Stats.gauge("dag_processing.file_path_queue_size", len(self._file_path_queue))
 
-        callback_paths_to_del = list(x for x in self._callback_to_execute.keys() if x not in new_file_paths)
+        callback_paths_to_del = [x for x in self._callback_to_execute if x not in new_file_paths]
         for path_to_del in callback_paths_to_del:
             del self._callback_to_execute[path_to_del]
 

--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
@@ -95,6 +95,9 @@ Name                                                                   Descripti
 ``scheduler_heartbeat``                                                Scheduler heartbeats
 ``dag_processing.processes``                                           Number of currently running DAG parsing processes
 ``dag_processing.processor_timeouts``                                  Number of file processors that have been killed due to taking too long
+``dag_processing.sla_callback_count``                                  Number of SLA callbacks received
+``dag_processing.other_callback_count``                                Number of non-SLA callbacks received
+``dag_processing.file_path_queue_update_count``                        Number of times we've scanned the filesystem and queued all existing dags
 ``dag_file_processor_timeouts``                                        (DEPRECATED) same behavior as ``dag_processing.processor_timeouts``
 ``dag_processing.manager_stalls``                                      Number of stalled ``DagFileProcessorManager``
 ``dag_file_refresh_error``                                             Number of failures loading any DAG files
@@ -138,6 +141,7 @@ Name                                                Description
 ``dag_processing.import_errors``                    Number of errors from trying to parse DAG files
 ``dag_processing.total_parse_time``                 Seconds taken to scan and import all DAG files once
 ``dag_processing.last_run.seconds_ago.<dag_file>``  Seconds since ``<dag_file>`` was last processed
+``dag_processing.file_path_queue_size``             Size of the dag file queue.
 ``scheduler.tasks.running``                         Number of tasks running in executor
 ``scheduler.tasks.starving``                        Number of tasks that cannot be scheduled because of no open slot in pool
 ``scheduler.tasks.executable``                      Number of tasks that are ready for execution (set to queued)

--- a/newsfragments/30076.significant.rst
+++ b/newsfragments/30076.significant.rst
@@ -1,0 +1,3 @@
+SLA callbacks no longer add files to the dag processor manager's queue
+
+This stops SLA callbacks from keeping the dag processor manager permanently busy. It means reduced CPU, and fixes issues where SLAs stop the system from seeing changes to existing dag files.

--- a/newsfragments/30076.significant.rst
+++ b/newsfragments/30076.significant.rst
@@ -1,3 +1,3 @@
 SLA callbacks no longer add files to the dag processor manager's queue
 
-This stops SLA callbacks from keeping the dag processor manager permanently busy. It means reduced CPU, and fixes issues where SLAs stop the system from seeing changes to existing dag files.
+This stops SLA callbacks from keeping the dag processor manager permanently busy. It means reduced CPU, and fixes issues where SLAs stop the system from seeing changes to existing dag files. Additional metrics added to help track queue state.

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -1081,6 +1081,12 @@ class TestDagFileProcessorManager:
             msg=None,
         )
 
+        dag3_sla1 = SlaCallbackRequest(
+            full_filepath="/green_eggs/ham/file3.py",
+            dag_id="dag3",
+            processor_subdir=tmpdir,
+        )
+
         # when
         manager._add_callback_to_queue(dag1_req1)
         manager._add_callback_to_queue(dag1_sla1)
@@ -1096,12 +1102,15 @@ class TestDagFileProcessorManager:
 
         # when
         manager._add_callback_to_queue(dag1_sla2)
+        manager._add_callback_to_queue(dag3_sla1)
 
-        # then - since sla2 == sla1, should not have brought dag1 to the fore
+        # then - since sla2 == sla1, should not have brought dag1 to the fore, and an SLA on dag3 doesn't
+        # update the queue, although the callback is registered
         assert manager._file_path_queue == collections.deque(
             [dag2_req1.full_filepath, dag1_req1.full_filepath]
         )
         assert manager._callback_to_execute[dag1_req1.full_filepath] == [dag1_req1, dag1_sla1]
+        assert manager._callback_to_execute[dag3_sla1.full_filepath] == [dag3_sla1]
 
         # when
         manager._add_callback_to_queue(dag1_req2)


### PR DESCRIPTION
# Let's make SLA's work

OK, so https://github.com/apache/airflow/pull/25147 made a start in this direction. Summing up the, er, summary from that MR, the problem was that SLA callbacks could keep occuring, and prevent the dag processor manager from ever processing more than 2 or 3 dags in the queue before the SLA callbacks re-upped and went to the front of the queue.

After that PR was merged, the SLA callbacks went to the back of the queue. This guaranteed that the queue would be processed at least once. However, it turns out that dags on disk would only be re-added to the queue once the queue was empty. But with SLA callbacks arriving All. The. Time. the queue would never drain, and we'd never re-read dags from disk. So if you updated the dag file, you'd have to bounce the scheduler to pick up the change, and then it would process all non-SLA-generating DAGs exactly once. And then you'd need to bounce again.

### Related Issues

Closes https://github.com/apache/airflow/issues/15596 (I hope!)

# Pay attention, here comes the science bit

Ok, so to briefly recap the queue behaviour prior to this change:
1. The scheduler spins up.
2. The worker loop starts.
3. It scans the disk to create a list of all known files. _It does not add these files to the queue_.
4. If the queue is empty (on start up it will be) then all known files are added to the queue.
5. It then spins up dag processors (via multiprocessing or in-line, depending on set up) to consume the first N entries in the queue (where N is a function of config settings, and includes a count of any files currently being processed from a previous pass of the loop)
6. It then goes back to step 2.

- Note that Step 3 is re-run periodically based on a time interval set in config (`dag_dir_list_interval`). It does not require that the queue be empty. Any changes to the set of files on disk e.g. dags being deleted will cause the manager to remove dags from the queue.
- After a few iterations of the loop, the contents of the queue are processed, and step 4 kicks in, and the dag files present on disk are re-added to the queue again.
    - The default config is to do this no more than once every 30 seconds (`min_file_process_interval`), so if your dag files only take 10 seconds to process, there will be 20 seconds of idle time, but if your dag files take a minute to process, then the manager will be permanently busy, because as soon as the queue drains, it'll be well past time to reload the queue from disk.
    - This only works if the queue _actually empties_ - as foreshadowed above, if the queue never empties (because SLAs) then step 4 will never kick in, and we'll never reload the queue. Step 3 will ensure that within a short interval any deleted dags are removed from the queue (should they happen to be one of the ones generating SLAs) but updated and newly added dag files will not be picked up.
    - To be clear, this is the problem I alluded to in my comments at the end of the previous PR after it got merged.

# What this PR changes

The fix is extremely simple - although the SLA callback is registered with the manager, simply getting an SLA callback no longer causes the dag to be added to the queue. This ensures that the queue will periodically empty, and thus all existing dag files will be re-added on a regular basis. If you update a dag file, the change will be picked up within `min_file_process_interval`.

The trade-off is that the SLA callback will not be processed until its dag file is processed as part of the periodic reload of all dag files onto the queue.

I have also added some comments and some extra metrics which I find useful, but the only functional change is the one above.

# Seems familiar?

I actually tried to make a change in this area last year (see #25489 / #27317). The change in that PR was a lot more involved as it tried to close several possible edge cases. While I was confident in that change (I have been running it in prod for months using a locally patched copy), I can understand the need for caution.

This change is less invasive. If you don't use SLA's there's no impact. If you _do_ use SLAs and sometimes find the system doesn't pick up changes to your dags ... well, this fixes that.

# Loose ends

The previous PR was more invasive, but closed a few additional edge cases:
1. Large numbers of non-SLA callbacks having the same effect and DoS'ing the queue:  
In my locally patched copy, this _never_ happens. Maybe other people will have different experiences in the wild, but (by virtue of having the additional queue metrics) I was able to see that the numbers were never anything like as big as the SLA callbacks
2. Increased time to SLA alert:  
Yes, this does mean that a SLA callback will not be picked up immediately - you'll have to wait until all the dag files have been processed and the queue is refreshed; this will either be `min_file_process_interval` or the time needed to process all your dag files, whichever is longer. But by default `min_file_process_interval` is 30 seconds, which is still pretty quick.

I'm happy with the above trade-offs, given that this change is so small vs the impact it has (finally fixes SLAs!)