### PR TITLE
Simplify logic to resolve tasks stuck in queued despite stalled_task_timeout

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2047,26 +2047,6 @@ celery:
       type: boolean
       example: ~
       default: "True"
-    task_adoption_timeout:
-      description: |
-        Time in seconds after which adopted tasks which are queued in celery are assumed to be stalled,
-        and are automatically rescheduled. This setting does the same thing as ``stalled_task_timeout`` but
-        applies specifically to adopted tasks only. When set to 0, the ``stalled_task_timeout`` setting
-        also applies to adopted tasks. To calculate adoption time, subtract the
-        :ref:`task duration<ui:task-duration>` from the task's :ref:`landing time<ui:landing-times>`.
-      version_added: 2.0.0
-      type: integer
-      example: ~
-      default: "600"
-    stalled_task_timeout:
-      description: |
-        Time in seconds after which tasks queued in celery are assumed to be stalled, and are automatically
-        rescheduled. Adopted tasks will instead use the ``task_adoption_timeout`` setting if specified.
-        When set to 0, automatic clearing of stalled tasks is disabled.
-      version_added: 2.3.1
-      type: integer
-      example: ~
-      default: "0"
     task_publish_max_retries:
       description: |
         The Maximum number of retries for publishing task messages to the broker when failing
@@ -2415,6 +2395,13 @@ scheduler:
       type: string
       example: ~
       default: "15"
+    task_queued_timeout:
+      description: |
+        Amount of time a task can be in the queued state before being retried or set to failed.
+      version_added: 2.6.0
+      type: float
+      example: ~
+      default: "600.0"
 triggerer:
   description: ~
   options:
@@ -2731,20 +2718,6 @@ kubernetes_executor:
       type: boolean
       example: ~
       default: "True"
-    worker_pods_pending_timeout:
-      description: |
-        How long in seconds a worker can be in Pending before it is considered a failure
-      version_added: 2.1.0
-      type: integer
-      example: ~
-      default: "300"
-    worker_pods_pending_timeout_check_interval:
-      description: |
-        How often in seconds to check if Pending workers have exceeded their timeouts
-      version_added: 2.1.0
-      type: integer
-      example: ~
-      default: "120"
     worker_pods_queued_check_interval:
       description: |
         How often in seconds to check for task instances stuck in "queued" status without a pod
@@ -2752,14 +2725,6 @@ kubernetes_executor:
       type: integer
       example: ~
       default: "60"
-    worker_pods_pending_timeout_batch_size:
-      description: |
-        How many pending pods to check for timeout violations in each check interval.
-        You may want this higher if you have a very large cluster and/or use ``multi_namespace_mode``.
-      version_added: 2.1.0
-      type: integer
-      example: ~
-      default: "100"
     ssl_ca_cert:
       description: |
         Path to a CA certificate to be used by the Kubernetes client to verify the server's SSL certificate.

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2402,6 +2402,14 @@ scheduler:
       type: float
       example: ~
       default: "600.0"
+    task_queued_timeout_check_interval:
+      description: |
+        How often to check for tasks that have been in the queued state for
+        longer than `[scheduler] task_queued_timeout`.
+      version_added: 2.6.0
+      type: float
+      example: ~
+      default: "120.0"
 triggerer:
   description: ~
   options:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1219,6 +1219,10 @@ trigger_timeout_check_interval = 15
 # Amount of time a task can be in the queued state before being retried or set to failed.
 task_queued_timeout = 600.0
 
+# How often to check for tasks that have been in the queued state for
+# longer than `[scheduler] task_queued_timeout`.
+task_queued_timeout_check_interval = 120.0
+
 [triggerer]
 # How many triggers a single Triggerer will run at once, by default.
 default_capacity = 1000

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1363,18 +1363,8 @@ tcp_keep_cnt = 6
 # Set this to false to skip verifying SSL certificate of Kubernetes python client.
 verify_ssl = True
 
-# How long in seconds a worker can be in Pending before it is considered a failure
-worker_pods_pending_timeout = 300
-
-# How often in seconds to check if Pending workers have exceeded their timeouts
-worker_pods_pending_timeout_check_interval = 120
-
 # How often in seconds to check for task instances stuck in "queued" status without a pod
 worker_pods_queued_check_interval = 60
-
-# How many pending pods to check for timeout violations in each check interval.
-# You may want this higher if you have a very large cluster and/or use ``multi_namespace_mode``.
-worker_pods_pending_timeout_batch_size = 100
 
 # Path to a CA certificate to be used by the Kubernetes client to verify the server's SSL certificate.
 ssl_ca_cert =

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1033,18 +1033,6 @@ operation_timeout = 1.0
 # or run in HA mode, it can adopt the orphan tasks launched by previous SchedulerJob.
 task_track_started = True
 
-# Time in seconds after which adopted tasks which are queued in celery are assumed to be stalled,
-# and are automatically rescheduled. This setting does the same thing as ``stalled_task_timeout`` but
-# applies specifically to adopted tasks only. When set to 0, the ``stalled_task_timeout`` setting
-# also applies to adopted tasks. To calculate adoption time, subtract the
-# :ref:`task duration<ui:task-duration>` from the task's :ref:`landing time<ui:landing-times>`.
-task_adoption_timeout = 600
-
-# Time in seconds after which tasks queued in celery are assumed to be stalled, and are automatically
-# rescheduled. Adopted tasks will instead use the ``task_adoption_timeout`` setting if specified.
-# When set to 0, automatic clearing of stalled tasks is disabled.
-stalled_task_timeout = 0
-
 # The Maximum number of retries for publishing task messages to the broker when failing
 # due to ``AirflowTaskTimeout`` error before giving up and marking Task as failed.
 task_publish_max_retries = 3
@@ -1227,6 +1215,9 @@ allow_trigger_in_future = False
 
 # How often to check for expired trigger requests that have not run yet.
 trigger_timeout_check_interval = 15
+
+# Amount of time a task can be in the queued state before being retried or set to failed.
+task_queued_timeout = 600.0
 
 [triggerer]
 # How many triggers a single Triggerer will run at once, by default.

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -237,7 +237,8 @@ class AirflowConfigParser(ConfigParser):
     }
 
     # A mapping of new configurations to a list of old configurations for when one configuration
-    # deprecates more than one other deprecation.
+    # deprecates more than one other deprecation. The deprecation logic for these configurations
+    # is defined in SchedulerJobRunner.
     many_to_one_deprecated_options: dict[tuple[str, str], list[tuple[str, str, str]]] = {
         ("scheduler", "task_queued_timeout"): [
             ("celery", "stalled_task_timeout", "2.6.0"),

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -236,6 +236,16 @@ class AirflowConfigParser(ConfigParser):
         ("scheduler", "parsing_cleanup_interval"): ("scheduler", "deactivate_stale_dags_interval", "2.5.0"),
     }
 
+    # A mapping of new configurations to a list of old configurations for when one configuration
+    # deprecates more than one other deprecation.
+    many_to_one_deprecated_options: dict[tuple[str, str], list[tuple[str, str, str]]] = {
+        ("scheduler", "task_queued_timeout"): [
+            ("celery", "stalled_task_timeout", "2.6.0"),
+            ("celery", "task_adoption_timeout", "2.6.0"),
+            ("kubernetes_executor", "worker_pods_pending_timeout", "2.6.0"),
+        ]
+    }
+
     # A mapping of new section -> (old section, since_version).
     deprecated_sections: dict[str, tuple[str, str]] = {"kubernetes_executor": ("kubernetes", "2.5.0")}
 
@@ -548,12 +558,10 @@ class AirflowConfigParser(ConfigParser):
 
     @overload  # type: ignore[override]
     def get(self, section: str, key: str, fallback: str = ..., **kwargs) -> str:  # type: ignore[override]
-
         ...
 
     @overload  # type: ignore[override]
     def get(self, section: str, key: str, **kwargs) -> str | None:  # type: ignore[override]
-
         ...
 
     def get(  # type: ignore[override, misc]
@@ -1070,7 +1078,7 @@ class AirflowConfigParser(ConfigParser):
             # This ensures the ones from config file is hidden too
             # if they are not provided through env, cmd and secret
             hidden = "< hidden >"
-            for (section, key) in self.sensitive_config_values:
+            for section, key in self.sensitive_config_values:
                 if not config_sources.get(section):
                     continue
                 if config_sources[section].get(key, None):
@@ -1089,7 +1097,7 @@ class AirflowConfigParser(ConfigParser):
         display_source: bool,
         raw: bool,
     ):
-        for (section, key) in self.sensitive_config_values:
+        for section, key in self.sensitive_config_values:
             value: str | None = self._get_secret_option_from_config_sources(config_sources, section, key)
             if value:
                 if not display_sensitive:
@@ -1110,7 +1118,7 @@ class AirflowConfigParser(ConfigParser):
         display_source: bool,
         raw: bool,
     ):
-        for (section, key) in self.sensitive_config_values:
+        for section, key in self.sensitive_config_values:
             opt = self._get_cmd_option_from_config_sources(config_sources, section, key)
             if not opt:
                 continue
