### PR TITLE
Add webserver serviceaccount

### DIFF
--- a/chart/templates/rbac/pod-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/pod-launcher-rolebinding.yaml
@@ -21,6 +21,7 @@
 {{- if and .Values.rbac.create .Values.allowPodLaunching }}
 {{- $schedulerLaunchExecutors := list "LocalExecutor" "LocalKubernetesExecutor" "KubernetesExecutor" "CeleryKubernetesExecutor" }}
 {{- $workerLaunchExecutors := list "CeleryExecutor" "LocalKubernetesExecutor" "KubernetesExecutor" "CeleryKubernetesExecutor" }}
+{{- $webserverLaunchExecutors := list "CeleryExecutor" "LocalKubernetesExecutor" "KubernetesExecutor" "CeleryKubernetesExecutor" }}
 {{- if .Values.multiNamespaceMode }}
 kind: ClusterRoleBinding
 {{- else }}
@@ -57,6 +58,11 @@ subjects:
 {{- if has .Values.executor $workerLaunchExecutors }}
   - kind: ServiceAccount
     name: {{ include "worker.serviceAccountName" . }}
+    namespace: "{{ .Release.Namespace }}"
+{{- end }}
+{{- if has .Values.executor $webserverLaunchExecutors }}
+  - kind: ServiceAccount
+    name: {{ include "webserver.serviceAccountName" . }}
     namespace: "{{ .Release.Namespace }}"
 {{- end }}
 {{- end }}


### PR DESCRIPTION
related: #28394 

The issue with running manual tasks was fixed in the PR above, however, this will still fail since the webserver doesn't have a rolebinding serviceaccount attached. Adding that to the pod-launcher-rolebinding template. 
