### PR TITLE
support requirepass redis sentinel

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2096,7 +2096,7 @@ celery_broker_transport_options:
         ETA you're planning to use.
         visibility_timeout is only supported for Redis and SQS celery brokers.
         See:
-        http://docs.celeryproject.org/en/master/userguide/configuration.html#std:setting-broker_transport_options
+        https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/redis.html#visibility-timeout
       version_added: ~
       type: string
       example: "21600"
@@ -2107,6 +2107,8 @@ celery_broker_transport_options:
         In a typical scenario where Redis Sentinel is used as the broker and Redis servers are
         password-protected, the password needs to be passed through this parameter. Although its
         type is string, it is required to pass a string that conforms to the dictionary format.
+        See:
+        https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/redis.html#configuration
       version_added: 2.7.0
       type: string
       example: '{"password": "password_for_redis_server"}'

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2106,9 +2106,8 @@ celery_broker_transport_options:
         The sentinel_kwargs parameter allows passing additional options to the Sentinel client.
         In a typical scenario where Redis Sentinel is used as the broker and Redis servers are
         password-protected, the password needs to be passed through this parameter. Although its
-        type is string, it is required to pass a string that conforms to the dictionary format,
-        which Airflow will perform special conversion on during reading.
-      version_added: 2.6.1
+        type is string, it is required to pass a string that conforms to the dictionary format.
+      version_added: 2.7.0
       type: string
       example: '{"password": "password_for_redis_server"}'
       default: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2101,6 +2101,17 @@ celery_broker_transport_options:
       type: string
       example: "21600"
       default: ~
+    sentinel_kwargs:
+      description: |
+        The sentinel_kwargs parameter allows passing additional options to the Sentinel client.
+        In a typical scenario where Redis Sentinel is used as the broker and Redis servers are
+        password-protected, the password needs to be passed through this parameter. Although its
+        type is string, it is required to pass a string that conforms to the dictionary format,
+        which Airflow will perform special conversion on during reading.
+      version_added: 2.6.1
+      type: string
+      example: '{"password": "password_for_redis_server"}'
+      default: ~
 dask:
   description: |
     This section only applies if you are using the DaskExecutor in

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1080,8 +1080,7 @@ worker_precheck = False
 # The sentinel_kwargs parameter allows passing additional options to the Sentinel client.
 # In a typical scenario where Redis Sentinel is used as the broker and Redis servers are
 # password-protected, the password needs to be passed through this parameter. Although its
-# type is string, it is required to pass a string that conforms to the dictionary format,
-# which Airflow will perform special conversion on during reading.
+# type is string, it is required to pass a string that conforms to the dictionary format.
 # Example: sentinel_kwargs = {{"password": "password_for_redis_server"}}
 # sentinel_kwargs =
 

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1077,6 +1077,14 @@ worker_precheck = False
 # Example: visibility_timeout = 21600
 # visibility_timeout =
 
+# The sentinel_kwargs parameter allows passing additional options to the Sentinel client.
+# In a typical scenario where Redis Sentinel is used as the broker and Redis servers are
+# password-protected, the password needs to be passed through this parameter. Although its
+# type is string, it is required to pass a string that conforms to the dictionary format,
+# which Airflow will perform special conversion on during reading.
+# Example: sentinel_kwargs = {{"password": "password_for_redis_server"}}
+# sentinel_kwargs =
+
 [dask]
 
 # This section only applies if you are using the DaskExecutor in

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1073,7 +1073,7 @@ worker_precheck = False
 # ETA you're planning to use.
 # visibility_timeout is only supported for Redis and SQS celery brokers.
 # See:
-# http://docs.celeryproject.org/en/master/userguide/configuration.html#std:setting-broker_transport_options
+# https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/redis.html#visibility-timeout
 # Example: visibility_timeout = 21600
 # visibility_timeout =
 
@@ -1081,6 +1081,8 @@ worker_precheck = False
 # In a typical scenario where Redis Sentinel is used as the broker and Redis servers are
 # password-protected, the password needs to be passed through this parameter. Although its
 # type is string, it is required to pass a string that conforms to the dictionary format.
+# See:
+# https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/redis.html#configuration
 # Example: sentinel_kwargs = {{"password": "password_for_redis_server"}}
 # sentinel_kwargs =
 

--- a/airflow/config_templates/default_celery.py
+++ b/airflow/config_templates/default_celery.py
@@ -42,6 +42,8 @@ broker_transport_options_for_celery: dict = dict.copy(broker_transport_options)
 if "sentinel_kwargs" in broker_transport_options:
     try:
         sentinel_kwargs = conf.getjson("celery_broker_transport_options", "sentinel_kwargs")
