### PR TITLE
Put AIP-44 internal API behind feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ env:
   IMAGE_TAG: "${{ github.event.pull_request.head.sha || github.sha }}"
   USE_SUDO: "true"
   INCLUDE_SUCCESS_OUTPUTS: "true"
+  AIRFLOW_ENABLE_AIP_44: "true"
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
@@ -937,7 +938,54 @@ jobs:
       BACKEND_VERSION: "${{needs.build-info.outputs.default-postgres-version}}"
       UPGRADE_BOTO: "true"
       JOB_ID: >
-        postgres-${{needs.build-info.outputs.default-python-version}}-
+        postgres-boto-${{needs.build-info.outputs.default-python-version}}-
+        ${{needs.build-info.outputs.default-postgres-version}}
+      COVERAGE: "${{needs.build-info.outputs.run-coverage}}"
+    if: needs.build-info.outputs.run-tests == 'true' && needs.build-info.outputs.run-amazon-tests == 'true'
+    steps:
+      - name: Cleanup repo
+        shell: bash
+        run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: >
+          Prepare breeze & CI image: ${{needs.build-info.outputs.default-python-version}}:${{env.IMAGE_TAG}}
+        uses: ./.github/actions/prepare_breeze_and_image
+      - name: >
+          Tests: ${{needs.build-info.outputs.default-python-version}}:
+          ${{needs.build-info.outputs.parallel-test-types}}
+        run: breeze testing tests --run-in-parallel
+      - name: >
+          Post Tests: ${{needs.build-info.outputs.default-python-version}}:
+          ${{needs.build-info.outputs.parallel-test-types}}
+        uses: ./.github/actions/post_tests
+
+  tests-postgres-in-progress-features-disabled:
+    timeout-minutes: 130
+    name: >
+      InProgressDisabledPostgres${{needs.build-info.outputs.default-postgres-version}},
+      Py${{needs.build-info.outputs.default-python-version}}:
+      ${{needs.build-info.outputs.parallel-test-types}}
+    runs-on: "${{needs.build-info.outputs.runs-on}}"
+    needs: [build-info, test-pytest-collection]
+    env:
+      RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
+      PARALLEL_TEST_TYPES: "${{needs.build-info.outputs.parallel-test-types}}"
+      SUSPENDED_PROVIDERS_FOLDERS: "${{ needs.build-info.outputs.suspended-providers-folders }}"
+      PR_LABELS: "${{needs.build-info.outputs.pull-request-labels}}"
+      FULL_TESTS_NEEDED: "${{needs.build-info.outputs.full-tests-needed}}"
+      DEBUG_RESOURCES: "${{needs.build-info.outputs.debug-resources}}"
+      BACKEND: "postgres"
+      PYTHON_MAJOR_MINOR_VERSION: "${{needs.build-info.outputs.default-python-version}}"
+      PYTHON_VERSION: "${needs.build-info.outputs.default-python-version}}"
+      POSTGRES_VERSION: "${{needs.build-info.outputs.default-postgres-version}}"
+      BACKEND_VERSION: "${{needs.build-info.outputs.default-postgres-version}}"
+      AIRFLOW_ENABLE_AIP_44: "false"
+      AIRFLOW_ENABLE_AIP_52: "false"
+      JOB_ID: >
+        postgres-in-progress-disabled-${{needs.build-info.outputs.default-python-version}}-
         ${{needs.build-info.outputs.default-postgres-version}}
       COVERAGE: "${{needs.build-info.outputs.run-coverage}}"
     if: needs.build-info.outputs.run-tests == 'true' && needs.build-info.outputs.run-amazon-tests == 'true'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -593,7 +593,7 @@ repos:
         files: config\.yml$|default_airflow\.cfg$|default\.cfg$
         pass_filenames: false
         require_serial: true
-        additional_dependencies: ['pyyaml']
+        additional_dependencies: ['pyyaml', 'packaging']
       - id: check-boring-cyborg-configuration
         name: Checks for Boring Cyborg configuration consistency
         language: python

--- a/airflow/api_internal/internal_api_call.py
+++ b/airflow/api_internal/internal_api_call.py
@@ -26,6 +26,7 @@ import requests
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException, AirflowException
+from airflow.settings import _ENABLE_AIP_44
 from airflow.typing_compat import ParamSpec
 
 PS = ParamSpec("PS")
@@ -63,7 +64,9 @@ class InternalApiConfig:
 
     @staticmethod
     def _init_values():
-        use_internal_api = conf.getboolean("core", "database_access_isolation")
+        use_internal_api = conf.getboolean("core", "database_access_isolation", fallback=False)
+        if use_internal_api and not _ENABLE_AIP_44:
+            raise RuntimeError("The AIP_44 is not enabled so you cannot use it.")
         internal_api_endpoint = ""
         if use_internal_api:
             internal_api_url = conf.get("core", "internal_api_url")

