### PR TITLE
Lazy load serialization modules

### DIFF
--- a/airflow/serialization/serializers/bignum.py
+++ b/airflow/serialization/serializers/bignum.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING
 from airflow.utils.module_loading import qualname
 
 if TYPE_CHECKING:
+    import decimal
+
     from airflow.serialization.serde import U
 
 
@@ -45,7 +47,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return float(o), name, __version__, True
 
 
-def deserialize(classname: str, version: int, data: object) -> "decimal.Decimal":
+def deserialize(classname: str, version: int, data: object) -> decimal.Decimal:
     from decimal import Decimal
 
     if version > __version__:

--- a/airflow/serialization/serializers/bignum.py
+++ b/airflow/serialization/serializers/bignum.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from airflow.utils.module_loading import qualname
@@ -26,13 +25,15 @@ if TYPE_CHECKING:
     from airflow.serialization.serde import U
 
 
-serializers = [Decimal]
+serializers = ["decimal.Decimal"]
 deserializers = serializers
 
 __version__ = 1
 
 
 def serialize(o: object) -> tuple[U, str, int, bool]:
+    from decimal import Decimal
+
     if not isinstance(o, Decimal):
         return "", "", 0, False
     name = qualname(o)
@@ -44,7 +45,9 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return float(o), name, __version__, True
 
 
-def deserialize(classname: str, version: int, data: object) -> Decimal:
+def deserialize(classname: str, version: int, data: object) -> "decimal.Decimal":
+    from decimal import Decimal
+
     if version > __version__:
         raise TypeError(f"serialized {version} of {classname} > {__version__}")
 

--- a/airflow/serialization/serializers/datetime.py
+++ b/airflow/serialization/serializers/datetime.py
@@ -17,11 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING
-
-from pendulum import DateTime
-from pendulum.tz import timezone
 
 from airflow.utils.module_loading import qualname
 from airflow.utils.timezone import convert_to_utc, is_naive
@@ -31,7 +27,7 @@ if TYPE_CHECKING:
 
 __version__ = 1
 
-serializers = [date, datetime, timedelta, DateTime]
+serializers = ["datetime.date", "datetime.datetime", "datetime.timedelta", "pendulum.datetime.DateTime"]
 deserializers = serializers
 
 TIMESTAMP = "timestamp"
@@ -39,6 +35,9 @@ TIMEZONE = "tz"
 
 
 def serialize(o: object) -> tuple[U, str, int, bool]:
+    from datetime import date, datetime, timedelta
+    from pendulum import DateTime
+
     if isinstance(o, DateTime) or isinstance(o, datetime):
         qn = qualname(o)
         if is_naive(o):
@@ -57,7 +56,12 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return "", "", 0, False
 
 
-def deserialize(classname: str, version: int, data: dict | str) -> datetime | timedelta | date:
+def deserialize(
+    classname: str, version: int, data: dict | str
+) -> "datetime.datetime" | "datetime.timedelta" | "datetime.date":
+    from datetime import date, datetime, timedelta
+    from pendulum import DateTime, timezone
+
     if classname == qualname(datetime) and isinstance(data, dict):
         return datetime.fromtimestamp(float(data[TIMESTAMP]), tz=timezone(data[TIMEZONE]))
 

--- a/airflow/serialization/serializers/kubernetes.py
+++ b/airflow/serialization/serializers/kubernetes.py
@@ -22,18 +22,14 @@ from typing import TYPE_CHECKING
 
 from airflow.utils.module_loading import qualname
 
-serializers = []
-
-try:
-    from kubernetes.client import models as k8s
-
-    serializers = [k8s.v1_pod.V1Pod, k8s.V1ResourceRequirements]
-except ImportError:
-    k8s = None
+# lazy loading for performance reasons
+serializers = [
+    "kubernetes.client.models.v1_resource_requirements.V1ResourceRequirements",
+    "kubernetes.client.models.v1_pod.V1Pod",
+]
 
 if TYPE_CHECKING:
     from airflow.serialization.serde import U
-
 
 __version__ = 1
 
@@ -42,6 +38,8 @@ log = logging.getLogger(__name__)
 
 
 def serialize(o: object) -> tuple[U, str, int, bool]:
+    from kubernetes.client import models as k8s
+
     if not k8s:
         return "", "", 0, False
 

