### PR TITLE
Add context manager to setup/teardown decorated tasks

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -88,6 +88,7 @@ from airflow.utils.decorators import fixup_decorator_warning_stack
 from airflow.utils.helpers import validate_key
 from airflow.utils.operator_resources import Resources
 from airflow.utils.session import NEW_SESSION, provide_session
+from airflow.utils.setup_teardown import SetupTeardownContext
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.weight_rule import WeightRule
 from airflow.utils.xcom import XCOM_RETURN_KEY
@@ -918,6 +919,9 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
                 stacklevel=2,
             )
             self.template_fields = [self.template_fields]
+
+        if SetupTeardownContext.active:
+            SetupTeardownContext.children.append(self)
 
     @classmethod
     def as_setup(cls, *args, **kwargs):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -921,19 +921,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
             self.template_fields = [self.template_fields]
 
         if SetupTeardownContext.active:
-            setup_task = SetupTeardownContext.get_context_managed_setup_task()
-            teardown_task = SetupTeardownContext.get_context_managed_teardown_task()
-            ins = SetupTeardownContext.instance_map
-            if setup_task:
-                if ins.get(setup_task) is None:
-                    ins[setup_task] = [self]
-                else:
-                    ins[setup_task].append(self)
-            if teardown_task:
-                if ins.get(teardown_task) is None:
-                    ins[teardown_task] = [self]
-                else:
-                    ins[teardown_task].append(self)
+            SetupTeardownContext.update_instance_map(self)
 
     @classmethod
     def as_setup(cls, *args, **kwargs):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -921,7 +921,19 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
             self.template_fields = [self.template_fields]
 
         if SetupTeardownContext.active:
-            SetupTeardownContext.children.append(self)
+            setup_task = SetupTeardownContext.get_context_managed_setup_task()
+            teardown_task = SetupTeardownContext.get_context_managed_teardown_task()
+            ins = SetupTeardownContext.instance_map
+            if setup_task:
+                if ins.get(setup_task) is None:
+                    ins[setup_task] = [self]
+                else:
+                    ins[setup_task].append(self)
+            if teardown_task:
+                if ins.get(teardown_task) is None:
+                    ins[teardown_task] = [self]
+                else:
+                    ins[teardown_task].append(self)
 
     @classmethod
     def as_setup(cls, *args, **kwargs):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -921,7 +921,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
             self.template_fields = [self.template_fields]
 
         if SetupTeardownContext.active:
-            SetupTeardownContext.update_instance_map(self)
+            SetupTeardownContext.update_context_map(self)
 
     @classmethod
     def as_setup(cls, *args, **kwargs):

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -209,16 +209,7 @@ class XComArg(ResolveMixin, DependencyMixin):
     def __enter__(self):
         if not self.operator._is_setup and not self.operator._is_teardown:
             raise AirflowException("Only setup/teardown tasks can be used as context managers.")
-        if self.operator._is_teardown:
-            SetupTeardownContext.push_context_managed_teardown_task(self.operator)
-            upstream_setup = [task for task in self.operator.upstream_list if task._is_setup]
-            if upstream_setup:
-                SetupTeardownContext.push_context_managed_setup_task(upstream_setup[-1])
-            else:
-                SetupTeardownContext.push_context_managed_setup_task(None)
-        elif self.operator._is_setup:
-            SetupTeardownContext.push_context_managed_setup_task(self.operator)
-            SetupTeardownContext.push_context_managed_teardown_task(None)
+        SetupTeardownContext.push_setup_teardown_task(self.operator)
         SetupTeardownContext.active = True
         return self
 

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -214,6 +214,11 @@ class XComArg(ResolveMixin, DependencyMixin):
             upstream_setup = [task for task in self.operator.upstream_list if task._is_setup]
             if upstream_setup:
                 SetupTeardownContext.push_context_managed_setup_task(upstream_setup[-1])
+            else:
+                SetupTeardownContext.push_context_managed_setup_task(None)
+        elif self.operator._is_setup:
+            SetupTeardownContext.push_context_managed_setup_task(self.operator)
+            SetupTeardownContext.push_context_managed_teardown_task(None)
         SetupTeardownContext.active = True
         return self
 

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -208,14 +208,10 @@ class XComArg(ResolveMixin, DependencyMixin):
         if not self.operator._is_setup and not self.operator._is_teardown:
             raise AirflowException("Only setup/teardown tasks can be used as context managers.")
         SetupTeardownContext.push_setup_teardown_task(self.operator)