--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -34,6 +34,7 @@ from airflow.cli.commands.legacy_commands import check_legacy_command
 from airflow.configuration import conf
 from airflow.executors.executor_constants import CELERY_EXECUTOR, CELERY_KUBERNETES_EXECUTOR
 from airflow.executors.executor_loader import ExecutorLoader
+from airflow.settings import _ENABLE_AIP_44
 from airflow.utils.cli import ColorMode
 from airflow.utils.module_loading import import_string
 from airflow.utils.timezone import parse as parsedate
@@ -2069,29 +2070,6 @@ core_commands: list[CLICommand] = [
         ),
     ),
     ActionCommand(
-        name="internal-api",
-        help="Start a Airflow Internal API instance",
-        func=lazy_load_command("airflow.cli.commands.internal_api_command.internal_api"),
-        args=(
-            ARG_INTERNAL_API_PORT,
-            ARG_INTERNAL_API_WORKERS,
-            ARG_INTERNAL_API_WORKERCLASS,
-            ARG_INTERNAL_API_WORKER_TIMEOUT,
-            ARG_INTERNAL_API_HOSTNAME,
-            ARG_PID,
-            ARG_DAEMON,
-            ARG_STDOUT,
-            ARG_STDERR,
-            ARG_INTERNAL_API_ACCESS_LOGFILE,
-            ARG_INTERNAL_API_ERROR_LOGFILE,
-            ARG_INTERNAL_API_ACCESS_LOGFORMAT,
-            ARG_LOG_FILE,
-            ARG_SSL_CERT,
-            ARG_SSL_KEY,
-            ARG_DEBUG,
-        ),
-    ),
-    ActionCommand(
         name="scheduler",
         help="Start a scheduler instance",
         func=lazy_load_command("airflow.cli.commands.scheduler_command.scheduler"),
@@ -2230,6 +2208,33 @@ core_commands: list[CLICommand] = [
         args=tuple(),
     ),
 ]
+
+if _ENABLE_AIP_44:
+    core_commands.append(
+        ActionCommand(
+            name="internal-api",
+            help="Start a Airflow Internal API instance",
+            func=lazy_load_command("airflow.cli.commands.internal_api_command.internal_api"),
+            args=(
+                ARG_INTERNAL_API_PORT,
+                ARG_INTERNAL_API_WORKERS,
+                ARG_INTERNAL_API_WORKERCLASS,
+                ARG_INTERNAL_API_WORKER_TIMEOUT,
+                ARG_INTERNAL_API_HOSTNAME,
+                ARG_PID,
+                ARG_DAEMON,
+                ARG_STDOUT,
+                ARG_STDERR,
+                ARG_INTERNAL_API_ACCESS_LOGFILE,
+                ARG_INTERNAL_API_ERROR_LOGFILE,
+                ARG_INTERNAL_API_ACCESS_LOGFORMAT,
+                ARG_LOG_FILE,
+                ARG_SSL_CERT,
+                ARG_SSL_KEY,
+                ARG_DEBUG,
+            ),
+        ),
+    )
 
 
 def _remove_dag_id_opt(command: ActionCommand):

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -438,14 +438,14 @@ core:
       example: '{"some_param": "some_value"}'
     database_access_isolation:
       description: (experimental) Whether components should use Airflow Internal API for DB connectivity.
-      version_added: 2.6.0
+      version_added: 2.7.0
       type: boolean
       example: ~
       default: "False"
     internal_api_url:
       description: |
-        (experimental)Airflow Internal API url. Only used if [core] database_access_isolation is True.
-      version_added: 2.6.0
+        (experimental) Airflow Internal API url. Only used if [core] database_access_isolation is True.
+      version_added: 2.7.0
       type: string
       default: ~
       example: 'http://localhost:8080'
@@ -1674,7 +1674,7 @@ webserver:
     run_internal_api:
       description: |
         Boolean for running Internal API in the webserver.
-      version_added: 2.6.0
+      version_added: 2.7.0
       type: boolean
       example: ~
       default: "False"

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -250,13 +250,6 @@ daemon_umask = 0o077
 # Example: dataset_manager_kwargs = {{"some_param": "some_value"}}
 # dataset_manager_kwargs =
 
-# (experimental) Whether components should use Airflow Internal API for DB connectivity.
-database_access_isolation = False
-
-# (experimental)Airflow Internal API url. Only used if [core] database_access_isolation is True.
-# Example: internal_api_url = http://localhost:8080
-# internal_api_url =
-
 [database]
 # The SqlAlchemy connection string to the metadata database.
 # SqlAlchemy supports many different database engines.
@@ -856,9 +849,6 @@ audit_view_excluded_events = gantt,landing_times,tries,duration,calendar,graph,g
 
 # Boolean for running SwaggerUI in the webserver.
 enable_swagger_ui = True
