### PR TITLE
Fix sla checks being skipped when the later task instance is skipped

### DIFF
--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -29,7 +29,7 @@ from multiprocessing.connection import Connection as MultiprocessingConnection
 from typing import TYPE_CHECKING, Iterator
 
 from setproctitle import setproctitle
-from sqlalchemy import exc, func, or_
+from sqlalchemy import exc, func
 from sqlalchemy.orm.session import Session
 
 from airflow import settings
@@ -406,7 +406,7 @@ class DagFileProcessor(LoggingMixin):
             session.query(TI.task_id, func.max(DR.execution_date).label("max_ti"))
             .join(TI.dag_run)
             .filter(TI.dag_id == dag.dag_id)
-            .filter(or_(TI.state == State.SUCCESS))
+            .filter(TI.state == State.SUCCESS)
             .filter(TI.task_id.in_(dag.task_ids))
             .group_by(TI.task_id)
             .subquery("sq")

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -347,9 +347,7 @@ class TestDagFileProcessor:
             .count()
         )
         assert sla_miss_count == 1
-        mock_stats_incr.assert_called_with(
-            "sla_missed", tags={"dag_id": "test_sla_miss", "run_id": "test_0", "task_id": "dummy"}
-        )
+        mock_stats_incr.assert_called_with("sla_missed", tags={"dag_id": "test_sla_miss", "task_id": "dummy"})
 
     @patch.object(DagFileProcessor, "logger")
     @mock.patch("airflow.dag_processing.processor.Stats.incr")


### PR DESCRIPTION
In the following code, even though t1 does not become "success",
no SLA miss occurs because the state of the subsequent t1 becomes "skipped".

```python
from datetime import timedelta
from time import sleep

import pendulum
from airflow import DAG
from airflow.exceptions import AirflowSkipException, AirflowFailException
from airflow.operators.python import PythonOperator
from airflow.utils.dates import days_ago


def f():
    if pendulum.now().minute % 2 == 0:
        raise AirflowSkipException("skip")
    else:
        sleep(80)
        raise AirflowFailException("fail")

with DAG(
    dag_id="example_sla",
    schedule_interval="* * * * *",
    start_date=days_ago(2),
    catchup=False,
) as dag:
    PythonOperator(task_id="t1", python_callable=f, sla=timedelta(seconds=70))
```

In this PR, we would like to correct only the following behavior

- As-is
    - t1_1(state=other than success and skip): sla checks skipped by skipped t1_2
    - t1_2(state=skipped)
- To-be
    - t1_1(state=other than success and skip): sla checked
    - t1_2(state=skipped)

I believe the state=skipped behavior expected in the following PR is preserved.
https://github.com/apache/airflow/pull/3370