### PR TITLE
DagBag: Use dag.fileloc instead of dag.full_filepath in exception

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -640,7 +640,7 @@ class DagBag(LoggingMixin):
             except OperationalError:
                 raise
             except Exception:
-                log.exception("Failed to write serialized DAG: %s", dag.full_filepath)
+                log.exception("Failed to write serialized DAG: %s", dag.fileloc)
                 dagbag_import_error_traceback_depth = conf.getint(
                     "core", "dagbag_import_error_traceback_depth"
                 )


### PR DESCRIPTION
DAG.full_filepath is deprecated, see:
https://github.com/apache/airflow/blob/2.5.3/airflow/models/dag.py#L1109-L1117

As a result, a DeprecationWarning is issued if this exception is hit. Instead, we should use dag.fileloc directly.

The same fileloc attribute is returned in either case, so this should be a no-op.