### PR TITLE
[AIP-49] Rename statsd_allow_list and statsd_block_list to metrics_*_list

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -876,6 +876,25 @@ metrics:
   description: |
     StatsD (https://github.com/etsy/statsd) integration settings.
   options:
+    metrics_allow_list:
+      description: |
+        If you want to avoid emitting all the available metrics, you can configure an
+        allow list of prefixes (comma separated) to send only the metrics that start
+        with the elements of the list (e.g: "scheduler,executor,dagrun")
+      version_added: 2.0.0
+      type: string
+      example: ~
+      default: ""
+    metrics_block_list:
+      description: |
+        If you want to avoid emitting all the available metrics, you can configure a
+        block list of prefixes (comma separated) to filter out metrics that start with
+        the elements of the list (e.g: "scheduler,executor,dagrun").
+        If metrics_allow_list and metrics_block_list are both configured, metrics_block_list is ignored.
+      version_added: 2.6.0
+      type: string
+      example: ~
+      default: ""
     statsd_on:
       description: |
         Enables sending metrics to StatsD.
@@ -903,19 +922,14 @@ metrics:
       default: "airflow"
     statsd_allow_list:
       description: |
-        If you want to avoid sending all the available metrics to StatsD,
-        you can configure an allow list of prefixes (comma separated) to send only the metrics that
-        start with the elements of the list (e.g: "scheduler,executor,dagrun")
+        Deprecated, see metrics_allow_list
       version_added: 2.0.0
       type: string
       example: ~
       default: ""
     statsd_block_list:
       description: |
-        If you want to avoid sending all the available metrics to StatsD,
-        you can configure a block list of prefixes (comma separated) to filter out metrics that
-        start with the elements of the list (e.g: "scheduler,executor,dagrun").
-        If statsd_allow_list and statsd_block_list are both configured, statsd_block_list is ignored
+        Deprecated, see metrics_allow_list
       version_added: 2.6.0
       type: string
       example: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -920,20 +920,6 @@ metrics:
       type: string
       example: ~
       default: "airflow"
-    statsd_allow_list:
-      description: |
-        Deprecated, see metrics_allow_list
-      version_added: 2.0.0
-      type: string
-      example: ~
-      default: ""
-    statsd_block_list:
-      description: |
-        Deprecated, see metrics_allow_list
-      version_added: 2.6.0
-      type: string
-      example: ~
-      default: ""
     stat_name_handler:
       description: |
         A function that validate the StatsD stat name, apply changes to the stat name if necessary and return

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -509,12 +509,6 @@ statsd_host = localhost
 statsd_port = 8125
 statsd_prefix = airflow
 
-# Deprecated, see metrics_allow_list
-statsd_allow_list =
-
-# Deprecated, see metrics_allow_list
-statsd_block_list =
-
 # A function that validate the StatsD stat name, apply changes to the stat name if necessary and return
 # the transformed stat name.
 #

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -492,21 +492,27 @@ file_task_handler_new_file_permissions = 0o664
 [metrics]
 
 # StatsD (https://github.com/etsy/statsd) integration settings.
+# If you want to avoid emitting all the available metrics, you can configure an
+# allow list of prefixes (comma separated) to send only the metrics that start
+# with the elements of the list (e.g: "scheduler,executor,dagrun")
+metrics_allow_list =
+
+# If you want to avoid emitting all the available metrics, you can configure a
+# block list of prefixes (comma separated) to filter out metrics that start with
+# the elements of the list (e.g: "scheduler,executor,dagrun").
+# If metrics_allow_list and metrics_block_list are both configured, metrics_block_list is ignored.
+metrics_block_list =
+
 # Enables sending metrics to StatsD.
 statsd_on = False
 statsd_host = localhost
 statsd_port = 8125
 statsd_prefix = airflow
 
-# If you want to avoid sending all the available metrics to StatsD,
-# you can configure an allow list of prefixes (comma separated) to send only the metrics that
-# start with the elements of the list (e.g: "scheduler,executor,dagrun")
+# Deprecated, see metrics_allow_list
 statsd_allow_list =
 
-# If you want to avoid sending all the available metrics to StatsD,
-# you can configure a block list of prefixes (comma separated) to filter out metrics that
-# start with the elements of the list (e.g: "scheduler,executor,dagrun").
-# If statsd_allow_list and statsd_block_list are both configured, statsd_block_list is ignored
+# Deprecated, see metrics_allow_list
 statsd_block_list =
 
 # A function that validate the StatsD stat name, apply changes to the stat name if necessary and return

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -199,6 +199,8 @@ class AirflowConfigParser(ConfigParser):
             "2.0.0",
         ),
         ("logging", "task_log_reader"): ("core", "task_log_reader", "2.0.0"),