@@ -1188,7 +1196,7 @@ class AirflowConfigParser(ConfigParser):
         :return: None, the given config_sources is filtered if necessary,
             otherwise untouched.
         """
-        for (section, key) in self.sensitive_config_values:
+        for section, key in self.sensitive_config_values:
             # Don't bother if we don't have section / key
             if section not in config_sources or key not in config_sources[section]:
                 continue
@@ -1222,7 +1230,7 @@ class AirflowConfigParser(ConfigParser):
         include_cmds: bool,
         include_secret: bool,
     ):
-        for (source_name, config) in configs:
+        for source_name, config in configs:
             for section in config.sections():
                 AirflowConfigParser._replace_section_config_with_display_sources(
                     config,
@@ -1249,7 +1257,7 @@ class AirflowConfigParser(ConfigParser):
                 continue
             try:
                 deprecated_section_array = config.items(section=deprecated_section, raw=True)
-                for (key_candidate, _) in deprecated_section_array:
+                for key_candidate, _ in deprecated_section_array:
                     if key_candidate == deprecated_key:
                         return True
             except NoSectionError:

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -234,6 +234,11 @@ class AirflowConfigParser(ConfigParser):
         ("database", "load_default_connections"): ("core", "load_default_connections", "2.3.0"),
         ("database", "max_db_retries"): ("core", "max_db_retries", "2.3.0"),
         ("scheduler", "parsing_cleanup_interval"): ("scheduler", "deactivate_stale_dags_interval", "2.5.0"),
+        ("scheduler", "task_queued_timeout_check_interval"): (
+            "kubernetes_executor",
+            "worker_pods_pending_timeout_check_interval",
+            "2.6.0",
+        ),
     }
 
     # A mapping of new configurations to a list of old configurations for when one configuration

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -375,8 +375,8 @@ class BaseExecutor(LoggingMixin):
     def terminate(self):
         """This method is called when the daemon receives a SIGTERM."""
         raise NotImplementedError()
-    
-    def cleanup_stuck_queued_tasks(self, tis: Sequence[TaskInstance]) -> None: # pragma: no cover
+
+    def cleanup_stuck_queued_tasks(self, tis: Sequence[TaskInstance]) -> None:  # pragma: no cover
         """
         Handle remnants of tasks that were failed because they were stuck in queued.
         Tasks can get stuck in queued. If such a task is detected, it will be marked

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -389,7 +389,10 @@ class BaseExecutor(LoggingMixin):
         readable_tis = []
         for ti in tis:
             readable_tis.append(repr(ti))
-            self.fail(ti.key, None)
+
+        self.log.warning(
+            "These tasks would have been failed on an executor that supports the configuration setting `[scheduler] task_queued_timeout`, but the current executor does not support it."
+        )
         return readable_tis
 
     def try_adopt_task_instances(self, tis: Sequence[TaskInstance]) -> Sequence[TaskInstance]:

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -376,13 +376,15 @@ class BaseExecutor(LoggingMixin):
         """This method is called when the daemon receives a SIGTERM."""
         raise NotImplementedError()
 
-    def cleanup_stuck_queued_task(self, ti: TaskInstance) -> None:  # pragma: no cover
+    def cleanup_stuck_queued_tasks(self, tis: list[TaskInstance]) -> list[str]:  # pragma: no cover
         """
         Handle remnants of tasks that were failed because they were stuck in queued.
         Tasks can get stuck in queued. If such a task is detected, it will be marked
         as `UP_FOR_RETRY` if the task instance has remaining retries or marked as `FAILED`
         if it doesn't.
-        :param ti: Task Instance to clean up
+
+        :param tis: List of Task Instances to clean up
+        :return: List of readable task instances for a warning message
         """
         raise NotImplementedError()
 

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -375,6 +375,16 @@ class BaseExecutor(LoggingMixin):
     def terminate(self):
         """This method is called when the daemon receives a SIGTERM."""
         raise NotImplementedError()
+    
+    def cleanup_stuck_queued_tasks(self, tis: Sequence[TaskInstance]) -> None: # pragma: no cover
+        """
+        Handle remnants of tasks that were failed because they were stuck in queued.
+        Tasks can get stuck in queued. If such a task is detected, it will be marked
+        as `UP_FOR_RETRY` if the task instance has remaining retries or marked as `FAILED`
+        if it doesn't.
+        :param tis: Task Instances to clean up
+        """
+        raise NotImplementedError()
 
     def try_adopt_task_instances(self, tis: Sequence[TaskInstance]) -> Sequence[TaskInstance]:
         """

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -376,13 +376,13 @@ class BaseExecutor(LoggingMixin):
         """This method is called when the daemon receives a SIGTERM."""
         raise NotImplementedError()
 
-    def cleanup_stuck_queued_tasks(self, tis: Sequence[TaskInstance]) -> None:  # pragma: no cover
+    def cleanup_stuck_queued_task(self, ti: TaskInstance) -> None:  # pragma: no cover
         """
         Handle remnants of tasks that were failed because they were stuck in queued.
         Tasks can get stuck in queued. If such a task is detected, it will be marked
         as `UP_FOR_RETRY` if the task instance has remaining retries or marked as `FAILED`
         if it doesn't.
-        :param tis: Task Instances to clean up
+        :param ti: Task Instance to clean up
         """
         raise NotImplementedError()
 

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -297,8 +297,10 @@ class BaseExecutor(LoggingMixin):
         """
         self.log.debug("Changing state: %s", key)
         try:
+            print(f"\n\n removing key {key}")
             self.running.remove(key)
         except KeyError:
+            print(f"Key error!")
             self.log.debug("Could not find key: %s", str(key))
         self.event_buffer[key] = state, info
 
@@ -386,7 +388,11 @@ class BaseExecutor(LoggingMixin):
         :param tis: List of Task Instances to clean up
         :return: List of readable task instances for a warning message
         """
-        raise NotImplementedError()
+        readable_tis = []
+        for ti in tis:
+            readable_tis.append(repr(ti))
+            self.fail(ti.key, None)
+        return readable_tis
 
     def try_adopt_task_instances(self, tis: Sequence[TaskInstance]) -> Sequence[TaskInstance]:
         """

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -376,7 +376,7 @@ class BaseExecutor(LoggingMixin):
         """This method is called when the daemon receives a SIGTERM."""
         raise NotImplementedError()
 
-    def cleanup_stuck_queued_tasks(self, tis: list[TaskInstance]) -> list[str]:
+    def cleanup_stuck_queued_tasks(self, tis: list[TaskInstance]) -> list[str]:  # pragma: no cover
         """
         Handle remnants of tasks that were failed because they were stuck in queued.
         Tasks can get stuck in queued. If such a task is detected, it will be marked
@@ -386,14 +386,7 @@ class BaseExecutor(LoggingMixin):
         :param tis: List of Task Instances to clean up
         :return: List of readable task instances for a warning message
         """
-        readable_tis = []
-        for ti in tis:
-            readable_tis.append(repr(ti))
-
-        self.log.warning(
-            "These tasks would have been failed on an executor that supports the configuration setting `[scheduler] task_queued_timeout`, but the current executor does not support it."
-        )
-        return readable_tis
+        raise NotImplementedError()
 
     def try_adopt_task_instances(self, tis: Sequence[TaskInstance]) -> Sequence[TaskInstance]:
         """

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -297,10 +297,8 @@ class BaseExecutor(LoggingMixin):
         """
         self.log.debug("Changing state: %s", key)
         try:
-            print(f"\n\n removing key {key}")
             self.running.remove(key)
         except KeyError:
-            print(f"Key error!")
             self.log.debug("Could not find key: %s", str(key))
         self.event_buffer[key] = state, info
 
@@ -378,7 +376,7 @@ class BaseExecutor(LoggingMixin):
         """This method is called when the daemon receives a SIGTERM."""
         raise NotImplementedError()
 
-    def cleanup_stuck_queued_tasks(self, tis: list[TaskInstance]) -> list[str]:  # pragma: no cover
+    def cleanup_stuck_queued_tasks(self, tis: list[TaskInstance]) -> list[str]:
         """
         Handle remnants of tasks that were failed because they were stuck in queued.
         Tasks can get stuck in queued. If such a task is detected, it will be marked

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -420,7 +420,7 @@ class CeleryExecutor(BaseExecutor):
             )
 
         return not_adopted_tis
-    
+
     def cleanup_stuck_queued_tasks(self, tis: Sequence[TaskInstanceKey]) -> None:
         """
         Handle remnants of tasks that were failed because they were stuck in queued.
@@ -438,6 +438,7 @@ class CeleryExecutor(BaseExecutor):
                     app.control.revoke(celery_async_result.task_id)
                 except Exception as ex:
                     self.log.error("Error revoking task instance %s from celery: %s", task_instance_key, ex)
+
 
 def fetch_celery_task_state(async_result: AsyncResult) -> tuple[str, str | ExceptionWithTraceback, Any]:
     """

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -425,7 +425,6 @@ class CeleryExecutor(BaseExecutor):
         if it doesn't.
         :param ti: Task Instance to clean up
         """
-        print(f"\n\nti: {type(ti)}\n\n")
         task_instance_key = ti.key
         self.running.discard(task_instance_key)
         celery_async_result = self.tasks.pop(task_instance_key, None)

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -33,7 +33,6 @@ import time
 import traceback
 from collections import Counter
 from concurrent.futures import ProcessPoolExecutor
-from enum import Enum
 from multiprocessing import cpu_count
 from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Optional, Sequence, Tuple
 
@@ -214,11 +213,6 @@ def on_celery_import_modules(*args, **kwargs):
         pass
 
 
