### PR TITLE
Fix AzureDataFactoryPipelineRunLink UI link generation

### DIFF
--- a/airflow/providers/microsoft/azure/operators/data_factory.py
+++ b/airflow/providers/microsoft/azure/operators/data_factory.py
@@ -48,11 +48,8 @@ class AzureDataFactoryPipelineRunLink(LoggingMixin, BaseOperatorLink):
         *,
         ti_key: TaskInstanceKey,
     ) -> str:
-        if not isinstance(operator, AzureDataFactoryRunPipelineOperator):
-            self.log.info("The %s is not %s class.", operator.__class__, AzureDataFactoryRunPipelineOperator)
-            return ""
         run_id = XCom.get_value(key="run_id", ti_key=ti_key)
-        conn_id = operator.azure_data_factory_conn_id
+        conn_id = operator.azure_data_factory_conn_id  # type: ignore
         conn = BaseHook.get_connection(conn_id)
         extras = conn.extra_dejson
         subscription_id = get_field(extras, "subscriptionId")
@@ -60,8 +57,10 @@ class AzureDataFactoryPipelineRunLink(LoggingMixin, BaseOperatorLink):
             raise KeyError(f"Param subscriptionId not found in conn_id '{conn_id}'")
         # Both Resource Group Name and Factory Name can either be declared in the Azure Data Factory
         # connection or passed directly to the operator.
-        resource_group_name = operator.resource_group_name or get_field(extras, "resource_group_name")
-        factory_name = operator.factory_name or get_field(extras, "factory_name")
+        resource_group_name = operator.resource_group_name or get_field(  # type: ignore
+            extras, "resource_group_name"
+        )
+        factory_name = operator.factory_name or get_field(extras, "factory_name")  # type: ignore
         url = (
             f"https://adf.azure.com/en-us/monitoring/pipelineruns/{run_id}"
             f"?factory=/subscriptions/{subscription_id}/"


### PR DESCRIPTION
closes: #30504 

---
In the `extra_links` route, we are using the method `dag.get_task` to get the task:
https://github.com/apache/airflow/blob/a9d8ea08c6e80faff37bed552f5c98f3cb21c849/airflow/www/views.py#L3514-L3514
knowing that the dag contains a dict of `SerializedBaseOperator` instead of `BaseOperator`.

In `AzureDataFactoryPipelineRunLink`, a check on the operator type was added to fix the static checks, but this condition is always False, because the provided operator is an instance of `SerializedBaseOperator`. To fix this I just remove the check for now as we do for the other link classes, but we need to refacto all the typing part and the methods signatures.
