### PR TITLE
Remove JobRunners back reference from Job

### DIFF
--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -25,8 +25,6 @@ from typing import Any, Callable
 from flask import Response
 
 from airflow.api_connexion.types import APIResponse
-from airflow.models import Trigger, Variable, XCom
-from airflow.models.dagwarning import DagWarning
 from airflow.serialization.serialized_objects import BaseSerialization
 
 log = logging.getLogger(__name__)
@@ -36,7 +34,9 @@ log = logging.getLogger(__name__)
 def _initialize_map() -> dict[str, Callable]:
     from airflow.dag_processing.manager import DagFileProcessorManager
     from airflow.dag_processing.processor import DagFileProcessor
+    from airflow.models import Trigger, Variable, XCom
     from airflow.models.dag import DagModel
+    from airflow.models.dagwarning import DagWarning
 
     functions: list[Callable] = [
         DagFileProcessor.update_import_errors,

--- a/airflow/cli/commands/dag_processor_command.py
+++ b/airflow/cli/commands/dag_processor_command.py
@@ -26,6 +26,8 @@ from daemon.pidfile import TimeoutPIDLockFile
 
 from airflow import settings
 from airflow.configuration import conf
+from airflow.dag_processing.manager import DagFileProcessorManager
+from airflow.jobs.dag_processor_job_runner import DagProcessorJobRunner
 from airflow.jobs.job import Job, run_job
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import setup_locations, setup_logging
@@ -33,22 +35,20 @@ from airflow.utils.cli import setup_locations, setup_logging
 log = logging.getLogger(__name__)
 
 
-def _create_dag_processor_job(args: Any) -> Job:
+def _create_dag_processor_job_runner(args: Any) -> DagProcessorJobRunner:
     """Creates DagFileProcessorProcess instance."""
-    from airflow.dag_processing.manager import DagFileProcessorManager
-
     processor_timeout_seconds: int = conf.getint("core", "dag_file_processor_timeout")
     processor_timeout = timedelta(seconds=processor_timeout_seconds)
 
-    processor = DagFileProcessorManager(
-        processor_timeout=processor_timeout,
-        dag_directory=args.subdir,
-        max_runs=args.num_runs,
-        dag_ids=[],
-        pickle_dags=args.do_pickle,
-    )
-    return Job(
-        job_runner=processor.job_runner,
+    return DagProcessorJobRunner(
+        job=Job(),
+        processor=DagFileProcessorManager(
+            processor_timeout=processor_timeout,
+            dag_directory=args.subdir,
+            max_runs=args.num_runs,
+            dag_ids=[],
+            pickle_dags=args.do_pickle,
+        ),
     )
 
 
@@ -62,7 +62,7 @@ def dag_processor(args):
     if sql_conn.startswith("sqlite"):
         raise SystemExit("Standalone DagProcessor is not supported when using sqlite.")
 
-    job = _create_dag_processor_job(args)
+    job_runner = _create_dag_processor_job_runner(args)
 
     if args.daemon:
         pid, stdout, stderr, log_file = setup_locations(
@@ -81,6 +81,6 @@ def dag_processor(args):
                 umask=int(settings.DAEMON_UMASK, 8),
             )
             with ctx:
-                run_job(job)
+                run_job(job=job_runner.job, execute_callable=job_runner._execute)
     else:
-        run_job(job)
+        run_job(job=job_runner.job, execute_callable=job_runner._execute)

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -248,7 +248,8 @@ def _run_task_by_executor(args, dag: DAG, ti: TaskInstance) -> None:
 
 def _run_task_by_local_task_job(args, ti: TaskInstance) -> TaskReturnCode | None:
     """Run LocalTaskJob, which monitors the raw task execution process."""
-    local_task_job_runner = LocalTaskJobRunner(
+    job_runner = LocalTaskJobRunner(
+        job=Job(dag_id=ti.dag_id),
         task_instance=ti,
         mark_success=args.mark_success,
         pickle_id=args.pickle,
@@ -260,12 +261,8 @@ def _run_task_by_local_task_job(args, ti: TaskInstance) -> TaskReturnCode | None
         pool=args.pool,
         external_executor_id=_extract_external_executor_id(args),
     )
-    local_task_job = Job(
-        job_runner=local_task_job_runner,
-        dag_id=ti.dag_id,
-    )
     try:
-        ret = run_job(local_task_job)
+        ret = run_job(job=job_runner.job, execute_callable=job_runner._execute)
     finally:
         if args.shut_down_logging:
             logging.shutdown()

--- a/airflow/cli/commands/triggerer_command.py
+++ b/airflow/cli/commands/triggerer_command.py
@@ -55,8 +55,7 @@ def triggerer(args):
     """Starts Airflow Triggerer."""
     settings.MASK_SECRETS_IN_LOGS = True
     print(settings.HEADER)
-    triggerer_job_runner = TriggererJobRunner(capacity=args.capacity)
-    job = Job(job_runner=triggerer_job_runner)
+    triggerer_job_runner = TriggererJobRunner(job=Job(), capacity=args.capacity)
 
     if args.daemon:
         pid, stdout, stderr, log_file = setup_locations(
@@ -75,10 +74,10 @@ def triggerer(args):
                 umask=int(settings.DAEMON_UMASK, 8),
             )
             with daemon_context, _serve_logs(args.skip_serve_logs):
-                run_job(job)
+                run_job(job=triggerer_job_runner.job, execute_callable=triggerer_job_runner._execute)
     else:
         signal.signal(signal.SIGINT, sigint_handler)
         signal.signal(signal.SIGTERM, sigint_handler)
         signal.signal(signal.SIGQUIT, sigquit_handler)
         with _serve_logs(args.skip_serve_logs):
-            run_job(job)
+            run_job(job=triggerer_job_runner.job, execute_callable=triggerer_job_runner._execute)

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -35,7 +35,7 @@ from datetime import datetime, timedelta
 from importlib import import_module
 from multiprocessing.connection import Connection as MultiprocessingConnection
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple, cast
+from typing import Any, Callable, NamedTuple, cast
 
 from setproctitle import setproctitle
 from sqlalchemy.orm import Session
@@ -46,7 +46,6 @@ from airflow.api_internal.internal_api_call import internal_api_call
 from airflow.callbacks.callback_requests import CallbackRequest, SlaCallbackRequest
 from airflow.configuration import conf
 from airflow.dag_processing.processor import DagFileProcessorProcess
-from airflow.jobs.job import perform_heartbeat
 from airflow.models import errors
 from airflow.models.dag import DagModel
 from airflow.models.dagwarning import DagWarning
@@ -66,9 +65,6 @@ from airflow.utils.process_utils import (
 from airflow.utils.retries import retry_db_transaction
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import prohibit_commit, skip_locked, with_row_locks
-
-if TYPE_CHECKING:
-    from airflow.jobs.dag_processor_job_runner import DagProcessorJobRunner
 
 
 class DagParsingStat(NamedTuple):
@@ -385,8 +381,6 @@ class DagFileProcessorManager(LoggingMixin):
         signal_conn: MultiprocessingConnection | None = None,
         async_mode: bool = True,
     ):
-        from airflow.jobs.dag_processor_job_runner import DagProcessorJobRunner
-
         super().__init__()
         # known files; this will be updated every `dag_dir_list_interval` and stuff added/removed accordingly
         self._file_paths: list[str] = []
@@ -399,9 +393,6 @@ class DagFileProcessorManager(LoggingMixin):
         self._async_mode = async_mode
         self._parsing_start_time: float | None = None
         self._dag_directory = dag_directory
-        self._job_runner = DagProcessorJobRunner(
-            processor=self,
-        )
         # Set the signal conn in to non-blocking mode, so that attempting to
         # send when the buffer is full errors, rather than hangs for-ever
         # attempting to send (this is to avoid deadlocks!)
@@ -465,10 +456,7 @@ class DagFileProcessorManager(LoggingMixin):
             if self._direct_scheduler_conn is not None
             else {}
         )
-
-    @property
-    def job_runner(self) -> DagProcessorJobRunner:
-        return self._job_runner
+        self.heartbeat: Callable[[], None] = lambda: None
 
     def register_exit_signals(self):
         """Register signals that stop child processes."""
@@ -585,11 +573,7 @@ class DagFileProcessorManager(LoggingMixin):
         while True:
             loop_start_time = time.monotonic()
             ready = multiprocessing.connection.wait(self.waitables.keys(), timeout=poll_time)
-            # we cannot (for now) define job in _job_runner nicely due to circular references of
-            # job and job runner, so we have to use getattr, but we might address it in the future
-            # change when decoupling these two even more
-            if getattr(self._job_runner, "job", None) is not None:
-                perform_heartbeat(self._job_runner.job, only_if_necessary=False)
+            self.heartbeat()
             if self._direct_scheduler_conn is not None and self._direct_scheduler_conn in ready:
                 agent_signal = self._direct_scheduler_conn.recv()
 

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -645,7 +645,7 @@ class DagFileProcessor(LoggingMixin):
     ) -> None:
         """
         Execute on failure callbacks.
-        These objects can come from SchedulerJob or from DagFileProcessorManager.
+        These objects can come from SchedulerJobRunner or from DagProcessorJobRunner.
 
         :param dagbag: Dag Bag of dags
         :param callback_requests: failure callbacks to execute

--- a/airflow/jobs/base_job_runner.py
+++ b/airflow/jobs/base_job_runner.py
@@ -25,15 +25,12 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from airflow.jobs.job import Job
-    from airflow.serialization.pydantic.job import JobPydantic
 
 
 class BaseJobRunner:
     """Abstract class for job runners to derive from."""
 
     job_type = "undefined"
-
-    job: Job | JobPydantic
 
     def _execute(self) -> int | None:
         """

--- a/airflow/jobs/job.py
+++ b/airflow/jobs/job.py
@@ -18,18 +18,17 @@
 from __future__ import annotations
 
 from time import sleep
-from typing import NoReturn
+from typing import Callable, NoReturn
 
 from sqlalchemy import Column, Index, Integer, String, case
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import Session, backref, foreign, relationship
-from sqlalchemy.orm.session import make_transient
+from sqlalchemy.orm import backref, foreign, relationship
+from sqlalchemy.orm.session import Session, make_transient
 
 from airflow.compat.functools import cached_property
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.executors.executor_loader import ExecutorLoader
-from airflow.jobs.base_job_runner import BaseJobRunner
 from airflow.listeners.listener import get_listener_manager
 from airflow.models.base import ID_LEN, Base
 from airflow.serialization.pydantic.job import JobPydantic
@@ -100,10 +99,9 @@ class Job(Base, LoggingMixin):
 
     heartrate = conf.getfloat("scheduler", "JOB_HEARTBEAT_SEC")
 
-    def __init__(self, job_runner: BaseJobRunner, executor=None, heartrate=None, **kwargs):
+    def __init__(self, executor=None, heartrate=None, **kwargs):
         # Save init parameters as DB fields
         self.hostname = get_hostname()
-        self.job_type = job_runner.job_type
         if executor:
             self.executor = executor
             self.executor_class = executor.__class__.__name__
@@ -116,8 +114,6 @@ class Job(Base, LoggingMixin):
         self.unixname = getuser()
         self.max_tis_per_query: int = conf.getint("scheduler", "max_tis_per_query")
         get_listener_manager().hook.on_starting(component=self)
-        self._job_runner = job_runner
-        self._job_runner.job = self
         super().__init__(**kwargs)
 
     @cached_property
@@ -157,7 +153,9 @@ class Job(Base, LoggingMixin):
         """Will be called when an external kill command is received."""
 
     @provide_session
-    def heartbeat(self, session: Session = NEW_SESSION) -> None:
+    def heartbeat(
+        self, heartbeat_callback: Callable[[Session], None], session: Session = NEW_SESSION
+    ) -> None:
         """
         Heartbeats update the job's entry in the database with a timestamp
         for the latest_heartbeat and allows for the job to be killed
@@ -176,6 +174,8 @@ class Job(Base, LoggingMixin):
         heart rate. If you go over 60 seconds before calling it, it won't
         sleep at all.
 
+        :param heartbeat_callback: Callback that will be run when the heartbeat is recorded in the Job
+        :param session to use for saving the job
         """
         previous_heartbeat = self.latest_heartbeat
 
@@ -206,7 +206,7 @@ class Job(Base, LoggingMixin):
                 # At this point, the DB has updated.
                 previous_heartbeat = self.latest_heartbeat
 
-                self.job_runner.heartbeat_callback(session=session)
+                heartbeat_callback(session)
                 self.log.debug("[heartbeat]")
         except OperationalError:
             Stats.incr(convert_camel_to_snake(self.__class__.__name__) + "_heartbeat_failure", 1, 1)
@@ -231,11 +231,6 @@ class Job(Base, LoggingMixin):
         session.merge(self)
         session.commit()
         Stats.incr(self.__class__.__name__.lower() + "_end", 1, 1)
-
-    @property
-    def job_runner(self) -> BaseJobRunner:
-        """Returns the job runner instance."""
-        return self._job_runner
 
     @provide_session
     def most_recent_job(self, session: Session = NEW_SESSION) -> Job | None:
@@ -267,7 +262,9 @@ def most_recent_job(job_type: str, session: Session = NEW_SESSION) -> Job | None
 
 
 @provide_session
-def run_job(job: Job | JobPydantic, session: Session = NEW_SESSION) -> int | None:
+def run_job(
+    job: Job | JobPydantic, execute_callable: Callable[[], int | None], session: Session = NEW_SESSION
+) -> int | None:
     """
     Runs the job. The Job is always an ORM object and setting the state is happening within the
     same DB session and the session is kept open throughout the whole execution
@@ -278,15 +275,15 @@ def run_job(job: Job | JobPydantic, session: Session = NEW_SESSION) -> int | Non
     """
     # The below assert is a temporary one, to make MyPy happy with partial AIP-44 work - we will remove it
     # once final AIP-44 changes are completed.
-    assert isinstance(job, Job), "Job should be ORM object not Pydantic one here (AIP-44 WIP)"
+    assert not isinstance(job, JobPydantic), "Job should be ORM object not Pydantic one here (AIP-44 WIP)"
     job.prepare_for_execution(session=session)
     try:
-        return execute_job(job)
+        return execute_job(job, execute_callable=execute_callable)
     finally:
         job.complete_execution(session=session)
 
 
-def execute_job(job: Job | JobPydantic) -> int | None:
+def execute_job(job: Job | JobPydantic, execute_callable: Callable[[], int | None]) -> int | None:
     """
     Executes the job.
 
@@ -304,12 +301,13 @@ def execute_job(job: Job | JobPydantic) -> int | None:
        not really matter, because except of running the heartbeat and state setting,
        the runner should not modify the job state.
 
+    :param execute_callable: callable to execute when running the job.
+
     :meta private:
     """
     ret = None
     try:
-        # This job_runner reference and type-ignore will be removed by further refactoring step
-        ret = job.job_runner._execute()  # type:ignore[union-attr]
+        ret = execute_callable()
         # In case of max runs or max duration
         job.state = State.SUCCESS
     except SystemExit:
@@ -321,21 +319,24 @@ def execute_job(job: Job | JobPydantic) -> int | None:
     return ret
 
 
-def perform_heartbeat(job: Job | JobPydantic, only_if_necessary: bool) -> None:
+def perform_heartbeat(
+    job: Job | JobPydantic, heartbeat_callback: Callable[[Session], None], only_if_necessary: bool
+) -> None:
     """
     Performs heartbeat for the Job passed to it,optionally checking if it is necessary.
 
     :param job: job to perform heartbeat for
+    :param heartbeat_callback: callback to run by the heartbeat
     :param only_if_necessary: only heartbeat if it is necessary (i.e. if there are things to run for
         triggerer for example)
     """
     # The below assert is a temporary one, to make MyPy happy with partial AIP-44 work - we will remove it
     # once final AIP-44 changes are completed.
-    assert isinstance(job, Job), "Job should be ORM object not Pydantic one here (AIP-44 WIP)"
+    assert not isinstance(job, JobPydantic), "Job should be ORM object not Pydantic one here (AIP-44 WIP)"
     seconds_remaining: float = 0.0
     if job.latest_heartbeat and job.heartrate:
         seconds_remaining = job.heartrate - (timezone.utcnow() - job.latest_heartbeat).total_seconds()
     if seconds_remaining > 0 and only_if_necessary:
         return
     with create_session() as session:
-        job.heartbeat(session=session)
+        job.heartbeat(heartbeat_callback=heartbeat_callback, session=session)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2468,28 +2468,27 @@ class DAG(LoggingMixin):
             executor = ExecutorLoader.get_default_executor()
         from airflow.jobs.job import Job
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                self,
-                start_date=start_date,
-                end_date=end_date,
-                mark_success=mark_success,
-                donot_pickle=donot_pickle,
-                ignore_task_deps=ignore_task_deps,
-                ignore_first_depends_on_past=ignore_first_depends_on_past,
-                pool=pool,
-                delay_on_limit_secs=delay_on_limit_secs,
-                verbose=verbose,
-                conf=conf,
-                rerun_failed_tasks=rerun_failed_tasks,
-                run_backwards=run_backwards,
-                run_at_least_once=run_at_least_once,
-                continue_on_failures=continue_on_failures,
-                disable_retry=disable_retry,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=self,
+            start_date=start_date,
+            end_date=end_date,
+            mark_success=mark_success,
+            donot_pickle=donot_pickle,
+            ignore_task_deps=ignore_task_deps,
+            ignore_first_depends_on_past=ignore_first_depends_on_past,
+            pool=pool,
+            delay_on_limit_secs=delay_on_limit_secs,
+            verbose=verbose,
+            conf=conf,
+            rerun_failed_tasks=rerun_failed_tasks,
+            run_backwards=run_backwards,
+            run_at_least_once=run_at_least_once,
+            continue_on_failures=continue_on_failures,
+            disable_retry=disable_retry,
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
     def cli(self):
         """Exposes a CLI specific to this DAG"""

--- a/airflow/serialization/enums.py
+++ b/airflow/serialization/enums.py
@@ -51,7 +51,7 @@ class DagAttributeTypes(str, Enum):
     XCOM_REF = "xcomref"
     DATASET = "dataset"
     SIMPLE_TASK_INSTANCE = "simple_task_instance"
-    BASE_JOB = "base_job"
+    BASE_JOB = "Job"
     TASK_INSTANCE = "task_instance"
     DAG_RUN = "dag_run"
     DATA_SET = "data_set"

--- a/airflow/task/task_runner/__init__.py
+++ b/airflow/task/task_runner/__init__.py
@@ -59,5 +59,5 @@ def get_task_runner(local_task_job_runner: LocalTaskJobRunner) -> BaseTaskRunner
                 f'The task runner could not be loaded. Please check "task_runner" key in "core" section. '
                 f'Current value: "{_TASK_RUNNER_NAME}".'
             )
