### PR TITLE
Add `priority` parameter to BigQueryHook

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -2718,7 +2718,7 @@ class BigQueryCursor(BigQueryBaseCursor):
         """
         sql = _bind_parameters(operation, parameters) if parameters else operation
         self.flush_results()
-        self.job_id = self.hook.run_query(sql)
+        self.job_id = self.hook.insert_job(sql)
 
         query_results = self._get_query_result()
         if "schema" in query_results:

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -2081,8 +2081,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         labels = labels or self.labels
         schema_update_options = list(schema_update_options or [])
 
-        if priority:
-            self.priority = priority
+        priority = priority or self.priority
 
         if time_partitioning is None:
             time_partitioning = {}
@@ -2141,7 +2140,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
 
         query_param_list: list[tuple[Any, str, str | bool | None | dict, type | tuple[type]]] = [
             (sql, "query", None, (str,)),
-            (priority, "priority", self.priority, (str,)),
+            (priority, "priority", priority, (str,)),
             (location, "location", self.location, (str,)),
             (use_legacy_sql, "useLegacySql", self.use_legacy_sql, bool),
             (query_params, "queryParameters", None, list),

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -559,6 +559,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
 
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#resource
 
+        This method is deprecated.
+        Please use `BigQueryHook.create_empty_table` method with passing the `table_resource` object
+
         for more details about these parameters.
 
         :param external_project_dataset_table:
@@ -748,6 +751,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         Patch information in an existing table.
         It only updates fields that are provided in the request object.
 
+        This method is deprecated. Please use `BigQueryHook.update_table`
+
         Reference: https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/patch
 
         :param dataset_id: The dataset containing the table to be patched.
@@ -933,6 +938,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         """
         Patches information in an existing dataset.
         It only replaces fields that are provided in the submitted dataset resource.
+
+        This method is deprecated. Please use `update_dataset`
+
         More info:
         https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/patch
 
@@ -976,6 +984,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         """
         Method returns tables list of a BigQuery tables. If table prefix is specified,
         only tables beginning by it are returned.
+
+        This method is deprecated. Please use `get_dataset_tables`
 
         For more information, see:
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/list
@@ -1167,6 +1177,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         If the table does not exist, return an error unless ignore_if_missing
         is set to True.
 
+        This method is deprecated. Please use `delete_table`
+
         :param deletion_dataset_table: A dotted
             ``(<project>.|<project>:)<dataset>.<table>`` that indicates which table
             will be deleted.
@@ -1211,6 +1223,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
     ) -> list[dict]:
         """
         Get the data of a given dataset.table and optionally with selected columns.
+
+        This method is deprecated. Please use `list_rows`
+
         see https://cloud.google.com/bigquery/docs/reference/v2/tabledata/list
 
         :param dataset_id: the dataset ID of the requested table.
@@ -1579,6 +1594,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
 
         https://cloud.google.com/bigquery/docs/reference/v2/jobs
 
+        This method is deprecated. Please use `BigQueryHook.insert_job`
+
         For more details about the configuration parameter.
 
         :param configuration: The configuration parameter maps directly to
@@ -1621,6 +1638,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         to BigQuery. See here:
 
         https://cloud.google.com/bigquery/docs/reference/v2/jobs
+
+        This method is deprecated. Please use `BigQueryHook.insert_job` method.
 
         For more details about these parameters.
 
@@ -1846,6 +1865,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
 
         https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.copy
 
+        This method is deprecated. Please use `BigQueryHook.insert_job` method.
+
         For more details about these parameters.
 
         :param source_project_dataset_tables: One or more dotted
@@ -1933,6 +1954,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
 
         https://cloud.google.com/bigquery/docs/reference/v2/jobs
 
+        This method is deprecated. Please use `BigQueryHook.insert_job` method.
+
         For more details about these parameters.
 
         :param source_project_dataset_table: The dotted ``<dataset>.<table>``
@@ -2017,6 +2040,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         table. See here:
 
         https://cloud.google.com/bigquery/docs/reference/v2/jobs
