### PR TITLE
Upgrade to MyPy 1.2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -160,7 +160,7 @@ repos:
         entry: ./scripts/ci/pre_commit/pre_commit_update_common_sql_api_stubs.py
         language: python
         files: ^scripts/ci/pre_commit/pre_commit_update_common_sql_api\.py|^airflow/providers/common/sql/.*\.pyi?$
-        additional_dependencies: ['rich>=12.4.4', 'mypy==1.0.0', 'black==22.12.0', 'jinja2']
+        additional_dependencies: ['rich>=12.4.4', 'mypy==1.2.0', 'black==22.12.0', 'jinja2']
         pass_filenames: false
         require_serial: true
       - id: update-black-version

--- a/airflow/decorators/task_group.py
+++ b/airflow/decorators/task_group.py
@@ -114,13 +114,15 @@ class _TaskGroupFactory(ExpandableFactory, Generic[FParams, FReturn]):
         return task_group
 
     def override(self, **kwargs: Any) -> _TaskGroupFactory[FParams, FReturn]:
-        return attr.evolve(self, tg_kwargs={**self.tg_kwargs, **kwargs})
+        # TODO: fixme when mypy gets compatible with new attrs
+        return attr.evolve(self, tg_kwargs={**self.tg_kwargs, **kwargs})  # type: ignore[arg-type]
 
     def partial(self, **kwargs: Any) -> _TaskGroupFactory[FParams, FReturn]:
         self._validate_arg_names("partial", kwargs)
         prevent_duplicates(self.partial_kwargs, kwargs, fail_reason="duplicate partial")
         kwargs.update(self.partial_kwargs)
-        return attr.evolve(self, partial_kwargs=kwargs)
+        # TODO: fixme when mypy gets compatible with new attrs
+        return attr.evolve(self, partial_kwargs=kwargs)  # type: ignore[arg-type]
 
     def expand(self, **kwargs: OperatorExpandArgument) -> DAGNode:
         if not kwargs:

--- a/airflow/providers/openlineage/utils/utils.py
+++ b/airflow/providers/openlineage/utils/utils.py
@@ -342,7 +342,8 @@ class OpenLineageRedactor(SecretsMasker):
             if name and should_hide_value_for_key(name):
                 return self._redact_all(item, depth, max_depth)
             if attrs.has(type(item)):
-                for dict_key, subval in attrs.asdict(item, recurse=False).items():
+                # TODO: fixme when mypy gets compatible with new attrs
+                for dict_key, subval in attrs.asdict(item, recurse=False).items():  # type: ignore[arg-type]
                     if _is_name_redactable(dict_key, item):
                         setattr(
                             item,

--- a/airflow/serialization/pydantic/taskinstance.py
+++ b/airflow/serialization/pydantic/taskinstance.py
@@ -111,4 +111,4 @@ class TaskInstancePydantic(BaseModelPydantic):
 
         :return: Pydantic serialized version of DaGrun
         """
-        return DagRunPydantic()
+        raise NotImplementedError()

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -157,7 +157,7 @@ def serialize(o: object, depth: int = 0) -> U | None:
     # dataclasses
     if dataclasses.is_dataclass(cls):
         # fixme: unfortunately using asdict with nested dataclasses it looses information
-        data = dataclasses.asdict(o)
+        data = dataclasses.asdict(o)  # type: ignore[call-overload]
         dct[DATA] = serialize(data, depth + 1)
         return dct
 

--- a/setup.py
+++ b/setup.py
@@ -332,7 +332,7 @@ mypy_dependencies = [
     # TODO: upgrade to newer versions of MyPy continuously as they are released
     # Make sure to upgrade the mypy version in update-common-sql-api-stubs in .pre-commit-config.yaml
     # when you upgrade it here !!!!
-    "mypy==1.0.0",
+    "mypy==1.2.0",
     "types-boto",
     "types-certifi",
     "types-croniter",


### PR DESCRIPTION
Upgrading to latest (released a week ago) MyPy in the hopes it will fix some more problem with attrs after upgrading new packages, but it seems that even the latest MyPy does not know about the new typing changes introduced in attrs (traditionally mypy has attrs plugin that injects appropriate typing but apparently it needs to catch up with those changes.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