-    task_runner = task_runner_class(local_task_job_runner.job)
+    task_runner = task_runner_class(local_task_job_runner)
     return task_runner

--- a/airflow/task/task_runner/cgroup_task_runner.py
+++ b/airflow/task/task_runner/cgroup_task_runner.py
@@ -25,7 +25,7 @@ import uuid
 import psutil
 from cgroupspy import trees
 
-from airflow.jobs.job import Job
+from airflow.jobs.local_task_job_runner import LocalTaskJobRunner
 from airflow.task.task_runner.base_task_runner import BaseTaskRunner
 from airflow.utils.operator_resources import Resources
 from airflow.utils.platform import getuser
@@ -62,8 +62,8 @@ class CgroupTaskRunner(BaseTaskRunner):
     airflow ALL= (root) NOEXEC: !/bin/chmod /CGROUPS_FOLDER/cpu/airflow/* *
     """
 
-    def __init__(self, base_job: Job):
-        super().__init__(base_job=base_job)
+    def __init__(self, job_runner: LocalTaskJobRunner):
+        super().__init__(job_runner=job_runner)
         self.process = None
         self._finished_running = False
         self._cpu_shares = None

--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -24,7 +24,7 @@ import os
 import psutil
 from setproctitle import setproctitle
 
-from airflow.jobs.job import Job
+from airflow.jobs.local_task_job_runner import LocalTaskJobRunner
 from airflow.models.taskinstance import TaskReturnCode
 from airflow.settings import CAN_FORK
 from airflow.task.task_runner.base_task_runner import BaseTaskRunner
@@ -35,10 +35,10 @@ from airflow.utils.process_utils import reap_process_group, set_new_process_grou
 class StandardTaskRunner(BaseTaskRunner):
     """Standard runner for all tasks."""
 
-    def __init__(self, base_job: Job):
-        super().__init__(base_job=base_job)
+    def __init__(self, job_runner: LocalTaskJobRunner):
+        super().__init__(job_runner=job_runner)
         self._rc = None
-        self.dag = self.job_runner.task_instance.task.dag
+        self.dag = self._task_instance.task.dag
 
     def start(self):
         if CAN_FORK and not self.run_as_user:

--- a/dev/perf/scheduler_dag_execution_timing.py
+++ b/dev/perf/scheduler_dag_execution_timing.py
@@ -92,7 +92,7 @@ class ShortCircuitExecutorMixin:
 
             if not self.dags_to_watch:
                 self.log.warning("STOPPING SCHEDULER -- all runs complete")
-                self.scheduler_job.job_runner.processor_agent._done = True
+                self.job_runner.processor_agent._done = True
                 return
         self.log.warning(
             "WAITING ON %d RUNS", sum(map(attrgetter("waiting_for"), self.dags_to_watch.values()))
@@ -119,7 +119,7 @@ def get_executor_under_test(dotted_path):
         Placeholder class that implements the inheritance hierarchy
         """
 
-        scheduler_job = None
+        job_runner = None
 
     return ShortCircuitExecutor
 
@@ -279,8 +279,9 @@ def main(num_runs, repeat, pre_create_dag_runs, executor_class, dag_ids):
     ShortCircuitExecutor = get_executor_under_test(executor_class)
 
     executor = ShortCircuitExecutor(dag_ids_to_watch=dag_ids, num_runs=num_runs)
-    scheduler_job = Job(job_runner=SchedulerJobRunner(dag_ids=dag_ids, do_pickle=False), executor=executor)
-    executor.scheduler_job = scheduler_job
+    scheduler_job = Job(executor=executor)
+    job_runner = SchedulerJobRunner(job=scheduler_job, dag_ids=dag_ids, do_pickle=False)
+    executor.job_runner = job_runner
 
     total_tasks = sum(len(dag.tasks) for dag in dags)
 
@@ -293,7 +294,7 @@ def main(num_runs, repeat, pre_create_dag_runs, executor_class, dag_ids):
 
     # Need a lambda to refer to the _latest_ value for scheduler_job, not just
     # the initial one
-    code_to_test = lambda: run_job(scheduler_job)
+    code_to_test = lambda: run_job(job=job_runner.job, execute_callable=job_runner._execute)
 
     for count in range(repeat):
         gc.disable()
@@ -310,9 +311,8 @@ def main(num_runs, repeat, pre_create_dag_runs, executor_class, dag_ids):
                     reset_dag(dag, session)
 
             executor.reset(dag_ids)
-            scheduler_job = Job(
-                job_runner=SchedulerJobRunner(dag_ids=dag_ids, do_pickle=False), executor=executor
-            )
+            scheduler_job = Job(executor=executor)
+            job_runner = SchedulerJobRunner(job=scheduler_job, dag_ids=dag_ids, do_pickle=False)
             executor.scheduler_job = scheduler_job
 
     print()

--- a/dev/perf/sql_queries.py
+++ b/dev/perf/sql_queries.py
@@ -124,7 +124,8 @@ def run_scheduler_job(with_db_reset=False) -> None:
 
     if with_db_reset:
         reset_db()
-    run_job(Job(job_runner=SchedulerJobRunner(subdir=DAG_FOLDER, do_pickle=False, num_runs=3)))
+    job_runner = SchedulerJobRunner(job=Job(), subdir=DAG_FOLDER, do_pickle=False, num_runs=3)
+    run_job(job=job_runner.job, execute_callable=job_runner._execute)
 
 
 def is_query(line: str) -> bool:

--- a/docs/apache-airflow/authoring-and-scheduling/dagfile-processing.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/dagfile-processing.rst
@@ -1,3 +1,4 @@
+
  .. Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
     distributed with this work for additional information

--- a/tests/api_connexion/endpoints/test_health_endpoint.py
+++ b/tests/api_connexion/endpoints/test_health_endpoint.py
@@ -48,14 +48,9 @@ class TestGetHealth(TestHealthTestBase):
     @provide_session
     def test_healthy_scheduler_status(self, session):
         last_scheduler_heartbeat_for_testing_1 = timezone.utcnow()
-        session.add(
-            Job(
-                job_type="SchedulerJob",
-                state=State.RUNNING,
-                latest_heartbeat=last_scheduler_heartbeat_for_testing_1,
-                job_runner=SchedulerJobRunner(),
-            )
-        )
+        job = Job(state=State.RUNNING, latest_heartbeat=last_scheduler_heartbeat_for_testing_1)
+        SchedulerJobRunner(job=job)
+        session.add(job)
         session.commit()
         resp_json = self.client.get("/api/v1/health").json
         assert "healthy" == resp_json["metadatabase"]["status"]
@@ -68,14 +63,9 @@ class TestGetHealth(TestHealthTestBase):
     @provide_session
     def test_unhealthy_scheduler_is_slow(self, session):
         last_scheduler_heartbeat_for_testing_2 = timezone.utcnow() - timedelta(minutes=1)
-        session.add(
-            Job(
-                job_type="SchedulerJob",
-                state=State.RUNNING,
-                latest_heartbeat=last_scheduler_heartbeat_for_testing_2,
-                job_runner=SchedulerJobRunner(),
-            )
-        )
+        job = Job(state=State.RUNNING, latest_heartbeat=last_scheduler_heartbeat_for_testing_2)
+        SchedulerJobRunner(job=job)
+        session.add(job)
         session.commit()
         resp_json = self.client.get("/api/v1/health").json
         assert "healthy" == resp_json["metadatabase"]["status"]

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -232,7 +232,8 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
         )[0]
         ti.trigger = Trigger("none", {})
         ti.trigger.created_date = now
-        ti.triggerer_job = Job(job_runner=TriggererJobRunner())
+        ti.triggerer_job = Job()
+        TriggererJobRunner(job=ti.triggerer_job)
         ti.triggerer_job.state = "running"
         session.commit()
         response = self.client.get(

--- a/tests/cli/commands/test_dag_processor_command.py
+++ b/tests/cli/commands/test_dag_processor_command.py
@@ -42,7 +42,7 @@ class TestDagProcessorCommand:
             ("core", "load_examples"): "False",
         }
     )
-    @mock.patch("airflow.jobs.dag_processor_job_runner.DagProcessorJobRunner")
+    @mock.patch("airflow.cli.commands.dag_processor_command.DagProcessorJobRunner")
     @pytest.mark.skipif(
         conf.get_mandatory_value("database", "sql_alchemy_conn").lower().startswith("sqlite"),
         reason="Standalone Dag Processor doesn't support sqlite.",
@@ -51,7 +51,7 @@ class TestDagProcessorCommand:
         self,
         mock_dag_job,
     ):
-        """Ensure that DagFileProcessorManager is started"""
+        """Ensure that DagProcessorJobRunner is started"""
         with conf_vars({("scheduler", "standalone_dag_processor"): "True"}):
             mock_dag_job.return_value.job_type = "DagProcessorJob"
             args = self.parser.parse_args(["dag-processor"])

--- a/tests/cli/commands/test_jobs_command.py
+++ b/tests/cli/commands/test_jobs_command.py
@@ -38,19 +38,21 @@ class TestCliConfigList:
     def setup_method(self) -> None:
         clear_db_jobs()
         self.scheduler_job = None
+        self.job_runner = None
 
     def teardown_method(self) -> None:
-        if self.scheduler_job and self.scheduler_job.job_runner.processor_agent:
-            self.scheduler_job.job_runner.processor_agent.end()
+        if self.job_runner and self.job_runner.processor_agent:
+            self.job_runner.processor_agent.end()
         clear_db_jobs()
 
     def test_should_report_success_for_one_working_scheduler(self):
         with create_session() as session:
-            self.scheduler_job = Job(job_runner=SchedulerJobRunner())
+            self.scheduler_job = Job()
+            self.job_runner = SchedulerJobRunner(job=self.scheduler_job)
             self.scheduler_job.state = State.RUNNING
             session.add(self.scheduler_job)
             session.commit()
-            self.scheduler_job.heartbeat()
+            self.scheduler_job.heartbeat(heartbeat_callback=self.job_runner.heartbeat_callback)
 
         with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
             jobs_command.check(self.parser.parse_args(["jobs", "check", "--job-type", "SchedulerJob"]))
@@ -58,12 +60,13 @@ class TestCliConfigList:
 
     def test_should_report_success_for_one_working_scheduler_with_hostname(self):
         with create_session() as session:
-            self.scheduler_job = Job(job_runner=SchedulerJobRunner())
+            self.scheduler_job = Job()
+            self.job_runner = SchedulerJobRunner(job=self.scheduler_job)
             self.scheduler_job.state = State.RUNNING
             self.scheduler_job.hostname = "HOSTNAME"
             session.add(self.scheduler_job)
             session.commit()
-            self.scheduler_job.heartbeat()
+            self.scheduler_job.heartbeat(heartbeat_callback=self.job_runner.heartbeat_callback)
 
         with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
             jobs_command.check(
@@ -75,52 +78,64 @@ class TestCliConfigList:
 
     def test_should_report_success_for_ha_schedulers(self):
         scheduler_jobs = []
+        job_runners = []
         with create_session() as session:
             for _ in range(3):
-                scheduler_job = Job(job_runner=SchedulerJobRunner())
+                scheduler_job = Job()
+                job_runner = SchedulerJobRunner(job=scheduler_job)
                 scheduler_job.state = State.RUNNING
                 session.add(scheduler_job)
                 scheduler_jobs.append(scheduler_job)
+                job_runners.append(job_runner)
             session.commit()
-            scheduler_job.heartbeat()
-
-        with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
-            jobs_command.check(
-                self.parser.parse_args(
-                    ["jobs", "check", "--job-type", "SchedulerJob", "--limit", "100", "--allow-multiple"]
+            scheduler_job.heartbeat(heartbeat_callback=job_runner.heartbeat_callback)
+        try:
+            with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
+                jobs_command.check(
+                    self.parser.parse_args(
+                        ["jobs", "check", "--job-type", "SchedulerJob", "--limit", "100", "--allow-multiple"]
+                    )
                 )
-            )
-        assert "Found 3 alive jobs." in temp_stdout.getvalue()
-        for scheduler_job in scheduler_jobs:
-            if scheduler_job.job_runner.processor_agent:
-                scheduler_job.job_runner.processor_agent.end()
+            assert "Found 3 alive jobs." in temp_stdout.getvalue()
+        finally:
+            for job_runner in job_runners:
+                if job_runner.processor_agent:
+                    job_runner.processor_agent.end()
 
     def test_should_ignore_not_running_jobs(self):
         scheduler_jobs = []
+        job_runners = []
         with create_session() as session:
             for _ in range(3):
-                scheduler_job = Job(job_runner=SchedulerJobRunner())
+                scheduler_job = Job()
+                job_runner = SchedulerJobRunner(job=scheduler_job)
                 scheduler_job.state = State.SHUTDOWN
                 session.add(scheduler_job)
                 scheduler_jobs.append(scheduler_job)
+                job_runners.append(job_runner)
             session.commit()
         # No alive jobs found.
         with pytest.raises(SystemExit, match=r"No alive jobs found."):
             jobs_command.check(self.parser.parse_args(["jobs", "check"]))
-        for scheduler_job in scheduler_jobs:
-            if scheduler_job.job_runner.processor_agent:
-                scheduler_job.job_runner.processor_agent.end()
+        for job_runner in job_runners:
+            if job_runner.processor_agent:
+                job_runner.processor_agent.end()
 
     def test_should_raise_exception_for_multiple_scheduler_on_one_host(self):
         scheduler_jobs = []
+        job_runners = []
         with create_session() as session:
             for _ in range(3):
-                scheduler_job = Job(job_runner=SchedulerJobRunner())
+                scheduler_job = Job()
+                job_runner = SchedulerJobRunner(job=scheduler_job)
+                job_runner.job = scheduler_job
                 scheduler_job.state = State.RUNNING
                 scheduler_job.hostname = "HOSTNAME"
                 session.add(scheduler_job)
+                scheduler_jobs.append(scheduler_job)
+                job_runners.append(job_runner)
             session.commit()
-            scheduler_job.heartbeat()
+            scheduler_job.heartbeat(heartbeat_callback=job_runner.heartbeat_callback)
 
         with pytest.raises(SystemExit, match=r"Found 3 alive jobs. Expected only one."):
             jobs_command.check(
@@ -135,9 +150,9 @@ class TestCliConfigList:
                     ]
                 )
             )
-        for scheduler_job in scheduler_jobs:
-            if scheduler_job.job_runner.processor_agent:
-                scheduler_job.job_runner.processor_agent.end()
+        for job_runner in job_runners:
+            if job_runner.processor_agent:
+                job_runner.processor_agent.end()
 
     def test_should_raise_exception_for_allow_multiple_and_limit_1(self):
         with pytest.raises(

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -246,7 +246,7 @@ class TestCliTasks:
             assert ti.xcom_pull(ti.task_id) == new_file_path.as_posix()
 
     @mock.patch("airflow.cli.commands.task_command.LocalTaskJobRunner")
-    def test_run_with_existing_dag_run_id(self, mock_local_job):
+    def test_run_with_existing_dag_run_id(self, mock_local_job_runner):
         """
         Test that we can run with existing dag_run_id
         """
@@ -260,9 +260,10 @@ class TestCliTasks:
             task0_id,
             self.run_id,
         ]
-        mock_local_job.return_value.job_type = "LocalTaskJob"
+        mock_local_job_runner.return_value.job_type = "LocalTaskJob"
         task_command.task_run(self.parser.parse_args(args0), dag=self.dag)
-        mock_local_job.assert_called_once_with(
+        mock_local_job_runner.assert_called_once_with(
+            job=mock.ANY,
             task_instance=mock.ANY,
             mark_success=False,
             ignore_all_deps=True,
@@ -646,6 +647,7 @@ class TestLogsfromTaskRunCommand:
 
         task_command.task_run(args)
         mock_local_job.assert_called_once_with(
+            job=mock.ANY,
             task_instance=mock.ANY,
             mark_success=False,
             pickle_id=None,
@@ -667,6 +669,7 @@ class TestLogsfromTaskRunCommand:
         with mock.patch.dict(os.environ, {"external_executor_id": "12345FEDCBA"}):
             task_command.task_run(args)
             mock_local_job.assert_called_once_with(
+                job=mock.ANY,
                 task_instance=mock.ANY,
                 mark_success=False,
                 pickle_id=None,

--- a/tests/cli/commands/test_triggerer_command.py
+++ b/tests/cli/commands/test_triggerer_command.py
@@ -45,4 +45,4 @@ class TestTriggererCommand:
         triggerer_command.triggerer(args)
         mock_serve.return_value.__enter__.assert_called_once()
         mock_serve.return_value.__exit__.assert_called_once()
-        mock_triggerer_job_runner.assert_called_once_with(capacity=42)
+        mock_triggerer_job_runner.assert_called_once_with(job=mock.ANY, capacity=42)

--- a/tests/core/test_impersonation_tests.py
+++ b/tests/core/test_impersonation_tests.py
@@ -113,7 +113,9 @@ class BaseImpersonationTest:
         dag = self.dagbag.get_dag(dag_id)
         dag.clear()
 
-        run_job(Job(job_runner=BackfillJobRunner(dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)))
+        job = Job()
+        job_runner = BackfillJobRunner(job=job, dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+        run_job(job=job, execute_callable=job_runner._execute)
         run_id = DagRun.generate_run_id(DagRunType.BACKFILL_JOB, execution_date=DEFAULT_DATE)
         ti = TaskInstance(task=dag.get_task(task_id), run_id=run_id)
         ti.refresh_from_db()

--- a/tests/executors/test_dask_executor.py
+++ b/tests/executors/test_dask_executor.py
@@ -109,15 +109,16 @@ class TestDaskExecutor(TestBaseDask):
         dag = self.dagbag.get_dag("example_bash_operator")
 
         job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE,
-                ignore_first_depends_on_past=True,
-            ),
             executor=DaskExecutor(cluster_address=self.cluster.scheduler_address),
         )
-        run_job(job)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE,
+            ignore_first_depends_on_past=True,
+        )
+        run_job(job=job, execute_callable=job_runner._execute)
 
     def teardown_method(self):
         self.cluster.close(timeout=5)

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -121,17 +121,16 @@ class TestBackfillJob:
         dag = self._get_dummy_dag(dag_maker)
         dag_run = dag_maker.create_dagrun(state=None)
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=8),
-                ignore_first_depends_on_past=True,
-            )
+        job = Job(executor=MockExecutor())
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=8),
+            ignore_first_depends_on_past=True,
         )
 
-        job.job_runner._set_unfinished_dag_runs_to_failed([dag_run])
-
+        job_runner._set_unfinished_dag_runs_to_failed([dag_run])
         dag_run.refresh_from_db()
 
         assert State.FAILED == dag_run.state
@@ -143,16 +142,15 @@ class TestBackfillJob:
         for ti in dag_run.get_task_instances():
             ti.set_state(State.SUCCESS)
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=8),
-                ignore_first_depends_on_past=True,
-            )
+        job = Job(executor=MockExecutor())
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=8),
+            ignore_first_depends_on_past=True,
         )
-
-        job.job_runner._set_unfinished_dag_runs_to_failed([dag_run])
+        job_runner._set_unfinished_dag_runs_to_failed([dag_run])
 
         dag_run.refresh_from_db()
 
@@ -167,17 +165,20 @@ class TestBackfillJob:
         target_dag_run = session.query(DagRun).filter(DagRun.dag_id == target_dag.dag_id).one_or_none()
         assert target_dag_run is None
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_first_depends_on_past=True
-            )
+        job = Job(executor=MockExecutor())
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE,
+            ignore_first_depends_on_past=True,
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         dag_run = session.query(DagRun).filter(DagRun.dag_id == dag.dag_id).one_or_none()
         assert dag_run is not None
 
-        task_instances_list = job.job_runner._task_instances_for_dag_run(dag=dag, dag_run=dag_run)
+        task_instances_list = job_runner._task_instances_for_dag_run(dag=dag, dag_run=dag_run)
 
         assert task_instances_list
 
@@ -188,17 +189,16 @@ class TestBackfillJob:
         end_date = DEFAULT_DATE + datetime.timedelta(days=1)
 
         executor = MockExecutor(parallelism=16)
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=end_date,
-                ignore_first_depends_on_past=True,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=end_date,
+            ignore_first_depends_on_past=True,
         )
 
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         expected_execution_order = [
             ("runme_0", DEFAULT_DATE),
@@ -282,17 +282,16 @@ class TestBackfillJob:
 
         logger.info("*** Running example DAG: %s", dag.dag_id)
         executor = MockExecutor()
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE,
-                ignore_first_depends_on_past=True,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE,
+            ignore_first_depends_on_past=True,
         )
 
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
         assert [
             ((dag_id, task_id, f"backfill__{DEFAULT_DATE.isoformat()}", 1, -1), (State.SUCCESS, None))
             for task_id in expected_execution_order
@@ -305,16 +304,15 @@ class TestBackfillJob:
         executor = MockExecutor()
 
         conf_ = json.loads("""{"key": "value"}""")
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=2),
-                conf=conf_,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=2),
+            conf=conf_,
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         # We ignore the first dag_run created by fixture
         dr = DagRun.find(
@@ -335,16 +333,15 @@ class TestBackfillJob:
 
         executor = MockExecutor()
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=7),
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=7),
         )
 
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         assert len(executor.history) > 0
 
@@ -387,16 +384,14 @@ class TestBackfillJob:
 
         executor = MockExecutor()
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=7),
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=7),
         )
-
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         assert len(executor.history) > 0
 
@@ -442,16 +437,15 @@ class TestBackfillJob:
 
         executor = MockExecutor()
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=7),
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=7),
         )
 
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         assert len(executor.history) > 0
 
@@ -500,17 +494,16 @@ class TestBackfillJob:
 
         executor = MockExecutor()
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=7),
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=7),
         )
 
         try:
-            run_job(job)
+            run_job(job=job, execute_callable=job_runner._execute)
         except AirflowException:
             return
 
@@ -535,16 +528,15 @@ class TestBackfillJob:
 
         executor = MockExecutor()
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=7),
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=7),
         )
 
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         assert len(executor.history) > 0
 
@@ -587,30 +579,28 @@ class TestBackfillJob:
 
         executor = MockExecutor()
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=2),
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=2),
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         ti = TI(task=dag.get_task("test_backfill_run_rescheduled_task-1"), execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
         ti.set_state(State.UP_FOR_RESCHEDULE)
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=2),
-                rerun_failed_tasks=True,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=2),
+            rerun_failed_tasks=True,
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
         ti = TI(task=dag.get_task("test_backfill_run_rescheduled_task-1"), execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
         assert ti.state == State.SUCCESS
@@ -626,22 +616,21 @@ class TestBackfillJob:
 
         executor = MockExecutor()
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=2),
-                conf={"a": 1},
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=2),
+            conf={"a": 1},
         )
 
         with patch.object(
-            job.job_runner,
+            job_runner,
             "_task_instances_for_dag_run",
-            wraps=job.job_runner._task_instances_for_dag_run,
+            wraps=job_runner._task_instances_for_dag_run,
         ) as wrapped_task_instances_for_dag_run:
-            run_job(job)
+            run_job(job=job, execute_callable=job_runner._execute)
             dr = wrapped_task_instances_for_dag_run.call_args_list[0][0][1]
             assert dr.conf == {"a": 1}
 
@@ -658,17 +647,16 @@ class TestBackfillJob:
 
         executor = MockExecutor()
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=2),
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=2),
         )
         with caplog.at_level(logging.ERROR, logger="airflow.jobs.backfill_job_runner.BackfillJob"):
             caplog.clear()
-            run_job(job)
+            run_job(job=job, execute_callable=job_runner._execute)
             assert "Backfill cannot be created for DagRun" in caplog.messages[0]
 
         ti = TI(
@@ -686,30 +674,28 @@ class TestBackfillJob:
 
         executor = MockExecutor()
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=2),
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=2),
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         ti = TI(task=dag.get_task("test_backfill_rerun_failed_task-1"), execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
         ti.set_state(State.FAILED)
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=2),
-                rerun_failed_tasks=True,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=2),
+            rerun_failed_tasks=True,
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
         ti = TI(task=dag.get_task("test_backfill_rerun_failed_task-1"), execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
         assert ti.state == State.SUCCESS
@@ -724,30 +710,28 @@ class TestBackfillJob:
 
         executor = MockExecutor()
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=2),
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=2),
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         ti = TI(task=dag.get_task("test_backfill_rerun_upstream_failed_task-1"), execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
         ti.set_state(State.UPSTREAM_FAILED)
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=2),
-                rerun_failed_tasks=True,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=2),
+            rerun_failed_tasks=True,
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
         ti = TI(task=dag.get_task("test_backfill_rerun_upstream_failed_task-1"), execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
         assert ti.state == State.SUCCESS
@@ -760,32 +744,30 @@ class TestBackfillJob:
 
         executor = MockExecutor()
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=2),
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=2),
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         ti = TI(task=dag.get_task("test_backfill_rerun_failed_task-1"), execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
         ti.set_state(State.FAILED)
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=2),
-                rerun_failed_tasks=False,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=2),
+            rerun_failed_tasks=False,
         )
 
         with pytest.raises(AirflowException):
-            run_job(job)
+            run_job(job=job, execute_callable=job_runner._execute)
 
     def test_backfill_retry_intermittent_failed_task(self, dag_maker):
         with dag_maker(
@@ -806,15 +788,14 @@ class TestBackfillJob:
         executor.mock_task_results[
             TaskInstanceKey(dag.dag_id, task1.task_id, DEFAULT_DATE, try_number=2)
         ] = State.UP_FOR_RETRY
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=2),
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=2),
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
     def test_backfill_retry_always_failed_task(self, dag_maker):
         with dag_maker(
@@ -833,16 +814,15 @@ class TestBackfillJob:
             TaskInstanceKey(dag.dag_id, task1.task_id, dr.run_id, try_number=1)
         ] = State.UP_FOR_RETRY
         executor.mock_task_fail(dag.dag_id, task1.task_id, dr.run_id, try_number=2)
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE,
         )
         with pytest.raises(BackfillUnfinished):
-            run_job(job)
+            run_job(job=job, execute_callable=job_runner._execute)
 
     def test_backfill_ordered_concurrent_execute(self, dag_maker):
 
@@ -864,15 +844,14 @@ class TestBackfillJob:
         dag_maker.create_dagrun(run_id=runid0)
 
         executor = MockExecutor(parallelism=16)
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=2),
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=2),
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         runid1 = f"backfill__{(DEFAULT_DATE + datetime.timedelta(days=1)).isoformat()}"
         runid2 = f"backfill__{(DEFAULT_DATE + datetime.timedelta(days=2)).isoformat()}"
@@ -908,16 +887,14 @@ class TestBackfillJob:
         dag.clear()
 
         executor = MockExecutor(do_update=True)
-        job = Job(
-            job_runner=BackfillJobRunner(dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE),
-            executor=executor,
-        )
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(job=job, dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
         # run with timeout because this creates an infinite loop if not
         # caught
         try:
             with timeout(seconds=5):
-                run_job(job)
+                run_job(job=job, execute_callable=job_runner._execute)
         except AirflowTaskTimeout:
             pass
         ti = TI(task=dag.get_task("test_backfill_pooled_task"), execution_date=DEFAULT_DATE)
@@ -932,17 +909,15 @@ class TestBackfillJob:
         dag.clear()
         run_date = DEFAULT_DATE + datetime.timedelta(days=5)
 
-        run_job(
-            Job(
-                job_runner=BackfillJobRunner(
-                    dag=dag,
-                    start_date=run_date,
-                    end_date=run_date,
-                    ignore_first_depends_on_past=ignore_depends_on_past,
-                ),
-                executor=MockExecutor(),
-            )
+        job = Job(executor=MockExecutor())
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=run_date,
+            end_date=run_date,
+            ignore_first_depends_on_past=ignore_depends_on_past,
         )
+        run_job(job=job, execute_callable=job_runner._execute)
 
         # ti should have succeeded
         ti = TI(dag.tasks[0], run_date)
@@ -964,11 +939,9 @@ class TestBackfillJob:
         dag.clear()
 
         executor = MockExecutor()
-        job = Job(
-            job_runner=BackfillJobRunner(dag=dag, ignore_first_depends_on_past=True, **kwargs),
-            executor=executor,
-        )
-        run_job(job)
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(job=job, dag=dag, ignore_first_depends_on_past=True, **kwargs)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         ti = TI(dag.get_task("test_dop_task"), end_date)
         ti.refresh_from_db()
@@ -979,11 +952,9 @@ class TestBackfillJob:
         expected_msg = "You cannot backfill backwards because one or more tasks depend_on_past: test_dop_task"
         with pytest.raises(AirflowException, match=expected_msg):
             executor = MockExecutor()
-            job = Job(
-                job_runner=BackfillJobRunner(dag=dag, run_backwards=True, **kwargs),
-                executor=executor,
-            )
-            run_job(job)
+            job = Job(executor=executor)
+            job_runner = BackfillJobRunner(job=job, dag=dag, run_backwards=True, **kwargs)
+            run_job(job=job, execute_callable=job_runner._execute)
 
     def test_cli_receives_delay_arg(self):
         """
@@ -1030,16 +1001,15 @@ class TestBackfillJob:
         end_date = DEFAULT_DATE
 
         executor = MockExecutor()
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=start_date,
-                end_date=end_date,
-                donot_pickle=True,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=start_date,
+            end_date=end_date,
+            donot_pickle=True,
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         dagruns = DagRun.find(dag_id=dag.dag_id)
         assert 2 == len(dagruns)
@@ -1055,17 +1025,16 @@ class TestBackfillJob:
         end_date = DEFAULT_DATE
 
         executor = MockExecutor()
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=start_date,
-                end_date=end_date,
-                donot_pickle=True,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=start_date,
+            end_date=end_date,
+            donot_pickle=True,
         )
         job.notification_threadpool = mock.MagicMock()
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         assert len(dag_listener.running) == 1
         assert len(dag_listener.success) == 1
@@ -1110,15 +1079,16 @@ class TestBackfillJob:
 
                 executor = MockExecutor()
                 job = Job(
-                    job_runner=BackfillJobRunner(
-                        dag=dag,
-                        start_date=start_date,
-                        end_date=end_date,
-                        donot_pickle=True,
-                    ),
                     executor=executor,
                 )
-                run_job(job)
+                job_runner = BackfillJobRunner(
+                    job=job,
+                    dag=dag,
+                    start_date=start_date,
+                    end_date=end_date,
+                    donot_pickle=True,
+                )
+                run_job(job=job, execute_callable=job_runner._execute)
 
         backfill_job_thread = threading.Thread(
             target=run_backfill, name="run_backfill", args=(dag_run_created_cond,)
@@ -1162,13 +1132,11 @@ class TestBackfillJob:
         dag_maker.create_dagrun(state=None)
 
         executor = MockExecutor()
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag, start_date=start_date, end_date=end_date, donot_pickle=True
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job, dag=dag, start_date=start_date, end_date=end_date, donot_pickle=True
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         # BackfillJobRunner will run since the existing DagRun does not count for the max
         # active limit since it's within the backfill date range.
@@ -1190,16 +1158,15 @@ class TestBackfillJob:
         # backfill job 3 times
         success_expected = 2
         executor = MockExecutor()
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=start_date,
-                end_date=end_date,
-                donot_pickle=True,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=start_date,
+            end_date=end_date,
+            donot_pickle=True,
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         success_dagruns = len(DagRun.find(dag_id=dag.dag_id, state=State.SUCCESS))
         running_dagruns = len(DagRun.find(dag_id=dag.dag_id, state=State.RUNNING))
@@ -1228,11 +1195,9 @@ class TestBackfillJob:
         sub_dag = dag.partial_subset(
             task_ids_or_regex="leave*", include_downstream=False, include_upstream=False
         )
-        job = Job(
-            job_runner=BackfillJobRunner(dag=sub_dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE),
-            executor=executor,
-        )
-        run_job(job)
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(job=job, dag=sub_dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         for ti in dr.get_task_instances():
             if ti.task_id == "leave1" or ti.task_id == "leave2":
@@ -1275,12 +1240,10 @@ class TestBackfillJob:
         session.commit()
         session.close()
 
-        job = Job(
-            job_runner=BackfillJobRunner(dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE),
-            executor=executor,
-        )
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(job=job, dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
         with pytest.raises(AirflowException, match="Some task instances failed"):
-            run_job(job)
+            run_job(job=job, execute_callable=job_runner._execute)
 
         dr.refresh_from_db()
 
@@ -1306,16 +1269,15 @@ class TestBackfillJob:
 
         start_date = timezone.utcnow()
         executor = MockExecutor()
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=subdag,
-                start_date=start_date,
-                end_date=start_date,
-                donot_pickle=True,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=subdag,
+            start_date=start_date,
+            end_date=start_date,
+            donot_pickle=True,
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         subdag_op_task.pre_execute(context={"execution_date": start_date})
         subdag_op_task.execute(context={"execution_date": start_date})
@@ -1351,18 +1313,17 @@ class TestBackfillJob:
         subdag = subdag_op_task.subdag
 
         executor = MockExecutor()
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE,
-                donot_pickle=True,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE,
+            donot_pickle=True,
         )
 
         with timeout(seconds=30):
-            run_job(job)
+            run_job(job=job, execute_callable=job_runner._execute)
 
         ti_subdag = TI(task=dag.get_task("daily_job"), execution_date=DEFAULT_DATE)
         ti_subdag.refresh_from_db()
@@ -1405,14 +1366,13 @@ class TestBackfillJob:
 
         session = settings.Session()
         executor = MockExecutor()
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=subdag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE,
-                donot_pickle=True,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=subdag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE,
+            donot_pickle=True,
         )
         dr = DagRun(
             dag_id=subdag.dag_id, execution_date=DEFAULT_DATE, run_id="test", run_type=DagRunType.BACKFILL_JOB
@@ -1428,7 +1388,7 @@ class TestBackfillJob:
         session.commit()
 
         with timeout(seconds=30):
-            run_job(job)
+            run_job(job=job, execute_callable=job_runner._execute)
 
         for task in subdag.tasks:
             instance = (
@@ -1452,8 +1412,8 @@ class TestBackfillJob:
         with dag_maker(dag_id="test_manage_executor_state", start_date=DEFAULT_DATE, session=session) as dag:
             task1 = EmptyOperator(task_id="dummy", owner="airflow")
         dr = dag_maker.create_dagrun(state=None)
-        job = Job(job_runner=BackfillJobRunner(dag=dag))
-
+        job = Job()
+        job_runner = BackfillJobRunner(job=job, dag=dag)
         ti = TI(task1, dr.execution_date)
         ti.refresh_from_db()
 
@@ -1470,7 +1430,7 @@ class TestBackfillJob:
         ti_status.running[ti.key] = ti  # Task is queued and marked as running
         ti._try_number += 1  # Try number is increased during ti.run()
         ti.set_state(State.SUCCESS, session)  # Task finishes with success state
-        job.job_runner._update_counters(ti_status=ti_status, session=session)  # Update counters
+        job_runner._update_counters(ti_status=ti_status, session=session)  # Update counters
         assert len(ti_status.running) == 0
         assert len(ti_status.succeeded) == 1
         assert len(ti_status.skipped) == 0
@@ -1483,7 +1443,7 @@ class TestBackfillJob:
         ti_status.running[ti.key] = ti
         ti._try_number += 1
         ti.set_state(State.SKIPPED, session)
-        job.job_runner._update_counters(ti_status=ti_status, session=session)
+        job_runner._update_counters(ti_status=ti_status, session=session)
         assert len(ti_status.running) == 0
         assert len(ti_status.succeeded) == 0
         assert len(ti_status.skipped) == 1
@@ -1496,7 +1456,7 @@ class TestBackfillJob:
         ti_status.running[ti.key] = ti
         ti._try_number += 1
         ti.set_state(State.FAILED, session)
-        job.job_runner._update_counters(ti_status=ti_status, session=session)
+        job_runner._update_counters(ti_status=ti_status, session=session)
         assert len(ti_status.running) == 0
         assert len(ti_status.succeeded) == 0
         assert len(ti_status.skipped) == 0
@@ -1509,7 +1469,7 @@ class TestBackfillJob:
         ti_status.running[ti.key] = ti
         ti._try_number += 1
         ti.set_state(State.UP_FOR_RETRY, session)
-        job.job_runner._update_counters(ti_status=ti_status, session=session)
+        job_runner._update_counters(ti_status=ti_status, session=session)
         assert len(ti_status.running) == 0
         assert len(ti_status.succeeded) == 0
         assert len(ti_status.skipped) == 0
@@ -1530,7 +1490,7 @@ class TestBackfillJob:
         ti._try_number += 1  # Try number is increased during ti.run()
         ti._try_number -= 1  # Task is being rescheduled, decrement try_number
         ti.set_state(State.UP_FOR_RESCHEDULE, session)  # Task finishes with reschedule state
-        job.job_runner._update_counters(ti_status=ti_status, session=session)
+        job_runner._update_counters(ti_status=ti_status, session=session)
         assert len(ti_status.running) == 0
         assert len(ti_status.succeeded) == 0
         assert len(ti_status.skipped) == 0
@@ -1548,7 +1508,7 @@ class TestBackfillJob:
         session.merge(ti)
         session.commit()
         ti_status.running[ti.key] = ti
-        job.job_runner._update_counters(ti_status=ti_status, session=session)
+        job_runner._update_counters(ti_status=ti_status, session=session)
         assert len(ti_status.running) == 0
         assert len(ti_status.succeeded) == 0
         assert len(ti_status.skipped) == 0
@@ -1562,7 +1522,7 @@ class TestBackfillJob:
         # Deferred tasks are put into scheduled by the triggerer
         # Check that they are put into to_run
         ti_status.running[ti.key] = ti
-        job.job_runner._update_counters(ti_status=ti_status, session=session)
+        job_runner._update_counters(ti_status=ti_status, session=session)
         assert len(ti_status.running) == 0
         assert len(ti_status.succeeded) == 0
         assert len(ti_status.skipped) == 0
@@ -1575,7 +1535,7 @@ class TestBackfillJob:
         # to reschedule it, we should leave it in ti_status.running
         ti.set_state(State.DEFERRED)
         ti_status.running[ti.key] = ti
-        job.job_runner._update_counters(ti_status=ti_status, session=session)
+        job_runner._update_counters(ti_status=ti_status, session=session)
         assert len(ti_status.running) == 1
         assert len(ti_status.succeeded) == 0
         assert len(ti_status.skipped) == 0
@@ -1618,16 +1578,15 @@ class TestBackfillJob:
 
         executor = MockExecutor(parallelism=16)
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=1),
-                run_backwards=True,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=1),
+            run_backwards=True,
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         session = settings.Session()
         tis = (
@@ -1659,8 +1618,8 @@ class TestBackfillJob:
                 tasks.append(task)
 
         session = settings.Session()
-        job = Job(job_runner=BackfillJobRunner(dag=dag))
-
+        job = Job()
+        job_runner = BackfillJobRunner(job=job, dag=dag)
         # create dagruns
         dr1 = dag_maker.create_dagrun(state=State.RUNNING)
         dr2 = dag.create_dagrun(run_id="test2", state=State.SUCCESS)
@@ -1681,7 +1640,7 @@ class TestBackfillJob:
             session.merge(ti2)
             session.commit()
 
-        assert 2 == job.job_runner.reset_state_for_orphaned_tasks()
+        assert 2 == job_runner.reset_state_for_orphaned_tasks()
 
         for ti in dr1_tis + dr2_tis:
             ti.refresh_from_db()
@@ -1701,7 +1660,7 @@ class TestBackfillJob:
             ti.state = state
         session.commit()
 
-        job.job_runner.reset_state_for_orphaned_tasks(filter_by_dag_run=dr1, session=session)
+        job_runner.reset_state_for_orphaned_tasks(filter_by_dag_run=dr1, session=session)
 
         # check same for dag_run version
         for state, ti in zip(states, dr2_tis):
@@ -1719,7 +1678,8 @@ class TestBackfillJob:
         ) as dag:
             EmptyOperator(task_id=task_id, dag=dag)
 
-        job = Job(job_runner=BackfillJobRunner(dag=dag))
+        job = Job()
+        job_runner = BackfillJobRunner(job=job, dag=dag)
         # make two dagruns, only reset for one
         dr1 = dag_maker.create_dagrun(state=State.SUCCESS)
         dr2 = dag.create_dagrun(run_id="test2", state=State.RUNNING, session=session)
@@ -1734,7 +1694,7 @@ class TestBackfillJob:
         session.merge(dr2)
         session.flush()
 
-        num_reset_tis = job.job_runner.reset_state_for_orphaned_tasks(filter_by_dag_run=dr2, session=session)
+        num_reset_tis = job_runner.reset_state_for_orphaned_tasks(filter_by_dag_run=dr2, session=session)
         assert 1 == num_reset_tis
         ti1.refresh_from_db(session=session)
         ti2.refresh_from_db(session=session)
@@ -1746,11 +1706,11 @@ class TestBackfillJob:
         with dag_maker(dag_id=dag_id, start_date=DEFAULT_DATE, schedule="@daily") as dag:
             EmptyOperator(task_id="dummy_task", dag=dag)
 
-        job = Job(
-            job_runner=BackfillJobRunner(dag=dag, start_date=timezone.utcnow() - datetime.timedelta(days=1)),
-            executor=MockExecutor(),
+        job = Job(executor=MockExecutor())
+        job_runner = BackfillJobRunner(
+            job=job, dag=dag, start_date=timezone.utcnow() - datetime.timedelta(days=1)
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
         dr: DagRun = dag.get_last_dagrun()
         assert dr.creating_job_id == job.id
 
@@ -1761,16 +1721,15 @@ class TestBackfillJob:
 
         executor = MockExecutor(parallelism=16)
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=1),
-                run_backwards=True,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=1),
+            run_backwards=True,
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
         assert isinstance(executor.job_id, int)
 
     @pytest.mark.long_running
@@ -1792,16 +1751,15 @@ class TestBackfillJob:
 
         when = timezone.datetime(2022, 1, 1)
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=when,
-                end_date=when,
-                donot_pickle=True,
-                executor=ExecutorLoader.load_executor(executor_name),
-            )
+        job = Job(executor=ExecutorLoader.load_executor(executor_name))
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=when,
+            end_date=when,
+            donot_pickle=True,
         )
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         dr = DagRun.find(dag_id=dag.dag_id, execution_date=when, session=session)[0]
         assert dr
@@ -1852,14 +1810,13 @@ class TestBackfillJob:
         ti_status.active_runs.append(dr)
         ti_status.to_run = {ti.key: ti for ti in dr.task_instances}
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=dr.execution_date,
-                end_date=dr.execution_date,
-                donot_pickle=True,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=dr.execution_date,
+            end_date=dr.execution_date,
+            donot_pickle=True,
         )
 
         executor_change_state = executor.change_state
@@ -1880,7 +1837,7 @@ class TestBackfillJob:
             executor_change_state(key, state, info)
 
         with patch.object(executor, "change_state", side_effect=on_change_state):
-            job.job_runner._process_backfill_task_instances(
+            job_runner._process_backfill_task_instances(
                 ti_status=ti_status,
                 executor=job.executor,
                 start_date=dr.execution_date,
@@ -1925,13 +1882,9 @@ class TestBackfillJob:
 
         executor = MockExecutor()
         when = timezone.datetime(2022, 1, 1)
-        run_job(
-            Job(
-                job_runner=BackfillJobRunner(dag=dag, start_date=when, end_date=when, donot_pickle=True),
-                executor=executor,
-            )
-        )
-
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(job=job, dag=dag, start_date=when, end_date=when, donot_pickle=True)
+        run_job(job=job, execute_callable=job_runner._execute)
         (dr,) = DagRun.find(dag_id=dag.dag_id, execution_date=when, session=session)
         assert dr.state == DagRunState.FAILED
 
@@ -1952,17 +1905,15 @@ class TestBackfillJob:
         session.merge(dr)
         session.flush()
         dag.clear()
-        run_job(
-            Job(
-                job_runner=BackfillJobRunner(
-                    dag=dag,
-                    start_date=DEFAULT_DATE,
-                    end_date=DEFAULT_DATE,
-                    donot_pickle=True,
-                ),
-                executor=MockExecutor(),
-            )
+        job = Job(executor=MockExecutor())
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE,
+            donot_pickle=True,
         )
+        run_job(job=job, execute_callable=job_runner._execute)
 
         (dr,) = DagRun.find(dag_id=dag.dag_id, execution_date=DEFAULT_DATE, session=session)
         assert dr.start_date
@@ -1984,17 +1935,16 @@ class TestBackfillJob:
 
         dag.clear()
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE + datetime.timedelta(days=1),
-                end_date=DEFAULT_DATE + datetime.timedelta(days=4),
-                donot_pickle=True,
-            ),
-            executor=MockExecutor(),
+        job = Job(executor=MockExecutor())
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE + datetime.timedelta(days=1),
+            end_date=DEFAULT_DATE + datetime.timedelta(days=4),
+            donot_pickle=True,
         )
         for dr in DagRun.find(dag_id=dag.dag_id, session=session):
-            tasks_to_run = job.job_runner._task_instances_for_dag_run(dag, dr, session=session)
+            tasks_to_run = job_runner._task_instances_for_dag_run(dag, dr, session=session)
             states = [ti.state for _, ti in tasks_to_run.items()]
             assert TaskInstanceState.SCHEDULED in states
             assert State.NONE in states
@@ -2026,17 +1976,16 @@ class TestBackfillJob:
             TaskInstanceKey(dag.dag_id, task1.task_id, dag_run.run_id, try_number=2)
         ] = TaskInstanceState.FAILED
 
-        job = Job(
-            job_runner=BackfillJobRunner(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE,
-                disable_retry=disable_retry,
-            ),
-            executor=executor,
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE,
+            disable_retry=disable_retry,
         )
         with pytest.raises(exception):
-            run_job(job)
+            run_job(job=job, execute_callable=job_runner._execute)
         ti = dag_run.get_task_instance(task_id=task1.task_id)
 
         assert ti._try_number == try_number

--- a/tests/jobs/test_base_job.py
+++ b/tests/jobs/test_base_job.py
@@ -37,8 +37,9 @@ from tests.utils.test_helpers import MockJobRunner
 
 class TestJob:
     def test_state_success(self):
-        job = Job(job_runner=MockJobRunner())
-        run_job(job)
+        job = Job()
+        job_runner = MockJobRunner(job=job)
+        run_job(job=job, execute_callable=job_runner._execute)
 
         assert job.state == State.SUCCESS
         assert job.end_date is not None
@@ -46,8 +47,9 @@ class TestJob:
     def test_state_sysexit(self):
         import sys
 
-        job = Job(job_runner=MockJobRunner(lambda: sys.exit(0)))
-        run_job(job)
+        job = Job()
+        job_runner = MockJobRunner(job=job, func=lambda: sys.exit(0))
+        run_job(job=job, execute_callable=job_runner._execute)
 
         assert job.state == State.SUCCESS
         assert job.end_date is not None
@@ -56,8 +58,9 @@ class TestJob:
 
         import sys
 
-        job = Job(job_runner=MockJobRunner(lambda: sys.exit(0)))
-        run_job(job)
+        job = Job()
+        job_runner = MockJobRunner(job=job, func=lambda: sys.exit(0))
+        run_job(job=job, execute_callable=job_runner._execute)
 
         assert job.state == State.SUCCESS
         assert job.end_date is not None
@@ -68,8 +71,9 @@ class TestJob:
         """
         get_listener_manager().add_listener(lifecycle_listener)
 
-        job = Job(job_runner=MockJobRunner(lambda: sys.exit(0)))
-        run_job(job)
+        job = Job()
+        job_runner = MockJobRunner(job=job, func=lambda: sys.exit(0))
+        run_job(job=job, execute_callable=job_runner._execute)
 
         assert lifecycle_listener.started_component is job
         assert lifecycle_listener.stopped_component is job
@@ -78,18 +82,21 @@ class TestJob:
         def abort():
             raise RuntimeError("fail")
 
-        job = Job(job_runner=MockJobRunner(abort))
+        job = Job()
+        job_runner = MockJobRunner(job=job, func=abort)
         with raises(RuntimeError):
-            run_job(job)
+            run_job(job=job, execute_callable=job_runner._execute)
 
         assert job.state == State.FAILED
         assert job.end_date is not None
 
     def test_most_recent_job(self):
         with create_session() as session:
-            old_job = Job(job_runner=MockJobRunner(), heartrate=10)
+            old_job = Job(heartrate=10)
+            MockJobRunner(job=old_job)
             old_job.latest_heartbeat = old_job.latest_heartbeat - datetime.timedelta(seconds=20)
-            job = Job(job_runner=MockJobRunner(), heartrate=10)
+            job = Job(heartrate=10)
+            MockJobRunner(job=job)
             session.add(job)
             session.add(old_job)
             session.flush()
@@ -101,13 +108,16 @@ class TestJob:
 
     def test_most_recent_job_running_precedence(self):
         with create_session() as session:
-            old_running_state_job = Job(job_runner=MockJobRunner(), heartrate=10)
+            old_running_state_job = Job(heartrate=10)
+            MockJobRunner(job=old_running_state_job)
             old_running_state_job.latest_heartbeat = timezone.utcnow()
             old_running_state_job.state = State.RUNNING
-            new_failed_state_job = Job(job_runner=MockJobRunner(), heartrate=10)
+            new_failed_state_job = Job(heartrate=10)
+            MockJobRunner(job=new_failed_state_job)
             new_failed_state_job.latest_heartbeat = timezone.utcnow()
             new_failed_state_job.state = State.FAILED
-            new_null_state_job = Job(job_runner=MockJobRunner(), heartrate=10)
+            new_null_state_job = Job(heartrate=10)
+            MockJobRunner(job=new_null_state_job)
             new_null_state_job.latest_heartbeat = timezone.utcnow()
             new_null_state_job.state = None
             session.add(old_running_state_job)
@@ -120,7 +130,7 @@ class TestJob:
             session.rollback()
 
     def test_is_alive(self):
-        job = Job(job_runner=MockJobRunner(), heartrate=10, state=State.RUNNING)
+        job = Job(heartrate=10, state=State.RUNNING)
         assert job.is_alive() is True
 
         job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=20)
@@ -145,12 +155,12 @@ class TestJob:
             mock_session = Mock(spec_set=session, name="MockSession")
             mock_create_session.return_value.__enter__.return_value = mock_session
 
-            job = Job(job_runner=MockJobRunner(), heartrate=10, state=State.RUNNING)
+            job = Job(heartrate=10, state=State.RUNNING)
             job.latest_heartbeat = when
 
             mock_session.commit.side_effect = OperationalError("Force fail", {}, None)
 
-            job.heartbeat()
+            job.heartbeat(heartbeat_callback=lambda: None)
 
             assert job.latest_heartbeat == when, "attribute not updated when heartbeat fails"
 
@@ -169,7 +179,8 @@ class TestJob:
         mock_getuser.return_value = "testuser"
         mock_default_executor.return_value = mock_sequential_executor
 
-        test_job = Job(job_runner=MockJobRunner(), heartrate=10, dag_id="example_dag", state=State.RUNNING)
+        test_job = Job(heartrate=10, dag_id="example_dag", state=State.RUNNING)
+        MockJobRunner(job=test_job)
         assert test_job.executor_class == "SequentialExecutor"
         assert test_job.heartrate == 10
         assert test_job.dag_id == "example_dag"
@@ -182,18 +193,16 @@ class TestJob:
     def test_heartbeat(self, frozen_sleep, monkeypatch):
         monkeypatch.setattr("airflow.jobs.job.sleep", frozen_sleep)
         with create_session() as session:
-            job = Job(job_runner=MockJobRunner(), heartrate=10)
+            job = Job(heartrate=10)
             job.latest_heartbeat = timezone.utcnow()
             session.add(job)
             session.commit()
 
             hb_callback = Mock()
-            job.job_runner.heartbeat_callback = hb_callback
+            job.heartbeat(heartbeat_callback=hb_callback)
 
-            job.heartbeat()
-
-            hb_callback.assert_called_once_with(session=ANY)
+            hb_callback.assert_called_once_with(ANY)
 
             hb_callback.reset_mock()
-            perform_heartbeat(job=job, only_if_necessary=True)
+            perform_heartbeat(job=job, heartbeat_callback=hb_callback, only_if_necessary=True)
             assert hb_callback.called is False

--- a/tests/listeners/test_listeners.py
+++ b/tests/listeners/test_listeners.py
@@ -80,9 +80,10 @@ def test_multiple_listeners(create_task_instance, session=None):
     lm.add_listener(full_listener)
     lm.add_listener(lifecycle_listener)
 
-    job = Job(job_runner=MockJobRunner())
+    job = Job()
+    job_runner = MockJobRunner(job=job)
     try:
-        run_job(job)
+        run_job(job=job, execute_callable=job_runner._execute)
     except NotImplementedError:
         pass  # just for lifecycle
 

--- a/tests/models/test_trigger.py
+++ b/tests/models/test_trigger.py
@@ -140,14 +140,17 @@ def test_assign_unassigned(session, create_task_instance):
     """
     Tests that unassigned triggers of all appropriate states are assigned.
     """
-    finished_triggerer = Job(job_runner=TriggererJobRunner(None), heartrate=10, state=State.SUCCESS)
+    finished_triggerer = Job(heartrate=10, state=State.SUCCESS)
+    TriggererJobRunner(finished_triggerer)
     finished_triggerer.end_date = timezone.utcnow() - datetime.timedelta(hours=1)
     session.add(finished_triggerer)
     assert not finished_triggerer.is_alive()
-    healthy_triggerer = Job(job_runner=TriggererJobRunner(None), heartrate=10, state=State.RUNNING)
+    healthy_triggerer = Job(heartrate=10, state=State.RUNNING)
+    TriggererJobRunner(healthy_triggerer)
     session.add(healthy_triggerer)
     assert healthy_triggerer.is_alive()
-    new_triggerer = Job(job_runner=TriggererJobRunner(None), heartrate=10, state=State.RUNNING)
+    new_triggerer = Job(heartrate=10, state=State.RUNNING)
+    TriggererJobRunner(new_triggerer)
     session.add(new_triggerer)
     assert new_triggerer.is_alive()
     session.commit()

--- a/tests/serialization/test_pydantic_models.py
+++ b/tests/serialization/test_pydantic_models.py
@@ -76,7 +76,8 @@ def test_serializing_pydantic_dagrun(session, create_task_instance):
 def test_serializing_pydantic_local_task_job(session, create_task_instance):
     dag_id = "test-dag"
     ti = create_task_instance(dag_id=dag_id, session=session)
-    ltj = Job(job_runner=LocalTaskJobRunner(task_instance=ti), dag_id=ti.dag_id)
+    ltj = Job(dag_id=ti.dag_id)
+    LocalTaskJobRunner(job=ltj, task_instance=ti)
     ltj.state = State.RUNNING
     session.commit()
     pydantic_job = JobPydantic.from_orm(ltj)

--- a/tests/task/task_runner/test_base_task_runner.py
+++ b/tests/task/task_runner/test_base_task_runner.py
@@ -39,9 +39,9 @@ def test_config_copy_mode(tmp_configuration_copy, subprocess_call, dag_maker, im
     dr = dag_maker.create_dagrun()
 
     ti = dr.task_instances[0]
-    task_runner = LocalTaskJobRunner(ti)
-    job = Job(job_runner=task_runner, dag_id=ti.dag_id)
-    runner = BaseTaskRunner(job)
+    job = Job(dag_id=ti.dag_id)
+    job_runner = LocalTaskJobRunner(job=job, task_instance=ti)
+    runner = BaseTaskRunner(job_runner)
     # So we don't try to delete it -- cos the file won't exist
     del runner._cfg_path
 

--- a/tests/task/task_runner/test_cgroup_task_runner.py
+++ b/tests/task/task_runner/test_cgroup_task_runner.py
@@ -32,12 +32,13 @@ class TestCgroupTaskRunner:
         and when task finishes, CgroupTaskRunner.on_finish() calls
         super().on_finish() to delete the temp cfg file.
         """
-        base_job = mock.Mock()
-        base_job.task_instance = mock.MagicMock()
-        base_job.task_instance.run_as_user = None
-        base_job.task_instance.command_as_list.return_value = ["sleep", "1000"]
+        Job = mock.Mock()
+        Job.job_type = None
+        Job.task_instance = mock.MagicMock()
+        Job.task_instance.run_as_user = None
+        Job.task_instance.command_as_list.return_value = ["sleep", "1000"]
 
-        runner = CgroupTaskRunner(base_job)
+        runner = CgroupTaskRunner(Job)
         assert mock_super_init.called
 
         runner.on_finish()

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -94,10 +94,11 @@ class TestStandardTaskRunner:
     @patch("airflow.utils.log.file_task_handler.FileTaskHandler._init_file")
     def test_start_and_terminate(self, mock_init):
         mock_init.return_value = "/tmp/any"
-        base_job = mock.Mock()
-        base_job.task_instance = mock.MagicMock()
-        base_job.task_instance.run_as_user = None
-        base_job.task_instance.command_as_list.return_value = [
+        Job = mock.Mock()
+        Job.job_type = None
+        Job.task_instance = mock.MagicMock()
+        Job.task_instance.run_as_user = None
+        Job.task_instance.command_as_list.return_value = [
             "airflow",
             "tasks",
             "run",
@@ -105,27 +106,26 @@ class TestStandardTaskRunner:
             "task1",
             "2016-01-01",
         ]
-        base_job.job_runner = LocalTaskJobRunner(base_job.task_instance)
-
-        runner = StandardTaskRunner(base_job)
-        runner.start()
+        job_runner = LocalTaskJobRunner(job=Job, task_instance=Job.task_instance)
+        task_runner = StandardTaskRunner(job_runner)
+        task_runner.start()
         # Wait until process sets its pgid to be equal to pid
         with timeout(seconds=1):
             while True:
-                runner_pgid = os.getpgid(runner.process.pid)
-                if runner_pgid == runner.process.pid:
+                runner_pgid = os.getpgid(task_runner.process.pid)
+                if runner_pgid == task_runner.process.pid:
                     break
                 time.sleep(0.01)
 
         assert runner_pgid > 0
         assert runner_pgid != os.getpgid(0), "Task should be in a different process group to us"
         processes = list(self._procs_in_pgroup(runner_pgid))
-        runner.terminate()
+        task_runner.terminate()
 
         for process in processes:
             assert not psutil.pid_exists(process.pid), f"{process} is still alive"
 
-        assert runner.return_code() is not None
+        assert task_runner.return_code() is not None
 
     def test_notifies_about_start_and_stop(self):
         path_listener_writer = "/tmp/test_notifies_about_start_and_stop"
@@ -150,20 +150,21 @@ class TestStandardTaskRunner:
             start_date=DEFAULT_DATE,
         )
         ti = TaskInstance(task=task, run_id="test")
-        job1 = Job(job_runner=LocalTaskJobRunner(task_instance=ti, ignore_ti_state=True), dag_id=ti.dag_id)
-        runner = StandardTaskRunner(job1)
-        runner.start()
+        job = Job(dag_id=ti.dag_id)
+        job_runner = LocalTaskJobRunner(job=job, task_instance=ti, ignore_ti_state=True)
+        task_runner = StandardTaskRunner(job_runner)
+        task_runner.start()
 
         # Wait until process makes itself the leader of its own process group
         with timeout(seconds=1):
             while True:
-                runner_pgid = os.getpgid(runner.process.pid)
-                if runner_pgid == runner.process.pid:
+                runner_pgid = os.getpgid(task_runner.process.pid)
+                if runner_pgid == task_runner.process.pid:
                     break
                 time.sleep(0.01)
 
             # Wait till process finishes
-        assert runner.return_code(timeout=10) is not None
+        assert task_runner.return_code(timeout=10) is not None
         with open(path_listener_writer) as f:
             assert f.readline() == "on_starting\n"
             assert f.readline() == "on_task_instance_running\n"
@@ -193,20 +194,21 @@ class TestStandardTaskRunner:
             start_date=DEFAULT_DATE,
         )
         ti = TaskInstance(task=task, run_id="test")
-        job1 = Job(job_runner=LocalTaskJobRunner(task_instance=ti, ignore_ti_state=True), dag_id=ti.dag_id)
-        runner = StandardTaskRunner(job1)
-        runner.start()
+        job = Job(dag_id=ti.dag_id)
+        job_runner = LocalTaskJobRunner(job=job, task_instance=ti, ignore_ti_state=True)
+        task_runner = StandardTaskRunner(job_runner)
+        task_runner.start()
 
         # Wait until process makes itself the leader of its own process group
         with timeout(seconds=1):
             while True:
-                runner_pgid = os.getpgid(runner.process.pid)
-                if runner_pgid == runner.process.pid:
+                runner_pgid = os.getpgid(task_runner.process.pid)
+                if runner_pgid == task_runner.process.pid:
                     break
                 time.sleep(0.01)
 
             # Wait till process finishes
-        assert runner.return_code(timeout=10) is not None
+        assert task_runner.return_code(timeout=10) is not None
         with open(path_listener_writer) as f:
             assert f.readline() == "on_starting\n"
             assert f.readline() == "on_task_instance_running\n"
@@ -216,12 +218,13 @@ class TestStandardTaskRunner:
     @patch("airflow.utils.log.file_task_handler.FileTaskHandler._init_file")
     def test_start_and_terminate_run_as_user(self, mock_init):
         mock_init.return_value = "/tmp/any"
-        base_job = mock.Mock()
-        base_job.task_instance = mock.MagicMock()
-        base_job.task_instance.task_id = "task_id"
-        base_job.task_instance.dag_id = "dag_id"
-        base_job.task_instance.run_as_user = getuser()
-        base_job.task_instance.command_as_list.return_value = [
+        Job = mock.Mock()
+        Job.job_type = None
+        Job.task_instance = mock.MagicMock()
+        Job.task_instance.task_id = "task_id"
+        Job.task_instance.dag_id = "dag_id"
+        Job.task_instance.run_as_user = getuser()
+        Job.task_instance.command_as_list.return_value = [
             "airflow",
             "tasks",
             "test",
@@ -229,24 +232,25 @@ class TestStandardTaskRunner:
             "task1",
             "2016-01-01",
         ]
-        base_job.job_runner = LocalTaskJobRunner(base_job.task_instance)
-        runner = StandardTaskRunner(base_job)
+        job_runner = LocalTaskJobRunner(job=Job, task_instance=Job.task_instance)
+        task_runner = StandardTaskRunner(job_runner)
 
-        runner.start()
-        time.sleep(0.5)
+        task_runner.start()
+        try:
+            time.sleep(0.5)
 
-        pgid = os.getpgid(runner.process.pid)
-        assert pgid > 0
-        assert pgid != os.getpgid(0), "Task should be in a different process group to us"
+            pgid = os.getpgid(task_runner.process.pid)
+            assert pgid > 0
+            assert pgid != os.getpgid(0), "Task should be in a different process group to us"
 
-        processes = list(self._procs_in_pgroup(pgid))
-
-        runner.terminate()
+            processes = list(self._procs_in_pgroup(pgid))
+        finally:
+            task_runner.terminate()
 
         for process in processes:
             assert not psutil.pid_exists(process.pid), f"{process} is still alive"
 
-        assert runner.return_code() is not None
+        assert task_runner.return_code() is not None
 
     @propagate_task_logger()
     @patch("airflow.utils.log.file_task_handler.FileTaskHandler._init_file")
@@ -257,12 +261,13 @@ class TestStandardTaskRunner:
         -9 and a log message.
         """
         mock_init.return_value = "/tmp/any"
-        base_job = mock.Mock()
-        base_job.task_instance = mock.MagicMock()
-        base_job.task_instance.task_id = "task_id"
-        base_job.task_instance.dag_id = "dag_id"
-        base_job.task_instance.run_as_user = getuser()
-        base_job.task_instance.command_as_list.return_value = [
+        Job = mock.Mock()
+        Job.job_type = None
+        Job.task_instance = mock.MagicMock()
+        Job.task_instance.task_id = "task_id"
+        Job.task_instance.dag_id = "dag_id"
+        Job.task_instance.run_as_user = getuser()
+        Job.task_instance.command_as_list.return_value = [
             "airflow",
             "tasks",
             "test",
@@ -270,24 +275,24 @@ class TestStandardTaskRunner:
             "task1",
             "2016-01-01",
         ]
-        base_job.job_runner = LocalTaskJobRunner(base_job.task_instance)
+        job_runner = LocalTaskJobRunner(job=Job, task_instance=Job.task_instance)
 
         # Kick off the runner
-        runner = StandardTaskRunner(base_job)
-        runner.start()
+        task_runner = StandardTaskRunner(job_runner)
+        task_runner.start()
         time.sleep(0.2)
 
         # Kill the child process externally from the runner
         # Note that we have to do this from ANOTHER process, as if we just
         # call os.kill here we're doing it from the parent process and it
         # won't be the same as an external kill in terms of OS tracking.
-        pgid = os.getpgid(runner.process.pid)
+        pgid = os.getpgid(task_runner.process.pid)
         os.system(f"kill -s KILL {pgid}")
         time.sleep(0.2)
 
-        runner.terminate()
+        task_runner.terminate()
 
-        assert runner.return_code() == -9
+        assert task_runner.return_code() == -9
         assert "running out of memory" in caplog.text
 
     def test_on_kill(self):
@@ -319,14 +324,15 @@ class TestStandardTaskRunner:
             start_date=DEFAULT_DATE,
         )
         ti = TaskInstance(task=task, run_id="test")
-        job1 = Job(job_runner=LocalTaskJobRunner(task_instance=ti, ignore_ti_state=True), dag_id=ti.dag_id)
-        runner = StandardTaskRunner(job1)
-        runner.start()
+        job = Job(dag_id=ti.dag_id)
+        job_runner = LocalTaskJobRunner(job=job, task_instance=ti, ignore_ti_state=True)
+        task_runner = StandardTaskRunner(job_runner)
+        task_runner.start()
 
         with timeout(seconds=3):
             while True:
-                runner_pgid = os.getpgid(runner.process.pid)
-                if runner_pgid == runner.process.pid:
+                runner_pgid = os.getpgid(task_runner.process.pid)
+                if runner_pgid == task_runner.process.pid:
                     break
                 time.sleep(0.01)
 
@@ -341,7 +347,7 @@ class TestStandardTaskRunner:
         logging.info("Task started. Give the task some time to settle")
         time.sleep(3)
         logging.info("Terminating processes %s belonging to %s group", processes, runner_pgid)
-        runner.terminate()
+        task_runner.terminate()
 
         logging.info("Waiting for the on kill killed file to appear")
         with timeout(seconds=4):
@@ -377,26 +383,27 @@ class TestStandardTaskRunner:
             start_date=DEFAULT_DATE,
         )
         ti = TaskInstance(task=task, run_id="test")
-        job1 = Job(job_runner=LocalTaskJobRunner(task_instance=ti, ignore_ti_state=True), dag_id=ti.dag_id)
-        runner = StandardTaskRunner(job1)
-        runner.start()
+        job = Job(dag_id=ti.dag_id)
+        job_runner = LocalTaskJobRunner(job=job, task_instance=ti, ignore_ti_state=True)
+        task_runner = StandardTaskRunner(job_runner)
+        task_runner.start()
 
         # Wait until process sets its pgid to be equal to pid
         with timeout(seconds=1):
             while True:
-                runner_pgid = os.getpgid(runner.process.pid)
-                if runner_pgid == runner.process.pid:
+                runner_pgid = os.getpgid(task_runner.process.pid)
+                if runner_pgid == task_runner.process.pid:
                     break
                 time.sleep(0.01)
 
         assert runner_pgid > 0
         assert runner_pgid != os.getpgid(0), "Task should be in a different process group to us"
         processes = list(self._procs_in_pgroup(runner_pgid))
-        psutil.wait_procs([runner.process])
+        psutil.wait_procs([task_runner.process])
 
         for process in processes:
             assert not psutil.pid_exists(process.pid), f"{process} is still alive"
-        assert runner.return_code() == 0
+        assert task_runner.return_code() == 0
         text = context_file.read_text()
         assert (
             text == "_AIRFLOW_PARSING_CONTEXT_DAG_ID=test_parsing_context\n"

--- a/tests/task/task_runner/test_task_runner.py
+++ b/tests/task/task_runner/test_task_runner.py
@@ -38,10 +38,10 @@ class TestGetTaskRunner:
         ti = mock.MagicMock(map_index=-1, run_as_user=None)
         ti.get_template_context.return_value = {"ti": ti}
         ti.get_dagrun.return_value.get_log_template.return_value.filename = "blah"
-        base_job = mock.MagicMock(task_instance=ti)
-        base_job.job_runner = LocalTaskJobRunner(ti)
-        base_job.job_runner.job = base_job
-        task_runner = get_task_runner(base_job.job_runner)
+        Job = mock.MagicMock(task_instance=ti)
+        Job.job_type = None
+        job_runner = LocalTaskJobRunner(job=Job, task_instance=ti)
+        task_runner = get_task_runner(job_runner)
 
         assert "StandardTaskRunner" == task_runner.__class__.__name__
 
@@ -50,13 +50,11 @@ class TestGetTaskRunner:
         "tests.task.task_runner.test_task_runner.custom_task_runner",
     )
     def test_should_support_custom_legacy_task_runner(self):
-        base_job = mock.MagicMock(
-            **{"task_instance.get_template_context.return_value": {"ti": mock.MagicMock()}}
-        )
+        mock.MagicMock(**{"task_instance.get_template_context.return_value": {"ti": mock.MagicMock()}})
         custom_task_runner.reset_mock()
 
-        task_runner = get_task_runner(base_job)
+        task_runner = get_task_runner(custom_task_runner)
 
-        custom_task_runner.assert_called_once_with(base_job.job)
+        custom_task_runner.assert_called_once_with(custom_task_runner)
 
         assert custom_task_runner.return_value == task_runner

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -24,6 +24,8 @@ import pytest
 
 from airflow import AirflowException
 from airflow.jobs.base_job_runner import BaseJobRunner
+from airflow.jobs.job import Job
+from airflow.serialization.pydantic.job import JobPydantic
 from airflow.utils import helpers, timezone
 from airflow.utils.helpers import (
     at_most_one,
@@ -329,9 +331,11 @@ class TestHelpers:
 class MockJobRunner(BaseJobRunner):
     job_type = "MockJob"
 
-    def __init__(self, func=None):
-        self.func = func
+    def __init__(self, job: Job | JobPydantic, func=None):
         super().__init__()
+        self.job = job
+        self.job.job_type = self.job_type
+        self.func = func
 
     def _execute(self):
         if self.func is not None:

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -403,7 +403,7 @@ class TestFileTaskLogHandler:
         assert isinstance(ti, TaskInstance)
         if is_a_trigger:
             ti.is_trigger_log_context = True
-            job = Job(job_runner=TriggererJobRunner())
+            job = Job()
             t = Trigger("", {})
             t.triggerer_job = job
             ti.triggerer = t
@@ -475,7 +475,7 @@ class TestLogUrl:
         )
         ti.hostname = "hostname"
         trigger = Trigger("", {})
-        job = Job(job_runner=TriggererJobRunner())
+        job = Job(TriggererJobRunner.job_type)
         job.id = 123
         trigger.triggerer_job = job
         ti.trigger = trigger

--- a/tests/www/views/test_views_base.py
+++ b/tests/www/views/test_views_base.py
@@ -63,11 +63,10 @@ def heartbeat_healthy():
     # case-1: healthy scheduler status
     last_heartbeat = timezone.utcnow()
     job = Job(
-        job_type="SchedulerJob",
         state="running",
         latest_heartbeat=last_heartbeat,
-        job_runner=SchedulerJobRunner(),
     )
+    SchedulerJobRunner(job=job),
     with create_session() as session:
         session.add(job)
     yield "healthy", last_heartbeat.isoformat()
@@ -84,11 +83,10 @@ def heartbeat_too_slow():
     # case-2: unhealthy scheduler status - scenario 1 (SchedulerJob is running too slowly)
     last_heartbeat = timezone.utcnow() - datetime.timedelta(minutes=1)
     job = Job(
-        job_type="SchedulerJob",
         state="running",
         latest_heartbeat=last_heartbeat,
-        job_runner=SchedulerJobRunner(),
     )
+    SchedulerJobRunner(job=job),
     with create_session() as session:
         session.query(Job).filter(
             Job.job_type == "SchedulerJob",


### PR DESCRIPTION
This is the final step of decoupling of the job runner from ORM
based BaseJob. After this change, finally we rich the state that
the BaseJob is just a state of the Job being run, but all
the logic is kept in separate "JobRunner" entity which just
keeps the reference to the job. Also it makes sure that
job in each runner is defined as appropriate for each job type:

* SchedulerJobRunner, BackfillJobRunner can only use BaseJob
* DagProcessorJobRunner, TriggererJobRunner and especially the
  LocalTaskJobRunner can keep both BaseJob and it's Pydantic
  BaseJobPydantic representation - for AIP-44 usage.

The highlights of this change:

* Job does not have job_runner reference any more
* Job is a mandatory parameter when creating each JobRunner
* run_job method takes as parameter the job (i.e. where the state
  of the job is called) and executor_callable - i.e. the method
  to run when the job gets executed
* heartbeat callback is also passed a generic callable in order
  to execute the post-heartbeat operation of each of the job
  type
* there is no more need to specify job_type when you create
  BaseJob, the job gets its type by a simply creating a runner
  with the job
* DagFileProcessorManager is now merged into DagProcessorJobRunner.
  The JobRuner was essentially calling the processormanager that
  created processors. In order to make it consistent with other
  Runners - all of it has been moved into runner, so that it
  starts doing "something" - similar as other runners - rather than
  creating processor manager and running it.

This is the final stage of refactoring that was split into
reviewable stages: https://github.com/apache/airflow/pull/30255 -> https://github.com/apache/airflow/pull/30302 -> https://github.com/apache/airflow/pull/30308 -> this PR.

Please check only the last commit.

Closes: https://github.com/apache/airflow/issues/30325

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
