### PR TITLE
Support minAvailable property for PodDisruptionBudget

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1864,6 +1864,14 @@
                                         "string"
                                     ],
                                     "default": 1
+                                },
+                                "minAvailable": {
+                                    "description": "Min available pods for scheduler.",
+                                    "type": [
+                                        "integer",
+                                        "string"
+                                    ],
+                                    "default": 1
                                 }
                             }
                         }
@@ -3359,6 +3367,14 @@
                                         "string"
                                     ],
                                     "default": 1
+                                },
+                                "minAvailable": {
+                                    "description": "Min available pods for webserver.",
+                                    "type": [
+                                        "integer",
+                                        "string"
+                                    ],
+                                    "default": 1
                                 }
                             }
                         }
@@ -4427,6 +4443,14 @@
                             "properties": {
                                 "maxUnavailable": {
                                     "description": "Max unavailable pods for PgBouncer.",
+                                    "type": [
+                                        "integer",
+                                        "string"
+                                    ],
+                                    "default": 1
+                                },
+                                "minAvailable": {
+                                    "description": "Min available pods for PgBouncer.",
                                     "type": [
                                         "integer",
                                         "string"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -710,7 +710,9 @@ scheduler:
 
     # PDB configuration
     config:
+      # minAvailable and maxUnavailable are mutually exclusive
       maxUnavailable: 1
+      # minAvailable: 1
 
   resources: {}
   #  limits:
@@ -997,7 +999,9 @@ webserver:
 
     # PDB configuration
     config:
+      # minAvailable and maxUnavailable are mutually exclusive
       maxUnavailable: 1
+      # minAvailable: 1
 
   # Allow overriding Update Strategy for Webserver
   strategy: ~
@@ -1591,7 +1595,9 @@ pgbouncer:
 
     # PDB configuration
     config:
+      # minAvailable and maxUnavailable are mutually exclusive
       maxUnavailable: 1
+      # minAvailable: 1
 
   # Limit the resources to PgBouncer.
   # When you specify the resource request the k8s scheduler uses this information to decide which node to

--- a/tests/charts/airflow_core/test_pdb_scheduler.py
+++ b/tests/charts/airflow_core/test_pdb_scheduler.py
@@ -48,3 +48,16 @@ class TestSchedulerPdb:
 
         assert "test_label" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
+
+    def test_should_pass_validation_with_pdb_enabled_and_min_available_param(self):
+        render_chart(
+            values={
+                "scheduler": {
+                    "podDisruptionBudget": {
+                        "enabled": True,
+                        "config": {"maxUnavailable": None, "minAvailable": 1},
+                    }
+                }
+            },
+            show_only=["templates/scheduler/scheduler-poddisruptionbudget.yaml"],
+        )  # checks that no validation exception is raised

--- a/tests/charts/other/test_pdb_pgbouncer.py
+++ b/tests/charts/other/test_pdb_pgbouncer.py
@@ -32,3 +32,17 @@ class TestPgbouncerPdb:
             show_only=["templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml"],
             kubernetes_version="1.16.0",
         )  # checks that no validation exception is raised
+
+    def test_should_pass_validation_with_pdb_enabled_and_min_available_param(self):
+        render_chart(
+            values={
+                "pgbouncer": {
+                    "enabled": True,
+                    "podDisruptionBudget": {
+                        "enabled": True,
+                        "config": {"maxUnavailable": None, "minAvailable": 1},
+                    },
+                }
+            },
+            show_only=["templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml"],
+        )  # checks that no validation exception is raised

--- a/tests/charts/webserver/test_pdb_webserver.py
+++ b/tests/charts/webserver/test_pdb_webserver.py
@@ -47,3 +47,16 @@ class TestWebserverPdb:
         )
         assert "test_label" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
+
+    def test_should_pass_validation_with_pdb_enabled_and_min_available_param(self):
+        render_chart(
+            values={
+                "webserver": {
+                    "podDisruptionBudget": {
+                        "enabled": True,
+                        "config": {"maxUnavailable": None, "minAvailable": 1},
+                    }
+                }
+            },
+            show_only=["templates/webserver/webserver-poddisruptionbudget.yaml"],
+        )  # checks that no validation exception is raised


### PR DESCRIPTION
The PR contains updates of `values.schema.json `to support minAvailable property for PodDisruptionBudget.
Unit tests were updated.
closes: #30247