### PR TITLE
Remove duplicate Dag Details code

### DIFF
--- a/airflow/www/static/js/dag/details/Dag.tsx
+++ b/airflow/www/static/js/dag/details/Dag.tsx
@@ -146,45 +146,6 @@ const Dag = () => {
           )}
           <Tr borderBottomWidth={2} borderBottomColor="gray.300">
             <Td>
-              <Heading size="sm">DAG Runs Summary</Heading>
-            </Td>
-            <Td />
-          </Tr>
-          <Tr>
-            <Td>Total Runs Displayed</Td>
-            <Td>{durations.length}</Td>
-          </Tr>
-          {stateSummary}
-          {firstStart && (
-            <Tr>
-              <Td>First Run Start</Td>
-              <Td>
-                <Time dateTime={firstStart} />
-              </Td>
-            </Tr>
-          )}
-          {lastStart && (
-            <Tr>
-              <Td>Last Run Start</Td>
-              <Td>
-                <Time dateTime={lastStart} />
-              </Td>
-            </Tr>
-          )}
-          <Tr>
-            <Td>Max Run Duration</Td>
-            <Td>{formatDuration(max)}</Td>
-          </Tr>
-          <Tr>
-            <Td>Mean Run Duration</Td>
-            <Td>{formatDuration(avg)}</Td>
-          </Tr>
-          <Tr>
-            <Td>Min Run Duration</Td>
-            <Td>{formatDuration(min)}</Td>
-          </Tr>
-          <Tr borderBottomWidth={2} borderBottomColor="gray.300">
-            <Td>
               <Heading size="sm">DAG Summary</Heading>
             </Td>
             <Td />


### PR DESCRIPTION
We were listing the Dag Runs Summary twice in the Grid -> Dag Details. Looks to have been an issue when rebasing the new graph PR.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