-class _CeleryPendingTaskTimeoutType(Enum):
-    ADOPTED = 1
-    STALLED = 2
-
-
 class CeleryExecutor(BaseExecutor):
     """
     CeleryExecutor is recommended for production use of Airflow.
@@ -244,15 +238,6 @@ class CeleryExecutor(BaseExecutor):
             self._sync_parallelism = max(1, cpu_count() - 1)
         self.bulk_state_fetcher = BulkStateFetcher(self._sync_parallelism)
         self.tasks = {}
-        self.stalled_task_timeouts: dict[TaskInstanceKey, datetime.datetime] = {}
-        self.stalled_task_timeout = datetime.timedelta(
-            seconds=conf.getint("celery", "stalled_task_timeout", fallback=0)
-        )
-        self.adopted_task_timeouts: dict[TaskInstanceKey, datetime.datetime] = {}
-        self.task_adoption_timeout = (
-            datetime.timedelta(seconds=conf.getint("celery", "task_adoption_timeout", fallback=600))
-            or self.stalled_task_timeout
-        )
         self.task_publish_retries: Counter[TaskInstanceKey] = Counter()
         self.task_publish_max_retries = conf.getint("celery", "task_publish_max_retries", fallback=3)
 
@@ -302,7 +287,6 @@ class CeleryExecutor(BaseExecutor):
                 result.backend = cached_celery_backend
                 self.running.add(key)
                 self.tasks[key] = result
-                self._set_celery_pending_task_timeout(key, _CeleryPendingTaskTimeoutType.STALLED)
 
                 # Store the Celery task_id in the event buffer. This will get "overwritten" if the task
                 # has another event, but that is fine, because the only other events are success/failed at
@@ -333,115 +317,12 @@ class CeleryExecutor(BaseExecutor):
             self.log.debug("No task to query celery, skipping sync")
             return
         self.update_all_task_states()
-        self._check_for_timedout_adopted_tasks()
-        self._check_for_stalled_tasks()
-
-    def _check_for_timedout_adopted_tasks(self) -> None:
-        timedout_keys = self._get_timedout_ti_keys(self.adopted_task_timeouts)
-        if timedout_keys:
-            self.log.error(
-                "Adopted tasks were still pending after %s, assuming they never made it to celery "
-                "and sending back to the scheduler:\n\t%s",
-                self.task_adoption_timeout,
-                "\n\t".join(repr(x) for x in timedout_keys),
-            )
-            self._send_stalled_tis_back_to_scheduler(timedout_keys)
-
-    def _check_for_stalled_tasks(self) -> None:
-        timedout_keys = self._get_timedout_ti_keys(self.stalled_task_timeouts)
-        if timedout_keys:
-            self.log.error(
-                "Tasks were still pending after %s, assuming they never made it to celery "
-                "and sending back to the scheduler:\n\t%s",
-                self.stalled_task_timeout,
-                "\n\t".join(repr(x) for x in timedout_keys),
-            )
-            self._send_stalled_tis_back_to_scheduler(timedout_keys)
-
-    def _get_timedout_ti_keys(
-        self, task_timeouts: dict[TaskInstanceKey, datetime.datetime]
-    ) -> list[TaskInstanceKey]:
-        """
-        Evaluate whether other tasks have stalled during the expected time.
-
-        This can happen for few different reasons,
-        usually related to race conditions while shutting down schedulers and celery workers.
-
-        It is, of course, always possible that these tasks are not actually
-        stalled - they could just be waiting in a long celery queue.
-        Unfortunately, there's no way for us to know for sure, so we'll just
-        reschedule them and let the normal scheduler loop requeue them.
-        """
-        now = utcnow()
-        timedout_keys = []
-        for key, stalled_after in task_timeouts.items():
-            if stalled_after > now:
-                # Since items are stored sorted, if we get to a stalled_after
-                # in the future then we can stop
-                break
-
-            # If the task gets updated to STARTED (which Celery does) or has
-            # already finished, then it will be removed from this list -- so
-            # the only time it's still in this list is when it a) never made it
-            # to celery in the first place (i.e. race condition somewhere in
-            # the dying executor), b) celery lost the task before execution
-            # started, or  c) a really long celery queue and it just
-            # hasn't started yet -- better cancel it and let the scheduler
-            # re-queue rather than have this task risk stalling for ever
-            timedout_keys.append(key)
-        return timedout_keys
-
-    @provide_session
-    def _send_stalled_tis_back_to_scheduler(
-        self, keys: list[TaskInstanceKey], session: Session = NEW_SESSION
-    ) -> None:
-        from airflow.models.taskinstance import TaskInstance
-
-        try:
-            session.query(TaskInstance).filter(
-                TaskInstance.filter_for_tis(keys),
-                TaskInstance.state == State.QUEUED,
-                TaskInstance.queued_by_job_id == self.job_id,
-            ).update(
-                {
-                    TaskInstance.state: State.SCHEDULED,
-                    TaskInstance.queued_dttm: None,
-                    TaskInstance.queued_by_job_id: None,
-                    TaskInstance.external_executor_id: None,
-                },
-                synchronize_session=False,
-            )
-            session.commit()
-        except Exception:
-            self.log.exception("Error sending tasks back to scheduler")
-            session.rollback()
-            return
-
-        for key in keys:
-            self._set_celery_pending_task_timeout(key, None)
-            self.running.discard(key)
-            celery_async_result = self.tasks.pop(key, None)
-            if celery_async_result:
-                try:
-                    app.control.revoke(celery_async_result.task_id)
-                except Exception as ex:
-                    self.log.error("Error revoking task instance %s from celery: %s", key, ex)
 
     def debug_dump(self) -> None:
         """Called in response to SIGUSR2 by the scheduler."""
         super().debug_dump()
         self.log.info(
             "executor.tasks (%d)\n\t%s", len(self.tasks), "\n\t".join(map(repr, self.tasks.items()))
-        )
-        self.log.info(
-            "executor.adopted_task_timeouts (%d)\n\t%s",
-            len(self.adopted_task_timeouts),
-            "\n\t".join(map(repr, self.adopted_task_timeouts.items())),
-        )
-        self.log.info(
-            "executor.stalled_task_timeouts (%d)\n\t%s",
-            len(self.stalled_task_timeouts),
-            "\n\t".join(map(repr, self.stalled_task_timeouts.items())),
         )
 
     def update_all_task_states(self) -> None:
@@ -458,7 +339,6 @@ class CeleryExecutor(BaseExecutor):
     def change_state(self, key: TaskInstanceKey, state: str, info=None) -> None:
         super().change_state(key, state, info)
         self.tasks.pop(key, None)
-        self._set_celery_pending_task_timeout(key, None)
 
     def update_task_state(self, key: TaskInstanceKey, state: str, info: Any) -> None:
         """Updates state of a single task."""
@@ -468,8 +348,7 @@ class CeleryExecutor(BaseExecutor):
             elif state in (celery_states.FAILURE, celery_states.REVOKED):
                 self.fail(key, info)
             elif state == celery_states.STARTED:
-                # It's now actually running, so we know it made it to celery okay!
-                self._set_celery_pending_task_timeout(key, None)
+                pass
             elif state == celery_states.PENDING:
                 pass
             else:
@@ -529,7 +408,6 @@ class CeleryExecutor(BaseExecutor):
 
             # Set the correct elements of the state dicts, then update this
             # like we just queried it.
-            self._set_celery_pending_task_timeout(ti.key, _CeleryPendingTaskTimeoutType.ADOPTED)
             self.tasks[ti.key] = result
             self.running.add(ti.key)
             self.update_task_state(ti.key, state, info)
@@ -542,24 +420,24 @@ class CeleryExecutor(BaseExecutor):
             )
 
         return not_adopted_tis
-
-    def _set_celery_pending_task_timeout(
-        self, key: TaskInstanceKey, timeout_type: _CeleryPendingTaskTimeoutType | None
-    ) -> None:
+    
+    def cleanup_stuck_queued_tasks(self, tis: Sequence[TaskInstanceKey]) -> None:
         """
-        Set pending task timeout.
-
-        We use the fact that dicts maintain insertion order, and the the timeout for a
-        task is always "now + delta" to maintain the property that oldest item = first to
-        time out.
+        Handle remnants of tasks that were failed because they were stuck in queued.
+        Tasks can get stuck in queued. If such a task is detected, it will be marked
+        as `UP_FOR_RETRY` if the task instance has remaining retries or marked as `FAILED`
+        if it doesn't.
+        :param tis: Task Instances to clean up
         """
-        self.adopted_task_timeouts.pop(key, None)
-        self.stalled_task_timeouts.pop(key, None)
-        if timeout_type == _CeleryPendingTaskTimeoutType.ADOPTED and self.task_adoption_timeout:
-            self.adopted_task_timeouts[key] = utcnow() + self.task_adoption_timeout
-        elif timeout_type == _CeleryPendingTaskTimeoutType.STALLED and self.stalled_task_timeout:
-            self.stalled_task_timeouts[key] = utcnow() + self.stalled_task_timeout
-
+        for ti in tis:
+            task_instance_key = ti.key
+            self.running.discard(task_instance_key)
+            celery_async_result = self.tasks.pop(task_instance_key, None)
+            if celery_async_result:
+                try:
+                    app.control.revoke(celery_async_result.task_id)
+                except Exception as ex:
+                    self.log.error("Error revoking task instance %s from celery: %s", task_instance_key, ex)
 
 def fetch_celery_task_state(async_result: AsyncResult) -> tuple[str, str | ExceptionWithTraceback, Any]:
     """

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -417,23 +417,23 @@ class CeleryExecutor(BaseExecutor):
 
         return not_adopted_tis
 
-    def cleanup_stuck_queued_tasks(self, tis: Sequence[TaskInstance]) -> None:
+    def cleanup_stuck_queued_task(self, ti: TaskInstance) -> None:
         """
         Handle remnants of tasks that were failed because they were stuck in queued.
         Tasks can get stuck in queued. If such a task is detected, it will be marked
         as `UP_FOR_RETRY` if the task instance has remaining retries or marked as `FAILED`
         if it doesn't.
-        :param tis: Task Instances to clean up
+        :param ti: Task Instance to clean up
         """
