### PR TITLE
[AIP-49]  [OTel Integration] Add tagging to existing stats

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -1212,7 +1212,7 @@ class DagFileProcessorManager(LoggingMixin):
                 Stats.decr("dag_processing.processes", tags={"file_path": file_path, "action": "timeout"})
                 Stats.incr("dag_processing.processor_timeouts", tags={"file_path": file_path})
                 # Deprecated; may be removed in a future Airflow release.
-                Stats.incr("dag_file_processor_timeouts", tags={"file_path": file_path})
+                Stats.incr("dag_file_processor_timeouts")
                 processor.kill()
 
                 # Clean up processor references

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -1212,7 +1212,7 @@ class DagFileProcessorManager(LoggingMixin):
                 Stats.decr("dag_processing.processes", tags={"file_path": file_path, "action": "timeout"})
                 Stats.incr("dag_processing.processor_timeouts", tags={"file_path": file_path})
                 # Deprecated; may be removed in a future Airflow release.
-                Stats.incr("dag_file_processor_timeouts")
+                Stats.incr("dag_file_processor_timeouts", tags={"file_path": file_path})
                 processor.kill()
 
                 # Clean up processor references

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -174,7 +174,6 @@ class DagFileProcessorProcess(LoggingMixin, MultiprocessingStartMethodMixin):
                 ), Stats.timer() as timer:
                     _handle_dag_file_processing()
             log.info("Processing %s took %.3f seconds", file_path, timer.duration)
-            Stats.timing("dag.processor.parse.time", dt=timer.duration, tags={"file_path": file_path})
         except Exception:
             # Log exceptions through the logging framework.
             log.exception("Got an exception! Propagating...")

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -534,9 +534,7 @@ class DagFileProcessor(LoggingMixin):
                     email_sent = True
                     notification_sent = True
                 except Exception:
-                    Stats.incr(
-                        "sla_email_notification_failure", tags={"dag_id": dag.dag_id, "email": str(emails)}
-                    )
+                    Stats.incr("sla_email_notification_failure", tags={"dag_id": dag.dag_id})
                     cls.logger().exception(
                         "Could not send SLA Miss email notification for DAG %s", dag.dag_id
                     )

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -440,9 +440,7 @@ class DagFileProcessor(LoggingMixin):
                         timestamp=ts,
                     )
                     sla_misses.append(sla_miss)
-                    Stats.incr(
-                        "sla_missed", tags={"dag_id": ti.dag_id, "run_id": ti.run_id, "task_id": ti.task_id}
-                    )
+                    Stats.incr("sla_missed", tags={"dag_id": ti.dag_id, "task_id": ti.task_id})
             if sla_misses:
                 session.add_all(sla_misses)
         session.commit()

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -217,9 +217,10 @@ class BaseExecutor(LoggingMixin):
         self.log.debug("%s in queue", num_queued_tasks)
         self.log.debug("%s open slots", open_slots)
 
-        Stats.gauge("executor.open_slots", open_slots)
-        Stats.gauge("executor.queued_tasks", num_queued_tasks)
-        Stats.gauge("executor.running_tasks", num_running_tasks)
+        name = {"name": self.__class__.__name__}
+        Stats.gauge("executor.open_slots", value=open_slots, tags={"status": "open", **name})
+        Stats.gauge("executor.queued_tasks", value=num_queued_tasks, tags={"status": "queued", **name})
+        Stats.gauge("executor.running_tasks", value=num_running_tasks, tags={"status": "running", **name})
 
         self.trigger_tasks(open_slots)
 

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -217,10 +217,19 @@ class BaseExecutor(LoggingMixin):
         self.log.debug("%s in queue", num_queued_tasks)
         self.log.debug("%s open slots", open_slots)
 
