### PR TITLE
Change log level of serialization information

### DIFF
--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -332,7 +332,7 @@ def _register():
                 log.debug("registering %s for stringifying", c)
                 _stringifiers[c] = name
 
-    log.info("loading serializers took %.3f seconds", timer.duration)
+    log.debug("loading serializers took %.3f seconds", timer.duration)
 
 
 @functools.lru_cache(maxsize=None)


### PR DESCRIPTION
The #30094 introduced info log on how long serialization takes, and coupled with the fact that serialization register() function is called by just importing the serde module it caused a potential of breaking airflow CLI method that produce formatted output (with `--output` flag with json format).

Those methods block warnings and logs, but only after initial CLI parsing is complete and the right CLI method is selected (with @suppress_logs_and_warnings). However in case serde module is imported before, default "info" log level might cause the log to be printed before it has been blocked.

The log level seemed to be left here by mistake (it's not a good practice to log anything at import time), so changing it to debug seems appropriate.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
