### PR TITLE
Fix release process signing step

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
@@ -102,8 +102,8 @@ def create_artifacts_with_breeze():
 
 def sign_the_release(repo_root):
     if confirm_action("Do you want to sign the release?"):
-        os.chdir(repo_root)
-        run_command("./dev/sign.sh dist/*", dry_run_override=DRY_RUN, check=True, shell=True)
+        os.chdir(f"{repo_root}/dist")
+        run_command("./../dev/sign.sh *", dry_run_override=DRY_RUN, check=True, shell=True)
         console_print("Release signed")
 
 


### PR DESCRIPTION
Signing from the `repo_root` would add an extra 'dist' in the filename path, such as:
```shell
3b7137843031b36fe359e97108b3d65a0c6eefeb5ef23864621669c0c195b38656236cdf08f31c7f3ba18ccecc03c770d235f7dc6f305e48a8cb8840ee9dcc4d  dist/apache_airflow-2.5.3-py3-none-any.whl
```
Update this so the checksum looks like:
```
3b7137843031b36fe359e97108b3d65a0c6eefeb5ef23864621669c0c195b38656236cdf08f31c7f3ba18ccecc03c770d235f7dc6f305e48a8cb8840ee9dcc4d  apache_airflow-2.5.3-py3-none-any.whl
```