### PR TITLE
Fix inconsistent returned value of `airflow dags next-execution` cli command

### DIFF
--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -27,7 +27,6 @@ import sys
 
 from graphviz.dot import Dot
 from sqlalchemy.orm import Session
-from sqlalchemy.sql.functions import func
 
 from airflow import settings
 from airflow.api.client import get_current_api_client

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -296,8 +296,7 @@ def dag_next_execution(args):
         print("[INFO] Please be reminded this DAG is PAUSED now.", file=sys.stderr)
         with create_session() as session:
             last_parsed_dag: DagModel = (
-                session.query(DagModel)
-                .filter(DagModel.dag_id == dag.dag_id)
+                session.query(DagModel).filter(DagModel.dag_id == dag.dag_id)
             ).one_or_none()
         print(last_parsed_dag.next_dagrun.isoformat())
     else:
@@ -314,7 +313,10 @@ def dag_next_execution(args):
             )
 
             if max_date_run is None:
-                print("[WARN] Only applicable when there is execution record found for the DAG.", file=sys.stderr)
+                print(
+                    "[WARN] Only applicable when there is execution record found for the DAG.",
+                    file=sys.stderr,
+                )
                 print(None)
                 return
 

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -294,34 +294,16 @@ def dag_next_execution(args):
 
     if dag.get_is_paused():
         print("[INFO] Please be reminded this DAG is PAUSED now.", file=sys.stderr)
-        with create_session() as session:
-            last_parsed_dag: DagModel = (
-                session.query(DagModel).filter(DagModel.dag_id == dag.dag_id)
-            ).one_or_none()
-        print(last_parsed_dag.next_dagrun.isoformat())
-    else:
-        with create_session() as session:
-            max_date_subq = (
-                session.query(func.max(DagRun.execution_date).label("max_date"))
-                .filter(DagRun.dag_id == dag.dag_id)
-                .subquery()
-            )
-            max_date_run: DagRun | None = (
-                session.query(DagRun)
-                .filter(DagRun.dag_id == dag.dag_id, DagRun.execution_date == max_date_subq.c.max_date)
-                .one_or_none()
-            )
 
-            if max_date_run is None:
-                print(
-                    "[WARN] Only applicable when there is execution record found for the DAG.",
-                    file=sys.stderr,
-                )
-                print(None)
-                return
+    with create_session() as session:
+        last_parsed_dag: DagModel = session.query(DagModel).filter(DagModel.dag_id == dag.dag_id).one()
 
-        next_info = dag.next_dagrun_info(dag.get_run_data_interval(max_date_run), restricted=False)
-        if next_info is None:
+    next_interval = dag.get_next_data_interval(last_parsed_dag)
+    for i in range(args.num_executions):
+        if i != 0:
+            next_info = dag.next_dagrun_info(next_interval, restricted=False)
+            next_interval = None if next_info is None else next_info.data_interval
+        if next_interval is None:
             print(
                 "[WARN] No following schedule can be found. "
                 "This DAG may have schedule interval '@once' or `None`.",
@@ -329,11 +311,7 @@ def dag_next_execution(args):
             )
             print(None)
             return
-
-        print(next_info.logical_date.isoformat())
-        for _ in range(1, args.num_executions):
-            next_info = dag.next_dagrun_info(next_info.data_interval, restricted=False)
-            print(next_info.logical_date.isoformat())
+        print(next_interval.start.isoformat())
 
 
 @cli_utils.action_cli


### PR DESCRIPTION
closes: #22474 

- This commit is to fix the inconsistent returned value of `airflow dags next-execution` cli command when the dag is paused and catchup is False

In brief:
- When the dag is unpaused, the cli command would get the next-execution run from the `DagRun` model. However, when the dag is paused, getting the next-execution run from the `DagRun` model would yield the next dag run time from the last executed dag run, which is incorrect as time passes.
- To avoid this, we can get the next-execution run time from `dag_model.next_dag_run` (as in: [dag.html L143](https://github.com/apache/airflow/blob/main/airflow/www/templates/airflow/dag.html#L143)) to make it more consistent with the UI.

Modification:
- Use only the `DagModel` to get a dag next execution info. This way we could:
  - Handle the `catchup=False` case and when the Dag is paused.
  - Handle the case of next execution info is `None` when `args.num_executions` is specified. Previous code will throw an error as follow: None type has no attribute logical_date ...
  - Modify test case to handle all dag parsing scenarios.

This is my first PR, please let me know if there is anything I could do differently.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.