+        ("metrics", "metrics_allow_list"): ("metrics", "statsd_allow_list", "2.5.3"),
+        ("metrics", "metrics_block_list"): ("metrics", "statsd_block_list", "2.5.3"),
         ("metrics", "statsd_on"): ("scheduler", "statsd_on", "2.0.0"),
         ("metrics", "statsd_host"): ("scheduler", "statsd_host", "2.0.0"),
         ("metrics", "statsd_port"): ("scheduler", "statsd_port", "2.0.0"),

--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -600,14 +600,15 @@ class _Stats(type):
             port=conf.getint("metrics", "statsd_port"),
             prefix=conf.get("metrics", "statsd_prefix"),
         )
-        if conf.get("metrics", "statsd_allow_list", fallback=None):
-            metrics_validator = AllowListValidator(conf.get("metrics", "statsd_allow_list"))
-            if conf.get("metrics", "statsd_block_list", fallback=None):
+        if conf.get("metrics", "metrics_allow_list", fallback=None):
+            metrics_validator = AllowListValidator(conf.get("metrics", "metrics_allow_list"))
+            if conf.get("metrics", "metrics_block_list", fallback=None):
                 log.warning(
-                    "Ignoring statsd_block_list as both statsd_allow_list and statsd_block_list have been set"
+                    "Ignoring metrics_block_list as both metrics_allow_list "
+                    "and metrics_block_list have been set"
                 )
-        elif conf.get("metrics", "statsd_block_list", fallback=None):
-            metrics_validator = BlockListValidator(conf.get("metrics", "statsd_block_list"))
+        elif conf.get("metrics", "metrics_block_list", fallback=None):
+            metrics_validator = BlockListValidator(conf.get("metrics", "metrics_block_list"))
         else:
             metrics_validator = AllowListValidator()
         influxdb_tags_enabled = conf.getboolean("metrics", "statsd_influxdb_enabled", fallback=False)
@@ -627,14 +628,15 @@ class _Stats(type):
             namespace=conf.get("metrics", "statsd_prefix"),
             constant_tags=cls.get_constant_tags(),
         )
-        if conf.get("metrics", "statsd_allow_list", fallback=None):
-            metrics_validator = AllowListValidator(conf.get("metrics", "statsd_allow_list"))
-            if conf.get("metrics", "statsd_block_list", fallback=None):
+        if conf.get("metrics", "metrics_allow_list", fallback=None):
+            metrics_validator = AllowListValidator(conf.get("metrics", "metrics_allow_list"))
+            if conf.get("metrics", "metrics_block_list", fallback=None):
                 log.warning(
-                    "Ignoring statsd_block_list as both statsd_allow_list and statsd_block_list have been set"
+                    "Ignoring metrics_block_list as both metrics_allow_list "
+                    "and metrics_block_list have been set"
                 )
-        elif conf.get("metrics", "statsd_block_list", fallback=None):
-            metrics_validator = BlockListValidator(conf.get("metrics", "statsd_block_list"))
+        elif conf.get("metrics", "metrics_block_list", fallback=None):
+            metrics_validator = BlockListValidator(conf.get("metrics", "metrics_block_list"))
         else:
             metrics_validator = AllowListValidator()
         datadog_metrics_tags = conf.getboolean("metrics", "statsd_datadog_metrics_tags", fallback=True)

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -139,36 +139,6 @@ class TestStats:
         # Avoid side-effects
         importlib.reload(airflow.stats)
 