+
+        This method is deprecated. Please use `BigQueryHook.insert_job` method.
 
         For more details about these parameters.
 

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -2718,7 +2718,7 @@ class BigQueryCursor(BigQueryBaseCursor):
         """
         sql = _bind_parameters(operation, parameters) if parameters else operation
         self.flush_results()
-        self.job_id = self.hook.insert_job(sql)
+        self.job_id = self.hook.run_query(sql)
 
         query_results = self._get_query_result()
         if "schema" in query_results:

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -2056,7 +2056,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             table to be updated as a side effect of the query job.
         :param priority: Specifies a priority for the query.
             Possible values include INTERACTIVE and BATCH.
-            If `None`, defaults to `self.use_legacy_sql`.
+            If `None`, defaults to `self.priority`.
         :param time_partitioning: configure optional time partitioning fields i.e.
             partition by field, type and expiration as per API specifications.
         :param cluster_fields: Request that the result of this query be stored sorted

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -2086,9 +2086,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         if time_partitioning is None:
             time_partitioning = {}
 
-        if location:
-            self.location = location
-
         if not api_resource_configs:
             api_resource_configs = self.api_resource_configs
         else:
@@ -2141,7 +2138,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         query_param_list: list[tuple[Any, str, str | bool | None | dict, type | tuple[type]]] = [
             (sql, "query", None, (str,)),
             (priority, "priority", priority, (str,)),
-            (location, "location", self.location, (str,)),
             (use_legacy_sql, "useLegacySql", self.use_legacy_sql, bool),
             (query_params, "queryParameters", None, list),
             (udf_config, "userDefinedFunctionResources", None, list),
@@ -2210,7 +2206,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         if encryption_configuration:
             configuration["query"]["destinationEncryptionConfiguration"] = encryption_configuration
 
-        job = self.insert_job(configuration=configuration, project_id=self.project_id)
+        job = self.insert_job(configuration=configuration, project_id=self.project_id, location=location)
         self.running_job_id = job.job_id
         return job.job_id
 

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -2142,6 +2142,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         query_param_list: list[tuple[Any, str, str | bool | None | dict, type | tuple[type]]] = [
             (sql, "query", None, (str,)),
             (priority, "priority", self.priority, (str,)),
+            (location, "location", self.location, (str,)),
             (use_legacy_sql, "useLegacySql", self.use_legacy_sql, bool),
             (query_params, "queryParameters", None, list),
             (udf_config, "userDefinedFunctionResources", None, list),

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -1212,7 +1212,6 @@ class TestBigQueryCursor(_BigQueryBaseTestClass):
         bq_cursor = self.hook.get_cursor()
         bq_cursor.execute("SELECT %(foo)s", {"foo": "bar"})
         conf = {
-            "location": None,
             "query": {
                 "query": "SELECT 'bar'",
                 "priority": "INTERACTIVE",
@@ -1220,7 +1219,7 @@ class TestBigQueryCursor(_BigQueryBaseTestClass):
                 "schemaUpdateOptions": [],
             }
         }
-        mock_insert.assert_called_once_with(configuration=conf, project_id=PROJECT_ID)
+        mock_insert.assert_called_once_with(configuration=conf, project_id=PROJECT_ID, location=None)
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job")
@@ -1231,8 +1230,8 @@ class TestBigQueryCursor(_BigQueryBaseTestClass):
         mock_insert.assert_has_calls(
             [
                 mock.call(
+                    location=None,
                     configuration={
-                        "location": None,
                         "query": {
                             "query": "SELECT 'bar'",
                             "priority": "INTERACTIVE",
@@ -1243,8 +1242,8 @@ class TestBigQueryCursor(_BigQueryBaseTestClass):
                     project_id=PROJECT_ID,
                 ),
                 mock.call(
+                    location=None,
                     configuration={
-                        "location": None,
                         "query": {
                             "query": "SELECT 'baz'",
                             "priority": "INTERACTIVE",
@@ -1717,7 +1716,7 @@ class TestTimePartitioningInRunJob(_BigQueryBaseTestClass):
             }
         }
 
-        mock_insert.assert_called_once_with(configuration=configuration, project_id=PROJECT_ID)
+        mock_insert.assert_called_once_with(configuration=configuration, project_id=PROJECT_ID, location=None)
 
     def test_dollar_makes_partition(self):
         tp_out = _cleanse_time_partitioning("test.teast$20170101", {})

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -102,6 +102,13 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         assert run_with_config.call_count == 1
         assert self.hook.location == "US"
 
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job")
+    def test_run_query_location(self, mock_insert, _):
+        self.hook.run_query("query", location="US")
+        _, kwargs = mock_insert.call_args
+        assert kwargs["configuration"]["query"]["location"] = "US"
+
     def test_bigquery_insert_rows_not_implemented(self):
         with pytest.raises(NotImplementedError):
             self.hook.insert_rows(table="table", rows=[1, 2])

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -1695,13 +1695,14 @@ class TestTimePartitioningInRunJob(_BigQueryBaseTestClass):
         self.hook.run_query(
             sql="select 1",
             destination_dataset_table=f"{DATASET_ID}.{TABLE_ID}",
+            priority="BATCH"
             time_partitioning={"type": "DAY", "field": "test_field", "expirationMs": 1000},
         )
 
         configuration = {
             "query": {
                 "query": "select 1",
-                "priority": "INTERACTIVE",
+                "priority": "BATCH",
                 "useLegacySql": True,
                 "timePartitioning": {"type": "DAY", "field": "test_field", "expirationMs": 1000},
                 "schemaUpdateOptions": [],

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -1212,6 +1212,7 @@ class TestBigQueryCursor(_BigQueryBaseTestClass):
         bq_cursor = self.hook.get_cursor()
         bq_cursor.execute("SELECT %(foo)s", {"foo": "bar"})
         conf = {
+            "location": None,
             "query": {
                 "query": "SELECT 'bar'",
                 "priority": "INTERACTIVE",
@@ -1231,6 +1232,7 @@ class TestBigQueryCursor(_BigQueryBaseTestClass):
             [
                 mock.call(
                     configuration={
+                        "location": None,
                         "query": {
                             "query": "SELECT 'bar'",
                             "priority": "INTERACTIVE",
@@ -1242,6 +1244,7 @@ class TestBigQueryCursor(_BigQueryBaseTestClass):
                 ),
                 mock.call(
                     configuration={
+                        "location": None,
                         "query": {
                             "query": "SELECT 'baz'",
                             "priority": "INTERACTIVE",

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -93,22 +93,6 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         )
         assert mock_bigquery_connection.return_value == result
 
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job")
-    def test_location_propagates_properly(self, run_with_config, _):
-        # TODO: this creates side effect
-        assert self.hook.location is None
-        self.hook.run_query(sql="select 1", location="US")
-        assert run_with_config.call_count == 1
-        assert self.hook.location == "US"
-
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job")
-    def test_run_query_location(self, mock_insert, _):
-        self.hook.run_query("query", location="US")
-        _, kwargs = mock_insert.call_args
-        assert kwargs["configuration"]["query"]["location"] = "US"
-
     def test_bigquery_insert_rows_not_implemented(self):
         with pytest.raises(NotImplementedError):
             self.hook.insert_rows(table="table", rows=[1, 2])

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -1695,7 +1695,7 @@ class TestTimePartitioningInRunJob(_BigQueryBaseTestClass):
         self.hook.run_query(
             sql="select 1",
             destination_dataset_table=f"{DATASET_ID}.{TABLE_ID}",
-            priority="BATCH"
+            priority="BATCH",
             time_partitioning={"type": "DAY", "field": "test_field", "expirationMs": 1000},
         )
 

--- a/tests/system/providers/google/cloud/bigquery/example_bigquery_queries.py
+++ b/tests/system/providers/google/cloud/bigquery/example_bigquery_queries.py
@@ -105,6 +105,7 @@ for index, location in enumerate(locations, 1):
                 "query": {
                     "query": INSERT_ROWS_QUERY,
                     "useLegacySql": False,
+                    "priority": "BATCH",
                 }
             },
             location=location,

--- a/tests/system/providers/google/cloud/bigquery/example_bigquery_queries_async.py
+++ b/tests/system/providers/google/cloud/bigquery/example_bigquery_queries_async.py
@@ -134,6 +134,7 @@ with DAG(
             "query": {
                 "query": INSERT_ROWS_QUERY,
                 "useLegacySql": False,
+                "priority": "BATCH",
             }
         },
         location=LOCATION,


### PR DESCRIPTION
Currently `priority=` is available in `run_query()` function within `BigQueryHook` class but can't be set when class is created.

This causes problems when you're using `SQLExecuteQueryOperator` since `priority` is missing from class constructor, you won't be able to pass in with `hook_params={"priority":"BATCH"}`. Trying to workaround using `hook_params={"api_resource_configs": {"query": {"priority": "BATCH"}}"` will error on `_api_resource_configs_duplication_check()` since `priority` is defaulted to 'INTERACTIVE'.

This PR adds `priority` to `BigQueryHook` constructor and defaults to using that value for `run_query()`