### PR TITLE
Change RSA SSH host key in docs to reflect update from Github

### DIFF
--- a/docs/helm-chart/production-guide.rst
+++ b/docs/helm-chart/production-guide.rst
@@ -203,7 +203,7 @@ They match, right? Good. Now, add the public key to your values. It'll look some
     dags:
       gitSync:
         knownHosts: |
-          github.com ssh-rsa AAAA...FAaQ==
+          github.com ssh-rsa AAAA...1/wsjk=
 
 
 Accessing the Airflow UI


### PR DESCRIPTION
Github just updated their RSA SSH host key: https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key/ . This commit updates the last 6 values of the host key in the `knownHosts` section of the Helm production guide to reflect the update.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
