### PR TITLE
Validate `executor` and `config.core.executor` match

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -193,3 +193,7 @@ https://airflow.apache.org/docs/helm-chart/stable/production-guide.html#webserve
    {{ fail "postgresql.postgresqlUsername and postgresql.postgresqlPassword are no longer supported. If you wish to use the 'postgres' user, set its password with postgresql.auth.postgresPassword. If you wish to create a different user, do so with postgresql.auth.username and postgresql.auth.password." }}
 
 {{- end }}
+
+{{- if ne .Values.executor (tpl .Values.config.core.executor $) }}
+   {{ fail "Please configure the executor with `executor`, not `config.core.executor`." }}
+{{- end }}


### PR DESCRIPTION
The chart expects the executor to be set in `executor`, however if a user only sets `config.core.executor` it is difficult to diagnose as the chart deploys the wrong rbac resources. This tries to catch that situation.