### PR TITLE
Only allow setup/teardown tasks

### DIFF
--- a/airflow/decorators/task_group.py
+++ b/airflow/decorators/task_group.py
@@ -182,9 +182,6 @@ def task_group(
     ui_color: str = "CornflowerBlue",
     ui_fgcolor: str = "#000",
     add_suffix_on_collision: bool = False,
-    setup: bool = False,
-    teardown: bool = False,
-    on_failure_fail_dagrun: bool = False,
 ) -> Callable[[Callable[FParams, FReturn]], _TaskGroupFactory[FParams, FReturn]]:
     ...
 

--- a/airflow/example_dags/example_setup_teardown_taskflow.py
+++ b/airflow/example_dags/example_setup_teardown_taskflow.py
@@ -65,31 +65,6 @@ with DAG(
         hello()
         my_teardown()
 
-    @task_group
-    def section_2():
-        # You can also mark task groups as setup and teardown
-        # and all tasks in them will be setup/teardown tasks
-        @setup
-        @task_group
-        def my_setup_taskgroup():
-            @task
-            def first_setup():
-                print("I set some stuff up")
-
-            @task
-            def second_setup():
-                print("I set some other stuff up")
-
-            first_setup()
-            second_setup()
-
-        @task
-        def hello():
-            print("I say hello")
-
-        my_setup_taskgroup()
-        hello()
-
     root_setup()
-    normal() >> section_1() >> section_2()
+    normal() >> section_1()
     root_teardown()

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -89,6 +89,7 @@ from airflow.utils.decorators import fixup_decorator_warning_stack
 from airflow.utils.helpers import validate_key
 from airflow.utils.operator_resources import Resources
 from airflow.utils.session import NEW_SESSION, provide_session
+from airflow.utils.setup_teardown import SetupTeardownContext
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.weight_rule import WeightRule
 
@@ -918,6 +919,13 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
                 stacklevel=2,
             )
             self.template_fields = [self.template_fields]
+
+        if SetupTeardownContext.is_setup:
+            self._is_setup = True
+        elif SetupTeardownContext.is_teardown:
+            self._is_teardown = True
+            if SetupTeardownContext.on_failure_fail_dagrun:
+                self._on_failure_fail_dagrun = True
 
     @classmethod
     def as_setup(cls, *args, **kwargs):

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -32,9 +32,7 @@ class SetupTeardownContext:
     @contextmanager
     def setup(cls):
         if cls.is_setup or cls.is_teardown:
-            raise AirflowException(
-                "A setup task or taskgroup cannot be nested inside another setup/teardown task or taskgroup"
-            )
+            raise AirflowException("You cannot mark a setup or teardown task as setup or teardown again.")
 
         cls.is_setup = True
         try:
@@ -46,10 +44,7 @@ class SetupTeardownContext:
     @contextmanager
     def teardown(cls, *, on_failure_fail_dagrun=False):
         if cls.is_setup or cls.is_teardown:
-            raise AirflowException(
-                "A teardown task or taskgroup cannot be nested inside another"
-                " setup/teardown task or taskgroup"
-            )
+            raise AirflowException("You cannot mark a setup or teardown task as setup or teardown again.")
 
         cls.is_teardown = True
         cls.on_failure_fail_dagrun = on_failure_fail_dagrun

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -92,22 +92,11 @@ class TaskGroup(DAGNode):
         ui_color: str = "CornflowerBlue",
         ui_fgcolor: str = "#000",
         add_suffix_on_collision: bool = False,
-        setup: bool = False,
-        teardown: bool = False,
-        on_failure_fail_dagrun: bool = False,
     ):
         from airflow.models.dag import DagContext
 
-        if setup and teardown:
-            raise AirflowException("Cannot set both setup and teardown to True")
-        if on_failure_fail_dagrun and not teardown:
-            raise AirflowException("on_failure_fail_dagrun can only be set to True if teardown is True")
-
         self.prefix_group_id = prefix_group_id
         self.default_args = copy.deepcopy(default_args or {})
-        self.setup = setup
-        self.teardown = teardown
-        self.on_failure_fail_dagrun = on_failure_fail_dagrun
 
         dag = dag or DagContext.get_current_dag()
 
