### PR TITLE
Fix failing SQS tests on moto upgrade

### DIFF
--- a/tests/providers/amazon/aws/operators/test_sqs.py
+++ b/tests/providers/amazon/aws/operators/test_sqs.py
@@ -87,7 +87,9 @@ class TestSqsPublishOperator:
     def test_execute_success_fifo_queue(self):
         self.operator.sqs_queue = FIFO_QUEUE_URL
         self.operator.message_group_id = "abc"
-        self.sqs_hook.create_queue(FIFO_QUEUE_NAME, attributes={"FifoQueue": "true"})
+        self.sqs_hook.create_queue(
+            FIFO_QUEUE_NAME, attributes={"FifoQueue": "true", "ContentBasedDeduplication": "true"}
+        )
         result = self.operator.execute(self.mock_context)
         assert "MD5OfMessageBody" in result
         assert "MessageId" in result


### PR DESCRIPTION
The new moto (4.1.7) performs additional validation on the queues created during tests and it failes the tests when content deduplication is not specified.

Explicit setting the deduplication mode, fixes the problem and allows the new moto to be installed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
