### PR TITLE
Add asgiref as a core dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,7 @@ install_requires =
     # together with SQLAlchemy. Our experience with Alembic is that it very stable in minor version
     alembic>=1.6.3, <2.0
     argcomplete>=1.10
+    asgiref
     attrs>=22.1.0
     blinker
     cached_property>=1.5.0;python_version<="3.7"


### PR DESCRIPTION
We added asgiref to core a few months back for the `sync_to_async` in
airflow.triggers.external_task.

Although the core http provider depends on asgiref since v 4.2 it is
possible to have an older version http installed meaning that you end up
without asgiref, which leads to every dag failing to parse as the
"dependency detector" code inside the DAG Serializer ends up importing
this module!

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