-        name = {"name": self.__class__.__name__}
-        Stats.gauge("executor.open_slots", value=open_slots, tags={"status": "open", **name})
-        Stats.gauge("executor.queued_tasks", value=num_queued_tasks, tags={"status": "queued", **name})
-        Stats.gauge("executor.running_tasks", value=num_running_tasks, tags={"status": "running", **name})
+        Stats.gauge(
+            "executor.open_slots", value=open_slots, tags={"status": "open", "name": self.__class__.__name__}
+        )
+        Stats.gauge(
+            "executor.queued_tasks",
+            value=num_queued_tasks,
+            tags={"status": "queued", "name": self.__class__.__name__},
+        )
+        Stats.gauge(
+            "executor.running_tasks",
+            value=num_running_tasks,
+            tags={"status": "running", "name": self.__class__.__name__},
+        )
 
         self.trigger_tasks(open_slots)
 

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -698,7 +698,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             if ti_queued and not ti_requeued:
                 Stats.incr(
                     "scheduler.tasks.killed_externally",
-                    tags={"dag_id": ti.dag_id, "run_id": ti.run_id, "task_id": ti.task_id},
+                    tags={"dag_id": ti.dag_id, "task_id": ti.task_id},
                 )
                 msg = (
                     "Executor reports task instance %s finished (%s) although the "
@@ -1594,9 +1594,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             )
             self.log.error("Detected zombie job: %s", request)
             self.job.executor.send_callback(request)
-            Stats.incr(
-                "zombies_killed", tags={"dag_id": ti.dag_id, "run_id": ti.run_id, "task_id": ti.task_id}
-            )
+            Stats.incr("zombies_killed", tags={"dag_id": ti.dag_id, "task_id": ti.task_id})
 
     @staticmethod
     def _generate_zombie_message_details(ti: TaskInstance):

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1341,9 +1341,7 @@ class DAG(LoggingMixin):
                     callback(context)
                 except Exception:
                     self.log.exception("failed to invoke dag state update callback")
