### PR TITLE
Reformat chart templates part 3

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -86,7 +86,7 @@ spec:
   hostAliases: {{- toYaml .Values.workers.hostAliases | nindent 4 }}
   {{- end }}
   restartPolicy: Never
-  securityContext: {{- $securityContext | nindent 4 }}
+  securityContext: {{ $securityContext | nindent 4 }}
   nodeSelector: {{- toYaml $nodeSelector | nindent 4 }}
   affinity: {{- toYaml $affinity | nindent 4 }}
   tolerations: {{- toYaml $tolerations | nindent 4 }}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -33,7 +33,6 @@ If release name contains chart name it will be used as a full name.
   {{- end }}
 {{- end }}
 
-
 {{/* Standard Airflow environment variables */}}
 {{- define "standard_airflow_environment" }}
   # Hard Coded Airflow Envs
@@ -147,7 +146,7 @@ If release name contains chart name it will be used as a full name.
   # Extra env
   {{- $Global := . }}
   {{- with .Values.extraEnv }}
-  {{- tpl . $Global | nindent 2 }}
+    {{- tpl . $Global | nindent 2 }}
   {{- end }}
 {{- end }}
 
@@ -155,12 +154,12 @@ If release name contains chart name it will be used as a full name.
 {{- define "custom_airflow_environment_from" }}
   {{- $Global := . }}
   {{- with .Values.extraEnvFrom }}
-  {{- tpl . $Global | nindent 2 }}
+    {{- tpl . $Global | nindent 2 }}
   {{- end }}
 {{- end }}
 
 {{/*  Git ssh key volume */}}
-{{- define "git_sync_ssh_key_volume"}}
+{{- define "git_sync_ssh_key_volume" }}
 - name: git-sync-ssh-key
   secret:
     secretName: {{ .Values.dags.gitSync.sshKeySecret }}
@@ -168,11 +167,11 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*  Git sync container */}}
-{{- define "git_sync_container"}}
+{{- define "git_sync_container" }}
 - name: {{ .Values.dags.gitSync.containerName }}{{ if .is_init }}-init{{ end }}
   image: {{ template "git_sync_image" . }}
   imagePullPolicy: {{ .Values.images.gitSync.pullPolicy }}
-  securityContext: {{ include "localSecurityContext" .Values.dags.gitSync | nindent 4 }}
+  securityContext: {{- include "localSecurityContext" .Values.dags.gitSync | nindent 4 }}
   env:
     {{- if .Values.dags.gitSync.sshKeySecret }}
     - name: GIT_SSH_KEY_FILE
@@ -242,117 +241,117 @@ If release name contains chart name it will be used as a full name.
     subPath: known_hosts
   {{- end }}
   {{- end }}
-{{- if .Values.dags.gitSync.extraVolumeMounts }}
-{{ toYaml .Values.dags.gitSync.extraVolumeMounts | indent 2 }}
-{{- end }}
-{{- end }}
-
-# This helper will change when customers deploy a new image.
-{{ define "airflow_image" -}}
-{{ printf "%s:%s" (.Values.images.airflow.repository | default .Values.defaultAirflowRepository) (.Values.images.airflow.tag | default .Values.defaultAirflowTag) }}
+  {{- if .Values.dags.gitSync.extraVolumeMounts }}
+    {{- toYaml .Values.dags.gitSync.extraVolumeMounts | nindent 2 }}
+  {{- end }}
 {{- end }}
 
-{{ define "pod_template_image" -}}
-{{ printf "%s:%s" (.Values.images.pod_template.repository | default .Values.defaultAirflowRepository) (.Values.images.pod_template.tag | default .Values.defaultAirflowTag) }}
+{{/* This helper will change when customers deploy a new image */}}
+{{- define "airflow_image" -}}
+  {{- printf "%s:%s" (.Values.images.airflow.repository | default .Values.defaultAirflowRepository) (.Values.images.airflow.tag | default .Values.defaultAirflowTag) }}
 {{- end }}
 
-# This helper is used for airflow containers that do not need the users code.
-{{ define "default_airflow_image" -}}
-{{ printf "%s:%s" .Values.defaultAirflowRepository .Values.defaultAirflowTag }}
+{{- define "pod_template_image" -}}
+  {{- printf "%s:%s" (.Values.images.pod_template.repository | default .Values.defaultAirflowRepository) (.Values.images.pod_template.tag | default .Values.defaultAirflowTag) }}
+{{- end }}
+
+{{/* This helper is used for airflow containers that do not need the users code */}}
+{{- define "default_airflow_image" -}}
+  {{- printf "%s:%s" .Values.defaultAirflowRepository .Values.defaultAirflowTag }}
 {{- end }}
 
 {{ define "airflow_image_for_migrations" -}}
-{{- if .Values.images.useDefaultImageForMigration -}}
-{{ template "default_airflow_image" . }}
-{{- else -}}
-{{ template "airflow_image" . }}
-{{- end -}}
+  {{- if .Values.images.useDefaultImageForMigration }}
+    {{- template "default_airflow_image" . }}
+  {{- else }}
+    {{- template "airflow_image" . }}
+  {{- end }}
 {{- end }}
 
-{{ define "flower_image" -}}
-{{ printf "%s:%s" (.Values.images.flower.repository | default .Values.defaultAirflowRepository) (.Values.images.flower.tag | default .Values.defaultAirflowTag) }}
+{{- define "flower_image" -}}
+  {{- printf "%s:%s" (.Values.images.flower.repository | default .Values.defaultAirflowRepository) (.Values.images.flower.tag | default .Values.defaultAirflowTag) }}
 {{- end }}
 
-{{ define "statsd_image" -}}
-{{ printf "%s:%s" .Values.images.statsd.repository .Values.images.statsd.tag }}
+{{- define "statsd_image" -}}
+  {{- printf "%s:%s" .Values.images.statsd.repository .Values.images.statsd.tag }}
 {{- end }}
 
-{{ define "redis_image" -}}
-{{ printf "%s:%s" .Values.images.redis.repository .Values.images.redis.tag }}
+{{- define "redis_image" -}}
+  {{- printf "%s:%s" .Values.images.redis.repository .Values.images.redis.tag }}
 {{- end }}
 
-{{ define "pgbouncer_image" -}}
-{{ printf "%s:%s" .Values.images.pgbouncer.repository .Values.images.pgbouncer.tag }}
+{{- define "pgbouncer_image" -}}
+  {{- printf "%s:%s" .Values.images.pgbouncer.repository .Values.images.pgbouncer.tag }}
 {{- end }}
 
