### PR TITLE
Fix copy dag run config in grid detail

### DIFF
--- a/airflow/www/static/js/dag/details/dagRun/index.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/index.tsx
@@ -55,6 +55,13 @@ interface Props {
   runId: DagRunType["runId"];
 }
 
+const formatConf = (conf: string | null | undefined): string => {
+  if (!conf) {
+    return "";
+  }
+  return JSON.stringify(JSON.parse(conf), null, 4);
+};
+
 const DagRun = ({ runId }: Props) => {
   const {
     data: { dagRuns },
@@ -63,9 +70,7 @@ const DagRun = ({ runId }: Props) => {
   const offsetTop = useOffsetTop(detailsRef);
 
   const run = dagRuns.find((dr) => dr.runId === runId);
-  const { onCopy, hasCopied } = useClipboard(
-    JSON.stringify(JSON.parse(run?.conf || ""), null, 4)
-  );
+  const { onCopy, hasCopied } = useClipboard(formatConf(run?.conf));
   if (!run) return null;
   const {
     state,


### PR DESCRIPTION
https://github.com/apache/airflow/pull/30103 added support for formatting the json sent to the clipboard.

Unfortunately it looks like this breaks for DagRun that have no configuration. (trying to `JSON.parse("")`).

![image](https://user-images.githubusercontent.com/14861206/226175582-a8150ad0-a3b4-45b4-8437-cb0c76d0cdab.png)
