### PR TITLE
Account for change in UTC offset when performing next schedule calculations

### DIFF
--- a/airflow/timetables/_cron.py
+++ b/airflow/timetables/_cron.py
@@ -26,7 +26,7 @@ from pendulum.tz.timezone import Timezone
 
 from airflow.exceptions import AirflowTimetableInvalid
 from airflow.utils.dates import cron_presets
-from airflow.utils.timezone import convert_to_utc, in_timezone, make_aware, make_naive
+from airflow.utils.timezone import convert_to_utc, make_aware, make_naive
 
 
 class CronMixin:
@@ -79,12 +79,12 @@ class CronMixin:
 
         # calculate the delta to the next scheduled time, taking into account
         # if the next scheduled time is in a different tz
-        current_offset = in_timezone(current, self._timezone).utcoffset()
+        current_offset = self._timezone.convert(current).utcoffset()
         scheduled_offset = instance(scheduled, self._timezone).utcoffset()
         if current_offset is not None and scheduled_offset is not None:
             utc_offset_delta = current_offset - scheduled_offset
         else:
-            utc_offset_delta = datetime.timedelta(seconds=0)
+            utc_offset_delta = datetime.timedelta()
 
         # here we need to re-offset UTC because our next calculation was in local time
         return convert_to_utc(make_aware(scheduled, self._timezone)) - utc_offset_delta
@@ -97,12 +97,12 @@ class CronMixin:
 
         # calculate the delta to the next scheduled time, taking into account
         # if the next scheduled time is in a different tz
-        current_offset = in_timezone(current, self._timezone).utcoffset()
+        current_offset = self._timezone.convert(current).utcoffset()
         scheduled_offset = instance(scheduled, self._timezone).utcoffset()
         if current_offset is not None and scheduled_offset is not None:
             utc_offset_delta = current_offset - scheduled_offset
         else:
-            utc_offset_delta = datetime.timedelta(seconds=0)
+            utc_offset_delta = datetime.timedelta()
 
         # here we need to re-offset UTC because our next calculation was in local time
         # return convert_to_utc(make_aware(scheduled, self._timezone)) - utc_offset_delta

--- a/airflow/timetables/_cron.py
+++ b/airflow/timetables/_cron.py
@@ -112,9 +112,7 @@ class CronMixin:
         scheduled_offset = instance(scheduled, self._timezone).utcoffset()
         utc_offset_delta = current_offset - scheduled_offset
         delta = scheduled - naive
-        return convert_to_utc(
-            current.in_timezone(self._timezone) + delta + utc_offset_delta
-        )
+        return convert_to_utc(current.in_timezone(self._timezone) + delta + utc_offset_delta)
 
     def _get_prev(self, current: DateTime) -> DateTime:
         """Get the first schedule before specified time, with DST fixed."""
@@ -123,16 +121,14 @@ class CronMixin:
         scheduled = cron.get_prev(datetime.datetime)
         if not self._should_fix_dst:
             return convert_to_utc(make_aware(scheduled, self._timezone))
-        delta = naive - scheduled
+
         # calculate the delta to the next scheduled time, taking into account
         # if the next scheduled time is in a different tz
         current_offset = current.in_timezone(self._timezone).utcoffset()
         scheduled_offset = instance(scheduled, self._timezone).utcoffset()
         utc_offset_delta = current_offset - scheduled_offset
         delta = naive - scheduled
