### PR TITLE
Add serializer for pandas dataframe

### DIFF
--- a/airflow/serialization/serializers/pandas.py
+++ b/airflow/serialization/serializers/pandas.py
@@ -1,0 +1,65 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from airflow.utils.module_loading import qualname
+
+# lazy loading for performance reasons
+serializers = [
+    "pandas.core.frame.DataFrame",
+]
+deserializers = serializers
+
+if TYPE_CHECKING:
+    from airflow.serialization.serde import U
+    from pandas import DataFrame
+
+__version__ = 1
+
+
+def serialize(o: object) -> tuple[U, str, int, bool]:
+    import pyarrow as pa
+    from pyarrow import parquet as pq
+    from pandas import DataFrame
+
+    if not isinstance(o, DataFrame):
+        return "", "", 0, False
+
+    # for now, we *always* serialize into in memory
+    # until we have a generic backend that manages
+    # sinks
+    table = pa.Table.from_pandas(o)
+    buf = pa.BufferOutputStream()
+    pq.write_table(table, buf, compression="snappy")
+
+    return buf.getvalue().hex().decode("utf-8"), qualname(o), __version__, True
+
+
+def deserialize(classname: str, version: int, data: object) -> DataFrame:
+    if version > __version__:
+        raise TypeError(f"serialized {version} of {classname} > {__version__}")
+
+    import io
+    from pyarrow import parquet as pq
+
+    buf = io.BytesIO(bytes.fromhex(data))
+    df = pq.read_table(buf).to_pandas()
+
+    return df

--- a/airflow/serialization/serializers/pandas.py
+++ b/airflow/serialization/serializers/pandas.py
@@ -28,16 +28,18 @@ serializers = [
 deserializers = serializers
 
 if TYPE_CHECKING:
-    from airflow.serialization.serde import U
     from pandas import DataFrame
+
+    from airflow.serialization.serde import U
 
 __version__ = 1
 
 
 def serialize(o: object) -> tuple[U, str, int, bool]:
     import pyarrow as pa
-    from pyarrow import parquet as pq
+
     from pandas import DataFrame
+    from pyarrow import parquet as pq
 
     if not isinstance(o, DataFrame):
         return "", "", 0, False
@@ -57,8 +59,12 @@ def deserialize(classname: str, version: int, data: object) -> DataFrame:
         raise TypeError(f"serialized {version} of {classname} > {__version__}")
 
     import io
+
     from pyarrow import parquet as pq
 
+    if not isinstance(data, str):
+        raise TypeError(f"serialized {classname} has wrong data type {type(data)}")
+    
     buf = io.BytesIO(bytes.fromhex(data))
     df = pq.read_table(buf).to_pandas()
 

--- a/airflow/serialization/serializers/pandas.py
+++ b/airflow/serialization/serializers/pandas.py
@@ -37,7 +37,6 @@ __version__ = 1
 
 def serialize(o: object) -> tuple[U, str, int, bool]:
     import pyarrow as pa
-
     from pandas import DataFrame
     from pyarrow import parquet as pq
 
@@ -64,7 +63,7 @@ def deserialize(classname: str, version: int, data: object) -> DataFrame:
 
     if not isinstance(data, str):
         raise TypeError(f"serialized {classname} has wrong data type {type(data)}")
-    
+
     buf = io.BytesIO(bytes.fromhex(data))
     df = pq.read_table(buf).to_pandas()
 

--- a/setup.py
+++ b/setup.py
@@ -301,10 +301,7 @@ ldap = [
 ]
 leveldb = ["plyvel"]
 otel = ["opentelemetry-api==1.15.0", "opentelemetry-exporter-otlp", "opentelemetry-exporter-prometheus"]
-pandas = [
-    "pandas>=0.17.1",
-    "pyarrow>=9.0.0"
-]
+pandas = ["pandas>=0.17.1", "pyarrow>=9.0.0"]
 password = [
     "bcrypt>=2.0.0",
     "flask-bcrypt>=0.7.1",

--- a/setup.py
+++ b/setup.py
@@ -303,7 +303,7 @@ leveldb = ["plyvel"]
 otel = ["opentelemetry-api==1.15.0", "opentelemetry-exporter-otlp", "opentelemetry-exporter-prometheus"]
 pandas = [
     "pandas>=0.17.1",
-    "pyarrow>=10.0.0"
+    "pyarrow>=9.0.0"
 ]
 password = [
     "bcrypt>=2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -303,6 +303,7 @@ leveldb = ["plyvel"]
 otel = ["opentelemetry-api==1.15.0", "opentelemetry-exporter-otlp", "opentelemetry-exporter-prometheus"]
 pandas = [
     "pandas>=0.17.1",
+    "pyarrow>=11.0.0"
 ]
 password = [
     "bcrypt>=2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -303,7 +303,7 @@ leveldb = ["plyvel"]
 otel = ["opentelemetry-api==1.15.0", "opentelemetry-exporter-otlp", "opentelemetry-exporter-prometheus"]
 pandas = [
     "pandas>=0.17.1",
-    "pyarrow>=11.0.0"
+    "pyarrow>=10.0.0"
 ]
 password = [
     "bcrypt>=2.0.0",

--- a/tests/serialization/serializers/test_serializers.py
+++ b/tests/serialization/serializers/test_serializers.py
@@ -20,6 +20,7 @@ import datetime
 import decimal
 
 import numpy
+import pandas
 import pendulum.tz
 import pytest
 from pendulum import DateTime
@@ -91,3 +92,9 @@ class TestSerializers:
         e = serialize(i)
         d = deserialize(e)
         assert i["x"] == d["x"]
+
+    def test_pandas(self):
+        i = pandas.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})
+        e = serialize(i)
+        d = deserialize(e)
+        assert i.equals(d)


### PR DESCRIPTION
This adds an in-memory serializer for dataframes based on pyarrow. No checking of size limits is being done and it is up to the user to ensure the backend is configured to handle the potential size of a dataframe.

Using pyarrow is faster and less memory intensive than using pandas builtin functions.

@ashb @uranusjr @fletchjeff @kaxil 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
