### PR TITLE
Separate and split run job method into prepare/execute/complete steps

### DIFF
--- a/airflow/cli/commands/dag_processor_command.py
+++ b/airflow/cli/commands/dag_processor_command.py
@@ -26,7 +26,7 @@ from daemon.pidfile import TimeoutPIDLockFile
 
 from airflow import settings
 from airflow.configuration import conf
-from airflow.jobs.job import Job
+from airflow.jobs.job import Job, run_job
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import setup_locations, setup_logging
 
@@ -81,6 +81,6 @@ def dag_processor(args):
                 umask=int(settings.DAEMON_UMASK, 8),
             )
             with ctx:
-                job.run()
+                run_job(job)
     else:
-        job.run()
+        run_job(job)

--- a/airflow/cli/commands/scheduler_command.py
+++ b/airflow/cli/commands/scheduler_command.py
@@ -28,7 +28,7 @@ from airflow import settings
 from airflow.api_internal.internal_api_call import InternalApiConfig
 from airflow.configuration import conf
 from airflow.executors.executor_loader import ExecutorLoader
-from airflow.jobs.job import Job
+from airflow.jobs.job import Job, run_job
 from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import process_subdir, setup_locations, setup_logging, sigint_handler, sigquit_handler
@@ -39,7 +39,7 @@ def _run_scheduler_job(job: Job, *, skip_serve_logs: bool) -> None:
     InternalApiConfig.force_database_direct_access()
     enable_health_check = conf.getboolean("scheduler", "ENABLE_HEALTH_CHECK")
     with _serve_logs(skip_serve_logs), _serve_health_check(enable_health_check):
-        job.run()
+        run_job(job)
 
 
 @cli_utils.action_cli

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -37,7 +37,7 @@ from airflow.cli.simple_table import AirflowConsole
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, DagRunNotFound, TaskInstanceNotFound
 from airflow.executors.executor_loader import ExecutorLoader
-from airflow.jobs.job import Job
+from airflow.jobs.job import Job, run_job
 from airflow.jobs.local_task_job_runner import LocalTaskJobRunner
 from airflow.listeners.listener import get_listener_manager
 from airflow.models import DagPickle, TaskInstance
@@ -260,12 +260,12 @@ def _run_task_by_local_task_job(args, ti: TaskInstance) -> TaskReturnCode | None
         pool=args.pool,
         external_executor_id=_extract_external_executor_id(args),
     )
-    run_job = Job(
+    local_task_job = Job(
         job_runner=local_task_job_runner,
         dag_id=ti.dag_id,
     )
     try:
-        ret = run_job.run()
+        ret = run_job(local_task_job)
     finally:
         if args.shut_down_logging:
             logging.shutdown()

--- a/airflow/cli/commands/triggerer_command.py
+++ b/airflow/cli/commands/triggerer_command.py
@@ -28,7 +28,7 @@ from daemon.pidfile import TimeoutPIDLockFile
 
 from airflow import settings
 from airflow.configuration import conf
-from airflow.jobs.job import Job
+from airflow.jobs.job import Job, run_job
 from airflow.jobs.triggerer_job_runner import TriggererJobRunner
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import setup_locations, setup_logging, sigint_handler, sigquit_handler
@@ -75,10 +75,10 @@ def triggerer(args):
                 umask=int(settings.DAEMON_UMASK, 8),
             )
             with daemon_context, _serve_logs(args.skip_serve_logs):
-                job.run()
+                run_job(job)
     else:
         signal.signal(signal.SIGINT, sigint_handler)
         signal.signal(signal.SIGTERM, sigint_handler)
         signal.signal(signal.SIGQUIT, sigquit_handler)
         with _serve_logs(args.skip_serve_logs):
-            job.run()
+            run_job(job)

