### PR TITLE
Add pod annotation on PgBouncer

### DIFF
--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -66,6 +66,9 @@ spec:
       annotations:
         checksum/pgbouncer-config-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-config-secret.yaml") . | sha256sum }}
         checksum/pgbouncer-certificates-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-certificates-secret.yaml") . | sha256sum }}
+        {{- if .Values.pgbouncer.podAnnotations }}
+          {{- toYaml .Values.pgbouncer.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.pgbouncer.priorityClassName }}
       priorityClassName: {{ .Values.pgbouncer.priorityClassName }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4288,6 +4288,14 @@
                         "type": "string"
                     }
                 },
+                "podAnnotations": {
+                    "description": "Annotations to add to the PgBounder pods.",
+                    "type": "object",
+                    "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "replicas": {
                     "description": "Number of PgBouncer replicas to run in Deployment.",
                     "type": "integer",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1542,6 +1542,8 @@ pgbouncer:
   # annotations to be added to the PgBouncer deployment
   annotations: {}
 
+  podAnnotations: {}
+
   # Create ServiceAccount
   serviceAccount:
     # Specifies whether a ServiceAccount should be created

--- a/tests/charts/test_annotations.py
+++ b/tests/charts/test_annotations.py
@@ -366,6 +366,20 @@ class TestServiceAccountAnnotations:
                 "example": "statsd",
             },
         ),
+        (
+            {
+                "pgbouncer": {
+                    "enabled": True,
+                    "podAnnotations": {
+                        "example": "pgbouncer",
+                    },
+                },
+            },
+            "templates/pgbouncer/pgbouncer-deployment.yaml",
+            {
+                "example": "pgbouncer",
+            },
+        ),
     ],
 )
 class TestPerComponentPodAnnotations:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Adding capability to define pod annotation for PgBouncer.  
---

Ability to define pod annotation on PgBouncer pods.
Sample case: provide annotation for prometheus scraper that configured to look after pod annotation instead of service annotation.

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
