### PR TITLE
fix NameError "MappedTaskGroup" Not Found

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -122,6 +122,7 @@ from airflow.utils.sqlalchemy import (
 )
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.timeout import timeout
+from airflow.utils.task_group import MappedTaskGroup
 
 TR = TaskReschedule
 
@@ -136,7 +137,7 @@ if TYPE_CHECKING:
     from airflow.models.dagrun import DagRun
     from airflow.models.dataset import DatasetEvent
     from airflow.models.operator import Operator
-    from airflow.utils.task_group import MappedTaskGroup, TaskGroup
+    from airflow.utils.task_group import TaskGroup
 
     # This is a workaround because mypy doesn't work with hybrid_property
     # TODO: remove this hack and move hybrid_property back to main import block


### PR DESCRIPTION
In thise [line](https://github.com/apache/airflow/blob/732fcd789ddecd5251d391a8d9b72f130bafb046/airflow/models/taskinstance.py#L2797)，it explicitly used `MappedTaskGroup`. But [`MappedTaskGroup` is just imported when `TYPE_CHECKING`](https://github.com/apache/airflow/blob/732fcd789ddecd5251d391a8d9b72f130bafb046/airflow/models/taskinstance.py#L139). Therefore, there is a `NameError` during runtime.