@@ -168,6 +157,10 @@ class TaskGroup(DAGNode):
         self.downstream_group_ids: set[str | None] = set()
         self.upstream_task_ids = set()
         self.downstream_task_ids = set()
+
+        if SetupTeardownContext.is_setup or SetupTeardownContext.is_teardown:
+            # TODO: This might not be the ideal place to check this.
+            raise AirflowException("Task groups cannot be marked as setup or teardown.")
 
     def _check_for_group_id_collisions(self, add_suffix_on_collision: bool):
         if self._group_id is None:
@@ -242,38 +235,7 @@ class TaskGroup(DAGNode):
             if task.children:
                 raise AirflowException("Cannot add a non-empty TaskGroup")
 
-        is_setup, is_teardown = self._check_is_setup_teardown(task)
-
-        if SetupTeardownContext.is_setup or is_setup:
-            if isinstance(task, AbstractOperator):
-                setattr(task, "_is_setup", True)
-        elif SetupTeardownContext.is_teardown or is_teardown:
-            if isinstance(task, AbstractOperator):
-                setattr(task, "_is_teardown", True)
-                if SetupTeardownContext.on_failure_fail_dagrun or self.on_failure_fail_dagrun:
-                    setattr(task, "_on_failure_fail_dagrun", True)
-
         self.children[key] = task
-
-    def _check_is_setup_teardown(self, task_):
-        """Check if setup or teardown is set for the task"""
-        from airflow.models.abstractoperator import AbstractOperator
-
-        def _find_setup_teardown(tg):
-            setup, teardown = tg.setup, tg.teardown
-            while tg and tg.parent_group:
-                if setup or teardown:
-                    break
-                tg = tg.parent_group
-                setup, teardown = tg.setup, tg.teardown
-            return setup, teardown
-
-        if isinstance(task_, TaskGroup):
-            return _find_setup_teardown(task_)
-        if isinstance(task_, AbstractOperator):
-            tg = task_.task_group
-            return _find_setup_teardown(tg)
-        return False, False
 
     def _remove(self, task: DAGNode) -> None:
         key = task.node_id

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -21,9 +21,7 @@ import pytest
 
 from airflow import AirflowException
 from airflow.decorators import setup, task, task_group, teardown
-from airflow.models.baseoperator import BaseOperator
 from airflow.operators.bash import BashOperator
-from airflow.utils.task_group import TaskGroup
 
 
 class TestSetupTearDownTask:
@@ -65,7 +63,6 @@ class TestSetupTearDownTask:
         assert setup_task._is_setup
 
     def test_marking_operator_as_setup_task(self, dag_maker):
-
         with dag_maker() as dag:
             BashOperator.as_setup(task_id="mytask", bash_command='echo "I am a setup task"')
 
@@ -87,7 +84,6 @@ class TestSetupTearDownTask:
         assert teardown_task._is_teardown
 
     def test_marking_operator_as_teardown_task(self, dag_maker):
-
         with dag_maker() as dag:
             BashOperator.as_teardown(task_id="mytask", bash_command='echo "I am a setup task"')
 
@@ -105,14 +101,12 @@ class TestSetupTearDownTask:
 
             mytask()
 
-        with dag_maker() as dag:
-            mygroup()
-
-        assert len(dag.task_group.children) == 1
-        setup_task_group = dag.task_group.children["mygroup"]
-        assert len(setup_task_group.children) == 1
-        setup_task = setup_task_group.children["mygroup.mytask"]
-        assert setup_task._is_setup
+        with dag_maker():
+            with pytest.raises(
+                expected_exception=AirflowException,
+                match="Task groups cannot be marked as setup or teardown.",
+            ):
+                mygroup()
 
     def test_teardown_taskgroup_decorator(self, dag_maker):
         @teardown
@@ -124,344 +118,12 @@ class TestSetupTearDownTask:
 
             mytask()
 
