### PR TITLE
Change timer type back to float

### DIFF
--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -158,10 +158,10 @@ class Timer(TimerProtocol):
     """
 
     # pystatsd and dogstatsd both have a timer class, but present different API
-    # so we can't use this as a mixin on those, instead this class is contains the "real" timer
+    # so we can't use this as a mixin on those, instead this class contains the "real" timer
 
-    _start_time: int | None
-    duration: int | None
+    _start_time: float | None
+    duration: float | None
 
     def __init__(self, real_timer: Timer | None = None) -> None:
         self.real_timer = real_timer
@@ -176,12 +176,13 @@ class Timer(TimerProtocol):
         """Start the timer."""
         if self.real_timer:
             self.real_timer.start()
-        self._start_time = int(time.perf_counter())
+        self._start_time = time.perf_counter()
         return self
 
     def stop(self, send: bool = True) -> None:
         """Stop the timer, and optionally send it to stats backend."""
-        self.duration = int(time.perf_counter()) - (self._start_time or 0)
+        if self._start_time is not None:
+            self.duration = time.perf_counter() - self._start_time
         if send and self.real_timer:
             self.real_timer.stop()
 

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -67,9 +67,10 @@ class TestStats:
         self.statsd_client.assert_not_called()
 
     def test_timer(self):
-        with self.stats.timer("empty_timer"):
+        with self.stats.timer("empty_timer") as t:
             pass
         self.statsd_client.timer.assert_called_once_with("empty_timer")
+        assert type(t.duration) == float
 
     def test_empty_timer(self):
         with self.stats.timer():


### PR DESCRIPTION
PR #30024 changed the timer from a float to int, in the name of type hinting. This reverts that change and just fixes the type hints.

(cc @ferruzzi)