### PR TITLE
Put AIP-52 setup/teardown tasks behind feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ env:
   USE_SUDO: "true"
   INCLUDE_SUCCESS_OUTPUTS: "true"
   AIRFLOW_ENABLE_AIP_44: "true"
+  AIRFLOW_ENABLE_AIP_52: "true"
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}

--- a/airflow/decorators/setup_teardown.py
+++ b/airflow/decorators/setup_teardown.py
@@ -22,9 +22,13 @@ from typing import Callable
 from airflow import AirflowException
 from airflow.decorators import python_task
 from airflow.decorators.task_group import _TaskGroupFactory
+from airflow.settings import _ENABLE_AIP_52
 
 
 def setup_task(func: Callable) -> Callable:
+    if not _ENABLE_AIP_52:
+        raise AirflowException("AIP-52 Setup tasks are disabled.")
+
     # Using FunctionType here since _TaskDecorator is also a callable
     if isinstance(func, types.FunctionType):
         func = python_task(func)
@@ -35,6 +39,9 @@ def setup_task(func: Callable) -> Callable:
 
 
 def teardown_task(_func=None, *, on_failure_fail_dagrun: bool = False) -> Callable:
+    if not _ENABLE_AIP_52:
+        raise AirflowException("AIP-52 Teardown tasks are disabled.")
+
     def teardown(func: Callable) -> Callable:
         # Using FunctionType here since _TaskDecorator is also a callable
         if isinstance(func, types.FunctionType):

--- a/airflow/example_dags/example_setup_teardown.py
+++ b/airflow/example_dags/example_setup_teardown.py
@@ -22,23 +22,25 @@ import pendulum
 
 from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
+from airflow.settings import _ENABLE_AIP_52
 from airflow.utils.task_group import TaskGroup
 
-with DAG(
-    dag_id="example_setup_teardown",
-    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
-    catchup=False,
-    tags=["example"],
-) as dag:
-    BashOperator.as_setup(task_id="root_setup", bash_command="echo 'Hello from root_setup'")
-    normal = BashOperator(task_id="normal", bash_command="echo 'I am just a normal task'")
-    BashOperator.as_teardown(task_id="root_teardown", bash_command="echo 'Goodbye from root_teardown'")
+if _ENABLE_AIP_52:
+    with DAG(
+        dag_id="example_setup_teardown",
+        start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+        catchup=False,
+        tags=["example"],
+    ) as dag:
+        BashOperator.as_setup(task_id="root_setup", bash_command="echo 'Hello from root_setup'")
+        normal = BashOperator(task_id="normal", bash_command="echo 'I am just a normal task'")
+        BashOperator.as_teardown(task_id="root_teardown", bash_command="echo 'Goodbye from root_teardown'")
 
-    with TaskGroup("section_1") as section_1:
-        BashOperator.as_setup(task_id="taskgroup_setup", bash_command="echo 'Hello from taskgroup_setup'")
-        BashOperator(task_id="normal", bash_command="echo 'I am just a normal task'")
-        BashOperator.as_setup(
-            task_id="taskgroup_teardown", bash_command="echo 'Hello from taskgroup_teardown'"
-        )
+        with TaskGroup("section_1") as section_1:
+            BashOperator.as_setup(task_id="taskgroup_setup", bash_command="echo 'Hello from taskgroup_setup'")
+            BashOperator(task_id="normal", bash_command="echo 'I am just a normal task'")
+            BashOperator.as_setup(
+                task_id="taskgroup_teardown", bash_command="echo 'Hello from taskgroup_teardown'"
+            )
 
-    normal >> section_1
+        normal >> section_1

--- a/airflow/example_dags/example_setup_teardown_taskflow.py
+++ b/airflow/example_dags/example_setup_teardown_taskflow.py
@@ -22,49 +22,51 @@ import pendulum
 
 from airflow.decorators import setup, task, task_group, teardown
 from airflow.models.dag import DAG
+from airflow.settings import _ENABLE_AIP_52
 
