### PR TITLE
Fix ADF job failure during deferral

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -1102,9 +1102,6 @@ class AzureDataFactoryAsyncHook(AzureDataFactoryHook):
 
     async def get_async_conn(self) -> AsyncDataFactoryManagementClient:
         """Get async connection and connect to azure data factory"""
-        if self._async_conn is not None:
-            return self._async_conn
-
         conn = await sync_to_async(self.get_connection)(self.conn_id)
         extras = conn.extra_dejson
         tenant = get_field(extras, "tenantId")

--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -1102,6 +1102,9 @@ class AzureDataFactoryAsyncHook(AzureDataFactoryHook):
 
     async def get_async_conn(self) -> AsyncDataFactoryManagementClient:
         """Get async connection and connect to azure data factory"""
+        if self._async_conn is not None:
+            return self._async_conn
+
         conn = await sync_to_async(self.get_connection)(self.conn_id)
         extras = conn.extra_dejson
         tenant = get_field(extras, "tenantId")
@@ -1145,12 +1148,12 @@ class AzureDataFactoryAsyncHook(AzureDataFactoryHook):
         :param factory_name: The factory name.
         :param config: Extra parameters for the ADF client.
         """
-        async with await self.get_async_conn() as client:
-            try:
-                pipeline_run = await client.pipeline_runs.get(resource_group_name, factory_name, run_id)
-                return pipeline_run
-            except Exception as e:
-                raise AirflowException(e)
+        client = await self.get_async_conn()
+        try:
+            pipeline_run = await client.pipeline_runs.get(resource_group_name, factory_name, run_id)
+            return pipeline_run
+        except Exception as e:
+            raise AirflowException(e)
 
     async def get_adf_pipeline_run_status(
         self, run_id: str, resource_group_name: str | None = None, factory_name: str | None = None


### PR DESCRIPTION
This PR fixes the below error on `AzureDataFactoryRunPipelineOperator` when both the deferrable param and wait for termination param are set to True:

```
[2023-03-23, 06:12:29 UTC] {taskinstance.py:1844} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/opt/airflow/airflow/providers/microsoft/azure/operators/data_factory.py", line 225, in execute_complete
    raise AirflowException(event["message"])
airflow.exceptions.AirflowException: 'NoneType' object has no attribute 'request'
```

cc @josh-fell 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