-                    Stats.incr(
-                        "dag.callback_exceptions", tags={"dag_id": dagrun.dag_id, "run_id": dagrun.run_id}
-                    )
+                    Stats.incr("dag.callback_exceptions", tags={"dag_id": dagrun.dag_id})
 
     def get_active_runs(self):
         """

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -61,7 +61,7 @@ from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_states import SCHEDULEABLE_STATES
 from airflow.typing_compat import Literal
 from airflow.utils import timezone
-from airflow.utils.helpers import is_container
+from airflow.utils.helpers import is_container, prune_dict
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import UtcDateTime, nulls_first, skip_locked, tuple_in_condition, with_row_locks
@@ -232,6 +232,10 @@ class DagRun(Base, LoggingMixin):
             queued_at=self.queued_at,
             external_trigger=self.external_trigger,
         )
+
+    @property
+    def stats_tags(self) -> dict[str, str]:
+        return prune_dict({"dag_id": self.dag_id, "run_type": self.run_type})
 
     @property
     def logical_date(self) -> datetime:
@@ -561,7 +565,10 @@ class DagRun(Base, LoggingMixin):
 
         start_dttm = timezone.utcnow()
         self.last_scheduling_decision = start_dttm
-        with Stats.timer(f"dagrun.dependency-check.{self.dag_id}"):
+        with Stats.timer(
+            f"dagrun.dependency-check.{self.dag_id}",
+            tags=self.stats_tags,
+        ):
             dag = self.get_dag()
             info = self.task_instance_scheduling_decisions(session)
 
@@ -893,12 +900,10 @@ class DagRun(Base, LoggingMixin):
                 data_interval_end = dag.get_run_data_interval(self).end
                 true_delay = first_start_date - data_interval_end
                 if true_delay.total_seconds() > 0:
-                    Stats.timing(f"dagrun.{dag.dag_id}.first_task_scheduling_delay", true_delay)
                     Stats.timing(
-                        "dagrun.first_task_scheduling_delay",
-                        true_delay,
-                        tags={"dag_id": dag.dag_id},
+                        f"dagrun.{dag.dag_id}.first_task_scheduling_delay", true_delay, tags=self.stats_tags
                     )
+                    Stats.timing("dagrun.first_task_scheduling_delay", true_delay, tags=self.stats_tags)
         except Exception:
             self.log.warning("Failed to record first_task_scheduling_delay metric:", exc_info=True)
 
@@ -913,12 +918,9 @@ class DagRun(Base, LoggingMixin):
             return
 
         duration = self.end_date - self.start_date
-        if self.state == State.SUCCESS:
-            Stats.timing(f"dagrun.duration.success.{self.dag_id}", duration)
-            Stats.timing("dagrun.duration.success", duration, tags={"dag_id": self.dag_id})
-        elif self.state == State.FAILED:
-            Stats.timing(f"dagrun.duration.failed.{self.dag_id}", duration)
-            Stats.timing("dagrun.duration.failed", duration, tags={"dag_id": self.dag_id})
+        timer_params = {"dt": duration, "tags": self.stats_tags}
+        Stats.timing(f"dagrun.duration.{self.state.value}.{self.dag_id}", **timer_params)
+        Stats.timing(f"dagrun.duration.{self.state.value}", **timer_params)
 
     @provide_session
     def verify_integrity(self, *, session: Session = NEW_SESSION) -> None:
@@ -981,14 +983,14 @@ class DagRun(Base, LoggingMixin):
                 should_restore_task = (task is not None) and ti.state == State.REMOVED
                 if should_restore_task:
                     self.log.info("Restoring task '%s' which was previously removed from DAG '%s'", ti, dag)
-                    Stats.incr(f"task_restored_to_dag.{dag.dag_id}", 1, 1)
+                    Stats.incr(f"task_restored_to_dag.{dag.dag_id}", tags=self.stats_tags)
                     ti.state = State.NONE
             except AirflowException:
                 if ti.state == State.REMOVED:
                     pass  # ti has already been removed, just ignore it
                 elif self.state != State.RUNNING and not dag.partial:
                     self.log.warning("Failed to get task '%s' for dag '%s'. Marking it as removed.", ti, dag)
-                    Stats.incr(f"task_removed_from_dag.{dag.dag_id}", 1, 1)
+                    Stats.incr(f"task_removed_from_dag.{dag.dag_id}", tags=self.stats_tags)
                     ti.state = State.REMOVED
                 continue
 
@@ -1144,7 +1146,7 @@ class DagRun(Base, LoggingMixin):
                 session.bulk_save_objects(tasks)
 
             for task_type, count in created_counts.items():
-                Stats.incr(f"task_instance_created-{task_type}", count)
+                Stats.incr(f"task_instance_created-{task_type}", count, tags=self.stats_tags)
             session.flush()
         except IntegrityError:
             self.log.info(

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -105,7 +105,7 @@ from airflow.typing_compat import Literal, TypeGuard
 from airflow.utils import timezone
 from airflow.utils.context import ConnectionAccessor, Context, VariableAccessor, context_merge
 from airflow.utils.email import send_email
-from airflow.utils.helpers import render_template_to_string
+from airflow.utils.helpers import prune_dict, render_template_to_string
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.module_loading import qualname
 from airflow.utils.net import get_hostname
@@ -539,6 +539,10 @@ class TaskInstance(Base, LoggingMixin):
         self.raw = False
         # can be changed when calling 'run'
         self.test_mode = False
+
+    @property
+    def stats_tags(self) -> dict[str, str]:
+        return prune_dict({"dag_id": self.dag_id, "run_id": str(self.run_id), "task_id": self.task_id})
 
     @staticmethod
     def insert_mapping(run_id: str, task: Operator, map_index: int) -> dict[str, Any]:
@@ -1259,12 +1263,7 @@ class TaskInstance(Base, LoggingMixin):
         self.pid = None
 
         if not ignore_all_deps and not ignore_ti_state and self.state == State.SUCCESS:
-            Stats.incr(
-                "previously_succeeded",
-                1,
-                1,
-                tags={"dag_id": self.dag_id, "run_id": self.run_id, "task_id": self.task_id},
-            )
+            Stats.incr("previously_succeeded", tags=self.stat_tags)
 
         if not mark_success:
             # Firstly find non-runnable and non-requeueable tis.
@@ -1409,10 +1408,14 @@ class TaskInstance(Base, LoggingMixin):
             session.merge(self)
             session.commit()
         actual_start_date = timezone.utcnow()
-        Stats.incr(f"ti.start.{self.task.dag_id}.{self.task.task_id}")
+        Stats.incr(f"ti.start.{self.task.dag_id}.{self.task.task_id}", tags=self.stats_tags)
         # Initialize final state counters at zero
         for state in State.task_states:
-            Stats.incr(f"ti.finish.{self.task.dag_id}.{self.task.task_id}.{state}", count=0)
+            Stats.incr(
+                f"ti.finish.{self.task.dag_id}.{self.task.task_id}.{state}",
+                count=0,
+                tags=self.stats_tags,
+            )
 
         self.task = self.task.prepare_for_execution()
         context = self.get_template_context(ignore_param_exceptions=False)
@@ -1482,7 +1485,7 @@ class TaskInstance(Base, LoggingMixin):
             session.commit()
             raise
         finally:
-            Stats.incr(f"ti.finish.{self.dag_id}.{self.task_id}.{self.state}")
+            Stats.incr(f"ti.finish.{self.dag_id}.{self.task_id}.{self.state}", tags=self.stats_tags)
 
         # Recording SKIPPED or SUCCESS
         self.clear_next_method_args()
@@ -1544,7 +1547,7 @@ class TaskInstance(Base, LoggingMixin):
         if not self.next_method:
             self.clear_xcom_data()
 
-        with Stats.timer(f"dag.{self.task.dag_id}.{self.task.task_id}.duration"):
+        with Stats.timer(f"dag.{self.task.dag_id}.{self.task.task_id}.duration", tags=self.stats_tags):
             # Set the validated/merged params on the task object.
             self.task.params = context["params"]
 
@@ -1579,10 +1582,8 @@ class TaskInstance(Base, LoggingMixin):
             # Run post_execute callback
             self.task.post_execute(context=context, result=result)
 
-        Stats.incr(f"operator_successes_{self.task.task_type}", 1, 1)
-        Stats.incr(
-            "ti_successes", tags={"dag_id": self.dag_id, "run_id": self.run_id, "task_id": self.task_id}
-        )
+        Stats.incr(f"operator_successes_{self.task.task_type}", tags=self.stats_tags)
+        Stats.incr("ti_successes", tags=self.stats_tags)
 
     def _run_finished_callback(
         self,
@@ -1849,10 +1850,10 @@ class TaskInstance(Base, LoggingMixin):
 
         self.end_date = timezone.utcnow()
         self.set_duration()
-        Stats.incr(f"operator_failures_{self.operator}")
-        Stats.incr(
-            "ti_failures", tags={"dag_id": self.dag_id, "run_id": self.run_id, "task_id": self.task_id}
-        )
+
+        Stats.incr(f"operator_failures_{self.operator}", tags=self.stats_tags)
+        Stats.incr("ti_failures", tags=self.stats_tags)
+
         if not test_mode:
             session.add(Log(State.FAILED, self))
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -542,7 +542,7 @@ class TaskInstance(Base, LoggingMixin):
 
     @property
     def stats_tags(self) -> dict[str, str]:
-        return prune_dict({"dag_id": self.dag_id, "run_id": str(self.run_id), "task_id": self.task_id})
+        return prune_dict({"dag_id": self.dag_id, "task_id": self.task_id})
 
     @staticmethod
     def insert_mapping(run_id: str, task: Operator, map_index: int) -> dict[str, Any]:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1263,7 +1263,7 @@ class TaskInstance(Base, LoggingMixin):
         self.pid = None
 
         if not ignore_all_deps and not ignore_ti_state and self.state == State.SUCCESS:
-            Stats.incr("previously_succeeded", tags=self.stat_tags)
+            Stats.incr("previously_succeeded", tags=self.stats_tags)
 
         if not mark_success:
             # Firstly find non-runnable and non-requeueable tis.

--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -24,7 +24,7 @@ import socket
 import string
 import time
 from functools import partial, wraps
-from typing import TYPE_CHECKING, Callable, Iterable, TypeVar, cast
+from typing import TYPE_CHECKING, Callable, Iterable, TypeVar, Union, cast
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException, InvalidStatsNameException
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from statsd import StatsClient
 
 log = logging.getLogger(__name__)
+DeltaType = Union[int, float, datetime.timedelta]
 
 
 class TimerProtocol(Protocol):
@@ -96,7 +97,7 @@ class StatsLogger(Protocol):
     def timing(
         cls,
         stat: str,
-        dt: int | float | datetime.timedelta,
+        dt: DeltaType | None,
         *,
         tags: dict[str, str] | None = None,
     ) -> None:
@@ -333,9 +334,7 @@ class NoStatsLogger:
         """Gauge stat."""
 
     @classmethod
-    def timing(
-        cls, stat: str, dt: int | float | datetime.timedelta, *, tags: dict[str, str] | None = None
-    ) -> None:
+    def timing(cls, stat: str, dt: DeltaType, *, tags: dict[str, str] | None = None) -> None:
         """Stats timing."""
 
     @classmethod
@@ -410,7 +409,7 @@ class SafeStatsdLogger:
     def timing(
         self,
         stat: str,
-        dt: int | float | datetime.timedelta,
+        dt: DeltaType,
         *,
         tags: dict[str, str] | None = None,
     ) -> None:
@@ -514,7 +513,7 @@ class SafeDogStatsdLogger:
     def timing(
         self,
         stat: str,
-        dt: int | float | datetime.timedelta,
+        dt: DeltaType,
         *,
         tags: dict[str, str] | None = None,
     ) -> None:

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -435,9 +435,7 @@ class TestDagFileProcessor:
         mock_log.exception.assert_called_once_with(
             "Could not send SLA Miss email notification for DAG %s", dag_id
         )
-        mock_stats_incr.assert_called_once_with(
-            "sla_email_notification_failure", tags={"dag_id": dag_id, "email": str({email})}
-        )
+        mock_stats_incr.assert_called_once_with("sla_email_notification_failure", tags={"dag_id": dag_id})
 
     @mock.patch("airflow.dag_processing.processor.DagFileProcessor._get_dagbag")
     def test_dag_file_processor_sla_miss_deleted_task(self, mock_get_dagbag, create_dummy_dag):

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -248,9 +248,7 @@ class TestDagFileProcessor:
             .count()
         )
         assert sla_miss_count == 1
-        mock_stats_incr.assert_called_with(
-            "sla_missed", tags={"dag_id": "test_sla_miss", "run_id": "test", "task_id": "dummy"}
-        )
+        mock_stats_incr.assert_called_with("sla_missed", tags={"dag_id": "test_sla_miss", "task_id": "dummy"})
         # Now call manage_slas and see that it runs without errors
         # because of existing SlaMiss above.
         # Since this is run often, it's possible that it runs before another
@@ -300,9 +298,7 @@ class TestDagFileProcessor:
             .count()
         )
         assert sla_miss_count == 2
-        mock_stats_incr.assert_called_with(
-            "sla_missed", tags={"dag_id": "test_sla_miss", "run_id": "test", "task_id": "dummy"}
-        )
+        mock_stats_incr.assert_called_with("sla_missed", tags={"dag_id": "test_sla_miss", "task_id": "dummy"})
 
     @patch.object(DagFileProcessor, "logger")
     @mock.patch("airflow.dag_processing.processor.Stats.incr")

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -404,15 +404,18 @@ class TestDagFileProcessor:
         sending an email
         """
         session = settings.Session()
