### PR TITLE
Preserve queue on task clear

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -215,7 +215,7 @@ def clear_task_instances(
             if dag and dag.has_task(task_id):
                 task = dag.get_task(task_id)
                 # Preserve original assigned queue when clearing a task
-                ti.refresh_from_task(task, queue_override=task.queue)
+                ti.refresh_from_task(task, queue_override=ti.queue)
                 task_retries = task.retries
                 ti.max_tries = ti.try_number + task_retries - 1
             else:
@@ -859,7 +859,7 @@ class TaskInstance(Base, LoggingMixin):
 
     def refresh_from_task(
         self, task: Operator, pool_override: str | None = None, queue_override: str | None = None
-        ) -> None:
+    ) -> None:
         """
         Copy common attributes from the given task.
 

--- a/tests/models/test_cleartasks.py
+++ b/tests/models/test_cleartasks.py
@@ -47,8 +47,8 @@ class TestClearTasks:
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE + datetime.timedelta(days=10),
         ) as dag:
-            task0 = EmptyOperator(task_id="0")
-            task1 = EmptyOperator(task_id="1", retries=2)
+            task0 = EmptyOperator(task_id="0", queue="test_queue")
+            task1 = EmptyOperator(task_id="1", retries=2, queue="test_queue")
 
         dr = dag_maker.create_dagrun(
             state=State.RUNNING,
@@ -75,9 +75,11 @@ class TestClearTasks:
         assert ti0.state is None
         assert ti0.try_number == 2
         assert ti0.max_tries == 1
+        assert ti0.queue == "test_queue"
         assert ti1.state is None
         assert ti1.try_number == 2
         assert ti1.max_tries == 3
+        assert ti1.queue == "test_queue"
 
     def test_clear_task_instances_external_executor_id(self, dag_maker):
         with dag_maker(

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2896,7 +2896,8 @@ class TestTaskInstance:
 
 
 @pytest.mark.parametrize("pool_override", [None, "test_pool2"])
-def test_refresh_from_task(pool_override):
+@pytest.mark.parametrize("queue_override", [None, "test_queue2"])
+def test_refresh_from_task(pool_override, queue_override):
     task = EmptyOperator(
         task_id="empty",
         queue="test_queue",
@@ -2908,9 +2909,12 @@ def test_refresh_from_task(pool_override):
         executor_config={"KubernetesExecutor": {"image": "myCustomDockerImage"}},
     )
     ti = TI(task, run_id=None)
-    ti.refresh_from_task(task, pool_override=pool_override)
+    ti.refresh_from_task(task, pool_override=pool_override, queue_override=queue_override)
 
-    assert ti.queue == task.queue
+    if queue_override:
+        assert ti.queue == queue_override
+    else:
+        assert ti.queue == task.queue
 
     if pool_override:
         assert ti.pool == pool_override


### PR DESCRIPTION
This change will update logic to preserve original assigned queue when clearing a task. This PR was created based on the discussion in #20143.