### PR TITLE
Ensure teardown failure with on_failure_fail_dagrun=True fails the DagRun

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1219,7 +1219,7 @@ class DAG(LoggingMixin):
 
     @property
     def tasks_upstream_of_teardowns(self) -> list[Operator]:
-        upstream_tasks = [t.upstream_list if isinstance(t.upstream_list, list) else [t.upstream_list]) t.upstream_list for t in self.teardowns]
+        upstream_tasks = [t.upstream_list for t in self.teardowns]
         return [
             val for sublist in upstream_tasks for val in sublist if not getattr(val, "_is_teardown", None)
         ]

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1214,6 +1214,18 @@ class DAG(LoggingMixin):
         return list(self.task_dict.keys())
 
     @property
+    def teardowns(self):
+        return [task for task in self.tasks if getattr(task, "_is_teardown", None)]
+
+    @property
+    def tasks_upstream_of_teardowns(self):
+        upstream_tasks = [t.upstream_list for t in self.teardowns]
+        flatten_tasks = [
+            val for sublist in upstream_tasks for val in (sublist if isinstance(sublist, list) else [sublist])
+        ]
+        return [val for val in flatten_tasks if not getattr(val, "_is_teardown", None)]
+
+    @property
     def task_group(self) -> TaskGroup:
         return self._task_group
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1214,16 +1214,15 @@ class DAG(LoggingMixin):
         return list(self.task_dict.keys())
 
     @property
-    def teardowns(self):
+    def teardowns(self) -> list[Operator]:
         return [task for task in self.tasks if getattr(task, "_is_teardown", None)]
 
     @property
-    def tasks_upstream_of_teardowns(self):
-        upstream_tasks = [t.upstream_list for t in self.teardowns]
-        flatten_tasks = [
-            val for sublist in upstream_tasks for val in (sublist if isinstance(sublist, list) else [sublist])
+    def tasks_upstream_of_teardowns(self) -> list[Operator]:
+        upstream_tasks = [t.upstream_list if isinstance(t.upstream_list, list) else [t.upstream_list]) t.upstream_list for t in self.teardowns]
+        return [
+            val for sublist in upstream_tasks for val in sublist if not getattr(val, "_is_teardown", None)
         ]
-        return [val for val in flatten_tasks if not getattr(val, "_is_teardown", None)]
 
     @property
     def task_group(self) -> TaskGroup:

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -598,6 +598,8 @@ class DagRun(Base, LoggingMixin):
         leaf_tis = [ti for ti in tis if ti.task_id in leaf_task_ids if ti.state != TaskInstanceState.REMOVED]
         # TODO: Remove 'getattr' if setup/teardown is available for mapped task
         if dag.teardowns:
+            # when on_failure_fail_dagrun is `False`, the final state of the DagRun
+            # will be computed as if the teardown task simply didn't exist.
             teardown_task_ids = [t.task_id for t in dag.teardowns]
             upstream_of_teardowns = [t.task_id for t in dag.tasks_upstream_of_teardowns]
             teardown_tis = [ti for ti in tis if ti.task_id in teardown_task_ids]

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -597,10 +597,11 @@ class DagRun(Base, LoggingMixin):
 
         leaf_task_ids = {t.task_id for t in dag.leaves}
         leaf_tis = [ti for ti in tis if ti.task_id in leaf_task_ids if ti.state != TaskInstanceState.REMOVED]
-        # modify if setup/teardown is available for mapped task
-        teardown_tis = [
-            ti for ti in leaf_tis if not isinstance(ti.task, MappedOperator) and ti.task._is_teardown
-        ]
+        # TODO: Remove isintance(.., MappedOperator) if setup/teardown is available for mapped task
+        teardown_tasks_ids = {
+            t.task_id for t in dag.tasks if not isinstance(t, MappedOperator) and t._is_teardown
+        }
+        teardown_tis = [ti for ti in tis if ti.task_id in teardown_tasks_ids]
         leaf_tis = list(set(leaf_tis) - set(teardown_tis))
         include_on_failure = [
             ti

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -51,7 +51,6 @@ from airflow.callbacks.callback_requests import DagCallbackRequest
 from airflow.configuration import conf as airflow_conf
 from airflow.exceptions import AirflowException, RemovedInAirflow3Warning, TaskNotFound
 from airflow.listeners.listener import get_listener_manager
-from airflow.models import MappedOperator
 from airflow.models.abstractoperator import NotMapped
 from airflow.models.base import Base, StringID
 from airflow.models.expandinput import NotFullyPopulated
@@ -597,18 +596,16 @@ class DagRun(Base, LoggingMixin):
 
         leaf_task_ids = {t.task_id for t in dag.leaves}
         leaf_tis = [ti for ti in tis if ti.task_id in leaf_task_ids if ti.state != TaskInstanceState.REMOVED]
-        # TODO: Remove isintance(.., MappedOperator) if setup/teardown is available for mapped task
-        teardown_tasks_ids = {
-            t.task_id for t in dag.tasks if not isinstance(t, MappedOperator) and t._is_teardown
-        }
-        teardown_tis = [ti for ti in tis if ti.task_id in teardown_tasks_ids]
-        leaf_tis = list(set(leaf_tis) - set(teardown_tis))
-        include_on_failure = [
-            ti
-            for ti in teardown_tis
-            if not isinstance(ti.task, MappedOperator) and ti.task._on_failure_fail_dagrun
-        ]
-        leaf_tis.extend(include_on_failure)
+        # TODO: Remove 'getattr' if setup/teardown is available for mapped task
+        if dag.teardowns:
+            teardown_task_ids = [t.task_id for t in dag.teardowns]
+            upstream_of_teardowns = [t.task_id for t in dag.tasks_upstream_of_teardowns]
+            teardown_tis = [ti for ti in tis if ti.task_id in teardown_task_ids]
+            on_failure_fail_tis = [ti for ti in teardown_tis if getattr(ti.task, "_on_failure_fail_dagrun")]
+            tis_upstream_of_teardowns = [ti for ti in tis if ti.task_id in upstream_of_teardowns]
+            leaf_tis = list(set(leaf_tis) - set(teardown_tis))
+            leaf_tis.extend(on_failure_fail_tis)
+            leaf_tis.extend(tis_upstream_of_teardowns)
 
         # if all roots finished and at least one failed, the run failed
         if not unfinished.tis and any(leaf_ti.state in State.failed_states for leaf_ti in leaf_tis):


### PR DESCRIPTION
My approach here is not to include teardown tasks in the leaf_tis when deciding on dagrun state except if the teardown task has _on_failure_fail_dagrun set

- [x] Add test for when a teardown has upstream failed

closes: #29125
