### PR TITLE
Merge BigQueryTableExistencePartitionAsyncSensor into BigQueryTableExistencePartitionSensor

### DIFF
--- a/airflow/providers/google/cloud/sensors/bigquery.py
+++ b/airflow/providers/google/cloud/sensors/bigquery.py
@@ -166,7 +166,8 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
         self.impersonation_chain = impersonation_chain
 
         self.deferrable = deferrable
-        self.poke_interval = poke_interval
+        if self.deferrable:
+            self.poke_interval = kwargs.get("poke_interval", 5)
 
     def poke(self, context: Context) -> bool:
         table_uri = f"{self.project_id}:{self.dataset_id}.{self.table_id}"
@@ -184,7 +185,10 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
         )
 
     def execute(self, context: Context) -> None:
-        """Airflow runs this method on the worker and defers using the trigger."""
+        """
+        Airflow runs this method on the worker and defers using the triggers
+        if deferrable is set to True.
+        """
         if not self.deferrable:
             super().execute(context)
         else:

--- a/airflow/providers/google/cloud/sensors/bigquery.py
+++ b/airflow/providers/google/cloud/sensors/bigquery.py
@@ -147,6 +147,8 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        deferrable: bool = False,
+        poke_interval: int = 5,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -163,6 +165,9 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
         self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
+        self.deferrable = deferrable
+        self.poke_interval = poke_interval
+
     def poke(self, context: Context) -> bool:
         table_uri = f"{self.project_id}:{self.dataset_id}.{self.table_id}"
         self.log.info('Sensor checks existence of partition: "%s" in table: %s', self.partition_id, table_uri)
@@ -177,6 +182,41 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
             table_id=self.table_id,
             partition_id=self.partition_id,
         )
+
+    def execute(self, context: Context) -> None:
+        """Airflow runs this method on the worker and defers using the trigger."""
+        if not self.deferrable:
+            super().execute(context)
+        else:
+            self.defer(
+                timeout=timedelta(seconds=self.timeout),
+                trigger=BigQueryTablePartitionExistenceTrigger(
+                    dataset_id=self.dataset_id,
+                    table_id=self.table_id,
+                    project_id=self.project_id,
+                    partition_id=self.partition_id,
+                    poll_interval=self.poke_interval,
+                    gcp_conn_id=self.gcp_conn_id,
+                    hook_params={
+                        "impersonation_chain": self.impersonation_chain,
+                    },
+                ),
+                method_name="execute_complete",
+            )
+
+    def execute_complete(self, context: dict[str, Any], event: dict[str, str] | None = None) -> str:
+        """
+        Callback for when the trigger fires - returns immediately.
+        Relies on trigger to throw an exception, otherwise it assumes execution was
+        successful.
+        """
+        table_uri = f"{self.project_id}:{self.dataset_id}.{self.table_id}"
+        self.log.info('Sensor checks existence of partition: "%s" in table: %s', self.partition_id, table_uri)
+        if event:
+            if event["status"] == "success":
+                return event["message"]
+            raise AirflowException(event["message"])
+        raise AirflowException("No event received in trigger callback")
 
 
 class BigQueryTableExistenceAsyncSensor(BigQueryTableExistenceSensor):
