### PR TITLE
rename airflow-how-to-pr Slack channel

### DIFF
--- a/.github/ISSUE_TEMPLATE/airflow_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_bug_report.yml
@@ -115,7 +115,7 @@ body:
         This is absolutely not required, but we are happy to guide you in the contribution process
         especially if you already have a good understanding of how to implement the fix.
         Airflow is a community-managed project and we love to bring new contributors in.
-        Find us in #airflow-how-to-pr on Slack!
+        Find us in #development-first-pr-support on Slack!
       options:
         - label: Yes I am willing to submit a PR!
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/airflow_doc_issue_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_doc_issue_report.yml
@@ -50,7 +50,7 @@ body:
         This is absolutely not required, but we are happy to guide you in the contribution process
         especially if you already have a good understanding of how to implement the fix.
         Airflow is a community-managed project and we love to bring new contributors in.
-        Find us in #airflow-how-to-pr on Slack!
+        Find us in #development-first-pr-support on Slack!
       options:
         - label: Yes I am willing to submit a PR!
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/airflow_helmchart_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_helmchart_bug_report.yml
@@ -114,7 +114,7 @@ body:
         This is absolutely not required, but we are happy to guide you in the contribution process
         especially if you already have a good understanding of how to implement the fix.
         Airflow is a community-managed project and we love to bring new contributors in.
-        Find us in #airflow-how-to-pr on Slack!
+        Find us in #development-first-pr-support on Slack!
       options:
         - label: Yes I am willing to submit a PR!
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/airflow_providers_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_providers_bug_report.yml
@@ -195,7 +195,7 @@ body:
         This is absolutely not required, but we are happy to guide you in the contribution process
         especially if you already have a good understanding of how to implement the fix.
         Airflow is a community-managed project and we love to bring new contributors in.
-        Find us in #airflow-how-to-pr on Slack!
+        Find us in #development-first-pr-support on Slack!
       options:
         - label: Yes I am willing to submit a PR!
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -52,8 +52,9 @@ body:
         If want to submit a PR you do not need to open feature request, <b>just create the PR!</b>.
         Especially if you already have a good understanding of how to implement the feature.
         Airflow is a community-managed project and we love to bring new contributors in.
-        Find us in #airflow-how-to-pr on Slack! It's optional though - if you have good idea for small
-        feature, others might implement it if they pick an interest in it, so feel free to leave that
+        Find us in #development-first-pr-support on Slack!
+        It's optional though - if you have good idea for small feature,
+        others might implement it if they pick an interest in it, so feel free to leave that
         checkbox unchecked.
       options:
         - label: Yes I am willing to submit a PR!


### PR DESCRIPTION
See https://apache-airflow.slack.com/archives/CCZRF2U5A/p1679003716893149
Motivation: the current channel gets so many random Airflow questions probably due to the how-to in it's name.

This PR suggest the new name `development-first-pr-support` (Open to suggestions for other names)

This PR should be merged together with the Slack name change

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
