### PR TITLE
Fix cloud build async credentials

### DIFF
--- a/airflow/providers/google/cloud/hooks/cloud_build.py
+++ b/airflow/providers/google/cloud/hooks/cloud_build.py
@@ -645,7 +645,9 @@ class CloudBuildAsyncHook(GoogleBaseHook):
         client_options = None
         if location != "global":
             client_options = ClientOptions(api_endpoint=f"{location}-cloudbuild.googleapis.com:443")
-        client = CloudBuildAsyncClient(client_options=client_options)
+        client = CloudBuildAsyncClient(
+            credentials=self.get_credentials(), client_info=CLIENT_INFO, client_options=client_options
+        )
 
         request = GetBuildRequest(
             project_id=project_id,

--- a/tests/providers/google/cloud/hooks/test_cloud_build.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_build.py
@@ -329,10 +329,13 @@ class TestAsyncHook:
         )
 
     @pytest.mark.asyncio
-    @async_mock.patch.object(CloudBuildAsyncClient, "__init__", lambda self, client_options: None)
+    @async_mock.patch.object(
+        CloudBuildAsyncClient, "__init__", lambda self, credentials, client_info, client_options: None
+    )
+    @async_mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncHook.get_credentials"))
     @async_mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncClient.get_build"))
     async def test_async_cloud_build_service_client_creation_should_execute_successfully(
-        self, mocked_get_build, hook
+        self, mocked_get_build, mock_get_creds, hook
     ):
         mocked_get_build.return_value = Future()
         await hook.get_cloud_build(project_id=PROJECT_ID, id_=BUILD_ID)
@@ -342,6 +345,7 @@ class TestAsyncHook:
                 id=BUILD_ID,
             )
         )
+        mock_get_creds.assert_called_once()
         mocked_get_build.assert_called_once_with(request=request, retry=DEFAULT, timeout=None, metadata=())
 
     @pytest.mark.asyncio

--- a/tests/providers/google/cloud/triggers/test_cloud_build.py
+++ b/tests/providers/google/cloud/triggers/test_cloud_build.py
@@ -16,19 +16,19 @@
 # under the License.
 from __future__ import annotations
 
+from asyncio import Future
+
 import asyncio
 import logging
 
 import pytest
-from google.cloud.devtools.cloudbuild_v1 import CloudBuildAsyncClient
 from google.cloud.devtools.cloudbuild_v1.types import Build, BuildStep
 
-from airflow.providers.google.cloud.hooks.cloud_build import CloudBuildAsyncHook
 from airflow.providers.google.cloud.triggers.cloud_build import CloudBuildCreateBuildTrigger
 from airflow.triggers.base import TriggerEvent
 from tests.providers.google.cloud.utils.compat import async_mock
 
-CLOUD_BUILD_PATH = "airflow.providers.google.cloud.hooks.cloud_build.{}"
+CLOUD_BUILD_PATH = "airflow.providers.google.cloud.triggers.cloud_build.{}"
 TEST_PROJECT_ID = "cloud-build-project"
 TEST_BUILD_ID = "test-build-id-9832662"
 REPO_SOURCE = {"repo_source": {"repo_name": "test_repo", "branch_name": "main"}}
