### PR TITLE
Add Bolke as serialization code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 /airflow/models/ @kaxil @XD-DENG @ashb
 
 # DAG Serialization
-/airflow/serialization/ @kaxil @ashb
+/airflow/serialization/ @kaxil @ashb @bolkedebruin
 
 # DAG Parsing
 /airflow/dag_processing @jedcunningham @ephraimbuddy


### PR DESCRIPTION
We already do this anyway (by manually tagging) so let's just make GitHub do it automatically.