### PR TITLE
Add REST API method to revoke role permissions

### DIFF
--- a/airflow/api_connexion/exceptions.py
+++ b/airflow/api_connexion/exceptions.py
@@ -32,7 +32,7 @@ EXCEPTIONS_LINK_MAP = {
     404: f"{doc_link}#section/Errors/NotFound",
     405: f"{doc_link}#section/Errors/MethodNotAllowed",
     401: f"{doc_link}#section/Errors/Unauthenticated",
-    409: f"{doc_link}#section/Errors/AlreadyExists",
+    409: f"{doc_link}#section/Errors/Conflict",
     403: f"{doc_link}#section/Errors/PermissionDenied",
     500: f"{doc_link}#section/Errors/Unknown",
 }
@@ -152,8 +152,8 @@ class PermissionDenied(ProblemException):
         )
 
 
-class AlreadyExists(ProblemException):
-    """Raise when the object already exists."""
+class Conflict(ProblemException):
+    """Raise when the object is in a conflicting state with the request."""
 
     def __init__(
         self,
@@ -170,6 +170,10 @@ class AlreadyExists(ProblemException):
             headers=headers,
             **kwargs,
         )
+
+
+class AlreadyExists(Conflict):
+    """Raise when the object already exists."""
 
 
 class Unknown(ProblemException):

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -219,7 +219,7 @@ info:
     agent, according to the proactive negotiation header fields received in the request, and the
     server is unwilling to supply a default representation.
 
-    ## AlreadyExists
+    ## Conflict
 
     The request could not be completed due to a conflict with the current state of the target
     resource, e.g. the resource it tries to create already exists.
@@ -551,7 +551,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
-          $ref: '#/components/responses/AlreadyExists'
+          $ref: '#/components/responses/Conflict'
 
   /dags/{dag_id}/clearTaskInstances:
     parameters:
@@ -755,7 +755,7 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthenticated'
         '409':
-          $ref: '#/components/responses/AlreadyExists'
+          $ref: '#/components/responses/Conflict'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':
@@ -1158,7 +1158,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
-          $ref: '#/components/responses/AlreadyExists'
+          $ref: '#/components/responses/Conflict'
 
     delete:
       summary: Delete a pool
@@ -2267,7 +2267,7 @@ paths:
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '409':
-          $ref: '#/components/responses/AlreadyExists'
+          $ref: '#/components/responses/Conflict'
 
   /users/{username}:
     parameters:
@@ -5082,7 +5082,7 @@ components:
           schema:
             $ref: '#/components/schemas/Error'
     # 409
-    'AlreadyExists':
+    'Conflict':
       description: An existing resource conflicts with the request.
       content:
         application/json:

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2159,6 +2159,34 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /roles/{role_name}/actions/revoke:
+    parameters:
+      - $ref: '#/components/parameters/RoleName'
+    post:
+      summary: Revoke permissions assigned to a role.
+      description: |
+        Revoke permissions (i.e., (action, resource) pairs) assigned to a role.
+      x-openapi-router-controller: airflow.api_connexion.endpoints.role_and_permission_endpoint
+      operationId: post_revoke_role_permissions
+      tags: [Role]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RoleActions'
+      responses:
+        '204':
+          description: Success.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /permissions:
     get:
       summary: List permissions
@@ -3720,6 +3748,18 @@ components:
               items:
                 $ref: '#/components/schemas/Role'
         - $ref: '#/components/schemas/CollectionInfo'
+
+    RoleActions:
+      description: |
+        A list of (action, resource) pairs for a role.
+      type: object
+      properties:
+        actions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ActionResource'
+      required:
+        - actions
 
     Action:
       description: |

--- a/airflow/api_connexion/schemas/role_and_permission_schema.py
+++ b/airflow/api_connexion/schemas/role_and_permission_schema.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from typing import NamedTuple
 
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, validate
 from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
 
 from airflow.www.fab_security.sqla.models import Action, Permission, Resource, Role
@@ -84,6 +84,17 @@ class RoleSchema(SQLAlchemySchema):
     permissions = fields.List(fields.Nested(ActionResourceSchema), data_key="actions")
 
 
+class PermissionsSchema(Schema):
+    """List of permissions schema."""
+
+    permissions = fields.List(
+        fields.Nested(ActionResourceSchema),
+        data_key="actions",
+        required=True,
+        validate=validate.Length(min=1),
+    )
+
+
 class RoleCollection(NamedTuple):
     """List of roles."""
 
@@ -101,3 +112,4 @@ class RoleCollectionSchema(Schema):
 role_schema = RoleSchema()
 role_collection_schema = RoleCollectionSchema()
 action_collection_schema = ActionCollectionSchema()
+permissions_schema = PermissionsSchema()

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -2177,7 +2177,7 @@ export interface components {
       };
     };
     /** An existing resource conflicts with the request. */
