### PR TITLE
Fix XCom.get_one exactly one exception text

### DIFF
--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -366,7 +366,7 @@ class BaseXCom(Base, LoggingMixin):
     ) -> Any | None:
         """:sphinx-autoapi-skip:"""
         if not exactly_one(execution_date is not None, run_id is not None):
-            raise ValueError("Exactly one of ti_key, run_id, or execution_date must be passed")
+            raise ValueError("Exactly one of run_id or execution_date must be passed")
 
         if run_id:
             query = BaseXCom.get_many(


### PR DESCRIPTION
In `BaseXCom.get_one` we got rid of the `ti_key` parameter passing and, hence, checking in https://github.com/apache/airflow/commit/d08284ed251b7c5712190181623b500a38cd640d, but didn't tune the exception message, what I'm doing here.