### PR TITLE
Ignore error when changing log folder permissions

### DIFF
--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -441,8 +441,16 @@ class FileTaskHandler(logging.Handler):
         )
         directory.mkdir(mode=new_folder_permissions, parents=True, exist_ok=True)
         if directory.stat().st_mode % 0o1000 != new_folder_permissions % 0o1000:
-            print(f"Changing dir permission to {new_folder_permissions}")
-            directory.chmod(new_folder_permissions)
+            print(f"Changing {directory} permission to {new_folder_permissions}")
+            try:
+                directory.chmod(new_folder_permissions)
+            except PermissionError as e:
+                # In some circumstances (depends on user and filesystem) we might not be able to
+                # change the permission for the folder (when the folder was created by another user
+                # before or when the filesystem does not allow to change permission). We should not
+                # fail in this case but rather ignore it.
+                print(f"Failed to change {directory} permission to {new_folder_permissions}: {e}")
+                pass
 
     def _init_file(self, ti):
         """


### PR DESCRIPTION
In some circumstances, changing the permission of a parent folder for the log might not be possible - for example when it was created by another user (with impersonation) or when the filesystem does not allow for permission change.

Fixes: #29112

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
