### PR TITLE
add a describe step on failure in eks system tests

### DIFF
--- a/tests/system/providers/amazon/aws/example_eks_with_nodegroup_in_one_step.py
+++ b/tests/system/providers/amazon/aws/example_eks_with_nodegroup_in_one_step.py
@@ -20,6 +20,7 @@ from datetime import datetime
 
 from airflow.models.baseoperator import chain
 from airflow.models.dag import DAG
+from airflow.operators.bash import BashOperator
 from airflow.providers.amazon.aws.hooks.eks import ClusterStates, NodegroupStates
 from airflow.providers.amazon.aws.operators.eks import (
     EksCreateClusterOperator,
@@ -86,8 +87,21 @@ with DAG(
         cmds=["sh", "-c", "echo Test Airflow; date"],
         labels={"demo": "hello_world"},
         get_logs=True,
-        # Delete the pod when it reaches its final state, or the execution is interrupted.
-        is_delete_operator_pod=True,
+        # Keep the pod alive, so we can describe it in case of trouble. It's deleted with the cluster anyway.
+        is_delete_operator_pod=False,
+    )
+
+    describe_pod = BashOperator(
+        task_id="describe_pod",
+        bash_command=""
+        # using reinstall option so that it doesn't fail if already present
+        "install_aws.sh --reinstall " "&& install_kubectl.sh --reinstall "
+        # configure kubectl to hit the cluster created
+        f"&& aws eks update-kubeconfig --name {cluster_name} "
+        # once all this setup is done, actually describe the pod
+        "&& kubectl describe pod {{ ti.xcom_pull(key='pod_name', task_ids='run_pod') }}",
+        # only describe the pod if the task above failed, to help diagnose
+        trigger_rule=TriggerRule.ONE_FAILED,
     )
 
     # [START howto_operator_eks_force_delete_cluster]
@@ -116,6 +130,8 @@ with DAG(
         create_cluster_and_nodegroup,
         await_create_nodegroup,
         start_pod,
+        # TEST TEARDOWN
+        describe_pod,
         delete_nodegroup_and_cluster,
         await_delete_cluster,
     )

--- a/tests/system/providers/amazon/aws/example_eks_with_nodegroups.py
+++ b/tests/system/providers/amazon/aws/example_eks_with_nodegroups.py
@@ -20,6 +20,7 @@ from datetime import datetime
 
 from airflow.models.baseoperator import chain
 from airflow.models.dag import DAG
+from airflow.operators.bash import BashOperator
 from airflow.providers.amazon.aws.hooks.eks import ClusterStates, NodegroupStates
 from airflow.providers.amazon.aws.operators.eks import (
     EksCreateClusterOperator,
@@ -111,6 +112,23 @@ with DAG(
     )
     # [END howto_operator_eks_pod_operator]
 
+    # In this specific situation we want to keep the pod to be able to describe it,
+    # it is cleaned anyway with the cluster later on.
+    start_pod.is_delete_operator_pod = False
+
+    describe_pod = BashOperator(
+        task_id="describe_pod",
+        bash_command=""
+        # using reinstall option so that it doesn't fail if already present
+        "install_aws.sh --reinstall " "&& install_kubectl.sh --reinstall "
+        # configure kubectl to hit the cluster created
+        f"&& aws eks update-kubeconfig --name {cluster_name} "
+        # once all this setup is done, actually describe the pod
+        "&& kubectl describe pod {{ ti.xcom_pull(key='pod_name', task_ids='run_pod') }}",
+        # only describe the pod if the task above failed, to help diagnose
+        trigger_rule=TriggerRule.ONE_FAILED,
+    )
+
     # [START howto_operator_eks_delete_nodegroup]
     delete_nodegroup = EksDeleteNodegroupOperator(
         task_id="delete_nodegroup",
@@ -153,9 +171,11 @@ with DAG(
         create_nodegroup,
         await_create_nodegroup,
         start_pod,
-        delete_nodegroup,
+        # TEST TEARDOWN
+        describe_pod,
+        delete_nodegroup,  # part of the test AND teardown
         await_delete_nodegroup,
-        delete_cluster,
+        delete_cluster,  # part of the test AND teardown
         await_delete_cluster,
     )
 


### PR DESCRIPTION
we've seen that every once in a while, an eks system test will fail with a timeout on the pod starting. 
Since we delete all resources in the teardown, we're pretty clueless on what's happening, and the failures appear to be random so we cannot reproduce it in a controlled environment.

With this change, we'll get at least a pod description if there is a failure, which should help us understand the root cause.

This step is run only on failure (`trigger_rule=TriggerRule.ONE_FAILED`), expecting to run after the start_pod operation failed. It is possible that an earlier step would fail and trigger this, but that's how life is. The main point is that we don't want to run it every single time because it makes the test ~1 minute longer (installing awscli, necessary to get the kube config, is quite long).