-with DAG(
-    dag_id="example_setup_teardown_taskflow",
-    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
-    catchup=False,
-    tags=["example"],
-) as dag:
-    # You can use the setup and teardown decorators to add setup and teardown tasks at the DAG level
-    @setup
-    @task
-    def root_setup():
-        print("Hello from root_setup")
-
-    @teardown
-    @task
-    def root_teardown():
-        print("Goodbye from root_teardown")
-
-    @task
-    def normal():
-        print("I am just a normal task")
-
-    @task_group
-    def section_1():
-        # You can also have setup and teardown tasks at the task group level
+if _ENABLE_AIP_52:
+    with DAG(
+        dag_id="example_setup_teardown_taskflow",
+        start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+        catchup=False,
+        tags=["example"],
+    ) as dag:
+        # You can use the setup and teardown decorators to add setup and teardown tasks at the DAG level
         @setup
         @task
-        def my_setup():
-            print("I set up")
+        def root_setup():
+            print("Hello from root_setup")
 
         @teardown
         @task
-        def my_teardown():
-            print("I tear down")
+        def root_teardown():
+            print("Goodbye from root_teardown")
 
         @task
-        def hello():
-            print("I say hello")
+        def normal():
+            print("I am just a normal task")
 
-        my_setup()
-        hello()
-        my_teardown()
+        @task_group
+        def section_1():
+            # You can also have setup and teardown tasks at the task group level
+            @setup
+            @task
+            def my_setup():
+                print("I set up")
 
-    root_setup()
-    normal() >> section_1()
-    root_teardown()
+            @teardown
+            @task
+            def my_teardown():
+                print("I tear down")
+
+            @task
+            def hello():
+                print("I say hello")
+
+            my_setup()
+            hello()
+            my_teardown()
+
+        root_setup()
+        normal() >> section_1()
+        root_teardown()

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -925,12 +925,22 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
 
     @classmethod
     def as_setup(cls, *args, **kwargs):
+        from airflow.settings import _ENABLE_AIP_52
+
+        if not _ENABLE_AIP_52:
+            raise AirflowException("AIP-52 Setup tasks are disabled.")
+
         op = cls(*args, **kwargs)
         op._is_setup = True
         return op
 
     @classmethod
     def as_teardown(cls, *args, **kwargs):
+        from airflow.settings import _ENABLE_AIP_52
+
+        if not _ENABLE_AIP_52:
+            raise AirflowException("AIP-52 Teardown tasks are disabled.")
+
         on_failure_fail_dagrun = kwargs.pop("on_failure_fail_dagrun", False)
         op = cls(*args, **kwargs)
         op._is_teardown = True

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -610,6 +610,7 @@ DAEMON_UMASK: str = conf.get("core", "daemon_umask", fallback="0o077")
 # AIP-52: setup/teardown (experimental)
 # This feature is not complete yet, so we disable it by default.
 _ENABLE_AIP_52 = os.environ.get("AIRFLOW_ENABLE_AIP_52", "false").lower() in {"true", "t", "yes", "y", "1"}
+
 # AIP-44: internal_api (experimental)
 # This feature is not complete yet, so we disable it by default.
-_ENABLE_AIP_44 = os.environ.get("AIRFLOW_ENABLE_AIP_44", "false").lower() in ("true", "t", "yes", "y", "1")
+_ENABLE_AIP_44 = os.environ.get("AIRFLOW_ENABLE_AIP_44", "false").lower() in {"true", "t", "yes", "y", "1"}

--- a/tests/always/test_example_dags.py
+++ b/tests/always/test_example_dags.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import pytest
 
 from airflow.models import DagBag
+from airflow.settings import _ENABLE_AIP_52
 from airflow.utils import yaml
 from tests.test_utils.asserts import assert_queries_count
 
@@ -59,8 +60,12 @@ def example_not_suspended_dags():
     for example_dir in example_dirs:
         candidates = glob(f"{AIRFLOW_SOURCES_ROOT.as_posix()}/{example_dir}", recursive=True)
         for candidate in candidates:
-            if not any(candidate.startswith(s) for s in suspended_providers_folders):
-                yield candidate
+            if any(candidate.startswith(s) for s in suspended_providers_folders):
+                continue
+            # we will also suspend AIP-52 DAGs unless it is enabled
+            if not _ENABLE_AIP_52 and "example_setup_teardown" in candidate:
+                continue
+            yield candidate
 
 
 def example_dags_except_db_exception():

