### PR TITLE
Improve DAG ORM cleanup code

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -40,7 +40,6 @@ from typing import (
     Callable,
     Collection,
     Container,
-    Deque,
     Iterable,
     Iterator,
     List,

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -39,6 +39,8 @@ from typing import (
     Any,
     Callable,
     Collection,
+    Container,
+    Deque,
     Iterable,
     Iterator,
     List,
@@ -3508,7 +3510,11 @@ class DagModel(Base):
     @classmethod
     @internal_api_call
     @provide_session
-    def deactivate_deleted_dags(cls, alive_dag_filelocs: list[str], session=NEW_SESSION):
+    def deactivate_deleted_dags(
+        cls,
+        alive_dag_filelocs: Container[str],
+        session: Session = NEW_SESSION,
+    ) -> None:
         """
         Set ``is_active=False`` on the DAGs for which the DAG files have been removed.
 
@@ -3516,13 +3522,9 @@ class DagModel(Base):
         :param session: ORM Session
         """
         log.debug("Deactivating DAGs (for which DAG files are deleted) from %s table ", cls.__tablename__)
-
-        dag_models = session.query(cls).all()
-        for dag_model in dag_models:
-            if dag_model.fileloc is not None and dag_model.fileloc not in alive_dag_filelocs:
+        for dag_model in session.query(cls).filter(cls.fileloc.is_not(None)):
+            if dag_model.fileloc not in alive_dag_filelocs:
                 dag_model.is_active = False
-            else:
-                continue
 
     @classmethod
     def dags_needing_dagruns(cls, session: Session) -> tuple[Query, dict[str, tuple[datetime, datetime]]]:

--- a/airflow/models/dagcode.py
+++ b/airflow/models/dagcode.py
@@ -20,7 +20,7 @@ import logging
 import os
 import struct
 from datetime import datetime
-from typing import Iterable
+from typing import Collection, Iterable
 
 from sqlalchemy import BigInteger, Column, String, Text, delete
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
@@ -126,7 +126,7 @@ class DagCode(Base):
 
     @classmethod
     @provide_session
-    def remove_deleted_code(cls, alive_dag_filelocs: list[str], session: Session = NEW_SESSION) -> None:
+    def remove_deleted_code(cls, alive_dag_filelocs: Collection[str], session: Session = NEW_SESSION) -> None:
         """Deletes code not included in alive_dag_filelocs.
 
         :param alive_dag_filelocs: file paths of alive DAGs

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import logging
 import zlib
 from datetime import datetime, timedelta
+from typing import Collection
 
 import sqlalchemy_jsonfield
 from sqlalchemy import BigInteger, Column, Index, LargeBinary, String, and_, or_
@@ -234,7 +235,7 @@ class SerializedDagModel(Base):
     @provide_session
     def remove_deleted_dags(
         cls,
-        alive_dag_filelocs: list[str],
+        alive_dag_filelocs: Collection[str],
         processor_subdir: str | None = None,
         session: Session = NEW_SESSION,
     ) -> None:

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -25,13 +25,12 @@ import re
 import zipfile
 from collections import OrderedDict
 from pathlib import Path
-from typing import TYPE_CHECKING, Generator, NamedTuple, Pattern, Protocol, overload
+from typing import Generator, NamedTuple, Protocol, overload
 
 from pathspec.patterns import GitWildMatchPattern
 
 from airflow.configuration import conf
 from airflow.exceptions import RemovedInAirflow3Warning
-from airflow.typing_compat import Protocol
 
 log = logging.getLogger(__name__)
 

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -31,9 +31,7 @@ from pathspec.patterns import GitWildMatchPattern
 
 from airflow.configuration import conf
 from airflow.exceptions import RemovedInAirflow3Warning
-
-if TYPE_CHECKING:
-    import pathlib
+from airflow.typing_compat import Protocol
 
 log = logging.getLogger(__name__)
 
@@ -56,7 +54,7 @@ class _IgnoreRule(Protocol):
 class _RegexpIgnoreRule(NamedTuple):
     """Typed namedtuple with utility functions for regexp ignore rules."""
 
-    pattern: Pattern
+    pattern: re.Pattern
     base_dir: Path
 
     @staticmethod
@@ -82,7 +80,7 @@ class _RegexpIgnoreRule(NamedTuple):
 class _GlobIgnoreRule(NamedTuple):
     """Typed namedtuple with utility functions for glob ignore rules."""
 
-    pattern: Pattern
+    pattern: re.Pattern
     raw_pattern: str
     include: bool | None = None
     relative_to: Path | None = None
@@ -199,13 +197,12 @@ def open_maybe_zipped(fileloc, mode="r"):
 
 
 def _find_path_from_directory(
-    base_dir_path: str,
+    base_dir_path: str | os.PathLike[str],
     ignore_file_name: str,
     ignore_rule_type: type[_IgnoreRule],
 ) -> Generator[str, None, None]:
-    """
-    Recursively search the base path and return the list of file paths that should not be ignored by
-    regular expressions in any ignore files at each directory level.
+    """Recursively search the base path and return the list of file paths that should not be ignored.
+
     :param base_dir_path: the base path to be searched
     :param ignore_file_name: the file name containing regular expressions for files that should be ignored.
     :param ignore_rule_type: the concrete class for ignore rules, which implements the _IgnoreRule interface.
@@ -258,12 +255,11 @@ def _find_path_from_directory(
 
 
 def find_path_from_directory(
-    base_dir_path: str,
+    base_dir_path: str | os.PathLike[str],
     ignore_file_name: str,
     ignore_file_syntax: str = conf.get_mandatory_value("core", "DAG_IGNORE_FILE_SYNTAX", fallback="regexp"),
 ) -> Generator[str, None, None]:
-    """
-    Recursively search the base path and return the list of file paths that should not be ignored.
+    """Recursively search the base path for a list of file paths that should not be ignored.
 
     :param base_dir_path: the base path to be searched
     :param ignore_file_name: the file name in which specifies the patterns of files/dirs to be ignored
@@ -280,12 +276,11 @@ def find_path_from_directory(
 
 
 def list_py_file_paths(
-    directory: str | pathlib.Path,
+    directory: str | os.PathLike[str] | None,
     safe_mode: bool = conf.getboolean("core", "DAG_DISCOVERY_SAFE_MODE", fallback=True),
     include_examples: bool | None = None,
 ) -> list[str]:
-    """
-    Traverse a directory and look for Python files.
+    """Traverse a directory and look for Python files.
 
     :param directory: the directory to traverse
     :param safe_mode: whether to use a heuristic to determine whether a file
@@ -307,16 +302,16 @@ def list_py_file_paths(
     if include_examples:
         from airflow import example_dags
 
-        example_dag_folder = example_dags.__path__[0]  # type: ignore
+        example_dag_folder = next(iter(example_dags.__path__))
         file_paths.extend(list_py_file_paths(example_dag_folder, safe_mode, include_examples=False))
     return file_paths
 
 
-def find_dag_file_paths(directory: str | pathlib.Path, safe_mode: bool) -> list[str]:
+def find_dag_file_paths(directory: str | os.PathLike[str], safe_mode: bool) -> list[str]:
     """Finds file paths of all DAG files."""
     file_paths = []
 
-    for file_path in find_path_from_directory(str(directory), ".airflowignore"):
+    for file_path in find_path_from_directory(directory, ".airflowignore"):
         try:
             if not os.path.isfile(file_path):
                 continue


### PR DESCRIPTION
I identified when reviewing #30608 that the _refresh_dag_dir() function can use some cleanup, mainly to use a set instead of list to speed up lookup. To maintain backward comaptibility in type hints, the called functions are changed to use the Collection generic instead of the very narrow list type.

This somehow triggers a bunch of (legistimate) Mypy errors not emitted previously, mostly around mixing the os.PathLike generic and the pathlib.Path concrete type. I fixed those as well.