### PR TITLE
Add exception class name to DAG-parsing error message

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -438,7 +438,7 @@ class DagBag(LoggingMixin):
                 self.bag_dag(dag=dag, root_dag=dag)
             except Exception as e:
                 self.log.exception("Failed to bag_dag: %s", dag.fileloc)
-                self.import_errors[dag.fileloc] = repr(e)
+                self.import_errors[dag.fileloc] = f"{type(e).__name__}: {e}"
                 self.file_last_changed[dag.fileloc] = file_last_changed_on_disk
             else:
                 found_dags.append(dag)

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -438,7 +438,7 @@ class DagBag(LoggingMixin):
                 self.bag_dag(dag=dag, root_dag=dag)
             except Exception as e:
                 self.log.exception("Failed to bag_dag: %s", dag.fileloc)
-                self.import_errors[dag.fileloc] = str(e)
+                self.import_errors[dag.fileloc] = repr(e)
                 self.file_last_changed[dag.fileloc] = file_last_changed_on_disk
             else:
                 found_dags.append(dag)

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -1007,12 +1007,14 @@ class TestDagBag:
         obey cluster policy.
         """
         dag_file = os.path.join(TEST_DAGS_FOLDER, "test_missing_owner.py")
+        dag_id = "test_missing_owner"
+        err_cls_name = "AirflowClusterPolicyViolation"
 
         dagbag = DagBag(dag_folder=dag_file, include_examples=False)
         assert set() == set(dagbag.dag_ids)
         expected_import_errors = {
             dag_file: (
-                f"""AirflowClusterPolicyViolation: DAG policy violation (DAG ID: test_missing_owner, Path: {dag_file}):\n"""
+                f"""{err_cls_name}: DAG policy violation (DAG ID: {dag_id}, Path: {dag_file}):\n"""
                 """Notices:\n"""
                 """ * Task must have non-None non-default owner. Current value: airflow"""
             )
@@ -1027,12 +1029,14 @@ class TestDagBag:
         """
         TEST_DAGS_CORRUPTED_FOLDER = pathlib.Path(__file__).parent.with_name("dags_corrupted")
         dag_file = os.path.join(TEST_DAGS_CORRUPTED_FOLDER, "test_nonstring_owner.py")
+        dag_id = "test_nonstring_owner"
+        err_cls_name = "AirflowClusterPolicyViolation"
 
         dagbag = DagBag(dag_folder=dag_file, include_examples=False)
         assert set() == set(dagbag.dag_ids)
         expected_import_errors = {
             dag_file: (
-                f"""DAG policy violation (DAG ID: test_nonstring_owner, Path: {dag_file}):\n"""
+                f"""{err_cls_name}: DAG policy violation (DAG ID: {dag_id}, Path: {dag_file}):\n"""
                 """Notices:\n"""
                 """ * owner should be a string. Current value: ['a']"""
             )
@@ -1061,7 +1065,6 @@ class TestDagBag:
         assert "has no tags" in dagbag.import_errors[dag_file]
 
     def test_dagbag_dag_collection(self):
-
         dagbag = DagBag(dag_folder=TEST_DAGS_FOLDER, include_examples=False, collect_dags=False)
         # since collect_dags is False, dagbag.dags should be empty
         assert not dagbag.dags

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -184,7 +184,7 @@ class TestDagBag:
 
             found_2 = dagbag.process_file(tf_2.name)
             assert len(found_2) == 0
-            assert dagbag.import_errors[tf_2.name].startswith("Ignoring DAG")
+            assert dagbag.import_errors[tf_2.name].startswith("AirflowDagDuplicatedIdException: Ignoring DAG")
             assert dagbag.dags == dags_in_bag  # Should not change.
 
     def test_zip_skip_log(self, caplog):
@@ -1012,7 +1012,7 @@ class TestDagBag:
         assert set() == set(dagbag.dag_ids)
         expected_import_errors = {
             dag_file: (
-                f"""DAG policy violation (DAG ID: test_missing_owner, Path: {dag_file}):\n"""
+                f"""AirflowClusterPolicyViolation: DAG policy violation (DAG ID: test_missing_owner, Path: {dag_file}):\n"""
                 """Notices:\n"""
                 """ * Task must have non-None non-default owner. Current value: airflow"""
             )


### PR DESCRIPTION
related: #29056
related: https://github.com/apache/airflow/issues/30028#issuecomment-1468437023

---

Tested #29056 (minor fix for handling error on cluster policy itself) and looks good.
![image](https://user-images.githubusercontent.com/81631424/225090602-914cd52c-fa6c-4762-98c4-89169fae4c73.png)

But i think it's better to use repr(e) than str(e) for showing error class name on web UI message.

`self.import_errors[dag.fileloc] = str(e)` -> `self.import_errors[dag.fileloc] = repr(e)`

In other exception cases(=error on DAG module itself), there are `traceback` related configurations to show error traceback on the web UI.
```python
    self.dagbag_import_error_tracebacks = conf.getboolean('core', 'dagbag_import_error_tracebacks')
    self.dagbag_import_error_traceback_depth = conf.getint('core', 'dagbag_import_error_traceback_depth')
```

But, I think, use of error traceback on this case is a bit too much, but it's enough to show exception class name on the Import Error Web UI
- AirflowTimetableInvalid
- AirflowClusterPolicyViolation
- AirflowClusterPolicyError
- AirflowDagCycleException
- AirflowDagDuplicatedIdException
- AirflowDagInconsistent
- ParamValidationError