### PR TITLE
Use http.server to serve logs

### DIFF
--- a/airflow/utils/serve_logs.py
+++ b/airflow/utils/serve_logs.py
@@ -18,12 +18,13 @@
 from __future__ import annotations
 
 import collections
+import functools
+import http.client
+import http.server
 import logging
 import os
 import socket
 
-import gunicorn.app.base
-from flask import Flask, abort, request, send_from_directory
 from jwt.exceptions import (
     ExpiredSignatureError,
     ImmatureSignatureError,
@@ -40,48 +41,55 @@ from airflow.utils.jwt_signer import JWTSigner
 logger = logging.getLogger(__name__)
 
 
-def create_app():
-    flask_app = Flask(__name__, static_folder=None)
-    expiration_time_in_seconds = conf.getint("webserver", "log_request_clock_grace", fallback=30)
-    log_directory = os.path.expanduser(conf.get("logging", "BASE_LOG_FOLDER"))
+class _Abort(Exception):
+    code: http.HTTPStatus
 
-    signer = JWTSigner(
-        secret_key=conf.get("webserver", "secret_key"),
-        expiration_time_in_seconds=expiration_time_in_seconds,
-        audience="task-instance-logs",
-    )
+    def __init__(self) -> None:
+        super().__init__(self.code.description)
 
-    # Prevent direct access to the logs port
-    @flask_app.before_request
-    def validate_pre_signed_url():
+
+class _Forbidden(_Abort):
+    code = http.HTTPStatus.FORBIDDEN
+
+
+class _NotFound(_Abort):
+    code = http.HTTPStatus.NOT_FOUND
+
+
+class _JWTSignedFileRequestHandler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, signer: JWTSigner, directory: str) -> None:
+        super().__init__(*args, directory=directory)
+        self.signer = signer
+
+    def translate_path(self, path: str) -> str:
+        """Convert path for filesystem lookup.
+
+        This is what SimpleHTTPRequestHandler uses to route the request to a
+        file. We also perform auth here since it's the best place to get the
+        URL path.
+        """
+        auth = self.headers.get("Authorization")
+        if auth is None:
+            logger.warning("The Authorization header is missing: %s.", self.headers)
+            raise _Forbidden
+
+        path = super().translate_path(path)
+        if not path.startswith("/log/"):
+            raise _NotFound
+        request_filename = path[5:]
+
         try:
-            auth = request.headers.get("Authorization")
-            if auth is None:
-                logger.warning("The Authorization header is missing: %s.", request.headers)
-                abort(403)
-            payload = signer.verify_token(auth)
+            payload = self.signer.verify_token(auth)
             token_filename = payload.get("filename")
-            request_filename = request.view_args["filename"]
-            if token_filename is None:
-                logger.warning("The payload does not contain 'filename' key: %s.", payload)
-                abort(403)
-            if token_filename != request_filename:
-                logger.warning(
-                    "The payload log_relative_path key is different than the one in token:"
-                    "Request path: %s. Token path: %s.",
-                    request_filename,
-                    token_filename,
-                )
-                abort(403)
         except InvalidAudienceError:
             logger.warning("Invalid audience for the request", exc_info=True)
-            abort(403)
+            raise _Forbidden
         except InvalidSignatureError:
             logger.warning("The signature of the request was wrong", exc_info=True)
-            abort(403)
+            raise _Forbidden
         except ImmatureSignatureError:
             logger.warning("The signature of the request was sent from the future", exc_info=True)
-            abort(403)
+            raise _Forbidden
         except ExpiredSignatureError:
             logger.warning(
                 "The signature of the request has expired. Make sure that all components "
@@ -90,7 +98,7 @@ def create_app():
                 get_docs_url("configurations-ref.html#secret-key"),
                 exc_info=True,
             )
-            abort(403)
+            raise _Forbidden
         except InvalidIssuedAtError:
             logger.warning(
                 "The request was issues in the future. Make sure that all components "
@@ -99,61 +107,72 @@ def create_app():
                 get_docs_url("configurations-ref.html#secret-key"),
                 exc_info=True,
             )
