### PR TITLE
Merge DbtCloudJobRunAsyncSensor logic to DbtCloudJobRunSensor

### DIFF
--- a/airflow/providers/dbt/cloud/sensors/dbt.py
+++ b/airflow/providers/dbt/cloud/sensors/dbt.py
@@ -54,19 +54,22 @@ class DbtCloudJobRunSensor(BaseSensorOperator):
         deferrable: bool = False,
         **kwargs,
     ) -> None:
-        if deferrable and "poke_interval" not in kwargs:
-            # TODO: Remove once deprecated
-            if "polling_interval" in kwargs:
-                kwargs["poke_interval"] = kwargs["polling_interval"]
-                warnings.warn(
-                    "Argument `poll_interval` is deprecated and will be removed "
-                    "in a future release.  Please use `poke_interval` instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-            else:
-                kwargs["timeout"] = 60 * 60 * 24 * 7
-                kwargs["poke_interval"] = 5
+        if deferrable:
+            if "poke_interval" not in kwargs:
+                # TODO: Remove once deprecated
+                if "polling_interval" in kwargs:
+                    kwargs["poke_interval"] = kwargs["polling_interval"]
+                    warnings.warn(
+                        "Argument `poll_interval` is deprecated and will be removed "
+                        "in a future release.  Please use `poke_interval` instead.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+                else:
+                    kwargs["poke_interval"] = 5
+
+                if "timeout" not in kwargs:
+                    kwargs["timeout"] = 60 * 60 * 24 * 7
 
         super().__init__(**kwargs)
         self.dbt_cloud_conn_id = dbt_cloud_conn_id

--- a/airflow/providers/dbt/cloud/sensors/dbt.py
+++ b/airflow/providers/dbt/cloud/sensors/dbt.py
@@ -122,17 +122,9 @@ class DbtCloudJobRunSensor(BaseSensorOperator):
 
 class DbtCloudJobRunAsyncSensor(DbtCloudJobRunSensor):
     """
-    Checks the status of a dbt Cloud job run asynchronously.
-
-    .. seealso::
-        For more information on the DbtCloudJobRunAsyncSensor, take a look at the guide::
-        :ref:`howto/operator:DbtCloudJobRunAsyncSensor`
-
-    :param dbt_cloud_conn_id: The connection identifier for connecting to dbt Cloud.
-    :param run_id: The job run identifier.
-    :param account_id: The dbt Cloud account identifier.
-    :param poll_interval: Periodic time interval for the sensor to check for job status.
-    :param timeout: Time in seconds to wait for a job run to reach a terminal status. Defaults to 7 days.
+    This class is deprecated.
+    Please use
+    :class:`airflow.providers.dbt.cloud.sensor.dbt.DbtCloudJobRunSensor`.
     """
 
     def __init__(self, **kwargs: Any) -> None:

--- a/docs/apache-airflow-providers-dbt-cloud/operators.rst
+++ b/docs/apache-airflow-providers-dbt-cloud/operators.rst
@@ -78,7 +78,6 @@ via the ``additional_run_config`` dictionary.
     :start-after: [START howto_operator_dbt_cloud_run_job_async]
     :end-before: [END howto_operator_dbt_cloud_run_job_async]
 
-
 .. _howto/operator:DbtCloudJobRunSensor:
 
 Poll for status of a dbt Cloud Job run
@@ -98,16 +97,21 @@ the ``account_id`` for the task is referenced within the ``default_args`` of the
     :start-after: [START howto_operator_dbt_cloud_run_job_sensor]
     :end-before: [END howto_operator_dbt_cloud_run_job_sensor]
 
+Also you can use deferrable mode in this sensor if you would like to free up the worker slots while the sensor is running.
+
+.. exampleinclude:: /../../tests/system/providers/dbt/cloud/example_dbt_cloud.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_dbt_cloud_run_job_sensor_defered]
+    :end-before: [END howto_operator_dbt_cloud_run_job_sensor_defered]
+
 .. _howto/operator:DbtCloudJobRunAsyncSensor:
 
 Poll for status of a dbt Cloud Job run asynchronously
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :class:`~airflow.providers.dbt.cloud.sensors.dbt.DbtCloudJobRunAsyncSensor`
-(deferrable version) to periodically retrieve the
-status of a dbt Cloud job run asynchronously. This sensor will free up the worker slots since
-polling for job status happens on the Airflow triggerer, leading to efficient utilization
-of resources within Airflow.
+.. note::
+    :class:`~airflow.providers.dbt.cloud.sensors.dbt.DbtCloudJobRunAsyncSensor` is deprecated and will be removed in a future release. Please use :class:`~airflow.providers.dbt.cloud.sensors.dbt.DbtCloudJobRunSensor` and use the deferrable mode in that operator.
 
 .. exampleinclude:: /../../tests/system/providers/dbt/cloud/example_dbt_cloud.py
     :language: python

--- a/tests/system/providers/dbt/cloud/example_dbt_cloud.py
+++ b/tests/system/providers/dbt/cloud/example_dbt_cloud.py
@@ -77,6 +77,12 @@ with DAG(
     )
     # [END howto_operator_dbt_cloud_run_job_sensor]
 
+    # [START howto_operator_dbt_cloud_run_job_sensor_defered]
+    job_run_sensor_defered = DbtCloudJobRunSensor(
+        task_id="job_run_sensor_defered", run_id=trigger_job_run2.output, timeout=20
+    )
+    # [END howto_operator_dbt_cloud_run_job_sensor_defered]
+
     # [START howto_operator_dbt_cloud_run_job_async_sensor]
     job_run_async_sensor = DbtCloudJobRunAsyncSensor(
         task_id="job_run_async_sensor", run_id=trigger_job_run2.output, timeout=20

--- a/tests/system/providers/dbt/cloud/example_dbt_cloud.py
+++ b/tests/system/providers/dbt/cloud/example_dbt_cloud.py
@@ -79,7 +79,7 @@ with DAG(
 
     # [START howto_operator_dbt_cloud_run_job_sensor_defered]
     job_run_sensor_defered = DbtCloudJobRunSensor(
-        task_id="job_run_sensor_defered", run_id=trigger_job_run2.output, timeout=20
+        task_id="job_run_sensor_defered", run_id=trigger_job_run2.output, timeout=20, deferrable=True
     )
     # [END howto_operator_dbt_cloud_run_job_sensor_defered]
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

### Why making this change?
apache-airflow-providers-dbt-cloud treats the deferred execution of its operators and sensors differently, which might cause confusion. For example, [DbtCloudRunJobOperator](https://github.com/apache/airflow/blob/main/airflow/providers/dbt/cloud/operators/dbt.py#L46) uses the [deferrable](https://github.com/apache/airflow/blob/main/airflow/providers/dbt/cloud/operators/dbt.py#L100) parameter to toggle deferred execution while we need to use another sensor for [DbtCloudJobRunSensor](https://github.com/apache/airflow/blob/main/airflow/providers/dbt/cloud/sensors/dbt.py#L31) (i.e., [DbtCloudJobRunAsyncSensor](https://github.com/apache/airflow/blob/main/airflow/providers/dbt/cloud/sensors/dbt.py#L72)) to achieve the same thing.

### What's changed?
In this pull request, I move the deferred logic from [DbtCloudJobRunAsyncSensor](https://github.com/apache/airflow/blob/main/airflow/providers/dbt/cloud/sensors/dbt.py#L72) to [DbtCloudJobRunSensor](https://github.com/apache/airflow/blob/main/airflow/providers/dbt/cloud/sensors/dbt.py#L31)  so that we can keep the consistency and reduce maintenance effort. Instead of removing [DbtCloudJobRunSensor](https://github.com/apache/airflow/blob/main/airflow/providers/dbt/cloud/sensors/dbt.py#L72), I add a deprecation warning in case there're users using it.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
