### PR TITLE
Checkout main before creating testing issue

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
@@ -243,6 +243,7 @@ def create_issue_for_testing(version, previous_version, github_token):
         console_print()
         console_print(f"Status of testing of Apache Airflow {version}")
         console_print()
+        run_command(["git", "checkout", "main"], dry_run_override=DRY_RUN, check=True)
         if CI:
             run_command(["git", "fetch"], check=True)
         if confirm_action("Print the issue body?"):

--- a/dev/prepare_release_issue.py
+++ b/dev/prepare_release_issue.py
@@ -288,8 +288,7 @@ def generate_issue_content(
                 except UnknownObjectException:
                     console.print(f"[red]The PR #{pr_number} could not be found[/]")
                     continue
-
-            if pr.user.login == "dependabot":
+            if pr.user.login == "dependabot[bot]":
                 console.print(f"[yellow]Skipping PR #{pr_number} as it was created by dependabot[/]")
                 continue
             # Ignore doc-only and skipped PRs


### PR DESCRIPTION
https://github.com/apache/airflow/pull/28954 wasn't taken into effect for [2.5.3rc1 testing issue](https://github.com/apache/airflow/issues/30337), see my manual edit. The reason is because the generation of the testing issue is currently done on the `rc tag`, checked out by `prepare_pypi_packages`.

To solve this we can simply checkout `main` before running the issue generation. (Another option is to cherry pick #28954 in the next release, but I think it is not necessary).

Doing this will also solve a similar issue for the recently added `remove_old_releases` step that only exists in main at the moment.

Also it looks like the username for `dependabot` was not accurate. (maybe it changed by the time).

![image](https://user-images.githubusercontent.com/14861206/228067333-c363e11a-2750-4388-b287-459c02845d01.png)
