### PR TITLE
Allow setting the DagRun state in create DAGRun API

### DIFF
--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -338,7 +338,7 @@ def post_dag_run(*, dag_id: str, session: Session = NEW_SESSION) -> APIResponse:
                 run_id=run_id,
                 execution_date=logical_date,
                 data_interval=dag.timetable.infer_manual_data_interval(run_after=logical_date),
-                state=post_body.get("state"),
+                state=post_body.get("state", DagRunState.QUEUED),
                 conf=post_body.get("conf"),
                 external_trigger=True,
                 dag_hash=get_airflow_app().dag_bag.dags_hash.get(dag_id),

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -338,7 +338,7 @@ def post_dag_run(*, dag_id: str, session: Session = NEW_SESSION) -> APIResponse:
                 run_id=run_id,
                 execution_date=logical_date,
                 data_interval=dag.timetable.infer_manual_data_interval(run_after=logical_date),
-                state=DagRunState.QUEUED,
+                state=post_body.get("state"),
                 conf=post_body.get("conf"),
                 external_trigger=True,
                 dag_hash=get_airflow_app().dag_bag.dags_hash.get(dag_id),

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2805,7 +2805,7 @@ components:
             - dataset_triggered
         state:
           $ref: '#/components/schemas/DagState'
-          readOnly: true
+          default: queued
         external_trigger:
           type: boolean
           default: true

--- a/airflow/api_connexion/schemas/dag_run_schema.py
+++ b/airflow/api_connexion/schemas/dag_run_schema.py
@@ -66,7 +66,7 @@ class DAGRunSchema(SQLAlchemySchema):
     execution_date = auto_field(data_key="logical_date", validate=validate_istimezone)
     start_date = auto_field(dump_only=True)
     end_date = auto_field(dump_only=True)
-    state = DagStateField(dump_only=True)
+    state = DagStateField(dump_only=False)
     external_trigger = auto_field(dump_default=True, dump_only=True)
     conf = ConfObject()
     data_interval_start = auto_field(dump_only=True)

--- a/airflow/api_connexion/schemas/dag_run_schema.py
+++ b/airflow/api_connexion/schemas/dag_run_schema.py
@@ -66,7 +66,7 @@ class DAGRunSchema(SQLAlchemySchema):
     execution_date = auto_field(data_key="logical_date", validate=validate_istimezone)
     start_date = auto_field(dump_only=True)
     end_date = auto_field(dump_only=True)
-    state = DagStateField(dump_only=False)
+    state = DagStateField()
     external_trigger = auto_field(dump_default=True, dump_only=True)
     conf = ConfObject()
     data_interval_start = auto_field(dump_only=True)

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -1228,6 +1228,27 @@ class TestPostDagRun(TestDagRunEndpoint):
         assert response.status_code == 400
         assert response.json["detail"] == expected
 
+    @pytest.mark.parametrize(
+        "data, expected",
+        [
+            (
+                {
+                    "dag_run_id": "TEST_DAG_RUN",
+                    "execution_date": "2020-06-11T18:00:00+00:00",
+                    "state": "queueueued",
+                },
+                "'queueueued' is not one of ['queued', 'running', 'success', 'failed'] - 'state'",
+            )
+        ],
+    )
+    def test_should_response_400_for_invalid_state(self, data, expected):
+        self._create_dag("TEST_DAG_ID")
+        response = self.client.post(
+            "api/v1/dags/TEST_DAG_ID/dagRuns", json=data, environ_overrides={"REMOTE_USER": "test"}
+        )
+        assert response.status_code == 400
+        assert response.json["detail"] == expected
+
     def test_response_404(self):
         response = self.client.post(
             "api/v1/dags/TEST_DAG_ID/dagRuns",


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/30075

This allows incoming API requests to create DAGs in non-queued states (`running`, `success`, `failed`), which is more consistent with the documentation. 

As-per the original issue, I'm not sure whether:
 - The code is wrong (in which case this is the correct fix)
  - The documentation generated from the OpenAPI spec is wrong (which is due to the reference overriding the readOnly attribute [here](https://github.com/apache/airflow/blob/a6715805c7e4694e85b8f3ebff162a2c3905110e/airflow/api_connexion/openapi/v1.yaml#L2806-L2808), as described [here](https://github.com/swagger-api/swagger-ui/issues/3445#issuecomment-339649576)).
  
Let me know what you think, and if you think that this functionality is undesirable then I can update my PR to simply fix the API Docs.

Tested in Breeze by creating several non-queued DAGRuns via the API.