+        dag_id = "test_sla_miss"
+        task_id = "test_ti"
+        email = "test@test.com"
 
         # Mock the callback function so we can verify that it was not called
         mock_send_email.side_effect = RuntimeError("Could not send an email")
 
         test_start_date = timezone.utcnow() - datetime.timedelta(days=1)
         dag, task = create_dummy_dag(
-            dag_id="test_sla_miss",
-            task_id="dummy",
-            email="test@test.com",
+            dag_id=dag_id,
+            task_id=task_id,
+            email=email,
             default_args={"start_date": test_start_date, "sla": datetime.timedelta(hours=1)},
         )
         mock_stats_incr.reset_mock()
@@ -420,7 +423,7 @@ class TestDagFileProcessor:
         session.merge(TaskInstance(task=task, execution_date=test_start_date, state="Success"))
 
         # Create an SlaMiss where notification was sent, but email was not
-        session.merge(SlaMiss(task_id="dummy", dag_id="test_sla_miss", execution_date=test_start_date))
+        session.merge(SlaMiss(task_id=task_id, dag_id=dag_id, execution_date=test_start_date))
 
         mock_log = mock.Mock()
         mock_get_log.return_value = mock_log
@@ -428,12 +431,12 @@ class TestDagFileProcessor:
         mock_dagbag.get_dag.return_value = dag
         mock_get_dagbag.return_value = mock_dagbag
 
