### PR TITLE
Move read only property in order to fix Dagrun API docs

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2805,7 +2805,6 @@ components:
             - dataset_triggered
         state:
           $ref: '#/components/schemas/DagState'
-          readOnly: true
         external_trigger:
           type: boolean
           default: true
@@ -3964,7 +3963,6 @@ components:
           nullable: true
         state:
           $ref: '#/components/schemas/DagState'
-          readOnly: true
 
     DatasetEventCollection:
       description: |
@@ -4538,6 +4536,7 @@ components:
 
         *Changed in version 2.1.3*&#58; 'queued' is added as a possible value.
       type: string
+      readOnly: true
       enum:
         - queued
         - running


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/30075

**Note:** We should either merge this _or_ https://github.com/apache/airflow/pull/30113, but not both.

Using `$ref` alongside other attributes can lead to unintentional errors in the API documentation ([source](https://swagger.io/docs/specification/using-ref/)):

> Any sibling elements of a $ref are ignored. This is because $ref works by replacing itself and everything on its level with the definition it is pointing at.

Because of this, the `state` field was incorrectly showing up in the API docs for the trigger DagRun endpoint:

<img width="1311" alt="Screenshot 2023-03-16 at 9 36 37 AM" src="https://user-images.githubusercontent.com/16950874/225691402-08baa350-177a-4836-a3b5-2cada94bf6da.png">

By instead these attributes under `allOf:`, this change removes this field from the docs, making it more consistent with the intended API behaviour:
<img width="1327" alt="Screenshot 2023-03-16 at 9 38 03 AM" src="https://user-images.githubusercontent.com/16950874/225691638-364e64fd-e030-403c-8111-c40b5b721691.png">

There are a few other instances in the Spec in which $ref is used alongside another attribute which could lead to similar issues, I will fix those in a subsequent PR when I have a bit more time.
