### PR TITLE
Remove protobuf limitation from eager upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1245,14 +1245,10 @@ ARG ADDITIONAL_PYTHON_DEPS=""
 # * dill<0.3.3 required by apache-beam
 # * pyarrow>=6.0.0 is because pip resolver decides for Python 3.10 to downgrade pyarrow to 5 even if it is OK
 #   for python 3.10 and other dependencies adding the limit helps resolver to make better decisions
-# We need to limit the protobuf library to < 4.21.0 because not all google libraries we use
-# are compatible with the new protobuf version. All the google python client libraries need
-# to be upgraded to >=2.0.0 in order to able to lift that limitation
-# https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
 # * authlib, gcloud_aio_auth, adal are needed to generate constraints for PyPI packages and can be removed after we release
 #   new google, azure providers
 # !!! MAKE SURE YOU SYNCHRONIZE THE LIST BETWEEN: Dockerfile, Dockerfile.ci, find_newer_dependencies.py
-ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="dill<0.3.3 pyarrow>=6.0.0 protobuf<4.21.0 authlib>=1.0.0 gcloud_aio_auth>=4.0.0 adal>=1.2.7"
+ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="dill<0.3.3 pyarrow>=6.0.0 authlib>=1.0.0 gcloud_aio_auth>=4.0.0 adal>=1.2.7"
 
 ENV ADDITIONAL_PYTHON_DEPS=${ADDITIONAL_PYTHON_DEPS} \
     INSTALL_PACKAGES_FROM_CONTEXT=${INSTALL_PACKAGES_FROM_CONTEXT} \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1327,14 +1327,10 @@ RUN echo "Airflow version: ${AIRFLOW_VERSION}"
 # * dill<0.3.3 required by apache-beam
 # * pyarrow>=6.0.0 is because pip resolver decides for Python 3.10 to downgrade pyarrow to 5 even if it is OK
 #   for python 3.10 and other dependencies adding the limit helps resolver to make better decisions
-# We need to limit the protobuf library to < 4.21.0 because not all google libraries we use
-# are compatible with the new protobuf version. All the google python client libraries need
-# to be upgraded to >= 2.0.0 in order to able to lift that limitation
-# https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
 # * authlib, gcloud_aio_auth, adal are needed to generate constraints for PyPI packages and can be removed after we release
 #   new google, azure providers
 # !!! MAKE SURE YOU SYNCHRONIZE THE LIST BETWEEN: Dockerfile, Dockerfile.ci, find_newer_dependencies.py
-ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="dill<0.3.3 pyarrow>=6.0.0 protobuf<4.21.0 authlib>=1.0.0 gcloud_aio_auth>=4.0.0 adal>=1.2.7"
+ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="dill<0.3.3 pyarrow>=6.0.0 authlib>=1.0.0 gcloud_aio_auth>=4.0.0 adal>=1.2.7"
 ARG UPGRADE_TO_NEWER_DEPENDENCIES="false"
 ENV EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS=${EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS} \
     UPGRADE_TO_NEWER_DEPENDENCIES=${UPGRADE_TO_NEWER_DEPENDENCIES}

--- a/dev/breeze/src/airflow_breeze/utils/find_newer_dependencies.py
+++ b/dev/breeze/src/airflow_breeze/utils/find_newer_dependencies.py
@@ -93,7 +93,7 @@ def find_newer_dependencies(
     # !!! MAKE SURE YOU SYNCHRONIZE THE LIST BETWEEN: Dockerfile, Dockerfile.ci, find_newer_dependencies.py
     get_console().print(
         'pip install ".[devel_all]" --upgrade --upgrade-strategy eager '
-        '"dill<0.3.3" "pyarrow>=6.0.0" "protobuf<4.21.0" '
+        '"dill<0.3.3" "pyarrow>=6.0.0" '
         '"authlib>=1.0.0" "gcloud_aio_auth>=4.0.0" "adal>=1.2.7"' + constraint_string,
         markup=False,
         soft_wrap=True,


### PR DESCRIPTION
Protobuf limitation was added to help pip resolve eager upgrade dependencies, however it is not needed any more.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
