### PR TITLE
Small Documentation Fix in GCSToGCSOperator

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -150,7 +150,7 @@ class GCSToGCSOperator(BaseOperator):
         )
 
     The following Operator would move all the Avro files from ``sales/sales-2019``
-     and ``sales/sales-2020` folder in ``data`` bucket to the same folder in the
+     and ``sales/sales-2020`` folder in ``data`` bucket to the same folder in the
      ``data_backup`` bucket, deleting the original files in the process. ::
 
         move_files = GCSToGCSOperator(


### PR DESCRIPTION
![Screenshot 2023-04-03 at 16 30 26](https://user-images.githubusercontent.com/9142569/229654574-6d40cd9f-b2fa-479e-a300-ebd5d87da369.png)
A missing backtick letter causes wrong parsing in the documentation. 
Documentation link [airflow.providers.google.cloud.transfers.gcs_to_gcs](https://airflow.apache.org/docs/apache-airflow-providers-google/2.0.0/_api/airflow/providers/google/cloud/transfers/gcs_to_gcs/index.html)