### PR TITLE
Fix output to outputs typos in ci.yaml everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -873,7 +873,7 @@ jobs:
     timeout-minutes: 130
     name: >
       Postgres${{matrix.postgres-version}},Py${{matrix.python-version}}:
-      ${{needs.build-info.output.parallel-test-types}}
+      ${{needs.build-info.outputs.parallel-test-types}}
     runs-on: "${{needs.build-info.outputs.runs-on}}"
     needs: [build-info, test-pytest-collection]
     strategy:
@@ -884,7 +884,7 @@ jobs:
       fail-fast: false
     env:
       RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
-      PARALLEL_TEST_TYPES: "${{needs.build-info.output.parallel-test-types}}"
+      PARALLEL_TEST_TYPES: "${{needs.build-info.outputs.parallel-test-types}}"
       SUSPENDED_PROVIDERS_FOLDERS: "${{ needs.build-info.outputs.suspended-providers-folders }}"
       PR_LABELS: "${{needs.build-info.outputs.pull-request-labels}}"
       FULL_TESTS_NEEDED: "${{needs.build-info.outputs.full-tests-needed}}"
@@ -906,13 +906,13 @@ jobs:
           persist-credentials: false
       - name: "Prepare breeze & CI image: ${{matrix.python-version}}:${{env.IMAGE_TAG}}"
         uses: ./.github/actions/prepare_breeze_and_image
-      - name: "Migration Tests: ${{matrix.python-version}}:${{needs.build-info.output.parallel-test-types}}"
+      - name: "Migration Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         uses: ./.github/actions/migration_tests
-      - name: "Tests: ${{matrix.python-version}}:${{needs.build-info.output.parallel-test-types}}"
+      - name: "Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         run: breeze testing tests --run-in-parallel
       - name: "Tests ARM Pytest collection: ${{matrix.python-version}}"
         run: breeze testing tests --run-in-parallel --collect-only --remove-arm-packages
-      - name: "Post Tests: ${{matrix.python-version}}:${{needs.build-info.output.parallel-test-types}}"
+      - name: "Post Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         uses: ./.github/actions/post_tests
 
   tests-postgres-boto:
@@ -920,12 +920,12 @@ jobs:
     name: >
       LatestBotoPostgres${{needs.build-info.outputs.default-postgres-version}},
       Py${{needs.build-info.outputs.default-python-version}}:
-      ${{needs.build-info.output.parallel-test-types}}
+      ${{needs.build-info.outputs.parallel-test-types}}
     runs-on: "${{needs.build-info.outputs.runs-on}}"
     needs: [build-info, test-pytest-collection]
     env:
       RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
-      PARALLEL_TEST_TYPES: "${{needs.build-info.output.parallel-test-types}}"
+      PARALLEL_TEST_TYPES: "${{needs.build-info.outputs.parallel-test-types}}"
       SUSPENDED_PROVIDERS_FOLDERS: "${{ needs.build-info.outputs.suspended-providers-folders }}"
       PR_LABELS: "${{needs.build-info.outputs.pull-request-labels}}"
       FULL_TESTS_NEEDED: "${{needs.build-info.outputs.full-tests-needed}}"
@@ -954,18 +954,18 @@ jobs:
         uses: ./.github/actions/prepare_breeze_and_image
       - name: >
           Tests: ${{needs.build-info.outputs.default-python-version}}:
-          ${{needs.build-info.output.parallel-test-types}}
+          ${{needs.build-info.outputs.parallel-test-types}}
         run: breeze testing tests --run-in-parallel
       - name: >
           Post Tests: ${{needs.build-info.outputs.default-python-version}}:
-          ${{needs.build-info.output.parallel-test-types}}
+          ${{needs.build-info.outputs.parallel-test-types}}
         uses: ./.github/actions/post_tests
 
   tests-mysql:
     timeout-minutes: 130
     name: >
       MySQL${{matrix.mysql-version}}, Py${{matrix.python-version}}:
-      ${{needs.build-info.output.parallel-test-types}}
+      ${{needs.build-info.outputs.parallel-test-types}}
     runs-on: "${{needs.build-info.outputs.runs-on}}"
     needs: [build-info, test-pytest-collection]
     strategy:
