### PR TITLE
Remove Norm and Hussein from the triage group

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -74,9 +74,7 @@ github:
     - gmcdonald
     - mhenc
     - ferruzzi
-    - norm
     - mobuchowski
-    - hussein-awala
 
 notifications:
   jobs: jobs@airflow.apache.org


### PR DESCRIPTION
Hussein is now a commiter and Norm has completed building out the initial AIP-52 tasks.