### PR TITLE
Do not remove docker provider for Airflow 2.3 check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -748,8 +748,10 @@ jobs:
           SKIP_CONSTRAINTS: "${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}"
       - name: "Remove airflow package and replace providers with 2.3-compliant versions"
         run: |
-          rm -vf dist/apache_airflow-*.whl dist/apache_airflow_providers_docker*.whl
-          pip download --no-deps --dest dist apache-airflow-providers-docker==3.1.0
+          rm -vf dist/apache_airflow-*.whl
+          # remove the provider packages that are not compatible with 2.3
+          # rm -vf dist/apache_airflow_providers_docker*.whl
+          # pip download --no-deps --dest dist apache-airflow-providers-docker==3.1.0
         if: matrix.package-format == 'wheel'
       - name: "Get all provider extras as AIRFLOW_EXTRAS env variable"
         run: >


### PR DESCRIPTION
This removal is a remnant of old docker provider for 2.2 and should not be happening.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