-        SetupTeardownContext.active = True
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         SetupTeardownContext.set_work_task_roots_and_leaves()
-        SetupTeardownContext.pop_context_managed_setup_task()
-        SetupTeardownContext.pop_context_managed_teardown_task()
-        SetupTeardownContext.active = False
 
 
 class PlainXComArg(XComArg):

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -139,7 +139,6 @@ class XComArg(ResolveMixin, DependencyMixin):
     ):
         """Proxy to underlying operator set_upstream method. Required by TaskMixin."""
         for operator, _ in self.iter_references():
-            SetupTeardownContext.connect_teardown_downstream(operator)
             operator.set_upstream(task_or_task_list, edge_modifier)
 
     def set_downstream(
@@ -149,7 +148,6 @@ class XComArg(ResolveMixin, DependencyMixin):
     ):
         """Proxy to underlying operator set_downstream method. Required by TaskMixin."""
         for operator, _ in self.iter_references():
-            SetupTeardownContext.connect_setup_upstream(operator)
             operator.set_downstream(task_or_task_list, edge_modifier)
 
     def _serialize(self) -> dict[str, Any]:

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -1,0 +1,114 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from airflow.models.mappedoperator import MappedOperator
+
+if TYPE_CHECKING:
+    from airflow.models.operator import Operator
+
+
+class SetupTeardownContext:
+    """Context manager for setup/teardown XComArg."""
+
+    _context_managed_setup_task: Operator | None = None
+    _previous_context_managed_setup_task: list[Operator] = []
+    _context_managed_teardown_task: Operator | None = None
+    _previous_context_managed_teardown_task: list[Operator] = []
+    active: bool = False
+    children: list[Operator] = []
+
+    @classmethod
+    def push_context_managed_setup_task(cls, task: Operator):
+        if cls._context_managed_setup_task:
+            cls._previous_context_managed_setup_task.append(cls._context_managed_setup_task)
+        cls._context_managed_setup_task = task
+
+    @classmethod
+    def push_context_managed_teardown_task(cls, task: Operator):
+        if cls._context_managed_teardown_task:
+            cls._previous_context_managed_teardown_task.append(cls._context_managed_teardown_task)
+        cls._context_managed_teardown_task = task
+
+    @classmethod
+    def pop_context_managed_setup_task(cls) -> Operator | None:
+        old_setup_task = cls._context_managed_setup_task
+        if cls._previous_context_managed_setup_task:
+            cls._context_managed_setup_task = cls._previous_context_managed_setup_task.pop()
+            if cls._context_managed_setup_task and old_setup_task:
+                cls._context_managed_setup_task.set_downstream(old_setup_task)
+        else:
+            cls._context_managed_setup_task = None
+        return old_setup_task
+
+    @classmethod
+    def pop_context_managed_teardown_task(cls) -> Operator | None:
+        old_teardown_task = cls._context_managed_teardown_task
+        if cls._previous_context_managed_teardown_task:
+            cls._context_managed_teardown_task = cls._previous_context_managed_teardown_task.pop()
+            if cls._context_managed_teardown_task and old_teardown_task:
+                cls._context_managed_teardown_task.set_upstream(old_teardown_task)
+        else:
+            cls._context_managed_teardown_task = None
+        return old_teardown_task
+
+    @classmethod
+    def get_context_managed_setup_task(cls) -> Operator | None:
+        return cls._context_managed_setup_task
+
+    @classmethod
+    def get_context_managed_teardown_task(cls) -> Operator | None:
+        return cls._context_managed_teardown_task
+
+    @classmethod
+    def connect_setup_upstream(cls, operator):
+
+        if (
+            SetupTeardownContext.active
+            and not isinstance(operator, MappedOperator)
+            and not (operator._is_setup or operator._is_teardown)
+        ):
+            if not operator.upstream_list:
+                setup_task = SetupTeardownContext.get_context_managed_setup_task()
+                if setup_task:
+                    setup_task.set_downstream(operator)
+
+    @classmethod
+    def connect_teardown_downstream(cls, operator):
+        if (
+            SetupTeardownContext.active
+            and not isinstance(operator, MappedOperator)
+            and not (operator._is_setup or operator._is_teardown)
+        ):
+            if not operator.upstream_list:
+                teardown_task = SetupTeardownContext.get_context_managed_teardown_task()
+                if teardown_task:
+                    teardown_task.set_upstream(operator)
+
+    @classmethod
+    def set_work_task_roots_and_leaves(cls):
+        normal_tasks = [
+            task for task in SetupTeardownContext.children if not task._is_setup and not task._is_teardown
+        ]
+        for child in normal_tasks:
+            if not child.downstream_list:
+                child.set_downstream(SetupTeardownContext.get_context_managed_teardown_task())
+            if not child.upstream_list:
+                child.set_upstream(SetupTeardownContext.get_context_managed_setup_task())

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -79,36 +79,33 @@ class SetupTeardownContext:
 
     @classmethod
     def connect_setup_upstream(cls, operator):
