### PR TITLE
Make the webserver startup respect update_fab_perms

### DIFF
--- a/airflow/api_connexion/security.py
+++ b/airflow/api_connexion/security.py
@@ -41,7 +41,8 @@ def check_authentication() -> None:
 def requires_access(permissions: Sequence[tuple[str, str]] | None = None) -> Callable[[T], T]:
     """Factory for decorator that checks current user's permissions against required permissions."""
     appbuilder = get_airflow_app().appbuilder
-    appbuilder.sm.sync_resource_permissions(permissions)
+    if appbuilder.update_perms:
+        appbuilder.sm.sync_resource_permissions(permissions)
 
     def requires_access_decorator(func: T):
         @wraps(func)

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -204,6 +204,12 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
             view.datamodel = CustomSQLAInterface(view.datamodel.obj)
         self.perms = None
 
+    def create_db(self):
+        if not self.appbuilder.update_perms:
+            self.log.debug("Skipping db since appbuilder disables update_perms")
+            return
+        super().create_db()
+
     def _get_root_dag_id(self, dag_id):
         if "." in dag_id:
             dm = (


### PR DESCRIPTION
This config should control whether we sync FAB permissions on startup, as designed in #5940, but a few things in the process is not respecting it and still try
to sync. This eliminates them.

We are reading the config from `appbuilder.update_perms` instead of the Airflow settings directly, since we also allow Flask app-wise configs to disable perm syncs.