### PR TITLE
Revert "Also limit importlib on Python 3.9 (#30069)"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -103,8 +103,8 @@ install_requires =
     httpx
     # Importlib-metadata 5 is breaking Celery import due to regression it introduced
     # This was tracked and fixed in https://github.com/celery/celery/pull/7785 but it is not released yet
-    # We can remove the < 5.0.0 limitation when Celery 5.3.0 gets released and we bump celeryt o >= 5.3.0
-    importlib_metadata>=1.7,<5.0.0;python_version<="3.9"
+    # We can remove the < 5.0.0 limitation hwne Celery 5.3.0 gets released and we bump celeryt o >= 5.3.0
+    importlib_metadata>=1.7,<5.0.0;python_version<"3.9"
     importlib_resources>=5.2;python_version<"3.9"
     itsdangerous>=2.0
     jinja2>=3.0.0


### PR DESCRIPTION
This reverts commit 6e2bdcfebe3e6dd43854f6e62e4e326079c6df79.

The change was done hastily when we released rc1 of 2.5.1 but it turned out to be a red-herring and something that was not really caused by Airflow's dependencies. The importlib_metadata should still be only added as dependency for Python < 3.9 as Python 3.9 does not need it. Also installing importlib_metadata manually (or by other dependencies) even in 6.1 version does not result in automated triggering of the issue - if someone happens to install importlib_metadata in Python 3.9 simply uninstalling it should solve the problem.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
