### PR TITLE
Restore graph expand/collapse scale

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -667,7 +667,7 @@ function focusGroup(nodeId, followMouse = true) {
 
     // Calculate zoom scale to fill most of the canvas with the node/cluster in focus.
     const scale =
-      Math.min(Math.min(width / nodeWidth, height / nodeHeight), maxZoom) * 0.8;
+      Math.min(Math.min(width / nodeWidth, height / nodeHeight), maxZoom) * 0.4;
 
     // Move the graph so that the node that was expanded/collapsed is centered around
     // the mouse click.


### PR DESCRIPTION
#30355

Changing the degree of expand/collapse group scaling. It was fine with 1-level task groups, but it was too zoomed in. This PR just zooms it out a little bit. I'd do more logic to actually calculate the top-level parent size and keep the zoom there, but we'll have a new graph in 2.6.0

Before:
<img width="1133" alt="Screenshot 2023-03-29 at 2 14 21 PM" src="https://user-images.githubusercontent.com/4600967/228630531-db156f02-0767-47c4-b9e1-d8fab6013bb5.png">


After:
<img width="830" alt="Screenshot 2023-03-29 at 2 13 59 PM" src="https://user-images.githubusercontent.com/4600967/228630573-2870ffc8-97c9-448a-aa1a-aaa69e591fc8.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
