### PR TITLE
Re-enable note ordering in DagRunModelView

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -173,7 +173,12 @@ class DagRun(Base, LoggingMixin):
         uselist=False,
         viewonly=True,
     )
-    dag_run_note = relationship("DagRunNote", back_populates="dag_run", uselist=False)
+    dag_run_note = relationship(
+        "DagRunNote",
+        cascade="save-update, merge, delete, delete-orphan",
+        back_populates="dag_run",
+        uselist=False,
+    )
     note = association_proxy("dag_run_note", "content", creator=_creator_note)
 
     DEFAULT_DAGRUNS_TO_EXAMINE = airflow_conf.getint(

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -175,7 +175,7 @@ class DagRun(Base, LoggingMixin):
     )
     dag_run_note = relationship(
         "DagRunNote",
-        cascade="save-update, merge, delete, delete-orphan",
+        cascade="all, delete-orphan",
         back_populates="dag_run",
         uselist=False,
     )

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -5036,7 +5036,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         "queued_at",
         "start_date",
         "end_date",
-        "note",
+        "dag_run_note.content",
         "external_trigger",
         "conf",
         "duration",
@@ -5049,10 +5049,11 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         "run_type",
         "start_date",
         "end_date",
-        # "note",  # todo: maybe figure out how to re-enable this
+        # "dag_run_note.content",  # todo: maybe figure out how to re-enable this
         "external_trigger",
     ]
     label_columns = {
+        "dag_run_note.content": "Note",
         "execution_date": "Logical Date",
     }
     edit_columns = [
@@ -5076,7 +5077,9 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         "queued_at",
         "start_date",
         "end_date",
-        # "note", # todo: maybe figure out how to re-enable this
+        # TODO: This would sort by DagRunNote's primary key. How do we sort
+        # alphabetically by the content instead?
+        # "dag_run_note.content",
         "external_trigger",
         "conf",
     ]


### PR DESCRIPTION
Following up https://github.com/apache/airflow/issues/30041 and #30043. This is actually much easier than I thought; instead of the associated proxy, we can reference the actual field here, and use a custom label.