### PR TITLE
Push latest image in CI

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/image.py
+++ b/dev/breeze/src/airflow_breeze/utils/image.py
@@ -178,17 +178,31 @@ def tag_image_as_latest(image_params: CommonBuildParams, output: Output | None) 
             f"[info]Skip tagging {image_params.airflow_image_name} as latest as it is already 'latest'[/]"
         )
         return subprocess.CompletedProcess(returncode=0, args=[])
-    return run_command(
+    command = run_command(
         [
             "docker",
             "tag",
             image_params.airflow_image_name_with_tag,
-            image_params.airflow_image_name,
+            image_params.airflow_image_name + ":latest",
         ],
         output=output,
         capture_output=True,
         check=False,
     )
+    if command.returncode != 0:
+        return command
+    if image_params.push:
+        command = run_command(
+            [
+                "docker",
+                "push",
+                image_params.airflow_image_name + ":latest",
+            ],
+            output=output,
+            capture_output=True,
+            check=False,
+        )
+    return command
 
 
 def run_pull_and_verify_image(


### PR DESCRIPTION
When --tag-as-latest and --push were used, the images were build and tagged but not pushed on CI. This was not a problem, because the latest images are not used on CI nor locally, but if one would like to get the latest image from CI, they would have to find it by commit hash.

This change causes AMD images to be pushed as "latest" after successfull main build.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
