### PR TITLE
BigQueryHook list_rows/get_datasets_list can return iterator

### DIFF
--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -23,8 +23,10 @@ from unittest import mock
 
 import pytest
 from gcloud.aio.bigquery import Job, Table as Table_async
+from google.api_core import page_iterator
 from google.cloud.bigquery import DEFAULT_RETRY, DatasetReference, Table, TableReference
 from google.cloud.bigquery.dataset import AccessEntry, Dataset, DatasetListItem
+from google.cloud.bigquery.table import _EmptyRowIterator
 from google.cloud.exceptions import NotFound
 
 from airflow.exceptions import AirflowException
@@ -431,45 +433,63 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.SchemaField")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Client")
     def test_list_rows(self, mock_client, mock_schema, mock_table):
-        self.hook.list_rows(
-            dataset_id=DATASET_ID,
-            table_id=TABLE_ID,
-            max_results=10,
-            selected_fields=["field_1", "field_2"],
-            page_token="page123",
-            start_index=5,
-            location=LOCATION,
-        )
-        mock_table.from_api_repr.assert_called_once_with({"tableReference": TABLE_REFERENCE_REPR})
-        mock_schema.assert_has_calls([mock.call(x, "") for x in ["field_1", "field_2"]])
-        mock_client.return_value.list_rows.assert_called_once_with(
-            table=mock_table.from_api_repr.return_value,
-            max_results=10,
-            selected_fields=mock.ANY,
-            page_token="page123",
-            start_index=5,
-        )
+        mock_row_iterator = _EmptyRowIterator()
+        mock_client.return_value.list_rows.return_value = mock_row_iterator
+
+        for return_iterator, expected in [(False, []), (True, mock_row_iterator)]:
+            actual = self.hook.list_rows(
+                dataset_id=DATASET_ID,
+                table_id=TABLE_ID,
+                max_results=10,
+                selected_fields=["field_1", "field_2"],
+                page_token="page123",
+                start_index=5,
+                location=LOCATION,
+                return_iterator=return_iterator,
+            )
+            mock_table.from_api_repr.assert_called_once_with({"tableReference": TABLE_REFERENCE_REPR})
+            mock_schema.assert_has_calls([mock.call(x, "") for x in ["field_1", "field_2"]])
+            mock_client.return_value.list_rows.assert_called_once_with(
+                table=mock_table.from_api_repr.return_value,
+                max_results=10,
+                selected_fields=mock.ANY,
+                page_token="page123",
+                start_index=5,
+                retry=DEFAULT_RETRY,
+            )
+            assert actual == expected
+            mock_table.from_api_repr.reset_mock()
+            mock_client.return_value.list_rows.reset_mock()
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Table")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Client")
     def test_list_rows_with_empty_selected_fields(self, mock_client, mock_table):
-        self.hook.list_rows(
-            dataset_id=DATASET_ID,
-            table_id=TABLE_ID,
-            max_results=10,
-            page_token="page123",
-            selected_fields=[],
-            start_index=5,
-            location=LOCATION,
-        )
-        mock_table.from_api_repr.assert_called_once_with({"tableReference": TABLE_REFERENCE_REPR})
-        mock_client.return_value.list_rows.assert_called_once_with(
-            table=mock_table.from_api_repr.return_value,
-            max_results=10,
-            page_token="page123",
-            selected_fields=None,
-            start_index=5,
-        )
+        mock_row_iterator = _EmptyRowIterator()
+        mock_client.return_value.list_rows.return_value = mock_row_iterator
+
+        for return_iterator, expected in [(False, []), (True, mock_row_iterator)]:
+            actual = self.hook.list_rows(
+                dataset_id=DATASET_ID,
+                table_id=TABLE_ID,
+                max_results=10,
+                page_token="page123",
+                selected_fields=[],
+                start_index=5,
+                location=LOCATION,
+                return_iterator=return_iterator,
+            )
+            mock_table.from_api_repr.assert_called_once_with({"tableReference": TABLE_REFERENCE_REPR})
+            mock_client.return_value.list_rows.assert_called_once_with(
+                table=mock_table.from_api_repr.return_value,
+                max_results=10,
+                page_token="page123",
+                selected_fields=None,
+                start_index=5,
+                retry=DEFAULT_RETRY,
+            )
+            assert actual == expected
+            mock_table.from_api_repr.reset_mock()
+            mock_client.return_value.list_rows.reset_mock()
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Client")
     def test_run_table_delete(self, mock_client):