-        with dag_maker() as dag:
-            mygroup()
-
-        assert len(dag.task_group.children) == 1
-        teardown_task_group = dag.task_group.children["mygroup"]
-        assert len(teardown_task_group.children) == 1
-        teardown_task = teardown_task_group.children["mygroup.mytask"]
-        assert teardown_task._is_teardown
-
-    def test_setup_taskgroup_classic(self, dag_maker):
-        with dag_maker() as dag:
-            with TaskGroup("mygroup", setup=True):
-                BashOperator(task_id="mytask", bash_command='echo "I am a setup task"')
-
-        assert len(dag.task_group.children) == 1
-        setup_task_group = dag.task_group.children["mygroup"]
-        assert len(setup_task_group.children) == 1
-        setup_task = setup_task_group.children["mygroup.mytask"]
-        assert setup_task._is_setup
-
-    def test_teardown_taskgroup_classic(self, dag_maker):
-        with dag_maker() as dag:
-            with TaskGroup("mygroup", teardown=True):
-                BashOperator(task_id="mytask", bash_command='echo "I am a setup task"')
-
-        assert len(dag.task_group.children) == 1
-        teardown_task_group = dag.task_group.children["mygroup"]
-        assert len(teardown_task_group.children) == 1
-        teardown_task = teardown_task_group.children["mygroup.mytask"]
-        assert teardown_task._is_teardown
-
-    def test_setup_taskgroup_decorator_with_subgroup(self, dag_maker):
-        @setup
-        @task_group
-        def mygroup():
-            @task
-            def mytask():
-                print("I am a setup task")
-
-            @task_group
-            def subgroup():
-                @task
-                def mytask2():
-                    print("I am a task")
-
-                mytask2()
-
-            mytask()
-            subgroup()
-
-        with dag_maker() as dag:
-            mygroup()
-
-        assert len(dag.task_group.children) == 1
-        setup_task_group = dag.task_group.children["mygroup"]
-        assert len(setup_task_group.children) == 2
-        setup_task = setup_task_group.children["mygroup.mytask"]
-        assert setup_task._is_setup
-        subgroup_task_group = setup_task_group.children["mygroup.subgroup"]
-        assert len(subgroup_task_group.children) == 1
-        subgroup_task = subgroup_task_group.children["mygroup.subgroup.mytask2"]
-        assert subgroup_task._is_setup
-
-    def test_teardown_taskgroup_decorator_with_subgroup(self, dag_maker):
-        @teardown
-        @task_group
-        def mygroup():
-            @task
-            def mytask():
-                print("I am a teardown task")
-
-            @task_group
-            def subgroup():
-                @task
-                def mytask2():
-                    print("I am a task")
-
-                mytask2()
-
-            mytask()
-            subgroup()
-
-        with dag_maker() as dag:
-            mygroup()
-
-        assert len(dag.task_group.children) == 1
-        teardown_task_group = dag.task_group.children["mygroup"]
-        assert len(teardown_task_group.children) == 2
-        teardown_task = teardown_task_group.children["mygroup.mytask"]
-        assert teardown_task._is_teardown
-        subgroup_task_group = teardown_task_group.children["mygroup.subgroup"]
-        assert len(subgroup_task_group.children) == 1
-        subgroup_task = subgroup_task_group.children["mygroup.subgroup.mytask2"]
-        assert subgroup_task._is_teardown
-
-    def test_teardown_taskgroup_with_subgroup_classic(self, dag_maker):
-        with dag_maker() as dag:
-            with TaskGroup("mygroup", teardown=True):
-
-                @task
-                def mytask():
-                    print("I am a teardown task")
-
-                with TaskGroup("subgroup"):
-
-                    @task
-                    def mytask2():
-                        print("I am a teardown task")
-
-                    mytask2()
-
-                mytask()
-
-        assert len(dag.task_group.children) == 1
-        teardown_task_group = dag.task_group.children["mygroup"]
-        assert len(teardown_task_group.children) == 2
-        teardown_task = teardown_task_group.children["mygroup.mytask"]
-        assert teardown_task._is_teardown
-        subgroup_task_group = teardown_task_group.children["mygroup.subgroup"]
-        assert len(subgroup_task_group.children) == 1
-        subgroup_task = subgroup_task_group.children["mygroup.subgroup.mytask2"]
-        assert subgroup_task._is_teardown
-
-    def test_setup_taskgroup_with_subgroup_classic(self, dag_maker):
-        with dag_maker() as dag:
-            with TaskGroup("mygroup", setup=True):
-
-                @task
-                def mytask():
-                    print("I am a setup task")
-
-                with TaskGroup("subgroup"):
-
-                    @task
-                    def mytask2():
-                        print("I am a setup task")
-
-                    mytask2()
-
-                mytask()
-
-        assert len(dag.task_group.children) == 1
-        setup_task_group = dag.task_group.children["mygroup"]
-        assert len(setup_task_group.children) == 2
-        setup_task = setup_task_group.children["mygroup.mytask"]
-        assert setup_task._is_setup
-        subgroup_task_group = setup_task_group.children["mygroup.subgroup"]
-        assert len(subgroup_task_group.children) == 1
-        subgroup_task = subgroup_task_group.children["mygroup.subgroup.mytask2"]
-        assert subgroup_task._is_setup
-
-    def test_setup_taskgroup_with_subgroup_being_the_setup_decorated(self, dag_maker):
-        """Here, the subgroup is the setup taskgroup while the parent is not"""
-        with dag_maker() as dag:
-
-            @task_group
-            def mygroup():
-                @task
-                def mytask():
-                    print("I am a task")
-
-                @setup
-                @task_group
-                def subgroup():
-                    @task
-                    def mytask2():
-                        print("I am a setup task")
-
-                    mytask2()
-
-                subgroup()
-                mytask()
-
-            mygroup()
-        assert len(dag.task_group.children) == 1
-        normal_task_group = dag.task_group.children["mygroup"]
-        assert isinstance(normal_task_group, TaskGroup)
-        assert len(normal_task_group.children) == 2
-        normal_task = normal_task_group.children["mygroup.mytask"]
-        assert isinstance(normal_task, BaseOperator)
-        assert not normal_task._is_setup
-        setup_task_group = normal_task_group.children["mygroup.subgroup"]
-        assert isinstance(setup_task_group, TaskGroup)
-        assert len(setup_task_group.children) == 1
-        subgroup_task = setup_task_group.children["mygroup.subgroup.mytask2"]
-        assert isinstance(subgroup_task, BaseOperator)
-        assert subgroup_task._is_setup
-
-    def test_teardown_taskgroup_with_subgroup_being_the_teardown_decorated(self, dag_maker):
-        """Here, the subgroup is the teardown taskgroup while the parent is not"""
-
-        @task_group
-        def mygroup():
-            @task
-            def mytask():
-                print("I am not a teardown task")
-
-            @teardown
-            @task_group
-            def subgroup():
-                @task
-                def mytask2():
-                    print("I am a teardown task")
-
-                mytask2()
-
-            mytask()
-            subgroup()
-
-        with dag_maker() as dag:
-            mygroup()
-
-        assert len(dag.task_group.children) == 1
-        normal_task_group = dag.task_group.children["mygroup"]
-        assert isinstance(normal_task_group, TaskGroup)
-        assert len(normal_task_group.children) == 2
-        normal_task = normal_task_group.children["mygroup.mytask"]
-        assert isinstance(normal_task, BaseOperator)
-        assert not normal_task._is_teardown
-        teardown_task_group = normal_task_group.children["mygroup.subgroup"]
-        assert isinstance(teardown_task_group, TaskGroup)
-        assert len(teardown_task_group.children) == 1
-        subgroup_task = teardown_task_group.children["mygroup.subgroup.mytask2"]
-        assert isinstance(subgroup_task, BaseOperator)
-        assert subgroup_task._is_teardown
-
-    def test_setup_taskgroup_with_subgroup_being_the_setup_classic(self, dag_maker):
-        """Here, the subgroup is the setup taskgroup while the parent is not"""
-        with dag_maker() as dag:
-            with TaskGroup("mygroup"):
-
-                @task
-                def mytask():
-                    print("I am not a setup task")
-
-                with TaskGroup("subgroup", setup=True):
-
-                    @task
-                    def mytask2():
-                        print("I am a setup task")
-
-                    mytask2()
-
-                mytask()
-
-        assert len(dag.task_group.children) == 1
-        normal_task_group = dag.task_group.children["mygroup"]
-        assert isinstance(normal_task_group, TaskGroup)
-        assert len(normal_task_group.children) == 2
-        normal_task = normal_task_group.children["mygroup.mytask"]
-        assert isinstance(normal_task, BaseOperator)
-        assert not normal_task._is_setup
-        setup_task_group = normal_task_group.children["mygroup.subgroup"]
-        assert isinstance(setup_task_group, TaskGroup)
-        assert len(setup_task_group.children) == 1
-        subgroup_task = setup_task_group.children["mygroup.subgroup.mytask2"]
-        assert isinstance(subgroup_task, BaseOperator)
-        assert subgroup_task._is_setup
-
-    def test_teardown_taskgroup_with_subgroup_being_the_teardown_classic(self, dag_maker):
-        """Here, the subgroup is the teardown taskgroup while the parent is not"""
-        with dag_maker() as dag:
-            with TaskGroup("mygroup"):
-
-                @task
-                def mytask():
-                    print("I am not a teardown task")
-
-                with TaskGroup("subgroup", teardown=True):
-
-                    @task
-                    def mytask2():
-                        print("I am a teardown task")
-
-                    mytask2()
-
-                mytask()
-
-        assert len(dag.task_group.children) == 1
-        normal_task_group = dag.task_group.children["mygroup"]
-        assert isinstance(normal_task_group, TaskGroup)
-        assert len(normal_task_group.children) == 2
-        normal_task = normal_task_group.children["mygroup.mytask"]
-        assert isinstance(normal_task, BaseOperator)
-        assert not normal_task._is_teardown
-        teardown_task_group = normal_task_group.children["mygroup.subgroup"]
-        assert isinstance(teardown_task_group, TaskGroup)
-        assert len(teardown_task_group.children) == 1
-        subgroup_task = teardown_task_group.children["mygroup.subgroup.mytask2"]
-        assert isinstance(subgroup_task, BaseOperator)
-        assert subgroup_task._is_teardown
-
-    def test_setup_taskgroup_using_alternative_syntax(self, dag_maker):
-        """Here, the subgroup is the setup taskgroup while the parent is not"""
-        with dag_maker() as dag:
-            tg1 = TaskGroup("mygroup")
-
-            @task(task_group=tg1)
-            def mytask():
-                print("I am not a setup task")
-
-            tg2 = TaskGroup("subgroup", setup=True, parent_group=tg1)
-
-            @task(task_group=tg2)
-            def mytask2():
-                print("I am a setup task")
-
-            mytask2()
-
-            mytask()
-
-        assert len(dag.task_group.children) == 1
-        normal_task_group = dag.task_group.children["mygroup"]
-        assert isinstance(normal_task_group, TaskGroup)
-        assert len(normal_task_group.children) == 2
-        normal_task = normal_task_group.children["mygroup.mytask"]
-        assert isinstance(normal_task, BaseOperator)
-        assert not normal_task._is_setup
-        setup_task_group = normal_task_group.children["mygroup.subgroup"]
-        assert isinstance(setup_task_group, TaskGroup)
-        assert len(setup_task_group.children) == 1
-        subgroup_task = setup_task_group.children["mygroup.subgroup.mytask2"]
-        assert isinstance(subgroup_task, BaseOperator)
-        assert subgroup_task._is_setup
-
-    def test_setup_teardown_are_mutually_exclusive_on_taskgroup(self, dag_maker):
-        """Test that setup and teardown are mutually exclusive on TaskGroup"""
-        with dag_maker():
-            with pytest.raises(AirflowException, match="Cannot set both setup and teardown to True"):
-                TaskGroup("mygroup", setup=True, teardown=True)
-
-    def test_cannot_use_on_failure_fail_dagrun_without_teardown(self, dag_maker):
-        """Test that on_failure_fail_dagrun can only be used with teardown"""
         with dag_maker():
             with pytest.raises(
-                AirflowException, match="on_failure_fail_dagrun can only be set to True if teardown is True"
+                expected_exception=AirflowException,
+                match="Task groups cannot be marked as setup or teardown.",
             ):
