### PR TITLE
Add poll_interval param in BigQueryInsertJobOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -2630,7 +2630,7 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator):
     :param result_retry: How to retry the `result` call that retrieves rows
     :param result_timeout: The number of seconds to wait for `result` method before using `result_retry`
     :param deferrable: Run operator in the deferrable mode
-    :param poll_interval: polling period in seconds to check for the status of job
+    :param poll_interval: polling period in seconds to check for the status of job. Defaults to 4 seconds.
     """
 
     template_fields: Sequence[str] = (

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -2630,6 +2630,7 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator):
     :param result_retry: How to retry the `result` call that retrieves rows
     :param result_timeout: The number of seconds to wait for `result` method before using `result_retry`
     :param deferrable: Run operator in the deferrable mode
+    :param poll_interval: polling period in seconds to check for the status of job
     """
 
     template_fields: Sequence[str] = (
@@ -2660,6 +2661,7 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator):
         result_retry: Retry = DEFAULT_RETRY,
         result_timeout: float | None = None,
         deferrable: bool = False,
+        poll_interval: float = 4.0,
         delegate_to: str | None = None,
         **kwargs,
     ) -> None:
@@ -2682,6 +2684,7 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator):
         self.result_timeout = result_timeout
         self.hook: BigQueryHook | None = None
         self.deferrable = deferrable
+        self.poll_interval = poll_interval
 
     def prepare_template(self) -> None:
         # If .json is passed then we have to read the file
@@ -2789,6 +2792,7 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator):
                 conn_id=self.gcp_conn_id,
                 job_id=self.job_id,
                 project_id=self.project_id,
+                poll_interval=self.poll_interval,
             ),
             method_name="execute_complete",
         )


### PR DESCRIPTION
currently, `poll_interval` is hardcoded for `BigQueryInsertJobOperator` lets expose this to user

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