-        for ti in tis:
-            task_instance_key = ti.key
-            self.running.discard(task_instance_key)
-            celery_async_result = self.tasks.pop(task_instance_key, None)
-            if celery_async_result:
-                try:
-                    app.control.revoke(celery_async_result.task_id)
-                except Exception as ex:
-                    self.log.error("Error revoking task instance %s from celery: %s", task_instance_key, ex)
+        print(f"\n\nti: {type(ti)}\n\n")
+        task_instance_key = ti.key
+        self.running.discard(task_instance_key)
+        celery_async_result = self.tasks.pop(task_instance_key, None)
+        if celery_async_result:
+            try:
+                app.control.revoke(celery_async_result.task_id)
+            except Exception as ex:
+                self.log.error("Error revoking task instance %s from celery: %s", task_instance_key, ex)
 
 
 def fetch_celery_task_state(async_result: AsyncResult) -> tuple[str, str | ExceptionWithTraceback, Any]:

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -23,7 +23,6 @@
 """
 from __future__ import annotations
 
-import datetime
 import logging
 import math
 import operator
@@ -42,7 +41,6 @@ from celery.backends.database import DatabaseBackend, Task as TaskDb, session_cl
 from celery.result import AsyncResult
 from celery.signals import import_modules as celery_import_modules
 from setproctitle import setproctitle
-from sqlalchemy.orm.session import Session
 
 import airflow.settings as settings
 from airflow.config_templates.default_celery import DEFAULT_CELERY_CONFIG
@@ -53,10 +51,8 @@ from airflow.stats import Stats
 from airflow.utils.dag_parsing_context import _airflow_parsing_context_manager
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.net import get_hostname
-from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import State
 from airflow.utils.timeout import timeout
-from airflow.utils.timezone import utcnow
 
 if TYPE_CHECKING:
     from airflow.executors.base_executor import CommandType, EventBufferValueType, TaskTuple
@@ -421,7 +417,7 @@ class CeleryExecutor(BaseExecutor):
 
         return not_adopted_tis
 
-    def cleanup_stuck_queued_tasks(self, tis: Sequence[TaskInstanceKey]) -> None:
+    def cleanup_stuck_queued_tasks(self, tis: Sequence[TaskInstance]) -> None:
         """
         Handle remnants of tasks that were failed because they were stuck in queued.
         Tasks can get stuck in queued. If such a task is detected, it will be marked

--- a/airflow/executors/celery_kubernetes_executor.py
+++ b/airflow/executors/celery_kubernetes_executor.py
@@ -199,6 +199,14 @@ class CeleryKubernetesExecutor(LoggingMixin):
             *self.kubernetes_executor.try_adopt_task_instances(kubernetes_tis),
         ]
 
+    def cleanup_stuck_queued_tasks(self, tis: list[TaskInstance]) -> list[str]:
+        celery_tis = [ti for ti in tis if ti.queue != self.KUBERNETES_QUEUE]
+        kubernetes_tis = [ti for ti in tis if ti.queue == self.KUBERNETES_QUEUE]
+        return [
+            *self.celery_executor.cleanup_stuck_queued_tasks(celery_tis),
+            *self.kubernetes_executor.cleanup_stuck_queued_tasks(kubernetes_tis),
+        ]
+
     def end(self) -> None:
         """End celery and kubernetes executor."""
         self.celery_executor.end()

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -864,6 +864,39 @@ class KubernetesExecutor(BaseExecutor):
         self._adopt_completed_pods(kube_client)
         tis_to_flush.extend(pod_ids.values())
         return tis_to_flush