-                TaskGroup("mygroup", on_failure_fail_dagrun=True)
+                mygroup()
 
     @pytest.mark.parametrize("on_failure_fail_dagrun", [True, False])
     def test_teardown_task_decorators_works_with_on_failure_fail_dagrun(
@@ -491,34 +153,3 @@ class TestSetupTearDownTask:
         assert teardown_task._is_teardown
         assert teardown_task._on_failure_fail_dagrun is on_failure_fail_dagrun
         assert len(dag.task_group.children) == 1
-
-    @pytest.mark.parametrize("on_failure_fail_dagrun", [True, False])
-    def test_teardown_taskgroup_classic_works_with_on_failure_fail_dagrun(
-        self, on_failure_fail_dagrun, dag_maker
-    ):
-        with dag_maker() as dag:
-            with TaskGroup("mygroup", teardown=True, on_failure_fail_dagrun=on_failure_fail_dagrun):
-                BashOperator(task_id="mytask", bash_command="echo 1")
-
-        teardown_task = dag.task_group.children["mygroup"].children["mygroup.mytask"]
-        assert teardown_task._is_teardown
-        assert teardown_task._on_failure_fail_dagrun is on_failure_fail_dagrun
-
-    @pytest.mark.parametrize("on_failure_fail_dagrun", [True, False])
-    def test_teardown_taskgroup_decorator_works_with_on_failure_fail_dagrun(
-        self, on_failure_fail_dagrun, dag_maker
-    ):
-        with dag_maker() as dag:
-
-            @task_group(teardown=True, on_failure_fail_dagrun=on_failure_fail_dagrun)
-            def mygroup():
-                @task
-                def mytask():
-                    print(1)
-
-                mytask()
-
-            mygroup()
-        teardown_task = dag.task_group.children["mygroup"].children["mygroup.mytask"]
-        assert teardown_task._is_teardown
-        assert teardown_task._on_failure_fail_dagrun is on_failure_fail_dagrun

--- a/tests/utils/test_setup_teardown.py
+++ b/tests/utils/test_setup_teardown.py
@@ -68,10 +68,7 @@ class TestSetupTearDownContext:
         with SetupTeardownContext.setup():
             with pytest.raises(
                 AirflowException,
-                match=(
-                    "A setup task or taskgroup cannot be nested inside another"
-                    " setup/teardown task or taskgroup"
-                ),
+                match=("You cannot mark a setup or teardown task as setup or teardown again."),
             ):
                 with SetupTeardownContext.setup():
                     raise Exception("This should not be reached")
@@ -83,10 +80,7 @@ class TestSetupTearDownContext:
         with SetupTeardownContext.teardown():
             with pytest.raises(
                 AirflowException,
-                match=(
-                    "A teardown task or taskgroup cannot be nested inside another"
-                    " setup/teardown task or taskgroup"
-                ),
+                match=("You cannot mark a setup or teardown task as setup or teardown again."),
             ):
                 with SetupTeardownContext.teardown():
                     raise Exception("This should not be reached")
@@ -98,10 +92,7 @@ class TestSetupTearDownContext:
         with SetupTeardownContext.setup():
             with pytest.raises(
                 AirflowException,
-                match=(
-                    "A teardown task or taskgroup cannot be nested inside another"
-                    " setup/teardown task or taskgroup"
-                ),
+                match=("You cannot mark a setup or teardown task as setup or teardown again."),
             ):
                 with SetupTeardownContext.teardown():
                     raise Exception("This should not be reached")
@@ -113,10 +104,7 @@ class TestSetupTearDownContext:
         with SetupTeardownContext.teardown():
             with pytest.raises(
                 AirflowException,
-                match=(
-                    "A setup task or taskgroup cannot be nested inside another"
-                    " setup/teardown task or taskgroup"
-                ),
+                match=("You cannot mark a setup or teardown task as setup or teardown again."),
             ):
                 with SetupTeardownContext.setup():
                     raise Exception("This should not be reached")


### PR DESCRIPTION
We've decided to simply support only single setup and teardown tasks, so we can remove support for task groups.