### PR TITLE
Limit Redis secrets chart creation to Celery*Executor

### DIFF
--- a/chart/templates/secrets/redis-secrets.yaml
+++ b/chart/templates/secrets/redis-secrets.yaml
@@ -22,6 +22,7 @@
 # when we need them. We will always deploy them defensively to make the executor
 # update path actually work.
 
+{{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
 ################################
 ## Airflow Redis Password Secret
 #################################
@@ -78,4 +79,5 @@ data:
   {{- else }}
   connection: {{ (printf "%s" .Values.data.brokerUrl) | b64enc | quote }}
   {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Add logic to helm-generate Redis secrets resources only when `CeleryExecutor` or `CeleryKubernetesExecutor` is defined in the helm config. This is consistent with the others Redis resources defined within [./chart/templates/redis](https://github.com/apache/airflow/tree/b102ead49857c7524ecbe68c7f07e54d12cc6bb7/chart/templates/redis).

closes:#30420