-        DagFileProcessor.manage_slas(dag_folder=dag.fileloc, dag_id="test_sla_miss", session=session)
+        DagFileProcessor.manage_slas(dag_folder=dag.fileloc, dag_id=dag_id, session=session)
         mock_log.exception.assert_called_once_with(
-            "Could not send SLA Miss email notification for DAG %s", "test_sla_miss"
+            "Could not send SLA Miss email notification for DAG %s", dag_id
         )
         mock_stats_incr.assert_called_once_with(
-            "sla_email_notification_failure", tags={"dag_id": "test_sla_miss"}
+            "sla_email_notification_failure", tags={"dag_id": dag_id, "email": str({email})}
         )
 
     @mock.patch("airflow.dag_processing.processor.DagFileProcessor._get_dagbag")

--- a/tests/executors/test_base_executor.py
+++ b/tests/executors/test_base_executor.py
@@ -87,9 +87,11 @@ def test_gauge_executor_metrics(mock_stats_gauge, mock_trigger_tasks, mock_sync)
     executor = BaseExecutor()
     executor.heartbeat()
     calls = [
-        mock.call("executor.open_slots", mock.ANY),
-        mock.call("executor.queued_tasks", mock.ANY),
-        mock.call("executor.running_tasks", mock.ANY),
+        mock.call("executor.open_slots", value=mock.ANY, tags={"status": "open", "name": "BaseExecutor"}),
+        mock.call("executor.queued_tasks", value=mock.ANY, tags={"status": "queued", "name": "BaseExecutor"}),
+        mock.call(
+            "executor.running_tasks", value=mock.ANY, tags={"status": "running", "name": "BaseExecutor"}
+        ),
     ]
     mock_stats_gauge.assert_has_calls(calls)
 

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -124,9 +124,15 @@ class TestCeleryExecutor:
         executor = celery_executor.CeleryExecutor()
         executor.heartbeat()
         calls = [
-            mock.call("executor.open_slots", mock.ANY),
-            mock.call("executor.queued_tasks", mock.ANY),
-            mock.call("executor.running_tasks", mock.ANY),
+            mock.call(
+                "executor.open_slots", value=mock.ANY, tags={"status": "open", "name": "CeleryExecutor"}
+            ),
+            mock.call(
+                "executor.queued_tasks", value=mock.ANY, tags={"status": "queued", "name": "CeleryExecutor"}
+            ),
+            mock.call(
+                "executor.running_tasks", value=mock.ANY, tags={"status": "running", "name": "CeleryExecutor"}
+            ),
         ]
         mock_stats_gauge.assert_has_calls(calls)
 

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -396,9 +396,19 @@ class TestKubernetesExecutor:
         executor = self.kubernetes_executor
         executor.heartbeat()
         calls = [
-            mock.call("executor.open_slots", mock.ANY),
-            mock.call("executor.queued_tasks", mock.ANY),
-            mock.call("executor.running_tasks", mock.ANY),
+            mock.call(
+                "executor.open_slots", value=mock.ANY, tags={"status": "open", "name": "KubernetesExecutor"}
+            ),
+            mock.call(
+                "executor.queued_tasks",
+                value=mock.ANY,
+                tags={"status": "queued", "name": "KubernetesExecutor"},
+            ),
+            mock.call(
+                "executor.running_tasks",
+                value=mock.ANY,
+                tags={"status": "running", "name": "KubernetesExecutor"},
+            ),
         ]
         mock_stats_gauge.assert_has_calls(calls)
 