-
-# Boolean for running Internal API in the webserver.
-run_internal_api = False
 
 # Boolean for enabling rate limiting on authentication endpoints.
 auth_rate_limited = True

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -605,3 +605,11 @@ DASHBOARD_UIALERTS: list[UIAlert] = []
 AIRFLOW_MOVED_TABLE_PREFIX = "_airflow_moved"
 
 DAEMON_UMASK: str = conf.get("core", "daemon_umask", fallback="0o077")
+
+
+# AIP-52: setup/teardown (experimental)
+# This feature is not complete yet, so we disable it by default.
+_ENABLE_AIP_52 = os.environ.get("AIRFLOW_ENABLE_AIP_52", "false").lower() in {"true", "t", "yes", "y", "1"}
+# AIP-44: internal_api (experimental)
+# This feature is not complete yet, so we disable it by default.
+_ENABLE_AIP_44 = os.environ.get("AIRFLOW_ENABLE_AIP_44", "false").lower() in ("true", "t", "yes", "y", "1")

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -34,6 +34,7 @@ from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException, RemovedInAirflow3Warning
 from airflow.logging_config import configure_logging
 from airflow.models import import_all_models
+from airflow.settings import _ENABLE_AIP_44
 from airflow.utils.json import AirflowJsonProvider
 from airflow.www.extensions.init_appbuilder import init_appbuilder
 from airflow.www.extensions.init_appbuilder_links import init_appbuilder_links
@@ -161,6 +162,8 @@ def create_app(config=None, testing=False):
         init_error_handlers(flask_app)
         init_api_connexion(flask_app)
         if conf.getboolean("webserver", "run_internal_api", fallback=False):
+            if not _ENABLE_AIP_44:
+                raise RuntimeError("The AIP_44 is not enabled so you cannot use it.")
             init_api_internal(flask_app)
         init_api_experimental(flask_app)
 

--- a/tests/api_internal/endpoints/test_rpc_api_endpoint.py
+++ b/tests/api_internal/endpoints/test_rpc_api_endpoint.py
@@ -27,6 +27,7 @@ from airflow.models.taskinstance import TaskInstance
 from airflow.operators.empty import EmptyOperator
 from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
 from airflow.serialization.serialized_objects import BaseSerialization
+from airflow.settings import _ENABLE_AIP_44
 from airflow.utils.state import State
 from airflow.www import app
 from tests.test_utils.config import conf_vars
@@ -53,6 +54,7 @@ def minimal_app_for_internal_api() -> Flask:
     return factory()
 
 
+@pytest.mark.skipif(not _ENABLE_AIP_44, reason="AIP-44 is disabled")
 class TestRpcApiEndpoint:
     @pytest.fixture(autouse=True)
     def setup_attrs(self, minimal_app_for_internal_api: Flask) -> Generator:

--- a/tests/api_internal/test_internal_api_call.py
+++ b/tests/api_internal/test_internal_api_call.py
@@ -29,6 +29,7 @@ from airflow.models.taskinstance import TaskInstance
 from airflow.operators.empty import EmptyOperator
 from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
 from airflow.serialization.serialized_objects import BaseSerialization
+from airflow.settings import _ENABLE_AIP_44
 from airflow.utils.state import State
 from tests.test_utils.config import conf_vars
 
@@ -38,6 +39,7 @@ def reset_init_api_config():
     InternalApiConfig._initialized = False
 
 
+@pytest.mark.skipif(not _ENABLE_AIP_44, reason="AIP-44 is disabled")
 class TestInternalApiConfig:
     @conf_vars(
         {
@@ -69,6 +71,7 @@ class TestInternalApiConfig:
         assert InternalApiConfig.get_use_internal_api() is False
 
 
+@pytest.mark.skipif(not _ENABLE_AIP_44, reason="AIP-44 is disabled")
 class TestInternalApiCall:
     @staticmethod
     @internal_api_call

--- a/tests/cli/commands/test_internal_api_command.py
+++ b/tests/cli/commands/test_internal_api_command.py
@@ -31,6 +31,7 @@ from airflow import settings
 from airflow.cli import cli_parser
 from airflow.cli.commands import internal_api_command
 from airflow.cli.commands.internal_api_command import GunicornMonitor
+from airflow.settings import _ENABLE_AIP_44
 from tests.cli.commands._common_cli_classes import _ComonCLIGunicornTestClass
 
 console = Console(width=400, color_system="standard")
@@ -82,6 +83,7 @@ class TestCLIGetNumReadyWorkersRunning:
             assert self.monitor._get_num_ready_workers_running() == 0
 
 
+@pytest.mark.skipif(not _ENABLE_AIP_44, reason="AIP-44 is disabled")
 class TestCliInternalAPI(_ComonCLIGunicornTestClass):
 
     main_process_regexp = r"airflow internal-api"


### PR DESCRIPTION
This includes:

* configurable setting with defaults taken from env variable
* raising exception if config variables are used with feature flag not enabled
* hiding config values (adding mechanism to hide config values that are set for the future versions)
* skipping tests

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
