### PR TITLE
Rename JobRunner modules to *_job_runner and base_job* to job

### DIFF
--- a/airflow/api_connexion/endpoints/health_endpoint.py
+++ b/airflow/api_connexion/endpoints/health_endpoint.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 
 from airflow.api_connexion.schemas.health_schema import health_schema
 from airflow.api_connexion.types import APIResponse
-from airflow.jobs.scheduler_job import SchedulerJobRunner
-from airflow.jobs.triggerer_job import TriggererJobRunner
+from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
+from airflow.jobs.triggerer_job_runner import TriggererJobRunner
 
 HEALTHY = "healthy"
 UNHEALTHY = "unhealthy"

--- a/airflow/api_connexion/schemas/job_schema.py
+++ b/airflow/api_connexion/schemas/job_schema.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
 
-from airflow.jobs.base_job import BaseJob
+from airflow.jobs.job import Job
 
 
 class JobSchema(SQLAlchemySchema):
@@ -28,7 +28,7 @@ class JobSchema(SQLAlchemySchema):
     class Meta:
         """Meta."""
 
-        model = BaseJob
+        model = Job
 
     id = auto_field(dump_only=True)
     dag_id = auto_field(dump_only=True)

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -35,7 +35,7 @@ from airflow.api.client import get_current_api_client
 from airflow.cli.simple_table import AirflowConsole
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
-from airflow.jobs.base_job import BaseJob
+from airflow.jobs.job import Job
 from airflow.models import DagBag, DagModel, DagRun, TaskInstance
 from airflow.models.dag import DAG
 from airflow.models.serialized_dag import SerializedDagModel
@@ -391,15 +391,13 @@ def dag_list_jobs(args, dag: DAG | None = None, session: Session = NEW_SESSION) 
 
         if not dag:
             raise SystemExit(f"DAG: {args.dag_id} does not exist in 'dag' table")
-        queries.append(BaseJob.dag_id == args.dag_id)
+        queries.append(Job.dag_id == args.dag_id)
 
     if args.state:
-        queries.append(BaseJob.state == args.state)
+        queries.append(Job.state == args.state)
 
     fields = ["dag_id", "state", "job_type", "start_date", "end_date"]
-    all_jobs = (
-        session.query(BaseJob).filter(*queries).order_by(BaseJob.start_date.desc()).limit(args.limit).all()
-    )
+    all_jobs = session.query(Job).filter(*queries).order_by(Job.start_date.desc()).limit(args.limit).all()
     all_jobs = [{f: str(job.__getattribute__(f)) for f in fields} for job in all_jobs]
 
     AirflowConsole().print_as(

--- a/airflow/cli/commands/dag_processor_command.py
+++ b/airflow/cli/commands/dag_processor_command.py
@@ -26,14 +26,14 @@ from daemon.pidfile import TimeoutPIDLockFile
 
 from airflow import settings
 from airflow.configuration import conf
-from airflow.jobs.base_job import BaseJob
+from airflow.jobs.job import Job
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import setup_locations, setup_logging
 
 log = logging.getLogger(__name__)
 
 
-def _create_dag_processor_job(args: Any) -> BaseJob:
+def _create_dag_processor_job(args: Any) -> Job:
     """Creates DagFileProcessorProcess instance."""
     from airflow.dag_processing.manager import DagFileProcessorManager
 
@@ -47,7 +47,7 @@ def _create_dag_processor_job(args: Any) -> BaseJob:
         dag_ids=[],
         pickle_dags=args.do_pickle,
     )
