### PR TITLE
Make AWS RDS operator page title consistent

### DIFF
--- a/docs/apache-airflow-providers-amazon/operators/rds.rst
+++ b/docs/apache-airflow-providers-amazon/operators/rds.rst
@@ -15,9 +15,9 @@
     specific language governing permissions and limitations
     under the License.
 
-======================================================
-Amazon Relational Database Service Documentation (RDS)
-======================================================
+========================================
+Amazon Relational Database Service (RDS)
+========================================
 
 `Amazon Relational Database Service (Amazon RDS) <https://aws.amazon.com/rds/>`__ is a web service that makes it
 easier to set up, operate, and scale a relational database in the cloud.


### PR DESCRIPTION
This PR changes the title of the RDS documentation page from "Amazon Relational Database Service Documentation (RDS)" to "Amazon Relational Database Service (RDS)". This page was the only one with the word "Documentation" in its title, and several other services had a similar title format of ("Amazon <full service name> (<acronym>)"), for example ["Amazon Simple Notification Service (SNS)"](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/operators/sns.html).

![image](https://user-images.githubusercontent.com/10214785/230679069-74c7694a-2716-49f8-b9ef-69943396ae42.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
