### PR TITLE
Add task.trigger rule to grid_data

### DIFF
--- a/airflow/www/static/js/dag/InstanceTooltip.test.tsx
+++ b/airflow/www/static/js/dag/InstanceTooltip.test.tsx
@@ -40,12 +40,18 @@ describe("Test Task InstanceTooltip", () => {
   test("Displays a normal task", () => {
     const { getByText, queryByText } = render(
       <InstanceTooltip
-        group={{ id: "task", label: "task", instances: [] }}
+        group={{
+          id: "task",
+          label: "task",
+          instances: [],
+          triggerRule: "all_failed",
+        }}
         instance={instance}
       />,
       { wrapper: Wrapper }
     );
 
+    expect(getByText("Trigger Rule: all_failed")).toBeDefined();
     expect(getByText("Status: success")).toBeDefined();
     expect(queryByText("Contains a note")).toBeNull();
     expect(getByText("Duration: 00:00:00")).toBeDefined();

--- a/airflow/www/static/js/dag/InstanceTooltip.tsx
+++ b/airflow/www/static/js/dag/InstanceTooltip.tsx
@@ -83,6 +83,7 @@ const InstanceTooltip = ({
           </Text>
         </>
       )}
+      {group.triggerRule && <Text>Trigger Rule: {group.triggerRule}</Text>}
       {note && <Text>Contains a note</Text>}
     </Box>
   );

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -42,7 +42,7 @@ const Details = ({ instance, group, dagId }: Props) => {
   const { taskId, runId, startDate, endDate, state, mappedStates, mapIndex } =
     instance;
 
-  const { isMapped, tooltip, operator, hasOutletDatasets } = group;
+  const { isMapped, tooltip, operator, hasOutletDatasets, triggerRule } = group;
 
   const { data: apiTI } = useTaskInstance({
     dagId,
@@ -166,6 +166,12 @@ const Details = ({ instance, group, dagId }: Props) => {
             <Tr>
               <Td>Operator</Td>
               <Td>{operator}</Td>
+            </Tr>
+          )}
+          {triggerRule && (
+            <Tr>
+              <Td>Trigger Rule</Td>
+              <Td>{triggerRule}</Td>
             </Tr>
           )}
           {startDate && (

--- a/airflow/www/static/js/types/index.ts
+++ b/airflow/www/static/js/types/index.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import * as API from "./api-generated";
+import type * as API from "./api-generated";
 
 type RunState = "success" | "running" | "queued" | "failed";
 
@@ -96,6 +96,7 @@ interface Task {
   isMapped?: boolean;
   operator?: string;
   hasOutletDatasets?: boolean;
+  triggerRule?: API.TriggerRule;
 }
 
 type RunOrdering = (

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -93,7 +93,6 @@ from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.jobs.triggerer_job import TriggererJob
 from airflow.models import Connection, DagModel, DagTag, Log, SlaMiss, TaskFail, XCom, errors
 from airflow.models.abstractoperator import AbstractOperator
-from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG, get_dataset_triggered_next_run_info
 from airflow.models.dagcode import DagCode
 from airflow.models.dagrun import DagRun, DagRunType
@@ -120,7 +119,7 @@ from airflow.utils.net import get_hostname
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.state import State, TaskInstanceState
 from airflow.utils.strings import to_boolean
-from airflow.utils.task_group import MappedTaskGroup, task_group_to_dict
+from airflow.utils.task_group import MappedTaskGroup, TaskGroup, task_group_to_dict
 from airflow.utils.timezone import td_format, utcnow
 from airflow.version import version
 from airflow.www import auth, utils as wwwutils
@@ -298,7 +297,7 @@ def dag_to_grid(dag: DagModel, dag_runs: Sequence[DagRun], session: Session):
     grouped_tis = {task_id: list(tis) for task_id, tis in itertools.groupby(query, key=lambda ti: ti.task_id)}
 
     def task_group_to_grid(item, grouped_tis, *, is_parent_mapped: bool):
-        if isinstance(item, BaseOperator):
+        if not isinstance(item, TaskGroup):
 
             def _get_summary(task_instance):
                 return {

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -93,6 +93,7 @@ from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.jobs.triggerer_job import TriggererJob
 from airflow.models import Connection, DagModel, DagTag, Log, SlaMiss, TaskFail, XCom, errors
 from airflow.models.abstractoperator import AbstractOperator
+from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG, get_dataset_triggered_next_run_info
 from airflow.models.dagcode import DagCode
 from airflow.models.dagrun import DagRun, DagRunType
@@ -297,7 +298,7 @@ def dag_to_grid(dag: DagModel, dag_runs: Sequence[DagRun], session: Session):
     grouped_tis = {task_id: list(tis) for task_id, tis in itertools.groupby(query, key=lambda ti: ti.task_id)}
 
     def task_group_to_grid(item, grouped_tis, *, is_parent_mapped: bool):
-        if isinstance(item, AbstractOperator):
+        if isinstance(item, BaseOperator):
 
             def _get_summary(task_instance):
                 return {
@@ -363,6 +364,7 @@ def dag_to_grid(dag: DagModel, dag_runs: Sequence[DagRun], session: Session):
                 "is_mapped": isinstance(item, MappedOperator) or is_parent_mapped,
                 "has_outlet_datasets": any(isinstance(i, Dataset) for i in (item.outlets or [])),
                 "operator": item.operator_name,
+                "trigger_rule": item.trigger_rule,
             }
 
         # Task Group

--- a/tests/www/views/test_views_grid.py
+++ b/tests/www/views/test_views_grid.py
@@ -108,6 +108,7 @@ def test_no_runs(admin_client, dag_without_runs):
                     "is_mapped": False,
                     "label": "task1",
                     "operator": "EmptyOperator",
+                    "trigger_rule": "all_success",
                 },
                 {
                     "children": [
@@ -119,6 +120,7 @@ def test_no_runs(admin_client, dag_without_runs):
                             "is_mapped": True,
                             "label": "subtask2",
                             "operator": "MockOperator",
+                            "trigger_rule": "all_success",
                         }
                     ],
                     "is_mapped": True,
@@ -137,6 +139,7 @@ def test_no_runs(admin_client, dag_without_runs):
                             "is_mapped": True,
                             "label": "mapped",
                             "operator": "MockOperator",
+                            "trigger_rule": "all_success",
                         }
                     ],
                     "id": "group",
@@ -255,6 +258,7 @@ def test_one_run(admin_client, dag_with_runs: list[DagRun], session):
                     "is_mapped": False,
                     "label": "task1",
                     "operator": "EmptyOperator",
+                    "trigger_rule": "all_success",
                 },
                 {
                     "children": [
@@ -283,6 +287,7 @@ def test_one_run(admin_client, dag_with_runs: list[DagRun], session):
                             "is_mapped": True,
                             "label": "subtask2",
                             "operator": "MockOperator",
+                            "trigger_rule": "all_success",
                         }
                     ],
                     "is_mapped": True,
@@ -335,6 +340,7 @@ def test_one_run(admin_client, dag_with_runs: list[DagRun], session):
                             "is_mapped": True,
                             "label": "mapped",
                             "operator": "MockOperator",
+                            "trigger_rule": "all_success",
                         },
                     ],
                     "id": "group",
@@ -398,6 +404,7 @@ def test_has_outlet_dataset_flag(admin_client, dag_maker, session, app, monkeypa
             "is_mapped": False,
             "label": task_id,
             "operator": "EmptyOperator",
+            "trigger_rule": "all_success",
         }
 
     assert resp.status_code == 200, resp.json


### PR DESCRIPTION
We added `task.trigger_rule` to the old graph view in 2.4.0 (see #26043). But that wasn't in the grid view nor in the new graph view.

Now it is included in the tooltip and in the instance details panel.

<img width="759" alt="Screenshot 2023-03-15 at 12 01 47 AM" src="https://user-images.githubusercontent.com/4600967/225380106-f67cf904-f114-485b-adc6-416231608ddd.png">
<img width="630" alt="Screenshot 2023-03-15 at 12 01 07 AM" src="https://user-images.githubusercontent.com/4600967/225380107-c137358f-8339-4987-a3ff-6ade5873efd9.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