-    return BaseJob(
+    return Job(
         job_runner=processor.job_runner,
     )
 

--- a/airflow/cli/commands/jobs_command.py
+++ b/airflow/cli/commands/jobs_command.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from sqlalchemy.orm import Session
 
-from airflow.jobs.base_job import BaseJob
+from airflow.jobs.job import Job
 from airflow.utils.net import get_hostname
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import State
@@ -32,22 +32,17 @@ def check(args, session: Session = NEW_SESSION) -> None:
     if args.hostname and args.local:
         raise SystemExit("You can't use --hostname and --local at the same time")
 
-    query = (
-        session.query(BaseJob)
-        .filter(BaseJob.state == State.RUNNING)
-        .order_by(BaseJob.latest_heartbeat.desc())
-    )
+    query = session.query(Job).filter(Job.state == State.RUNNING).order_by(Job.latest_heartbeat.desc())
     if args.job_type:
-        query = query.filter(BaseJob.job_type == args.job_type)
+        query = query.filter(Job.job_type == args.job_type)
     if args.hostname:
-        query = query.filter(BaseJob.hostname == args.hostname)
+        query = query.filter(Job.hostname == args.hostname)
     if args.local:
-        query = query.filter(BaseJob.hostname == get_hostname())
+        query = query.filter(Job.hostname == get_hostname())
     if args.limit > 0:
         query = query.limit(args.limit)
 
-    jobs: list[BaseJob] = query.all()
-    alive_jobs = [job for job in jobs if job.is_alive()]
+    alive_jobs: list[Job] = [job for job in query.all() if job.is_alive()]
 
     count_alive_jobs = len(alive_jobs)
     if count_alive_jobs == 0:

--- a/airflow/cli/commands/scheduler_command.py
+++ b/airflow/cli/commands/scheduler_command.py
@@ -28,14 +28,14 @@ from airflow import settings
 from airflow.api_internal.internal_api_call import InternalApiConfig
 from airflow.configuration import conf
 from airflow.executors.executor_loader import ExecutorLoader
-from airflow.jobs.base_job import BaseJob
-from airflow.jobs.scheduler_job import SchedulerJobRunner
+from airflow.jobs.job import Job
+from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import process_subdir, setup_locations, setup_logging, sigint_handler, sigquit_handler
 from airflow.utils.scheduler_health import serve_health_check
 
 
-def _run_scheduler_job(job: BaseJob, *, skip_serve_logs: bool) -> None:
+def _run_scheduler_job(job: Job, *, skip_serve_logs: bool) -> None:
     InternalApiConfig.force_database_direct_access()
     enable_health_check = conf.getboolean("scheduler", "ENABLE_HEALTH_CHECK")
     with _serve_logs(skip_serve_logs), _serve_health_check(enable_health_check):
@@ -47,7 +47,7 @@ def scheduler(args):
     """Starts Airflow Scheduler."""
     print(settings.HEADER)
 
-    job = BaseJob(
+    job = Job(
         job_runner=SchedulerJobRunner(
             subdir=process_subdir(args.subdir),
             num_runs=args.num_runs,

--- a/airflow/cli/commands/standalone_command.py
+++ b/airflow/cli/commands/standalone_command.py
@@ -30,10 +30,10 @@ from termcolor import colored
 from airflow.configuration import AIRFLOW_HOME, conf, make_group_other_inaccessible
 from airflow.executors import executor_constants
 from airflow.executors.executor_loader import ExecutorLoader
-from airflow.jobs.base_job import most_recent_job
-from airflow.jobs.job_runner import BaseJobRunner
-from airflow.jobs.scheduler_job import SchedulerJobRunner
-from airflow.jobs.triggerer_job import TriggererJobRunner
+from airflow.jobs.base_job_runner import BaseJobRunner
+from airflow.jobs.job import most_recent_job
+from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
+from airflow.jobs.triggerer_job_runner import TriggererJobRunner
 from airflow.utils import db
 
 

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -37,8 +37,8 @@ from airflow.cli.simple_table import AirflowConsole
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, DagRunNotFound, TaskInstanceNotFound
 from airflow.executors.executor_loader import ExecutorLoader
-from airflow.jobs.base_job import BaseJob
-from airflow.jobs.local_task_job import LocalTaskJobRunner
+from airflow.jobs.job import Job
+from airflow.jobs.local_task_job_runner import LocalTaskJobRunner
 from airflow.listeners.listener import get_listener_manager
 from airflow.models import DagPickle, TaskInstance
 from airflow.models.dag import DAG
@@ -260,7 +260,7 @@ def _run_task_by_local_task_job(args, ti: TaskInstance) -> TaskReturnCode | None
         pool=args.pool,
         external_executor_id=_extract_external_executor_id(args),
     )
-    run_job = BaseJob(
+    run_job = Job(
         job_runner=local_task_job_runner,
         dag_id=ti.dag_id,
     )

--- a/airflow/cli/commands/triggerer_command.py
+++ b/airflow/cli/commands/triggerer_command.py
@@ -28,8 +28,8 @@ from daemon.pidfile import TimeoutPIDLockFile
 
 from airflow import settings
 from airflow.configuration import conf
-from airflow.jobs.base_job import BaseJob
-from airflow.jobs.triggerer_job import TriggererJobRunner
+from airflow.jobs.job import Job
+from airflow.jobs.triggerer_job_runner import TriggererJobRunner
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import setup_locations, setup_logging, sigint_handler, sigquit_handler
 from airflow.utils.serve_logs import serve_logs
@@ -56,7 +56,7 @@ def triggerer(args):
     settings.MASK_SECRETS_IN_LOGS = True
     print(settings.HEADER)
     triggerer_job_runner = TriggererJobRunner(capacity=args.capacity)
-    job = BaseJob(job_runner=triggerer_job_runner)
+    job = Job(job_runner=triggerer_job_runner)
 
     if args.daemon:
         pid, stdout, stderr, log_file = setup_locations(

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -46,7 +46,7 @@ from airflow.api_internal.internal_api_call import internal_api_call
 from airflow.callbacks.callback_requests import CallbackRequest, SlaCallbackRequest
 from airflow.configuration import conf
 from airflow.dag_processing.processor import DagFileProcessorProcess
-from airflow.jobs.base_job import perform_heartbeat
+from airflow.jobs.job import perform_heartbeat
 from airflow.models import errors
 from airflow.models.dag import DagModel
 from airflow.models.dagwarning import DagWarning
@@ -68,7 +68,7 @@ from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import prohibit_commit, skip_locked, with_row_locks
 
 if TYPE_CHECKING:
-    from airflow.jobs.dag_processor_job import DagProcessorJobRunner
+    from airflow.jobs.dag_processor_job_runner import DagProcessorJobRunner
 
 
 class DagParsingStat(NamedTuple):
@@ -385,7 +385,7 @@ class DagFileProcessorManager(LoggingMixin):
         signal_conn: MultiprocessingConnection | None = None,
         async_mode: bool = True,
     ):
-        from airflow.jobs.dag_processor_job import DagProcessorJobRunner
+        from airflow.jobs.dag_processor_job_runner import DagProcessorJobRunner
 
         super().__init__()
         # known files; this will be updated every `dag_dir_list_interval` and stuff added/removed accordingly

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -197,7 +197,7 @@ def on_celery_import_modules(*args, **kwargs):
     """
     import jinja2.ext  # noqa: F401
 
-    import airflow.jobs.local_task_job
+    import airflow.jobs.local_task_job_runner
     import airflow.macros
     import airflow.operators.bash
     import airflow.operators.python

--- a/airflow/jobs/backfill_job_runner.py
+++ b/airflow/jobs/backfill_job_runner.py
@@ -37,8 +37,8 @@ from airflow.exceptions import (
     TaskConcurrencyLimitReached,
 )
 from airflow.executors.executor_loader import ExecutorLoader
-from airflow.jobs.base_job import BaseJob
-from airflow.jobs.job_runner import BaseJobRunner
+from airflow.jobs.base_job_runner import BaseJobRunner
+from airflow.jobs.job import Job
 from airflow.models import DAG, DagPickle
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
@@ -69,7 +69,7 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
 
     STATES_COUNT_AS_RUNNING = (State.RUNNING, State.QUEUED)
 
-    job: BaseJob  # backfill_job can only run with BaseJob class not the Pydantic serialized version
+    job: Job  # backfill_job can only run with Job class not the Pydantic serialized version
 
     @attr.define
     class _DagRunTaskStatus:

--- a/airflow/jobs/base_job_runner.py
+++ b/airflow/jobs/base_job_runner.py
@@ -24,8 +24,8 @@ from airflow.utils.session import NEW_SESSION, provide_session
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
-    from airflow.jobs.base_job import BaseJob
-    from airflow.serialization.pydantic.base_job import BaseJobPydantic
+    from airflow.jobs.job import Job
+    from airflow.serialization.pydantic.job import JobPydantic
 
 
 class BaseJobRunner:
@@ -33,7 +33,7 @@ class BaseJobRunner:
 
     job_type = "undefined"
 
-    job: BaseJob | BaseJobPydantic
+    job: Job | JobPydantic
 
     def _execute(self) -> int | None:
         """
@@ -51,8 +51,8 @@ class BaseJobRunner:
 
     @classmethod
     @provide_session
-    def most_recent_job(cls, session: Session = NEW_SESSION) -> BaseJob | None:
+    def most_recent_job(cls, session: Session = NEW_SESSION) -> Job | None:
         """Returns the most recent job of this type, if any, based on last heartbeat received."""
-        from airflow.jobs.base_job import most_recent_job
+        from airflow.jobs.job import most_recent_job
 
         return most_recent_job(cls.job_type, session=session)

--- a/airflow/jobs/dag_processor_job_runner.py
+++ b/airflow/jobs/dag_processor_job_runner.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 from airflow.dag_processing.manager import DagFileProcessorManager
-from airflow.jobs.job_runner import BaseJobRunner
+from airflow.jobs.base_job_runner import BaseJobRunner
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 

--- a/airflow/jobs/local_task_job_runner.py
+++ b/airflow/jobs/local_task_job_runner.py
@@ -24,8 +24,8 @@ from sqlalchemy.orm import Session
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
-from airflow.jobs.base_job import perform_heartbeat
-from airflow.jobs.job_runner import BaseJobRunner
+from airflow.jobs.base_job_runner import BaseJobRunner
+from airflow.jobs.job import perform_heartbeat
 from airflow.models.taskinstance import TaskInstance, TaskReturnCode
 from airflow.stats import Stats
 from airflow.utils import timezone

--- a/airflow/jobs/triggerer_job_runner.py
+++ b/airflow/jobs/triggerer_job_runner.py
@@ -33,8 +33,8 @@ from typing import TYPE_CHECKING, Deque
 from sqlalchemy import func
 
 from airflow.configuration import conf
-from airflow.jobs.base_job import perform_heartbeat
-from airflow.jobs.job_runner import BaseJobRunner
+from airflow.jobs.base_job_runner import BaseJobRunner
+from airflow.jobs.job import perform_heartbeat
 from airflow.models.trigger import Trigger
 from airflow.stats import Stats
 from airflow.triggers.base import BaseTrigger, TriggerEvent

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -59,7 +59,7 @@ def import_all_models():
     for name in __lazy_imports:
         __getattr__(name)
 
-    import airflow.jobs.base_job
+    import airflow.jobs.job
     import airflow.models.dagwarning
     import airflow.models.dataset
     import airflow.models.serialized_dag

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2455,7 +2455,7 @@ class DAG(LoggingMixin):
         :param run_at_least_once: If true, always run the DAG at least once even
             if no logical run exists within the time range.
         """
-        from airflow.jobs.backfill_job import BackfillJobRunner
+        from airflow.jobs.backfill_job_runner import BackfillJobRunner
 
         if not executor and local:
             from airflow.executors.local_executor import LocalExecutor
@@ -2465,9 +2465,9 @@ class DAG(LoggingMixin):
             from airflow.executors.executor_loader import ExecutorLoader
 
             executor = ExecutorLoader.get_default_executor()
-        from airflow.jobs.base_job import BaseJob
+        from airflow.jobs.job import Job
 
-        job = BaseJob(
+        job = Job(
             job_runner=BackfillJobRunner(
                 self,
                 start_date=start_date,

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -265,9 +265,9 @@ def clear_task_instances(
         session.execute(delete_qry)
 
     if job_ids:
-        from airflow.jobs.base_job import BaseJob
+        from airflow.jobs.job import Job
 
-        for job in session.query(BaseJob).filter(BaseJob.id.in_(job_ids)).all():
+        for job in session.query(Job).filter(Job.id.in_(job_ids)).all():
             job.state = TaskInstanceState.RESTARTING
 
     if activate_dag_runs is not None:
@@ -2955,6 +2955,6 @@ class TaskInstanceNote(Base):
 STATICA_HACK = True
 globals()["kcah_acitats"[::-1].upper()] = False
 if STATICA_HACK:  # pragma: no cover
-    from airflow.jobs.base_job import BaseJob
+    from airflow.jobs.job import Job
 
-    TaskInstance.queued_by_job = relationship(BaseJob)
+    TaskInstance.queued_by_job = relationship(Job)

--- a/airflow/models/trigger.py
+++ b/airflow/models/trigger.py
@@ -60,8 +60,8 @@ class Trigger(Base):
     triggerer_id = Column(Integer, nullable=True)
 
     triggerer_job = relationship(
-        "BaseJob",
-        primaryjoin="BaseJob.id == Trigger.triggerer_id",
+        "Job",
+        primaryjoin="Job.id == Trigger.triggerer_id",
         foreign_keys=triggerer_id,
         uselist=False,
     )
@@ -201,7 +201,7 @@ class Trigger(Base):
         Takes a triggerer_id and the capacity for that triggerer and assigns unassigned
         triggers until that capacity is reached, or there are no more unassigned triggers.
         """
-        from airflow.jobs.base_job import BaseJob  # To avoid circular import
+        from airflow.jobs.job import Job  # To avoid circular import
 
         count = session.query(func.count(cls.id)).filter(cls.triggerer_id == triggerer_id).scalar()
         capacity -= count
@@ -211,10 +211,10 @@ class Trigger(Base):
 
         alive_triggerer_ids = [
             row[0]
-            for row in session.query(BaseJob.id).filter(
-                BaseJob.end_date.is_(None),
-                BaseJob.latest_heartbeat > timezone.utcnow() - datetime.timedelta(seconds=30),
-                BaseJob.job_type == "TriggererJob",
+            for row in session.query(Job.id).filter(
+                Job.end_date.is_(None),
+                Job.latest_heartbeat > timezone.utcnow() - datetime.timedelta(seconds=30),
+                Job.job_type == "TriggererJob",
             )
         ]
 

--- a/airflow/serialization/pydantic/job.py
+++ b/airflow/serialization/pydantic/job.py
@@ -19,7 +19,7 @@ from typing import Optional
 
 from pydantic import BaseModel as BaseModelPydantic
 
-from airflow.jobs.job_runner import BaseJobRunner
+from airflow.jobs.base_job_runner import BaseJobRunner
 
 
 def check_runner_initialized(job_runner: Optional[BaseJobRunner], job_type: str) -> BaseJobRunner:
@@ -28,8 +28,8 @@ def check_runner_initialized(job_runner: Optional[BaseJobRunner], job_type: str)
     return job_runner
 
 
-class BaseJobPydantic(BaseModelPydantic):
-    """Serializable representation of the BaseJob ORM SqlAlchemyModel used by internal API"""
+class JobPydantic(BaseModelPydantic):
+    """Serializable representation of the Job ORM SqlAlchemyModel used by internal API"""
 
     id: Optional[int]
     dag_id: Optional[str]

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -38,7 +38,7 @@ from airflow.compat.functools import cache
 from airflow.configuration import conf
 from airflow.datasets import Dataset
 from airflow.exceptions import AirflowException, RemovedInAirflow3Warning, SerializationError
-from airflow.jobs.base_job import BaseJob
+from airflow.jobs.job import Job
 from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
 from airflow.models.connection import Connection
 from airflow.models.dag import DAG, create_timetable
@@ -54,9 +54,9 @@ from airflow.providers_manager import ProvidersManager
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
 from airflow.serialization.helpers import serialize_template_field
 from airflow.serialization.json_schema import Validator, load_dag_schema
-from airflow.serialization.pydantic.base_job import BaseJobPydantic
 from airflow.serialization.pydantic.dag_run import DagRunPydantic
 from airflow.serialization.pydantic.dataset import DatasetPydantic
+from airflow.serialization.pydantic.job import JobPydantic
 from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
 from airflow.settings import _ENABLE_AIP_44, DAGS_FOLDER, json
 from airflow.timetables.base import Timetable
@@ -479,8 +479,8 @@ class BaseSerialization:
                 type_=DAT.SIMPLE_TASK_INSTANCE,
             )
         elif use_pydantic_models and _ENABLE_AIP_44:
-            if isinstance(var, BaseJob):
-                return cls._encode(BaseJobPydantic.from_orm(var).dict(), type_=DAT.BASE_JOB)
+            if isinstance(var, Job):
+                return cls._encode(JobPydantic.from_orm(var).dict(), type_=DAT.BASE_JOB)
             elif isinstance(var, TaskInstance):
                 return cls._encode(TaskInstancePydantic.from_orm(var).dict(), type_=DAT.TASK_INSTANCE)
             elif isinstance(var, DagRun):
@@ -554,7 +554,7 @@ class BaseSerialization:
             return SimpleTaskInstance(**cls.deserialize(var))
         elif use_pydantic_models and _ENABLE_AIP_44:
             if type_ == DAT.BASE_JOB:
-                return BaseJobPydantic.parse_obj(var)
+                return JobPydantic.parse_obj(var)
             elif type_ == DAT.TASK_INSTANCE:
                 return TaskInstancePydantic.parse_obj(var)
             elif type_ == DAT.DAG_RUN:

--- a/airflow/task/task_runner/__init__.py
+++ b/airflow/task/task_runner/__init__.py
@@ -21,7 +21,7 @@ import logging
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
-from airflow.jobs.local_task_job import LocalTaskJobRunner
+from airflow.jobs.local_task_job_runner import LocalTaskJobRunner
 from airflow.task.task_runner.base_task_runner import BaseTaskRunner
 from airflow.utils.module_loading import import_string
 

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -23,8 +23,8 @@ import subprocess
 import threading
 from typing import cast
 
-from airflow.jobs.base_job import BaseJob
-from airflow.jobs.local_task_job import LocalTaskJobRunner
+from airflow.jobs.job import Job
+from airflow.jobs.local_task_job_runner import LocalTaskJobRunner
 from airflow.utils.dag_parsing_context import _airflow_parsing_context_manager
 from airflow.utils.platform import IS_WINDOWS
 
@@ -53,7 +53,7 @@ class BaseTaskRunner(LoggingMixin):
            should be LocalTaskJobRunner
     """
 
-    def __init__(self, base_job: BaseJob):
+    def __init__(self, base_job: Job):
         self.job_runner: LocalTaskJobRunner = cast(LocalTaskJobRunner, base_job.job_runner)
         if not hasattr(self.job_runner, "task_instance"):
             raise ValueError(

--- a/airflow/task/task_runner/cgroup_task_runner.py
+++ b/airflow/task/task_runner/cgroup_task_runner.py
@@ -25,7 +25,7 @@ import uuid
 import psutil
 from cgroupspy import trees
 
-from airflow.jobs.base_job import BaseJob
+from airflow.jobs.job import Job
 from airflow.task.task_runner.base_task_runner import BaseTaskRunner
 from airflow.utils.operator_resources import Resources
 from airflow.utils.platform import getuser
@@ -62,7 +62,7 @@ class CgroupTaskRunner(BaseTaskRunner):
     airflow ALL= (root) NOEXEC: !/bin/chmod /CGROUPS_FOLDER/cpu/airflow/* *
     """
 
-    def __init__(self, base_job: BaseJob):
+    def __init__(self, base_job: Job):
         super().__init__(base_job=base_job)
         self.process = None
         self._finished_running = False

--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -24,7 +24,7 @@ import os
 import psutil
 from setproctitle import setproctitle
 
-from airflow.jobs.base_job import BaseJob
+from airflow.jobs.job import Job
 from airflow.models.taskinstance import TaskReturnCode
 from airflow.settings import CAN_FORK
 from airflow.task.task_runner.base_task_runner import BaseTaskRunner
@@ -35,7 +35,7 @@ from airflow.utils.process_utils import reap_process_group, set_new_process_grou
 class StandardTaskRunner(BaseTaskRunner):
     """Standard runner for all tasks."""
 
-    def __init__(self, base_job: BaseJob):
+    def __init__(self, base_job: Job):
         super().__init__(base_job=base_job)
         self._rc = None
         self.dag = self.job_runner.task_instance.task.dag

--- a/airflow/utils/scheduler_health.py
+++ b/airflow/utils/scheduler_health.py
@@ -20,8 +20,8 @@ import logging
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 from airflow.configuration import conf
-from airflow.jobs.base_job import BaseJob
-from airflow.jobs.scheduler_job import SchedulerJobRunner
+from airflow.jobs.job import Job
+from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
 from airflow.utils.net import get_hostname
 from airflow.utils.session import create_session
 
@@ -36,10 +36,10 @@ class HealthServer(BaseHTTPRequestHandler):
             try:
                 with create_session() as session:
                     scheduler_job = (
-                        session.query(BaseJob)
+                        session.query(Job)
                         .filter_by(job_type=SchedulerJobRunner.job_type)
                         .filter_by(hostname=get_hostname())
-                        .order_by(BaseJob.latest_heartbeat.desc())
+                        .order_by(Job.latest_heartbeat.desc())
                         .first()
                     )
                 if scheduler_job and scheduler_job.is_alive():

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -88,9 +88,9 @@ from airflow.configuration import AIRFLOW_CONFIG, conf
 from airflow.datasets import Dataset
 from airflow.exceptions import AirflowException, ParamValidationError, RemovedInAirflow3Warning
 from airflow.executors.executor_loader import ExecutorLoader
-from airflow.jobs.base_job import BaseJob
-from airflow.jobs.scheduler_job import SchedulerJobRunner
-from airflow.jobs.triggerer_job import TriggererJobRunner
+from airflow.jobs.job import Job
+from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
+from airflow.jobs.triggerer_job_runner import TriggererJobRunner
 from airflow.models import Connection, DagModel, DagTag, Log, SlaMiss, TaskFail, XCom, errors
 from airflow.models.abstractoperator import AbstractOperator
 from airflow.models.dag import DAG, get_dataset_triggered_next_run_info
@@ -4945,7 +4945,7 @@ class JobModelView(AirflowModelView):
 
     route_base = "/job"
 
-    datamodel = AirflowModelView.CustomSQLAInterface(BaseJob)  # type: ignore
+    datamodel = AirflowModelView.CustomSQLAInterface(Job)  # type: ignore
 
     class_permission_name = permissions.RESOURCE_JOB
     method_permission_name = {

--- a/dev/perf/scheduler_dag_execution_timing.py
+++ b/dev/perf/scheduler_dag_execution_timing.py
@@ -240,8 +240,8 @@ def main(num_runs, repeat, pre_create_dag_runs, executor_class, dag_ids):
     if pre_create_dag_runs:
         os.environ["AIRFLOW__SCHEDULER__USE_JOB_SCHEDULE"] = "False"
 
-    from airflow.jobs.base_job import BaseJob
-    from airflow.jobs.scheduler_job import SchedulerJobRunner
+    from airflow.jobs.job import Job
+    from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
     from airflow.models.dagbag import DagBag
     from airflow.utils import db
 
@@ -277,9 +277,7 @@ def main(num_runs, repeat, pre_create_dag_runs, executor_class, dag_ids):
     ShortCircuitExecutor = get_executor_under_test(executor_class)
 
     executor = ShortCircuitExecutor(dag_ids_to_watch=dag_ids, num_runs=num_runs)
-    scheduler_job = BaseJob(
-        job_runner=SchedulerJobRunner(dag_ids=dag_ids, do_pickle=False), executor=executor
-    )
+    scheduler_job = Job(job_runner=SchedulerJobRunner(dag_ids=dag_ids, do_pickle=False), executor=executor)
     executor.scheduler_job = scheduler_job
 
     total_tasks = sum(len(dag.tasks) for dag in dags)
@@ -310,7 +308,7 @@ def main(num_runs, repeat, pre_create_dag_runs, executor_class, dag_ids):
                     reset_dag(dag, session)
 
             executor.reset(dag_ids)
-            scheduler_job = BaseJob(
+            scheduler_job = Job(
                 job_runner=SchedulerJobRunner(dag_ids=dag_ids, do_pickle=False), executor=executor
             )
             executor.scheduler_job = scheduler_job

--- a/dev/perf/sql_queries.py
+++ b/dev/perf/sql_queries.py
@@ -23,7 +23,7 @@ from typing import NamedTuple
 
 import pandas as pd
 
-from airflow.jobs.base_job import BaseJob
+from airflow.jobs.job import Job
 
 # Setup environment before any Airflow import
 DAG_FOLDER = os.path.join(os.path.dirname(__file__), "dags")
@@ -120,11 +120,11 @@ def run_scheduler_job(with_db_reset=False) -> None:
     """
     Run the scheduler job, selectively resetting the db before creating a ScheduleJob instance
     """
-    from airflow.jobs.scheduler_job import SchedulerJobRunner
+    from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
 
     if with_db_reset:
         reset_db()
-    BaseJob(job_runner=SchedulerJobRunner(subdir=DAG_FOLDER, do_pickle=False, num_runs=3)).run()
+    Job(job_runner=SchedulerJobRunner(subdir=DAG_FOLDER, do_pickle=False, num_runs=3)).run()
 
 
 def is_query(line: str) -> bool:

--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/check-health.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/check-health.rst
@@ -99,7 +99,7 @@ using `http.server.BaseHTTPRequestHandler <https://docs.python.org/3/library/htt
 CLI Check for Scheduler
 -----------------------
 
-Scheduler creates an entry in the table :class:`airflow.jobs.base_job.BaseJob` with information about the host and
+Scheduler creates an entry in the table :class:`airflow.jobs.job.Job` with information about the host and
 timestamp (heartbeat) at startup, and then updates it regularly. You can use this to check if the scheduler is
 working correctly. To do this, you can use the ``airflow jobs checks`` command. On failure, the command will exit
 with a non-zero error code.

--- a/tests/api_connexion/endpoints/test_health_endpoint.py
+++ b/tests/api_connexion/endpoints/test_health_endpoint.py
@@ -21,8 +21,8 @@ from unittest import mock
 
 import pytest
 
-from airflow.jobs.base_job import BaseJob
-from airflow.jobs.scheduler_job import SchedulerJobRunner
+from airflow.jobs.job import Job
+from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
 from airflow.utils import timezone
 from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
@@ -37,11 +37,11 @@ class TestHealthTestBase:
         self.app = minimal_app_for_api
         self.client = self.app.test_client()  # type:ignore
         with create_session() as session:
-            session.query(BaseJob).delete()
+            session.query(Job).delete()
 
     def teardown_method(self):
         with create_session() as session:
-            session.query(BaseJob).delete()
+            session.query(Job).delete()
 
 
 class TestGetHealth(TestHealthTestBase):
@@ -49,7 +49,7 @@ class TestGetHealth(TestHealthTestBase):
     def test_healthy_scheduler_status(self, session):
         last_scheduler_heartbeat_for_testing_1 = timezone.utcnow()
         session.add(
-            BaseJob(
+            Job(
                 job_type="SchedulerJob",
                 state=State.RUNNING,
                 latest_heartbeat=last_scheduler_heartbeat_for_testing_1,
@@ -69,7 +69,7 @@ class TestGetHealth(TestHealthTestBase):
     def test_unhealthy_scheduler_is_slow(self, session):
         last_scheduler_heartbeat_for_testing_2 = timezone.utcnow() - timedelta(minutes=1)
         session.add(
-            BaseJob(
+            Job(
                 job_type="SchedulerJob",
                 state=State.RUNNING,
                 latest_heartbeat=last_scheduler_heartbeat_for_testing_2,

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -24,8 +24,8 @@ import pendulum
 import pytest
 from sqlalchemy.orm import contains_eager
 
-from airflow.jobs.base_job import BaseJob
-from airflow.jobs.triggerer_job import TriggererJobRunner
+from airflow.jobs.job import Job
+from airflow.jobs.triggerer_job_runner import TriggererJobRunner
 from airflow.models import DagRun, SlaMiss, TaskInstance, Trigger
 from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
 from airflow.security import permissions
@@ -232,7 +232,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
         )[0]
         ti.trigger = Trigger("none", {})
         ti.trigger.created_date = now
-        ti.triggerer_job = BaseJob(job_runner=TriggererJobRunner())
+        ti.triggerer_job = Job(job_runner=TriggererJobRunner())
         ti.triggerer_job.state = "running"
         session.commit()
         response = self.client.get(

--- a/tests/cli/commands/test_dag_processor_command.py
+++ b/tests/cli/commands/test_dag_processor_command.py
@@ -42,7 +42,7 @@ class TestDagProcessorCommand:
             ("core", "load_examples"): "False",
         }
     )
-    @mock.patch("airflow.jobs.dag_processor_job.DagProcessorJobRunner")
+    @mock.patch("airflow.jobs.dag_processor_job_runner.DagProcessorJobRunner")
     @pytest.mark.skipif(
         conf.get_mandatory_value("database", "sql_alchemy_conn").lower().startswith("sqlite"),
         reason="Standalone Dag Processor doesn't support sqlite.",

--- a/tests/cli/commands/test_jobs_command.py
+++ b/tests/cli/commands/test_jobs_command.py
@@ -23,8 +23,8 @@ import pytest
 
 from airflow.cli import cli_parser
 from airflow.cli.commands import jobs_command
-from airflow.jobs.base_job import BaseJob
-from airflow.jobs.scheduler_job import SchedulerJobRunner
+from airflow.jobs.job import Job
+from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
 from airflow.utils.session import create_session
 from airflow.utils.state import State
 from tests.test_utils.db import clear_db_jobs
@@ -46,7 +46,7 @@ class TestCliConfigList:
 
     def test_should_report_success_for_one_working_scheduler(self):
         with create_session() as session:
-            self.scheduler_job = BaseJob(job_runner=SchedulerJobRunner())
+            self.scheduler_job = Job(job_runner=SchedulerJobRunner())
             self.scheduler_job.state = State.RUNNING
             session.add(self.scheduler_job)
             session.commit()
@@ -58,7 +58,7 @@ class TestCliConfigList:
 
     def test_should_report_success_for_one_working_scheduler_with_hostname(self):
         with create_session() as session:
-            self.scheduler_job = BaseJob(job_runner=SchedulerJobRunner())
+            self.scheduler_job = Job(job_runner=SchedulerJobRunner())
             self.scheduler_job.state = State.RUNNING
             self.scheduler_job.hostname = "HOSTNAME"
             session.add(self.scheduler_job)
@@ -77,7 +77,7 @@ class TestCliConfigList:
         scheduler_jobs = []
         with create_session() as session:
             for _ in range(3):
-                scheduler_job = BaseJob(job_runner=SchedulerJobRunner())
+                scheduler_job = Job(job_runner=SchedulerJobRunner())
                 scheduler_job.state = State.RUNNING
                 session.add(scheduler_job)
                 scheduler_jobs.append(scheduler_job)
@@ -99,7 +99,7 @@ class TestCliConfigList:
         scheduler_jobs = []
         with create_session() as session:
             for _ in range(3):
-                scheduler_job = BaseJob(job_runner=SchedulerJobRunner())
+                scheduler_job = Job(job_runner=SchedulerJobRunner())
                 scheduler_job.state = State.SHUTDOWN
                 session.add(scheduler_job)
                 scheduler_jobs.append(scheduler_job)
@@ -115,7 +115,7 @@ class TestCliConfigList:
         scheduler_jobs = []
         with create_session() as session:
             for _ in range(3):
-                scheduler_job = BaseJob(job_runner=SchedulerJobRunner())
+                scheduler_job = Job(job_runner=SchedulerJobRunner())
                 scheduler_job.state = State.RUNNING
                 scheduler_job.hostname = "HOSTNAME"
                 session.add(scheduler_job)

--- a/tests/core/test_impersonation_tests.py
+++ b/tests/core/test_impersonation_tests.py
@@ -24,8 +24,8 @@ import sys
 
 import pytest
 
-from airflow.jobs.backfill_job import BackfillJobRunner
-from airflow.jobs.base_job import BaseJob
+from airflow.jobs.backfill_job_runner import BackfillJobRunner
+from airflow.jobs.job import Job
 from airflow.models import DagBag, DagRun, TaskInstance
 from airflow.utils.db import add_default_pool_if_not_exists
 from airflow.utils.state import State
@@ -113,7 +113,7 @@ class BaseImpersonationTest:
         dag = self.dagbag.get_dag(dag_id)
         dag.clear()
 
-        BaseJob(job_runner=BackfillJobRunner(dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)).run()
+        Job(job_runner=BackfillJobRunner(dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)).run()
         run_id = DagRun.generate_run_id(DagRunType.BACKFILL_JOB, execution_date=DEFAULT_DATE)
         ti = TaskInstance(task=dag.get_task(task_id), run_id=run_id)
         ti.refresh_from_db()

--- a/tests/executors/test_dask_executor.py
+++ b/tests/executors/test_dask_executor.py
@@ -25,8 +25,8 @@ from distributed import LocalCluster
 
 from airflow.exceptions import AirflowException
 from airflow.executors.dask_executor import DaskExecutor
-from airflow.jobs.backfill_job import BackfillJobRunner
-from airflow.jobs.base_job import BaseJob
+from airflow.jobs.backfill_job_runner import BackfillJobRunner
+from airflow.jobs.job import Job
 from airflow.models import DagBag
 from airflow.utils import timezone
 from tests.test_utils.config import conf_vars
@@ -108,7 +108,7 @@ class TestDaskExecutor(TestBaseDask):
         """
         dag = self.dagbag.get_dag("example_bash_operator")
 
-        job = BaseJob(
+        job = Job(
             job_runner=BackfillJobRunner(
                 dag=dag,
                 start_date=DEFAULT_DATE,

--- a/tests/jobs/test_base_job.py
+++ b/tests/jobs/test_base_job.py
@@ -25,7 +25,7 @@ from pytest import raises
 from sqlalchemy.exc import OperationalError
 
 from airflow.executors.sequential_executor import SequentialExecutor
-from airflow.jobs.base_job import BaseJob, most_recent_job
+from airflow.jobs.job import Job, most_recent_job
 from airflow.listeners.listener import get_listener_manager
 from airflow.utils import timezone
 from airflow.utils.session import create_session
@@ -35,9 +35,9 @@ from tests.test_utils.config import conf_vars
 from tests.utils.test_helpers import MockJobRunner
 
 
-class TestBaseJob:
+class TestJob:
     def test_state_success(self):
-        job = BaseJob(job_runner=MockJobRunner())
+        job = Job(job_runner=MockJobRunner())
         job.run()
 
         assert job.state == State.SUCCESS
@@ -46,7 +46,7 @@ class TestBaseJob:
     def test_state_sysexit(self):
         import sys
 
-        job = BaseJob(job_runner=MockJobRunner(lambda: sys.exit(0)))
+        job = Job(job_runner=MockJobRunner(lambda: sys.exit(0)))
         job.run()
 
         assert job.state == State.SUCCESS
@@ -56,7 +56,7 @@ class TestBaseJob:
 
         import sys
 
-        job = BaseJob(job_runner=MockJobRunner(lambda: sys.exit(0)))
+        job = Job(job_runner=MockJobRunner(lambda: sys.exit(0)))
         job.run()
 
         assert job.state == State.SUCCESS
@@ -68,7 +68,7 @@ class TestBaseJob:
         """
         get_listener_manager().add_listener(lifecycle_listener)
 
-        job = BaseJob(job_runner=MockJobRunner(lambda: sys.exit(0)))
+        job = Job(job_runner=MockJobRunner(lambda: sys.exit(0)))
         job.run()
 
         assert lifecycle_listener.started_component is job
@@ -78,7 +78,7 @@ class TestBaseJob:
         def abort():
             raise RuntimeError("fail")
 
-        job = BaseJob(job_runner=MockJobRunner(abort))
+        job = Job(job_runner=MockJobRunner(abort))
         with raises(RuntimeError):
             job.run()
 
@@ -87,9 +87,9 @@ class TestBaseJob:
 
     def test_most_recent_job(self):
         with create_session() as session:
-            old_job = BaseJob(job_runner=MockJobRunner(), heartrate=10)
+            old_job = Job(job_runner=MockJobRunner(), heartrate=10)
             old_job.latest_heartbeat = old_job.latest_heartbeat - datetime.timedelta(seconds=20)
-            job = BaseJob(job_runner=MockJobRunner(), heartrate=10)
+            job = Job(job_runner=MockJobRunner(), heartrate=10)
             session.add(job)
             session.add(old_job)
             session.flush()
@@ -101,13 +101,13 @@ class TestBaseJob:
 
     def test_most_recent_job_running_precedence(self):
         with create_session() as session:
-            old_running_state_job = BaseJob(job_runner=MockJobRunner(), heartrate=10)
+            old_running_state_job = Job(job_runner=MockJobRunner(), heartrate=10)
             old_running_state_job.latest_heartbeat = timezone.utcnow()
             old_running_state_job.state = State.RUNNING
-            new_failed_state_job = BaseJob(job_runner=MockJobRunner(), heartrate=10)
+            new_failed_state_job = Job(job_runner=MockJobRunner(), heartrate=10)
             new_failed_state_job.latest_heartbeat = timezone.utcnow()
             new_failed_state_job.state = State.FAILED
-            new_null_state_job = BaseJob(job_runner=MockJobRunner(), heartrate=10)
+            new_null_state_job = Job(job_runner=MockJobRunner(), heartrate=10)
             new_null_state_job.latest_heartbeat = timezone.utcnow()
             new_null_state_job.state = None
             session.add(old_running_state_job)
@@ -120,7 +120,7 @@ class TestBaseJob:
             session.rollback()
 
     def test_is_alive(self):
-        job = BaseJob(job_runner=MockJobRunner(), heartrate=10, state=State.RUNNING)
+        job = Job(job_runner=MockJobRunner(), heartrate=10, state=State.RUNNING)
         assert job.is_alive() is True
 
         job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=20)
@@ -138,14 +138,14 @@ class TestBaseJob:
         job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=10)
         assert job.is_alive() is False, "Completed jobs even with recent heartbeat should not be alive"
 
-    @patch("airflow.jobs.base_job.create_session")
+    @patch("airflow.jobs.job.create_session")
     def test_heartbeat_failed(self, mock_create_session):
         when = timezone.utcnow() - datetime.timedelta(seconds=60)
         with create_session() as session:
             mock_session = Mock(spec_set=session, name="MockSession")
             mock_create_session.return_value.__enter__.return_value = mock_session
 
-            job = BaseJob(job_runner=MockJobRunner(), heartrate=10, state=State.RUNNING)
+            job = Job(job_runner=MockJobRunner(), heartrate=10, state=State.RUNNING)
             job.latest_heartbeat = when
 
             mock_session.commit.side_effect = OperationalError("Force fail", {}, None)
@@ -160,18 +160,16 @@ class TestBaseJob:
             ("core", "executor"): "SequentialExecutor",
         }
     )
-    @patch("airflow.jobs.base_job.ExecutorLoader.get_default_executor")
-    @patch("airflow.jobs.base_job.get_hostname")
-    @patch("airflow.jobs.base_job.getuser")
+    @patch("airflow.jobs.job.ExecutorLoader.get_default_executor")
+    @patch("airflow.jobs.job.get_hostname")
+    @patch("airflow.jobs.job.getuser")
     def test_essential_attr(self, mock_getuser, mock_hostname, mock_default_executor):
         mock_sequential_executor = SequentialExecutor()
         mock_hostname.return_value = "test_hostname"
         mock_getuser.return_value = "testuser"
         mock_default_executor.return_value = mock_sequential_executor
 
-        test_job = BaseJob(
-            job_runner=MockJobRunner(), heartrate=10, dag_id="example_dag", state=State.RUNNING
-        )
+        test_job = Job(job_runner=MockJobRunner(), heartrate=10, dag_id="example_dag", state=State.RUNNING)
         assert test_job.executor_class == "SequentialExecutor"
         assert test_job.heartrate == 10
         assert test_job.dag_id == "example_dag"
@@ -182,9 +180,9 @@ class TestBaseJob:
         assert test_job.executor == mock_sequential_executor
 
     def test_heartbeat(self, frozen_sleep, monkeypatch):
-        monkeypatch.setattr("airflow.jobs.base_job.sleep", frozen_sleep)
+        monkeypatch.setattr("airflow.jobs.job.sleep", frozen_sleep)
         with create_session() as session:
-            job = BaseJob(job_runner=MockJobRunner(), heartrate=10)
+            job = Job(job_runner=MockJobRunner(), heartrate=10)
             job.latest_heartbeat = timezone.utcnow()
             session.add(job)
             session.commit()

--- a/tests/listeners/test_listeners.py
+++ b/tests/listeners/test_listeners.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import pytest as pytest
 
 from airflow import AirflowException
-from airflow.jobs.base_job import BaseJob
+from airflow.jobs.job import Job
 from airflow.listeners.listener import get_listener_manager
 from airflow.operators.bash import BashOperator
 from airflow.utils import timezone
@@ -80,7 +80,7 @@ def test_multiple_listeners(create_task_instance, session=None):
     lm.add_listener(full_listener)
     lm.add_listener(lifecycle_listener)
 
-    job = BaseJob(job_runner=MockJobRunner())
+    job = Job(job_runner=MockJobRunner())
     try:
         job.run()
     except NotImplementedError:

--- a/tests/models/test_trigger.py
+++ b/tests/models/test_trigger.py
@@ -20,8 +20,8 @@ import datetime
 
 import pytest
 
-from airflow.jobs.base_job import BaseJob
-from airflow.jobs.triggerer_job import TriggererJobRunner
+from airflow.jobs.job import Job
+from airflow.jobs.triggerer_job_runner import TriggererJobRunner
 from airflow.models import TaskInstance, Trigger
 from airflow.operators.empty import EmptyOperator
 from airflow.triggers.base import TriggerEvent
@@ -41,11 +41,11 @@ def session():
 def clear_db(session):
     session.query(TaskInstance).delete()
     session.query(Trigger).delete()
-    session.query(BaseJob).delete()
+    session.query(Job).delete()
     yield session
     session.query(TaskInstance).delete()
     session.query(Trigger).delete()
-    session.query(BaseJob).delete()
+    session.query(Job).delete()
     session.commit()
 
 
@@ -140,14 +140,14 @@ def test_assign_unassigned(session, create_task_instance):
     """
     Tests that unassigned triggers of all appropriate states are assigned.
     """
-    finished_triggerer = BaseJob(job_runner=TriggererJobRunner(None), heartrate=10, state=State.SUCCESS)
+    finished_triggerer = Job(job_runner=TriggererJobRunner(None), heartrate=10, state=State.SUCCESS)
     finished_triggerer.end_date = timezone.utcnow() - datetime.timedelta(hours=1)
     session.add(finished_triggerer)
     assert not finished_triggerer.is_alive()
-    healthy_triggerer = BaseJob(job_runner=TriggererJobRunner(None), heartrate=10, state=State.RUNNING)
+    healthy_triggerer = Job(job_runner=TriggererJobRunner(None), heartrate=10, state=State.RUNNING)
     session.add(healthy_triggerer)
     assert healthy_triggerer.is_alive()
-    new_triggerer = BaseJob(job_runner=TriggererJobRunner(None), heartrate=10, state=State.RUNNING)
+    new_triggerer = Job(job_runner=TriggererJobRunner(None), heartrate=10, state=State.RUNNING)
     session.add(new_triggerer)
     assert new_triggerer.is_alive()
     session.commit()

--- a/tests/serialization/test_pydantic_models.py
+++ b/tests/serialization/test_pydantic_models.py
@@ -19,17 +19,17 @@ from __future__ import annotations
 
 from pydantic import parse_raw_as
 
-from airflow.jobs.base_job import BaseJob
-from airflow.jobs.local_task_job import LocalTaskJobRunner
+from airflow.jobs.job import Job
+from airflow.jobs.local_task_job_runner import LocalTaskJobRunner
 from airflow.models.dataset import (
     DagScheduleDatasetReference,
     DatasetEvent,
     DatasetModel,
     TaskOutletDatasetReference,
 )
-from airflow.serialization.pydantic.base_job import BaseJobPydantic
 from airflow.serialization.pydantic.dag_run import DagRunPydantic
 from airflow.serialization.pydantic.dataset import DatasetEventPydantic
+from airflow.serialization.pydantic.job import JobPydantic
 from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
 from airflow.utils import timezone
 from airflow.utils.state import State
@@ -76,15 +76,15 @@ def test_serializing_pydantic_dagrun(session, create_task_instance):
 def test_serializing_pydantic_local_task_job(session, create_task_instance):
     dag_id = "test-dag"
     ti = create_task_instance(dag_id=dag_id, session=session)
-    ltj = BaseJob(job_runner=LocalTaskJobRunner(task_instance=ti), dag_id=ti.dag_id)
+    ltj = Job(job_runner=LocalTaskJobRunner(task_instance=ti), dag_id=ti.dag_id)
     ltj.state = State.RUNNING
     session.commit()
-    pydantic_job = BaseJobPydantic.from_orm(ltj)
+    pydantic_job = JobPydantic.from_orm(ltj)
 
     json_string = pydantic_job.json()
     print(json_string)
 
-    deserialized_model = parse_raw_as(BaseJobPydantic, json_string)
+    deserialized_model = parse_raw_as(JobPydantic, json_string)
     assert deserialized_model.dag_id == dag_id
     assert deserialized_model.job_type == "LocalTaskJob"
     assert deserialized_model.state == State.RUNNING

--- a/tests/task/task_runner/test_base_task_runner.py
+++ b/tests/task/task_runner/test_base_task_runner.py
@@ -21,8 +21,8 @@ from unittest import mock
 
 import pytest
 
-from airflow.jobs.base_job import BaseJob
-from airflow.jobs.local_task_job import LocalTaskJobRunner
+from airflow.jobs.job import Job
+from airflow.jobs.local_task_job_runner import LocalTaskJobRunner
 from airflow.models.baseoperator import BaseOperator
 from airflow.task.task_runner.base_task_runner import BaseTaskRunner
 
@@ -40,7 +40,7 @@ def test_config_copy_mode(tmp_configuration_copy, subprocess_call, dag_maker, im
 
     ti = dr.task_instances[0]
     task_runner = LocalTaskJobRunner(ti)
-    job = BaseJob(job_runner=task_runner, dag_id=ti.dag_id)
+    job = Job(job_runner=task_runner, dag_id=ti.dag_id)
     runner = BaseTaskRunner(job)
     # So we don't try to delete it -- cos the file won't exist
     del runner._cfg_path

--- a/tests/task/task_runner/test_cgroup_task_runner.py
+++ b/tests/task/task_runner/test_cgroup_task_runner.py
@@ -32,12 +32,12 @@ class TestCgroupTaskRunner:
         and when task finishes, CgroupTaskRunner.on_finish() calls
         super().on_finish() to delete the temp cfg file.
         """
-        local_task_job = mock.Mock()
-        local_task_job.task_instance = mock.MagicMock()
-        local_task_job.task_instance.run_as_user = None
-        local_task_job.task_instance.command_as_list.return_value = ["sleep", "1000"]
+        base_job = mock.Mock()
+        base_job.task_instance = mock.MagicMock()
+        base_job.task_instance.run_as_user = None
+        base_job.task_instance.command_as_list.return_value = ["sleep", "1000"]
 
-        runner = CgroupTaskRunner(local_task_job)
+        runner = CgroupTaskRunner(base_job)
         assert mock_super_init.called
 
         runner.on_finish()

--- a/tests/task/task_runner/test_task_runner.py
+++ b/tests/task/task_runner/test_task_runner.py
@@ -20,7 +20,7 @@ from unittest import mock
 
 import pytest
 
-from airflow.jobs.local_task_job import LocalTaskJobRunner
+from airflow.jobs.local_task_job_runner import LocalTaskJobRunner
 from airflow.task.task_runner import CORE_TASK_RUNNERS, get_task_runner
 from airflow.utils.module_loading import import_string
 
@@ -38,10 +38,10 @@ class TestGetTaskRunner:
         ti = mock.MagicMock(map_index=-1, run_as_user=None)
         ti.get_template_context.return_value = {"ti": ti}
         ti.get_dagrun.return_value.get_log_template.return_value.filename = "blah"
-        local_task_job = mock.MagicMock(task_instance=ti)
-        local_task_job.job_runner = LocalTaskJobRunner(ti)
-        local_task_job.job_runner.job = local_task_job
-        task_runner = get_task_runner(local_task_job.job_runner)
+        base_job = mock.MagicMock(task_instance=ti)
+        base_job.job_runner = LocalTaskJobRunner(ti)
+        base_job.job_runner.job = base_job
+        task_runner = get_task_runner(base_job.job_runner)
 
         assert "StandardTaskRunner" == task_runner.__class__.__name__
 
@@ -50,13 +50,13 @@ class TestGetTaskRunner:
         "tests.task.task_runner.test_task_runner.custom_task_runner",
     )
     def test_should_support_custom_legacy_task_runner(self):
-        local_task_job = mock.MagicMock(
+        base_job = mock.MagicMock(
             **{"task_instance.get_template_context.return_value": {"ti": mock.MagicMock()}}
         )
         custom_task_runner.reset_mock()
 
-        task_runner = get_task_runner(local_task_job)
+        task_runner = get_task_runner(base_job)
 
-        custom_task_runner.assert_called_once_with(local_task_job.job)
+        custom_task_runner.assert_called_once_with(base_job.job)
 
         assert custom_task_runner.return_value == task_runner

--- a/tests/test_utils/db.py
+++ b/tests/test_utils/db.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from airflow.jobs.base_job import BaseJob
+from airflow.jobs.job import Job
 from airflow.models import (
     Connection,
     DagModel,
@@ -55,7 +55,7 @@ from airflow.www.fab_security.sqla.models import Permission, Resource, assoc_per
 
 def clear_db_runs():
     with create_session() as session:
-        session.query(BaseJob).delete()
+        session.query(Job).delete()
         session.query(Trigger).delete()
         session.query(DagRun).delete()
         session.query(TaskInstance).delete()
@@ -156,7 +156,7 @@ def clear_db_logs():
 
 def clear_db_jobs():
     with create_session() as session:
-        session.query(BaseJob).delete()
+        session.query(Job).delete()
 
 
 def clear_db_task_fail():

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -23,7 +23,7 @@ from itertools import product
 import pytest
 
 from airflow import AirflowException
-from airflow.jobs.job_runner import BaseJobRunner
+from airflow.jobs.base_job_runner import BaseJobRunner
 from airflow.utils import helpers, timezone
 from airflow.utils.helpers import (
     at_most_one,

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -31,8 +31,8 @@ import pytest
 from kubernetes.client import models as k8s
 
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
-from airflow.jobs.base_job import BaseJob
-from airflow.jobs.triggerer_job import TriggererJobRunner
+from airflow.jobs.job import Job
+from airflow.jobs.triggerer_job_runner import TriggererJobRunner
 from airflow.models import DAG, DagRun, TaskInstance, Trigger
 from airflow.operators.python import PythonOperator
 from airflow.utils.log.file_task_handler import (
@@ -403,7 +403,7 @@ class TestFileTaskLogHandler:
         assert isinstance(ti, TaskInstance)
         if is_a_trigger:
             ti.is_trigger_log_context = True
-            job = BaseJob(job_runner=TriggererJobRunner())
+            job = Job(job_runner=TriggererJobRunner())
             t = Trigger("", {})
             t.triggerer_job = job
             ti.triggerer = t
@@ -475,7 +475,7 @@ class TestLogUrl:
         )
         ti.hostname = "hostname"
         trigger = Trigger("", {})
-        job = BaseJob(job_runner=TriggererJobRunner())
+        job = Job(job_runner=TriggererJobRunner())
         job.id = 123
         trigger.triggerer_job = job
         ti.trigger = trigger

--- a/tests/www/views/test_views_base.py
+++ b/tests/www/views/test_views_base.py
@@ -22,8 +22,8 @@ import json
 
 import pytest
 
-from airflow.jobs.base_job import BaseJob
-from airflow.jobs.scheduler_job import SchedulerJobRunner
+from airflow.jobs.job import Job
+from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.www import app as application
@@ -62,7 +62,7 @@ def test_doc_urls(admin_client, monkeypatch):
 def heartbeat_healthy():
     # case-1: healthy scheduler status
     last_heartbeat = timezone.utcnow()
-    job = BaseJob(
+    job = Job(
         job_type="SchedulerJob",
         state="running",
         latest_heartbeat=last_heartbeat,
@@ -72,10 +72,10 @@ def heartbeat_healthy():
         session.add(job)
     yield "healthy", last_heartbeat.isoformat()
     with create_session() as session:
-        session.query(BaseJob).filter(
-            BaseJob.job_type == "SchedulerJob",
-            BaseJob.state == "running",
-            BaseJob.latest_heartbeat == last_heartbeat,
+        session.query(Job).filter(
+            Job.job_type == "SchedulerJob",
+            Job.state == "running",
+            Job.latest_heartbeat == last_heartbeat,
         ).delete()
 
 
@@ -83,23 +83,23 @@ def heartbeat_healthy():
 def heartbeat_too_slow():
     # case-2: unhealthy scheduler status - scenario 1 (SchedulerJob is running too slowly)
     last_heartbeat = timezone.utcnow() - datetime.timedelta(minutes=1)
-    job = BaseJob(
+    job = Job(
         job_type="SchedulerJob",
         state="running",
         latest_heartbeat=last_heartbeat,
         job_runner=SchedulerJobRunner(),
     )
     with create_session() as session:
-        session.query(BaseJob).filter(
-            BaseJob.job_type == "SchedulerJob",
+        session.query(Job).filter(
+            Job.job_type == "SchedulerJob",
         ).update({"latest_heartbeat": last_heartbeat - datetime.timedelta(seconds=1)})
         session.add(job)
     yield "unhealthy", last_heartbeat.isoformat()
     with create_session() as session:
-        session.query(BaseJob).filter(
-            BaseJob.job_type == "SchedulerJob",
-            BaseJob.state == "running",
-            BaseJob.latest_heartbeat == last_heartbeat,
+        session.query(Job).filter(
+            Job.job_type == "SchedulerJob",
+            Job.state == "running",
+            Job.latest_heartbeat == last_heartbeat,
         ).delete()
 
 
@@ -107,9 +107,9 @@ def heartbeat_too_slow():
 def heartbeat_not_running():
     # case-3: unhealthy scheduler status - scenario 2 (no running SchedulerJob)
     with create_session() as session:
-        session.query(BaseJob).filter(
-            BaseJob.job_type == "SchedulerJob",
-            BaseJob.state == "running",
+        session.query(Job).filter(
+            Job.job_type == "SchedulerJob",
+            Job.state == "running",
         ).delete()
     yield "unhealthy", None
 


### PR DESCRIPTION
The https://github.com/apache/airflow/pull/30255 introduced "JobRunner" concept and decoupled the job logic
from the ORM polymorphic *Job objects. The change was implemented
in the way to minimise the review effort needed, so it avoided renaming
the modules for the runners (from `_job` to `_job_runner`).

Also BaseJob lost its "polymorphism" properties so the package, and class name 
can be renamed to simply job.

This PR completes the JobRunner concept introduction by applying the
renames.

Closes: https://github.com/apache/airflow/issues/30296

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
