### PR TITLE
Workaround type-incompatibility with new attrs in openlineage

### DIFF
--- a/airflow/providers/openlineage/utils/utils.py
+++ b/airflow/providers/openlineage/utils/utils.py
@@ -341,8 +341,10 @@ class OpenLineageRedactor(SecretsMasker):
         try:
             if name and should_hide_value_for_key(name):
                 return self._redact_all(item, depth, max_depth)
+            # TODO: Those type: ignores here should be reviewed and fixed
+            # See: https://github.com/apache/airflow/issues/30673
             if attrs.has(item):  # type: ignore
-                for dict_key, subval in attrs.asdict(item, recurse=False).items():
+                for dict_key, subval in attrs.asdict(item, recurse=False).items():  # type: ignore
                     if _is_name_redactable(dict_key, item):
                         setattr(
                             item,


### PR DESCRIPTION
The new attrs released today (11 hours ago) had added typing information and they caused OpenLineageRedactor to fail mypy checks.

Temporary adding type: ignore should allow to upgrade to the new attrs and stop PRs changing dependencies from failing.

Related: #30673

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