--- a/tests/executors/test_local_executor.py
+++ b/tests/executors/test_local_executor.py
@@ -132,8 +132,14 @@ class TestLocalExecutor:
         executor = LocalExecutor()
         executor.heartbeat()
         calls = [
-            mock.call("executor.open_slots", mock.ANY),
-            mock.call("executor.queued_tasks", mock.ANY),
-            mock.call("executor.running_tasks", mock.ANY),
+            mock.call(
+                "executor.open_slots", value=mock.ANY, tags={"status": "open", "name": "LocalExecutor"}
+            ),
+            mock.call(
+                "executor.queued_tasks", value=mock.ANY, tags={"status": "queued", "name": "LocalExecutor"}
+            ),
+            mock.call(
+                "executor.running_tasks", value=mock.ANY, tags={"status": "running", "name": "LocalExecutor"}
+            ),
         ]
         mock_stats_gauge.assert_has_calls(calls)

--- a/tests/executors/test_sequential_executor.py
+++ b/tests/executors/test_sequential_executor.py
@@ -48,8 +48,18 @@ class TestSequentialExecutor:
         executor = SequentialExecutor()
         executor.heartbeat()
         calls = [
-            mock.call("executor.open_slots", mock.ANY),
-            mock.call("executor.queued_tasks", mock.ANY),
-            mock.call("executor.running_tasks", mock.ANY),
+            mock.call(
+                "executor.open_slots", value=mock.ANY, tags={"status": "open", "name": "SequentialExecutor"}
+            ),
+            mock.call(
+                "executor.queued_tasks",
+                value=mock.ANY,
+                tags={"status": "queued", "name": "SequentialExecutor"},
+            ),
+            mock.call(
+                "executor.running_tasks",
+                value=mock.ANY,
+                tags={"status": "running", "name": "SequentialExecutor"},
+            ),
         ]
         mock_stats_gauge.assert_has_calls(calls)

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -271,10 +271,8 @@ class TestSchedulerJob:
                     "scheduler.tasks.killed_externally",
                     tags={"dag_id": dag_id, "run_id": ti1.run_id, "task_id": ti1.task_id},
                 ),