+        if not isinstance(sentinel_kwargs, dict):
+            raise ValueError
         broker_transport_options_for_celery["sentinel_kwargs"] = sentinel_kwargs
     except Exception:
         raise AirflowException("sentinel_kwargs should be written in the correct dictionary format.")

--- a/airflow/config_templates/default_celery.py
+++ b/airflow/config_templates/default_celery.py
@@ -37,10 +37,12 @@ broker_transport_options = conf.getsection("celery_broker_transport_options") or
 if "visibility_timeout" not in broker_transport_options:
     if _broker_supports_visibility_timeout(broker_url):
         broker_transport_options["visibility_timeout"] = 21600
+
+broker_transport_options_for_celery: dict = dict.copy(broker_transport_options)
 if "sentinel_kwargs" in broker_transport_options:
     try:
-        sen_kwargs = conf.getjson("celery_broker_transport_options", "sentinel_kwargs")
-        broker_transport_options["sentinel_kwargs"] = sen_kwargs
+        sentinel_kwargs = conf.getjson("celery_broker_transport_options", "sentinel_kwargs")
+        broker_transport_options_for_celery["sentinel_kwargs"] = sentinel_kwargs
     except Exception:
         raise AirflowException("sentinel_kwargs should be written in the correct dictionary format.")
 
@@ -59,7 +61,7 @@ DEFAULT_CELERY_CONFIG = {
     "task_default_exchange": conf.get("operators", "DEFAULT_QUEUE"),
     "task_track_started": conf.getboolean("celery", "task_track_started"),
     "broker_url": broker_url,
-    "broker_transport_options": broker_transport_options,
+    "broker_transport_options": broker_transport_options_for_celery,
     "result_backend": result_backend,
     "worker_concurrency": conf.getint("celery", "WORKER_CONCURRENCY"),
     "worker_enable_remote_control": conf.getboolean("celery", "worker_enable_remote_control"),

--- a/docs/apache-airflow/core-concepts/executor/celery.rst
+++ b/docs/apache-airflow/core-concepts/executor/celery.rst
@@ -22,7 +22,7 @@ Celery Executor
 ===============
 
 ``CeleryExecutor`` is one of the ways you can scale out the number of workers. For this
-to work, you need to setup a Celery backend (**RabbitMQ**, **Redis**, ...) and
+to work, you need to setup a Celery backend (**RabbitMQ**, **Redis**, **Redis Sentinel** ...) and
 change your ``airflow.cfg`` to point the executor parameter to
 ``CeleryExecutor`` and provide the related Celery settings.
 
@@ -83,6 +83,7 @@ Some caveats:
 
 - Make sure to use a database backed result backend
 - Make sure to set a visibility timeout in ``[celery_broker_transport_options]`` that exceeds the ETA of your longest running task
+- Make sure to specify the password for Redis Server in the [celery_broker_transport_options] section if you are using Redis Sentinel as your broker and the Redis servers are password-protected
 - Make sure to set umask in ``[worker_umask]`` to set permissions for newly created files by workers.
 - Tasks can consume resources. Make sure your worker has enough resources to run ``worker_concurrency`` tasks
 - Queue names are limited to 256 characters, but each broker backend might have its own restrictions

--- a/docs/apache-airflow/core-concepts/executor/celery.rst
+++ b/docs/apache-airflow/core-concepts/executor/celery.rst
@@ -83,7 +83,7 @@ Some caveats:
 
 - Make sure to use a database backed result backend
 - Make sure to set a visibility timeout in ``[celery_broker_transport_options]`` that exceeds the ETA of your longest running task
-- Make sure to specify the password for Redis Server in the [celery_broker_transport_options] section if you are using Redis Sentinel as your broker and the Redis servers are password-protected
+- Make sure to specify the password for Redis Server in the ``[celery_broker_transport_options]`` section if you are using Redis Sentinel as your broker and the Redis servers are password-protected
 - Make sure to set umask in ``[worker_umask]`` to set permissions for newly created files by workers.
 - Tasks can consume resources. Make sure your worker has enough resources to run ``worker_concurrency`` tasks
 - Queue names are limited to 256 characters, but each broker backend might have its own restrictions


### PR DESCRIPTION
In my deployment, I am using a celery worker with Redis Sentinel configured as a broker, with both Redis and Sentinel having password authentication enabled. To configure the password in sentinel_kwargs, I encountered an error when I added it to the celery_broker_transport_options section. However, I was able to resolve the issue by using conf.getjson() to load the sentinel_kwargs configuration, and it now works without any issues.

Closes: https://github.com/apache/airflow/issues/28010