### PR TITLE
Remove stray parenthesis in spark provider docs

### DIFF
--- a/docs/apache-airflow-providers-apache-spark/index.rst
+++ b/docs/apache-airflow-providers-apache-spark/index.rst
@@ -76,7 +76,7 @@ Installation
 ------------
 
 You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below)
-for the minimum Airflow version supported) via
+for the minimum Airflow version supported via
 ``pip install apache-airflow-providers-apache-spark``
 
 Requirements


### PR DESCRIPTION
There was an extra closing parenthesis in the spark provider docs. :)