### PR TITLE
Speed up dag runs deletion

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -829,12 +829,8 @@ class DagRunCustomSQLAInterface(CustomSQLAInterface):
 
     def delete(self, item: Model, raise_exception: bool = False) -> bool:
         try:
-            self._delete_files(item)
             self.session.query(TaskInstance).where(TaskInstance.run_id == item.run_id).delete()
-            self.session.delete(item)
-            self.session.commit()
-            self.message = (as_unicode(self.delete_row_message), "success")
-            return True
+            return super().delete(item, raise_exception=raise_exception)
         except IntegrityError as e:
             self.message = (as_unicode(self.delete_integrity_error_message), "warning")
             log.warning(LOGMSG_WAR_DBI_DEL_INTEGRITY.format(str(e)))
@@ -856,12 +852,8 @@ class DagRunCustomSQLAInterface(CustomSQLAInterface):
     def delete_all(self, items: list[Model]) -> bool:
         try:
             for item in items:
-                self._delete_files(item)
                 self.session.query(TaskInstance).where(TaskInstance.run_id == item.run_id).delete()
-                self.session.delete(item)
-            self.session.commit()
-            self.message = (as_unicode(self.delete_row_message), "success")
-            return True
+            return super().delete_all(items)
         except IntegrityError as e:
             self.message = (as_unicode(self.delete_integrity_error_message), "warning")
             log.warning(LOGMSG_WAR_DBI_DEL_INTEGRITY.format(str(e)))

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -813,11 +813,11 @@ class CustomSQLAInterface(SQLAInterface):
 
 
 class DagRunCustomSQLAInterface(CustomSQLAInterface):
-    """
-    Overwrite of custom delete and delete_all methods for speeding up
-    the DagRun deletion when DagRun has a lot of task instances.
-    The default cascade deletion was performing very slowly when task instances were more than 10k.
-
+    """Custom interface to allow faster deletion.
+    
+    The ``delete`` and ``delete_all`` methods are overridden to speed up
+    deletion when a DAG run has a lot of related task instances. Relying on
+    SQLAlchemy's cascading deletion is comparatively slow in this situation.
     """
 
     def delete(self, item: Model, raise_exception: bool = False) -> bool:

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -814,7 +814,7 @@ class CustomSQLAInterface(SQLAInterface):
 
 class DagRunCustomSQLAInterface(CustomSQLAInterface):
     """Custom interface to allow faster deletion.
-    
+
     The ``delete`` and ``delete_all`` methods are overridden to speed up
     deletion when a DAG run has a lot of related task instances. Relying on
     SQLAlchemy's cascading deletion is comparatively slow in this situation.

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4999,7 +4999,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
 
     route_base = "/dagrun"
 
-    datamodel = AirflowModelView.CustomSQLAInterface(models.DagRun)  # type: ignore
+    datamodel = wwwutils.DagRunCustomSQLAInterface(models.DagRun)  # type: ignore
 
     class_permission_name = permissions.RESOURCE_DAG_RUN
     method_permission_name = {


### PR DESCRIPTION
Provide custom deletion for dag runs to speed up when a DagRun has a lot of related task instances

**Context:**
The solution is overwriting of custom delete and delete_all methods for the DagRun model to speed up their deletion when DagRun has a lot of task instances. The default ORM cascade deletion is performing very slowly when task instances are more than 10k because ORM is fetching all task instances from DB and then deleting them one by one.
The solution can handle the deletion of DagRun with  > 100k  task instances easily.

Closes: https://github.com/apache/airflow/issues/30196.