-                mock.call("operator_failures_EmptyOperator"),
-                mock.call(
-                    "ti_failures", tags={"dag_id": dag_id, "run_id": ti1.run_id, "task_id": ti1.task_id}
-                ),
+                mock.call("operator_failures_EmptyOperator", tags={"dag_id": dag_id, "task_id": ti1.task_id}),
+                mock.call("ti_failures", tags={"dag_id": dag_id, "task_id": ti1.task_id}),
             ],
             any_order=True,
         )
@@ -283,7 +281,8 @@ class TestSchedulerJob:
     @mock.patch("airflow.jobs.scheduler_job_runner.Stats.incr")
     def test_process_executor_events_with_no_callback(self, mock_stats_incr, mock_task_callback, dag_maker):
         dag_id = "test_process_executor_events_with_no_callback"
-        task_id_1 = "dummy_task"
+        task_id = "test_task"
+        run_id = "test_run"
 
         mock_stats_incr.reset_mock()
         executor = MockExecutor(do_update=False)
@@ -295,9 +294,9 @@ class TestSchedulerJob:
 
         session = settings.Session()
         with dag_maker(dag_id=dag_id, fileloc="/test_path1/"):
-            task1 = EmptyOperator(task_id=task_id_1, retries=1)
+            task1 = EmptyOperator(task_id=task_id, retries=1)
         ti1 = dag_maker.create_dagrun(
-            run_id="dr2", execution_date=DEFAULT_DATE + timedelta(hours=1)
+            run_id=run_id, execution_date=DEFAULT_DATE + timedelta(hours=1)
         ).get_task_instance(task1.task_id)
 
         mock_stats_incr.reset_mock()
