### PR TITLE
Install twine with --force for package verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -735,10 +735,10 @@ jobs:
       - name: "Prepare airflow package: ${{matrix.package-format}}"
         run: breeze release-management prepare-airflow-package --version-suffix-for-pypi dev0
       - name: "Verify wheel packages with twine"
-        run: pipx install twine && twine check dist/*.whl
+        run: pipx install twine --force && twine check dist/*.whl
         if: matrix.package-format == 'wheel'
       - name: "Verify sdist packages with twine"
-        run: pipx install twine && twine check dist/*.tar.gz
+        run: pipx install twine --force && twine check dist/*.tar.gz
         if: matrix.package-format == 'sdist'
       - name: "Test providers issue generation automatically"
         run: >


### PR DESCRIPTION
In some cases when the machine has been reused across builds, pipx installed twine might seem both installed and removed (this happens when builds are cancelled while installing twine.

Installing twine with --force should fix the problem.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
