### PR TITLE
In `DockerOperator`, adding an attribute `tls_verify` to choose whether to validate certificate (#30309)

### DIFF
--- a/airflow/providers/docker/hooks/docker.py
+++ b/airflow/providers/docker/hooks/docker.py
@@ -87,7 +87,7 @@ class DockerHook(BaseHook):
         ca_cert: str | None = None,
         client_cert: str | None = None,
         client_key: str | None = None,
-        verify: bool | None = None,
+        verify: bool = True,
         assert_hostname: str | bool | None = None,
         ssl_version: str | None = None,
     ) -> TLSConfig | bool:

--- a/airflow/providers/docker/hooks/docker.py
+++ b/airflow/providers/docker/hooks/docker.py
@@ -87,6 +87,7 @@ class DockerHook(BaseHook):
         ca_cert: str | None = None,
         client_cert: str | None = None,
         client_key: str | None = None,
+        verify: bool | None = None,
         assert_hostname: str | bool | None = None,
         ssl_version: str | None = None,
     ) -> TLSConfig | bool:
@@ -96,6 +97,7 @@ class DockerHook(BaseHook):
         :param ca_cert: Path to a PEM-encoded CA (Certificate Authority) certificate file.
         :param client_cert: Path to PEM-encoded certificate file.
         :param client_key: Path to PEM-encoded key file.
+        :param verify: Set ``True`` to verify the validity of the provided certificate.
         :param assert_hostname: Hostname to match against the docker server certificate
             or ``False`` to disable the check.
         :param ssl_version: Version of SSL to use when communicating with docker daemon.
@@ -106,7 +108,7 @@ class DockerHook(BaseHook):
             return TLSConfig(
                 ca_cert=ca_cert,
                 client_cert=(client_cert, client_key),
-                verify=True,
+                verify=verify,
                 ssl_version=ssl_version,
                 assert_hostname=assert_hostname,
             )

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -187,7 +187,7 @@ class DockerOperator(BaseOperator):
         tls_ca_cert: str | None = None,
         tls_client_cert: str | None = None,
         tls_client_key: str | None = None,
-        tls_verify: bool | None = None,
+        tls_verify: bool = True,
         tls_hostname: str | bool | None = None,
         tls_ssl_version: str | None = None,
         mount_tmp_dir: bool = True,

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -112,6 +112,7 @@ class DockerOperator(BaseOperator):
     :param tls_client_cert: Path to the PEM-encoded certificate
         used to authenticate docker client.
     :param tls_client_key: Path to the PEM-encoded key used to authenticate docker client.
+    :param tls_verify: Set ``True`` to verify the validity of the provided certificate.
     :param tls_hostname: Hostname to match against
         the docker server certificate or False to disable the check.
     :param tls_ssl_version: Version of SSL to use when communicating with docker daemon.
@@ -186,6 +187,7 @@ class DockerOperator(BaseOperator):
         tls_ca_cert: str | None = None,
         tls_client_cert: str | None = None,
         tls_client_key: str | None = None,
+        tls_verify: bool | None = None,
         tls_hostname: str | bool | None = None,
         tls_ssl_version: str | None = None,
         mount_tmp_dir: bool = True,
@@ -248,6 +250,7 @@ class DockerOperator(BaseOperator):
         self.tls_ca_cert = tls_ca_cert
         self.tls_client_cert = tls_client_cert
         self.tls_client_key = tls_client_key
+        self.tls_verify = tls_verify
         self.tls_hostname = tls_hostname
         self.tls_ssl_version = tls_ssl_version
         self.mount_tmp_dir = mount_tmp_dir
@@ -282,6 +285,7 @@ class DockerOperator(BaseOperator):
             ca_cert=self.tls_ca_cert,
             client_cert=self.tls_client_cert,
             client_key=self.tls_client_key,
+            verify=self.tls_verify,
             assert_hostname=self.tls_hostname,
             ssl_version=self.tls_ssl_version,
         )

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -66,7 +66,7 @@ def test_hook_usage(docker_hook_patcher, docker_conn_id, tls_params: dict):
         "ca_cert": tls_params.get("tls_ca_cert"),
         "client_cert": tls_params.get("tls_client_cert"),
         "client_key": tls_params.get("tls_client_key"),
-        "verify": tls_params.get("tls_verify") or True,
+        "verify": tls_params.get("tls_verify", True),
         "assert_hostname": tls_params.get("tls_hostname"),
         "ssl_version": tls_params.get("tls_ssl_version"),
     }

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -51,6 +51,7 @@ TEMPDIR_MOCK_RETURN_VALUE = "/mkdtemp"
                 "tls_ca_cert": "foo",
                 "tls_client_cert": "bar",
                 "tls_client_key": "spam",
+                "tls_verify": True,
                 "tls_hostname": "egg",
                 "tls_ssl_version": "super-secure",
             },
@@ -65,6 +66,7 @@ def test_hook_usage(docker_hook_patcher, docker_conn_id, tls_params: dict):
         "ca_cert": tls_params.get("tls_ca_cert"),
         "client_cert": tls_params.get("tls_client_cert"),
         "client_key": tls_params.get("tls_client_key"),
+        "verify": tls_params.get("tls_verify"),
         "assert_hostname": tls_params.get("tls_hostname"),
         "ssl_version": tls_params.get("tls_ssl_version"),
     }

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -66,7 +66,7 @@ def test_hook_usage(docker_hook_patcher, docker_conn_id, tls_params: dict):
         "ca_cert": tls_params.get("tls_ca_cert"),
         "client_cert": tls_params.get("tls_client_cert"),
         "client_key": tls_params.get("tls_client_key"),
-        "verify": tls_params.get("tls_verify"),
+        "verify": tls_params.get("tls_verify") or True,
         "assert_hostname": tls_params.get("tls_hostname"),
         "ssl_version": tls_params.get("tls_ssl_version"),
     }


### PR DESCRIPTION
I think it would be nice to add an option (`tls_verify`) to choose whether or not to validate the provided certificate. 

closes: #30309 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
