### PR TITLE
Accept None for `EmailOperator.from_email` to load it from smtp connection

### DIFF
--- a/airflow/providers/smtp/operators/smtp.py
+++ b/airflow/providers/smtp/operators/smtp.py
@@ -51,9 +51,9 @@ class EmailOperator(BaseOperator):
         self,
         *,
         to: list[str] | str,
-        from_email: str,
         subject: str,
         html_content: str,
+        from_email: str | None = None,
         files: list | None = None,
         cc: list[str] | str | None = None,
         bcc: list[str] | str | None = None,
@@ -65,9 +65,9 @@ class EmailOperator(BaseOperator):
     ) -> None:
         super().__init__(**kwargs)
         self.to = to
-        self.from_email = from_email
         self.subject = subject
         self.html_content = html_content
+        self.from_email = from_email
         self.files = files or []
         self.cc = cc
         self.bcc = bcc
@@ -80,9 +80,9 @@ class EmailOperator(BaseOperator):
         with SmtpHook(smtp_conn_id=self.conn_id) as smtp_hook:
             return smtp_hook.send_email_smtp(
                 to=self.to,
-                from_email=self.from_email,
                 subject=self.subject,
                 html_content=self.html_content,
+                from_email=self.from_email,
                 files=self.files,
                 cc=self.cc,
                 bcc=self.bcc,

--- a/tests/providers/smtp/operators/__init__.py
+++ b/tests/providers/smtp/operators/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/smtp/operators/test_smtp.py
+++ b/tests/providers/smtp/operators/test_smtp.py
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from airflow.models import Connection
+from airflow.providers.smtp.operators.smtp import EmailOperator
+
+smtplib_string = "airflow.providers.smtp.hooks.smtp.smtplib"
+
+
+class TestEmailOperator:
+    @patch("airflow.providers.smtp.hooks.smtp.SmtpHook.get_connection")
+    @patch(smtplib_string)
+    def test_loading_sender_email_from_connection(self, mock_smtplib, mock_hook_conn):
+        """Check if the EmailOperator is able to load the sender email from the smtp connection."""
+        custom_retry_limit = 10
+        custom_timeout = 60
+        sender_email = "sender_email"
+        mock_hook_conn.return_value = Connection(
+            conn_id="mock_conn",
+            conn_type="smtp",
+            host="smtp_server_address",
+            login="smtp_user",
+            password="smtp_password",
+            port=465,
+            extra=json.dumps(
+                dict(from_email=sender_email, timeout=custom_timeout, retry_limit=custom_retry_limit)
+            ),
+        )
+        smtp_client_mock = mock_smtplib.SMTP_SSL()
+        op = EmailOperator(task_id="test_email", to="to", subject="subject", html_content="content")
+        op.execute({})
+        assert smtp_client_mock.sendmail.call_args_list[0].kwargs["from_addr"] == sender_email

--- a/tests/providers/smtp/operators/test_smtp.py
+++ b/tests/providers/smtp/operators/test_smtp.py
@@ -48,4 +48,5 @@ class TestEmailOperator:
         smtp_client_mock = mock_smtplib.SMTP_SSL()
         op = EmailOperator(task_id="test_email", to="to", subject="subject", html_content="content")
         op.execute({})
-        assert smtp_client_mock.sendmail.call_args_list[0].kwargs["from_addr"] == sender_email
+        call_args = smtp_client_mock.sendmail.call_args[1]
+        assert call_args["from_addr"] == sender_email


### PR DESCRIPTION
In this PR, I change the typing of `from_email` in the `EmailOperator` to accept None and I set the default value to None to automatically use the email provided in the connection without the need to explicitly set it to None.