### PR TITLE
Fix graph zoom scale

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -253,6 +253,7 @@ function draw() {
 }
 
 let zoom = null;
+const maxZoom = 0.3;
 
 function setUpZoomSupport() {
   // Set up zoom support for Graph
@@ -272,12 +273,14 @@ function setUpZoomSupport() {
   const padding = width * 0.05;
 
   // Calculate applicable scale for zoom
+
   const zoomScale =
-    Math.min(Math.min(width / graphWidth, height / graphHeight)) * 0.8;
+    Math.min(Math.min(width / graphWidth, height / graphHeight), maxZoom) * 0.8;
 
   zoom.translate([width / 2 - (graphWidth * zoomScale) / 2 + padding, padding]);
   zoom.scale(zoomScale);
   zoom.event(innerSvg);
+  zoom.scaleExtent([0, maxZoom]);
 }
 
 function highlightNodes(nodes) {
@@ -664,7 +667,7 @@ function focusGroup(nodeId, followMouse = true) {
 
     // Calculate zoom scale to fill most of the canvas with the node/cluster in focus.
     const scale =
-      Math.min(Math.min(width / nodeWidth, height / nodeHeight), 1) * 0.2;
+      Math.min(Math.min(width / nodeWidth, height / nodeHeight), maxZoom) * 0.8;
 
     // Move the graph so that the node that was expanded/collapsed is centered around
     // the mouse click.


### PR DESCRIPTION
Addressing an issue raised in https://github.com/apache/airflow/issues/30337#issuecomment-1485924177 coming from https://github.com/apache/airflow/pull/29971

The default zoom in was way too much and disconnected vertical elements were not visible by default.
This PR adds a max zoom and also makes sure that the default zoom stays the same when expanding/collapsing groups:




| Before    | After |
| -------- | ------- |
| <img width="1319" alt="Screenshot 2023-03-29 at 9 48 52 AM" src="https://user-images.githubusercontent.com/4600967/228563519-0cf42803-5057-4fa7-958d-231d185e4fea.png">  | <img width="1318" alt="Screenshot 2023-03-29 at 9 49 06 AM" src="https://user-images.githubusercontent.com/4600967/228563566-bcd8a798-0c7b-4895-bb55-7e243f9c650d.png">    |
| ![before](https://user-images.githubusercontent.com/4600967/228563686-a362ba86-2f0a-4666-9219-d1ac8b1bad40.gif) | ![after](https://user-images.githubusercontent.com/4600967/228563736-22da1db1-e27d-4fb1-b786-1e95b51e6191.gif) |



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