-            abort(403)
+            raise _Forbidden
         except Exception:
             logger.warning("Unknown error", exc_info=True)
-            abort(403)
+            raise _Forbidden
 
-    @flask_app.route("/log/<path:filename>")
-    def serve_logs_view(filename):
-        return send_from_directory(log_directory, filename, mimetype="application/json", as_attachment=False)
+        if token_filename is None:
+            logger.warning("The payload does not contain 'filename' key: %s.", payload)
+            raise _Forbidden
+        if token_filename != request_filename:
+            logger.warning(
+                "The requested log path is different than the one in token:"
+                "Request path: %s. Token path: %s.",
+                request_filename,
+                token_filename,
+            )
+            raise _Forbidden
 
-    return flask_app
+        return request_filename
+
+    def guess_type(self, path):
+        """Guess Content-Type to use in the response.
+
+        This is simple since we only ever serves logs anyway.
+        """
+        return "application/json"
+
+    def send_head(self):
+        try:
+            resp = super().send_head()
+        except _Abort as e:
+            self.send_error(e.code, str(e))
+            resp = None
+        return resp
+
+
+def create_server(host, port) -> http.server.HTTPServer:
+    handler_class = functools.partial(
+        _JWTSignedFileRequestHandler,
+        signer=JWTSigner(
+            secret_key=conf.get("webserver", "secret_key"),
+            expiration_time_in_seconds=conf.getint("webserver", "log_request_clock_grace", fallback=30),
+            audience="task-instance-logs",
+        ),
+        directory=os.path.expanduser(conf.get("logging", "BASE_LOG_FOLDER")),
+    )
+    return http.server.ThreadingHTTPServer((host, port), handler_class)
 
 
 GunicornOption = collections.namedtuple("GunicornOption", ["key", "value"])
 
 
-class StandaloneGunicornApplication(gunicorn.app.base.BaseApplication):
-    """
-    Standalone Gunicorn application/serve for usage with any WSGI-application.
-
-    Code inspired by an example from the Gunicorn documentation.
-    https://github.com/benoitc/gunicorn/blob/cf55d2cec277f220ebd605989ce78ad1bb553c46/examples/standalone_app.py
-
-    For details, about standalone gunicorn application, see:
-    https://docs.gunicorn.org/en/stable/custom.html
-    """
-
-    def __init__(self, app, options=None):
-        self.options = options or []
-        self.application = app
-        super().__init__()
-
-    def load_config(self):
-        for option in self.options:
-            self.cfg.set(option.key.lower(), option.value)
-
-    def load(self):
-        return self.application
-
-
-def serve_logs(port=None):
+def serve_logs(port: int | None = None) -> None:
     """Serves logs generated by Worker"""
     setproctitle("airflow serve-logs")
-    wsgi_app = create_app()
+
+    # If dual stack is available and IPV6_V6ONLY is not enabled on the socket
+    # then when IPV6 is bound to it will also bind to IPV4 automatically.
+    if getattr(socket, "has_dualstack_ipv6", bool)():
+        host = "[::]"
+    else:
+        host = "0.0.0.0"
 
     port = port or conf.getint("logging", "WORKER_LOG_SERVER_PORT")
 
-    # If dual stack is available and IPV6_V6ONLY is not enabled on the socket
-    # then when IPV6 is bound to it will also bind to IPV4 automatically
-    if getattr(socket, "has_dualstack_ipv6", lambda: False)():
-        bind_option = GunicornOption("bind", f"[::]:{port}")
-    else:
-        bind_option = GunicornOption("bind", f"0.0.0.0:{port}")
-
-    options = [bind_option, GunicornOption("workers", 2)]
-    StandaloneGunicornApplication(wsgi_app, options).run()
+    server = create_server(host, port)
+    server.serve_forever()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The original Gunicorn + Flask setup is pretty heavy and produces significant overhead during startup. Since we only really ever serve straight-up files anyway, the entire WSGI stack seems unnecessary.

Not sure if this is a good idea yet.