### PR TITLE
Expose missing params in AzureSynapseHook API docs

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/synapse.py
+++ b/airflow/providers/microsoft/azure/hooks/synapse.py
@@ -140,6 +140,7 @@ class AzureSynapseHook(BaseHook):
     ):
         """
         Run a job in an Apache Spark pool.
+
         :param payload: Livy compatible payload which represents the spark job that a user wants to submit.
         """
         job = self.get_conn().spark_batch.create_spark_batch_job(payload)
@@ -196,6 +197,7 @@ class AzureSynapseHook(BaseHook):
     ) -> None:
         """
         Cancel the spark job run.
+
         :param job_id: The synapse spark job identifier.
         """
         self.get_conn().spark_batch.cancel_spark_batch_job(job_id)


### PR DESCRIPTION
Poor formatting of some method docstrings where hiding parameters from being properly rendered in the Python API docs for AzureSynapseHook.

_Before_
<img width="927" alt="image" src="https://user-images.githubusercontent.com/48934154/225016460-56515886-a474-40b4-8adf-da9dfa376385.png">

_After_
<img width="937" alt="image" src="https://user-images.githubusercontent.com/48934154/225016596-1d69a339-7d80-4464-a26e-4dc672a07c1e.png">
