### PR TITLE
Better message on deserialization error

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -372,3 +372,13 @@ class AirflowProviderDeprecationWarning(DeprecationWarning):
 
     deprecated_provider_since: str | None = None
     "Indicates the provider version that started raising this deprecation warning"
+
+
+class DeserializingResultError(ValueError):
+    """Raised when an error is encountered while a pickling library deserializes a pickle file."""
+
+    def __str__(self):
+        return (
+            "Error deserializing result. Note that result deserialization "
+            "is not supported across major Python versions. Cause: " + str(self.__cause__)
+        )

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -38,6 +38,7 @@ from airflow.exceptions import (
     AirflowConfigException,
     AirflowException,
     AirflowSkipException,
+    DeserializingResultError,
     RemovedInAirflow3Warning,
 )
 from airflow.models.baseoperator import BaseOperator
@@ -376,12 +377,8 @@ class _BasePythonVirtualenvOperator(PythonOperator, metaclass=ABCMeta):
             return None
         try:
             return self.pickling_library.loads(path.read_bytes())
-        except ValueError:
-            self.log.error(
-                "Error deserializing result. Note that result deserialization "
-                "is not supported across major Python versions."
-            )
-            raise
+        except ValueError as value_error:
+            raise DeserializingResultError() from value_error
 
     def __deepcopy__(self, memo):
         # module objects can't be copied _at all__

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -427,6 +427,7 @@ deserialize
 Deserialized
 deserialized
 deserializer
+deserializes
 deserializing
 dest
 dev

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -31,7 +31,7 @@ from unittest import mock
 import pytest
 from slugify import slugify
 
-from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
+from airflow.exceptions import AirflowException, DeserializingResultError, RemovedInAirflow3Warning
 from airflow.models import DAG, DagRun, TaskInstance as TI
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.taskinstance import clear_task_instances, set_current_context
@@ -278,6 +278,20 @@ class TestPythonOperator(BasePythonTest):
         else:
             assert "Done. Returned value was: test_return_value" not in caplog.messages
             assert "Done. Returned value not shown" in caplog.messages
+
+    def test_python_operator_templates_exts(self):
+        def func():
+            return "test_return_value"
+
+        python_operator = PythonOperator(
+            task_id="python_operator",
+            python_callable=func,
+            dag=self.dag,
+            show_return_value_in_logs=False,
+            templates_exts=["test_ext"],
+        )
+
+        assert python_operator.template_ext == ["test_ext"]
 
 
 class TestBranchOperator(BasePythonTest):
@@ -964,6 +978,21 @@ class TestPythonVirtualenvOperator(BasePythonTest):
                 **(extra_kwargs if extra_kwargs else {}),
             )
             assert ti.state == expected_state
+
+    @mock.patch("pickle.loads")
+    def test_except_value_error(self, loads_mock):
+        def f():
+            return 1
+
+        task = PythonVirtualenvOperator(
+            python_callable=f,
+            task_id="task",
+            dag=self.dag,
+        )
+
+        loads_mock.side_effect = DeserializingResultError
+        with pytest.raises(DeserializingResultError):
+            task._read_result(path=mock.Mock())
 
 
 class TestCurrentContext:


### PR DESCRIPTION
Previously deserialization error thrown a pretty mysterious ValueError
in case for example there was a Python version mismatch - the python
object serialized in one version of Python produced "version error"
messsage. This change turns such ValueError in specific
Deserilization error, with better message explaining possible reason,
but also without loosing the cause.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
