### PR TITLE
BigQueryGetDataOperator should use project_id

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -905,6 +905,7 @@ class BigQueryGetDataOperator(GoogleCloudBaseOperator):
                 schema: dict[str, list] = hook.get_schema(
                     dataset_id=self.dataset_id,
                     table_id=self.table_id,
+                    project_id=self.project_id,
                 )
                 if "fields" in schema:
                     self.selected_fields = ",".join([field["name"] for field in schema["fields"]])


### PR DESCRIPTION
When calling `BigQueryGetDataOperator` without `selected_fields` the function will look up the schema using `hook.get_schema()`. Currently, this lookup doesn't use `project_id`, this PR fixes that and closes https://github.com/apache/airflow/issues/30635