--- a/tests/decorators/test_external_python.py
+++ b/tests/decorators/test_external_python.py
@@ -28,6 +28,7 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from airflow.decorators import setup, task, teardown
+from airflow.settings import _ENABLE_AIP_52
 from airflow.utils import timezone
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
@@ -126,6 +127,7 @@ class TestExternalPythonDecorator:
 
         ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
+    @pytest.mark.skipif(not _ENABLE_AIP_52, reason="AIP-52 is disabled")
     def test_marking_external_python_task_as_setup(self, dag_maker, venv_python):
         @setup
         @task.external_python(python=venv_python)
@@ -140,6 +142,7 @@ class TestExternalPythonDecorator:
         assert setup_task._is_setup
         ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
+    @pytest.mark.skipif(not _ENABLE_AIP_52, reason="AIP-52 is disabled")
     def test_marking_external_python_task_as_teardown(self, dag_maker, venv_python):
         @teardown
         @task.external_python(python=venv_python)
@@ -154,6 +157,7 @@ class TestExternalPythonDecorator:
         assert teardown_task._is_teardown
         ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
+    @pytest.mark.skipif(not _ENABLE_AIP_52, reason="AIP-52 is disabled")
     @pytest.mark.parametrize("on_failure_fail_dagrun", [True, False])
     def test_marking_external_python_task_as_teardown_with_on_failure_fail(
         self, dag_maker, on_failure_fail_dagrun, venv_python

--- a/tests/decorators/test_python_virtualenv.py
+++ b/tests/decorators/test_python_virtualenv.py
@@ -24,6 +24,7 @@ from subprocess import CalledProcessError
 import pytest
 
 from airflow.decorators import setup, task, teardown
+from airflow.settings import _ENABLE_AIP_52
 from airflow.utils import timezone
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
@@ -177,6 +178,7 @@ class TestPythonVirtualenvDecorator:
 
         ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
+    @pytest.mark.skipif(not _ENABLE_AIP_52, reason="AIP-52 is disabled")
     def test_marking_virtualenv_python_task_as_setup(self, dag_maker):
         @setup
         @task.virtualenv
@@ -191,6 +193,7 @@ class TestPythonVirtualenvDecorator:
         assert setup_task._is_setup
         ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
+    @pytest.mark.skipif(not _ENABLE_AIP_52, reason="AIP-52 is disabled")
     def test_marking_virtualenv_python_task_as_teardown(self, dag_maker):
         @teardown
         @task.virtualenv
@@ -205,6 +208,7 @@ class TestPythonVirtualenvDecorator:
         assert teardown_task._is_teardown
         ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
+    @pytest.mark.skipif(not _ENABLE_AIP_52, reason="AIP-52 is disabled")
     @pytest.mark.parametrize("on_failure_fail_dagrun", [True, False])
     def test_marking_virtualenv_python_task_as_teardown_with_on_failure_fail(
         self, dag_maker, on_failure_fail_dagrun

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -22,8 +22,10 @@ import pytest
 from airflow import AirflowException
 from airflow.decorators import setup, task, task_group, teardown
 from airflow.operators.bash import BashOperator
+from airflow.settings import _ENABLE_AIP_52
 
 
+@pytest.mark.skipif(not _ENABLE_AIP_52, reason="AIP-52 is disabled")
 class TestSetupTearDownTask:
     def test_marking_functions_as_setup_task(self, dag_maker):
         @setup

--- a/tests/providers/cncf/kubernetes/decorators/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/decorators/test_kubernetes.py
@@ -23,6 +23,7 @@ from unittest import mock
 import pytest
 
 from airflow.decorators import setup, task, teardown
+from airflow.settings import _ENABLE_AIP_52
 from airflow.utils import timezone
 
 DEFAULT_DATE = timezone.datetime(2021, 9, 1)
@@ -166,6 +167,7 @@ def test_kubernetes_with_input_output(
     assert containers[1].volume_mounts[0].mount_path == "/airflow/xcom"
 
 
+@pytest.mark.skipif(not _ENABLE_AIP_52, reason="AIP-52 is disabled")
 def test_kubernetes_with_marked_as_setup(
     dag_maker, session, mock_create_pod: mock.Mock, mock_hook: mock.Mock
 ) -> None:
@@ -188,6 +190,7 @@ def test_kubernetes_with_marked_as_setup(
     assert setup_task._is_setup
 
 
+@pytest.mark.skipif(not _ENABLE_AIP_52, reason="AIP-52 is disabled")
 def test_kubernetes_with_marked_as_teardown(
     dag_maker, session, mock_create_pod: mock.Mock, mock_hook: mock.Mock
 ) -> None:

--- a/tests/providers/docker/decorators/test_docker.py
+++ b/tests/providers/docker/decorators/test_docker.py
@@ -22,6 +22,7 @@ from airflow.decorators import setup, task, teardown
 from airflow.exceptions import AirflowException
 from airflow.models import TaskInstance
 from airflow.models.dag import DAG
+from airflow.settings import _ENABLE_AIP_52
 from airflow.utils import timezone
 from airflow.utils.state import TaskInstanceState
 
@@ -145,6 +146,7 @@ class TestDockerDecorator:
             ti = dr.get_task_instances()[0]
             assert ti.state == expected_state
 
+    @pytest.mark.skipif(not _ENABLE_AIP_52, reason="AIP-52 is disabled")
     def test_setup_decorator_with_decorated_docker_task(self, dag_maker):
         @setup
         @task.docker(image="python:3.9-slim", auto_remove="force")
@@ -158,6 +160,7 @@ class TestDockerDecorator:
         setup_task = dag.task_group.children["f"]
         assert setup_task._is_setup
 
+    @pytest.mark.skipif(not _ENABLE_AIP_52, reason="AIP-52 is disabled")
     def test_teardown_decorator_with_decorated_docker_task(self, dag_maker):
         @teardown
         @task.docker(image="python:3.9-slim", auto_remove="force")
@@ -171,6 +174,7 @@ class TestDockerDecorator:
         teardown_task = dag.task_group.children["f"]
         assert teardown_task._is_teardown
 
+    @pytest.mark.skipif(not _ENABLE_AIP_52, reason="AIP-52 is disabled")
     @pytest.mark.parametrize("on_failure_fail_dagrun", [True, False])
     def test_teardown_decorator_with_decorated_docker_task_and_on_failure_fail_arg(
         self, dag_maker, on_failure_fail_dagrun

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1318,6 +1318,7 @@ class TestStringifiedDAGs:
         assert task._is_setup == is_setup
         assert task._is_teardown == is_teardown
 
+    @pytest.mark.skipif(not airflow.settings._ENABLE_AIP_52, reason="AIP-52 is disabled")
     def test_setup_teardown_tasks(self):
         """
         Test setup and teardown task serialization/deserialization.
@@ -1375,6 +1376,7 @@ class TestStringifiedDAGs:
             se_second_group.children["group1.group2.teardown2"], is_teardown=True
         )
 
+    @pytest.mark.skipif(not airflow.settings._ENABLE_AIP_52, reason="AIP-52 is disabled")
     def test_teardown_task_on_failure_fail_dagrun_serialization(self, dag_maker):
         with dag_maker() as dag:
 

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -25,6 +25,7 @@ import pytest
 
 from airflow.models import DagModel
 from airflow.security import permissions
+from airflow.settings import _ENABLE_AIP_52
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.state import State
@@ -249,13 +250,16 @@ def test_dag_autocomplete_success(client_all_dags):
         "dagmodel/autocomplete?query=flow",
         follow_redirects=False,
     )
-    assert resp.json == [
+    expected = [
         {"name": "airflow", "type": "owner"},
-        {"name": "example_setup_teardown_taskflow", "type": "dag"},
         {"name": "test_mapped_taskflow", "type": "dag"},
         {"name": "tutorial_taskflow_api", "type": "dag"},
         {"name": "tutorial_taskflow_api_virtualenv", "type": "dag"},
     ]
+    if _ENABLE_AIP_52:
+        expected.insert(1, {"name": "example_setup_teardown_taskflow", "type": "dag"})
+
+    assert resp.json == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We aren't going to land AIP-52 in time for 2.6, so put the authoring api behind a feature flag. I've chosen to put it in `airflow.settings` so users can set it in `airflow_local_settings`, or set it via env var.