-{{ define "pgbouncer_exporter_image" -}}
-{{ printf "%s:%s" .Values.images.pgbouncerExporter.repository .Values.images.pgbouncerExporter.tag }}
+{{- define "pgbouncer_exporter_image" -}}
+  {{- printf "%s:%s" .Values.images.pgbouncerExporter.repository .Values.images.pgbouncerExporter.tag }}
 {{- end }}
 
-{{ define "git_sync_image" -}}
-{{ printf "%s:%s" .Values.images.gitSync.repository .Values.images.gitSync.tag }}
+{{- define "git_sync_image" -}}
+  {{- printf "%s:%s" .Values.images.gitSync.repository .Values.images.gitSync.tag }}
 {{- end }}
 
-{{ define "fernet_key_secret" -}}
-{{ default (printf "%s-fernet-key" .Release.Name) .Values.fernetKeySecretName }}
+{{- define "fernet_key_secret" -}}
+  {{- default (printf "%s-fernet-key" .Release.Name) .Values.fernetKeySecretName }}
 {{- end }}
 
-{{ define "webserver_secret_key_secret" -}}
-{{ default (printf "%s-webserver-secret-key" .Release.Name) .Values.webserverSecretKeySecretName }}
+{{- define "webserver_secret_key_secret" -}}
+  {{- default (printf "%s-webserver-secret-key" .Release.Name) .Values.webserverSecretKeySecretName }}
 {{- end }}
 
-{{ define "redis_password_secret" -}}
-{{ default (printf "%s-redis-password" .Release.Name) .Values.redis.passwordSecretName }}
+{{- define "redis_password_secret" -}}
+  {{- default (printf "%s-redis-password" .Release.Name) .Values.redis.passwordSecretName }}
 {{- end }}
 
-{{ define "airflow_metadata_secret" -}}
-{{ default (printf "%s-airflow-metadata" .Release.Name) .Values.data.metadataSecretName }}
+{{- define "airflow_metadata_secret" -}}
+  {{- default (printf "%s-airflow-metadata" .Release.Name) .Values.data.metadataSecretName }}
 {{- end }}
 
-{{ define "airflow_result_backend_secret" -}}
-{{ default (printf "%s-airflow-result-backend" .Release.Name) .Values.data.resultBackendSecretName }}
+{{- define "airflow_result_backend_secret" -}}
+  {{- default (printf "%s-airflow-result-backend" .Release.Name) .Values.data.resultBackendSecretName }}
 {{- end }}
 
-{{ define "airflow_pod_template_file" -}}
-{{ (printf "%s/pod_templates" .Values.airflowHome) }}
+{{- define "airflow_pod_template_file" -}}
+  {{- printf "%s/pod_templates" .Values.airflowHome }}
 {{- end }}
 
-{{ define "pgbouncer_config_secret" -}}
-{{ default (printf "%s-pgbouncer-config" .Release.Name) .Values.pgbouncer.configSecretName }}
+{{- define "pgbouncer_config_secret" -}}
+  {{- default (printf "%s-pgbouncer-config" .Release.Name) .Values.pgbouncer.configSecretName }}
 {{- end }}
 
-{{ define "pgbouncer_certificates_secret" -}}
-{{ .Release.Name }}-pgbouncer-certificates
+{{- define "pgbouncer_certificates_secret" -}}
+  {{- printf "%s-pgbouncer-certificates" .Release.Name }}
 {{- end }}
 
-{{ define "pgbouncer_stats_secret" -}}
-{{ .Release.Name }}-pgbouncer-stats
+{{- define "pgbouncer_stats_secret" -}}
+  {{- printf "%s-pgbouncer-stats" .Release.Name }}
 {{- end }}
 
-{{ define "registry_secret" -}}
-{{ default (printf "%s-registry" .Release.Name) .Values.registry.secretName }}
+{{- define "registry_secret" -}}
+  {{- default (printf "%s-registry" .Release.Name) .Values.registry.secretName }}
 {{- end }}
 
-{{ define "elasticsearch_secret" -}}
-{{ default (printf "%s-elasticsearch" .Release.Name) .Values.elasticsearch.secretName }}
+{{- define "elasticsearch_secret" -}}
+  {{- default (printf "%s-elasticsearch" .Release.Name) .Values.elasticsearch.secretName }}
 {{- end }}
 
-{{ define "flower_secret" -}}
-{{ default (printf "%s-flower" .Release.Name) .Values.flower.secretName }}
+{{- define "flower_secret" -}}
+  {{- default (printf "%s-flower" .Release.Name) .Values.flower.secretName }}
 {{- end }}
 
-{{ define "kerberos_keytab_secret" -}}
-{{ .Release.Name }}-kerberos-keytab
+{{- define "kerberos_keytab_secret" -}}
+  {{- printf "%s-kerberos-keytab" .Release.Name }}
 {{- end }}
 
-{{ define "kerberos_ccache_path" -}}
-{{ printf "%s/%s" .Values.kerberos.ccacheMountPath .Values.kerberos.ccacheFileName }}
+{{- define "kerberos_ccache_path" -}}
+  {{- printf "%s/%s" .Values.kerberos.ccacheMountPath .Values.kerberos.ccacheFileName }}
 {{- end }}
 
-{{ define "pgbouncer_config" }}
-{{- $resultBackendConnection := .Values.data.resultBackendConnection | default .Values.data.metadataConnection }}
-{{- $pgMetadataHost := .Values.data.metadataConnection.host | default (printf "%s-%s.%s" .Release.Name "postgresql" .Release.Namespace) }}
-{{- $pgResultBackendHost := $resultBackendConnection.host | default (printf "%s-%s.%s" .Release.Name "postgresql" .Release.Namespace) }}
+{{- define "pgbouncer_config" -}}
+{{ $resultBackendConnection := .Values.data.resultBackendConnection | default .Values.data.metadataConnection }}
+{{ $pgMetadataHost := .Values.data.metadataConnection.host | default (printf "%s-%s.%s" .Release.Name "postgresql" .Release.Namespace) }}
+{{ $pgResultBackendHost := $resultBackendConnection.host | default (printf "%s-%s.%s" .Release.Name "postgresql" .Release.Namespace) }}
 [databases]
 {{ .Release.Name }}-metadata = host={{ $pgMetadataHost }} dbname={{ .Values.data.metadataConnection.db }} port={{ .Values.data.metadataConnection.port }} pool_size={{ .Values.pgbouncer.metadataPoolSize }} {{ .Values.pgbouncer.extraIniMetadata | default "" }}
 {{ .Release.Name }}-result-backend = host={{ $pgResultBackendHost }} dbname={{ $resultBackendConnection.db }} port={{ $resultBackendConnection.port }} pool_size={{ .Values.pgbouncer.resultBackendPoolSize }} {{ .Values.pgbouncer.extraIniResultBackend | default "" }}
