### PR TITLE
Improve internal-api and webserver CLI tests 

### DIFF
--- a/tests/cli/commands/_common_cli_classes.py
+++ b/tests/cli/commands/_common_cli_classes.py
@@ -1,0 +1,145 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import os
+import re
+import time
+
+import psutil
+import pytest
+from psutil import Error
+from rich.console import Console
+
+from airflow.cli import cli_parser
+from airflow.utils.cli import setup_locations
+
+console = Console(width=400, color_system="standard")
+
+
+class _ComonCLIGunicornTestClass:
+
+    main_process_regexp: str = "process_to_look_for"
+
+    @pytest.fixture(autouse=True)
+    def _make_parser(self):
+        self.parser = cli_parser.get_parser()
+
+    def _check_processes(self, ignore_running: bool):
+        if self.main_process_regexp == "process_to_look_for":
+            raise Exception(
+                "The main_process_regexp must be set in the subclass to something different than"
+                " 'process_to_look_for'"
+            )
+        # Confirm that nmain procss hasn't been launched.
+        # pgrep returns exit status 1 if no process matched.
+        # Use more specific regexps (^) to avoid matching pytest run when running specific method.
+        # For instance, we want to be able to do: pytest -k 'gunicorn'
+        airflow_internal_api_pids = self._find_all_processes(self.main_process_regexp)
+        gunicorn_pids = self._find_all_processes(r"gunicorn: ")
+        if airflow_internal_api_pids or gunicorn_pids:
+            console.print("[blue]Some processes are still running")
+            for pid in gunicorn_pids + airflow_internal_api_pids:
+                console.print(psutil.Process(pid).as_dict(attrs=["pid", "name", "cmdline"]))
+            console.print("[blue]Here list of processes ends")
+            if airflow_internal_api_pids:
+                console.print(f"[yellow]Forcefully killing {self.main_process_regexp} processes")
+                for pid in airflow_internal_api_pids:
+                    psutil.Process(pid).kill()
+            if gunicorn_pids:
+                console.print("[yellow]Forcefully killing all gunicorn processes")
+                for pid in gunicorn_pids:
+                    psutil.Process(pid).kill()
+            if not ignore_running:
+                raise AssertionError(
+                    "Background processes are running that prevent the test from passing successfully."
+                )
+
+    @pytest.fixture(autouse=True)
+    def _cleanup(self):
+        self._check_processes(ignore_running=True)
+        self._clean_pidfiles()
+
+        yield
+
+        self._check_processes(ignore_running=True)
+        self._clean_pidfiles()
+
+    def _clean_pidfiles(self):
+        pidfile_internal_api = setup_locations("internal-api")[0]
+        pidfile_monitor = setup_locations("internal-api-monitor")[0]
+        if os.path.exists(pidfile_internal_api):
+            console.print(f"[blue]Removing pidfile{pidfile_internal_api}")
+            os.remove(pidfile_internal_api)
+        if os.path.exists(pidfile_monitor):
+            console.print(f"[blue]Removing pidfile{pidfile_monitor}")
+            os.remove(pidfile_monitor)
+
+    def _wait_pidfile(self, pidfile):
+        start_time = time.monotonic()
+        while True:
+            try:
+                with open(pidfile) as file:
+                    return int(file.read())
+            except Exception:
+                if start_time - time.monotonic() > 60:
+                    raise
+                console.print(f"[blue]Waiting for pidfile {pidfile} to be created ...")
+                time.sleep(1)
+
+    def _find_process(self, regexp_match: str, print_found_process=False) -> int | None:
+        """
+        Find if process is running by matching its command line with a regexp.
+        :param regexp_match: regexp to match the command line of the process
+        :param print_found_process: if True, print the process found
+        :return: PID of the process if found, None otherwise
+        """
+        matcher = re.compile(regexp_match)
+        for proc in psutil.process_iter():
+            try:
+                proc_cmdline = " ".join(proc.cmdline())
+            except Error:
+                # only check processes we can access and are existing
+                continue
+            if matcher.search(proc_cmdline):
+                if print_found_process:
+                    console.print(proc.as_dict(attrs=["pid", "name", "cmdline"]))
+                return proc.pid
+        return None
+
+    def _find_all_processes(self, regexp_match: str, print_found_process=False) -> list[int]:
+        """
+        Find all running process matching their command line with a regexp and return the list of pids
+        of the processes. found
+        :param regexp_match: regexp to match the command line of the processes
+        :param print_found_process: if True, print the processes found
+        :return: list of PID of the processes matching the regexp
+        """
+        matcher = re.compile(regexp_match)
+        pids: list[int] = []
+        for proc in psutil.process_iter():
+            try:
+                proc_cmdline = " ".join(proc.cmdline())
+            except Error:
+                # only check processes we can access and are existing
+                continue
+            if matcher.match(proc_cmdline):
+                if print_found_process:
+                    console.print(proc.as_dict(attrs=["pid", "name", "cmdline"]))
+                pids.append(proc.pid)
+        return pids

--- a/tests/cli/commands/test_webserver_command.py
+++ b/tests/cli/commands/test_webserver_command.py
@@ -21,17 +21,21 @@ import subprocess
 import sys
 import tempfile
 import time
+from pathlib import Path
 from unittest import mock
 
 import psutil
 import pytest
+from rich.console import Console
 
 from airflow import settings
 from airflow.cli import cli_parser
 from airflow.cli.commands import webserver_command
 from airflow.cli.commands.webserver_command import GunicornMonitor
-from airflow.utils.cli import setup_locations
+from tests.cli.commands._common_cli_classes import _ComonCLIGunicornTestClass
 from tests.test_utils.config import conf_vars
+
+console = Console(width=400, color_system="standard")
 
 
 class TestGunicornMonitor:
