### PR TITLE
Make pandas optional in workday calendar example

### DIFF
--- a/airflow/example_dags/plugins/workday.py
+++ b/airflow/example_dags/plugins/workday.py
@@ -18,28 +18,38 @@
 """Plugin to demonstrate timetable registration and accommodate example DAGs."""
 from __future__ import annotations
 
+import logging
 from datetime import timedelta
 
 # [START howto_timetable]
-from pandas.tseries.holiday import USFederalHolidayCalendar
 from pendulum import UTC, Date, DateTime, Time
 
 from airflow.plugins_manager import AirflowPlugin
 from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
 
+log = logging.getLogger(__name__)
+holiday_calendar = None
+
+try:
+    from pandas.tseries.holiday import USFederalHolidayCalendar
+
+    holiday_calendar = USFederalHolidayCalendar()
+except ImportError:
+    log.warning("Could not import pandas. Holidays will not be considered.")
+
 
 class AfterWorkdayTimetable(Timetable):
     def get_next_workday(self, d: DateTime, incr=1) -> DateTime:
-        cal = USFederalHolidayCalendar()
         next_start = d
         while True:
             if next_start.weekday() in (5, 6):  # If next start is in the weekend go to next day
                 next_start = next_start + incr * timedelta(days=1)
                 continue
-            holidays = cal.holidays(start=next_start, end=next_start).to_pydatetime()
-            if next_start in holidays:  # If next start is a holiday go to next day
-                next_start = next_start + incr * timedelta(days=1)
-                continue
+            if holiday_calendar is not None:
+                holidays = holiday_calendar.holidays(start=next_start, end=next_start).to_pydatetime()
+                if next_start in holidays:  # If next start is a holiday go to next day
+                    next_start = next_start + incr * timedelta(days=1)
+                    continue
             break
         return next_start
 


### PR DESCRIPTION
The workday calendar expected pandas to be available and it is part of our examples, however Airflow does not have pandas as a core dependency, so in case someone does not have pandas installed, importing of the workday example would fail.

This change makes pandas optional and fallbacks to regular working days for the example in case it is not available (including warning about it). It also fixes a slight inefficiency where the USFederalHoliday calendar has been created every time next workday was calculated.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
