### PR TITLE
Fix `RedshiftResumeClusterOperator` deferrable implementation

### DIFF
--- a/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -470,7 +470,7 @@ class RedshiftResumeClusterOperator(BaseOperator):
                 raise AirflowException(msg)
             elif "status" in event and event["status"] == "success":
                 self.log.info("%s completed successfully.", self.task_id)
-                self.log.info("Paused cluster successfully")
+                self.log.info("Resumed cluster successfully")
         else:
             raise AirflowException("No event received from trigger")
 

--- a/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -440,7 +440,7 @@ class RedshiftResumeClusterOperator(BaseOperator):
                     aws_conn_id=self.aws_conn_id,
                     cluster_identifier=self.cluster_identifier,
                     attempts=self._attempts,
-                    operation_type="pause_cluster",
+                    operation_type="resume_cluster",
                 ),
                 method_name="execute_complete",
             )

--- a/airflow/providers/amazon/aws/triggers/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/triggers/redshift_cluster.py
@@ -70,6 +70,16 @@ class RedshiftClusterTrigger(BaseTrigger):
                     else:
                         if self.attempts < 1:
                             yield TriggerEvent({"status": "error", "message": f"{self.task_id} failed"})
+                elif self.operation_type == "resume_cluster":
+                    response = await hook.resume_cluster(
+                        cluster_identifier=self.cluster_identifier,
+                        polling_period_seconds=self.poll_interval,
+                    )
+                    if response:
+                        yield TriggerEvent(response)
+                    else:
+                        error_message = f"{self.task_id} failed"
+                        yield TriggerEvent({"status": "error", "message": error_message})
                 else:
                     yield TriggerEvent(f"{self.operation_type} is not supported")
             except Exception as e:

--- a/tests/providers/amazon/aws/deferrable/hooks/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/deferrable/hooks/test_redshift_cluster.py
@@ -82,3 +82,44 @@ class TestRedshiftAsyncHook:
             "message": "An error occurred (SomeServiceException) when calling the "
             "redshift operation: Details/context around the exception or error",
         }
+
+    @pytest.mark.asyncio
+    @async_mock.patch("aiobotocore.client.AioBaseClient._make_api_call")
+    async def test_resume_cluster(self, mock_make_api_call):
+        """Test Resume cluster async hook function by mocking return value of resume_cluster"""
+
+        hook = RedshiftAsyncHook(aws_conn_id="test_aws_connection_id")
+        await hook.resume_cluster(cluster_identifier="redshift_cluster_1")
+        mock_make_api_call.assert_called_once_with(
+            "ResumeCluster", {"ClusterIdentifier": "redshift_cluster_1"}
+        )
+
+    @pytest.mark.asyncio
+    @async_mock.patch(
+        "airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftAsyncHook.get_client_async"
+    )
+    async def test_resume_cluster_exception(self, mock_client):
+        """Test Resume cluster async hook function with exception by mocking return value of resume_cluster"""
+        mock_client.return_value.__aenter__.return_value.resume_cluster.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "SomeServiceException",
+                    "Message": "Details/context around the exception or error",
+                },
+                "ResponseMetadata": {
+                    "RequestId": "1234567890ABCDEF",
+                    "HostId": "host ID data will appear here as a hash",
+                    "HTTPStatusCode": 500,
+                    "HTTPHeaders": {"header metadata key/values will appear here"},
+                    "RetryAttempts": 0,
+                },
+            },
+            operation_name="redshift",
+        )
+        hook = RedshiftAsyncHook(aws_conn_id="test_aws_connection_id")
+        result = await hook.resume_cluster(cluster_identifier="test")
+        assert result == {
+            "status": "error",
+            "message": "An error occurred (SomeServiceException) when calling the "
+            "redshift operation: Details/context around the exception or error",
+        }


### PR DESCRIPTION
This PR fixes the bug on `RedshiftResumeClusterOperator` implementation when deferrable flag is set to True
Related to https://github.com/apache/airflow/pull/30090

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
