### PR TITLE
Bash sensor has an explicit retry code

### DIFF
--- a/airflow/sensors/bash.py
+++ b/airflow/sensors/bash.py
@@ -22,6 +22,7 @@ from subprocess import PIPE, STDOUT, Popen
 from tempfile import NamedTemporaryFile, TemporaryDirectory, gettempdir
 from typing import Sequence
 
+from airflow import AirflowException
 from airflow.sensors.base import BaseSensorOperator
 from airflow.utils.context import Context
 
@@ -40,6 +41,12 @@ class BashSensor(BaseSensorOperator):
         of inheriting the current process environment, which is the default
         behavior. (templated)
     :param output_encoding: output encoding of bash command.
+    :param retry_exit_code: If task exits with this code, treat the sensor
+        as not-yet-complete and retry the check later according to the
+        usual retry/timeout settings. Any other return code will be
+        treated as an error, and cause the sensor to file. If set to
+        ``None`` (the default), any non-zero exit code will cause a retry
+        and the task will never raise an error except on time-out.
 
     .. seealso::
         For more information on how to use this sensor,take a look at the guide:
@@ -48,11 +55,12 @@ class BashSensor(BaseSensorOperator):
 
     template_fields: Sequence[str] = ("bash_command", "env")
 
-    def __init__(self, *, bash_command, env=None, output_encoding="utf-8", **kwargs):
+    def __init__(self, *, bash_command, env=None, output_encoding="utf-8", retry_exit_code: int | None = None, **kwargs):
         super().__init__(**kwargs)
         self.bash_command = bash_command
         self.env = env
         self.output_encoding = output_encoding
+        self.retry_exit_code = retry_exit_code
 
     def poke(self, context: Context):
         """Execute the bash command in a temporary directory."""
@@ -83,4 +91,17 @@ class BashSensor(BaseSensorOperator):
                     resp.wait()
                     self.log.info("Command exited with return code %s", resp.returncode)
 
-                    return not resp.returncode
+                    # zero code means success, the sensor can go green
+                    if resp.returncode == 0:
+                        return True
+
+                    # we have a retry exit code, sensor retries if return code matches, otherwise error
+                    elif self.retry_exit_code is not None:
+                        if resp.returncode == self.retry_exit_code:
+                            return False
+                        else:
+                            raise AirflowException(f"Command exited with return code {resp.returncode}")
+
+                    # backwards compatibility: sensor retries no matter the error code
+                    else:
+                        return False

--- a/airflow/sensors/bash.py
+++ b/airflow/sensors/bash.py
@@ -43,8 +43,8 @@ class BashSensor(BaseSensorOperator):
     :param output_encoding: output encoding of bash command.
     :param retry_exit_code: If task exits with this code, treat the sensor
         as not-yet-complete and retry the check later according to the
-        usual retry/timeout settings. Any other return code will be
-        treated as an error, and cause the sensor to file. If set to
+        usual retry/timeout settings. Any other non-zero return code will
+        be treated as an error, and cause the sensor to fail. If set to
         ``None`` (the default), any non-zero exit code will cause a retry
         and the task will never raise an error except on time-out.
 

--- a/airflow/sensors/bash.py
+++ b/airflow/sensors/bash.py
@@ -55,7 +55,9 @@ class BashSensor(BaseSensorOperator):
 
     template_fields: Sequence[str] = ("bash_command", "env")
 
-    def __init__(self, *, bash_command, env=None, output_encoding="utf-8", retry_exit_code: int | None = None, **kwargs):
+    def __init__(
+        self, *, bash_command, env=None, output_encoding="utf-8", retry_exit_code: int | None = None, **kwargs
+    ):
         super().__init__(**kwargs)
         self.bash_command = bash_command
         self.env = env

--- a/airflow/sensors/bash.py
+++ b/airflow/sensors/bash.py
@@ -100,10 +100,12 @@ class BashSensor(BaseSensorOperator):
                     # we have a retry exit code, sensor retries if return code matches, otherwise error
                     elif self.retry_exit_code is not None:
                         if resp.returncode == self.retry_exit_code:
+                            self.log.info("Return code matches retry code, will retry later")
                             return False
                         else:
                             raise AirflowException(f"Command exited with return code {resp.returncode}")
 
                     # backwards compatibility: sensor retries no matter the error code
                     else:
