### PR TITLE
`JenkinsHook` fix connection intake on https

### DIFF
--- a/airflow/providers/jenkins/hooks/jenkins.py
+++ b/airflow/providers/jenkins/hooks/jenkins.py
@@ -17,10 +17,40 @@
 # under the License.
 from __future__ import annotations
 
+from functools import wraps
+from typing import Any
+
 import jenkins
 
 from airflow.hooks.base import BaseHook
-from airflow.utils.strings import to_boolean
+
+
+def _ensure_prefixes(conn_type):
+    """
+    Remove when provider min airflow version >= 2.5.0 since this is handled by
+    provider manager from that version.
+    """
+
+    def dec(func):
+        @wraps(func)
+        def inner():
+            field_behaviors = func()
+            conn_attrs = {"host", "schema", "login", "password", "port", "extra"}
+
+            def _ensure_prefix(field):
+                if field not in conn_attrs and not field.startswith("extra__"):
+                    return f"extra__{conn_type}__{field}"
+                else:
+                    return field
+
+            if "placeholders" in field_behaviors:
+                placeholders = field_behaviors["placeholders"]
+                field_behaviors["placeholders"] = {_ensure_prefix(k): v for k, v in placeholders.items()}
+            return field_behaviors
+
+        return inner
+
+    return dec
 
 
 class JenkinsHook(BaseHook):
@@ -31,13 +61,41 @@ class JenkinsHook(BaseHook):
     conn_type = "jenkins"
     hook_name = "Jenkins"
 
+    @staticmethod
+    def get_connection_form_widgets() -> dict[str, Any]:
+        """Returns connection widgets to add to connection form"""
+        from flask_babel import lazy_gettext
+        from wtforms import BooleanField
+
+        return {
+            "use_https": BooleanField(
+                label=lazy_gettext("Use Https"),
+                description="Specifies whether to use https scheme. Defaults to http",
+            ),
+        }
+
+    @staticmethod
+    @_ensure_prefixes(conn_type="jenkins")
+    def get_ui_field_behaviour() -> dict[str, Any]:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ["schema", "extra"],
+            "relabeling": {},
+            "placeholders": {
+                "login": "Login for the Jenkins service you would like to connect to",
+                "password": "Password for the Jenkins service you would like to connect too",
+                "host": "Host for your Jenkins server. Should NOT contain scheme (http:// or https://)",
+                "port": "Specify a port number",
+            },
+        }
+
     def __init__(self, conn_id: str = default_conn_name) -> None:
         super().__init__()
         connection = self.get_connection(conn_id)
         self.connection = connection
         connection_prefix = "http"
         # connection.extra contains info about using https (true) or http (false)
-        if to_boolean(connection.extra):
+        if connection.extra_dejson.get("use_https"):
             connection_prefix = "https"
         url = f"{connection_prefix}://{connection.host}:{connection.port}/{connection.schema}"
         self.log.info("Trying to connect to %s", url)

--- a/docs/apache-airflow-providers-jenkins/connections.rst
+++ b/docs/apache-airflow-providers-jenkins/connections.rst
@@ -47,8 +47,8 @@ Host
 Port
     Specify a port number.
 
-Extras (optional)
-    Specify whether you want to use ``http`` or ``https`` scheme by entering ``true`` to use ``https`` or ``false`` for ``http`` in extras.  Default is ``http``.
+Use Https
+    Specify whether you want to use ``https``.  Default is ``http``.
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.

--- a/tests/providers/jenkins/hooks/test_jenkins.py
+++ b/tests/providers/jenkins/hooks/test_jenkins.py
@@ -30,14 +30,14 @@ class TestJenkinsHook:
         """tests `init` method to validate http client creation when all parameters are passed"""
         default_connection_id = "jenkins_default"
 
-        connection_host = "http://test.com"
+        connection_host = "test.com"
         connection_port = 8080
         get_connection_mock.return_value = mock.Mock(
             connection_id=default_connection_id,
             login="test",
             password="test",
             schema="",
-            extra="",
+            extra_dejson={"use_https": False},
             host=connection_host,
             port=connection_port,
         )
