### PR TITLE
Allow customized rules to check if a file has dag

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -45,7 +45,7 @@ core:
     might_contain_dag_callable:
       description: |
          A callable to check if a python file has airflow dags defined or not
-         with argument as: `(file_path: str, safe_mode: bool, zip_file: zipfile.ZipFile | None = None)`
+         with argument as: `(file_path: str, zip_file: zipfile.ZipFile | None = None)`
          return True if it has dags otherwise False
          If this is not provided, Airflow uses its own heuristic rules.
       version_added: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -42,6 +42,16 @@ core:
       type: string
       example: ~
       default: "airflow.utils.net.getfqdn"
+    might_contain_dag_callable:
+      description: |
+         A callable to check if a python file has airflow dags defined or not
+         with argument as: `(file_path: str, safe_mode: bool, zip_file: zipfile.ZipFile | None = None)`
+         return True if it has dags otherwise False
+         If this is not provided, Airflow uses its own heuristic rules.
+      version_added: ~
+      type: string
+      example: ~
+      default: "airflow.utils.file.might_contain_dag_via_default_heuristic"
     default_timezone:
       description: |
         Default timezone in case supplied date times are naive

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -42,6 +42,12 @@ dags_folder = {AIRFLOW_HOME}/dags
 # If using IP address as hostname is preferred, use value ``airflow.utils.net.get_host_ip_address``
 hostname_callable = airflow.utils.net.getfqdn
 
+# A callable to check if a python file has airflow dags defined or not
+# with argument as: `(file_path: str, safe_mode: bool, zip_file: zipfile.ZipFile | None = None)`
+# return True if it has dags otherwise False
+# If this is not provided, Airflow uses its own heuristic rules.
+might_contain_dag_callable = airflow.utils.file.might_contain_dag_via_default_heuristic
+
 # Default timezone in case supplied date times are naive
 # can be utc (default), system, or any IANA timezone string (e.g. Europe/Amsterdam)
 default_timezone = utc

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -43,7 +43,7 @@ dags_folder = {AIRFLOW_HOME}/dags
 hostname_callable = airflow.utils.net.getfqdn
 
 # A callable to check if a python file has airflow dags defined or not
