### PR TITLE
Ensure that `dag.partial_subset` doesn't mutate task group properties

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2216,7 +2216,7 @@ class DAG(LoggingMixin):
         def filter_task_group(group, parent_group):
             """Exclude tasks not included in the subdag from the given TaskGroup."""
             # We want to deepcopy _most but not all_ attributes of the task group, so we create a shallow copy
-            # and then manually deep copy the instances. (memo argyment to deepcopy only works for instances
+            # and then manually deep copy the instances. (memo argument to deepcopy only works for instances
             # of classes, not "native" properties of an instance, )
             copied = copy.copy(group)
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2217,7 +2217,7 @@ class DAG(LoggingMixin):
             """Exclude tasks not included in the subdag from the given TaskGroup."""
             # We want to deepcopy _most but not all_ attributes of the task group, so we create a shallow copy
             # and then manually deep copy the instances. (memo argument to deepcopy only works for instances
-            # of classes, not "native" properties of an instance, )
+            # of classes, not "native" properties of an instance)
             copied = copy.copy(group)
 
             memo[id(group.children)] = {}


### PR DESCRIPTION
We had a few properties that we failed to deepcopy that we should have. To fix that in such a way that we don't miss things in the future I've converted it to use deepcopy everything by default and exclude `children` and `parent_group`.

This also made me notice that we were not correctly setting `parent_group` after partial_subset anymore -- it clearly hasn't mattered, but we were setting a now-unused `_parent_group` attribute.

Fixes #26059