-
         if (
-            SetupTeardownContext.active
+            cls.active
             and not isinstance(operator, MappedOperator)
             and not (operator._is_setup or operator._is_teardown)
         ):
             if not operator.upstream_list:
-                setup_task = SetupTeardownContext.get_context_managed_setup_task()
+                setup_task = cls.get_context_managed_setup_task()
                 if setup_task:
                     setup_task.set_downstream(operator)
 
     @classmethod
     def connect_teardown_downstream(cls, operator):
         if (
-            SetupTeardownContext.active
+            cls.active
             and not isinstance(operator, MappedOperator)
             and not (operator._is_setup or operator._is_teardown)
         ):
             if not operator.upstream_list:
-                teardown_task = SetupTeardownContext.get_context_managed_teardown_task()
+                teardown_task = cls.get_context_managed_teardown_task()
                 if teardown_task:
                     teardown_task.set_upstream(operator)
 
     @classmethod
     def set_work_task_roots_and_leaves(cls):
-        normal_tasks = [
-            task for task in SetupTeardownContext.children if not task._is_setup and not task._is_teardown
-        ]
+        normal_tasks = [task for task in cls.children if not task._is_setup and not task._is_teardown]
         for child in normal_tasks:
             if not child.downstream_list:
-                child.set_downstream(SetupTeardownContext.get_context_managed_teardown_task())
+                child.set_downstream(cls.get_context_managed_teardown_task())
             if not child.upstream_list:
-                child.set_upstream(SetupTeardownContext.get_context_managed_setup_task())
+                child.set_upstream(cls.get_context_managed_setup_task())

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -104,8 +104,11 @@ class SetupTeardownContext:
     @classmethod
     def set_work_task_roots_and_leaves(cls):
         normal_tasks = [task for task in cls.children if not task._is_setup and not task._is_teardown]
+        setup_task = cls.get_context_managed_setup_task()
+        teardown_task = cls.get_context_managed_teardown_task()
+
         for child in normal_tasks:
-            if not child.downstream_list:
-                child.set_downstream(cls.get_context_managed_teardown_task())
-            if not child.upstream_list:
-                child.set_upstream(cls.get_context_managed_setup_task())
+            if not child.downstream_list and teardown_task:
+                child.set_downstream(teardown_task)
+            if not child.upstream_list and setup_task:
+                child.set_upstream(setup_task)

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 
 class SetupTeardownContext:
-    """Context manager for setup/teardown XComArg."""
+    """Context manager for setup/teardown tasks."""
 
     _context_managed_setup_task: Operator | None = None
     _previous_context_managed_setup_task: list[Operator] = []

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -31,7 +31,7 @@ class SetupTeardownContext:
     _context_managed_teardown_task: Operator | None = None
     _previous_context_managed_teardown_task: list[Operator] = []
     active: bool = False
-    instance_map: dict[Operator, list[Operator]] = {}
+    context_map: dict[Operator, list[Operator]] = {}
 
     @classmethod
     def push_context_managed_setup_task(cls, task: Operator):
@@ -57,10 +57,10 @@ class SetupTeardownContext:
         return old_setup_task
 
     @classmethod
-    def update_instance_map(cls, operator):
+    def update_context_map(cls, operator):
         setup_task = SetupTeardownContext.get_context_managed_setup_task()
         teardown_task = SetupTeardownContext.get_context_managed_teardown_task()
-        ins = SetupTeardownContext.instance_map
+        ins = SetupTeardownContext.context_map
         if setup_task:
             if ins.get(setup_task) is None:
                 ins[setup_task] = [operator]
@@ -110,7 +110,7 @@ class SetupTeardownContext:
         setup_task = cls.get_context_managed_setup_task()
         teardown_task = cls.get_context_managed_teardown_task()
         if setup_task:
