### PR TITLE
adjust stale bots

### DIFF
--- a/.github/workflows/recheck-old-bug-report.yml
+++ b/.github/workflows/recheck-old-bug-report.yml
@@ -23,7 +23,6 @@ on:  # yamllint disable-line rule:truthy
     - cron: '0 7 * * *'
 permissions:
   # All other permissions are set to none
-  pull-requests: write
   issues: write
 jobs:
   recheck-old-bug-report:
@@ -41,7 +40,8 @@ jobs:
           # we set high number of days thus effectively this job will not do any changes on PRs
           days-before-pr-stale: 7000
           days-before-pr-close: 7000
-          remove-stale-when-updated: true
+          remove-stale-when-updated: false
+          remove-issue-stale-when-updated: true
           labels-to-add-when-unstale: 'needs-triage'
           stale-issue-message: >
             This issue has been automatically marked as stale because it has been open for 365 days

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -39,6 +39,7 @@ jobs:
           days-before-pr-close: 5
           exempt-pr-labels: 'pinned,security'
           only-issue-labels: 'pending-response'
+          remove-stale-when-updated: true
           days-before-issue-stale: 30
           days-before-issue-close: 7
           stale-issue-message: >


### PR DESCRIPTION
We had cases where needs-triage label was aded by bot on PRs:
![Screenshot 2023-03-27 at 11 44 00](https://user-images.githubusercontent.com/45845474/227889949-0412c155-baa5-4c23-8a2d-43218df2688e.png)

https://github.com/apache/airflow/pull/28187

This is not right so this PR adjust the bots to avoid such cases.



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
