### PR TITLE
Update MANIFEST_TEMPLATE.in.jinja2

### DIFF
--- a/dev/provider_packages/MANIFEST_TEMPLATE.in.jinja2
+++ b/dev/provider_packages/MANIFEST_TEMPLATE.in.jinja2
@@ -33,5 +33,4 @@ include airflow/providers/cncf/kubernetes/*.jinja2
 include NOTICE
 include LICENSE
 include CHANGELOG.rst
-include README.md
 global-exclude __pycache__  *.pyc

--- a/dev/provider_packages/MANIFEST_TEMPLATE.in.jinja2
+++ b/dev/provider_packages/MANIFEST_TEMPLATE.in.jinja2
@@ -35,6 +35,6 @@ include airflow/providers/cncf/kubernetes/*.jinja2
 
 include NOTICE
 include LICENSE
-include CHANGELOG.txt
+include CHANGELOG.rst
 include README.md
 global-exclude __pycache__  *.pyc

--- a/dev/provider_packages/MANIFEST_TEMPLATE.in.jinja2
+++ b/dev/provider_packages/MANIFEST_TEMPLATE.in.jinja2
@@ -26,9 +26,6 @@
 {% if PROVIDER_PACKAGE_ID == 'amazon' %}
 include airflow/providers/amazon/aws/hooks/batch_waiters.json
 include airflow/providers/amazon/aws/waiters/*.json
-{% elif PROVIDER_PACKAGE_ID == 'google' %}
-include airflow/providers/google/cloud/example_dags/*.yaml
-include airflow/providers/google/cloud/example_dags/*.sql
 {% elif PROVIDER_PACKAGE_ID == 'cncf.kubernetes' %}
 include airflow/providers/cncf/kubernetes/*.jinja2
 {% endif %}


### PR DESCRIPTION
During provider release I noticed several warnnings:

```
Generated regular package setup files for google
########## Prepare provider package for 'google' ##########
Changing directory to /opt/airflow/provider_packages
Building provider package: google in format both
Executing command: 'python3 setup.py build --build-temp /tmp/tmplaa_85oz egg_info --tag-build sdist bdist_wheel --bdist-dir /tmp/tmpyjwnfmkg'
warning: no files found matching 'airflow/providers/google/cloud/example_dags/*.yaml'
warning: no files found matching 'airflow/providers/google/cloud/example_dags/*.sql'
warning: no files found matching 'CHANGELOG.txt'
warning: no files found matching 'README.md'
warning: no previously-included files matching '__pycache__' found anywhere in distribution
warning: no previously-included files matching '*.pyc' found anywhere in distribution
warning: build_py: byte-compiling is disabled, skipping.

```
This PR will address them

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