-            tasks_in_context = cls.instance_map.get(setup_task, [])
+            tasks_in_context = cls.context_map.get(setup_task, [])
             if tasks_in_context:
                 roots = [task for task in tasks_in_context if not task.upstream_list]
                 if not roots:
@@ -118,7 +118,7 @@ class SetupTeardownContext:
                 else:
                     setup_task.set_downstream(roots)
         if teardown_task:
-            tasks_in_context = cls.instance_map.get(teardown_task, [])
+            tasks_in_context = cls.context_map.get(teardown_task, [])
             if tasks_in_context:
                 leaves = [task for task in tasks_in_context if not task.downstream_list]
                 if not leaves:
@@ -128,5 +128,5 @@ class SetupTeardownContext:
         setup_task = SetupTeardownContext.pop_context_managed_setup_task()
         teardown_task = SetupTeardownContext.pop_context_managed_teardown_task()
         SetupTeardownContext.active = False
-        SetupTeardownContext.instance_map.pop(setup_task, None)
-        SetupTeardownContext.instance_map.pop(teardown_task, None)
+        SetupTeardownContext.context_map.pop(setup_task, None)
+        SetupTeardownContext.context_map.pop(teardown_task, None)

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -60,17 +60,17 @@ class SetupTeardownContext:
     def update_context_map(cls, operator):
         setup_task = SetupTeardownContext.get_context_managed_setup_task()
         teardown_task = SetupTeardownContext.get_context_managed_teardown_task()
-        ins = SetupTeardownContext.context_map
+        ctx = SetupTeardownContext.context_map
         if setup_task:
-            if ins.get(setup_task) is None:
-                ins[setup_task] = [operator]
+            if ctx.get(setup_task) is None:
+                ctx[setup_task] = [operator]
             else:
-                ins[setup_task].append(operator)
+                ctx[setup_task].append(operator)
         if teardown_task:
-            if ins.get(teardown_task) is None:
-                ins[teardown_task] = [operator]
+            if ctx.get(teardown_task) is None:
+                ctx[teardown_task] = [operator]
             else:
-                ins[teardown_task].append(operator)
+                ctx[teardown_task].append(operator)
 
     @classmethod
     def pop_context_managed_teardown_task(cls) -> Operator | None:

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -87,6 +87,7 @@ class SetupTeardownContext:
             downstream_teardown = [task for task in operator.downstream_list if task._is_teardown]
             if downstream_teardown:
                 SetupTeardownContext.push_context_managed_teardown_task(downstream_teardown[0])
+        SetupTeardownContext.active = True
 
     @classmethod
     def set_work_task_roots_and_leaves(cls):
@@ -98,4 +99,7 @@ class SetupTeardownContext:
                 child.set_downstream(teardown_task)
             if not child.upstream_list and setup_task:
                 child.set_upstream(setup_task)
+        SetupTeardownContext.pop_context_managed_setup_task()
+        SetupTeardownContext.pop_context_managed_teardown_task()
+        SetupTeardownContext.active = False
         cls.children = []

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -19,8 +19,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from airflow.models.mappedoperator import MappedOperator
-
 if TYPE_CHECKING:
     from airflow.models.operator import Operator
 
@@ -76,30 +74,6 @@ class SetupTeardownContext:
     @classmethod
     def get_context_managed_teardown_task(cls) -> Operator | None:
         return cls._context_managed_teardown_task
-
-    @classmethod
-    def connect_setup_upstream(cls, operator):
-        if (
-            cls.active
-            and not isinstance(operator, MappedOperator)
-            and not (operator._is_setup or operator._is_teardown)
-        ):
-            if not operator.upstream_list:
-                setup_task = cls.get_context_managed_setup_task()
-                if setup_task:
-                    setup_task.set_downstream(operator)
-
-    @classmethod
-    def connect_teardown_downstream(cls, operator):
-        if (
-            cls.active
-            and not isinstance(operator, MappedOperator)
-            and not (operator._is_setup or operator._is_teardown)
-        ):
-            if not operator.upstream_list:
-                teardown_task = cls.get_context_managed_teardown_task()
-                if teardown_task:
-                    teardown_task.set_upstream(operator)
 
     @classmethod
     def push_setup_teardown_task(cls, operator):

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -57,6 +57,22 @@ class SetupTeardownContext:
         return old_setup_task
 
     @classmethod