@@ -229,57 +233,9 @@ class TestCLIGetNumReadyWorkersRunning:
             assert self.monitor._get_num_ready_workers_running() == 0
 
 
-class TestCliWebServer:
-    @pytest.fixture(autouse=True)
-    def _make_parser(self):
-        self.parser = cli_parser.get_parser()
+class TestCliWebServer(_ComonCLIGunicornTestClass):
 
-    @pytest.fixture(autouse=True)
-    def _cleanup(self):
-        self._check_processes()
-        self._clean_pidfiles()
-
-        yield
-
-        self._check_processes(ignore_running=True)
-        self._clean_pidfiles()
-
-    def _check_processes(self, ignore_running=False):
-        # Confirm that webserver hasn't been launched.
-        # pgrep returns exit status 1 if no process matched.
-        # Use more specific regexps (^) to avoid matching pytest run when running specific method.
-        # For instance, we want to be able to do: pytest -k 'gunicorn'
-        exit_code_pgrep_webserver = subprocess.Popen(["pgrep", "-c", "-f", "airflow webserver"]).wait()
-        exit_code_pgrep_gunicorn = subprocess.Popen(["pgrep", "-c", "-f", "^gunicorn"]).wait()
-        if exit_code_pgrep_webserver != 1 or exit_code_pgrep_gunicorn != 1:
-            subprocess.Popen(["ps", "-ax"]).wait()
-            if exit_code_pgrep_webserver != 1:
-                subprocess.Popen(["pkill", "-9", "-f", "airflow webserver"]).wait()
-            if exit_code_pgrep_gunicorn != 1:
-                subprocess.Popen(["pkill", "-9", "-f", "^gunicorn"]).wait()
-            if not ignore_running:
-                raise AssertionError(
-                    "Background processes are running that prevent the test from passing successfully."
-                )
-
-    def _clean_pidfiles(self):
-        pidfile_webserver = setup_locations("webserver")[0]
-        pidfile_monitor = setup_locations("webserver-monitor")[0]
-        if os.path.exists(pidfile_webserver):
-            os.remove(pidfile_webserver)
-        if os.path.exists(pidfile_monitor):
-            os.remove(pidfile_monitor)
-
-    def _wait_pidfile(self, pidfile):
-        start_time = time.monotonic()
-        while True:
-            try:
-                with open(pidfile) as file:
-                    return int(file.read())
-            except Exception:
-                if start_time - time.monotonic() > 60:
-                    raise
-                time.sleep(1)
+    main_process_regexp = r"airflow webserver"
 
     @pytest.mark.execution_timeout(210)
     def test_cli_webserver_background(self):
@@ -315,28 +271,37 @@ class TestCliWebServer:
                 assert proc.poll() is None
 
                 pid_monitor = self._wait_pidfile(pidfile_monitor)
-                self._wait_pidfile(pidfile_webserver)
-
-                # Assert that gunicorn and its monitor are launched.
-                assert 0 == subprocess.Popen(["pgrep", "-f", "-c", "airflow webserver --daemon"]).wait()
+                console.print(f"[blue]Monitor started at {pid_monitor}")
+                pid_webserver = self._wait_pidfile(pidfile_webserver)
+                console.print(f"[blue]Webserver started at {pid_webserver}")
+                console.print("[blue]Running airflow webserver process:")
+                # Assert that the webserver and gunicorn processes are running (by name rather than pid).
+                assert self._find_process(r"airflow webserver", print_found_process=True)
+                console.print("[blue]Waiting for gunicorn processes:")
                 # wait for gunicorn to start
                 for i in range(30):
-                    if 0 == subprocess.Popen(["pgrep", "-f", "-c", "^gunicorn"]).wait():
+                    if self._find_process(r"^gunicorn"):
                         break
+                    console.print("[blue]Waiting for gunicorn to start ...")
                     time.sleep(1)
-                assert 0 == subprocess.Popen(["pgrep", "-c", "-f", "gunicorn: master"]).wait()
-
-                # Terminate monitor process.
+                console.print("[blue]Running gunicorn processes:")
+                assert self._find_all_processes("^gunicorn", print_found_process=True)
+                console.print("[magenta]Webserver process started successfully.")
+                console.print(
+                    "[magenta]Terminating monitor process and expect "
+                    "Webserver and gunicorn processes to terminate as well"
+                )
                 proc = psutil.Process(pid_monitor)
                 proc.terminate()
                 assert proc.wait(120) in (0, None)
-
-                self._check_processes()
+                self._check_processes(ignore_running=False)
+                console.print("[magenta]All Webserver and gunicorn processes are terminated.")
             except Exception:
-                # List all logs
-                subprocess.Popen(["ls", "-lah", tmpdir]).wait()
+                console.print("[red]Exception occurred. Dumping all logs.")
                 # Dump all logs
-                subprocess.Popen(["bash", "-c", f"ls {tmpdir}/* | xargs -n 1 -t cat"]).wait()
+                for file in Path(tmpdir).glob("*"):
+                    console.print(f"Dumping {file} (size: {file.stat().st_size})")
+                    console.print(file.read_text())
                 raise
 
     # Patch for causing webserver timeout


### PR DESCRIPTION
The test_cli_internal_api_background test has been flakey for some time, however it's been difficult to debug and locally reproduce the problem especially on MacOS because it used pgrep newer syntax that is not supported on MacOS.

This change improves the test by using psutil instead, it also improves the diagnostics to explain more what's going on and to display more information immediately (earlier the test had separately stdout and stderr making it difficult to understand what is the sequence of events.

Also intention of the test is better explained by adding helpful messages and adding colors and rich ability to format the output and color it to make it more straightforward to diagnose the issues.

The same was applied to the original webserver background test
which the implmentation was based on.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
