### PR TITLE
Change EC2 System test to be more selective about its instance image

### DIFF
--- a/tests/system/providers/amazon/aws/example_ec2.py
+++ b/tests/system/providers/amazon/aws/example_ec2.py
@@ -50,7 +50,11 @@ def get_latest_ami_id():
     image_prefix = "Amazon Linux*"
 
     images = boto3.client("ec2").describe_images(
-        Filters=[{"Name": "description", "Values": [image_prefix]}], Owners=["amazon"]
+        Filters=[
+            {"Name": "description", "Values": [image_prefix]},
+            {"Name": "architecture", "Values": ["arm64"]},
+        ],
+        Owners=["amazon"],
     )
     # Sort on CreationDate
     sorted_images = sorted(images["Images"], key=itemgetter("CreationDate"), reverse=True)
@@ -92,7 +96,7 @@ with DAG(
     image_id = get_latest_ami_id()
 
     config = {
-        "InstanceType": "t2.micro",
+        "InstanceType": "t4g.micro",
         "KeyName": key_name,
         "TagSpecifications": [
             {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": instance_name}]}


### PR DESCRIPTION
The `example_ec2` system test was failing because the image Id of the instance being created was not compatible with the instance type (`t2.micro`). The reason this occurred was we were not placing any conditions on the image that we selected - we just selected the most recent image. This lead to a situation where the most recent image was not compatible with the instance type. 

The solution proposed in this PR is to change the instance type to T4g, which are powered by Arm-based AWS Graviton2 processors. Also, when getting the latest AMI Id, we now filter by selecting images compatible with `arm64`. This ensures that we get a compatible image every time.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
