### PR TITLE
Add task state hover highlighting to new graph

### DIFF
--- a/airflow/www/static/js/dag/Main.tsx
+++ b/airflow/www/static/js/dag/Main.tsx
@@ -182,6 +182,7 @@ const Main = () => {
                   <Details
                     openGroupIds={openGroupIds}
                     onToggleGroups={onToggleGroups}
+                    hoveredTaskState={hoveredTaskState}
                   />
                 </Box>
               </>

--- a/airflow/www/static/js/dag/StatusBox.tsx
+++ b/airflow/www/static/js/dag/StatusBox.tsx
@@ -139,6 +139,7 @@ const StatusBox = ({
           onMouseEnter={onMouseEnter}
           onMouseLeave={onMouseLeave}
           opacity={isActive ? 1 : 0.3}
+          transition="opacity 0.2s"
         />
       </Box>
     </Tooltip>

--- a/airflow/www/static/js/dag/details/graph/Node.test.tsx
+++ b/airflow/www/static/js/dag/details/graph/Node.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/airflow/www/static/js/dag/details/graph/Node.test.tsx
+++ b/airflow/www/static/js/dag/details/graph/Node.test.tsx
@@ -1,0 +1,126 @@
+/* eslint-disable class-methods-use-this */
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* global describe, test, expect */
+
+import React from "react";
+import { render } from "@testing-library/react";
+
+import { Wrapper } from "src/utils/testUtils";
+
+import type { NodeProps } from "reactflow";
+import type { Task, TaskInstance } from "src/types";
+import { CustomNodeProps, BaseNode as Node } from "./Node";
+
+const mockNode: NodeProps<CustomNodeProps> = {
+  id: "task_id",
+  data: {
+    label: "task_id",
+    height: 50,
+    width: 200,
+    instance: {
+      state: "success",
+      runId: "run_id",
+      taskId: "task_id",
+      startDate: "",
+      endDate: "",
+      note: "",
+    },
+    task: {
+      id: "task_id",
+      label: "task_id",
+      instances: [],
+      operator: "operator",
+    },
+    isSelected: false,
+    latestDagRunId: "run_id",
+    onToggleCollapse: () => {},
+    isActive: true,
+  },
+  selected: false,
+  zIndex: 0,
+  type: "custom",
+  isConnectable: false,
+  xPos: 0,
+  yPos: 0,
+  dragging: false,
+};
+
+describe("Test Graph Node", () => {
+  test("Renders normal task correctly", async () => {
+    const { getByText, getByTestId } = render(<Node {...mockNode} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(getByTestId("node")).toHaveStyle("opacity: 1");
+    expect(getByText("success")).toBeInTheDocument();
+    expect(getByText("task_id")).toBeInTheDocument();
+    expect(getByText("operator")).toBeInTheDocument();
+  });
+
+  test("Renders mapped task correctly", async () => {
+    const { getByText } = render(
+      <Node
+        {...mockNode}
+        data={{
+          ...mockNode.data,
+          task: { ...mockNode.data.task, isMapped: true } as Task,
+          instance: {
+            ...mockNode.data.instance,
+            mappedStates: { success: 4 },
+          } as TaskInstance,
+        }}
+      />,
+      {
+        wrapper: Wrapper,
+      }
+    );
+
+    expect(getByText("success")).toBeInTheDocument();
+    expect(getByText("task_id [4]")).toBeInTheDocument();
+  });
+
+  test("Renders task group correctly", async () => {
+    const { getByText } = render(
+      <Node
+        {...mockNode}
+        data={{ ...mockNode.data, childCount: 5, isOpen: false }}
+      />,
+      {
+        wrapper: Wrapper,
+      }
+    );
+
+    expect(getByText("success")).toBeInTheDocument();
+    expect(getByText("task_id")).toBeInTheDocument();
+    expect(getByText("+ 5 tasks")).toBeInTheDocument();
+  });
+
+  test("Renders normal task correctly", async () => {
+    const { getByTestId } = render(
+      <Node {...mockNode} data={{ ...mockNode.data, isActive: false }} />,
+      {
+        wrapper: Wrapper,
+      }
+    );
+
+    expect(getByTestId("node")).toHaveStyle("opacity: 0.3");
+  });
+});

--- a/airflow/www/static/js/dag/details/graph/Node.tsx
+++ b/airflow/www/static/js/dag/details/graph/Node.tsx
@@ -41,6 +41,7 @@ export interface CustomNodeProps {
   childCount?: number;
   onToggleCollapse: () => void;
   isOpen?: boolean;
+  isActive?: boolean;
 }
 
 const Node = ({
@@ -57,6 +58,7 @@ const Node = ({
     latestDagRunId,
     onToggleCollapse,
     isOpen,
+    isActive,
   },
 }: NodeProps<CustomNodeProps>) => {
   const { onSelect } = useSelection();
@@ -122,6 +124,8 @@ const Node = ({
           height={`${height}px`}
           width={`${width}px`}
           cursor={latestDagRunId ? "cursor" : "default"}
+          opacity={isActive ? 1 : 0.3}
+          transition="opacity 0.2s"
           onClick={() => {
             if (latestDagRunId) {
               onSelect({

--- a/airflow/www/static/js/dag/details/graph/Node.tsx
+++ b/airflow/www/static/js/dag/details/graph/Node.tsx
@@ -44,14 +44,13 @@ export interface CustomNodeProps {
   isActive?: boolean;
 }
 
-const Node = ({
+export const BaseNode = ({
   id,
   data: {
     label,
     childCount,
     height,
     width,
-    isJoinNode,
     instance,
     task,
     isSelected,
@@ -64,6 +63,96 @@ const Node = ({
   const { onSelect } = useSelection();
   const containerRef = useContainerRef();
 
+  if (!task) return null;
+
+  const { isMapped } = task;
+  const mappedStates = instance?.mappedStates;
+
+  const { totalTasks } = getGroupAndMapSummary({ group: task, mappedStates });
+
+  const taskName = isMapped
+    ? `${label} [${instance ? totalTasks : " "}]`
+    : label;
+
+  return (
+    <Tooltip
+      label={
+        instance && task ? (
+          <InstanceTooltip instance={instance} group={task} />
+        ) : null
+      }
+      portalProps={{ containerRef }}
+      hasArrow
+      placement="top"
+      openDelay={hoverDelay}
+    >
+      <Box
+        borderRadius={5}
+        borderWidth={1}
+        borderColor={isSelected ? "blue.400" : "gray.400"}
+        bg={isSelected ? "blue.50" : "white"}
+        height={`${height}px`}
+        width={`${width}px`}
+        cursor={latestDagRunId ? "cursor" : "default"}
+        opacity={isActive ? 1 : 0.3}
+        transition="opacity 0.2s"
+        data-testid="node"
+        onClick={() => {
+          if (latestDagRunId) {
+            onSelect({
+              runId: instance?.runId || latestDagRunId,
+              taskId: isSelected ? undefined : id,
+            });
+          }
+        }}
+      >
+        <Flex
+          justifyContent="space-between"
+          width={width}
+          p={2}
+          flexWrap="wrap"
+        >
+          <Flex flexDirection="column">
+            <Text noOfLines={1} maxWidth={`calc(${width}px - 8px)`}>
+              {taskName}
+            </Text>
+            {!!instance && instance.state && (
+              <Flex alignItems="center">
+                <SimpleStatus state={instance.state} />
+                <Text ml={2} color="gray.500" fontSize="sm">
+                  {instance.state}
+                </Text>
+              </Flex>
+            )}
+            {task?.operator && (
+              <Text color="gray.500" fontWeight={400} fontSize="md">
+                {task.operator}
+              </Text>
+            )}
+          </Flex>
+          {!!childCount && (
+            <Text
+              color="blue.600"
+              cursor="pointer"
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleCollapse();
+              }}
+            >
+              {isOpen ? "- " : "+ "}
+              {childCount} tasks
+            </Text>
+          )}
+        </Flex>
+      </Box>
+    </Tooltip>
+  );
+};
+
+const Node = (props: NodeProps<CustomNodeProps>) => {
+  const {
+    data: { height, width, isJoinNode, task },
+  } = props;
   if (isJoinNode) {
     return (
       <>
@@ -88,16 +177,6 @@ const Node = ({
   }
 
   if (!task) return null;
-
-  const { isMapped } = task;
-  const mappedStates = instance?.mappedStates;
-
-  const { totalTasks } = getGroupAndMapSummary({ group: task, mappedStates });
-
-  const taskName = isMapped
-    ? `${label} [${instance ? totalTasks : " "}]`
-    : label;
-
   return (
     <>
       <Handle
@@ -105,76 +184,7 @@ const Node = ({
         position={Position.Top}
         style={{ visibility: "hidden" }}
       />
-      <Tooltip
-        label={
-          instance && task ? (
-            <InstanceTooltip instance={instance} group={task} />
-          ) : null
-        }
-        portalProps={{ containerRef }}
-        hasArrow
-        placement="top"
-        openDelay={hoverDelay}
-      >
-        <Box
-          borderRadius={5}
-          borderWidth={1}
-          borderColor={isSelected ? "blue.400" : "gray.400"}
-          bg={isSelected ? "blue.50" : "white"}
-          height={`${height}px`}
-          width={`${width}px`}
-          cursor={latestDagRunId ? "cursor" : "default"}
-          opacity={isActive ? 1 : 0.3}
-          transition="opacity 0.2s"
-          onClick={() => {
-            if (latestDagRunId) {
-              onSelect({
-                runId: instance?.runId || latestDagRunId,
-                taskId: isSelected ? undefined : id,
-              });
-            }
-          }}
-        >
-          <Flex
-            justifyContent="space-between"
-            width={width}
-            p={2}
-            flexWrap="wrap"
-          >
-            <Flex flexDirection="column">
-              <Text noOfLines={1} maxWidth={`calc(${width}px - 8px)`}>
-                {taskName}
-              </Text>
-              {!!instance && instance.state && (
-                <Flex alignItems="center">
-                  <SimpleStatus state={instance.state} />
-                  <Text ml={2} color="gray.500" fontSize="sm">
-                    {instance.state}
-                  </Text>
-                </Flex>
-              )}
-              {task?.operator && (
-                <Text color="gray.500" fontWeight={400} fontSize="md">
-                  {task.operator}
-                </Text>
-              )}
-            </Flex>
-            {!!childCount && (
-              <Text
-                color="blue.600"
-                cursor="pointer"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onToggleCollapse();
-                }}
-              >
-                {isOpen ? "- " : "+ "}
-                {childCount} tasks
-              </Text>
-            )}
-          </Flex>
-        </Box>
-      </Tooltip>
+      <BaseNode {...props} />
       <Handle
         type="source"
         position={Position.Bottom}

--- a/airflow/www/static/js/dag/details/graph/index.tsx
+++ b/airflow/www/static/js/dag/details/graph/index.tsx
@@ -49,9 +49,10 @@ const edgeTypes = { custom: Edge };
 interface Props {
   openGroupIds: string[];
   onToggleGroups: (groupIds: string[]) => void;
+  hoveredTaskState?: string | null;
 }
 
-const Graph = ({ openGroupIds, onToggleGroups }: Props) => {
+const Graph = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
   const graphRef = useRef(null);
   const containerRef = useContainerRef();
   const { data } = useGraphData();
@@ -96,6 +97,7 @@ const Graph = ({ openGroupIds, onToggleGroups }: Props) => {
       onToggleGroups,
       latestDagRunId,
       groups,
+      hoveredTaskState,
     });
   }
 
@@ -184,9 +186,17 @@ const Graph = ({ openGroupIds, onToggleGroups }: Props) => {
   );
 };
 
-const GraphWrapper = ({ openGroupIds, onToggleGroups }: Props) => (
+const GraphWrapper = ({
+  openGroupIds,
+  onToggleGroups,
+  hoveredTaskState,
+}: Props) => (
   <ReactFlowProvider>
-    <Graph openGroupIds={openGroupIds} onToggleGroups={onToggleGroups} />
+    <Graph
+      openGroupIds={openGroupIds}
+      onToggleGroups={onToggleGroups}
+      hoveredTaskState={hoveredTaskState}
+    />
   </ReactFlowProvider>
 );
 

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -52,6 +52,7 @@ const dagId = getMetaValue("dag_id")!;
 interface Props {
   openGroupIds: string[];
   onToggleGroups: (groupIds: string[]) => void;
+  hoveredTaskState?: string | null;
 }
 
 const tabToIndex = (tab?: string) => {
@@ -87,7 +88,7 @@ const indexToTab = (
 
 const TAB_PARAM = "tab";
 
-const Details = ({ openGroupIds, onToggleGroups }: Props) => {
+const Details = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
   const {
     selected: { runId, taskId, mapIndex },
     onSelect,
@@ -210,6 +211,7 @@ const Details = ({ openGroupIds, onToggleGroups }: Props) => {
             <Graph
               openGroupIds={openGroupIds}
               onToggleGroups={onToggleGroups}
+              hoveredTaskState={hoveredTaskState}
             />
           </TabPanel>
           {showLogs && run && (


### PR DESCRIPTION
Hovering over the legend of task states should highlight tasks in both the grid and graph at the same time. This is also reflected in the minimap.

Also, added a transition for the opacity.

Related: [#29852](https://github.com/apache/airflow/issues/29852)

<img width="1002" alt="Screenshot 2023-03-14 at 9 51 47 AM" src="https://user-images.githubusercontent.com/4600967/225023418-4acc7e30-8bf3-4bd3-9c76-586af815b363.png">

![Mar-14-2023 09-52-30](https://user-images.githubusercontent.com/4600967/225023409-c6a1d467-68ee-4c07-8a6e-b75acd6e1daa.gif)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