@@ -394,75 +393,75 @@ server_tls_key_file = /etc/pgbouncer/server.key
 {{ $resultBackendConnection.user | quote }} {{ $resultBackendConnection.pass | quote }}
 {{- end }}
 
-{{ define "airflow_logs" -}}
-{{ (printf "%s/logs" .Values.airflowHome) | quote }}
+{{- define "airflow_logs" -}}
+  {{- printf "%s/logs" .Values.airflowHome | quote }}
 {{- end }}
 
-{{ define "airflow_logs_no_quote" -}}
-{{ (printf "%s/logs" .Values.airflowHome) }}
+{{- define "airflow_logs_no_quote" -}}
+  {{- printf "%s/logs" .Values.airflowHome }}
 {{- end }}
 
-{{ define "airflow_logs_volume_claim" -}}
-  {{- if .Values.logs.persistence.existingClaim -}}
+{{- define "airflow_logs_volume_claim" -}}
+  {{- if .Values.logs.persistence.existingClaim }}
     {{- .Values.logs.persistence.existingClaim }}
-  {{- else -}}
-    {{- .Release.Name }}-logs
-  {{- end -}}
-{{- end -}}
+  {{- else }}
+    {{- printf "%s-logs" .Release.Name }}
+  {{- end }}
+{{- end }}
 
-{{ define "airflow_dags" -}}
-  {{- if .Values.dags.gitSync.enabled -}}
-    {{- (printf "%s/dags/repo/%s" .Values.airflowHome .Values.dags.gitSync.subPath) }}
-  {{- else -}}
-    {{- (printf "%s/dags" .Values.airflowHome) }}
-  {{- end -}}
-{{- end -}}
+{{- define "airflow_dags" -}}
+  {{- if .Values.dags.gitSync.enabled }}
+    {{- printf "%s/dags/repo/%s" .Values.airflowHome .Values.dags.gitSync.subPath }}
+  {{- else }}
+    {{- printf "%s/dags" .Values.airflowHome }}
+  {{- end }}
+{{- end }}
 
-{{ define "airflow_dags_volume_claim" -}}
-  {{- if .Values.dags.persistence.existingClaim -}}
+{{- define "airflow_dags_volume_claim" -}}
+  {{- if .Values.dags.persistence.existingClaim }}
     {{- .Values.dags.persistence.existingClaim }}
-  {{- else -}}
-    {{- .Release.Name }}-dags
-  {{- end -}}
-{{- end -}}
+  {{- else }}
+    {{- printf "%s-dags" .Release.Name }}
+  {{- end }}
+{{- end }}
 
-{{ define "airflow_dags_mount" -}}
+{{- define "airflow_dags_mount" -}}
 - name: dags
-  mountPath: {{ (printf "%s/dags" .Values.airflowHome) -}}
+  mountPath: {{ printf "%s/dags" .Values.airflowHome }}
   {{- if .Values.dags.persistence.subPath }}
   subPath: {{ .Values.dags.persistence.subPath }}
   {{- end }}
   readOnly: {{ .Values.dags.gitSync.enabled | ternary "True" "False" }}
-{{- end -}}
-
-{{ define "airflow_config_path" -}}
-{{ (printf "%s/airflow.cfg" .Values.airflowHome) | quote }}
 {{- end }}
 
-{{ define "airflow_webserver_config_path" -}}
-{{ (printf "%s/webserver_config.py" .Values.airflowHome) | quote }}
+{{- define "airflow_config_path" -}}
+  {{- printf "%s/airflow.cfg" .Values.airflowHome | quote }}
 {{- end }}
 
-{{ define "airflow_webserver_config_configmap_name" -}}
-{{ default (printf "%s-webserver-config" .Release.Name) .Values.webserver.webserverConfigConfigMapName }}
+{{- define "airflow_webserver_config_path" -}}
+  {{- printf "%s/webserver_config.py" .Values.airflowHome | quote }}
 {{- end }}
 
-{{ define "airflow_webserver_config_mount" -}}
+{{- define "airflow_webserver_config_configmap_name" -}}
+  {{- default (printf "%s-webserver-config" .Release.Name) .Values.webserver.webserverConfigConfigMapName }}
+{{- end }}
+
+{{- define "airflow_webserver_config_mount" -}}
 - name: webserver-config
   mountPath: {{ template "airflow_webserver_config_path" . }}
   subPath: webserver_config.py
   readOnly: True
-{{- end -}}
-
-{{ define "airflow_local_setting_path" -}}
-{{ (printf "%s/config/airflow_local_settings.py" .Values.airflowHome) | quote }}
 {{- end }}
 
-{{ define "airflow_config" -}}
-{{ (printf "%s-airflow-config" .Release.Name) }}
+{{- define "airflow_local_setting_path" -}}
+  {{- printf "%s/config/airflow_local_settings.py" .Values.airflowHome | quote }}
 {{- end }}
 
-{{ define "airflow_config_mount" -}}
+{{- define "airflow_config" -}}
+  {{- printf "%s-airflow-config" .Release.Name }}
+{{- end }}
+
+{{- define "airflow_config_mount" -}}
 - name: config
   mountPath: {{ template "airflow_config_path" . }}
   subPath: airflow.cfg
@@ -473,141 +472,117 @@ server_tls_key_file = /etc/pgbouncer/server.key
   subPath: airflow_local_settings.py
   readOnly: true
   {{- end }}
-{{- end -}}
+{{- end }}
 
-{{/*
-Create the name of the webserver service account to use
-*/}}
+{{/* Create the name of the webserver service account to use */}}
 {{- define "webserver.serviceAccountName" -}}
