### PR TITLE
Add precisions in doc about `dag_processing.total_parse_time`

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -393,7 +393,7 @@ class DagFileProcessorManager(LoggingMixin):
         self._pickle_dags = pickle_dags
         self._dag_ids = dag_ids
         self._async_mode = async_mode
-        self._parsing_start_time: int | None = None
+        self._parsing_start_time: float | None = None
         self._dag_directory = dag_directory
         self._job = job
 

--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
@@ -139,7 +139,8 @@ Name                                                Description
 ``dagbag_size``                                     Number of DAGs found when the scheduler ran a scan based on it's
                                                     configuration
 ``dag_processing.import_errors``                    Number of errors from trying to parse DAG files
-``dag_processing.total_parse_time``                 Seconds taken to scan and import all DAG files once
+``dag_processing.total_parse_time``                 Seconds taken to scan and import ``dag_processing.file_path_queue_size`` DAG files
+``dag_processing.file_path_queue_size``             Number of DAG files to be considered for the next scan
 ``dag_processing.last_run.seconds_ago.<dag_file>``  Seconds since ``<dag_file>`` was last processed
 ``dag_processing.file_path_queue_size``             Size of the dag file queue.
 ``scheduler.tasks.running``                         Number of tasks running in executor


### PR DESCRIPTION
I think the doc is misleading on this specific metric, it says this is the time it takes to parse ALL dag files, but it's not the case. There are some reasons for why a dag could be excluded from a run:
https://github.com/apache/airflow/blob/42db6ab4327da1a4bfd215194aee37a3d36c92d3/airflow/dag_processing/manager.py#L1179-L1182
and it makes this metric very disconcerting to look at in some circumstances, because the number of files varies, so the numbers may be inconsistent.

There is a metric for the number of files processed, but it is not mentioned in the doc. I think the `total_parse_time` should always be looked at in conjunction with `file_path_queue_size`. They are emitted at different times though (the queue size is sent before parsing, and the time, obviously, after), which might make it hard to combine depending on the visualization.
We could eventually move that metric to be emitted at the same time.