--- a/airflow/jobs/JOB_LIFECYCLE.md
+++ b/airflow/jobs/JOB_LIFECYCLE.md
@@ -1,0 +1,158 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+Those sequence diagrams explain what is the lifecycle of the Job with relation to the database
+operation in the context of the internal API of Airflow.
+
+As part of AIP-44 implementation we separated the ORM Job instance from the code the job runs,
+introducing a concept of Job Runners. The Job Runner is a class that is responsible for running
+the code and it might execute either in-process when direct database is used, or remotely when
+the job is run remotely and communicates via internal API (this part is a work-in-progress and we
+will keep on updating the state.
+
+Those chart apply to all kinds of CLI components Airflow runs (Scheduler, DagFileProcessor, Triggerer,
+Worker) that can run the job. The AIP-44 implementation is not yet complete, but when complete it will
+apply to some of the components (DagFileProcessor, Triggerer, Worker) and not to others (Scheduler).
+
+## In-Process Job Runner
+
+```mermaid
+sequenceDiagram
+    participant CLI component
+    participant JobRunner
+    participant DB
+
+    activate CLI component
+    CLI component-->>DB: Create Session
+
+    activate DB
+
+    CLI component->>DB: Create Job
+    DB->>CLI component: Job object
+
+    CLI component->>JobRunner: Create Job Runner
+    JobRunner ->> CLI component: JobRunner object
+
+    CLI component->>JobRunner: Run Job
+
+    activate JobRunner
+
+    JobRunner->>DB: prepare_for_execution [Job]
+    DB->>JobRunner: prepared
+
+    par
+        JobRunner->>JobRunner: execute_job
+    and
+        JobRunner->>DB: access DB (Variables/Connections etc.)
+        DB ->> JobRunner: returned data
+    and
+        JobRunner-->>DB: create heartbeat session
+        Note over DB: Note: During heartbeat<br> two DB sessions <br>are opened in parallel(!)
+        JobRunner->>DB: perform_heartbeat [Job]
+        JobRunner ->> JobRunner: Heartbeat Callback [Job]
+        DB ->> JobRunner: heartbeat response
+        DB -->> JobRunner: close heartbeat session
+    end
+
+    JobRunner->>DB: complete_execution [Job]
+    DB ->> JobRunner: completed
+
+    JobRunner ->> CLI component: completed
+    deactivate JobRunner
+
+    deactivate DB
+    deactivate CLI component
+```
+
+## Internal API Job Runner (WIP)
+
+```mermaid
+sequenceDiagram
+    participant CLI component
+    participant JobRunner
+    participant Internal API
+    participant DB
+
+    activate CLI component
+
+
+    CLI component->>Internal API: Create Job
+    Internal API-->>DB: Create Session
+    activate DB
+    Internal API ->> DB: Create Job
+    DB ->> Internal API: Job object
+    DB --> Internal API: Close Session
+    deactivate DB
+
+    Internal API->>CLI component: JobPydantic object
+
+    CLI component->>JobRunner: Create Job Runner
+    JobRunner ->> CLI component: JobRunner object
+
+    CLI component->>JobRunner: Run Job
+
+    activate JobRunner
+
+    JobRunner->>Internal API: prepare_for_execution [JobPydantic]
+
+    Internal API-->>DB: Create Session
+    activate DB
+    Internal API ->> DB: prepare_for_execution [Job]
+    DB->>Internal API: prepared
+    DB-->>Internal API: Close Session
+    deactivate DB
+    Internal API->>JobRunner: prepared
+
+    par
+        JobRunner->>JobRunner: execute_job
+    and
+        JobRunner ->> Internal API: access DB (Variables/Connections etc.)
+        Internal API-->>DB: Create Session
+        activate DB
+        Internal API ->> DB: access DB (Variables/Connections etc.)
+        DB ->> Internal API: returned data
+        DB-->>Internal API: Close Session
+        deactivate DB
+        Internal API ->> JobRunner: returned data
+    and
+        JobRunner->>Internal API: perform_heartbeat <br> [Job Pydantic]
+        Internal API-->>DB: Create Session
+        activate DB
+        Internal API->>DB: perform_heartbeat [Job]
+        Internal API ->> Internal API: Heartbeat Callback [Job]
+        DB ->> Internal API: heartbeat response
+        Internal API ->> JobRunner: heartbeat response
+        DB-->>Internal API: Close Session
+        deactivate DB
+    end
+
+    JobRunner->>Internal API: complete_execution  <br> [Job Pydantic]
+    Internal API-->>DB: Create Session
+    Internal API->>DB: complete_execution [Job]
+    activate DB
+    DB ->> Internal API: completed
+    DB-->>Internal API: Close Session
+    deactivate DB
+    Internal API->>JobRunner: completed
+    JobRunner ->> CLI component: completed
+
+    deactivate JobRunner
+
+    deactivate CLI component
+```

--- a/airflow/jobs/JOB_LIFECYCLE.md
+++ b/airflow/jobs/JOB_LIFECYCLE.md
@@ -27,7 +27,7 @@ the job is run remotely and communicates via internal API (this part is a work-i
 will keep on updating these lifecycle diagrams).
 
 Those chart apply to all kinds of CLI components Airflow runs (Scheduler, DagFileProcessor, Triggerer,
-Worker) that can run the job. The AIP-44 implementation is not yet complete, but when complete it will
+Worker) that run a job. The AIP-44 implementation is not yet complete, but when complete it will
 apply to some of the components (DagFileProcessor, Triggerer, Worker) and not to others (Scheduler).
 
 ## In-Process Job Runner

