### PR TITLE
Fix Breeze failing with error on Windows

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/main_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/main_command.py
@@ -138,15 +138,21 @@ def check_for_python_emulation():
             )
             from inputimeout import TimeoutOccurred, inputimeout
 
-            user_status = inputimeout(
-                prompt="Are you REALLY sure you want to continue? (answer with y otherwise we exit in 20s)\n",
-                timeout=20,
-            )
-            if user_status.upper() not in ["Y", "YES"]:
+            try:
+                user_status = inputimeout(
+                    prompt="Are you REALLY sure you want to continue? "
+                    "(answer with y otherwise we exit in 20s)\n",
+                    timeout=20,
+                )
+                if user_status.upper() not in ["Y", "YES"]:
+                    sys.exit(1)
+            except TimeoutOccurred:
+                from airflow_breeze.utils.console import get_console
+
+                get_console().print("\nNo answer, exiting...")
                 sys.exit(1)
-    except TimeoutOccurred:
-        get_console().print("\nNo answer, exiting...")
-        sys.exit(1)
+    except FileNotFoundError:
+        pass
     except subprocess.CalledProcessError:
         pass
     except PermissionError:


### PR DESCRIPTION
When breeze is run on Windows it fails with FileNotFoundException when running uname during emulation check. This is now fixed alongside fixing TimeoutError misplacement - after moving it to local import, an exception triggered before importing it causes UnboundLocaalError.

Related: https://github.com/apache/airflow/pull/30405#issuecomment-1496414377

Fixes: https://github.com/apache/airflow/issues/30465

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