+                        self.log.info("Non-zero return code and no retry code set, will retry later")
                         return False

--- a/airflow/sensors/bash.py
+++ b/airflow/sensors/bash.py
@@ -22,7 +22,7 @@ from subprocess import PIPE, STDOUT, Popen
 from tempfile import NamedTemporaryFile, TemporaryDirectory, gettempdir
 from typing import Sequence
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowFailException
 from airflow.sensors.base import BaseSensorOperator
 from airflow.utils.context import Context
 
@@ -103,7 +103,7 @@ class BashSensor(BaseSensorOperator):
                             self.log.info("Return code matches retry code, will retry later")
                             return False
                         else:
-                            raise AirflowException(f"Command exited with return code {resp.returncode}")
+                            raise AirflowFailException(f"Command exited with return code {resp.returncode}")
 
                     # backwards compatibility: sensor retries no matter the error code
                     else:

--- a/tests/sensors/test_bash.py
+++ b/tests/sensors/test_bash.py
@@ -21,7 +21,7 @@ import datetime
 
 import pytest
 
-from airflow.exceptions import AirflowSensorTimeout
+from airflow.exceptions import AirflowSensorTimeout, AirflowException
 from airflow.models.dag import DAG
 from airflow.sensors.bash import BashSensor
 
@@ -53,4 +53,30 @@ class TestBashSensor:
             dag=self.dag,
         )
         with pytest.raises(AirflowSensorTimeout):
+            op.execute(None)
+
+    def test_retry_code_retries(self):
+        op = BashSensor(
+            task_id="test_false_condition",
+            bash_command='freturn() { return "$1"; }; freturn 99',
+            output_encoding="utf-8",
+            poke_interval=1,
+            timeout=2,
+            retry_exit_code=99,
+            dag=self.dag,
+        )
+        with pytest.raises(AirflowSensorTimeout):
+            op.execute(None)
+
+    def test_retry_code_fails(self):
+        op = BashSensor(
+            task_id="test_false_condition",
+            bash_command='freturn() { return "$1"; }; freturn 1',
+            output_encoding="utf-8",
+            poke_interval=1,
+            timeout=2,
+            retry_exit_code=99,
+            dag=self.dag,
+        )
+        with pytest.raises(AirflowException):
             op.execute(None)

--- a/tests/sensors/test_bash.py
+++ b/tests/sensors/test_bash.py
@@ -21,7 +21,7 @@ import datetime
 
 import pytest
 
-from airflow.exceptions import AirflowSensorTimeout, AirflowException
+from airflow.exceptions import AirflowException, AirflowSensorTimeout
 from airflow.models.dag import DAG
 from airflow.sensors.bash import BashSensor
 

--- a/tests/sensors/test_bash.py
+++ b/tests/sensors/test_bash.py
@@ -21,7 +21,7 @@ import datetime
 
 import pytest
 
-from airflow.exceptions import AirflowException, AirflowSensorTimeout
+from airflow.exceptions import AirflowFailException, AirflowSensorTimeout
 from airflow.models.dag import DAG
 from airflow.sensors.bash import BashSensor
 
@@ -78,5 +78,5 @@ class TestBashSensor:
             retry_exit_code=99,
             dag=self.dag,
         )
-        with pytest.raises(AirflowException):
+        with pytest.raises(AirflowFailException):
             op.execute(None)


### PR DESCRIPTION
# When is an error code not an error code?

The `BashOperator` has a `skip_exit_code` param, which is used to identify the return code from the underlying command which means 'this task hasn't failed, but should instead be skipped'.

This PR adds something similar to the `BashSensor`: a `retry_exit_code` that (if set) defines the only non-zero return code that _doesn't_ cause the sensor to fail. All other non-zero return codes result in the sensor failing.

For backwards compatibility, if the code is not set (which is the default) then you get the current behaviour which is for all non-zero return codes to cause the sensor to retry the check, i.e. it retries until timeout or it returns zero.

# Why is this useful?

 If your sensor is e.g. spinning up a docker container and you get some flags wrong, then under the current behaviour the sensor will never succeed, but also never fail until it times out. It would be much more useful if you could detect malformed commands immediately (fail fast).
