### PR TITLE
Fix www/utils.dag_run_link redirection

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -496,7 +496,7 @@ def dag_run_link(attr):
     """Generates a URL to the Graph view for a DagRun."""
     dag_id = attr.get("dag_id")
     run_id = attr.get("run_id")
-    execution_date = attr.get("dag_run.exectuion_date") or attr.get("execution_date")
+    execution_date = attr.get("dag_run.execution_date") or attr.get("execution_date")
     url = url_for("Airflow.graph", dag_id=dag_id, run_id=run_id, execution_date=execution_date)
     return Markup('<a href="{url}">{run_id}</a>').format(url=url, run_id=run_id)
 


### PR DESCRIPTION
Fix the problem with creating URL for the taskinstance. 

When you go to /taskinstance/list/ URL every runid in the table would be without the execution_date query param, which will cause a redirect to the latest graph when clicking on it instead of needed. That happened because execution_date was not found in attrs because of a spelling mistake. 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