--- a/airflow/serialization/serializers/numpy.py
+++ b/airflow/serialization/serializers/numpy.py
@@ -41,7 +41,7 @@ serializers = [
 if TYPE_CHECKING:
     from airflow.serialization.serde import U
 
-deserializers: list = serializers
+deserializers = serializers
 
 __version__ = 1
 

--- a/airflow/serialization/serializers/numpy.py
+++ b/airflow/serialization/serializers/numpy.py
@@ -19,47 +19,36 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from airflow.utils.module_loading import qualname
+from airflow.utils.module_loading import import_string, qualname
 
-serializers = []
-
-try:
-    import numpy as np
-
-    serializers = [
-        np.int_,
-        np.intc,
-        np.intp,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.bool_,
-        np.float_,
-        np.float16,
-        np.float64,
-        np.complex_,
-        np.complex64,
-        np.complex128,
-    ]
-except ImportError:
-    np = None  # type: ignore
-
+# lazy loading for performance reasons
+serializers = [
+    "numpy.int8",
+    "numpy.int16",
+    "numpy.int32",
+    "numpy.int64",
+    "numpy.uint8",
+    "numpy.uint16",
+    "numpy.uint32",
+    "numpy.uint64",
+    "numpy.bool_",
+    "numpy.float64",
+    "numpy.float16",
+    "numpy.complex128",
+    "numpy.complex64",
+]
 
 if TYPE_CHECKING:
     from airflow.serialization.serde import U
 
 deserializers: list = serializers
-_deserializers: dict[str, type[object]] = {qualname(x): x for x in deserializers}
 
 __version__ = 1
 
 
 def serialize(o: object) -> tuple[U, str, int, bool]:
+    import numpy as np
+
     if np is None:
         return "", "", 0, False
 
@@ -97,8 +86,7 @@ def deserialize(classname: str, version: int, data: str) -> Any:
     if version > __version__:
         raise TypeError("serialized version is newer than class version")
 
-    f = _deserializers.get(classname, None)
-    if callable(f):
-        return f(data)  # type: ignore [call-arg]
+    if classname not in deserializers:
+        raise TypeError(f"unsupported {classname} found for numpy deserialization")
 
-    raise TypeError(f"unsupported {classname} found for numpy deserialization")
+    return import_string(classname)(data)

--- a/airflow/serialization/serializers/timezone.py
+++ b/airflow/serialization/serializers/timezone.py
@@ -19,16 +19,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pendulum
-from pendulum.tz.timezone import FixedTimezone, Timezone
-
 from airflow.utils.module_loading import qualname
 
 if TYPE_CHECKING:
     from airflow.serialization.serde import U
 
 
-serializers = [FixedTimezone, Timezone]
+serializers = ["pendulum.tz.timezone.FixedTimezone", "pendulum.tz.timezone.Timezone"]
 deserializers = serializers
 
 __version__ = 1
@@ -44,6 +41,8 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     0 without the special case), but passing 0 into ``pendulum.timezone`` does
     not give us UTC (but ``+00:00``).
     """
+    from pendulum.tz.timezone import FixedTimezone, Timezone
+
     name = qualname(o)
     if isinstance(o, FixedTimezone):
         if o.offset == 0:
@@ -56,7 +55,9 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return "", "", 0, False
 
 
-def deserialize(classname: str, version: int, data: object) -> Timezone:
+def deserialize(classname: str, version: int, data: object) -> "pendulum.tz.timezone.Timezone":
+    from pendulum.tz import fixed_timezone, timezone
+
     if not isinstance(data, (str, int)):
         raise TypeError(f"{data} is not of type int or str but of {type(data)}")
 
@@ -64,6 +65,6 @@ def deserialize(classname: str, version: int, data: object) -> Timezone:
         raise TypeError(f"serialized {version} of {classname} > {__version__}")
 
     if isinstance(data, int):
-        return pendulum.tz.fixed_timezone(data)
+        return fixed_timezone(data)
 
-    return pendulum.tz.timezone(data)
+    return timezone(data)

--- a/airflow/serialization/serializers/timezone.py
+++ b/airflow/serialization/serializers/timezone.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING
 from airflow.utils.module_loading import qualname
 
 if TYPE_CHECKING:
+    from pendulum.tz.timezone import Timezone
+
     from airflow.serialization.serde import U
 
 
@@ -55,7 +57,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     return "", "", 0, False
 
 
-def deserialize(classname: str, version: int, data: object) -> "pendulum.tz.timezone.Timezone":
+def deserialize(classname: str, version: int, data: object) -> Timezone:
     from pendulum.tz import fixed_timezone, timezone
 
     if not isinstance(data, (str, int)):

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -35,9 +35,8 @@ from airflow.serialization.serde import (
     _match,
     deserialize,
     serialize,
-    _serializers,
 )
-from airflow.utils.module_loading import qualname, import_string, iter_namespace
+from airflow.utils.module_loading import import_string, iter_namespace, qualname
 from tests.test_utils.config import conf_vars
 
 
@@ -241,11 +240,11 @@ class TestSerDe:
         import airflow.serialization.serializers
 
         for _, name, _ in iter_namespace(airflow.serialization.serializers):
-            name = import_module(name)
-            for s in getattr(name, "serializers", list()):
+            mod = import_module(name)
+            for s in getattr(mod, "serializers", list()):
                 if not isinstance(s, str):
                     raise TypeError(f"{s} is not of type str. This is required for lazy loading")
                 try:
                     import_string(s)
-                except ImportError as e:
-                    raise AttributeError(f"{s} cannot be imported")
+                except ImportError:
+                    raise AttributeError(f"{s} cannot be imported (located in {name})")

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import datetime
 import enum
 from dataclasses import dataclass
+from importlib import import_module
 from typing import ClassVar
 
 import attr
@@ -30,13 +31,19 @@ from airflow.serialization.serde import (
     DATA,
     SCHEMA_ID,
     VERSION,
-    _compile_patterns,
+    _get_patterns,
     _match,
     deserialize,
     serialize,
+    _serializers,
 )
-from airflow.utils.module_loading import qualname
+from airflow.utils.module_loading import qualname, import_string, iter_namespace
 from tests.test_utils.config import conf_vars
+
+
+@pytest.fixture()
+def recalculate_patterns():
+    _get_patterns.cache_clear()
 
 
 class Z:
@@ -74,12 +81,8 @@ class W:
     x: int
 
 
+@pytest.mark.usefixtures("recalculate_patterns")
 class TestSerDe:
-    @pytest.fixture(autouse=True)
-    def ensure_clean_allow_list(self):
-        _compile_patterns()
-        yield
-
     def test_ser_primitives(self):
         i = 10
         e = serialize(i)
@@ -173,8 +176,8 @@ class TestSerDe:
             ("core", "allowed_deserialization_classes"): "airflow[.].*",
         }
     )
+    @pytest.mark.usefixtures("recalculate_patterns")
     def test_allow_list_for_imports(self):
-        _compile_patterns()
         i = Z(10)
         e = serialize(i)
         with pytest.raises(ImportError) as ex:
@@ -187,8 +190,8 @@ class TestSerDe:
             ("core", "allowed_deserialization_classes"): "tests.*",
         }
     )
+    @pytest.mark.usefixtures("recalculate_patterns")
     def test_allow_list_replace(self):
-        _compile_patterns()
         assert _match("tests.airflow.deep")
         assert _match("testsfault") is False
 
@@ -232,3 +235,17 @@ class TestSerDe:
         dataset = Dataset("mytest://dataset")
         obj = deserialize(serialize(dataset))
         assert dataset.uri == obj.uri
+
+    def test_serializers_importable_and_str(self):
+        """test if all distributed serializers are lazy loading and can be imported"""
+        import airflow.serialization.serializers
+
+        for _, name, _ in iter_namespace(airflow.serialization.serializers):
+            name = import_module(name)
+            for s in getattr(name, "serializers", list()):
+                if not isinstance(s, str):
+                    raise TypeError(f"{s} is not of type str. This is required for lazy loading")
+                try:
+                    import_string(s)
+                except ImportError as e:
+                    raise AttributeError(f"{s} cannot be imported")


### PR DESCRIPTION
Currently the serde modules for kubernetes and numpy are loaded on startup which are notriously slow, even if they are never used.

This changes the behavior of those modules to lazy load them and adds functionality to the serde module to report how much time serialization classes take to load and caches the regexp pattern for matching against the allow list.

This is an alternative to: https://github.com/apache/airflow/pull/29721 

cc @uranusjr 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
