### PR TITLE
Only restrict spark binary passed via extra

### DIFF
--- a/tests/providers/apache/spark/hooks/test_spark_submit.py
+++ b/tests/providers/apache/spark/hooks/test_spark_submit.py
@@ -461,9 +461,8 @@ class TestSparkSubmitHook:
         assert connection == expected_spark_connection
         assert cmd[0] == "spark3-submit"
 
-    def test_resolve_connection_custom_spark_binary_not_allowed_runtime_error(self):
-        with pytest.raises(RuntimeError):
-            SparkSubmitHook(conn_id="spark_binary_set", spark_binary="another-custom-spark-submit")
+    def test_resolve_connection_custom_spark_binary_allowed_in_hook(self):
+        SparkSubmitHook(conn_id="spark_binary_set", spark_binary="another-custom-spark-submit")
 
     def test_resolve_connection_spark_binary_extra_not_allowed_runtime_error(self):
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
As discussed in #30064 - the security vulnerabilty fix from the #27646 restricted the spark binaries a little too much (the binaries should be restricted only when passed via extra).

This PR fixes it, spark submit is only restricted when passed via extra, you can still pass any binary via Hook parameter.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
