### PR TITLE
fix position of __version__ in imports to prevent potential circular import

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -26,6 +26,8 @@ isort:skip_file
 """
 from __future__ import annotations
 
+__version__ = "2.6.0.dev0"
+
 # flake8: noqa: F401
 
 import os
@@ -51,8 +53,6 @@ from airflow import configuration
 from airflow import settings
 
 __all__ = ["__version__", "login", "DAG", "PY36", "PY37", "PY38", "PY39", "PY310", "XComArg"]
-
-__version__ = "2.6.0.dev0"
 
 # Make `airflow` an namespace package, supporting installing
 # airflow.providers.* in different locations (i.e. one in site, and one in user

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -25,6 +25,7 @@ from typing import Any
 from urllib.parse import unquote
 
 from airflow.compat.functools import cached_property
+from airflow.providers.amazon.aws.utils import trim_none_values
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
 
@@ -178,7 +179,6 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
     def client(self):
         """Create a Secrets Manager client"""
         from airflow.providers.amazon.aws.hooks.base_aws import SessionFactory
-        from airflow.providers.amazon.aws.utils import trim_none_values
         from airflow.providers.amazon.aws.utils.connection_wrapper import AwsConnectionWrapper
 
         conn_id = f"{self.__class__.__name__}__connection"

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -25,7 +25,6 @@ from typing import Any
 from urllib.parse import unquote
 
 from airflow.compat.functools import cached_property
-from airflow.providers.amazon.aws.utils import trim_none_values
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
 
@@ -179,6 +178,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
     def client(self):
         """Create a Secrets Manager client"""
         from airflow.providers.amazon.aws.hooks.base_aws import SessionFactory
+        from airflow.providers.amazon.aws.utils import trim_none_values
         from airflow.providers.amazon.aws.utils.connection_wrapper import AwsConnectionWrapper
 
         conn_id = f"{self.__class__.__name__}__connection"


### PR DESCRIPTION
Following #29723 by @ashb, aws secret manager couldn't be used anymore, as it fails at initialization with 

```
  ...
  File "/opt/airflow/airflow/providers/amazon/aws/secrets/secrets_manager.py", line 28, in <module>
    from airflow.providers.amazon.aws.utils import trim_none_values
  File "/opt/airflow/airflow/providers/amazon/aws/utils/__init__.py", line 23, in <module>
    from airflow.version import version
  File "/opt/airflow/airflow/version.py", line 21, in <module>
    from airflow import __version__ as version
ImportError: cannot import name '__version__' from 'airflow' (/opt/airflow/airflow/__init__.py)
```

On a suggestion from Jarek, moving where version is initialized fixes it at the root, solving it for all possible cases where this could happen.