-        return convert_to_utc(
-            current.in_timezone(self._timezone) - delta + utc_offset_delta
-        )
+        return convert_to_utc(current.in_timezone(self._timezone) - delta + utc_offset_delta)
 
     def _align_to_next(self, current: DateTime) -> DateTime:
         """Get the next scheduled time.

--- a/airflow/utils/timezone.py
+++ b/airflow/utils/timezone.py
@@ -18,14 +18,11 @@
 from __future__ import annotations
 
 import datetime as dt
-from typing import TYPE_CHECKING, overload
+from typing import overload
 
 import pendulum
 from dateutil.relativedelta import relativedelta
 from pendulum.datetime import DateTime
-
-if TYPE_CHECKING:
-    from pendulum.tz.timezone import Timezone
 
 # UTC time zone as a tzinfo instance.
 utc = pendulum.tz.timezone("UTC")
@@ -75,20 +72,6 @@ def utc_epoch() -> dt.datetime:
     result = result.replace(tzinfo=utc)
 
     return result
-
-
-def in_timezone(datetime: DateTime, tz: Timezone, dst_rule: str = pendulum.PRE_TRANSITION) -> DateTime:
-    """Convert a datetime to a timezone, but also allow for dst_rule override.
-
-    :param datetime: pendulum DateTime
-    :param tz: pendulum Timezone
-    :param dst_rule: pendulum.PRE_TRANSITION or pendulum.POST_TRANSITION
-    :return: localized datetime in timezone
-
-    :meta private:
-    """
-    tz = pendulum._safe_timezone(tz)
-    return tz.convert(datetime, dst_rule=dst_rule)
 
 
 @overload

--- a/airflow/utils/timezone.py
+++ b/airflow/utils/timezone.py
@@ -84,6 +84,8 @@ def in_timezone(datetime: DateTime, tz: Timezone, dst_rule: str = pendulum.PRE_T
     :param tz: pendulum Timezone
     :param dst_rule: pendulum.PRE_TRANSITION or pendulum.POST_TRANSITION
     :return: localized datetime in timezone
+
+    :meta private:
     """
     tz = pendulum._safe_timezone(tz)
     return tz.convert(datetime, dst_rule=dst_rule)

--- a/newsfragments/30083.significant.rst
+++ b/newsfragments/30083.significant.rst
@@ -1,7 +1,8 @@
-Timezone-traversing non-fixed cron timetables properly account for timezone delta.
+Timezone-traversing non-fixed cron timetables properly accounts for timezone delta.
 
-Given a cron expression which results in an `interval` based schedule instead of a `fixed` schedule such as `0 9-16 * * *`, the Monday after a timezone change (e.g. Daylight Savings Time) the first job would be one hour incorrect.
-This was due to not accounting for the timezone delta when performing the `get_next` calculation (and similarly for `get_prev`).
+Given a cron expression which results in an `interval` based schedule instead of a `fixed` schedule such as `0 9-16 * * *`, the Monday after a timezone change (e.g. Daylight Savings Time) the first job would be one hour offset.
+This was due to intentional code which accounted for timezone deltas, introduced after the switch to timetables (in `airflow>=2`).
 
-As an example, if operating in the `America/New_York` timezone when entering daylight savings time, the above schedule would result in a `10am` execution on Monday morning. This is because the transition from UTC-5 to UTC-4 results in an unaccounted for timezone delta
-of one hour. This problem is now resolved, and the Monday execution time will now properly be `9am`.
+As an example, if operating in the `America/New_York` timezone when entering daylight savings time, the above schedule would result in a `10am` execution on Monday morning, instead of the previous `9am`.
+
+This functionality is now deprecated and reverted, so timezone-aware timetables will now run at the same time, e.g. a `9am` timetable will always run at `9am` local time.

--- a/newsfragments/30083.significant.rst
+++ b/newsfragments/30083.significant.rst
@@ -1,0 +1,7 @@
+Timezone-traversing non-fixed cron timetables properly account for timezone delta.
+
+Given a cron expression which results in an `interval` based schedule instead of a `fixed` schedule such as `0 9-16 * * *`, the Monday after a timezone change (e.g. Daylight Savings Time) the first job would be one hour incorrect.
+This was due to not accounting for the timezone delta when performing the `get_next` calculation (and similarly for `get_prev`).
+
+As an example, if operating in the `America/New_York` timezone when entering daylight savings time, the above schedule would result in a `10am` execution on Monday morning. This is because the transition from UTC-5 to UTC-4 results in an unaccounted for timezone delta
+of one hour. This problem is now resolved, and the Monday execution time will now properly be `9am`.

--- a/newsfragments/30083.significant.rst
+++ b/newsfragments/30083.significant.rst
@@ -1,8 +1,8 @@
-Timezone-traversing non-fixed cron timetables properly accounts for timezone delta.
+Timezone-traversing non-fixed cron timetables no longer accounts for timezone delta.
 
 Given a cron expression which results in an `interval` based schedule instead of a `fixed` schedule such as `0 9-16 * * *`, the Monday after a timezone change (e.g. Daylight Savings Time) the first job would be one hour offset.
 This was due to intentional code which accounted for timezone deltas, introduced after the switch to timetables (in `airflow>=2`).
 
 As an example, if operating in the `America/New_York` timezone when entering daylight savings time, the above schedule would result in a `10am` execution on Monday morning, instead of the previous `9am`.
 
