### PR TITLE
add more info to quicksight errors

### DIFF
--- a/airflow/providers/amazon/aws/hooks/quicksight.py
+++ b/airflow/providers/amazon/aws/hooks/quicksight.py
@@ -119,11 +119,20 @@ class QuickSightHook(AwsBaseHook):
             raise AirflowException(f"AWS request failed: {e}")
 
     def get_error_info(self, aws_account_id: str, data_set_id: str, ingestion_id: str) -> dict | None:
-        """If the ingestion failed, returns the error info. Else, returns None."""
+        """
+        Gets info about the error if any.
+
+        :param aws_account_id: An AWS Account ID
+        :param data_set_id: QuickSight Data Set ID
+        :param ingestion_id: QuickSight Ingestion ID
+        :return: Error info dict containing the error type (key 'Type') and message (key 'Message')
+            if available. Else, returns None.
+        """
         describe_ingestion_response = self.get_conn().describe_ingestion(
             AwsAccountId=aws_account_id, DataSetId=data_set_id, IngestionId=ingestion_id
         )
-        return describe_ingestion_response["Ingestion"].get("ErrorInfo", None)
+        # using .get() to get None if the key is not present, instead of an exception.
+        return describe_ingestion_response["Ingestion"].get("ErrorInfo")
 
     def wait_for_state(
         self,

--- a/airflow/providers/amazon/aws/sensors/quicksight.py
+++ b/airflow/providers/amazon/aws/sensors/quicksight.py
@@ -77,7 +77,8 @@ class QuickSightSensor(BaseSensorOperator):
         )
         self.log.info("QuickSight Status: %s", quicksight_ingestion_state)
         if quicksight_ingestion_state in self.errored_statuses:
-            raise AirflowException("The QuickSight Ingestion failed!")
+            error = self.quicksight_hook.get_error_info(aws_account_id, self.data_set_id, self.ingestion_id)
+            raise AirflowException(f"The QuickSight Ingestion failed. Error info: {error}")
         return quicksight_ingestion_state == self.success_status
 
     @cached_property

--- a/tests/providers/amazon/aws/sensors/test_quicksight.py
+++ b/tests/providers/amazon/aws/sensors/test_quicksight.py
@@ -49,7 +49,8 @@ class TestQuickSightSensor:
 
     @mock_sts
     @mock.patch.object(QuickSightHook, "get_status")
-    def test_poke_cancelled(self, mock_get_status):
+    @mock.patch.object(QuickSightHook, "get_error_info")
+    def test_poke_cancelled(self, mock_get_status, _):
         mock_get_status.return_value = "CANCELLED"
         with pytest.raises(AirflowException):
             self.sensor.poke({})
@@ -57,7 +58,8 @@ class TestQuickSightSensor:
 
     @mock_sts
     @mock.patch.object(QuickSightHook, "get_status")
-    def test_poke_failed(self, mock_get_status):
+    @mock.patch.object(QuickSightHook, "get_error_info")
+    def test_poke_failed(self, mock_get_status, _):
         mock_get_status.return_value = "FAILED"
         with pytest.raises(AirflowException):
             self.sensor.poke({})

--- a/tests/providers/amazon/aws/sensors/test_quicksight.py
+++ b/tests/providers/amazon/aws/sensors/test_quicksight.py
@@ -50,7 +50,7 @@ class TestQuickSightSensor:
     @mock_sts
     @mock.patch.object(QuickSightHook, "get_status")
     @mock.patch.object(QuickSightHook, "get_error_info")
-    def test_poke_cancelled(self, mock_get_status, _):
+    def test_poke_cancelled(self, _, mock_get_status):
         mock_get_status.return_value = "CANCELLED"
         with pytest.raises(AirflowException):
             self.sensor.poke({})
@@ -59,7 +59,7 @@ class TestQuickSightSensor:
     @mock_sts
     @mock.patch.object(QuickSightHook, "get_status")
     @mock.patch.object(QuickSightHook, "get_error_info")
-    def test_poke_failed(self, mock_get_status, _):
+    def test_poke_failed(self, _, mock_get_status):
         mock_get_status.return_value = "FAILED"
         with pytest.raises(AirflowException):
             self.sensor.poke({})


### PR DESCRIPTION
in the current state, error handling was not very helpful. Adding the exception and error info available in the response will help with debugging.

Took the opportunity to rearrange the code so that we sleep before polling for the state, not between polling and checking the value. This will shorten wait time by poll_interval for everyone.