### PR TITLE
Add a new parameter for base sensor to catch the exceptions in poke method

### DIFF
--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 import datetime
 import functools
 import hashlib
+import logging
 import time
+import traceback
 from datetime import timedelta
 from typing import Any, Callable, Iterable
 
@@ -28,9 +30,11 @@ from airflow import settings
 from airflow.configuration import conf
 from airflow.exceptions import (
     AirflowException,
+    AirflowFailException,
     AirflowRescheduleException,
     AirflowSensorTimeout,
     AirflowSkipException,
+    AirflowTaskTimeout,
 )
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.models.baseoperator import BaseOperator
@@ -101,6 +105,11 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
     :param exponential_backoff: allow progressive longer waits between
         pokes by using exponential backoff algorithm
     :param max_wait: maximum wait interval between pokes, can be ``timedelta`` or ``float`` seconds
+    :param silent_fail: If true, and poke method raises an exception different from
+        AirflowSensorTimeout, AirflowTaskTimeout, AirflowSkipException
+        and AirflowFailException, the sensor will log the error and continue
+        its execution. Otherwise, the sensor task fails, and it can be retried
+        based on the provided `retries` parameter.
     """
 
     ui_color: str = "#e6f1f2"
@@ -119,6 +128,7 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         mode: str = "poke",
         exponential_backoff: bool = False,
         max_wait: timedelta | float | None = None,
+        silent_fail: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -128,6 +138,7 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         self.mode = mode
         self.exponential_backoff = exponential_backoff
         self.max_wait = self._coerce_max_wait(max_wait)
+        self.silent_fail = silent_fail
         self._validate_input_values()
 
     @staticmethod
@@ -197,7 +208,22 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
 
         xcom_value = None
         while True:
-            poke_return = self.poke(context)
+            try:
+                poke_return = self.poke(context)
+            except (
+                AirflowSensorTimeout,
+                AirflowTaskTimeout,
+                AirflowSkipException,
+                AirflowFailException,
+            ) as e:
+                raise e
+            except Exception as e:
+                if self.silent_fail:
+                    logging.error("Sensor poke failed: \n %s", traceback.format_exc())
+                    poke_return = False
+                else:
+                    raise e
+
             if poke_return:
                 if isinstance(poke_return, PokeReturnValue):
                     xcom_value = poke_return.xcom_value

--- a/tests/sensors/test_base.py
+++ b/tests/sensors/test_base.py
@@ -657,6 +657,97 @@ class TestBaseSensor:
             self._run(sensor)
         assert_ti_state(4, 4, State.FAILED)
 
+    def test_reschedule_and_retry_timeout_and_silent_fail(self, make_sensor, time_machine):
+        """
+        Test mode="reschedule", silent_fail=True then retries and timeout configurations interact correctly.
+
+        Given a sensor configured like this:
+
+        poke_interval=5
+        timeout=10
+        retries=2
+        retry_delay=timedelta(seconds=3)
+        silent_fail=True
+
+        If the second poke raises RuntimeError, all other pokes return False, this is how it should
+        behave:
+
+        00:00 Returns False                try_number=1, max_tries=2, state=up_for_reschedule
+        00:05 Raises RuntimeError          try_number=1, max_tries=2, state=up_for_reschedule
+        00:08 Returns False                try_number=1, max_tries=2, state=up_for_reschedule
+        00:13 Raises AirflowSensorTimeout  try_number=2, max_tries=2, state=failed
+
+        And then the sensor is cleared at 00:19. It should behave like this:
+
+        00:19 Returns False                try_number=2, max_tries=3, state=up_for_reschedule
+        00:24 Returns False                try_number=2, max_tries=3, state=up_for_reschedule
+        00:26 Returns False                try_number=2, max_tries=3, state=up_for_reschedule
+        00:31 Raises AirflowSensorTimeout, try_number=3, max_tries=3, state=failed
+        """
+        sensor, dr = make_sensor(
+            return_value=None,
+            poke_interval=5,
+            timeout=10,
+            retries=2,
+            retry_delay=timedelta(seconds=3),
+            mode="reschedule",
+            silent_fail=True,
+        )
+
+        sensor.poke = Mock(side_effect=[False, RuntimeError, False, False, False, False, False, False])
+
+        def assert_ti_state(try_number, max_tries, state):
+            tis = dr.get_task_instances()
+
+            assert len(tis) == 2
+
+            for ti in tis:
+                if ti.task_id == SENSOR_OP:
+                    assert ti.try_number == try_number
+                    assert ti.max_tries == max_tries
+                    assert ti.state == state
+                    break
+            else:
+                self.fail("sensor not found")
+
+        # first poke returns False and task is re-scheduled
+        date1 = timezone.utcnow()
+        time_machine.move_to(date1, tick=False)
+        self._run(sensor)
+        assert_ti_state(1, 2, State.UP_FOR_RESCHEDULE)
+
+        # second poke raises RuntimeError and task instance is re-scheduled again
+        time_machine.coordinates.shift(sensor.poke_interval)
+        self._run(sensor)
+        assert_ti_state(1, 2, State.UP_FOR_RESCHEDULE)
+
+        # third poke returns False and task is rescheduled again
+        time_machine.coordinates.shift(sensor.retry_delay + timedelta(seconds=1))
+        self._run(sensor)
+        assert_ti_state(1, 2, State.UP_FOR_RESCHEDULE)
+
+        # fourth poke times out and raises AirflowSensorTimeout
+        time_machine.coordinates.shift(sensor.poke_interval)
+        with pytest.raises(AirflowSensorTimeout):
+            self._run(sensor)
+        assert_ti_state(2, 2, State.FAILED)
+
+        # Clear the failed sensor
+        sensor.clear()
+
+        time_machine.coordinates.shift(20)
+
+        for _ in range(3):
+            time_machine.coordinates.shift(sensor.poke_interval)
+            self._run(sensor)
+            assert_ti_state(2, 3, State.UP_FOR_RESCHEDULE)
+
+        # Last poke times out and raises AirflowSensorTimeout
+        time_machine.coordinates.shift(sensor.poke_interval)
+        with pytest.raises(AirflowSensorTimeout):
+            self._run(sensor)
+        assert_ti_state(3, 3, State.FAILED)
+
     def test_sensor_with_xcom(self, make_sensor):
         xcom_value = "TestValue"
         sensor, dr = make_sensor(True, xcom_value=xcom_value)


### PR DESCRIPTION
closes: #30289

---
Currently when an exception is raised in the poke method, the sensor fails as a normal task, and it can be retried if `retries` param is greater than 0.

In this PR I add a new param `silent_fail` to catch the exceptions when it is true and log an error message instead of failing the task sensor, but it raise the exception if it's an instance from `AirflowSensorTimeout`, `AirflowTaskTimeout`, `AirflowSkipException` or `AirflowFailException`.