-    @pytest.mark.parametrize(
-        ("list_name", "validator"), [("allow", AllowListValidator), ("block", BlockListValidator)]
-    )
-    @mock.patch("warnings.warn")
-    def test_statsd_allow_and_block_list_renames(self, mock_warnings, list_name, validator):
-        class AnyStringContainingAll(list):
-            def __eq__(self, other):
-                for s in self:
-                    if s not in other:
-                        return False
-                return True
-
-        old_name = f"statsd_{list_name}_list"
-        new_name = f"metrics_{list_name}_list"
-        with conf_vars(
-            {
-                ("metrics", "statsd_on"): "True",
-                ("metrics", old_name): "name1,name2",
-            }
-        ):
-            importlib.reload(airflow.stats)
-            assert isinstance(airflow.stats.Stats.metrics_validator, validator)
-            assert airflow.stats.Stats.metrics_validator.validate_list == ("name1", "name2")
-
-            mock_warnings.assert_called_with(
-                AnyStringContainingAll([old_name, f"renamed to {new_name}"]), mock.ANY, stacklevel=mock.ANY
-            )
-        # Avoid side-effects
-        importlib.reload(airflow.stats)
-
     def test_load_block_list_validator(self):
         with conf_vars(
             {
@@ -186,8 +156,8 @@ class TestStats:
         with conf_vars(
             {
                 ("metrics", "statsd_on"): "True",
-                ("metrics", "statsd_allow_list"): "name1,name2",
-                ("metrics", "statsd_block_list"): "name1,name2",
+                ("metrics", "metrics_allow_list"): "name1,name2",
+                ("metrics", "metrics_block_list"): "name1,name2",
             }
         ):
             importlib.reload(airflow.stats)

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -130,7 +130,7 @@ class TestStats:
         with conf_vars(
             {
                 ("metrics", "statsd_on"): "True",
-                ("metrics", "statsd_allow_list"): "name1,name2",
+                ("metrics", "metrics_allow_list"): "name1,name2",
             }
         ):
             importlib.reload(airflow.stats)
@@ -139,11 +139,41 @@ class TestStats:
         # Avoid side-effects
         importlib.reload(airflow.stats)
 
+    @pytest.mark.parametrize(
+        ("list_name", "validator"), [("allow", AllowListValidator), ("block", BlockListValidator)]
+    )
+    @mock.patch("warnings.warn")
+    def test_statsd_allow_and_block_list_renames(self, mock_warnings, list_name, validator):
+        class AnyStringContainingAll(list):
+            def __eq__(self, other):
+                for s in self:
+                    if s not in other:
+                        return False
+                return True
+
+        old_name = f"statsd_{list_name}_list"
+        new_name = f"metrics_{list_name}_list"
+        with conf_vars(
+            {
+                ("metrics", "statsd_on"): "True",
+                ("metrics", old_name): "name1,name2",
+            }
+        ):
+            importlib.reload(airflow.stats)
+            assert isinstance(airflow.stats.Stats.metrics_validator, validator)
+            assert airflow.stats.Stats.metrics_validator.validate_list == ("name1", "name2")
+
+            mock_warnings.assert_called_with(
+                AnyStringContainingAll([old_name, f"renamed to {new_name}"]), mock.ANY, stacklevel=mock.ANY
+            )
+        # Avoid side-effects
+        importlib.reload(airflow.stats)
+
     def test_load_block_list_validator(self):
         with conf_vars(
             {
                 ("metrics", "statsd_on"): "True",
-                ("metrics", "statsd_block_list"): "name1,name2",
+                ("metrics", "metrics_block_list"): "name1,name2",
             }
         ):
             importlib.reload(airflow.stats)


### PR DESCRIPTION
More groundwork for the OpenTelemetry support; renames the two existing config values and deprecates the old names.  Added a test that confirms it as well.  That is likely covered in other unit tests, but I wanted to make sure.