### PR TITLE
fix: force DAG last modified time to UTC

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -1134,7 +1134,7 @@ class DagFileProcessorManager(LoggingMixin):
                     self._file_stats.pop(file_path, None)
                     file_paths_to_stop_watching.add(file_path)
                     continue
-                file_modified_time = timezone.make_aware(datetime.fromtimestamp(files_with_mtime[file_path]))
+                file_modified_time = datetime.fromtimestamp(files_with_mtime[file_path], tz=timezone.utc)
             else:
                 file_paths.append(file_path)
                 file_modified_time = None


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Hello,

I've found an issue with the handling of the DAG file last modified time which can trigger an infinite parsing loop, when `file_parsing_sort_mode` is set to `modified_time` (which seems to be the default value).

`os.path.getmtime()` returns a timestamp, which is converted to a datetime using `datetime.fromtimestamp`. According to the documentation:

> If optional argument tz is None or not specified, the timestamp is converted to the platform’s local date and time, and the returned [datetime](https://docs.python.org/3/library/datetime.html#datetime.datetime) object is naive.

The resulting datetime is then made aware using `timezone.make_aware` using the user configured timezone, which is not guarantee to be the same as the platform's timezone. If that's not the case, we can end up with modified time in the future and trigger an infinite parsing loop.

The fix is to use `datetime.utcfromtimestamp` to convert the timestamp, to force the resulting datetime in UTC, and explicitly specify the UTC timezone to `make_aware`.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