--- a/airflow/jobs/JOB_LIFECYCLE.md
+++ b/airflow/jobs/JOB_LIFECYCLE.md
@@ -26,7 +26,7 @@ the code and it might execute either in-process when direct database is used, or
 the job is run remotely and communicates via internal API (this part is a work-in-progress and we
 will keep on updating these lifecycle diagrams).
 
-Those chart apply to all kinds of CLI components Airflow runs (Scheduler, DagFileProcessor, Triggerer,
+This apply to all of the CLI components Airflow runs (Scheduler, DagFileProcessor, Triggerer,
 Worker) that run a job. The AIP-44 implementation is not yet complete, but when complete it will
 apply to some of the components (DagFileProcessor, Triggerer, Worker) and not to others (Scheduler).
 

--- a/airflow/jobs/JOB_LIFECYCLE.md
+++ b/airflow/jobs/JOB_LIFECYCLE.md
@@ -17,7 +17,7 @@
  under the License.
  -->
 
-Those sequence diagrams explain what is the lifecycle of the Job with relation to the database
+These sequence diagrams explain the lifecycle of a Job with relation to the database
 operation in the context of the internal API of Airflow.
 
 As part of AIP-44 implementation we separated the ORM Job instance from the code the job runs,

--- a/airflow/jobs/JOB_LIFECYCLE.md
+++ b/airflow/jobs/JOB_LIFECYCLE.md
@@ -24,7 +24,7 @@ As part of AIP-44 implementation we separated the ORM Job instance from the code
 introducing a concept of Job Runners. The Job Runner is a class that is responsible for running
 the code and it might execute either in-process when direct database is used, or remotely when
 the job is run remotely and communicates via internal API (this part is a work-in-progress and we
-will keep on updating the state.
+will keep on updating these lifecycle diagrams).
 
 Those chart apply to all kinds of CLI components Airflow runs (Scheduler, DagFileProcessor, Triggerer,
 Worker) that can run the job. The AIP-44 implementation is not yet complete, but when complete it will

--- a/airflow/jobs/backfill_job_runner.py
+++ b/airflow/jobs/backfill_job_runner.py
@@ -38,7 +38,7 @@ from airflow.exceptions import (
 )
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job_runner import BaseJobRunner
-from airflow.jobs.job import Job
+from airflow.jobs.job import Job, perform_heartbeat
 from airflow.models import DAG, DagPickle
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
@@ -632,7 +632,7 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
             except (NoAvailablePoolSlot, DagConcurrencyLimitReached, TaskConcurrencyLimitReached) as e:
                 self.log.debug(e)
 
-            self.job.heartbeat(only_if_necessary=is_unit_test)
+            perform_heartbeat(job=self.job, only_if_necessary=is_unit_test)
             # execute the tasks in the queue
             executor.heartbeat()
 

--- a/airflow/jobs/job.py
+++ b/airflow/jobs/job.py
@@ -305,7 +305,6 @@ def execute_job(job: Job | JobPydantic) -> int | None:
        the runner should not modify the job state.
 
     :meta private:
-
     """
     ret = None
     try:

--- a/airflow/jobs/job.py
+++ b/airflow/jobs/job.py
@@ -156,7 +156,8 @@ class Job(Base, LoggingMixin):
     def on_kill(self):
         """Will be called when an external kill command is received."""
 
-    def heartbeat(self, only_if_necessary: bool = False) -> None:
+    @provide_session
+    def heartbeat(self, session: Session = NEW_SESSION) -> None:
         """
         Heartbeats update the job's entry in the database with a timestamp
         for the latest_heartbeat and allows for the job to be killed
@@ -175,25 +176,16 @@ class Job(Base, LoggingMixin):
         heart rate. If you go over 60 seconds before calling it, it won't
         sleep at all.
 
-        :param only_if_necessary: If the heartbeat is not yet due then do
-            nothing (don't update column, don't call ``heartbeat_callback``)
         """
-        seconds_remaining = 0
-        if self.latest_heartbeat:
-            seconds_remaining = self.heartrate - (timezone.utcnow() - self.latest_heartbeat).total_seconds()
-
-        if seconds_remaining > 0 and only_if_necessary:
-            return
-
         previous_heartbeat = self.latest_heartbeat
 
         try:
-            with create_session() as session:
-                # This will cause it to load from the db
-                session.merge(self)
-                previous_heartbeat = self.latest_heartbeat
+            # This will cause it to load from the db
+            session.merge(self)
+            previous_heartbeat = self.latest_heartbeat
 
             if self.state in State.terminating_states:
+                # TODO: Make sure it is AIP-44 compliant
                 self.kill()
 
             # Figure out how long to sleep for
@@ -222,34 +214,23 @@ class Job(Base, LoggingMixin):
             # We didn't manage to heartbeat, so make sure that the timestamp isn't updated
             self.latest_heartbeat = previous_heartbeat
 
-    def run(self) -> int | None:
-        """Starts the job."""
+    @provide_session
+    def prepare_for_execution(self, session: Session = NEW_SESSION):
+        """Prepares the job for execution."""
         Stats.incr(self.__class__.__name__.lower() + "_start", 1, 1)
-        # Adding an entry in the DB
-        ret = None
-        with create_session() as session:
-            self.state = State.RUNNING
-            session.add(self)
-            session.commit()
-            make_transient(self)
-            try:
-                ret = self.job_runner._execute()
-                # In case of max runs or max duration
-                self.state = State.SUCCESS
-            except SystemExit:
-                # In case of ^C or SIGTERM
-                self.state = State.SUCCESS
-            except Exception:
-                self.state = State.FAILED
-                raise
-            finally:
-                get_listener_manager().hook.before_stopping(component=self)
-                self.end_date = timezone.utcnow()
-                session.merge(self)
-                session.commit()
+        self.state = State.RUNNING
+        self.start_date = timezone.utcnow()
+        session.add(self)
+        session.commit()
+        make_transient(self)
 
+    @provide_session
+    def complete_execution(self, session: Session = NEW_SESSION):
+        get_listener_manager().hook.before_stopping(component=self)
+        self.end_date = timezone.utcnow()
+        session.merge(self)
+        session.commit()
         Stats.incr(self.__class__.__name__.lower() + "_end", 1, 1)
-        return ret
 
     @property
     def job_runner(self) -> BaseJobRunner:
@@ -260,15 +241,6 @@ class Job(Base, LoggingMixin):
     def most_recent_job(self, session: Session = NEW_SESSION) -> Job | None:
         """Returns the most recent job of this type, if any, based on last heartbeat received."""
         return most_recent_job(self.job_type, session=session)
-
-
-@provide_session
-def perform_heartbeat(job: Job | JobPydantic, only_if_necessary: bool, session: Session = NEW_SESSION):
-    if isinstance(job, Job):
-        job.heartbeat()
-    else:
-        # TODO (potiuk): Make it works over internal API as a follow up
-        Job.get(job.id, session=session).heartbeat(only_if_necessary=only_if_necessary)
 
 
 @provide_session
@@ -292,3 +264,79 @@ def most_recent_job(job_type: str, session: Session = NEW_SESSION) -> Job | None
         )
         .first()
     )
+
+
+@provide_session
+def run_job(job: Job | JobPydantic, session: Session = NEW_SESSION) -> int | None:
+    """
+    Runs the job. The Job is always an ORM object and setting the state is happening within the
+    same DB session and the session is kept open throughout the whole execution
+
+    :meta private:
+
+    TODO: Maybe we should not keep the session during job execution ?.
+    """
+    # The below assert is a temporary one, to make MyPy happy with partial AIP-44 work - we will remove it
+    # once final AIP-44 changes are completed.
+    assert isinstance(job, Job), "Job should be ORM object not Pydantic one here (AIP-44 WIP)"
+    job.prepare_for_execution(session=session)
+    try:
+        return execute_job(job)
+    finally:
+        job.complete_execution(session=session)
+
+
+def execute_job(job: Job | JobPydantic) -> int | None:
+    """
+    Executes the job.
+
+    Job execution requires no session as generally executing session does not require an
+    active database connection. The session might be temporary acquired and used if the job
+    runs heartbeat during execution, but this connection is only acquired for the time of heartbeat
+    and in case of AIP-44 implementation it happens over the Internal API rather than directly via
+    the database.
+
+    After the job is completed, state of the Job is updated and it should be updated in the database,
+    which happens in the "complete_execution" step (which again can be executed locally in case of
+    database operations or over the Internal API call.
+
+    :param job: Job to execute - it can be either DB job or it's Pydantic serialized version. It does
+       not really matter, because except of running the heartbeat and state setting,
+       the runner should not modify the job state.
+
+    :meta private:
+
+    """
+    ret = None
+    try:
+        # This job_runner reference and type-ignore will be removed by further refactoring step
+        ret = job.job_runner._execute()  # type:ignore[union-attr]
+        # In case of max runs or max duration
+        job.state = State.SUCCESS
+    except SystemExit:
+        # In case of ^C or SIGTERM
+        job.state = State.SUCCESS
+    except Exception:
+        job.state = State.FAILED
+        raise
+    return ret
+
+
+def perform_heartbeat(job: Job | JobPydantic, only_if_necessary: bool) -> None:
+    """
+    Performs heartbeat for the Job passed to it,optionally checking if it is necessary.
+
+    :param job: job to perform heartbeat for
+    :param only_if_necessary: only heartbeat if it is necessary (i.e. if there are things to run for
+        triggerer for example)
+    """
+    # The below assert is a temporary one, to make MyPy happy with partial AIP-44 work - we will remove it
+    # once final AIP-44 changes are completed.
+    assert isinstance(job, Job), "Job should be ORM object not Pydantic one here (AIP-44 WIP)"
+    seconds_remaining: float = 0.0
+    if job.latest_heartbeat and job.heartrate:
+        seconds_remaining = job.heartrate - (timezone.utcnow() - job.latest_heartbeat).total_seconds()
+    if seconds_remaining > 0 and only_if_necessary:
+        return
+    with create_session() as session:
+        job.heartbeat(session=session)

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -43,7 +43,7 @@ from airflow.configuration import conf
 from airflow.exceptions import RemovedInAirflow3Warning
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job_runner import BaseJobRunner
-from airflow.jobs.job import Job
+from airflow.jobs.job import Job, perform_heartbeat
 from airflow.models.dag import DAG, DagModel
 from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun
@@ -915,7 +915,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     self.processor_agent.heartbeat()
 
                 # Heartbeat the scheduler periodically
-                self.job.heartbeat(only_if_necessary=True)
+                perform_heartbeat(job=self.job, only_if_necessary=True)
 
                 # Run any pending timed events
                 next_event = timers.run(blocking=False)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -74,6 +74,7 @@ from airflow.exceptions import (
     RemovedInAirflow3Warning,
     TaskNotFound,
 )
+from airflow.jobs.job import run_job
 from airflow.models.abstractoperator import AbstractOperator
 from airflow.models.base import Base, StringID
 from airflow.models.dagcode import DagCode
@@ -2488,7 +2489,7 @@ class DAG(LoggingMixin):
             ),
             executor=executor,
         )
-        job.run()
+        run_job(job)
 
     def cli(self):
         """Exposes a CLI specific to this DAG"""

--- a/dev/perf/scheduler_dag_execution_timing.py
+++ b/dev/perf/scheduler_dag_execution_timing.py
@@ -28,6 +28,8 @@ from operator import attrgetter
 
 import rich_click as click
 
+from airflow.jobs.job import run_job
+
 MAX_DAG_RUNS_ALLOWED = 1
 
 
@@ -291,7 +293,7 @@ def main(num_runs, repeat, pre_create_dag_runs, executor_class, dag_ids):
 
     # Need a lambda to refer to the _latest_ value for scheduler_job, not just
     # the initial one
-    code_to_test = lambda: scheduler_job.run()
+    code_to_test = lambda: run_job(scheduler_job)
 
     for count in range(repeat):
         gc.disable()

--- a/dev/perf/sql_queries.py
+++ b/dev/perf/sql_queries.py
@@ -23,7 +23,7 @@ from typing import NamedTuple
 
 import pandas as pd
 
-from airflow.jobs.job import Job
+from airflow.jobs.job import Job, run_job
 
 # Setup environment before any Airflow import
 DAG_FOLDER = os.path.join(os.path.dirname(__file__), "dags")
@@ -124,7 +124,7 @@ def run_scheduler_job(with_db_reset=False) -> None:
 
     if with_db_reset:
         reset_db()
-    Job(job_runner=SchedulerJobRunner(subdir=DAG_FOLDER, do_pickle=False, num_runs=3)).run()
+    run_job(Job(job_runner=SchedulerJobRunner(subdir=DAG_FOLDER, do_pickle=False, num_runs=3)))
 
 
 def is_query(line: str) -> bool:

--- a/tests/core/test_impersonation_tests.py
+++ b/tests/core/test_impersonation_tests.py
@@ -25,7 +25,7 @@ import sys
 import pytest
 
 from airflow.jobs.backfill_job_runner import BackfillJobRunner
-from airflow.jobs.job import Job
+from airflow.jobs.job import Job, run_job
 from airflow.models import DagBag, DagRun, TaskInstance
 from airflow.utils.db import add_default_pool_if_not_exists
 from airflow.utils.state import State
@@ -113,7 +113,7 @@ class BaseImpersonationTest:
         dag = self.dagbag.get_dag(dag_id)
         dag.clear()
 
-        Job(job_runner=BackfillJobRunner(dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)).run()
+        run_job(Job(job_runner=BackfillJobRunner(dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)))
         run_id = DagRun.generate_run_id(DagRunType.BACKFILL_JOB, execution_date=DEFAULT_DATE)
         ti = TaskInstance(task=dag.get_task(task_id), run_id=run_id)
         ti.refresh_from_db()

--- a/tests/executors/test_dask_executor.py
+++ b/tests/executors/test_dask_executor.py
@@ -26,7 +26,7 @@ from distributed import LocalCluster
 from airflow.exceptions import AirflowException
 from airflow.executors.dask_executor import DaskExecutor
 from airflow.jobs.backfill_job_runner import BackfillJobRunner
-from airflow.jobs.job import Job
+from airflow.jobs.job import Job, run_job
 from airflow.models import DagBag
 from airflow.utils import timezone
 from tests.test_utils.config import conf_vars
@@ -117,7 +117,7 @@ class TestDaskExecutor(TestBaseDask):
             ),
             executor=DaskExecutor(cluster_address=self.cluster.scheduler_address),
         )
-        job.run()
+        run_job(job)
 
     def teardown_method(self):
         self.cluster.close(timeout=5)

--- a/tests/listeners/test_listeners.py
+++ b/tests/listeners/test_listeners.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import pytest as pytest
 
 from airflow import AirflowException
-from airflow.jobs.job import Job
+from airflow.jobs.job import Job, run_job
 from airflow.listeners.listener import get_listener_manager
 from airflow.operators.bash import BashOperator
 from airflow.utils import timezone
@@ -82,7 +82,7 @@ def test_multiple_listeners(create_task_instance, session=None):
 
     job = Job(job_runner=MockJobRunner())
     try:
-        job.run()
+        run_job(job)
     except NotImplementedError:
         pass  # just for lifecycle
 


### PR DESCRIPTION
As a follow-up after decoupling of the job logic from the BaseJob
ORM object (#30255), the `run` method of BaseJob should also be
decoupled from it (allowing BaseJobPydantic to be passed) as well
as split into three steps, in order to allow db-less mode.

The "prepare" and "complete" steps of the `run` method are modifying
BaseJob ORM-mapped object, so they should be called over the
internal-api from LocalTask, DafFileProcessor and Triggerer running
in db-less mode. The "execute" method however does not need the
database however and should be run locally.

This is not yet full AIP-44 conversion, this is a prerequisite to do
so - and AIP-44 conversion will be done as a follow-up after this one.

Closes: #30295

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
