### PR TITLE
Add delete inactive run functionality to databricks provider

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -38,11 +38,11 @@ from airflow.providers.databricks.hooks.databricks_base import BaseDatabricksHoo
 RESTART_CLUSTER_ENDPOINT = ("POST", "api/2.0/clusters/restart")
 START_CLUSTER_ENDPOINT = ("POST", "api/2.0/clusters/start")
 TERMINATE_CLUSTER_ENDPOINT = ("POST", "api/2.0/clusters/delete")
-
 RUN_NOW_ENDPOINT = ("POST", "api/2.1/jobs/run-now")
 SUBMIT_RUN_ENDPOINT = ("POST", "api/2.1/jobs/runs/submit")
 GET_RUN_ENDPOINT = ("GET", "api/2.1/jobs/runs/get")
 CANCEL_RUN_ENDPOINT = ("POST", "api/2.1/jobs/runs/cancel")
+DELETE_RUN_ENDPOINT = ("POST", "api/2.1/jobs/runs/delete")
 OUTPUT_RUNS_JOB_ENDPOINT = ("GET", "api/2.1/jobs/runs/get-output")
 
 INSTALL_LIBS_ENDPOINT = ("POST", "api/2.0/libraries/install")
@@ -350,6 +350,15 @@ class DatabricksHook(BaseDatabricksHook):
         """
         json = {"run_id": run_id}
         self._do_api_call(CANCEL_RUN_ENDPOINT, json)
+
+    def delete_run(self, run_id: int) -> None:
+        """
+        Deletes a non-active run.
+
+        :param run_id: id of the run
+        """
+        json = {"run_id": run_id}
+        self._do_api_call(DELETE_RUN_ENDPOINT, json)
 
     def restart_cluster(self, json: dict) -> None:
         """

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -38,6 +38,7 @@ from airflow.providers.databricks.hooks.databricks_base import BaseDatabricksHoo
 RESTART_CLUSTER_ENDPOINT = ("POST", "api/2.0/clusters/restart")
 START_CLUSTER_ENDPOINT = ("POST", "api/2.0/clusters/start")
 TERMINATE_CLUSTER_ENDPOINT = ("POST", "api/2.0/clusters/delete")
+
 RUN_NOW_ENDPOINT = ("POST", "api/2.1/jobs/run-now")
 SUBMIT_RUN_ENDPOINT = ("POST", "api/2.1/jobs/runs/submit")
 GET_RUN_ENDPOINT = ("GET", "api/2.1/jobs/runs/get")

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -143,6 +143,13 @@ def cancel_run_endpoint(host):
     return f"https://{host}/api/2.1/jobs/runs/cancel"
 
 
+def delete_run_endpoint(host):
+    """
+    Utility function to generate delete run endpoint given the host.
+    """
+    return f"https://{host}/api/2.1/jobs/runs/delete"
+
+
 def start_cluster_endpoint(host):
     """
     Utility function to generate the get run endpoint given the host.
@@ -514,6 +521,21 @@ class TestDatabricksHook:
 
         mock_requests.post.assert_called_once_with(
             cancel_run_endpoint(HOST),
+            json={"run_id": RUN_ID},
+            params=None,
+            auth=HTTPBasicAuth(LOGIN, PASSWORD),
+            headers=self.hook.user_agent_header,
+            timeout=self.hook.timeout_seconds,
+        )
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests")
+    def test_delete_run(self, mock_requests):
+        mock_requests.post.return_value.json.return_value = GET_RUN_RESPONSE
+
+        self.hook.delete_run(RUN_ID)
+
+        mock_requests.post.assert_called_once_with(
+            delete_run_endpoint(HOST),
             json={"run_id": RUN_ID},
             params=None,
             auth=HTTPBasicAuth(LOGIN, PASSWORD),

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -530,7 +530,7 @@ class TestDatabricksHook:
 
     @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests")
     def test_delete_run(self, mock_requests):
-        mock_requests.post.return_value.json.return_value = GET_RUN_RESPONSE
+        mock_requests.post.return_value.json.return_value = {}
 
         self.hook.delete_run(RUN_ID)
 


### PR DESCRIPTION
This PR adds `delete inactive run` functionality to databricks provider.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
