### PR TITLE
Add unique dependencies check for DAG

### DIFF
--- a/tests/dags/test_invalid_dup_dependency.py
+++ b/tests/dags/test_invalid_dup_dependency.py
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+
+with DAG(
+    "test_invalid_dup_dependency",
+    start_date=datetime(2021, 1, 1),
+    schedule="@once",
+    unique_dependencies=True,
+):
+    task_1 = EmptyOperator(task_id="one")
+    task_2 = EmptyOperator(task_id="two")
+
+    task_1 >> task_2
+    task_1 >> task_2

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2912,6 +2912,7 @@ class TestSchedulerJob:
             "no_dags.py",
             "test_invalid_cron.py",
             "test_invalid_dup_task.py",
+            "test_invalid_dup_dependency.py",
             "test_ignore_this.py",
             "test_invalid_param.py",
             "test_nested_dag.py",

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -362,6 +362,9 @@ class TestDagBag:
         found = dagbag.process_file(str(TEST_DAGS_FOLDER / "test_invalid_dup_task.py"))
         assert [] == found
 
+        found = dagbag.process_file(str(TEST_DAGS_FOLDER / "test_invalid_dup_dependency.py"))
+        assert [] == found
+
     @pytest.fixture()
     def zip_with_valid_dag_and_dup_tasks(self, tmp_path: pathlib.Path) -> Iterator[str]:
         failing_dag_file = TEST_DAGS_FOLDER / "test_invalid_dup_task.py"


### PR DESCRIPTION
Based on this discussion: https://github.com/apache/airflow/discussions/30128

Adds flag to immediately throw exception when the same dependencies is defined more than once in a DAG.

This is useful for catching logical errors in large DAGs e.g. where 1000s of dependencies are defined or where utility functions create tasks and dependencies.

The current warning is often not visible to a DAG author and also doesn't specify where in the DAG the warning is coming from so is hard to use as a check to ensure DAG quality. Open to reworking the approach here, it was just my first idea for this.

Let me know if I missed anything, I ran pre-commit and relevant tests locally with Breeze, but I'm not sure I got all Airflow dev checks working and this would be my first PR that affects something so core to Airflow.