@@ -978,7 +978,7 @@ jobs:
       RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
       PR_LABELS: "${{needs.build-info.outputs.pull-request-labels}}"
       FULL_TESTS_NEEDED: "${{needs.build-info.outputs.full-tests-needed}}"
-      PARALLEL_TEST_TYPES: "${{needs.build-info.output.parallel-test-types}}"
+      PARALLEL_TEST_TYPES: "${{needs.build-info.outputs.parallel-test-types}}"
       SUSPENDED_PROVIDERS_FOLDERS: "${{ needs.build-info.outputs.suspended-providers-folders }}"
       DEBUG_RESOURCES: "${{needs.build-info.outputs.debug-resources}}"
       BACKEND: "mysql"
@@ -997,21 +997,21 @@ jobs:
           persist-credentials: false
       - name: "Prepare breeze & CI image: ${{matrix.python-version}}:${{env.IMAGE_TAG}}"
         uses: ./.github/actions/prepare_breeze_and_image
-      - name: "Migration Tests: ${{matrix.python-version}}:${{needs.build-info.output.parallel-test-types}}"
+      - name: "Migration Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         uses: ./.github/actions/migration_tests
-      - name: "Tests: ${{matrix.python-version}}:${{needs.build-info.output.parallel-test-types}}"
+      - name: "Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         run: breeze testing tests --run-in-parallel
       - name: "Tests ARM Pytest collection: ${{matrix.python-version}}"
         if: env.MYSQL_VERSION != '5.7'
         run: breeze testing tests --run-in-parallel --collect-only --remove-arm-packages
-      - name: "Post Tests: ${{matrix.python-version}}:${{needs.build-info.output.parallel-test-types}}"
+      - name: "Post Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         uses: ./.github/actions/post_tests
 
   tests-mssql:
     timeout-minutes: 130
     name: >
       MSSQL${{matrix.mssql-version}}, Py${{matrix.python-version}}:
-      ${{needs.build-info.output.parallel-test-types}}
+      ${{needs.build-info.outputs.parallel-test-types}}
     runs-on: "${{needs.build-info.outputs.runs-on}}"
     needs: [build-info, test-pytest-collection]
     strategy:
@@ -1022,7 +1022,7 @@ jobs:
       fail-fast: false
     env:
       RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
-      PARALLEL_TEST_TYPES: "${{needs.build-info.output.parallel-test-types}}"
+      PARALLEL_TEST_TYPES: "${{needs.build-info.outputs.parallel-test-types}}"
       SUSPENDED_PROVIDERS_FOLDERS: "${{ needs.build-info.outputs.suspended-providers-folders }}"
       PR_LABELS: "${{needs.build-info.outputs.pull-request-labels}}"
       FULL_TESTS_NEEDED: "${{needs.build-info.outputs.full-tests-needed}}"
@@ -1044,17 +1044,17 @@ jobs:
           persist-credentials: false
       - name: "Prepare breeze & CI image: ${{matrix.python-version}}:${{env.IMAGE_TAG}}"
         uses: ./.github/actions/prepare_breeze_and_image
-      - name: "Migration Tests: ${{matrix.python-version}}:${{needs.build-info.output.parallel-test-types}}"
+      - name: "Migration Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         uses: ./.github/actions/migration_tests
-      - name: "Tests: ${{matrix.python-version}}:${{needs.build-info.output.parallel-test-types}}"
+      - name: "Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         run: breeze testing tests --run-in-parallel
-      - name: "Post Tests: ${{matrix.python-version}}:${{needs.build-info.output.parallel-test-types}}"
+      - name: "Post Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         uses: ./.github/actions/post_tests
 
   tests-sqlite:
     timeout-minutes: 130
     name: >
-      Sqlite Py${{matrix.python-version}}: ${{needs.build-info.output.parallel-test-types}}
+      Sqlite Py${{matrix.python-version}}: ${{needs.build-info.outputs.parallel-test-types}}
     runs-on: "${{needs.build-info.outputs.runs-on}}"
     needs: [build-info, test-pytest-collection]
     strategy:
@@ -1065,7 +1065,7 @@ jobs:
     if: needs.build-info.outputs.run-tests == 'true'
     env:
       RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
