### PR TITLE
Migrated remaining google cloud operators to pytest

### DIFF
--- a/tests/providers/google/cloud/operators/test_cloud_base.py
+++ b/tests/providers/google/cloud/operators/test_cloud_base.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import copy
-import unittest
 
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
 from google.api_core.retry import Retry
@@ -40,17 +39,17 @@ class GoogleSampleOperator(GoogleCloudBaseOperator):
         self.config = config
 
 
-class TestGoogleCloudBaseOperator(unittest.TestCase):
+class TestGoogleCloudBaseOperator:
     def test_handles_deepcopy_with_method_default(self):
         op = GoogleSampleOperator(task_id=TASK_ID)
         copied_op = copy.deepcopy(op)
 
-        self.assertEqual(copied_op.retry, DEFAULT)
-        self.assertEqual(copied_op.config, None)
+        assert copied_op.retry == DEFAULT
+        assert copied_op.config == None
 
     def test_handles_deepcopy_with_non_default_retry(self):
         op = GoogleSampleOperator(task_id=TASK_ID, retry=Retry(deadline=30), config={"config": "value"})
         copied_op = copy.deepcopy(op)
 
-        self.assertEqual(copied_op.retry.deadline, 30)
-        self.assertEqual(copied_op.config, {"config": "value"})
+        assert copied_op.retry.deadline == 30
+        assert copied_op.config == {"config": "value"}

--- a/tests/providers/google/cloud/operators/test_cloud_base.py
+++ b/tests/providers/google/cloud/operators/test_cloud_base.py
@@ -45,7 +45,7 @@ class TestGoogleCloudBaseOperator:
         copied_op = copy.deepcopy(op)
 
         assert copied_op.retry == DEFAULT
-        assert copied_op.config == None
+        assert copied_op.config is None
 
     def test_handles_deepcopy_with_non_default_retry(self):
         op = GoogleSampleOperator(task_id=TASK_ID, retry=Retry(deadline=30), config={"config": "value"})


### PR DESCRIPTION
Some part of google/cloud/operators were still not migrated to unittest, that i have done.

related: https://github.com/apache/airflow/issues/29305