@@ -81,13 +81,6 @@ TEST_BUILD_INSTANCE = dict(
 
 
 @pytest.fixture
-def hook():
-    return CloudBuildAsyncHook(
-        gcp_conn_id="google_cloud_default",
-    )
-
-
-@pytest.fixture
 def trigger():
     return CloudBuildCreateBuildTrigger(
         id_=TEST_BUILD_ID,
@@ -101,6 +94,12 @@ def trigger():
 
 
 class TestCloudBuildCreateBuildTrigger:
+    @staticmethod
+    def _mock_build_result(result_to_mock):
+        f = Future()
+        f.set_result(result_to_mock)
+        return f
+
     def test_serialization(self, trigger):
         """
         Asserts that the CloudBuildCreateBuildTrigger correctly serializes its arguments
@@ -120,16 +119,14 @@ class TestCloudBuildCreateBuildTrigger:
         }
 
     @pytest.mark.asyncio
-    @async_mock.patch.object(CloudBuildAsyncClient, "__init__", lambda self, client_options: None)
-    @async_mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncClient.get_build"))
-    async def test_trigger_on_success_yield_successfully(self, mock_get_build, hook, trigger):
+    @async_mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncHook"))
+    async def test_trigger_on_success_yield_successfully(self, mock_hook, trigger):
         """
         Tests the CloudBuildCreateBuildTrigger only fires once the job execution reaches a successful state.
         """
-        mock_get_build.return_value = Build(
-            id=TEST_BUILD_ID, status=Build.Status.SUCCESS, steps=[BuildStep(name="ubuntu")]
+        mock_hook.return_value.get_cloud_build.return_value = self._mock_build_result(
+            Build(id=TEST_BUILD_ID, status=Build.Status.SUCCESS, steps=[BuildStep(name="ubuntu")])
         )
-
         generator = trigger.run()
         actual = await generator.asend(None)
         assert (
@@ -145,14 +142,13 @@ class TestCloudBuildCreateBuildTrigger:
         )
 
     @pytest.mark.asyncio
-    @async_mock.patch.object(CloudBuildAsyncClient, "__init__", lambda self, client_options: None)
-    @async_mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncClient.get_build"))
-    async def test_trigger_on_running_wait_successfully(self, mock_get_build, hook, caplog, trigger):
+    @async_mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncHook"))
+    async def test_trigger_on_running_wait_successfully(self, mock_hook, caplog, trigger):
         """
         Test that CloudBuildCreateBuildTrigger does not fire while a build is still running.
         """
-        mock_get_build.return_value = Build(
-            id=TEST_BUILD_ID, status=Build.Status.WORKING, steps=[BuildStep(name="ubuntu")]
+        mock_hook.return_value.get_cloud_build.return_value = self._mock_build_result(
+            Build(id=TEST_BUILD_ID, status=Build.Status.WORKING, steps=[BuildStep(name="ubuntu")])
         )
         caplog.set_level(logging.INFO)
 
@@ -169,17 +165,18 @@ class TestCloudBuildCreateBuildTrigger:
         asyncio.get_event_loop().stop()
 
     @pytest.mark.asyncio
-    @async_mock.patch.object(CloudBuildAsyncClient, "__init__", lambda self, client_options: None)
-    @async_mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncClient.get_build"))
-    async def test_trigger_on_error_yield_successfully(self, mock_get_build, hook, caplog, trigger):
+    @async_mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncHook"))
+    async def test_trigger_on_error_yield_successfully(self, mock_hook, caplog, trigger):
         """
         Test that CloudBuildCreateBuildTrigger fires the correct event in case of an error.
         """
-        mock_get_build.return_value = Build(
-            id=TEST_BUILD_ID,
-            status=Build.Status.FAILURE,
-            steps=[BuildStep(name="ubuntu")],
-            status_detail="error",
+        mock_hook.return_value.get_cloud_build.return_value = self._mock_build_result(
+            Build(
+                id=TEST_BUILD_ID,
+                status=Build.Status.FAILURE,
+                steps=[BuildStep(name="ubuntu")],
+                status_detail="error",
+            )
         )
         caplog.set_level(logging.INFO)
 
@@ -188,12 +185,12 @@ class TestCloudBuildCreateBuildTrigger:
         assert TriggerEvent({"status": "error", "message": "error"}) == actual
 
     @pytest.mark.asyncio
-    @async_mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncHook.get_cloud_build"))
-    async def test_trigger_on_exec_yield_successfully(self, mock_build_inst, trigger):
+    @async_mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncHook"))
+    async def test_trigger_on_exec_yield_successfully(self, mock_hook, trigger):
         """
         Test that CloudBuildCreateBuildTrigger fires the correct event in case of an error.
         """
-        mock_build_inst.side_effect = Exception("Test exception")
+        mock_hook.return_value.get_cloud_build.side_effect = Exception("Test exception")
 
         generator = trigger.run()
         actual = await generator.asend(None)

--- a/tests/providers/google/cloud/triggers/test_cloud_build.py
+++ b/tests/providers/google/cloud/triggers/test_cloud_build.py
@@ -16,10 +16,9 @@
 # under the License.
 from __future__ import annotations
 
-from asyncio import Future
-
 import asyncio
 import logging
+from asyncio import Future
 
 import pytest
 from google.cloud.devtools.cloudbuild_v1.types import Build, BuildStep


### PR DESCRIPTION
Found and fixed a related bug while testing the CloudBuild of Google provider.

CloudBuildAsyncClient had a bug where no credentials were set and the application default credentials were used.
So the connection settings are not used.

related: #29937, #30427