@@ -1552,6 +1572,25 @@ class TestDatasetsOperations(_BigQueryBaseTestClass):
         )
         for exp, res in zip(datasets, result):
             assert res.full_dataset_id == exp["id"]
+
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Client")
+    def test_get_datasets_list_returns_iterator(self, mock_client):
+        client = mock.sentinel.client
+        mock_iterator = page_iterator.HTTPIterator(
+            client, mock.sentinel.api_request, "/foo", mock.sentinel.item_to_value
+        )
+        mock_client.return_value.list_datasets.return_value = mock_iterator
+        actual = self.hook.get_datasets_list(project_id=PROJECT_ID, return_iterator=True)
+
+        mock_client.return_value.list_datasets.assert_called_once_with(
+            project=PROJECT_ID,
+            include_all=False,
+            filter=None,
+            max_results=None,
+            page_token=None,
+            retry=DEFAULT_RETRY,
+        )
+        assert actual == mock_iterator
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Client")
     def test_delete_dataset(self, mock_client):


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: https://github.com/apache/airflow/issues/29396

This PR adds a parameter, returns_iterator to both BigQueryHook.list_rows and BigQueryHook.get_datasets_list. Param defaults to False for backwards compatibility. If set to True, it returns a subclass of PageIterator (either a RowIterator in the case of list_rows or a HTTPIterator in the case of get_datasets_list). Some notes on PageIterator: https://googleapis.dev/python/google-api-core/latest/_modules/google/api_core/page_iterator.html

I also noticed the retry parameter was missing from list_rows. Added that as well and set it to the DEFAULT_RETRY object which is what it is set at if nothing is passed so should be backwards compatible but allow users to override if needed. --> https://github.com/googleapis/python-bigquery/blob/v2.34.4/google/cloud/bigquery/client.py#L3716

## Testing

Test DAG:

```py
from airflow import DAG
from airflow.decorators import task


DEFAULT_TASK_ARGS = {
    "owner": "gcp-data-platform",
    "start_date": "2023-03-13",
    "retries": 1,
    "retry_delay": 300,
}


@task
def list_rows(
    project_id: str, dataset_id: str, table_id: list[str], selected_fields: list[str]
):
    from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook

    hook = BigQueryHook(use_legacy_sql=False)
    iterator = hook.list_rows(
        project_id=project_id,
        dataset_id=dataset_id,
        table_id=table_id,
        selected_fields=selected_fields,
        return_iterator=True,
    )
    print(f"{iterator}")
    print(f"{iterator.next_page_token}")
    print(f"Num results {len(list(iterator))}")


@task
def list_datasets():
    from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook

    hook = BigQueryHook(use_legacy_sql=False)
    iterator = hook.get_datasets_list(
        project_id="bigquery-public-data",
        include_all=True,
        return_iterator=True
    )
    print(f"{iterator}")
    print(f"{iterator.next_page_token}")
    print(f"Num results {len(list(iterator))}")
    print(f"{iterator.next_page_token}")


with DAG(
    schedule_interval="@daily",
    max_active_runs=1,
    max_active_tasks=5,
    catchup=False,
    dag_id="test_bq_hook_ops",
    default_args=DEFAULT_TASK_ARGS,
) as dag:
    ls_rows = list_rows.override(task_id="ls_rows")(
        project_id="bigquery-public-data",
        dataset_id="baseball",
        table_id="schedules", # "games_wide",
        selected_fields=["gameId"],
    )

    ls_datasets = list_datasets.override(task_id="ls_datasets")()

```

<img width="1354" alt="image" src="https://user-images.githubusercontent.com/9200263/230728138-d1a20929-e980-472b-9567-2aac07fb03a9.png">

<img width="1363" alt="image" src="https://user-images.githubusercontent.com/9200263/230728143-c0fd6e65-1d53-4289-9de7-d59d1855611b.png">



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