+    def update_instance_map(cls, operator):
+        setup_task = SetupTeardownContext.get_context_managed_setup_task()
+        teardown_task = SetupTeardownContext.get_context_managed_teardown_task()
+        ins = SetupTeardownContext.instance_map
+        if setup_task:
+            if ins.get(setup_task) is None:
+                ins[setup_task] = [operator]
+            else:
+                ins[setup_task].append(operator)
+        if teardown_task:
+            if ins.get(teardown_task) is None:
+                ins[teardown_task] = [operator]
+            else:
+                ins[teardown_task].append(operator)
+
+    @classmethod
     def pop_context_managed_teardown_task(cls) -> Operator | None:
         old_teardown_task = cls._context_managed_teardown_task
         if cls._previous_context_managed_teardown_task:

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -110,7 +110,6 @@ class TestSetupTearDownTask:
                 mygroup()
 
     def test_teardown_taskgroup_decorator(self, dag_maker):
-
         with dag_maker():
             with pytest.raises(
                 expected_exception=AirflowException,
@@ -211,7 +210,6 @@ class TestSetupTearDownTask:
         assert dag.task_group.children["mytask"]._is_teardown is False
         assert dag.task_group.children["mytask2"]._is_setup is False
         assert dag.task_group.children["mytask2"]._is_teardown is False
-
 
     def test_setup_teardown_as_context_manager(self, dag_maker):
         @setup

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -452,7 +452,6 @@ class TestSetupTearDownTask:
         assert dag.task_group.children["mytask"].upstream_task_ids == {"setuptask"}
         assert dag.task_group.children["mytask"].downstream_task_ids == {"mytask2"}
         assert dag.task_group.children["mytask2"].upstream_task_ids == {"mytask"}
-        assert not dag.task_group.children["mytask2"].downstream_task_ids
         assert dag.task_group.children["mytask3"].upstream_task_ids == {"mytask2", "setuptask2"}
         assert dag.task_group.children["mytask3"].downstream_task_ids == {"mytask4"}
         assert dag.task_group.children["mytask4"].upstream_task_ids == {"mytask3"}

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -452,9 +452,11 @@ class TestSetupTearDownTask:
         assert dag.task_group.children["mytask"].upstream_task_ids == {"setuptask"}
         assert dag.task_group.children["mytask"].downstream_task_ids == {"mytask2"}
         assert dag.task_group.children["mytask2"].upstream_task_ids == {"mytask"}
+        assert not dag.task_group.children["mytask2"].downstream_task_ids
         assert dag.task_group.children["mytask3"].upstream_task_ids == {"mytask2", "setuptask2"}
         assert dag.task_group.children["mytask3"].downstream_task_ids == {"mytask4"}
         assert dag.task_group.children["mytask4"].upstream_task_ids == {"mytask3"}
+        assert not dag.task_group.children["mytask4"].downstream_task_ids
 
     def test_task_in_different_setup_context_2(self, dag_maker):
         @setup
@@ -503,6 +505,7 @@ class TestSetupTearDownTask:
         assert dag.task_group.children["mytask3"].upstream_task_ids == {"mytask2", "setuptask2"}
         assert dag.task_group.children["mytask3"].downstream_task_ids == {"mytask4"}
         assert dag.task_group.children["mytask4"].upstream_task_ids == {"mytask3"}
+        assert not dag.task_group.children["mytask4"].downstream_task_ids
 
     def test_setup_teardown_as_context_manager_with_work_task_rel_not_set(self, dag_maker):
         """

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -448,11 +448,11 @@ class TestSetupTearDownTask:
         assert not dag.task_group.children["setuptask"].upstream_task_ids
         assert not dag.task_group.children["setuptask2"].upstream_task_ids
         assert dag.task_group.children["setuptask"].downstream_task_ids == {"mytask"}
-        assert dag.task_group.children["setuptask2"].downstream_task_ids == {"mytask2"}
+        assert dag.task_group.children["setuptask2"].downstream_task_ids == {"mytask3"}
         assert dag.task_group.children["mytask"].upstream_task_ids == {"setuptask"}
         assert dag.task_group.children["mytask"].downstream_task_ids == {"mytask2"}
-        assert dag.task_group.children["mytask2"].upstream_task_ids == {"setuptask2", "mytask"}
-        assert dag.task_group.children["mytask3"].upstream_task_ids == {"mytask2"}
+        assert dag.task_group.children["mytask2"].upstream_task_ids == {"mytask"}
+        assert dag.task_group.children["mytask3"].upstream_task_ids == {"mytask2", "setuptask2"}
         assert dag.task_group.children["mytask3"].downstream_task_ids == {"mytask4"}
         assert dag.task_group.children["mytask4"].upstream_task_ids == {"mytask3"}
 
@@ -493,13 +493,14 @@ class TestSetupTearDownTask:
 
         assert len(dag.task_group.children) == 6
         assert not dag.task_group.children["setuptask"].upstream_task_ids
-        assert not dag.task_group.children["setuptask2"].upstream_task_ids
-        assert dag.task_group.children["setuptask"].downstream_task_ids == {"mytask"}
-        assert dag.task_group.children["setuptask2"].downstream_task_ids == {"mytask2"}
+        assert dag.task_group.children["setuptask2"].upstream_task_ids == {"setuptask"}
+        assert dag.task_group.children["setuptask"].downstream_task_ids == {"mytask", "setuptask2"}
+        assert dag.task_group.children["setuptask2"].downstream_task_ids == {"mytask3"}
         assert dag.task_group.children["mytask"].upstream_task_ids == {"setuptask"}
         assert dag.task_group.children["mytask"].downstream_task_ids == {"mytask2"}
-        assert dag.task_group.children["mytask2"].upstream_task_ids == {"setuptask2", "mytask"}
-        assert dag.task_group.children["mytask3"].upstream_task_ids == {"mytask2"}
+        assert dag.task_group.children["mytask2"].upstream_task_ids == {"mytask"}
+        assert dag.task_group.children["mytask2"].downstream_task_ids == {"mytask3"}
+        assert dag.task_group.children["mytask3"].upstream_task_ids == {"mytask2", "setuptask2"}
         assert dag.task_group.children["mytask3"].downstream_task_ids == {"mytask4"}
         assert dag.task_group.children["mytask4"].upstream_task_ids == {"mytask3"}
 

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -452,6 +452,7 @@ class TestSetupTearDownTask:
         assert dag.task_group.children["mytask"].upstream_task_ids == {"setuptask"}
         assert dag.task_group.children["mytask"].downstream_task_ids == {"mytask2"}
         assert dag.task_group.children["mytask2"].upstream_task_ids == {"mytask"}
+        assert dag.task_group.children["mytask2"].downstream_task_ids == {"mytask3"}
         assert dag.task_group.children["mytask3"].upstream_task_ids == {"mytask2", "setuptask2"}
         assert dag.task_group.children["mytask3"].downstream_task_ids == {"mytask4"}
         assert dag.task_group.children["mytask4"].upstream_task_ids == {"mytask3"}


### PR DESCRIPTION
Setup/teardown decorated tasks return XComArg when called. So, I implemented the __enter__ and __exit__ methods on XComArg and set the relationships there. Also ensured normal tasks do not have context managers

Given this Dag:

```python
from datetime import datetime
from airflow import DAG
from airflow.decorators import task, setup, teardown
from airflow.utils.task_group import TaskGroup

with DAG(
    dag_id='a_setupteardown22',
    catchup=False,
    start_date=datetime(2022, 12, 15, 7, 0, 0),
) as dag:
    @setup
    def setuptask():
        print("setup")


    @setup
    def setuptask2():
        print("setup")

    @setup
    def setuptask3():
        print("setup")


    @setup
    def setuptask4():
        print("setup")

    @teardown
    def teardowntask():
        print("teardown")

    @teardown
    def teardowntask2():
        print("teardown")

    @teardown
    def teardowntask3():
        print("teardown")

    @teardown
    def teardowntask4():
        print("teardown")

    @task()
    def mytask():
        print("mytask")

    @task()
    def mytask2():
        print("mytask")

    @task()
    def mytask3():
        print("mytask")

    @task()
    def mytask4():
        print("mytask")

    @task()
    def mytask5():
        print("mytask")

    @task()
    def mytask6():
        print("mytask")

    with TaskGroup("mygroup") as group1:
        with setuptask() >> teardowntask():
            with setuptask2() >> teardowntask2():
                with setuptask3() >> teardowntask3():
                    mytask() >> mytask2()>> mytask3()
    with setuptask4() >> teardowntask4():
        mytask5() >> mytask6()


    mytask3() >> group1 >> mytask4()
```
produces this graph:
![Screenshot 2023-03-29 at 14 57 43](https://user-images.githubusercontent.com/4122866/228561831-7c70e839-1266-4bc4-98b6-c5f7b7deba69.png)


