### PR TITLE
Remove "boilerplate" from all taskflow decorators

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -20,6 +20,7 @@ import inspect
 import re
 import warnings
 from itertools import chain
+from textwrap import dedent
 from typing import (
     Any,
     Callable,
@@ -66,6 +67,7 @@ from airflow.models.xcom_arg import XComArg
 from airflow.typing_compat import ParamSpec, Protocol
 from airflow.utils import timezone
 from airflow.utils.context import KNOWN_CONTEXT_KEYS, Context
+from airflow.utils.decorators import remove_task_decorator
 from airflow.utils.helpers import prevent_duplicates
 from airflow.utils.task_group import TaskGroup, TaskGroupContext
 from airflow.utils.types import NOTSET
@@ -266,6 +268,12 @@ class DecoratedOperator(BaseOperator):
                 op_kwargs[arg] = default_args[arg]
         kwargs["op_kwargs"] = op_kwargs
         return args, kwargs
+
+    def get_python_source(self):
+        raw_source = inspect.getsource(self.python_callable)
+        res = dedent(raw_source)
+        res = remove_task_decorator(res, self.custom_operator_name)
+        return res
 
 
 FParams = ParamSpec("FParams")

--- a/airflow/decorators/branch_python.py
+++ b/airflow/decorators/branch_python.py
@@ -16,13 +16,10 @@
 # under the License.
 from __future__ import annotations
 
-import inspect
-from textwrap import dedent
-from typing import Callable, Sequence
+from typing import Callable
 
 from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
 from airflow.operators.python import BranchPythonOperator
-from airflow.utils.decorators import remove_task_decorator
 
 
 class _BranchPythonDecoratedOperator(DecoratedOperator, BranchPythonOperator):
@@ -39,13 +36,6 @@ class _BranchPythonDecoratedOperator(DecoratedOperator, BranchPythonOperator):
         Defaults to False.
     """
 
-    template_fields: Sequence[str] = ("op_args", "op_kwargs")
-    template_fields_renderers = {"op_args": "py", "op_kwargs": "py"}
-
-    # since we won't mutate the arguments, we should just do the shallow copy
-    # there are some cases we can't deepcopy the objects (e.g protobuf).
-    shallow_copy_attrs: Sequence[str] = ("python_callable",)
-
     custom_operator_name: str = "@task.branch"
 
     def __init__(
@@ -58,12 +48,6 @@ class _BranchPythonDecoratedOperator(DecoratedOperator, BranchPythonOperator):
             "op_kwargs": kwargs["op_kwargs"],
         }
         super().__init__(kwargs_to_upstream=kwargs_to_upstream, **kwargs)
-
-    def get_python_source(self):
-        raw_source = inspect.getsource(self.python_callable)
-        res = dedent(raw_source)
-        res = remove_task_decorator(res, "@task.branch")
-        return res
 
 
 def branch_task(

--- a/airflow/decorators/external_python.py
+++ b/airflow/decorators/external_python.py
@@ -16,13 +16,10 @@
 # under the License.
 from __future__ import annotations
 
-import inspect
-from textwrap import dedent
-from typing import Callable, Sequence
+from typing import Callable
 
 from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
 from airflow.operators.python import ExternalPythonOperator
-from airflow.utils.decorators import remove_task_decorator
 
 
 class _PythonExternalDecoratedOperator(DecoratedOperator, ExternalPythonOperator):
@@ -41,13 +38,6 @@ class _PythonExternalDecoratedOperator(DecoratedOperator, ExternalPythonOperator
         multiple XCom values. Dict will unroll to XCom values with its keys as XCom keys. Defaults to False.
     """
 
-    template_fields: Sequence[str] = ("op_args", "op_kwargs")
-    template_fields_renderers = {"op_args": "py", "op_kwargs": "py"}
-
-    # since we won't mutate the arguments, we should just do the shallow copy
-    # there are some cases we can't deepcopy the objects (e.g protobuf).
-    shallow_copy_attrs: Sequence[str] = ("python_callable",)
-
     custom_operator_name: str = "@task.external_python"
 
     def __init__(self, *, python_callable, op_args, op_kwargs, **kwargs) -> None:
@@ -63,12 +53,6 @@ class _PythonExternalDecoratedOperator(DecoratedOperator, ExternalPythonOperator
             op_kwargs=op_kwargs,
             **kwargs,
         )
-
-    def get_python_source(self):
-        raw_source = inspect.getsource(self.python_callable)
-        res = dedent(raw_source)
-        res = remove_task_decorator(res, "@task.external_python")
-        return res
 
 
 def external_python_task(

--- a/airflow/decorators/python.py
+++ b/airflow/decorators/python.py
@@ -38,10 +38,6 @@ class _PythonDecoratedOperator(DecoratedOperator, PythonOperator):
     template_fields: Sequence[str] = ("templates_dict", "op_args", "op_kwargs")
     template_fields_renderers = {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}
 
-    # since we won't mutate the arguments, we should just do the shallow copy
-    # there are some cases we can't deepcopy the objects (e.g protobuf).
-    shallow_copy_attrs: Sequence[str] = ("python_callable",)
-
     custom_operator_name: str = "@task"
 
     def __init__(self, *, python_callable, op_args, op_kwargs, **kwargs) -> None:

--- a/airflow/decorators/python_virtualenv.py
+++ b/airflow/decorators/python_virtualenv.py
@@ -16,13 +16,10 @@
 # under the License.
 from __future__ import annotations
 
-import inspect
-from textwrap import dedent
-from typing import Callable, Sequence
+from typing import Callable
 
 from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
 from airflow.operators.python import PythonVirtualenvOperator
-from airflow.utils.decorators import remove_task_decorator
 
 
 class _PythonVirtualenvDecoratedOperator(DecoratedOperator, PythonVirtualenvOperator):
@@ -37,13 +34,6 @@ class _PythonVirtualenvDecoratedOperator(DecoratedOperator, PythonVirtualenvOper
     :param multiple_outputs: If set to True, the decorated function's return value will be unrolled to
         multiple XCom values. Dict will unroll to XCom values with its keys as XCom keys. Defaults to False.
     """
-
-    template_fields: Sequence[str] = ("op_args", "op_kwargs")
-    template_fields_renderers = {"op_args": "py", "op_kwargs": "py"}
-
-    # since we won't mutate the arguments, we should just do the shallow copy
-    # there are some cases we can't deepcopy the objects (e.g protobuf).
-    shallow_copy_attrs: Sequence[str] = ("python_callable",)
 
     custom_operator_name: str = "@task.virtualenv"
 
@@ -60,12 +50,6 @@ class _PythonVirtualenvDecoratedOperator(DecoratedOperator, PythonVirtualenvOper
             op_kwargs=op_kwargs,
             **kwargs,
         )
-
-    def get_python_source(self):
-        raw_source = inspect.getsource(self.python_callable)
-        res = dedent(raw_source)
-        res = remove_task_decorator(res, "@task.virtualenv")
-        return res
 
 
 def virtualenv_task(

--- a/airflow/decorators/short_circuit.py
+++ b/airflow/decorators/short_circuit.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Callable, Sequence
+from typing import Callable
 
 from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
 from airflow.operators.python import ShortCircuitOperator
@@ -34,13 +34,6 @@ class _ShortCircuitDecoratedOperator(DecoratedOperator, ShortCircuitOperator):
     :param multiple_outputs: If set to True, the decorated function's return value will be unrolled to
         multiple XCom values. Dict will unroll to XCom values with its keys as XCom keys. Defaults to False.
     """
-
-    template_fields: Sequence[str] = ("op_args", "op_kwargs")
-    template_fields_renderers = {"op_args": "py", "op_kwargs": "py"}
-
-    # since we won't mutate the arguments, we should just do the shallow copy
-    # there are some cases we can't deepcopy the objects (e.g protobuf).
-    shallow_copy_attrs: Sequence[str] = ("python_callable",)
 
     custom_operator_name: str = "@task.short_circuit"
 

--- a/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
@@ -77,10 +77,11 @@ class _KubernetesDecoratedOperator(DecoratedOperator, KubernetesPodOperator):
             **kwargs,
         )
 
-    def _get_python_source(self):
+    # TODO: Remove me once this provider min supported Airflow version is 2.6
+    def get_python_source(self):
         raw_source = inspect.getsource(self.python_callable)
         res = dedent(raw_source)
-        res = remove_task_decorator(res, "@task.kubernetes")
+        res = remove_task_decorator(res, self.custom_operator_name)
         return res
 
     def _generate_cmds(self) -> list[str]:
@@ -117,7 +118,7 @@ class _KubernetesDecoratedOperator(DecoratedOperator, KubernetesPodOperator):
             with open(input_filename, "wb") as file:
                 self.pickling_library.dump({"args": self.op_args, "kwargs": self.op_kwargs}, file)
 
-            py_source = self._get_python_source()
+            py_source = self.get_python_source()
             jinja_context = {
                 "op_args": self.op_args,
                 "op_kwargs": self.op_kwargs,

--- a/airflow/providers/docker/decorators/docker.py
+++ b/airflow/providers/docker/decorators/docker.py
@@ -79,10 +79,6 @@ class _DockerDecoratedOperator(DecoratedOperator, DockerOperator):
 
     template_fields: Sequence[str] = (*DockerOperator.template_fields, "op_args", "op_kwargs")
 
-    # since we won't mutate the arguments, we should just do the shallow copy
-    # there are some cases we can't deepcopy the objects (e.g protobuf).
-    shallow_copy_attrs: Sequence[str] = ("python_callable",)
-
     def __init__(
         self,
         use_dill=False,
@@ -114,7 +110,7 @@ class _DockerDecoratedOperator(DecoratedOperator, DockerOperator):
             with open(input_filename, "wb") as file:
                 if self.op_args or self.op_kwargs:
                     self.pickling_library.dump({"args": self.op_args, "kwargs": self.op_kwargs}, file)
-            py_source = self._get_python_source()
+            py_source = self.get_python_source()
             write_python_script(
                 jinja_context=dict(
                     op_args=self.op_args,
@@ -140,10 +136,11 @@ class _DockerDecoratedOperator(DecoratedOperator, DockerOperator):
             self.command = self.generate_command()
             return super().execute(context)
 
-    def _get_python_source(self):
+    # TODO: Remove me once this provider min supported Airflow version is 2.6
+    def get_python_source(self):
         raw_source = inspect.getsource(self.python_callable)
         res = dedent(raw_source)
-        res = remove_task_decorator(res, "@task.docker")
+        res = remove_task_decorator(res, self.custom_operator_name)
         return res
 
 


### PR DESCRIPTION
The code to get the function without the wrapper existed in every subclass of DecoratedOperator, but with the fact that we now set `custom_operator_name` on all these classes means we can easily move the code to one place.

Ditto for the template_fields and template_fields_renderers -- those are all the same and simple duplicate the same value from the parent mixin.