-      PARALLEL_TEST_TYPES: "${{needs.build-info.output.parallel-test-types}}"
+      PARALLEL_TEST_TYPES: "${{needs.build-info.outputs.parallel-test-types}}"
       SUSPENDED_PROVIDERS_FOLDERS: "${{ needs.build-info.outputs.suspended-providers-folders }}"
       PR_LABELS: "${{needs.build-info.outputs.pull-request-labels}}"
       PYTHON_MAJOR_MINOR_VERSION: "${{matrix.python-version}}"
@@ -1085,13 +1085,13 @@ jobs:
           persist-credentials: false
       - name: "Prepare breeze & CI image: ${{matrix.python-version}}:${{env.IMAGE_TAG}}"
         uses: ./.github/actions/prepare_breeze_and_image
-      - name: "Migration Tests: ${{matrix.python-version}}:${{needs.build-info.output.parallel-test-types}}"
+      - name: "Migration Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         uses: ./.github/actions/migration_tests
-      - name: "Tests: ${{matrix.python-version}}:${{needs.build-info.output.parallel-test-types}}"
+      - name: "Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         run: breeze testing tests --run-in-parallel
       - name: "Tests ARM Pytest collection: ${{matrix.python-version}}"
         run: breeze testing tests --run-in-parallel --collect-only --remove-arm-packages
-      - name: "Post Tests: ${{matrix.python-version}}:${{needs.build-info.output.parallel-test-types}}"
+      - name: "Post Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         uses: ./.github/actions/post_tests
 
   tests-integration-postgres:
@@ -1101,7 +1101,7 @@ jobs:
     needs: [build-info, test-pytest-collection]
     env:
       RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
-      PARALLEL_TEST_TYPES: "${{needs.build-info.output.parallel-test-types}}"
+      PARALLEL_TEST_TYPES: "${{needs.build-info.outputs.parallel-test-types}}"
       PR_LABELS: "${{needs.build-info.outputs.pull-request-labels}}"
       SUSPENDED_PROVIDERS_FOLDERS: "${{ needs.build-info.outputs.suspended-providers-folders }}"
       FULL_TESTS_NEEDED: "${{needs.build-info.outputs.full-tests-needed}}"
@@ -1152,7 +1152,7 @@ jobs:
       - name: "Integration Tests Postgres: all-testable"
         run: breeze testing integration-tests --integration all-testable
         if: needs.build-info.outputs.runs-on == 'self-hosted'
-      - name: "Post Tests: ${{matrix.python-version}}:${{needs.build-info.output.parallel-test-types}}"
+      - name: "Post Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         uses: ./.github/actions/post_tests
 
   tests-integration-mysql:
@@ -1162,7 +1162,7 @@ jobs:
     needs: [build-info, test-pytest-collection]
     env:
       RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
-      PARALLEL_TEST_TYPES: "${{needs.build-info.output.parallel-test-types}}"
+      PARALLEL_TEST_TYPES: "${{needs.build-info.outputs.parallel-test-types}}"
       SUSPENDED_PROVIDERS_FOLDERS: "${{ needs.build-info.outputs.suspended-providers-folders }}"
       PR_LABELS: "${{needs.build-info.outputs.pull-request-labels}}"
       FULL_TESTS_NEEDED: "${{needs.build-info.outputs.full-tests-needed}}"
@@ -1191,7 +1191,7 @@ jobs:
       - name: "Integration Tests MySQL: all-testable"
         run: breeze testing integration-tests --integration all-testable
         if: needs.build-info.outputs.runs-on == 'self-hosted'
-      - name: "Post Tests: ${{matrix.python-version}}:${{needs.build-info.output.parallel-test-types}}"
+      - name: "Post Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         uses: ./.github/actions/post_tests
         if: needs.build-info.outputs.runs-on == 'self-hosted'
 


### PR DESCRIPTION
(Facepalm) The typo of output -> outputs from #30482  was also in the ci.yaml where it was used and it was missed in this PR.

I can blame the GitHub Actions stupid choice of accepting typoed names of outputs and replacing them with blank strings (which I raised as an issue a long time ago)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
