### PR TITLE
Add deferrable mode to `RedshiftResumeClusterOperator`

### DIFF
--- a/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -397,8 +397,11 @@ class RedshiftResumeClusterOperator(BaseOperator):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:RedshiftResumeClusterOperator`
 
-    :param cluster_identifier: id of the AWS Redshift Cluster
-    :param aws_conn_id: aws connection to use
+    :param cluster_identifier:  Unique identifier of the AWS Redshift cluster
+    :param aws_conn_id: The Airflow connection used for AWS credentials.
+        The default connection id is ``aws_default``
+    :param deferrable: Run operator in deferrable mode
+    :param poll_interval: Time (in seconds) to wait between two consecutive calls to check cluster state
     """
 
     template_fields: Sequence[str] = ("cluster_identifier",)

--- a/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -410,11 +410,15 @@ class RedshiftResumeClusterOperator(BaseOperator):
         *,
         cluster_identifier: str,
         aws_conn_id: str = "aws_default",
+        deferrable: bool = False,
+        poll_interval: int = 10,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.cluster_identifier = cluster_identifier
         self.aws_conn_id = aws_conn_id
+        self.deferrable = deferrable
+        self.poll_interval = poll_interval
         # These parameters are added to address an issue with the boto3 API where the API
         # prematurely reports the cluster as available to receive requests. This causes the cluster
         # to reject initial attempts to resume the cluster despite reporting the correct state.
@@ -424,18 +428,48 @@ class RedshiftResumeClusterOperator(BaseOperator):
     def execute(self, context: Context):
         redshift_hook = RedshiftHook(aws_conn_id=self.aws_conn_id)
 
-        while self._attempts >= 1:
-            try:
-                redshift_hook.get_conn().resume_cluster(ClusterIdentifier=self.cluster_identifier)
-                return
-            except redshift_hook.get_conn().exceptions.InvalidClusterStateFault as error:
-                self._attempts = self._attempts - 1
+        if self.deferrable:
+            self.defer(
+                timeout=self.execution_timeout,
+                trigger=RedshiftClusterTrigger(
+                    task_id=self.task_id,
+                    poll_interval=self.poll_interval,
+                    aws_conn_id=self.aws_conn_id,
+                    cluster_identifier=self.cluster_identifier,
+                    attempts=self._attempts,
+                    operation_type="pause_cluster",
+                ),
+                method_name="execute_complete",
+            )
+        else:
+            while self._attempts >= 1:
+                try:
+                    redshift_hook.get_conn().resume_cluster(ClusterIdentifier=self.cluster_identifier)
+                    return
+                except redshift_hook.get_conn().exceptions.InvalidClusterStateFault as error:
+                    self._attempts = self._attempts - 1
 
-                if self._attempts > 0:
-                    self.log.error("Unable to resume cluster. %d attempts remaining.", self._attempts)
-                    time.sleep(self._attempt_interval)
-                else:
-                    raise error
+                    if self._attempts > 0:
+                        self.log.error("Unable to resume cluster. %d attempts remaining.", self._attempts)
+                        time.sleep(self._attempt_interval)
+                    else:
+                        raise error
+
+    def execute_complete(self, context: Context, event: Any = None) -> None:
+        """
+        Callback for when the trigger fires - returns immediately.
+        Relies on trigger to throw an exception, otherwise it assumes execution was
+        successful.
+        """
+        if event:
+            if "status" in event and event["status"] == "error":
+                msg = f"{event['status']}: {event['message']}"
+                raise AirflowException(msg)
+            elif "status" in event and event["status"] == "success":
+                self.log.info("%s completed successfully.", self.task_id)
+                self.log.info("Paused cluster successfully")
+        else:
+            raise AirflowException("No event received from trigger")
 
 
 class RedshiftPauseClusterOperator(BaseOperator):

--- a/docs/apache-airflow-providers-amazon/operators/redshift_cluster.rst
+++ b/docs/apache-airflow-providers-amazon/operators/redshift_cluster.rst
@@ -53,6 +53,7 @@ Resume an Amazon Redshift cluster
 
 To resume a 'paused' Amazon Redshift cluster you can use
 :class:`RedshiftResumeClusterOperator <airflow.providers.amazon.aws.operators.redshift_cluster>`
+You can also run this operator in deferrable mode by setting ``deferrable`` param to ``True``
 
 .. exampleinclude:: /../../tests/system/providers/amazon/aws/example_redshift.py
     :language: python

--- a/tests/providers/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_cluster.py
@@ -285,6 +285,31 @@ class TestResumeClusterOperator:
             exc.value.trigger, RedshiftClusterTrigger
         ), "Trigger is not a RedshiftClusterTrigger"
 
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.cluster_status")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftAsyncHook.resume_cluster")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftAsyncHook.get_client_async")
+    def test_resume_cluster_failure(
+        self, mock_async_client, mock_async_resume_cluster, mock_sync_cluster_statue
+    ):
+        """Test Resume cluster operator Failure"""
+        mock_sync_cluster_statue.return_value = "paused"
+        mock_async_client.return_value.resume_cluster.return_value = {
+            "Cluster": {"ClusterIdentifier": "test_cluster", "ClusterStatus": "resuming"}
+        }
+        mock_async_resume_cluster.return_value = {"status": "success", "cluster_state": "available"}
+
+        redshift_operator = RedshiftResumeClusterOperator(
+            task_id="task_test",
+            cluster_identifier="test_cluster",
+            aws_conn_id="aws_conn_test",
+            deferrable=True,
+        )
+
+        with pytest.raises(AirflowException):
+            redshift_operator.execute_complete(
+                context=None, event={"status": "error", "message": "test failure message"}
+            )
+
 
 class TestPauseClusterOperator:
     def test_init(self):

--- a/tests/providers/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_cluster.py
@@ -261,11 +261,9 @@ class TestResumeClusterOperator:
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.cluster_status")
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftAsyncHook.resume_cluster")
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftAsyncHook.get_client_async")
-    def test_resume_cluster(
-        self, mock_async_client, mock_async_resume_cluster, mock_sync_cluster_statue, context
-    ):
+    def test_resume_cluster(self, mock_async_client, mock_async_resume_cluster, mock_sync_cluster_status):
         """Test Resume cluster operator run"""
-        mock_sync_cluster_statue.return_value = "paused"
+        mock_sync_cluster_status.return_value = "paused"
         mock_async_client.return_value.resume_cluster.return_value = {
             "Cluster": {"ClusterIdentifier": "test_cluster", "ClusterStatus": "resuming"}
         }
@@ -279,7 +277,7 @@ class TestResumeClusterOperator:
         )
 
         with pytest.raises(TaskDeferred) as exc:
-            redshift_operator.execute(context)
+            redshift_operator.execute({})
 
         assert isinstance(
             exc.value.trigger, RedshiftClusterTrigger

--- a/tests/providers/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_cluster.py
@@ -258,6 +258,33 @@ class TestResumeClusterOperator:
             redshift_operator.execute(None)
         assert mock_conn.resume_cluster.call_count == 10
 
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.cluster_status")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftAsyncHook.resume_cluster")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftAsyncHook.get_client_async")
+    def test_resume_cluster(
+        self, mock_async_client, mock_async_resume_cluster, mock_sync_cluster_statue, context
+    ):
+        """Test Resume cluster operator run"""
+        mock_sync_cluster_statue.return_value = "paused"
+        mock_async_client.return_value.resume_cluster.return_value = {
+            "Cluster": {"ClusterIdentifier": "test_cluster", "ClusterStatus": "resuming"}
+        }
+        mock_async_resume_cluster.return_value = {"status": "success", "cluster_state": "available"}
+
+        redshift_operator = RedshiftResumeClusterOperator(
+            task_id="task_test",
+            cluster_identifier="test_cluster",
+            aws_conn_id="aws_conn_test",
+            deferrable=True,
+        )
+
+        with pytest.raises(TaskDeferred) as exc:
+            redshift_operator.execute(context)
+
+        assert isinstance(
+            exc.value.trigger, RedshiftClusterTrigger
+        ), "Trigger is not a RedshiftClusterTrigger"
+
 
 class TestPauseClusterOperator:
     def test_init(self):

--- a/tests/system/providers/amazon/aws/example_redshift.py
+++ b/tests/system/providers/amazon/aws/example_redshift.py
@@ -176,6 +176,12 @@ with DAG(
         task_id="resume_cluster",
         cluster_identifier=redshift_cluster_identifier,
     )
+
+    resume_cluster_in_deferred_mode = RedshiftResumeClusterOperator(
+        task_id="resume_cluster_in_deferred_mode",
+        cluster_identifier=redshift_cluster_identifier,
+        deferrable=True,
+    )
     # [END howto_operator_redshift_resume_cluster]
 
     wait_cluster_available_after_resume = RedshiftClusterSensor(
@@ -279,6 +285,7 @@ with DAG(
         pause_cluster,
         wait_cluster_paused,
         resume_cluster,
+        resume_cluster_in_deferred_mode,
         wait_cluster_available_after_resume,
         set_up_connection,
         create_table_redshift_data,


### PR DESCRIPTION
This PR donates the `RedshiftResumeClusterOperatorAsync` from [astronomer-providers](https://github.com/astronomer/astronomer-providers) to Airflow.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