-{{- if .Values.webserver.serviceAccount.create -}}
-    {{ default (printf "%s-webserver" (include "airflow.fullname" .)) .Values.webserver.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.webserver.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
+  {{- if .Values.webserver.serviceAccount.create }}
+    {{- default (printf "%s-webserver" (include "airflow.fullname" .)) .Values.webserver.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.webserver.serviceAccount.name }}
+  {{- end }}
+{{- end }}
 
-{{/*
-Create the name of the redis service account to use
-*/}}
+{{/* Create the name of the redis service account to use */}}
 {{- define "redis.serviceAccountName" -}}
-{{- if .Values.redis.serviceAccount.create -}}
-    {{ default (printf "%s-redis" (include "airflow.fullname" .)) .Values.redis.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.redis.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
+  {{- if .Values.redis.serviceAccount.create }}
+    {{- default (printf "%s-redis" (include "airflow.fullname" .)) .Values.redis.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.redis.serviceAccount.name }}
+  {{- end }}
+{{- end }}
 
-{{/*
-Create the name of the flower service account to use
-*/}}
+{{/* Create the name of the flower service account to use */}}
 {{- define "flower.serviceAccountName" -}}
-{{- if .Values.flower.serviceAccount.create -}}
-    {{ default (printf "%s-flower" (include "airflow.fullname" .)) .Values.flower.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.flower.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
+  {{- if .Values.flower.serviceAccount.create }}
+    {{- default (printf "%s-flower" (include "airflow.fullname" .)) .Values.flower.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.flower.serviceAccount.name }}
+  {{- end }}
+{{- end }}
 
-{{/*
-Create the name of the scheduler service account to use
-*/}}
+{{/* Create the name of the scheduler service account to use */}}
 {{- define "scheduler.serviceAccountName" -}}
-{{- if .Values.scheduler.serviceAccount.create -}}
-    {{ default (printf "%s-scheduler" (include "airflow.fullname" .)) .Values.scheduler.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.scheduler.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
+  {{- if .Values.scheduler.serviceAccount.create }}
+    {{- default (printf "%s-scheduler" (include "airflow.fullname" .)) .Values.scheduler.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.scheduler.serviceAccount.name }}
+  {{- end }}
+{{- end }}
 
-{{/*
-Create the name of the StatsD service account to use
-*/}}
+{{/* Create the name of the StatsD service account to use */}}
 {{- define "statsd.serviceAccountName" -}}
-{{- if .Values.statsd.serviceAccount.create -}}
-    {{ default (printf "%s-statsd" (include "airflow.fullname" .)) .Values.statsd.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.statsd.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
+  {{- if .Values.statsd.serviceAccount.create }}
+    {{- default (printf "%s-statsd" (include "airflow.fullname" .)) .Values.statsd.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.statsd.serviceAccount.name }}
+  {{- end }}
+{{- end }}
 
-{{/*
-Create the name of the create user job service account to use
-*/}}
+{{/* Create the name of the create user job service account to use */}}
 {{- define "createUserJob.serviceAccountName" -}}
-{{- if .Values.createUserJob.serviceAccount.create -}}
-    {{ default (printf "%s-create-user-job" (include "airflow.fullname" .)) .Values.createUserJob.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.createUserJob.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
+  {{- if .Values.createUserJob.serviceAccount.create }}
+    {{- default (printf "%s-create-user-job" (include "airflow.fullname" .)) .Values.createUserJob.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.createUserJob.serviceAccount.name }}
+  {{- end }}
+{{- end }}
 
-{{/*
-Create the name of the migrate database job service account to use
-*/}}
+{{/* Create the name of the migrate database job service account to use */}}
 {{- define "migrateDatabaseJob.serviceAccountName" -}}
-{{- if .Values.migrateDatabaseJob.serviceAccount.create -}}
-    {{ default (printf "%s-migrate-database-job" (include "airflow.fullname" .)) .Values.migrateDatabaseJob.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.migrateDatabaseJob.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
+  {{- if .Values.migrateDatabaseJob.serviceAccount.create }}
+    {{- default (printf "%s-migrate-database-job" (include "airflow.fullname" .)) .Values.migrateDatabaseJob.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.migrateDatabaseJob.serviceAccount.name }}
+  {{- end }}
+{{- end }}
 
-{{/*
-Create the name of the worker service account to use
-*/}}
+{{/* Create the name of the worker service account to use */}}
 {{- define "worker.serviceAccountName" -}}
-{{- if .Values.workers.serviceAccount.create -}}
-    {{ default (printf "%s-worker" (include "airflow.fullname" .)) .Values.workers.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.workers.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
+  {{- if .Values.workers.serviceAccount.create }}
+    {{- default (printf "%s-worker" (include "airflow.fullname" .)) .Values.workers.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.workers.serviceAccount.name }}
+  {{- end }}
+{{- end }}
 
-{{/*
-Create the name of the triggerer service account to use
-*/}}
+{{/* Create the name of the triggerer service account to use */}}
 {{- define "triggerer.serviceAccountName" -}}
-{{- if .Values.triggerer.serviceAccount.create -}}
-    {{ default (printf "%s-triggerer" (include "airflow.fullname" .)) .Values.triggerer.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.triggerer.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
+  {{- if .Values.triggerer.serviceAccount.create }}
+    {{- default (printf "%s-triggerer" (include "airflow.fullname" .)) .Values.triggerer.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.triggerer.serviceAccount.name }}
+  {{- end }}
+{{- end }}
 
-{{/*
-Create the name of the dag processor service account to use
-*/}}
+{{/* Create the name of the dag processor service account to use */}}
 {{- define "dagProcessor.serviceAccountName" -}}
-{{- if .Values.dagProcessor.serviceAccount.create -}}
-    {{ default (printf "%s-dag-processor" (include "airflow.fullname" .)) .Values.dagProcessor.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.dagProcessor.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
+  {{- if .Values.dagProcessor.serviceAccount.create }}
+    {{- default (printf "%s-dag-processor" (include "airflow.fullname" .)) .Values.dagProcessor.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.dagProcessor.serviceAccount.name }}
+  {{- end }}
+{{- end }}
 
-{{/*
-Create the name of the pgbouncer service account to use
-*/}}
+{{/* Create the name of the pgbouncer service account to use */}}
 {{- define "pgbouncer.serviceAccountName" -}}
-{{- if .Values.pgbouncer.serviceAccount.create -}}
-    {{ default (printf "%s-pgbouncer" (include "airflow.fullname" .)) .Values.pgbouncer.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.pgbouncer.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
+  {{- if .Values.pgbouncer.serviceAccount.create }}
+    {{- default (printf "%s-pgbouncer" (include "airflow.fullname" .)) .Values.pgbouncer.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.pgbouncer.serviceAccount.name }}
+  {{- end }}
+{{- end }}
 
-{{/*
-Create the name of the cleanup service account to use
-*/}}
+{{/* Create the name of the cleanup service account to use */}}
 {{- define "cleanup.serviceAccountName" -}}
-{{- if .Values.cleanup.serviceAccount.create -}}
-    {{ default (printf "%s-cleanup" (include "airflow.fullname" .)) .Values.cleanup.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.cleanup.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
+  {{- if .Values.cleanup.serviceAccount.create }}
+    {{- default (printf "%s-cleanup" (include "airflow.fullname" .)) .Values.cleanup.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.cleanup.serviceAccount.name }}
+  {{- end }}
+{{- end }}
 
-{{ define "wait-for-migrations-command" }}
+{{- define "wait-for-migrations-command" -}}
   {{- if semverCompare ">=2.0.0" .Values.airflowVersion }}
   - airflow
   - db
@@ -655,7 +630,7 @@ Create the name of the cleanup service account to use
   {{- end }}
 {{- end }}
 
-{{define "scheduler_liveness_check_command"}}
+{{- define "scheduler_liveness_check_command" }}
   {{- if semverCompare ">=2.5.0" .Values.airflowVersion }}
   - sh
   - -c
@@ -687,23 +662,23 @@ Create the name of the cleanup service account to use
   {{- end }}
 {{- end }}
 
-{{define "triggerer_liveness_check_command"}}
-    {{- if semverCompare ">=2.5.0" .Values.airflowVersion }}
-    - sh
-    - -c
-    - |
-      CONNECTION_CHECK_MAX_COUNT=0 AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR exec /entrypoint \
-      airflow jobs check --job-type TriggererJob --local
-    {{- else }}
-    - sh
-    - -c
-    - |
-      CONNECTION_CHECK_MAX_COUNT=0 AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR exec /entrypoint \
-      airflow jobs check --job-type TriggererJob  --hostname $(hostname)
-    {{- end }}
+{{- define "triggerer_liveness_check_command" }}
+  {{- if semverCompare ">=2.5.0" .Values.airflowVersion }}
+  - sh
+  - -c
+  - |
+    CONNECTION_CHECK_MAX_COUNT=0 AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR exec /entrypoint \
+    airflow jobs check --job-type TriggererJob --local
+  {{- else }}
+  - sh
+  - -c
+  - |
+    CONNECTION_CHECK_MAX_COUNT=0 AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR exec /entrypoint \
+    airflow jobs check --job-type TriggererJob  --hostname $(hostname)
+  {{- end }}
 {{- end }}
 
-{{define "dag_processor_liveness_check_command"}}
+{{- define "dag_processor_liveness_check_command" }}
   - sh
   - -c
   - |
@@ -711,33 +686,33 @@ Create the name of the cleanup service account to use
     airflow jobs check --hostname $(hostname)
 {{- end }}
 
-{{ define "registry_docker_config" -}}
+{{- define "registry_docker_config" }}
   {{- $host := .Values.registry.connection.host }}
   {{- $email := .Values.registry.connection.email }}
-  {{- $user := .Values.registry.connection.user -}}
-  {{- $pass := .Values.registry.connection.pass -}}
+  {{- $user := .Values.registry.connection.user }}
+  {{- $pass := .Values.registry.connection.pass }}
 
-  {{- $config := dict "auths" -}}
-  {{- $auth := dict -}}
-  {{- $data := dict -}}
-  {{- $_ := set $data "username" $user -}}
-  {{- $_ := set $data "password" $pass -}}
-  {{- $_ := set $data "email" $email -}}
-  {{- $_ := set $data "auth" (printf "%v:%v" $user $pass | b64enc) -}}
-  {{- $_ := set $auth $host $data -}}
-  {{- $_ := set $config "auths" $auth -}}
+  {{- $config := dict "auths" }}
+  {{- $auth := dict }}
+  {{- $data := dict }}
+  {{- $_ := set $data "username" $user }}
+  {{- $_ := set $data "password" $pass }}
+  {{- $_ := set $data "email" $email }}
+  {{- $_ := set $data "auth" (printf "%v:%v" $user $pass | b64enc) }}
+  {{- $_ := set $auth $host $data }}
+  {{- $_ := set $config "auths" $auth }}
   {{ $config | toJson | print }}
 {{- end }}
 
 {{/* Allow Kubernetes Version to be overridden. Credit to https://github.com/prometheus-community/helm-charts for Regex. */}}
-{{- define "kubeVersion" -}}
+{{- define "kubeVersion" }}
   {{- $kubeVersion := default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
   {{/* Special use case for Amazon EKS, Google GKE */}}
   {{- if and (regexMatch "\\d+\\.\\d+\\.\\d+-(?:eks|gke).+" $kubeVersion) (not .Values.kubeVersionOverride) -}}
     {{- $kubeVersion = regexFind "\\d+\\.\\d+\\.\\d+" $kubeVersion -}}
   {{- end -}}
   {{- $kubeVersion -}}
-{{- end -}}
+{{- end }}
 
 {{/*
 Set the default value for securityContext
@@ -756,18 +731,18 @@ The template can be called like so:
 Where `.` is the global variables scope and `.Values.webserver` the local variables scope for the webserver template.
 */}}
 {{- define "airflowSecurityContext" -}}
-  {{- $ := index . 0 -}}
+  {{- $ := index . 0 }}
   {{- with index . 1 }}
-    {{- if .securityContext -}}
-{{ toYaml .securityContext | print }}
-    {{- else if $.Values.securityContext -}}
-{{ toYaml $.Values.securityContext | print }}
-    {{- else -}}
+    {{- if .securityContext }}
+      {{- toYaml .securityContext }}
+    {{- else if $.Values.securityContext }}
+      {{- toYaml $.Values.securityContext }}
+    {{- else }}
 runAsUser: {{ $.Values.uid }}
 fsGroup: {{ $.Values.gid }}
-    {{- end -}}
-  {{- end -}}
-{{- end -}}
+    {{- end }}
+  {{- end }}
+{{- end }}
 
 {{/*
 Set the default value for securityContext
@@ -783,12 +758,12 @@ The template can be called like so:
 It is important to pass the local variables scope to this template as it is used to determine the local node value for uid.
 */}}
 {{- define "localSecurityContext" -}}
-  {{- if .securityContext -}}
-{{ toYaml .securityContext | print }}
-  {{- else -}}
-runAsUser: {{ .uid }}
-  {{- end -}}
-{{- end -}}
+  {{- if .securityContext }}
+    {{- toYaml .securityContext }}
+  {{- else }}
+    {{- printf "runAsUser: %v" .uid }}
+  {{- end }}
+{{- end }}
 
 {{/*
 Set the default value for workers chown for persistent storage
@@ -808,21 +783,22 @@ The template can be called like so:
 Where `.` is the global variables scope and `.Values.workers` the local variables scope for the workers template.
 */}}
 {{- define "airflowSecurityContextIds" -}}
-  {{- $ := index . 0 -}}
+  {{- $ := index . 0 }}
   {{- with index . 1 }}
-    {{- if .securityContext -}}
-{{ pluck "runAsUser" .securityContext | first | default $.Values.uid }}:{{ pluck "fsGroup" .securityContext | first | default $.Values.gid }}
-    {{- else if $.Values.securityContext -}}
-{{ pluck "runAsUser" $.Values.securityContext | first | default $.Values.uid }}:{{ pluck "fsGroup" $.Values.securityContext | first | default $.Values.gid }}
-    {{- else -}}
-{{ $.Values.uid }}:{{ $.Values.gid }}
-    {{- end -}}
-  {{- end -}}
-{{- end -}}
+    {{- if .securityContext }}
+      {{- pluck "runAsUser" .securityContext | first | default $.Values.uid }}:{{ pluck "fsGroup" .securityContext | first | default $.Values.gid }}
+    {{- else if $.Values.securityContext }}
+      {{- pluck "runAsUser" $.Values.securityContext | first | default $.Values.uid }}:{{ pluck "fsGroup" $.Values.securityContext | first | default $.Values.gid }}
+    {{- else }}
+      {{- printf "%s:%s" $.Values.uid $.Values.gid }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
 {{- define "container_extra_envs" -}}
-{{- $ := index . 0 -}}
-{{- $env := index . 1 -}}
-{{- range $i, $config := $env }}
+  {{- $ := index . 0 -}}
+  {{- $env := index . 1 -}}
+  {{- range $i, $config := $env }}
   - name: {{ $config.name }}
     value: {{ $config.value | quote }}
     {{- if or (eq $.Values.executor "KubernetesExecutor") (eq $.Values.executor "LocalKubernetesExecutor") (eq $.Values.executor "CeleryKubernetesExecutor") }}

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -114,11 +114,11 @@ spec:
           image: {{ template "airflow_image_for_migrations" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           volumeMounts: {{- include "airflow_config_mount" . | nindent 12 }}
-          args: {{- include "wait-for-migrations-command" . | nindent 10 }}
-          envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | nindent 10 }}
+          args: {{- include "wait-for-migrations-command" . | indent 10 }}
+          envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env:
-            {{- include "custom_airflow_environment" . | nindent 10 }}
-            {{- include "standard_airflow_environment" . | nindent 10 }}
+            {{- include "custom_airflow_environment" . | indent 10 }}
+            {{- include "standard_airflow_environment" . | indent 10 }}
             {{- if .Values.dagProcessor.waitForMigrations.env }}
               {{- tpl (toYaml .Values.dagProcessor.waitForMigrations.env) $ | nindent 12 }}
             {{- end }}
@@ -153,10 +153,10 @@ spec:
             {{- if or .Values.dags.persistence.enabled .Values.dags.gitSync.enabled }}
               {{- include "airflow_dags_mount" . | nindent 12 }}
             {{- end }}
-          envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | nindent 10 }}
+          envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env:
-            {{- include "custom_airflow_environment" . | nindent 10 }}
-            {{- include "standard_airflow_environment" . | nindent 10 }}
+            {{- include "custom_airflow_environment" . | indent 10 }}
+            {{- include "standard_airflow_environment" . | indent 10 }}
             {{- include "container_extra_envs" (list . .Values.dagProcessor.env) | indent 10 }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.dagProcessor.livenessProbe.initialDelaySeconds }}
@@ -165,11 +165,11 @@ spec:
             periodSeconds: {{ .Values.dagProcessor.livenessProbe.periodSeconds }}
             exec:
               command:
-                  {{- if .Values.dagProcessor.livenessProbe.command }}
-                  {{ toYaml .Values.dagProcessor.livenessProbe.command | nindent 16 }}
-                  {{- else }}
-                  {{- include "dag_processor_liveness_check_command" . | nindent 16 }}
-                  {{- end }}
+                {{- if .Values.dagProcessor.livenessProbe.command }}
+                  {{- toYaml .Values.dagProcessor.livenessProbe.command | nindent 16 }}
+                {{- else }}
+                  {{- include "dag_processor_liveness_check_command" . | indent 14 }}
+                {{- end }}
         {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
           {{- include "git_sync_container" . | indent 8 }}
         {{- end }}

--- a/chart/templates/jobs/create-user-job.yaml
+++ b/chart/templates/jobs/create-user-job.yaml
@@ -93,7 +93,7 @@ spec:
           {{- if .Values.createUserJob.applyCustomEnv }}
           envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env: {{- include "custom_airflow_environment" . | indent 10 }}
-          {{ else }}
+          {{- else }}
           env:
           {{- end }}
           {{- include "standard_airflow_environment" . | indent 10 }}
@@ -105,7 +105,7 @@ spec:
               {{- toYaml .Values.volumeMounts | nindent 12 }}
             {{- end }}
             {{- if .Values.createUserJob.extraVolumeMounts }}
-              {{ toYaml .Values.createUserJob.extraVolumeMounts | nindent 12 }}
+              {{- toYaml .Values.createUserJob.extraVolumeMounts | nindent 12 }}
             {{- end }}
         {{- if .Values.createUserJob.extraContainers }}
           {{- toYaml .Values.createUserJob.extraContainers | nindent 8 }}

--- a/chart/templates/jobs/migrate-database-job.yaml
+++ b/chart/templates/jobs/migrate-database-job.yaml
@@ -85,15 +85,15 @@ spec:
           image: {{ template "airflow_image_for_migrations" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           {{- if .Values.migrateDatabaseJob.command }}
-          command: {{ tpl (toYaml .Values.migrateDatabaseJob.command) . | nindent 12 }}
+          command: {{- tpl (toYaml .Values.migrateDatabaseJob.command) . | nindent 12 }}
           {{- end }}
           {{- if .Values.migrateDatabaseJob.args }}
-          args: {{ tpl (toYaml .Values.migrateDatabaseJob.args) . | nindent 12 }}
+          args: {{- tpl (toYaml .Values.migrateDatabaseJob.args) . | nindent 12 }}
           {{- end }}
           {{- if .Values.migrateDatabaseJob.applyCustomEnv }}
           envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env: {{- include "custom_airflow_environment" . | indent 10 }}
-          {{ else }}
+          {{- else }}
           env:
           {{- end }}
             - name: PYTHONUNBUFFERED
@@ -106,7 +106,7 @@ spec:
             {{- toYaml .Values.volumeMounts | nindent 12 }}
             {{- end }}
             {{- if .Values.migrateDatabaseJob.extraVolumeMounts }}
-              {{ tpl (toYaml .Values.migrateDatabaseJob.extraVolumeMounts) . | nindent 12 }}
+              {{- tpl (toYaml .Values.migrateDatabaseJob.extraVolumeMounts) . | nindent 12 }}
             {{- end }}
         {{- if .Values.migrateDatabaseJob.extraContainers }}
           {{- toYaml .Values.migrateDatabaseJob.extraContainers | nindent 8 }}

--- a/chart/templates/pgbouncer/pgbouncer-networkpolicy.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-networkpolicy.yaml
@@ -56,10 +56,10 @@ spec:
     {{- end }}
         matchLabels:
           app: keda-operator
-    {{- end}}
+    {{- end }}
     {{- if .Values.pgbouncer.extraNetworkPolicies}}
       {{- toYaml .Values.pgbouncer.extraNetworkPolicies | nindent 4 }}
-    {{- end}}
+    {{- end }}
     ports:
     - protocol: TCP
       port: {{ .Values.ports.pgbouncer }}

--- a/chart/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
@@ -42,5 +42,5 @@ spec:
       tier: airflow
       component: pgbouncer
       release: {{ .Release.Name }}
-{{ toYaml .Values.pgbouncer.podDisruptionBudget.config | indent 2 }}
+  {{- toYaml .Values.pgbouncer.podDisruptionBudget.config | nindent 2 }}
 {{- end }}

--- a/chart/templates/rbac/security-context-constraint-rolebinding.yaml
+++ b/chart/templates/rbac/security-context-constraint-rolebinding.yaml
@@ -64,7 +64,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "flower.serviceAccountName" . }}
     namespace: "{{ .Release.Namespace }}"
-  {{- end}}
+  {{- end }}
   {{- if and (semverCompare ">=2.2.0" .Values.airflowVersion) }}
   - kind: ServiceAccount
     name: {{ include "triggerer.serviceAccountName" . }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -125,10 +125,9 @@ spec:
       imagePullSecrets:
         - name: {{ template "registry_secret" . }}
       {{- end }}
-{{- if .Values.scheduler.hostAliases }}
-      hostAliases:
-{{ toYaml .Values.scheduler.hostAliases | indent 8 }}
-{{- end }}
+      {{- if .Values.scheduler.hostAliases }}
+      hostAliases: {{- toYaml .Values.scheduler.hostAliases | nindent 8 }}
+      {{- end }}
       initContainers:
         {{- if .Values.scheduler.waitForMigrations.enabled }}
         - name: wait-for-airflow-migrations
@@ -184,11 +183,11 @@ spec:
             periodSeconds: {{ .Values.scheduler.livenessProbe.periodSeconds }}
             exec:
               command:
-                  {{- if .Values.scheduler.livenessProbe.command }}
-                    {{- toYaml .Values.scheduler.livenessProbe.command  | nindent 16 }}
-                  {{- else}}
-                    {{- include "scheduler_liveness_check_command" . | nindent 16 }}
-                  {{- end }}
+                {{- if .Values.scheduler.livenessProbe.command }}
+                  {{- toYaml .Values.scheduler.livenessProbe.command  | nindent 16 }}
+                {{- else }}
+                  {{- include "scheduler_liveness_check_command" . | indent 14 }}
+                {{- end }}
           {{- if and $local (not $elasticsearch) }}
           # Serve logs if we're in local mode and we don't have elasticsearch enabled.
           ports:
@@ -219,7 +218,7 @@ spec:
               {{- toYaml .Values.scheduler.extraVolumeMounts | nindent 12 }}
             {{- end }}
         {{- if and $localOrDagProcessorDisabled .Values.dags.gitSync.enabled }}
-        {{- include "git_sync_container" . | indent 8 }}
+          {{- include "git_sync_container" . | indent 8 }}
         {{- end }}
         {{- if .Values.scheduler.logGroomerSidecar.enabled }}
         - name: scheduler-log-groomer
@@ -232,7 +231,7 @@ spec:
           {{- if .Values.scheduler.logGroomerSidecar.args }}
           args: {{- tpl (toYaml .Values.scheduler.logGroomerSidecar.args) . | nindent 12 }}
           {{- end }}
-          {{ if .Values.scheduler.logGroomerSidecar.retentionDays }}
+          {{- if .Values.scheduler.logGroomerSidecar.retentionDays }}
           env:
             - name: AIRFLOW__LOG_RETENTION_DAYS
               value: "{{ .Values.scheduler.logGroomerSidecar.retentionDays }}"
@@ -271,7 +270,7 @@ spec:
         - name: dags
           emptyDir: {}
         {{- if .Values.dags.gitSync.sshKeySecret }}
-        {{- include "git_sync_ssh_key_volume" . | indent 8 }}
+          {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/chart/templates/scheduler/scheduler-poddisruptionbudget.yaml
+++ b/chart/templates/scheduler/scheduler-poddisruptionbudget.yaml
@@ -42,5 +42,5 @@ spec:
       tier: airflow
       component: scheduler
       release: {{ .Release.Name }}
-{{ toYaml .Values.scheduler.podDisruptionBudget.config | indent 2 }}
+  {{- toYaml .Values.scheduler.podDisruptionBudget.config | nindent 2 }}
 {{- end }}

--- a/chart/templates/scheduler/scheduler-serviceaccount.yaml
+++ b/chart/templates/scheduler/scheduler-serviceaccount.yaml
@@ -36,6 +36,6 @@ metadata:
   annotations:
     {{- range $key, $value := . }}
       {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
-      {{- end }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/secrets/fernetkey-secret.yaml
+++ b/chart/templates/secrets/fernetkey-secret.yaml
@@ -19,7 +19,7 @@
 ## Airflow Fernet Key Secret
 #################################
 {{- if not .Values.fernetKeySecretName }}
-{{ $generated_fernet_key := (randAlphaNum 32 | b64enc) }}
+{{- $generated_fernet_key := (randAlphaNum 32 | b64enc) }}
 kind: Secret
 apiVersion: v1
 metadata:

--- a/chart/templates/secrets/kerberos-keytab-secret.yaml
+++ b/chart/templates/secrets/kerberos-keytab-secret.yaml
@@ -15,7 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-{{ if .Values.kerberos.keytabBase64Content }}
+################################
+## Kerberos Secret
+#################################
+{{- if .Values.kerberos.keytabBase64Content }}
 apiVersion: v1
 metadata:
   name: {{ include "kerberos_keytab_secret" . | quote }}
@@ -32,4 +35,4 @@ data:
   kerberos.keytab: {{ .Values.kerberos.keytabBase64Content }}
 kind: Secret
 type: Opaque
-{{ end }}
+{{- end }}

--- a/chart/templates/secrets/metadata-connection-secret.yaml
+++ b/chart/templates/secrets/metadata-connection-secret.yaml
@@ -26,7 +26,6 @@
 {{- $port := ((ternary .Values.ports.pgbouncer .Values.data.metadataConnection.port .Values.pgbouncer.enabled) | toString) }}
 {{- $database := (ternary (printf "%s-%s" .Release.Name "metadata") .Values.data.metadataConnection.db .Values.pgbouncer.enabled) }}
 {{- $query := ternary (printf "sslmode=%s" .Values.data.metadataConnection.sslmode) "" (eq .Values.data.metadataConnection.protocol "postgresql") }}
-
 kind: Secret
 apiVersion: v1
 metadata:

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -136,8 +136,8 @@ spec:
           args: {{- include "wait-for-migrations-command" . | indent 10 }}
           envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env:
-            {{- include "custom_airflow_environment" . | nindent 10 }}
-            {{- include "standard_airflow_environment" . | nindent 10 }}
+            {{- include "custom_airflow_environment" . | indent 10 }}
+            {{- include "standard_airflow_environment" . | indent 10 }}
             {{- if .Values.triggerer.waitForMigrations.env }}
               {{- tpl (toYaml .Values.triggerer.waitForMigrations.env) $ | nindent 12 }}
             {{- end }}
@@ -177,8 +177,8 @@ spec:
             {{- end }}
           envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env:
-            {{- include "custom_airflow_environment" . | nindent 10 }}
-            {{- include "standard_airflow_environment" . | nindent 10 }}
+            {{- include "custom_airflow_environment" . | indent 10 }}
+            {{- include "standard_airflow_environment" . | indent 10 }}
             {{- include "container_extra_envs" (list . .Values.triggerer.env) | nindent 10 }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.triggerer.livenessProbe.initialDelaySeconds }}
@@ -187,11 +187,11 @@ spec:
             periodSeconds: {{ .Values.triggerer.livenessProbe.periodSeconds }}
             exec:
               command:
-                  {{- if .Values.triggerer.livenessProbe.command }}
-                    {{- toYaml .Values.triggerer.livenessProbe.command | nindent 16 }}
-                  {{- else }}
-                    {{- include "triggerer_liveness_check_command" . | nindent 16 }}
-                  {{- end }}
+                {{- if .Values.triggerer.livenessProbe.command }}
+                  {{- toYaml .Values.triggerer.livenessProbe.command | nindent 16 }}
+                {{- else }}
+                  {{- include "triggerer_liveness_check_command" . | indent 14 }}
+                {{- end }}
         {{- /* Airflow version 2.6.0 is when triggerer logs serve introduced */ -}}
           {{- if semverCompare ">=2.6.0" .Values.airflowVersion }}
           ports:

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -63,8 +63,8 @@ spec:
       maxUnavailable: 0
     {{- else }}
     type: Recreate
-    {{- end}}
-    {{- end}}
+    {{- end }}
+    {{- end }}
   selector:
     matchLabels:
       tier: airflow
@@ -94,10 +94,9 @@ spec:
           {{- toYaml .Values.webserver.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
-{{- if .Values.webserver.hostAliases }}
-      hostAliases:
-{{ toYaml .Values.webserver.hostAliases | indent 8 }}
-{{- end }}
+      {{- if .Values.webserver.hostAliases }}
+      hostAliases: {{- toYaml .Values.webserver.hostAliases | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "webserver.serviceAccountName" . }}
       {{- if .Values.webserver.priorityClassName }}
       priorityClassName: {{ .Values.webserver.priorityClassName }}
@@ -196,7 +195,7 @@ spec:
               containerPort: {{ .Values.ports.airflowUI }}
           livenessProbe:
             httpGet:
-              path: {{if .Values.config.webserver.base_url }}{{- with urlParse (tpl .Values.config.webserver.base_url .) }}{{ .path }}{{end}}{{end}}/health
+              path: {{ if .Values.config.webserver.base_url }}{{- with urlParse (tpl .Values.config.webserver.base_url .) }}{{ .path }}{{ end }}{{ end }}/health
               port: {{ .Values.ports.airflowUI }}
               {{- if .Values.config.webserver.base_url}}
               httpHeaders:

--- a/chart/templates/webserver/webserver-poddisruptionbudget.yaml
+++ b/chart/templates/webserver/webserver-poddisruptionbudget.yaml
@@ -42,5 +42,5 @@ spec:
       tier: airflow
       component: webserver
       release: {{ .Release.Name }}
-{{ toYaml .Values.webserver.podDisruptionBudget.config | indent 2 }}
+  {{- toYaml .Values.webserver.podDisruptionBudget.config | nindent 2 }}
 {{- end }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -187,13 +187,13 @@ spec:
             periodSeconds: {{ .Values.workers.livenessProbe.periodSeconds }}
             exec:
               command:
-                  {{- if .Values.workers.livenessProbe.command }}
-                  {{ toYaml .Values.workers.livenessProbe.command  | nindent 16 }}
-                  {{- else}}
-                  - sh
-                  - -c
-                  - CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -m celery --app airflow.executors.celery_executor.app inspect ping -d celery@$(hostname)
-                  {{- end }}
+                {{- if .Values.workers.livenessProbe.command }}
+                  {{- toYaml .Values.workers.livenessProbe.command  | nindent 16 }}
+                {{- else }}
+                - sh
+                - -c
+                - CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -m celery --app airflow.executors.celery_executor.app inspect ping -d celery@$(hostname)
+                {{- end }}
           {{- end }}
           ports:
             - name: worker-logs
@@ -254,7 +254,7 @@ spec:
           {{- if .Values.workers.logGroomerSidecar.args }}
           args: {{ tpl (toYaml .Values.workers.logGroomerSidecar.args) . | nindent 12 }}
           {{- end }}
-          {{ if .Values.workers.logGroomerSidecar.retentionDays }}
+          {{- if .Values.workers.logGroomerSidecar.retentionDays }}
           env:
             - name: AIRFLOW__LOG_RETENTION_DAYS
               value: "{{ .Values.workers.logGroomerSidecar.retentionDays }}"
@@ -303,7 +303,7 @@ spec:
             {{- if or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName }}
               {{- include "airflow_webserver_config_mount" . | nindent 12 }}
             {{- end }}
-          envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | nindent 10 }}
+          envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env:
             - name: KRB5_CONFIG
               value:  {{ .Values.kerberos.configPath | quote }}


### PR DESCRIPTION
The PR reformats multiple chart templates as the continuation of https://github.com/apache/airflow/pull/29917 and https://github.com/apache/airflow/pull/29941
Less empty lines rendered when `helm template` is executed. Aligned indent style for templates.