### PR TITLE
Add custom_operator_name to @task.sensor tasks

### DIFF
--- a/airflow/decorators/sensor.py
+++ b/airflow/decorators/sensor.py
@@ -41,6 +41,8 @@ class DecoratedSensorOperator(PythonSensor):
     template_fields: Sequence[str] = ("op_args", "op_kwargs")
     template_fields_renderers: dict[str, str] = {"op_args": "py", "op_kwargs": "py"}
 
+    custom_operator_name = "@task.sensor"
+
     # since we won't mutate the arguments, we should just do the shallow copy
     # there are some cases we can't deepcopy the objects (e.g protobuf).
     shallow_copy_attrs: Sequence[str] = ("python_callable",)


### PR DESCRIPTION
Currently the operator name for TaskFlow tasks using the `@task.sensor` decorator was still "DecoratedSensorOperator". To keep consistent with the other TaskFlow decorators, adding a `custom_operator_name` for these tasks.