-# with argument as: `(file_path: str, safe_mode: bool, zip_file: zipfile.ZipFile | None = None)`
+# with argument as: `(file_path: str, zip_file: zipfile.ZipFile | None = None)`
 # return True if it has dags otherwise False
 # If this is not provided, Airflow uses its own heuristic rules.
 might_contain_dag_callable = airflow.utils.file.might_contain_dag_via_default_heuristic

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -335,7 +335,23 @@ def find_dag_file_paths(directory: str | pathlib.Path, safe_mode: bool) -> list[
 COMMENT_PATTERN = re.compile(r"\s*#.*")
 
 
-def might_contain_dag(file_path: str, safe_mode: bool, zip_file: zipfile.ZipFile | None = None):
+def might_contain_dag(file_path: str, safe_mode: bool, zip_file: zipfile.ZipFile | None = None) -> bool:
+    """
+    Check whether a Python file contains Airflow DAGs
+
+    If might_contain_dag_callable isn't specified, it uses airflow default heuristic
+    """
+    might_contain_dag_callable = conf.getimport(
+        "core",
+        "might_contain_dag_callable",
+        fallback="airflow.utils.file.might_contain_dag_via_default_heuristic",
+    )
+    return might_contain_dag_callable(file_path=file_path, safe_mode=safe_mode, zip_file=zip_file)
+
+
+def might_contain_dag_via_default_heuristic(
+    file_path: str, safe_mode: bool, zip_file: zipfile.ZipFile | None = None
+) -> bool:
     """
     Heuristic that guesses whether a Python file contains an Airflow DAG definition.
 

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -337,31 +337,30 @@ COMMENT_PATTERN = re.compile(r"\s*#.*")
 
 def might_contain_dag(file_path: str, safe_mode: bool, zip_file: zipfile.ZipFile | None = None) -> bool:
     """
-    Check whether a Python file contains Airflow DAGs
+    Check whether a Python file contains Airflow DAGs.
+    When safe_mode is off (with False value), this function always returns True.
 
     If might_contain_dag_callable isn't specified, it uses airflow default heuristic
     """
+    if not safe_mode:
+        return True
+
     might_contain_dag_callable = conf.getimport(
         "core",
         "might_contain_dag_callable",
         fallback="airflow.utils.file.might_contain_dag_via_default_heuristic",
     )
-    return might_contain_dag_callable(file_path=file_path, safe_mode=safe_mode, zip_file=zip_file)
+    return might_contain_dag_callable(file_path=file_path, zip_file=zip_file)
 
 
-def might_contain_dag_via_default_heuristic(
-    file_path: str, safe_mode: bool, zip_file: zipfile.ZipFile | None = None
-) -> bool:
+def might_contain_dag_via_default_heuristic(file_path: str, zip_file: zipfile.ZipFile | None = None) -> bool:
     """
     Heuristic that guesses whether a Python file contains an Airflow DAG definition.
 
     :param file_path: Path to the file to be checked.
-    :param safe_mode: Is safe mode active?. If no, this function always returns True.
     :param zip_file: if passed, checks the archive. Otherwise, check local filesystem.
     :return: True, if file might contain DAGs.
     """
-    if not safe_mode:
-        return True
     if zip_file:
         with zip_file.open(file_path) as current_file:
             content = current_file.read()

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -165,6 +165,15 @@ While both DAG constructors get called when the file is accessed, only ``dag_1``
 
 You can also provide an ``.airflowignore`` file inside your ``DAG_FOLDER``, or any of its subfolders, which describes patterns of files for the loader to ignore. It covers the directory it's in plus all subfolders underneath it. See  :ref:`.airflowignore <concepts:airflowignore>` below for details of the file syntax.
 
+In the case where the ``.airflowignore`` does not meet your needs and you want a more flexible way to control if a python file needs to be parsed by Airflow. You can plug your callable by setting ``might_contain_dag_callable`` in the config file.
+Note, this callable will replace the default Airflow heuristic, i.e. checking if the strings ``airflow`` and ``dag`` (case-insensitively) in the file.
+
+.. code-block::
+
+    def might_contain_dag(file_path: str, safe_mode: bool, zip_file: zipfile.ZipFile | None = None) -> bool:
+        # Your logic to check if there are DAGs defined in the file_path
+        # Return True if the file_path needs to be parsed, otherwise False
+
 
 .. _concepts-dag-run:
 

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -170,7 +170,7 @@ Note, this callable will replace the default Airflow heuristic, i.e. checking if
 
 .. code-block::
 
-    def might_contain_dag(file_path: str, safe_mode: bool, zip_file: zipfile.ZipFile | None = None) -> bool:
+    def might_contain_dag(file_path: str, zip_file: zipfile.ZipFile | None = None) -> bool:
         # Your logic to check if there are DAGs defined in the file_path
         # Return True if the file_path needs to be parsed, otherwise False
 

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -19,13 +19,20 @@ from __future__ import annotations
 
 import os
 import os.path
+import zipfile
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
+from airflow.utils import file as file_utils
 from airflow.utils.file import correct_maybe_zipped, find_path_from_directory, open_maybe_zipped
 from tests.models import TEST_DAGS_FOLDER
+from tests.test_utils.config import conf_vars
+
+
+def might_contain_dag(file_path: str, safe_mode: bool, zip_file: zipfile.ZipFile | None = None):
+    return False
 
 
 class TestCorrectMaybeZipped:
@@ -163,3 +170,18 @@ class TestListPyFilesPath:
                 f"Detected recursive loop when walking DAG directory {test_dir}: "
                 f"{Path(recursing_tgt).resolve()} has appeared more than once."
             )
+
+    def test_might_contain_dag_with_default_callable(self):
+        file_path_with_dag = os.path.join(TEST_DAGS_FOLDER, "test_scheduler_dags.py")
+
+        assert file_utils.might_contain_dag(file_path=file_path_with_dag, safe_mode=True)
+
+    @conf_vars({("core", "might_contain_dag_callable"): "tests.utils.test_file.might_contain_dag"})
+    def test_might_contain_dag(self):
+        """Test might_contain_dag_callable"""
+        file_path_with_dag = os.path.join(TEST_DAGS_FOLDER, "test_scheduler_dags.py")
+
+        # There is a DAG defined in the file_path_with_dag, however, the might_contain_dag_callable
+        # returns False no matter what, which is used to test might_contain_dag_callable actually
+        # overrides the default function
+        assert not file_utils.might_contain_dag(file_path=file_path_with_dag, safe_mode=True)

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -31,7 +31,7 @@ from tests.models import TEST_DAGS_FOLDER
 from tests.test_utils.config import conf_vars
 
 
-def might_contain_dag(file_path: str, safe_mode: bool, zip_file: zipfile.ZipFile | None = None):
+def might_contain_dag(file_path: str, zip_file: zipfile.ZipFile | None = None):
     return False
 
 
@@ -185,3 +185,6 @@ class TestListPyFilesPath:
         # returns False no matter what, which is used to test might_contain_dag_callable actually
         # overrides the default function
         assert not file_utils.might_contain_dag(file_path=file_path_with_dag, safe_mode=True)
+
+        # With safe_mode is False, the user defined callable won't be invoked
+        assert file_utils.might_contain_dag(file_path=file_path_with_dag, safe_mode=False)


### PR DESCRIPTION
Currently, Airflow uses its heuristic rules to check if a py file has DAGs defined or not by checking if `dag` or `airflow` in the file content. This generally works well however for cases with lots of py files, it could lead to lots of false positive. This change allows users to have more flexible rules to meet their needs.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
