### PR TITLE
Update dead link in Sentry integration document

### DIFF
--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/errors.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/errors.rst
@@ -97,7 +97,7 @@ environment variables are passed but also all existing environment variables are
 This behaviour can be disabled by setting ``default_integrations`` sentry configuration parameter to
 ``False`` which disables ``StdlibIntegration``. However, this also disables other default integrations,
 so you need to enable them manually if you want them to remain enabled
-(see `Sentry Default Integrations <https://docs.sentry.io/platforms/python/guides/wsgi/configuration/integrations/default-integrations/>`_).
+(see `Sentry Default Integrations <https://docs.sentry.io/platforms/python/guides/configuration/integrations/default-integrations/>`_).
 
 .. code-block:: ini
 

--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/errors.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/errors.rst
@@ -97,7 +97,7 @@ environment variables are passed but also all existing environment variables are
 This behaviour can be disabled by setting ``default_integrations`` sentry configuration parameter to
 ``False`` which disables ``StdlibIntegration``. However, this also disables other default integrations,
 so you need to enable them manually if you want them to remain enabled
-(see `Sentry Default Integrations <https://docs.sentry.io/platforms/python/guides/configuration/integrations/default-integrations/>`_).
+(see `Sentry Default Integrations <https://docs.sentry.io/platforms/python/configuration/integrations/default-integrations/>`_).
 
 .. code-block:: ini
 


### PR DESCRIPTION
Fix the dead link.
- as-is: https://docs.sentry.io/platforms/python/guides/wsgi/configuration/integrations/default-integrations
- to-be: https://docs.sentry.io/platforms/python/configuration/integrations/default-integrations/


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
