### PR TITLE
Use custom validator for OpenAPI request body

### DIFF
--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -875,6 +875,14 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
         )
         assert response.status_code == 403
 
+    def test_should_raise_400_for_no_json(self):
+        response = self.client.post(
+            "/api/v1/dags/~/dagRuns/~/taskInstances/list",
+            environ_overrides={"REMOTE_USER": "test"},
+        )
+        assert response.status_code == 400
+        assert response.json["detail"] == "Request body must not be empty"
+
     @pytest.mark.parametrize(
         "payload, expected",
         [


### PR DESCRIPTION
The default error message for an empty request body from Connexion is quite unhelpful (taken directly from JSONSchema). This custom validator emits a more helpful message for this particular context.

Close #30346.
Fix #26424.