-    AlreadyExists: {
+    Conflict: {
       content: {
         "application/json": components["schemas"]["Error"];
       };
@@ -2639,7 +2639,7 @@ export interface operations {
       401: components["responses"]["Unauthenticated"];
       403: components["responses"]["PermissionDenied"];
       404: components["responses"]["NotFound"];
-      409: components["responses"]["AlreadyExists"];
+      409: components["responses"]["Conflict"];
     };
   };
   patch_dag: {
@@ -2900,7 +2900,7 @@ export interface operations {
       401: components["responses"]["Unauthenticated"];
       403: components["responses"]["PermissionDenied"];
       404: components["responses"]["NotFound"];
-      409: components["responses"]["AlreadyExists"];
+      409: components["responses"]["Conflict"];
     };
     requestBody: {
       content: {
@@ -3288,7 +3288,7 @@ export interface operations {
       401: components["responses"]["Unauthenticated"];
       403: components["responses"]["PermissionDenied"];
       404: components["responses"]["NotFound"];
-      409: components["responses"]["AlreadyExists"];
+      409: components["responses"]["Conflict"];
     };
     requestBody: {
       content: {
@@ -4428,7 +4428,7 @@ export interface operations {
       400: components["responses"]["BadRequest"];
       401: components["responses"]["Unauthenticated"];
       403: components["responses"]["PermissionDenied"];
-      409: components["responses"]["AlreadyExists"];
+      409: components["responses"]["Conflict"];
     };
     requestBody: {
       content: {

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -671,6 +671,16 @@ export interface paths {
       };
     };
   };
+  "/roles/{role_name}/actions/revoke": {
+    /** Revoke permissions (i.e., (action, resource) pairs) assigned to a role. */
+    post: operations["post_revoke_role_permissions"];
+    parameters: {
+      path: {
+        /** The role name */
+        role_name: components["parameters"]["RoleName"];
+      };
+    };
+  };
   "/permissions": {
     /**
      * Get a list of permissions.
@@ -1545,6 +1555,10 @@ export interface components {
     RoleCollection: {
       roles?: components["schemas"]["Role"][];
     } & components["schemas"]["CollectionInfo"];
+    /** @description A list of (action, resource) pairs for a role. */
+    RoleActions: {
+      actions: components["schemas"]["ActionResource"][];
+    };
     /**
      * @description An action Item.
      *
@@ -4319,6 +4333,28 @@ export interface operations {
       };
     };
   };
+  /** Revoke permissions (i.e., (action, resource) pairs) assigned to a role. */
+  post_revoke_role_permissions: {
+    parameters: {
+      path: {
+        /** The role name */
+        role_name: components["parameters"]["RoleName"];
+      };
+    };
+    responses: {
+      /** Success. */
+      204: never;
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthenticated"];
+      403: components["responses"]["PermissionDenied"];
+      404: components["responses"]["NotFound"];
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["RoleActions"];
+      };
+    };
+  };
   /**
    * Get a list of permissions.
    *
@@ -4629,6 +4665,9 @@ export type PluginCollection = CamelCasedPropertiesDeep<
 export type Role = CamelCasedPropertiesDeep<components["schemas"]["Role"]>;
 export type RoleCollection = CamelCasedPropertiesDeep<
   components["schemas"]["RoleCollection"]
+>;
+export type RoleActions = CamelCasedPropertiesDeep<
+  components["schemas"]["RoleActions"]
 >;
 export type Action = CamelCasedPropertiesDeep<components["schemas"]["Action"]>;
 export type ActionCollection = CamelCasedPropertiesDeep<
@@ -4952,6 +4991,10 @@ export type PatchRoleVariables = CamelCasedPropertiesDeep<
   operations["patch_role"]["parameters"]["path"] &
     operations["patch_role"]["parameters"]["query"] &
     operations["patch_role"]["requestBody"]["content"]["application/json"]
+>;
+export type PostRevokeRolePermissionsVariables = CamelCasedPropertiesDeep<
+  operations["post_revoke_role_permissions"]["parameters"]["path"] &
+    operations["post_revoke_role_permissions"]["requestBody"]["content"]["application/json"]
 >;
 export type GetPermissionsVariables = CamelCasedPropertiesDeep<
   operations["get_permissions"]["parameters"]["query"]

--- a/tests/test_utils/security.py
+++ b/tests/test_utils/security.py
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.www.fab_security.sqla.models import Permission
+
+
+def assert_db_permissions_equal_to_pairs(
+    db_permissions: list[Permission], expected_permission_pairs: list[tuple[str, str]]
+):
+    permission_pairs = [(permission.action.name, permission.resource.name) for permission in db_permissions]
+    assert sorted(permission_pairs) == sorted(expected_permission_pairs)


### PR DESCRIPTION
Adding `POST /roles/{role_name}/actions/revoke` method to revoke permissions assigned to a role.

Closes: #18714