### PR TITLE
Fix DagProcessorJob integration for standalone dag-processor

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -1014,7 +1014,7 @@ ARG_MIN_PENDING_MINUTES = Arg(
 # jobs check
 ARG_JOB_TYPE_FILTER = Arg(
     ("--job-type",),
-    choices=("BackfillJob", "LocalTaskJob", "SchedulerJob", "TriggererJob"),
+    choices=("BackfillJob", "LocalTaskJob", "SchedulerJob", "TriggererJob", "DagProcessorJob"),
     action="store",
     help="The type of job(s) that will be checked.",
 )

--- a/airflow/jobs/dag_processor_job.py
+++ b/airflow/jobs/dag_processor_job.py
@@ -54,6 +54,7 @@ class DagProcessorJob(BaseJob):
             processor_timeout=processor_timeout,
             dag_ids=dag_ids,
             pickle_dags=pickle_dags,
+            job=self,
         )
         super().__init__(*args, **kwargs)
 

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -61,6 +61,7 @@ def import_all_models():
 
     import airflow.jobs.backfill_job
     import airflow.jobs.base_job
+    import airflow.jobs.dag_processor_job
     import airflow.jobs.local_task_job
     import airflow.jobs.scheduler_job
     import airflow.jobs.triggerer_job


### PR DESCRIPTION
The DagProcessorJob integration implemented in #28799 was not complete. It missed a few crucial changes:

* importing DagProcessorJob in airflow/models/__init__.py - not importing it there caused `airflow jobs check` to fail, when querying DagProcessorJob in the BaseJob query, because the DagProcessorJob was not registered by the time the query was run (so polimorphic ORM model retrieval was not aware of DagProcessorJob model.

* airflow jobs check command did not have DagProcessorJob added as valid job type, so it was impossible to monitor for it

* also the processor manager did not set heartbeats periodically, so the Job for the DagFileProcessor was considered as not alive pretty quickly even if standalone dag-processor was running.

This PR fixes all three problems.

Fixes: #30251

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