-This functionality is now deprecated and reverted, so timezone-aware timetables will now run at the same time, e.g. a `9am` timetable will always run at `9am` local time.
+This functionality is now reverted, so timezone-aware timetables will now run at the same time, e.g. a `9am` timetable will always run at `9am` local time.

--- a/newsfragments/30083.significant.rst
+++ b/newsfragments/30083.significant.rst
@@ -1,4 +1,4 @@
-Non-fixed cron timetables no longer account for changing in timezone.
+Variable-interval cron timetables no longer account for DST transition
 
 Given a cron expression resulting in an interval-based schedule, such as
 ``0 9-16 * * *``, job after a timezone change (e.g. entering or exiting daylight

--- a/newsfragments/30083.significant.rst
+++ b/newsfragments/30083.significant.rst
@@ -1,8 +1,13 @@
-Timezone-traversing non-fixed cron timetables no longer accounts for timezone delta.
+Non-fixed cron timetables no longer account for changing in timezone.
 
-Given a cron expression which results in an `interval` based schedule instead of a `fixed` schedule such as `0 9-16 * * *`, the Monday after a timezone change (e.g. Daylight Savings Time) the first job would be one hour offset.
-This was due to intentional code which accounted for timezone deltas, introduced after the switch to timetables (in `airflow>=2`).
+Given a cron expression resulting in an interval-based schedule, such as
+``0 9-16 * * *``, job after a timezone change (e.g. entering or exiting daylight
+saving time) used to be scheduled with an offset to the change in timezone. For
+example, when operating in *America/New_York*, the above schedule would result
+in a run at 10am on Monday morning after entering DST, instead of the previous
+9am.
 
-As an example, if operating in the `America/New_York` timezone when entering daylight savings time, the above schedule would result in a `10am` execution on Monday morning, instead of the previous `9am`.
-
-This functionality is now reverted, so timezone-aware timetables will now run at the same time, e.g. a `9am` timetable will always run at `9am` local time.
+This was intentional to account for the change in timezone introduced in Airflow
+2.2, but caused confusion to several use cases. The functionality is now
+reverted to its pre-2.2 state, and timetables will now always run at the same
+*clock time*, e.g. 9am in the above example.

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -819,34 +819,34 @@ class TestDag:
         next_utc = dag.following_schedule(next_utc)
         assert local_tz.convert(next_utc).isoformat() == "2018-03-25T05:00:00+02:00"
 
-    # def test_following_previous_schedule_daily_dag_cet_to_cest(self):
-    #     """
-    #     Make sure DST transitions are properly observed
-    #     """
-    #     local_tz = pendulum.timezone("Europe/Zurich")
-    #     start = local_tz.convert(datetime.datetime(2018, 3, 25, 2), dst_rule=pendulum.PRE_TRANSITION)
+    def test_following_previous_schedule_daily_dag_cet_to_cest(self):
+        """
+        Make sure DST transitions are properly observed
+        """
+        local_tz = pendulum.timezone("Europe/Zurich")
+        start = local_tz.convert(datetime.datetime(2018, 3, 25, 2), dst_rule=pendulum.PRE_TRANSITION)
 
-    #     utc = timezone.convert_to_utc(start)
+        utc = timezone.convert_to_utc(start)
 
-    #     dag = DAG("tz_dag", start_date=start, schedule="0 3 * * *")
+        dag = DAG("tz_dag", start_date=start, schedule="0 3 * * *")
 
-    #     prev = dag.previous_schedule(utc)
-    #     prev_local = local_tz.convert(prev)
+        prev = dag.previous_schedule(utc)
+        prev_local = local_tz.convert(prev)
 
-    #     assert prev_local.isoformat() == "2018-03-24T03:00:00+01:00"
-    #     assert prev.isoformat() == "2018-03-24T02:00:00+00:00"
+        assert prev_local.isoformat() == "2018-03-24T03:00:00+01:00"
+        assert prev.isoformat() == "2018-03-24T02:00:00+00:00"
 
-    #     _next = dag.following_schedule(utc)
-    #     next_local = local_tz.convert(_next)
+        _next = dag.following_schedule(utc)
+        next_local = local_tz.convert(_next)
 
-    #     assert next_local.isoformat() == "2018-03-25T03:00:00+02:00"
-    #     assert _next.isoformat() == "2018-03-25T01:00:00+00:00"
+        assert next_local.isoformat() == "2018-03-25T03:00:00+02:00"
+        assert _next.isoformat() == "2018-03-25T01:00:00+00:00"
 
-    #     prev = dag.previous_schedule(_next)
-    #     prev_local = local_tz.convert(prev)
+        prev = dag.previous_schedule(_next)
+        prev_local = local_tz.convert(prev)
 
-    #     assert prev_local.isoformat() == "2018-03-24T03:00:00+01:00"
-    #     assert prev.isoformat() == "2018-03-24T02:00:00+00:00"
+        assert prev_local.isoformat() == "2018-03-24T03:00:00+01:00"
+        assert prev.isoformat() == "2018-03-24T02:00:00+00:00"
 
     def test_following_schedule_relativedelta(self):
         """

--- a/tests/timetables/test_interval_timetable.py
+++ b/tests/timetables/test_interval_timetable.py
@@ -256,19 +256,17 @@ def test_cron_next_dagrun_info_alignment(last_data_interval: DataInterval, expec
 
 
 def test_cron_interval_dst_next():
-    '''
+    """
     This test is composed of several tests targeting an interval
     timetable crossing a timezone change boundary, e.g. DST
-    '''
+    """
     # Interval cron
     cron_interval = CronDataIntervalTimetable(
         "0 9-16 * * 1-5", timezone=pendulum.timezone("America/New_York")
     )
     # Fixed cron
-    cron_fixed = CronDataIntervalTimetable(
-        "0 9 * * 1-5", timezone=pendulum.timezone("America/New_York")
-    )
-    
+    cron_fixed = CronDataIntervalTimetable("0 9 * * 1-5", timezone=pendulum.timezone("America/New_York"))
+
     # last run friday before DST
     last_run = pendulum.datetime(2023, 3, 10, 21, 0)
 
@@ -277,20 +275,19 @@ def test_cron_interval_dst_next():
     # these should match:
     assert cron_interval._get_next(last_run).timestamp() == cron_fixed._get_next(last_run).timestamp()
 
+
 def test_cron_interval_dst_prev():
-    '''
+    """
     This test is composed of several tests targeting an interval
     timetable crossing a timezone change boundary, e.g. DST
-    '''
+    """
     # Interval cron
     cron_interval = CronDataIntervalTimetable(
         "0 9-16 * * 1-5", timezone=pendulum.timezone("America/New_York")
     )
     # Fixed cron
-    cron_fixed = CronDataIntervalTimetable(
-        "0 16 * * 1-5", timezone=pendulum.timezone("America/New_York")
-    )
-    
+    cron_fixed = CronDataIntervalTimetable("0 16 * * 1-5", timezone=pendulum.timezone("America/New_York"))
+
     last_run = pendulum.datetime(2023, 3, 10, 13, 0)
     # last run: 2023-03-13 13:00:00+00:00
     # expected prev run: 2023-03-10 21:00:00+00:00

--- a/tests/timetables/test_interval_timetable.py
+++ b/tests/timetables/test_interval_timetable.py
@@ -253,3 +253,46 @@ def test_cron_next_dagrun_info_alignment(last_data_interval: DataInterval, expec
         restriction=TimeRestriction(None, None, True),
     )
     assert info == expected_info
+
+
+def test_cron_interval_dst_next():
+    '''
+    This test is composed of several tests targeting an interval
+    timetable crossing a timezone change boundary, e.g. DST
+    '''
+    # Interval cron
+    cron_interval = CronDataIntervalTimetable(
+        "0 9-16 * * 1-5", timezone=pendulum.timezone("America/New_York")
+    )
+    # Fixed cron
+    cron_fixed = CronDataIntervalTimetable(
+        "0 9 * * 1-5", timezone=pendulum.timezone("America/New_York")
+    )
+    
+    # last run friday before DST
+    last_run = pendulum.datetime(2023, 3, 10, 21, 0)
+
+    # last run: 2023-03-10 21:00:00+00:00
+    # expected next run: 2023-03-13 13:00:00+00:00
+    # these should match:
+    assert cron_interval._get_next(last_run).timestamp() == cron_fixed._get_next(last_run).timestamp()
+
+def test_cron_interval_dst_prev():
+    '''
+    This test is composed of several tests targeting an interval
+    timetable crossing a timezone change boundary, e.g. DST
+    '''
+    # Interval cron
+    cron_interval = CronDataIntervalTimetable(
+        "0 9-16 * * 1-5", timezone=pendulum.timezone("America/New_York")
+    )
+    # Fixed cron
+    cron_fixed = CronDataIntervalTimetable(
+        "0 16 * * 1-5", timezone=pendulum.timezone("America/New_York")
+    )
+    
+    last_run = pendulum.datetime(2023, 3, 10, 13, 0)
+    # last run: 2023-03-13 13:00:00+00:00
+    # expected prev run: 2023-03-10 21:00:00+00:00
+    # these should match:
+    assert cron_interval._get_prev(last_run).timestamp() == cron_fixed._get_prev(last_run).timestamp()

--- a/tests/timetables/test_interval_timetable.py
+++ b/tests/timetables/test_interval_timetable.py
@@ -255,7 +255,7 @@ def test_cron_next_dagrun_info_alignment(last_data_interval: DataInterval, expec
     assert info == expected_info
 
 
-def test_cron_interval_dst_next():
+def test_cron_interval_dst_next_entering():
     """
     This test is composed of several tests targeting an interval
     timetable crossing a timezone change boundary, e.g. DST
@@ -276,7 +276,7 @@ def test_cron_interval_dst_next():
     assert cron_interval._get_next(last_run).timestamp() == cron_fixed._get_next(last_run).timestamp()
 
 
-def test_cron_interval_dst_prev():
+def test_cron_interval_dst_prev_entering():
     """
     This test is composed of several tests targeting an interval
     timetable crossing a timezone change boundary, e.g. DST
@@ -291,5 +291,45 @@ def test_cron_interval_dst_prev():
     last_run = pendulum.datetime(2023, 3, 10, 13, 0)
     # last run: 2023-03-13 13:00:00+00:00
     # expected prev run: 2023-03-10 21:00:00+00:00
+    # these should match:
+    assert cron_interval._get_prev(last_run).timestamp() == cron_fixed._get_prev(last_run).timestamp()
+
+
+def test_cron_interval_dst_next_leaving():
+    """
+    This test is composed of several tests targeting an interval
+    timetable crossing a timezone change boundary, e.g. DST
+    """
+    # Interval cron
+    cron_interval = CronDataIntervalTimetable(
+        "0 9-16 * * 1-5", timezone=pendulum.timezone("America/New_York")
+    )
+    # Fixed cron
+    cron_fixed = CronDataIntervalTimetable("0 9 * * 1-5", timezone=pendulum.timezone("America/New_York"))
+
+    # last run friday before DST
+    last_run = pendulum.datetime(2022, 11, 4, 21, 0)
+
+    # last run: 2022-11-04 21:00:00+00:00
+    # expected next run: 2022-11-07 13:00:00+00:00
+    # these should match:
+    assert cron_interval._get_next(last_run).timestamp() == cron_fixed._get_next(last_run).timestamp()
+
+
+def test_cron_interval_dst_prev_leaving():
+    """
+    This test is composed of several tests targeting an interval
+    timetable crossing a timezone change boundary, e.g. DST
+    """
+    # Interval cron
+    cron_interval = CronDataIntervalTimetable(
+        "0 9-16 * * 1-5", timezone=pendulum.timezone("America/New_York")
+    )
+    # Fixed cron
+    cron_fixed = CronDataIntervalTimetable("0 16 * * 1-5", timezone=pendulum.timezone("America/New_York"))
+
+    last_run = pendulum.datetime(2022, 11, 7, 13, 0)
+    # last run: 2022-11-07 13:00:00+00:00
+    # expected prev run: 2022-11-04 21:00:00+00:00
     # these should match:
     assert cron_interval._get_prev(last_run).timestamp() == cron_fixed._get_prev(last_run).timestamp()


### PR DESCRIPTION
Closes: #7999

When performing a next value calculation using a cron schedule with a non-fixed interval (e.g. `* 1,2,3 * * *`), changes in timezone are not properly accounted for. The functions `_get_next` and `_get_prev` do not account for the delta between the `current` and `scheduled` values' respective timezones. This PR fixes that, and accordingly fixes the closed but unfixed #7999 issue.

Note that this may want to be considered a breaking change, even though it is a fix in the behavior.