@@ -274,38 +314,12 @@ class BigQueryTableExistencePartitionAsyncSensor(BigQueryTablePartitionExistence
     :param poke_interval: The interval in seconds to wait between checks table existence.
     """
 
-    def __init__(self, poke_interval: int = 5, **kwargs):
-        super().__init__(**kwargs)
-        self.poke_interval = poke_interval
-
-    def execute(self, context: Context) -> None:
-        """Airflow runs this method on the worker and defers using the trigger."""
-        self.defer(
-            timeout=timedelta(seconds=self.timeout),
-            trigger=BigQueryTablePartitionExistenceTrigger(
-                dataset_id=self.dataset_id,
-                table_id=self.table_id,
-                project_id=self.project_id,
-                partition_id=self.partition_id,
-                poll_interval=self.poke_interval,
-                gcp_conn_id=self.gcp_conn_id,
-                hook_params={
-                    "impersonation_chain": self.impersonation_chain,
-                },
-            ),
-            method_name="execute_complete",
+    def __init__(self, **kwargs):
+        warnings.warn(
+            "Class `BigQueryTableExistencePartitionAsyncSensor` is deprecated and "
+            "will be removed in a future release. "
+            "Please use `BigQueryTableExistencePartitionSensor` and "
+            "set `deferrable` attribute to `True` instead",
+            DeprecationWarning,
         )
-
-    def execute_complete(self, context: dict[str, Any], event: dict[str, str] | None = None) -> str:
-        """
-        Callback for when the trigger fires - returns immediately.
-        Relies on trigger to throw an exception, otherwise it assumes execution was
-        successful.
-        """
-        table_uri = f"{self.project_id}:{self.dataset_id}.{self.table_id}"
-        self.log.info('Sensor checks existence of partition: "%s" in table: %s', self.partition_id, table_uri)
-        if event:
-            if event["status"] == "success":
-                return event["message"]
-            raise AirflowException(event["message"])
-        raise AirflowException("No event received in trigger callback")
+        super().__init__(deferrable=True, **kwargs)

--- a/airflow/providers/google/cloud/sensors/bigquery.py
+++ b/airflow/providers/google/cloud/sensors/bigquery.py
@@ -148,9 +148,10 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
         delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         deferrable: bool = False,
-        poke_interval: int = 5,
         **kwargs,
     ) -> None:
+        if deferrable and "poke_interval" not in kwargs:
+            kwargs["poke_interval"] = 5
         super().__init__(**kwargs)
 
         self.project_id = project_id
@@ -166,8 +167,6 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
         self.impersonation_chain = impersonation_chain
 
         self.deferrable = deferrable
-        if self.deferrable:
-            self.poke_interval = kwargs.get("poke_interval", 5)
 
     def poke(self, context: Context) -> bool:
         table_uri = f"{self.project_id}:{self.dataset_id}.{self.table_id}"

--- a/docs/apache-airflow-providers-google/operators/cloud/bigquery.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/bigquery.rst
@@ -509,10 +509,15 @@ To check that a table exists and has a partition you can use.
 
 For DAY partitioned tables, the partition_id parameter is a string on the "%Y%m%d" format
 
-Use the :class:`~airflow.providers.google.cloud.sensors.bigquery.BigQueryTableExistencePartitionAsyncSensor`
-(deferrable version) if you would like to free up the worker slots while the sensor is running.
+Also you can use deferrable mode in this operator if you would like to free up the worker slots while the sensor is running.
 
-:class:`~airflow.providers.google.cloud.sensors.bigquery.BigQueryTableExistencePartitionAsyncSensor`.
+.. exampleinclude:: /../../tests/system/providers/google/cloud/bigquery/example_bigquery_sensors.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_sensor_bigquery_table_partition_defered]
+    :end-before: [END howto_sensor_bigquery_table_partition_defered]
+
+:class:`~airflow.providers.google.cloud.sensors.bigquery.BigQueryTableExistencePartitionAsyncSensor` is deprecated and will be removed in a future release. Please use :class:`~airflow.providers.google.cloud.sensors.bigquery.BigQueryTablePartitionExistenceSensor` and use the deferrable mode in that operator.
 
 .. exampleinclude:: /../../tests/system/providers/google/cloud/bigquery/example_bigquery_sensors.py
     :language: python

--- a/tests/system/providers/google/cloud/bigquery/example_bigquery_sensors.py
+++ b/tests/system/providers/google/cloud/bigquery/example_bigquery_sensors.py
@@ -118,6 +118,17 @@ with models.DAG(
     )
     # [END howto_sensor_bigquery_table_partition]
 
+    # [START howto_sensor_bigquery_table_partition_defered]
+    check_table_partition_exists: BaseSensorOperator = BigQueryTablePartitionExistenceSensor(
+        task_id="check_table_partition_exists",
+        project_id=PROJECT_ID,
+        dataset_id=DATASET_NAME,
+        table_id=TABLE_NAME,
+        partition_id=PARTITION_NAME,
+        deferrable=True,
+    )
+    # [END howto_sensor_bigquery_table_partition_defered]
+
     # [START howto_sensor_bigquery_table_partition_async]
     check_table_partition_exists_async: BaseSensorOperator = BigQueryTableExistencePartitionAsyncSensor(
         task_id="check_table_partition_exists_async",

--- a/tests/system/providers/google/cloud/bigquery/example_bigquery_sensors.py
+++ b/tests/system/providers/google/cloud/bigquery/example_bigquery_sensors.py
@@ -120,7 +120,7 @@ with models.DAG(
 
     # [START howto_sensor_bigquery_table_partition_defered]
     check_table_partition_exists: BaseSensorOperator = BigQueryTablePartitionExistenceSensor(
-        task_id="check_table_partition_exists",
+        task_id="check_table_partition_exists_defered",
         project_id=PROJECT_ID,
         dataset_id=DATASET_NAME,
         table_id=TABLE_NAME,


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

### Why making this change?
apache-airflow-providers-google treats the deferred execution of its operators and sensors differently, which might cause confusion. For example, [BigQueryCheckOperator](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/operators/bigquery.py#L200) uses the [deferrable](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/operators/bigquery.py#L200) parameter to toggle deferred execution while we need to use another sensor for [BigQueryTablePartitionExistenceSensor](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/sensors/bigquery.py#L106) (i.e., [BigQueryTablePartitionExistenceAsyncSensor](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/sensors/bigquery.py#L252)) to achieve the same thing.

### What's changed?
In this pull request, I move the deferred logic from [BigQueryTablePartitionExistenceAsyncSensor](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/sensors/bigquery.py#L281) to [BigQueryTablePartitionExistenceSensor](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/sensors/bigquery.py#L106) so that we can keep the consistency and reduce maintenance effort. Instead of removing [BigQueryTablePartitionExistenceAsyncSensor](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/sensors/bigquery.py#L252), I add a deprecation warning in case users're using it.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