@@ -333,10 +332,10 @@ class TestSchedulerJob:
             [
                 mock.call(
                     "scheduler.tasks.killed_externally",
-                    tags={"dag_id": dag_id, "run_id": "dr2", "task_id": task_id_1},
+                    tags={"dag_id": dag_id, "run_id": run_id, "task_id": task_id},
                 ),
-                mock.call("operator_failures_EmptyOperator"),
-                mock.call("ti_failures", tags={"dag_id": dag_id, "run_id": "dr2", "task_id": task_id_1}),
+                mock.call("operator_failures_EmptyOperator", tags={"dag_id": dag_id, "task_id": task_id}),
+                mock.call("ti_failures", tags={"dag_id": dag_id, "task_id": task_id}),
             ],
             any_order=True,
         )

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -269,7 +269,7 @@ class TestSchedulerJob:
             [
                 mock.call(
                     "scheduler.tasks.killed_externally",
-                    tags={"dag_id": dag_id, "run_id": ti1.run_id, "task_id": ti1.task_id},
+                    tags={"dag_id": dag_id, "task_id": ti1.task_id},
                 ),
                 mock.call("operator_failures_EmptyOperator", tags={"dag_id": dag_id, "task_id": ti1.task_id}),
                 mock.call("ti_failures", tags={"dag_id": dag_id, "task_id": ti1.task_id}),
@@ -332,7 +332,7 @@ class TestSchedulerJob:
             [
                 mock.call(
                     "scheduler.tasks.killed_externally",
-                    tags={"dag_id": dag_id, "run_id": run_id, "task_id": task_id},
+                    tags={"dag_id": dag_id, "task_id": task_id},
                 ),
                 mock.call("operator_failures_EmptyOperator", tags={"dag_id": dag_id, "task_id": task_id}),
                 mock.call("ti_failures", tags={"dag_id": dag_id, "task_id": task_id}),
@@ -386,7 +386,6 @@ class TestSchedulerJob:
             "scheduler.tasks.killed_externally",
             tags={
                 "dag_id": "test_process_executor_events_with_callback",
-                "run_id": "test",
                 "task_id": "dummy_task",
             },
         )

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1478,7 +1478,7 @@ class TestDag:
 
         mock_stats.incr.assert_called_with(
             "dag.callback_exceptions",
-            tags={"dag_id": "test_dag_callback_crash", "run_id": "manual__2015-01-02T00:00:00+00:00"},
+            tags={"dag_id": "test_dag_callback_crash"},
         )
 
         dag.clear()

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2516,6 +2516,7 @@ class TestTaskInstance:
         ti.task = None
         ti.state = State.QUEUED
         session.flush()
+        expected_stats_tags = {"dag_id": ti.dag_id, "task_id": ti.task_id}
 
         assert ti.task is None, "Check critical pre-condition"
 
@@ -2529,10 +2530,8 @@ class TestTaskInstance:
         # Check 'ti.try_number' is bumped to 2. This is try_number for next run
         assert ti.try_number == 2
 
-        Stats_incr.assert_any_call(
-            "ti_failures", tags={"dag_id": ti.dag_id, "run_id": ti.run_id, "task_id": ti.task_id}
-        )
-        Stats_incr.assert_any_call("operator_failures_EmptyOperator")
+        Stats_incr.assert_any_call("ti_failures", tags=expected_stats_tags)
+        Stats_incr.assert_any_call("operator_failures_EmptyOperator", tags=expected_stats_tags)
 
     def test_handle_failure_task_undefined(self, create_task_instance):
         """
@@ -2641,10 +2640,23 @@ class TestTaskInstance:
         session.commit()
         ti._run_raw_task()
         ti.refresh_from_db()
-        stats_mock.assert_called_with(f"ti.finish.{ti.dag_id}.{ti.task_id}.{ti.state}")
+        stats_mock.assert_called_with(
+            f"ti.finish.{ti.dag_id}.{ti.task_id}.{ti.state}",
+            tags={"dag_id": ti.dag_id, "task_id": ti.task_id},
+        )
         for state in State.task_states:
-            assert call(f"ti.finish.{ti.dag_id}.{ti.task_id}.{state}", count=0) in stats_mock.mock_calls
-        assert call(f"ti.start.{ti.dag_id}.{ti.task_id}") in stats_mock.mock_calls
+            assert (
+                call(
+                    f"ti.finish.{ti.dag_id}.{ti.task_id}.{state}",
+                    count=0,
+                    tags={"dag_id": ti.dag_id, "task_id": ti.task_id},
+                )
+                in stats_mock.mock_calls
+            )
+        assert (
+            call(f"ti.start.{ti.dag_id}.{ti.task_id}", tags={"dag_id": ti.dag_id, "task_id": ti.task_id})
+            in stats_mock.mock_calls
+        )
         assert stats_mock.call_count == len(State.task_states) + 4
 
     def test_command_as_list(self, create_task_instance):


### PR DESCRIPTION
Groundwork PR for the AIP-49 OpenTelemetry integration work.  Many stats had tagging already, this PR cleans up some of them and adds tagging to the ones that were missing it.

cc @o-nikolas @vincbeck @vandonr-amz @syedahsn 