### PR TITLE
link fixed in CONTRIBUTING guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -45,9 +45,8 @@ we have a dedicated #newbie-questions Slack channel where you can ask any questi
 you want - it's a safe space where it is expected that people asking questions do not know
 a lot about Airflow (yet!).
 
-If you look for more structured mentoring experience, you can apply to Apache Software Foundation's
-`Official Mentoring Programme <http://community.apache.org/mentoringprogramme.html>`_. Feel free
-to follow it and apply to the programme and follow up with the community.
+To check on how mentoring works for the projects under Apache Software Foundation's
+`Apache Community Development - Mentoring <https://community.apache.org/mentoring/>`_.
 
 Report Bugs
 -----------


### PR DESCRIPTION
In contributing guidelines, it mentioned the mentoring program by ASF. But currently that link is broken and when checked in 
ASF website, there is no mentoring programme as such now. so i have updated with different link from ASF site that is closer to the information about mentoring. 
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
