### PR TITLE
Add additional annotations to the extra configmap and secrets

### DIFF
--- a/chart/templates/configmaps/extra-configmaps.yaml
+++ b/chart/templates/configmaps/extra-configmaps.yaml
@@ -39,6 +39,9 @@ metadata:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
     "helm.sh/hook-weight": "0"
+    {{- if $configMapContent.annotations }}
+      {{- toYaml $configMapContent.annotations | nindent 4 }}
+    {{- end }}
 {{- if $configMapContent.data }}
 data:
   {{- with $configMapContent.data }}

--- a/chart/templates/secrets/extra-secrets.yaml
+++ b/chart/templates/secrets/extra-secrets.yaml
@@ -39,6 +39,9 @@ metadata:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
     "helm.sh/hook-weight": "0"
+    {{- if $secretContent.annotations }}
+      {{- toYaml $secretContent.annotations | nindent 4 }}
+    {{- end }}
 {{- if $secretContent.type }}
 type: {{ $secretContent.type }}
 {{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -891,6 +891,14 @@
                             "type": "string"
                         }
                     },
+                    "annotations": {
+                        "description": "Annotations for the secret",
+                        "type": "object",
+                        "default": null,
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
                     "data": {
                         "description": "Content **as string** for the 'data' item of the secret (can be templated)",
                         "type": "string"
@@ -923,6 +931,14 @@
                 "properties": {
                     "labels": {
                         "description": "Labels for the configmap",
+                        "type": "object",
+                        "default": null,
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "annotations": {
+                        "description": "Annotations for the configmap",
                         "type": "object",
                         "default": null,
                         "additionalProperties": {

--- a/chart/values_schema.schema.json
+++ b/chart/values_schema.schema.json
@@ -9,7 +9,7 @@
                     "not": {
                         "properties": {
                             "description": {
-                                "pattern": "^Labels for the configmap$|^Labels for the secret$"
+                                "pattern": "^Labels for the configmap$|^Labels for the secret$|^Annotations for the configmap$|^Annotations for the secret$"
                             }
                         }
                     }

--- a/tests/charts/test_extra_configmaps_secrets.py
+++ b/tests/charts/test_extra_configmaps_secrets.py
@@ -210,6 +210,7 @@ class TestExtraConfigMapsSecrets:
             "helm.sh/hook": "pre-install,pre-upgrade",
             "helm.sh/hook-delete-policy": "before-hook-creation",
             "helm.sh/hook-weight": "0",
+            "test_annotation": "test_annotation_value",
         }
 
         for k8s_object in k8s_objects:

--- a/tests/charts/test_extra_configmaps_secrets.py
+++ b/tests/charts/test_extra_configmaps_secrets.py
@@ -185,3 +185,32 @@ class TestExtraConfigMapsSecrets:
         }
         for k8s_object in k8s_objects:
             assert k8s_object["metadata"]["labels"] == {**common_labels, **chart_labels, **local_labels}
+
+    def test_extra_configmaps_secrets_additional_annotations(self):
+        k8s_objects = render_chart(
+            name=RELEASE_NAME,
+            values={
+                "extraSecrets": {
+                    "{{ .Release.Name }}-extra-secret-1": {
+                        "annotations": {"test_annotation": "test_annotation_value"},
+                        "stringData": "data: secretData",
+                    }
+                },
+                "extraConfigMaps": {
+                    "{{ .Release.Name }}-extra-configmap-1": {
+                        "annotations": {"test_annotation": "test_annotation_value"},
+                        "data": "data: configData",
+                    }
+                },
+            },
+            show_only=["templates/configmaps/extra-configmaps.yaml", "templates/secrets/extra-secrets.yaml"],
+        )
+
+        expected_annotations = {
+            "helm.sh/hook": "pre-install,pre-upgrade",
+            "helm.sh/hook-delete-policy": "before-hook-creation",
+            "helm.sh/hook-weight": "0",
+        }
+
+        for k8s_object in k8s_objects:
+            assert k8s_object["metadata"]["annotations"] == expected_annotations


### PR DESCRIPTION
Add provision to have additional annotations to the extra configmap and secrets

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
