### PR TITLE
Correctly pass a type to attrs.has()

### DIFF
--- a/airflow/providers/openlineage/utils/utils.py
+++ b/airflow/providers/openlineage/utils/utils.py
@@ -341,10 +341,8 @@ class OpenLineageRedactor(SecretsMasker):
         try:
             if name and should_hide_value_for_key(name):
                 return self._redact_all(item, depth, max_depth)
-            # TODO: Those type: ignores here should be reviewed and fixed
-            # See: https://github.com/apache/airflow/issues/30673
-            if attrs.has(item):  # type: ignore
-                for dict_key, subval in attrs.asdict(item, recurse=False).items():  # type: ignore
+            if attrs.has(type(item)):
+                for dict_key, subval in attrs.asdict(item, recurse=False).items():
                     if _is_name_redactable(dict_key, item):
                         setattr(
                             item,


### PR DESCRIPTION
Properly fix https://github.com/apache/airflow/issues/30673.

Turns out this is simply an incorrect usage of `attrs.has()`? Attrs documentation says this function should take a _type_, but `item` here is an instance.