@@ -53,14 +53,14 @@ class TestJenkinsHook:
         parameters are passed"""
         default_connection_id = "jenkins_default"
 
-        connection_host = "http://test.com"
+        connection_host = "test.com"
         connection_port = 8080
         get_connection_mock.return_value = mock.Mock(
             connection_id=default_connection_id,
             login="test",
             password="test",
             schema="",
-            extra="true",
+            extra_dejson={"use_https": True},
             host=connection_host,
             port=connection_port,
         )


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:


related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: https://github.com/apache/airflow/issues/28465

### Testing

Add two Jenkins connections - 

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/9200263/227722072-950dd89d-e928-4edb-9a7a-6db4f501c163.png">

One with https:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/9200263/227722304-80073b33-f55c-444a-8a1b-d08ec4dc93c3.png">

And the other without:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/9200263/227722321-93073684-cc12-4aae-b3e9-eabf78a2aadb.png">


Test out connections in local python repl:
```
root@a0a6c7b4e782:/opt/airflow# python
Python 3.9.16 (main, Mar  1 2023, 15:47:56)
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from airflow.secrets .metastore import MetastoreBackend
>>> backend = MetastoreBackend()
>>> conn = backend.get_connection(conn_id="jenkins1")
/opt/airflow/airflow/models/dagrun.py:131 RemovedIn20Warning: [31mDeprecated API features detected! These feature(s) are not compatible with SQLAlchemy 2.0. [32mTo prevent incompatible upgrades prior to updating applications, ensure requirements files are pinned to "sqlalchemy<2.0". [36mSet environment variable SQLALCHEMY_WARN_20=1 to show all deprecation warnings.  Set environment variable SQLALCHEMY_SILENCE_UBER_WARNING=1 to silence this message.[0m (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
>>>
>>> conn.extra_dejson.get("use_https")
True
>>> conn.__dict__
{'_sa_instance_state': <sqlalchemy.orm.state.InstanceState object at 0x7f28d3c2e700>, 'id': 229, 'conn_type': 'jenkins', 'description': '', 'schema': '', 'port': 8080, 'is_extra_encrypted': True, '_extra': 'gAAAAABkHvrPg-cFw74KBDHi2TAh-BYZMCd2P3UgYdNLAdFm6o3Q3YGqnPVo4ikNAssuppjYsRTiicZcDSUFp2s3Mq3iD_eI3iP7oXCQeV7y3usnT53hhPw=', '_password': 'gAAAAABkHvrPtfwUF2cdzJW-W6TLlcA6UB9_0ZAlPS1HlQHsHjLTuZJ8oWzblVTYS8hF0h-PH6TepyFwFKRrnfyPPZNls_IjHw==', 'conn_id': 'jenkins1', 'host': 'jenkins.example.com', 'login': 'jenkins', 'is_encrypted': True}
>>>
>>> conn = backend.get_connection(conn_id="jenkins2")
>>> conn.extra_dejson.get("use_https")
False
>>> conn.__dict__
{'_sa_instance_state': <sqlalchemy.orm.state.InstanceState object at 0x7f28d3c2ea00>, 'id': 230, 'conn_type': 'jenkins', 'description': '', 'schema': '', 'port': 8080, 'is_extra_encrypted': True, '_extra': 'gAAAAABkHv3AQ9jh_6jZtvetDHK90UMLTgD8MZr0rwlGe4ETqVVDeyxFh5-8E1ujEhMi2v3WaaemkgU1D9v1DKrSOMPfZDiVgMzyg3HQ-c7pCb7iRuy3M-c=', '_password': 'gAAAAABkHv3AjJOpmi_80LPLEWTbEPShkA7zv7IdjKaBDjDcafdmMUrzJsRj7wO_OBtcRJC1k2o-ByGg2k69RKsv3Bn2vlluiQ==', 'conn_id': 'jenkins2', 'host': 'jenkins.example.com', 'login': 'jenkins', 'is_encrypted': True}
```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