+    
+    def cleanup_stuck_queued_tasks(self, tis: Sequence[TaskInstanceKey]) -> None:
+        """
+        Handle remnants of tasks that were failed because they were stuck in queued.
+        Tasks can get stuck in queued. If such a task is detected, it will be marked
+        as `UP_FOR_RETRY` if the task instance has remaining retries or marked as `FAILED`
+        if it doesn't.
+        :param tis: Task Instances to clean up
+        """
+        for ti in tis:
+            namespace = self._get_pod_namespace(ti)
+            selector = PodGenerator.build_selector_for_k8s_executor_pod(
+                dag_id=ti.dag_id,
+                task_id=ti.task_id,
+                try_number=ti.try_number,
+                map_index=ti.map_index,
+                run_id=ti.run_id,
+                airflow_worker=ti.queued_by_job_id,
+            )
+            namespace = self._get_pod_namespace(ti)
+            pod_list = client.list_namespaced_pod(
+                namespace=namespace,
+                label_selector=selector,
+            ).items
+            if not pod_list:
+                raise RuntimeError("Cannot find pod for ti %s", ti)
+            elif len(pod_list) > 1:
+                raise RuntimeError("Found multiple pods for ti %s: %s", ti, pod_list)
+            self.kube_scheduler.delete_pod(
+                pod_id=pod_list[0].metadata.name,
+                namespace=namespace
+            )
+            self.log.info("Deleted pod %s from namespace %s. Pod was stuck in queued for longer than `task_queued_timeout`.")
 
     def adopt_launched_task(
         self, kube_client: client.CoreV1Api, pod: k8s.V1Pod, pod_ids: dict[TaskInstanceKey, k8s.V1Pod]

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -837,7 +837,6 @@ class KubernetesExecutor(BaseExecutor):
         :param tis: Task Instances to clean up
         """
         for ti in tis:
-            namespace = self._get_pod_namespace(ti)
             selector = PodGenerator.build_selector_for_k8s_executor_pod(
                 dag_id=ti.dag_id,
                 task_id=ti.task_id,
@@ -847,7 +846,7 @@ class KubernetesExecutor(BaseExecutor):
                 airflow_worker=ti.queued_by_job_id,
             )
             namespace = self._get_pod_namespace(ti)
-            pod_list = client.list_namespaced_pod(
+            pod_list = self.kube_client.list_namespaced_pod(
                 namespace=namespace,
                 label_selector=selector,
             ).items

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -838,7 +838,6 @@ class KubernetesExecutor(BaseExecutor):
         """
         readable_tis = []
         for ti in tis:
-            readable_tis.append(repr(ti))
             selector = PodGenerator.build_selector_for_k8s_executor_pod(
                 dag_id=ti.dag_id,
                 task_id=ti.task_id,
@@ -853,15 +852,12 @@ class KubernetesExecutor(BaseExecutor):
                 label_selector=selector,
             ).items
             if not pod_list:
-                # Remove from list of tis that were cleaned up
-                readable_tis.pop()
                 self.log.warning("Cannot find pod for ti %s", ti)
                 continue
             elif len(pod_list) > 1:
-                # Remove from list of tis that were cleaned up
-                readable_tis.pop()
                 self.log.warning("Found multiple pods for ti %s: %s", ti, pod_list)
                 continue
+            readable_tis.append(repr(ti))
             self.kube_scheduler.delete_pod(pod_id=pod_list[0].metadata.name, namespace=namespace)
         return readable_tis
 

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -827,35 +827,44 @@ class KubernetesExecutor(BaseExecutor):
         tis_to_flush.extend(pod_ids.values())
         return tis_to_flush
 
-    def cleanup_stuck_queued_task(self, ti: TaskInstance) -> None:
+    def cleanup_stuck_queued_tasks(self, tis: list[TaskInstance]) -> list[str]:
         """
         Handle remnants of tasks that were failed because they were stuck in queued.
         Tasks can get stuck in queued. If such a task is detected, it will be marked
         as `UP_FOR_RETRY` if the task instance has remaining retries or marked as `FAILED`
         if it doesn't.
-        :param ti: Task Instance to clean up
+
+        :param tis: List of Task Instances to clean up
+        :return: List of readable task instances for a warning message
         """
-        selector = PodGenerator.build_selector_for_k8s_executor_pod(
-            dag_id=ti.dag_id,
-            task_id=ti.task_id,
-            try_number=ti.try_number,
-            map_index=ti.map_index,
-            run_id=ti.run_id,
-            airflow_worker=ti.queued_by_job_id,
-        )
-        namespace = self._get_pod_namespace(ti)
-        pod_list = self.kube_client.list_namespaced_pod(
-            namespace=namespace,
-            label_selector=selector,
-        ).items
-        if not pod_list:
-            raise RuntimeError("Cannot find pod for ti %s", ti)
-        elif len(pod_list) > 1:
-            raise RuntimeError("Found multiple pods for ti %s: %s", ti, pod_list)
-        self.kube_scheduler.delete_pod(pod_id=pod_list[0].metadata.name, namespace=namespace)
-        self.log.info(
-            "Deleted pod %s from namespace %s. Pod was stuck in queued for longer than `task_queued_timeout`."
-        )
+        readable_tis = []
+        for ti in tis:
+            readable_tis.append(repr(ti))
+            selector = PodGenerator.build_selector_for_k8s_executor_pod(
+                dag_id=ti.dag_id,
+                task_id=ti.task_id,
+                try_number=ti.try_number,
+                map_index=ti.map_index,
+                run_id=ti.run_id,
+                airflow_worker=ti.queued_by_job_id,
+            )
+            namespace = self._get_pod_namespace(ti)
+            pod_list = self.kube_client.list_namespaced_pod(
+                namespace=namespace,
+                label_selector=selector,
+            ).items
+            if not pod_list:
+                # Remove from list of tis that were cleaned up
+                readable_tis.pop()
+                self.log.warning("Cannot find pod for ti %s", ti)
+                continue
+            elif len(pod_list) > 1:
+                # Remove from list of tis that were cleaned up
+                readable_tis.pop()
+                self.log.warning("Found multiple pods for ti %s: %s", ti, pod_list)
+                continue
+            self.kube_scheduler.delete_pod(pod_id=pod_list[0].metadata.name, namespace=namespace)
+        return readable_tis
 
     def adopt_launched_task(
         self, kube_client: client.CoreV1Api, pod: k8s.V1Pod, pod_ids: dict[TaskInstanceKey, k8s.V1Pod]

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -29,7 +29,6 @@ import multiprocessing
 import time
 from collections import defaultdict
 from contextlib import suppress
-from datetime import timedelta
 from queue import Empty, Queue
 from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple
 
@@ -47,7 +46,7 @@ from airflow.kubernetes.kube_client import get_kube_client
 from airflow.kubernetes.kube_config import KubeConfig
 from airflow.kubernetes.kubernetes_helper_functions import annotations_to_key, create_pod_id
 from airflow.kubernetes.pod_generator import PodGenerator
-from airflow.utils import timezone
+from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 from airflow.utils.event_scheduler import EventScheduler
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
@@ -828,7 +827,7 @@ class KubernetesExecutor(BaseExecutor):
         tis_to_flush.extend(pod_ids.values())
         return tis_to_flush
 
-    def cleanup_stuck_queued_tasks(self, tis: Sequence[TaskInstanceKey]) -> None:
+    def cleanup_stuck_queued_tasks(self, tis: Sequence[TaskInstance]) -> None:
         """
         Handle remnants of tasks that were failed because they were stuck in queued.
         Tasks can get stuck in queued. If such a task is detected, it will be marked

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -46,7 +46,6 @@ from airflow.kubernetes.kube_client import get_kube_client
 from airflow.kubernetes.kube_config import KubeConfig
 from airflow.kubernetes.kubernetes_helper_functions import annotations_to_key, create_pod_id
 from airflow.kubernetes.pod_generator import PodGenerator
-from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 from airflow.utils.event_scheduler import EventScheduler
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -836,6 +836,9 @@ class KubernetesExecutor(BaseExecutor):
         :param tis: List of Task Instances to clean up
         :return: List of readable task instances for a warning message
         """
+        if TYPE_CHECKING:
+            assert self.kube_client
+            assert self.kube_scheduler
         readable_tis = []
         for ti in tis:
             selector = PodGenerator.build_selector_for_k8s_executor_pod(

--- a/airflow/executors/local_kubernetes_executor.py
+++ b/airflow/executors/local_kubernetes_executor.py
@@ -198,6 +198,12 @@ class LocalKubernetesExecutor(LoggingMixin):
             *self.kubernetes_executor.try_adopt_task_instances(kubernetes_tis),
         ]
 
+    def cleanup_stuck_queued_tasks(self, tis: list[TaskInstance]) -> list[str]:
+        # LocalExecutor doesn't have a cleanup_stuck_queued_tasks method, so we
+        # will only run KubernetesExecutor's
+        kubernetes_tis = [ti for ti in tis if ti.queue == self.KUBERNETES_QUEUE]
+        return self.kubernetes_executor.cleanup_stuck_queued_tasks(kubernetes_tis)
+
     def end(self) -> None:
         """End local and kubernetes executor."""
         self.local_executor.end()

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1485,9 +1485,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         TI.state == State.QUEUED,
                         TI.queued_dttm < (timezone.utcnow() - timedelta(seconds=self._task_queued_timeout)),
                     )
-                    tasks_stuck_in_queued: list[TaskInstance] = with_row_locks(
-                        query, of=TI, session=session, **skip_locked(session=session)
-                    ).all()
+                    tasks_stuck_in_queued: list[TaskInstance] = query.all()
                     tis_for_warning_message = self.job.executor.cleanup_stuck_queued_tasks(
                         tis=tasks_stuck_in_queued
                     )

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -902,8 +902,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         # Check on start up, then every configured interval
         self.adopt_or_reset_orphaned_tasks()
 
-        timers.call_regular_interval(self._task_queued_timeout, self._fail_tasks_stuck_in_queued)
-
         timers.call_regular_interval(
             conf.getfloat("scheduler", "orphaned_tasks_check_interval", fallback=300.0),
             self.adopt_or_reset_orphaned_tasks,
@@ -923,7 +921,13 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             conf.getfloat("scheduler", "zombie_detection_interval", fallback=10.0),
             self._find_zombies,
         )
+
         timers.call_regular_interval(60.0, self._update_dag_run_state_for_paused_dags)
+
+        timers.call_regular_interval(
+            conf.getfloat("scheduler", "task_queued_timeout_check_interval"),
+            self._fail_tasks_stuck_in_queued,
+        )
 
         timers.call_regular_interval(
             conf.getfloat("scheduler", "parsing_cleanup_interval"),

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1474,7 +1474,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         for attempt in run_with_db_retries(logger=self.log):
             with attempt:
                 self.log.debug(
-                    "Running SchedulerJob.adopt_or_reset_orphaned_tasks with retries. Try %d of %d",
+                    "Running SchedulerJob._fail_tasks_stuck_in_queued with retries. Try %d of %d",
                     attempt.retry_state.attempt_number,
                     MAX_DB_RETRIES,
                 )

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1466,11 +1466,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         """
         Mark tasks stuck in queued for longer than `task_queued_timeout` as failed.
 
-        If one of the configuration settings `kubernetes.worker_pods_pending_timeout`,
-        `celery.stalled_task_timeout`, or `celery.task_adoption_timeout` is set and
-        has a higher value than `scheduler.task_queued_timeout`, that value will be
-        used as `task_queued_timeout`.
-
         Tasks can get stuck in queued for a wide variety of reasons (e.g. celery loses
         track of a task, a cluster can't further scale up its workers, etc.), but tasks
         should not be stuck in queued for a long time. This will mark tasks stuck in

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -161,9 +161,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         self._standalone_dag_processor = conf.getboolean("scheduler", "standalone_dag_processor")
         self._dag_stale_not_seen_duration = conf.getint("scheduler", "dag_stale_not_seen_duration")
 
-        # Since the functionality for stalled_task_timeout, task_adoption_timeout, and worker_pods_pending_timeout
-        # are now handled by a single config (task_queued_timeout), we can't deprecate them as we normally would.
-        # So, we'll read each config and take the max value in order to ensure we're not undercutting a legitimate
+        # Since the functionality for stalled_task_timeout, task_adoption_timeout, and
+        # worker_pods_pending_timeout are now handled by a single config (task_queued_timeout),
+        # we can't deprecate them as we normally would. So, we'll read each config and take
+        # the max value in order to ensure we're not undercutting a legitimate
         # use of any of these configs.
         stalled_task_timeout = conf.getfloat("celery", "stalled_task_timeout", fallback=0)
         if stalled_task_timeout:
@@ -1498,7 +1499,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     if tis_for_warning_message:
                         task_instance_str = "\n\t".join(tis_for_warning_message)
                         self.log.warning(
-                            "Marked the following %s task instances stuck in queued as failed. If the task instance has available retries, it will be retried.\n\t%s",
+                            "Marked the following %s task instances stuck in queued as failed. "
+                            "If the task instance has available retries, it will be retried.\n\t%s",
                             len(tasks_stuck_in_queued),
                             task_instance_str,
                         )

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1484,6 +1484,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     query = session.query(TI).filter(
                         TI.state == State.QUEUED,
                         TI.queued_dttm < (timezone.utcnow() - timedelta(seconds=self._task_queued_timeout)),
+                        TI.queued_by_job_id == self.job_id,
                     )
                     tasks_stuck_in_queued: list[TaskInstance] = query.all()
                     tis_for_warning_message = self.job.executor.cleanup_stuck_queued_tasks(

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1493,6 +1493,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     tasks_stuck_in_queued: list[TaskInstance] = with_row_locks(
                         query, of=TI, session=session, **skip_locked(session=session)
                     ).all()
+                    print(f"\n\ntis: {tasks_stuck_in_queued}\n\n")
                     tis_for_warning_message = self.job.executor.cleanup_stuck_queued_tasks(
                         tis=tasks_stuck_in_queued
                     )

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -40,6 +40,7 @@ from airflow import settings
 from airflow.callbacks.callback_requests import DagCallbackRequest, SlaCallbackRequest, TaskCallbackRequest
 from airflow.callbacks.pipe_callback_sink import PipeCallbackSink
 from airflow.configuration import conf
+from airflow.exceptions import RemovedInAirflow3Warning
 from airflow.executors.base_executor import BaseExecutor
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job_runner import BaseJobRunner
@@ -151,7 +152,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             warnings.warn(
                 "The 'processor_poll_interval' parameter is deprecated. "
                 "Please use 'scheduler_idle_sleep_time'.",
-                DeprecationWarning,
+                RemovedInAirflow3Warning,
+                stacklevel=2,
             )
             scheduler_idle_sleep_time = processor_poll_interval
         self._scheduler_idle_sleep_time = scheduler_idle_sleep_time
@@ -169,7 +171,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         if stalled_task_timeout:
             # TODO: Remove in Airflow 3.0
             warnings.warn(
-                "The '[celery] stalled_task_timeout' parameter is deprecated. "
+                "The '[celery] stalled_task_timeout' config option is deprecated. "
                 "Please update your config to use '[scheduler] task_queued_timeout' instead.",
                 DeprecationWarning,
             )
@@ -177,7 +179,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         if task_adoption_timeout:
             # TODO: Remove in Airflow 3.0
             warnings.warn(
-                "The '[celery] task_adoption_timeout' parameter is deprecated. "
+                "The '[celery] task_adoption_timeout' config option is deprecated. "
                 "Please update your config to use '[scheduler] task_queued_timeout' instead.",
                 DeprecationWarning,
             )
@@ -187,7 +189,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         if worker_pods_pending_timeout:
             # TODO: Remove in Airflow 3.0
             warnings.warn(
-                "The '[kubernetes_executor] worker_pods_pending_timeout' parameter is deprecated. "
+                "The '[kubernetes_executor] worker_pods_pending_timeout' config option is deprecated. "
                 "Please update your config to use '[scheduler] task_queued_timeout' instead.",
                 DeprecationWarning,
             )

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1494,7 +1494,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                             repr(ti),
                             self._task_queued_timeout,
                         )
-                        ti.handle_failure(error=msg)
+                        ti.handle_failure(error=msg, session=session)
                     if tasks_stuck_in_queued_messages:
                         task_instance_str = "\n\t".join(tasks_stuck_in_queued_messages)
                         self.log.warning(

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1495,6 +1495,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                             self._task_queued_timeout,
                         )
                         ti.handle_failure(error=msg, session=session)
+                        self.executor.cleanup_stuck_queued_task(ti)
                     if tasks_stuck_in_queued_messages:
                         task_instance_str = "\n\t".join(tasks_stuck_in_queued_messages)
                         self.log.warning(

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -40,7 +40,6 @@ from airflow import settings
 from airflow.callbacks.callback_requests import DagCallbackRequest, SlaCallbackRequest, TaskCallbackRequest
 from airflow.callbacks.pipe_callback_sink import PipeCallbackSink
 from airflow.configuration import conf
-from airflow.exceptions import RemovedInAirflow3Warning
 from airflow.executors.base_executor import BaseExecutor
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job_runner import BaseJobRunner
@@ -152,8 +151,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             warnings.warn(
                 "The 'processor_poll_interval' parameter is deprecated. "
                 "Please use 'scheduler_idle_sleep_time'.",
-                RemovedInAirflow3Warning,
-                stacklevel=2,
+                DeprecationWarning,
             )
             scheduler_idle_sleep_time = processor_poll_interval
         self._scheduler_idle_sleep_time = scheduler_idle_sleep_time
@@ -171,28 +169,27 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         if stalled_task_timeout:
             # TODO: Remove in Airflow 3.0
             warnings.warn(
-                "The 'stalled_task_timeout' parameter is deprecated. "
-                "Please use 'scheduler.task_queued_timeout'.",
-                RemovedInAirflow3Warning,
-                stacklevel=2,
+                "The '[celery] stalled_task_timeout' parameter is deprecated. "
+                "Please update your config to use '[scheduler] task_queued_timeout' instead.",
+                DeprecationWarning,
             )
         task_adoption_timeout = conf.getfloat("celery", "task_adoption_timeout", fallback=0)
         if task_adoption_timeout:
             # TODO: Remove in Airflow 3.0
             warnings.warn(
-                "The 'task_adoption_timeout' parameter is deprecated. "
-                "Please use 'scheduler.task_queued_timeout'.",
-                RemovedInAirflow3Warning,
-                stacklevel=2,
+                "The '[celery] task_adoption_timeout' parameter is deprecated. "
+                "Please update your config to use '[scheduler] task_queued_timeout' instead.",
+                DeprecationWarning,
             )
-        worker_pods_pending_timeout = conf.getfloat("kubernetes", "worker_pods_pending_timeout", fallback=0)
+        worker_pods_pending_timeout = conf.getfloat(
+            "kubernetes_executor", "worker_pods_pending_timeout", fallback=0
+        )
         if worker_pods_pending_timeout:
             # TODO: Remove in Airflow 3.0
             warnings.warn(
-                "The 'worker_pods_pending_timeout' parameter is deprecated. "
-                "Please use 'scheduler.task_queued_timeout'.",
-                RemovedInAirflow3Warning,
-                stacklevel=2,
+                "The '[kubernetes_executor] worker_pods_pending_timeout' parameter is deprecated. "
+                "Please update your config to use '[scheduler] task_queued_timeout' instead.",
+                DeprecationWarning,
             )
         task_queued_timeout = conf.getfloat("scheduler", "task_queued_timeout")
         self._task_queued_timeout = max(

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1482,7 +1482,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             tasks_stuck_in_queued_messages = []
             for ti in tasks_stuck_in_queued:
                 tasks_stuck_in_queued_messages.append(repr(ti))
-                ti.handle_failure()
+                msg = "TI %s was in the queued state for longer than %s.", repr(ti), self._task_queued_timeout
+                ti.handle_failure(error=msg)
             if tasks_stuck_in_queued_messages:
                 task_instance_str = "\n\t".join(tasks_stuck_in_queued_messages)
                 self.log.warning(

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1492,7 +1492,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     tasks_stuck_in_queued: list[TaskInstance] = with_row_locks(
                         query, of=TI, session=session, **skip_locked(session=session)
                     ).all()
-                    tis_for_warning_message = self.executor.cleanup_stuck_queued_tasks(
+                    tis_for_warning_message = self.job.executor.cleanup_stuck_queued_tasks(
                         tis=tasks_stuck_in_queued
                     )
                     if tis_for_warning_message:

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1488,7 +1488,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     tasks_stuck_in_queued: list[TaskInstance] = with_row_locks(
                         query, of=TI, session=session, **skip_locked(session=session)
                     ).all()
-                    print(f"\n\ntis: {tasks_stuck_in_queued}\n\n")
                     tis_for_warning_message = self.job.executor.cleanup_stuck_queued_tasks(
                         tis=tasks_stuck_in_queued
                     )

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -161,7 +161,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         self._standalone_dag_processor = conf.getboolean("scheduler", "standalone_dag_processor")
         self._dag_stale_not_seen_duration = conf.getint("scheduler", "dag_stale_not_seen_duration")
 
-                # Since the functionality for stalled_task_timeout, task_adoption_timeout, and worker_pods_pending_timeout
+        # Since the functionality for stalled_task_timeout, task_adoption_timeout, and worker_pods_pending_timeout
         # are now handled by a single config (task_queued_timeout), we can't deprecate them as we normally would.
         # So, we'll read each config and take the max value in order to ensure we're not undercutting a legitimate
         # use of any of these configs.
@@ -193,7 +193,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 stacklevel=2,
             )
         task_queued_timeout = conf.getfloat("scheduler", "task_queued_timeout")
-        self._task_queued_timeout = max(stalled_task_timeout, task_adoption_timeout, worker_pods_pending_timeout, task_queued_timeout)
+        self._task_queued_timeout = max(
+            stalled_task_timeout, task_adoption_timeout, worker_pods_pending_timeout, task_queued_timeout
+        )
 
         self.do_pickle = do_pickle
 
@@ -355,7 +357,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         pool_num_starving_tasks: DefaultDict[str, int] = defaultdict(int)
 
         for loop_count in itertools.count(start=1):
-
             num_starved_pools = len(starved_pools)
             num_starved_dags = len(starved_dags)
             num_starved_tasks = len(starved_tasks)
@@ -935,7 +936,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         for loop_count in itertools.count(start=1):
             with Stats.timer("scheduler.scheduler_loop_duration") as timer:
-
                 if self.using_sqlite and self.processor_agent:
                     self.processor_agent.run_single_parsing_loop()
                     # For the sqlite case w/ 1 thread, wait until the processor
@@ -1122,7 +1122,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         )
 
         for dag_model in dag_models:
-
             dag = self.dagbag.get_dag(dag_model.dag_id, session=session)
             if not dag:
                 self.log.error("DAG '%s' not found in serialized_dag table", dag_model.dag_id)
@@ -1202,7 +1201,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # instead of falling in a loop of Integrity Error.
             exec_date = exec_dates[dag.dag_id]
             if (dag.dag_id, exec_date) not in existing_dagruns:
-
                 previous_dag_run = (
                     session.query(DagRun)
                     .filter(

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1484,7 +1484,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     query = session.query(TI).filter(
                         TI.state == State.QUEUED,
                         TI.queued_dttm < (timezone.utcnow() - timedelta(seconds=self._task_queued_timeout)),
-                        TI.queued_by_job_id == self.job_id,
+                        TI.queued_by_job_id == self.job.id,
                     )
                     tasks_stuck_in_queued: list[TaskInstance] = query.all()
                     tis_for_warning_message = self.job.executor.cleanup_stuck_queued_tasks(

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -41,6 +41,7 @@ from airflow.callbacks.callback_requests import DagCallbackRequest, SlaCallbackR
 from airflow.callbacks.pipe_callback_sink import PipeCallbackSink
 from airflow.configuration import conf
 from airflow.exceptions import RemovedInAirflow3Warning
+from airflow.executors.base_executor import BaseExecutor
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job_runner import BaseJobRunner
 from airflow.jobs.job import Job, perform_heartbeat
@@ -1473,6 +1474,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         available retries, it will be retried.
         """
         self.log.debug("Calling SchedulerJob._fail_tasks_stuck_in_queued method")
+
+        if type(self.job.executor).cleanup_stuck_queued_tasks == BaseExecutor.cleanup_stuck_queued_tasks:
+            self.log.debug("Executor doesn't support cleanup of stuck queued tasks. Skipping.")
+            return
+
         for attempt in run_with_db_retries(logger=self.log):
             with attempt:
                 self.log.debug(

--- a/airflow/kubernetes/kube_config.py
+++ b/airflow/kubernetes/kube_config.py
@@ -71,13 +71,6 @@ class KubeConfig:
         # interact with cluster components.
         self.executor_namespace = conf.get(self.kubernetes_section, "namespace")
 
-        self.worker_pods_pending_timeout = conf.getint(self.kubernetes_section, "worker_pods_pending_timeout")
-        self.worker_pods_pending_timeout_check_interval = conf.getint(
-            self.kubernetes_section, "worker_pods_pending_timeout_check_interval"
-        )
-        self.worker_pods_pending_timeout_batch_size = conf.getint(
-            self.kubernetes_section, "worker_pods_pending_timeout_batch_size"
-        )
         self.worker_pods_queued_check_interval = conf.getint(
             self.kubernetes_section, "worker_pods_queued_check_interval"
         )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -403,6 +403,10 @@ if PACKAGE_NAME == "apache-airflow":
     ) in AirflowConfigParser.deprecated_options.items():
         deprecated_options[deprecated_section][deprecated_key] = section, key, since_version
 
+    for (section, key), deprecated in AirflowConfigParser.many_to_one_deprecated_options.items():
+        for deprecated_section, deprecated_key, since_version in deprecated:
+            deprecated_options[deprecated_section][deprecated_key] = section, key, since_version
+
     configs = default_config_yaml()
 
     # We want the default/example we show in the docs to reflect the value _after_

--- a/newsfragments/30375.significant.rst
+++ b/newsfragments/30375.significant.rst
@@ -1,0 +1,9 @@
+Simplify logic to resolve tasks stuck in queued despite stalled_task_timeout
+
+Logic for handling tasks stuck in the queued state has been consolidated, and the all configurations 
+responsible for timing out stuck queued tasks have been deprecated and merged into 
+`scheduler.task_queued_timeout`. The configurations that have been deprecated are 
+`kubernetes.worker_pods_pending_timeout`, `celery.stalled_task_timeout`, and 
+`celery.task_adoption_timeout`. If any of these configurations are set, the longest timeout will be
+respected. For example, if `celery.stalled_task_timeout` is 1200, and `scheduler.task_queued_timeout` 
+is 600, Airflow will set `scheduler.task_queued_timeout` to 1200.

--- a/newsfragments/30375.significant.rst
+++ b/newsfragments/30375.significant.rst
@@ -1,9 +1,9 @@
 Consolidate handling of tasks stuck in queued under new ``task_queued_timeout`` config
 
-Logic for handling tasks stuck in the queued state has been consolidated, and the all configurations 
-responsible for timing out stuck queued tasks have been deprecated and merged into 
-``[scheduler] task_queued_timeout``. The configurations that have been deprecated are 
-``[kubernetes] worker_pods_pending_timeout``, ``[celery] stalled_task_timeout``, and 
-``celery.task_adoption_timeout``. If any of these configurations are set, the longest timeout will be
-respected. For example, if ``[celery] stalled_task_timeout`` is 1200, and ``[scheduler] task_queued_timeout`` 
+Logic for handling tasks stuck in the queued state has been consolidated, and the all configurations
+responsible for timing out stuck queued tasks have been deprecated and merged into
+``[scheduler] task_queued_timeout``. The configurations that have been deprecated are
+``[kubernetes] worker_pods_pending_timeout``, ``[celery] stalled_task_timeout``, and
+``[celery] task_adoption_timeout``. If any of these configurations are set, the longest timeout will be
+respected. For example, if ``[celery] stalled_task_timeout`` is 1200, and ``[scheduler] task_queued_timeout``
 is 600, Airflow will set ``[scheduler] task_queued_timeout`` to 1200.

--- a/newsfragments/30375.significant.rst
+++ b/newsfragments/30375.significant.rst
@@ -1,4 +1,4 @@
-Simplify logic to resolve tasks stuck in queued despite stalled_task_timeout
+Consolidate handling of tasks stuck in queued under new ``task_queued_timeout`` config
 
 Logic for handling tasks stuck in the queued state has been consolidated, and the all configurations 
 responsible for timing out stuck queued tasks have been deprecated and merged into 

--- a/newsfragments/30375.significant.rst
+++ b/newsfragments/30375.significant.rst
@@ -1,9 +1,9 @@
 Consolidate handling of tasks stuck in queued under new ``task_queued_timeout`` config
 
-Logic for handling tasks stuck in the queued state has been consolidated, and the all configurations
-responsible for timing out stuck queued tasks have been deprecated and merged into
-``scheduler.task_queued_timeout``. The configurations that have been deprecated are
-``kubernetes.worker_pods_pending_timeout``, ``celery.stalled_task_timeout``, and
+Logic for handling tasks stuck in the queued state has been consolidated, and the all configurations 
+responsible for timing out stuck queued tasks have been deprecated and merged into 
+``[scheduler] task_queued_timeout``. The configurations that have been deprecated are 
+``[kubernetes] worker_pods_pending_timeout``, ``[celery] stalled_task_timeout``, and 
 ``celery.task_adoption_timeout``. If any of these configurations are set, the longest timeout will be
-respected. For example, if ``celery.stalled_task_timeout`` is 1200, and ``scheduler.task_queued_timeout``
-is 600, Airflow will set ``scheduler.task_queued_timeout`` to 1200.
+respected. For example, if ``[celery] stalled_task_timeout`` is 1200, and ``[scheduler] task_queued_timeout`` 
+is 600, Airflow will set ``[scheduler] task_queued_timeout`` to 1200.

--- a/newsfragments/30375.significant.rst
+++ b/newsfragments/30375.significant.rst
@@ -1,9 +1,9 @@
 Consolidate handling of tasks stuck in queued under new ``task_queued_timeout`` config
 
-Logic for handling tasks stuck in the queued state has been consolidated, and the all configurations 
-responsible for timing out stuck queued tasks have been deprecated and merged into 
-`scheduler.task_queued_timeout`. The configurations that have been deprecated are 
-`kubernetes.worker_pods_pending_timeout`, `celery.stalled_task_timeout`, and 
-`celery.task_adoption_timeout`. If any of these configurations are set, the longest timeout will be
-respected. For example, if `celery.stalled_task_timeout` is 1200, and `scheduler.task_queued_timeout` 
-is 600, Airflow will set `scheduler.task_queued_timeout` to 1200.
+Logic for handling tasks stuck in the queued state has been consolidated, and the all configurations
+responsible for timing out stuck queued tasks have been deprecated and merged into
+``scheduler.task_queued_timeout``. The configurations that have been deprecated are
+``kubernetes.worker_pods_pending_timeout``, ``celery.stalled_task_timeout``, and
+``celery.task_adoption_timeout``. If any of these configurations are set, the longest timeout will be
+respected. For example, if ``celery.stalled_task_timeout`` is 1200, and ``scheduler.task_queued_timeout``
+is 600, Airflow will set ``scheduler.task_queued_timeout`` to 1200.

--- a/tests/executors/test_base_executor.py
+++ b/tests/executors/test_base_executor.py
@@ -106,18 +106,6 @@ def setup_dagrun(dag_maker):
     return dag_maker.create_dagrun(execution_date=date)
 
 
-def test_cleanup_stuck_queued_tasks(dag_maker):
-    executor = BaseExecutor()
-    dagrun = setup_dagrun(dag_maker)
-    tis = dagrun.task_instances
-    for ti in tis:
-        ti.state = State.QUEUED
-        ti.queued_dttm = timezone.utcnow() - timedelta(minutes=30)
-        executor.running.add(ti.key)
-    executor.cleanup_stuck_queued_tasks(tis)
-    assert executor.running == set()
-
-
 def test_try_adopt_task_instances(dag_maker):
     dagrun = setup_dagrun(dag_maker)
     tis = dagrun.task_instances

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -217,10 +217,10 @@ class TestCeleryExecutor:
             yield app.control.revoke
 
     @pytest.mark.backend("mysql", "postgres")
-    def test_cleanup_stuck_queued_tasks(self, session):
+    def test_cleanup_stuck_queued_task(self, session):
         start_date = timezone.utcnow() - timedelta(days=2)
 
-        with DAG("test_cleanup_stuck_queued_tasks_failed") as dag:
+        with DAG("test_cleanup_stuck_queued_task_failed"):
             task = BaseOperator(task_id="task_1", start_date=start_date)
 
         ti = TaskInstance(task=task, run_id=None)
@@ -236,7 +236,7 @@ class TestCeleryExecutor:
             executor.running = {ti.key}
             executor.tasks = {ti.key: AsyncResult("231")}
             executor.sync()
-            executor.cleanup_stuck_queued_tasks([ti])
+            executor.cleanup_stuck_queued_task(ti)
         assert executor.tasks == {}
         assert app.control.revoke.called_with("231")
 

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -199,8 +199,6 @@ class TestCeleryExecutor:
         tis = [ti1, ti2]
         executor = celery_executor.CeleryExecutor()
         assert executor.running == set()
-        assert executor.adopted_task_timeouts == {}
-        assert executor.stalled_task_timeouts == {}
         assert executor.tasks == {}
 
         not_adopted_tis = executor.try_adopt_task_instances(tis)
@@ -208,11 +206,7 @@ class TestCeleryExecutor:
         key_1 = TaskInstanceKey(dag.dag_id, task_1.task_id, None, try_number)
         key_2 = TaskInstanceKey(dag.dag_id, task_2.task_id, None, try_number)
         assert executor.running == {key_1, key_2}
-        assert executor.adopted_task_timeouts == {
-            key_1: timezone.utcnow() + executor.task_adoption_timeout,
-            key_2: timezone.utcnow() + executor.task_adoption_timeout,
-        }
-        assert executor.stalled_task_timeouts == {}
+
         assert executor.tasks == {key_1: AsyncResult("231"), key_2: AsyncResult("232")}
         assert not_adopted_tis == []
 

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -859,6 +859,23 @@ class TestKubernetesExecutor:
         assert not mock_kube_client.patch_namespaced_pod.called
         assert pod_ids == {"foobar": {}}
 
+    @mock.patch("airflow.executors.kubernetes_executor.get_kube_client")
+    def test_cleanup_stuck_queued_tasks(self, mock_kube_client, create_task_instance_of_operator):
+        """Delete any pods associated with a task stuck in queued."""
+        executor = self.kubernetes_executor
+        executor.scheduler_job_id = "123"
+        tis = [create_task_instance_of_operator(EmptyOperator, dag_id="test_k8s_cleanup_stuck_tasks", task_id="test_task")]
+        pod_namespace = executor._get_pod_namespace(tis[0]) 
+        pod_name = "foo"
+        executor.cleanup_stuck_queued_tasks(tis)
+
+        mock_delete_namespaced_pod = mock.MagicMock()
+        mock_kube_client.return_value.delete_namespaced_pod = mock_delete_namespaced_pod
+
+        mock_delete_namespaced_pod.assert_called_with(pod_name, pod_namespace, body=mock_kube_client.V1DeleteOptions())
+        
+        assert executor.running == set()
+
     @pytest.mark.parametrize(
         "raw_multi_namespace_mode, raw_value_namespace_list, expected_value_in_kube_config",
         [

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -861,7 +861,7 @@ class TestKubernetesExecutor:
 
     @mock.patch("airflow.executors.kubernetes_executor.get_kube_client")
     @mock.patch("airflow.executors.kubernetes_executor.AirflowKubernetesScheduler.delete_pod")
-    def test_cleanup_stuck_queued_tasks(
+    def test_cleanup_stuck_queued_task(
         self, mock_delete_pod, mock_kube_client, create_task_instance_of_operator
     ):
         """Delete any pods associated with a task stuck in queued."""
@@ -874,9 +874,8 @@ class TestKubernetesExecutor:
         ti.retries = 1
         ti.state = State.QUEUED
         ti.queued_dttm = timezone.utcnow() - timedelta(minutes=30)
-        tis = [ti]
         ti.refresh_from_db()
-        executor.cleanup_stuck_queued_tasks(tis)
+        executor.cleanup_stuck_queued_task(ti)
         ti.refresh_from_db()
         executor.sync()
         mock_delete_pod.assert_called_once()

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -866,7 +866,7 @@ class TestKubernetesExecutor:
         executor = KubernetesExecutor()
         executor.start()
         executor.scheduler_job_id = "123"
-        with dag_maker(dag_id="test_clear"):
+        with dag_maker(dag_id="test_cleanup_stuck_queued_tasks"):
             op = BashOperator(task_id="bash", bash_command=["echo 0", "echo 1"])
         dag_run = dag_maker.create_dagrun()
         ti = dag_run.get_task_instance(op.task_id, session)

--- a/tests/integration/executors/test_celery_executor.py
+++ b/tests/integration/executors/test_celery_executor.py
@@ -135,7 +135,7 @@ class TestCeleryExecutor:
                 ]
 
                 # "Enqueue" them. We don't have a real SimpleTaskInstance, so directly edit the dict
-                for (key, command, queue, task) in task_tuples_to_send:
+                for key, command, queue, task in task_tuples_to_send:
                     executor.queued_tasks[key] = (command, 1, queue, None)
                     executor.task_publish_retries[key] = 1
 
@@ -159,7 +159,6 @@ class TestCeleryExecutor:
         assert "fail" not in executor.tasks
 
         assert executor.queued_tasks == {}
-        assert timedelta(0, 600) == executor.task_adoption_timeout
 
     def test_error_sending_task(self):
         def fake_execute_command():

--- a/tests/integration/executors/test_celery_executor.py
+++ b/tests/integration/executors/test_celery_executor.py
@@ -22,7 +22,7 @@ import json
 import logging
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime
 from unittest import mock
 
 # leave this it is used by the test worker

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1583,13 +1583,14 @@ class TestSchedulerJob:
         ti.queued_dttm = timezone.utcnow() - timedelta(minutes=15)
         session.commit()
 
-        self.scheduler_job = SchedulerJob(num_runs=0)
-        self.scheduler_job._task_queued_timeout = 300
-        self.scheduler_job.executor = mock.MagicMock()
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=0)
+        self.job_runner._task_queued_timeout = 300
+        self.job_runner.executor = mock.MagicMock()
 
-        self.scheduler_job._fail_tasks_stuck_in_queued()
+        self.job_runner._fail_tasks_stuck_in_queued()
 
-        self.scheduler_job.executor.cleanup_stuck_queued_tasks.assert_called_once()
+        self.job_runner.executor.cleanup_stuck_queued_tasks.assert_called_once()
 
     def test_retry_stuck_queued_tasks(self, dag_maker):
         session = settings.Session()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1583,14 +1583,13 @@ class TestSchedulerJob:
         ti.queued_dttm = timezone.utcnow() - timedelta(minutes=15)
         session.commit()
 
-        processor = mock.MagicMock()
-
         self.scheduler_job = SchedulerJob(num_runs=0)
-        self.scheduler_job.processor_agent = processor
         self.scheduler_job._task_queued_timeout = 300
+        self.scheduler_job.executor = mock.MagicMock()
 
         self.scheduler_job._fail_tasks_stuck_in_queued()
 
+        self.scheduler_job.executor.cleanup_stuck_queued_task.assert_called_once()
         ti = dr.get_task_instance(task_id=op1.task_id, session=session)
         assert ti.state == State.FAILED
 
@@ -1605,14 +1604,13 @@ class TestSchedulerJob:
         ti.queued_dttm = timezone.utcnow() - timedelta(minutes=15)
         session.commit()
 
-        processor = mock.MagicMock()
-
         self.scheduler_job = SchedulerJob(num_runs=0)
-        self.scheduler_job.processor_agent = processor
         self.scheduler_job._task_queued_timeout = 300
+        self.scheduler_job.executor = mock.MagicMock()
 
         self.scheduler_job._fail_tasks_stuck_in_queued()
 
+        self.scheduler_job.executor.cleanup_stuck_queued_task.assert_called_once()
         ti = dr.get_task_instance(task_id=op1.task_id, session=session)
         assert ti.state == State.UP_FOR_RETRY
 

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1589,9 +1589,7 @@ class TestSchedulerJob:
 
         self.scheduler_job._fail_tasks_stuck_in_queued()
 
-        self.scheduler_job.executor.cleanup_stuck_queued_task.assert_called_once()
-        ti = dr.get_task_instance(task_id=op1.task_id, session=session)
-        assert ti.state == State.FAILED
+        self.scheduler_job.executor.cleanup_stuck_queued_tasks.assert_called_once()
 
     def test_retry_stuck_queued_tasks(self, dag_maker):
         session = settings.Session()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1574,7 +1574,7 @@ class TestSchedulerJob:
 
     def test_fail_stuck_queued_tasks(self, dag_maker):
         session = settings.Session()
-        with dag_maker("test_fail_stuck_queued_tasks") as dag:
+        with dag_maker("test_fail_stuck_queued_tasks"):
             op1 = EmptyOperator(task_id="op1")
 
         dr = dag_maker.create_dagrun()
@@ -1596,7 +1596,7 @@ class TestSchedulerJob:
 
     def test_retry_stuck_queued_tasks(self, dag_maker):
         session = settings.Session()
-        with dag_maker("test_retry_stuck_queued_tasks") as dag:
+        with dag_maker("test_retry_stuck_queued_tasks"):
             op1 = EmptyOperator(task_id="op1", retries=1)
 
         dr = dag_maker.create_dagrun()
@@ -2181,7 +2181,6 @@ class TestSchedulerJob:
         advance_execution_date=False,
         session=None,
     ):
-
         """
         Helper for testing DagRun states with simple two-task DAGs.
         This is hackish: a dag run is created but its tasks are
@@ -3020,7 +3019,6 @@ class TestSchedulerJob:
 
         default_args = {"depends_on_past": False, "start_date": start_date}
         with dag_maker(dag_name1, schedule="* * * * *", max_active_runs=1, default_args=default_args) as dag1:
-
             run_this_1 = EmptyOperator(task_id="run_this_1")
             run_this_2 = EmptyOperator(task_id="run_this_2")
             run_this_2.set_upstream(run_this_1)
@@ -4592,6 +4590,7 @@ class TestSchedulerJob:
         Note: This doesn't currently account for tasks that go into retry -- the scheduler would be detected
         as idle in that circumstance
         """
+
         # Spy on _do_scheduling and _process_executor_events so we can notice
         # if nothing happened, and abort early! Given we are using
         # SequentialExecutor this shouldn't be possible -- if there is nothing
@@ -5100,7 +5099,6 @@ class TestSchedulerJobQueriesCount:
                 ("core", "min_serialized_dag_fetch_interval"): "100",
             }
         ):
