### PR TITLE
Remove mocked `get_async_conn.__aenter__` in ADF hook tests

### DIFF
--- a/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
@@ -811,7 +811,7 @@ class TestAzureDataFactoryAsyncHook:
             extra=json.dumps({"extra__azure_data_factory__factory_name": DATAFACTORY_NAME})
         )
         mock_get_connection.return_value = mock_connection
-        mock_conn.return_value.__aenter__.return_value.pipeline_runs.get.return_value = mock_pipeline_run
+        mock_conn.return_value.pipeline_runs.get.return_value = mock_pipeline_run
         hook = AzureDataFactoryAsyncHook(AZURE_DATA_FACTORY_CONN_ID)
         with pytest.raises(AirflowException):
             await hook.get_pipeline_run(RUN_ID, None, DATAFACTORY_NAME)
@@ -820,9 +820,7 @@ class TestAzureDataFactoryAsyncHook:
     @async_mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_async_conn")
     async def test_get_pipeline_run_exception(self, mock_conn):
         """Test get_pipeline_run function with exception"""
-        mock_conn.return_value.__aenter__.return_value.pipeline_runs.get.side_effect = Exception(
-            "Test exception"
-        )
+        mock_conn.return_value.pipeline_runs.get.side_effect = Exception("Test exception")
         hook = AzureDataFactoryAsyncHook(AZURE_DATA_FACTORY_CONN_ID)
         with pytest.raises(AirflowException):
             await hook.get_pipeline_run(RUN_ID, RESOURCE_GROUP_NAME, DATAFACTORY_NAME)


### PR DESCRIPTION
As part of #30248, using the `get_async_conn()` method as a context manager was removed in the AzureDataFactoryHook. The Python 3.7 tests all passed, but 3.8+ tests on `main` were failing. There is no reason to mock the `__aenter__` property since method is no longer used as a context manager.