### PR TITLE
Update log level in scheduler critical section edge case

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -598,8 +598,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             if is_done or not found_new_filters:
                 break
 
-            self.log.debug(
-                "Found no task instances to queue on the %s. iteration "
+            self.log.info(
+                "Found no task instances to queue on query iteration %s "
                 "but there could be more candidate task instances to check.",
                 loop_count,
             )


### PR DESCRIPTION
This log message can be useful if the scheduler ends up needing to query TIs more than once per scheduler loop, so make it INFO vs DEBUG to increase discoverability.