-
             dagbag = DagBag(dag_folder=ELASTIC_DAG_FILE, include_examples=False)
             dagbag.sync_to_db()
 

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1583,14 +1583,14 @@ class TestSchedulerJob:
         ti.queued_dttm = timezone.utcnow() - timedelta(minutes=15)
         session.commit()
 
-        scheduler_job = Job()
-        self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=0)
-        self.job_runner._task_queued_timeout = 300
-        self.job_runner.executor = mock.MagicMock()
+        scheduler_job = Job(executor=mock.MagicMock(slots_available=8))
+        job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=0)
+        job_runner._task_queued_timeout = 300
+        job_runner.executor = mock.MagicMock()
 
-        self.job_runner._fail_tasks_stuck_in_queued()
+        job_runner._fail_tasks_stuck_in_queued()
 
-        self.job_runner.executor.cleanup_stuck_queued_tasks.assert_called_once()
+        job_runner.job.executor.cleanup_stuck_queued_tasks.assert_called_once()
 
     @mock.patch("airflow.dag_processing.manager.DagFileProcessorAgent")
     def test_executor_end_called(self, mock_processor_agent):


### PR DESCRIPTION
I accidentally closed #30108, so this is basically reopening that PR. Some updates:

* There's not really a mechanism to deprecate multiple configs into one. The nature of this change requires some unique deprecation logic which is implemented in `scheduler_job.py`.
* This deprecates `celery.stalled_task_timeout`, `kubernetes.worker_pods_pending_timeout`, and `celery.task_adoption_timeout`

closes: #28120
closes: #21225
closes: #28943

Tasks occasionally get stuck in queued and aren't resolved by `stalled_task_timeout` (#28120). This PR moves the logic for handling stalled tasks to the scheduler and simplifies the logic by marking any task that has been queued for more than `scheduler.task_queued_timeout` as failed, allowing it to be retried if the task has available retries.

This doesn't require an additional scheduler nor allow for the possibility of tasks to get stuck in an infinite loop of scheduled -> queued -> scheduled ... -> queued as exists in #28943.