### PR TITLE
Allow setup/teardown task decorators to take same args as task decorators

### DIFF
--- a/airflow/decorators/setup_teardown.py
+++ b/airflow/decorators/setup_teardown.py
@@ -36,9 +36,8 @@ def setup_task(_func=None, *, multiple_outputs=None, **kwargs) -> Callable:
         elif isinstance(func, _TaskGroupFactory):
             raise AirflowException("Task groups cannot be marked as setup or teardown.")
         else:
-            if not func.multiple_outputs:  # type: ignore[attr-defined]
-                func.multiple_outputs = multiple_outputs  # type: ignore[attr-defined]
-            func.kwargs.update(kwargs)  # type: ignore[attr-defined]
+            if kwargs or multiple_outputs:
+                raise AirflowException("@setup does not support kwargs when decorating a decorated task.")
         func._is_setup = True  # type: ignore[attr-defined]
         return func
 
@@ -60,9 +59,11 @@ def teardown_task(
         elif isinstance(func, _TaskGroupFactory):
             raise AirflowException("Task groups cannot be marked as setup or teardown.")
         else:
-            if not func.multiple_outputs:  # type: ignore[attr-defined]
-                func.multiple_outputs = multiple_outputs  # type: ignore[attr-defined]
-            func.kwargs.update(kwargs)  # type: ignore[attr-defined]
+            if kwargs or multiple_outputs:
+                raise AirflowException(
+                    "@teardown only supports on_failure_fail_dagrun argument "
+                    "when decorating a decorated task."
+                )
         func._is_teardown = True  # type: ignore[attr-defined]
         func._on_failure_fail_dagrun = on_failure_fail_dagrun  # type: ignore[attr-defined]
         return func

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -239,52 +239,59 @@ class TestSetupTearDownTask:
         assert teardown_task._is_teardown
 
     def test_setup_decorator_on_task_deco_with_op_args(self, dag_maker):
-        @setup(task_id="setuptask")
-        @task
-        def mytask():
-            print(2)
 
-        with dag_maker() as dag:
-            mytask()
-        assert len(dag.task_group.children) == 1
-        setup_task = dag.task_group.children["setuptask"]
-        assert setup_task._is_setup
+        with pytest.raises(
+            AirflowException, match="@setup does not support kwargs when decorating a decorated task."
+        ):
+
+            @setup(task_id="setuptask")
+            @task
+            def mytask():
+                print(2)
+
+            with dag_maker():
+                mytask()
 
     def test_teardown_decorator_on_task_deco_with_op_args(self, dag_maker):
-        @teardown(task_id="teardown_task")
-        @task
-        def mytask():
-            print(2)
+        with pytest.raises(
+            AirflowException,
+            match="@teardown only supports on_failure_fail_dagrun argument when decorating a decorated task.",
+        ):
 
-        with dag_maker() as dag:
-            mytask()
-        assert len(dag.task_group.children) == 1
-        teardown_task = dag.task_group.children["teardown_task"]
-        assert teardown_task._is_teardown
+            @teardown(task_id="teardown_task")
+            @task
+            def mytask():
+                print(2)
 
-    def test_setup_decorator_on_task_deco_with_same_op_args(self, dag_maker):
-        @setup(task_id="setuptask")
-        @task(task_id="mytask2")
-        def mytask():
-            print(2)
+            with dag_maker():
+                mytask()
 
-        with dag_maker() as dag:
-            mytask()
-        assert len(dag.task_group.children) == 1
-        setup_task = dag.task_group.children["setuptask"]
-        assert setup_task._is_setup
+    def test_setup_decorator_on_task_deco_raises_if_it_has_arg(self, dag_maker):
+        with pytest.raises(
+            AirflowException, match="@setup does not support kwargs when decorating a decorated task."
+        ):
+
+            @setup(task_id="setuptask")
+            @task(task_id="mytask2")
+            def mytask():
+                print(2)
+
+            with dag_maker():
+                mytask()
 
     def test_teardown_decorator_on_task_deco_with_same_op_args(self, dag_maker):
-        @teardown(task_id="teardown_task")
-        @task(task_id="mytask2")
-        def mytask():
-            print(2)
+        with pytest.raises(
+            AirflowException,
+            match="@teardown only supports on_failure_fail_dagrun argument when decorating a decorated task.",
+        ):
 
-        with dag_maker() as dag:
-            mytask()
-        assert len(dag.task_group.children) == 1
-        teardown_task = dag.task_group.children["teardown_task"]
-        assert teardown_task._is_teardown
+            @teardown(task_id="teardown_task")
+            @task(task_id="mytask2")
+            def mytask():
+                print(2)
+
+            with dag_maker():
+                mytask()
 
     def test_multiple_outputs_with_setup(self, dag_maker):
         """Tests pushing multiple outputs as a dictionary using setup tasks"""


### PR DESCRIPTION
The setup/teardown decorators should take same arguments as task decorators. In the event that both task decorator and setup/teardown decorator are given the same args, the arg on the setup/teardown takes precedence. e.g if we have:
```python
   @setup(task_id="setuptask")
   @task(task_id="mytask")
   def mytask2():
      ...
```

The task id would eventually be setuptask and not mytask.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
