### PR TITLE
Add ability to override waiter delay in EcsRunTaskOperator

### DIFF
--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -339,7 +339,9 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
 
         self.ecs._wait_for_task_ended()
         client_mock.get_waiter.assert_called_once_with("tasks_stopped")
-        client_mock.get_waiter.return_value.wait.assert_called_once_with(cluster="c", tasks=["arn"])
+        client_mock.get_waiter.return_value.wait.assert_called_once_with(
+            cluster="c", tasks=["arn"], WaiterConfig={}
+        )
         assert sys.maxsize == client_mock.get_waiter.return_value.config.max_attempts
 
     @mock.patch.object(EcsBaseOperator, "client")


### PR DESCRIPTION
Add ability to override waiter delay in `EcsRunTaskOperator`. The waiter might hit some throttling limit. Adding the capability to the user to override default waiter config in order to go around that limit.



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
