### PR TITLE
Fix airflow module version check when using ExternalPythonOperator and debug logging level

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -61,7 +61,8 @@ __path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
 
 
 # Perform side-effects unless someone has explicitly opted out before import
-# WARNING: DO NOT USE THIS UNLESS YOU REALLY KNOW WHAT YOU'RE DOING.
+# WARNING: Use with care, `_AIRFLOW__AS_LIBRARY` will prevent proper intialization (configs, syspath, logger...).
+#          It might be needed if you intend to use airflow as third-party package.
 if not os.environ.get("_AIRFLOW__AS_LIBRARY", None):
     settings.initialize()
 

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -61,8 +61,10 @@ __path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
 
 
 # Perform side-effects unless someone has explicitly opted out before import
-# WARNING: Use with care, `_AIRFLOW__AS_LIBRARY` will prevent proper intialization (configs, syspath, logger...).
-#          It might be needed if you intend to use airflow as third-party package.
+# WARNING: DO NOT USE THIS UNLESS YOU REALLY KNOW WHAT YOU'RE DOING.
+# This environment variable prevents proper intialization, and things like
+# configs, logging, the ORM, etc. will be broken. It is only useful if you only
+# access certain trivial constants and free functions (e.g. `__version__`).
 if not os.environ.get("_AIRFLOW__AS_LIBRARY", None):
     settings.initialize()
 

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -62,7 +62,7 @@ __path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
 
 # Perform side-effects unless someone has explicitly opted out before import
 # WARNING: DO NOT USE THIS UNLESS YOU REALLY KNOW WHAT YOU'RE DOING.
-# This environment variable prevents proper intialization, and things like
+# This environment variable prevents proper initialization, and things like
 # configs, logging, the ORM, etc. will be broken. It is only useful if you only
 # access certain trivial constants and free functions (e.g. `__version__`).
 if not os.environ.get("_AIRFLOW__AS_LIBRARY", None):

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -727,7 +727,9 @@ class ExternalPythonOperator(_BasePythonVirtualenvOperator):
 
         try:
             result = subprocess.check_output(
-                [self.python, "-c", "from airflow import __version__; print(__version__)"], text=True, env=dict(os.environ, _AIRFLOW__AS_LIBRARY="true")
+                [self.python, "-c", "from airflow import __version__; print(__version__)"],
+                text=True,
+                env={**os.environ, "_AIRFLOW__AS_LIBRARY": "true"},
             )
             target_airflow_version = result.strip()
             if target_airflow_version != airflow_version:

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -729,7 +729,8 @@ class ExternalPythonOperator(_BasePythonVirtualenvOperator):
             result = subprocess.check_output(
                 [self.python, "-c", "from airflow import __version__; print(__version__)"],
                 text=True,
-                env={**os.environ, "_AIRFLOW__AS_LIBRARY": "true"},  # Required to avoid `result` polluted by Airflow logs.
+                # Avoid Airflow logs polluting stdout.
+                env={**os.environ, "_AIRFLOW__AS_LIBRARY": "true"},
             )
             target_airflow_version = result.strip()
             if target_airflow_version != airflow_version:

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -729,7 +729,7 @@ class ExternalPythonOperator(_BasePythonVirtualenvOperator):
             result = subprocess.check_output(
                 [self.python, "-c", "from airflow import __version__; print(__version__)"],
                 text=True,
-                env={**os.environ, "_AIRFLOW__AS_LIBRARY": "true"},  # Required to avoid `result` polluted by airflow init logs.
+                env={**os.environ, "_AIRFLOW__AS_LIBRARY": "true"},  # Required to avoid `result` polluted by Airflow logs.
             )
             target_airflow_version = result.strip()
             if target_airflow_version != airflow_version:

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -727,7 +727,7 @@ class ExternalPythonOperator(_BasePythonVirtualenvOperator):
 
         try:
             result = subprocess.check_output(
-                [self.python, "-c", "from airflow import __version__; print(__version__)"], text=True
+                [self.python, "-c", "from airflow import __version__; print(__version__)"], text=True, env=dict(os.environ, _AIRFLOW__AS_LIBRARY="true")
             )
             target_airflow_version = result.strip()
             if target_airflow_version != airflow_version:

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -729,7 +729,7 @@ class ExternalPythonOperator(_BasePythonVirtualenvOperator):
             result = subprocess.check_output(
                 [self.python, "-c", "from airflow import __version__; print(__version__)"],
                 text=True,
-                env={**os.environ, "_AIRFLOW__AS_LIBRARY": "true"},
+                env={**os.environ, "_AIRFLOW__AS_LIBRARY": "true"},  # Required to avoid `result` polluted by airflow init logs.
             )
             target_airflow_version = result.strip()
             if target_airflow_version != airflow_version:


### PR DESCRIPTION
**Context:**
- An Airflow instance (2.5.2) with debug logging level
- A Dag with an `ExternalPythonOperator` or `PythonVirtualenvOperator` task

---

In the upper context, the task fails to retrieve the Airflow context, and this line appears in the task log:
> [2023-03-30, 10:15:17 CEST] {python.py:711} WARNING - When checking for Airflow installed in venv got The version of Airflow installed for the /venvs/shotgun/bin/python([2023-03-30T08:15:17.222+0000] {settings.py:267} DEBUG - Setting up DB connection pool (PID 241)

It appears that the result of the following call contains log outputs from the worker: https://github.com/apache/airflow/blob/6e751812d2e48b743ae1bc375e3bebb8414b4a0e/airflow/operators/python.py#L695-L697

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

