### PR TITLE
Save scheduler execution time by checking if DAG has interval or timetable

### DIFF
--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -305,7 +305,7 @@ def get_execution_dates(
     else:
         start_date = execution_date
     start_date = execution_date if not past else start_date
-    if not dag.timetable.can_run:
+    if not dag.timetable.can_be_scheduled:
         # If the DAG never schedules, need to look at existing DagRun if the user wants future or
         # past runs.
         dag_runs = dag.get_dagruns_between(start_date=start_date, end_date=end_date)
@@ -337,7 +337,7 @@ def get_run_ids(dag: DAG, run_id: str, future: bool, past: bool, session: SASess
     # determine run_id range of dag runs and tasks to consider
     end_date = last_dagrun.logical_date if future else current_dagrun.logical_date
     start_date = current_dagrun.logical_date if not past else first_dagrun.logical_date
-    if not dag.timetable.can_run:
+    if not dag.timetable.can_be_scheduled:
         # If the DAG never schedules, need to look at existing DagRun if the user wants future or
         # past runs.
         dag_runs = dag.get_dagruns_between(start_date=start_date, end_date=end_date, session=session)

--- a/airflow/jobs/backfill_job_runner.py
+++ b/airflow/jobs/backfill_job_runner.py
@@ -317,7 +317,7 @@ class BackfillJobRunner(BaseJobRunner[Job], LoggingMixin):
         run_date = dagrun_info.logical_date
 
         # consider max_active_runs but ignore when running subdags
-        respect_dag_max_active_limit = bool(dag.timetable.can_run and not dag.is_subdag)
+        respect_dag_max_active_limit = bool(dag.timetable.can_be_scheduled and not dag.is_subdag)
 
         current_active_dag_count = dag.get_num_active_runs(external_trigger=False)
 

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1178,7 +1178,7 @@ class SchedulerJobRunner(BaseJobRunner[Job], LoggingMixin):
                     creating_job_id=self.job.id,
                 )
                 active_runs_of_dags[dag.dag_id] += 1
-            if self._should_update_dag_next_dagruns(dag, dag_model, active_runs_of_dags[dag.dag_id]):
+            if self._should_update_dag_next_dagruns(dag, dag_model, session, active_runs_of_dags[dag.dag_id]):
                 dag_model.calculate_dagrun_date_fields(dag, data_interval)
         # TODO[HA]: Should we do a session.flush() so we don't have to keep lots of state/object in
         # memory for larger dags? or expunge_all()
@@ -1283,8 +1283,18 @@ class SchedulerJobRunner(BaseJobRunner[Job], LoggingMixin):
                     DatasetDagRunQueue.target_dag_id == dag_run.dag_id
                 ).delete()
 
-    def _should_update_dag_next_dagruns(self, dag: DAG, dag_model: DagModel, total_active_runs: int) -> bool:
+    def _should_update_dag_next_dagruns(
+        self, dag: DAG, dag_model: DagModel, session: Session, total_active_runs: int = -1
+    ) -> bool:
         """Check if the dag's next_dagruns_create_after should be updated."""
+        # If dag has no interval or timetable then skip save runtime
+        if not dag.schedule_interval and isinstance(dag.timetable, NullTimetable):
+            return False
+
+        # get active dag runs from DB if not available
+        if total_active_runs < 0:
+            total_active_runs = dag.get_num_active_runs(only_running=False, session=session)
+
         if total_active_runs >= dag.max_active_runs:
             self.log.info(
                 "DAG %s is at (or above) max_active_runs (%d of %d), not creating any more runs",
@@ -1397,9 +1407,8 @@ class SchedulerJobRunner(BaseJobRunner[Job], LoggingMixin):
                 session.merge(task_instance)
             session.flush()
             self.log.info("Run %s of %s has timed-out", dag_run.run_id, dag_run.dag_id)
-            active_runs = dag.get_num_active_runs(only_running=False, session=session)
             # Work out if we should allow creating a new DagRun now?
-            if self._should_update_dag_next_dagruns(dag, dag_model, active_runs):
+            if self._should_update_dag_next_dagruns(dag, dag_model, session):
                 dag_model.calculate_dagrun_date_fields(dag, dag.get_run_data_interval(dag_run))
 
             callback_to_execute = DagCallbackRequest(
@@ -1427,12 +1436,9 @@ class SchedulerJobRunner(BaseJobRunner[Job], LoggingMixin):
         # TODO[HA]: Rename update_state -> schedule_dag_run, ?? something else?
         schedulable_tis, callback_to_run = dag_run.update_state(session=session, execute_callbacks=False)
         # Check if DAG not scheduled then skip interval calculation to same scheduler runtime
-        if dag_run.state in State.finished and (
-            dag.schedule_interval or not isinstance(dag.timetable, NullTimetable)
-        ):
-            active_runs = dag.get_num_active_runs(only_running=False, session=session)
+        if dag_run.state in State.finished:
             # Work out if we should allow creating a new DagRun now?
-            if self._should_update_dag_next_dagruns(dag, dag_model, active_runs):
+            if self._should_update_dag_next_dagruns(dag, dag_model, session):
                 dag_model.calculate_dagrun_date_fields(dag, dag.get_run_data_interval(dag_run))
         # This will do one query per dag run. We "could" build up a complex
         # query to update all the TIs across all the execution dates and dag

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -59,7 +59,7 @@ from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance, TaskInstanceKey
 from airflow.stats import Stats
 from airflow.ti_deps.dependencies_states import EXECUTION_STATES
-from airflow.timetables.simple import DatasetTriggeredTimetable
+from airflow.timetables.simple import DatasetTriggeredTimetable, NullTimetable
 from airflow.utils import timezone
 from airflow.utils.event_scheduler import EventScheduler
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -1288,7 +1288,7 @@ class SchedulerJobRunner(BaseJobRunner[Job], LoggingMixin):
     ) -> bool:
         """Check if the dag's next_dagruns_create_after should be updated."""
         # If the DAG never schedules skip save runtime
-        if not dag.timetable.can_run:
+        if isinstance(dag.timetable, NullTimetable):
             return False
 
         # get active dag runs from DB if not available

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -59,7 +59,7 @@ from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance, TaskInstanceKey
 from airflow.stats import Stats
 from airflow.ti_deps.dependencies_states import EXECUTION_STATES
-from airflow.timetables.simple import DatasetTriggeredTimetable
+from airflow.timetables.simple import DatasetTriggeredTimetable, NullTimetable
 from airflow.utils import timezone
 from airflow.utils.event_scheduler import EventScheduler
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -1427,7 +1427,9 @@ class SchedulerJobRunner(BaseJobRunner[Job], LoggingMixin):
         # TODO[HA]: Rename update_state -> schedule_dag_run, ?? something else?
         schedulable_tis, callback_to_run = dag_run.update_state(session=session, execute_callbacks=False)
         # Check if DAG not scheduled then skip interval calculation to same scheduler runtime
-        if dag_run.state in State.finished and (dag.schedule_interval or not isinstance(dag.timetable, NullTimetable)):
+        if dag_run.state in State.finished and (
+            dag.schedule_interval or not isinstance(dag.timetable, NullTimetable)
+        ):
             active_runs = dag.get_num_active_runs(only_running=False, session=session)
             # Work out if we should allow creating a new DagRun now?
             if self._should_update_dag_next_dagruns(dag, dag_model, active_runs):

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1426,7 +1426,8 @@ class SchedulerJobRunner(BaseJobRunner[Job], LoggingMixin):
             return callback
         # TODO[HA]: Rename update_state -> schedule_dag_run, ?? something else?
         schedulable_tis, callback_to_run = dag_run.update_state(session=session, execute_callbacks=False)
-        if dag_run.state in State.finished:
+        # Check if DAG not scheduled then skip interval calculation to same scheduler runtime
+        if dag_run.state in State.finished and (dag.schedule_interval or not isinstance(dag.timetable, NullTimetable)):
             active_runs = dag.get_num_active_runs(only_running=False, session=session)
             # Work out if we should allow creating a new DagRun now?
             if self._should_update_dag_next_dagruns(dag, dag_model, active_runs):

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -877,7 +877,7 @@ class DAG(LoggingMixin):
         DO NOT use this method is there is a known data interval.
         """
         timetable_type = type(self.timetable)
-        if issubclass(timetable_type, (NullTimetable, OnceTimetable)):
+        if issubclass(timetable_type, (NullTimetable, OnceTimetable, DatasetTriggeredTimetable)):
             return DataInterval.exact(timezone.coerce_datetime(logical_date))
         start = timezone.coerce_datetime(logical_date)
         if issubclass(timetable_type, CronDataIntervalTimetable):
@@ -1272,7 +1272,7 @@ class DAG(LoggingMixin):
 
     @property
     def allow_future_exec_dates(self) -> bool:
-        return settings.ALLOW_FUTURE_EXEC_DATES and not self.timetable.can_run
+        return settings.ALLOW_FUTURE_EXEC_DATES and not self.timetable.can_be_scheduled
 
     @provide_session
     def get_concurrency_reached(self, session=NEW_SESSION) -> bool:
@@ -3217,7 +3217,7 @@ class DAG(LoggingMixin):
         Validates & raise exception if there are any Params in the DAG which neither have a default value nor
         have the null in schema['type'] list, but the DAG have a schedule_interval which is not None.
         """
-        if not self.timetable.can_run:
+        if not self.timetable.can_be_scheduled:
             return
 
         for k, v in self.params.items():

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -993,7 +993,7 @@ class TaskInstance(Base, LoggingMixin):
         # or the DAG is never scheduled. For legacy reasons, when
         # `catchup=True`, we use `get_previous_scheduled_dagrun` unless
         # `ignore_schedule` is `True`.
-        ignore_schedule = state is not None or not dag.timetable.can_run
+        ignore_schedule = state is not None or not dag.timetable.can_be_scheduled
         if dag.catchup is True and not ignore_schedule:
             last_dagrun = dr.get_previous_scheduled_dagrun(session=session)
         else:

--- a/airflow/timetables/base.py
+++ b/airflow/timetables/base.py
@@ -122,11 +122,12 @@ class Timetable(Protocol):
     like ``schedule=None`` and ``"@once"`` set it to *False*.
     """
 
-    can_run: bool = True
-    """Whether this timetable can actually schedule runs.
+    can_be_scheduled: bool = True
+    """Whether this timetable can actually schedule runs in an automated manner.
 
-    This defaults to and should generally be *True*, but ``NullTimetable`` sets
-    this to *False*.
+    This defaults to and should generally be *True* (including non periodic
+    execution types like *@once* and data triggered tables), but
+    ``NullTimetable`` sets this to *False*.
     """
 
     run_ordering: Sequence[str] = ("data_interval_end", "execution_date")

--- a/airflow/timetables/base.py
+++ b/airflow/timetables/base.py
@@ -123,7 +123,19 @@ class Timetable(Protocol):
     like ``schedule=None`` and ``"@once"`` set it to *False*.
     """
 
-    can_be_scheduled: bool = True
+    _can_be_scheduled: bool = True
+
+    @property
+    def can_be_scheduled(self):
+        if hasattr(self, "can_run"):
+            warn(
+                'can_run class variable is deprecated. Use "can_be_scheduled" instead.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return self.can_run
+        return self._can_be_scheduled
+
     """Whether this timetable can actually schedule runs in an automated manner.
 
     This defaults to and should generally be *True* (including non periodic
@@ -144,18 +156,6 @@ class Timetable(Protocol):
     (for example, the ContinuousTimetable) there are good reasons for limiting
     the DAGRun parallelism.
     """
-
-    def __getattribute__(self, item):
-        """Handle the deprecation of `can_run` attribute."""
-        if "can_run" == item:
-            warn(
-                f'{item} class variable is deprecated. Use "can_be_scheduled" instead.',
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return type.__getattribute__(self, "can_be_scheduled")
-
-        return type.__getattribute__(self, item)
 
     @classmethod
     def deserialize(cls, data: dict[str, Any]) -> Timetable:

--- a/airflow/timetables/base.py
+++ b/airflow/timetables/base.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NamedTuple, Sequence
+from warnings import warn
 
 from pendulum import DateTime
 
@@ -143,6 +144,18 @@ class Timetable(Protocol):
     (for example, the ContinuousTimetable) there are good reasons for limiting
     the DAGRun parallelism.
     """
+
+    def __getattribute__(self, item):
+        """Handle the deprecation of `can_run` attribute."""
+        if "can_run" == item:
+            warn(
+                f'{item} class variable is deprecated. Use "can_be_scheduled" instead.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return type.__getattribute__(self, "can_be_scheduled")
+
+        return type.__getattribute__(self, item)
 
     @classmethod
     def deserialize(cls, data: dict[str, Any]) -> Timetable:

--- a/airflow/timetables/simple.py
+++ b/airflow/timetables/simple.py
@@ -34,7 +34,6 @@ class _TrivialTimetable(Timetable):
     """Some code reuse for "trivial" timetables that has nothing complex."""
 
     periodic = False
-    can_run = False
     run_ordering = ("execution_date",)
 
     @classmethod
@@ -63,6 +62,7 @@ class NullTimetable(_TrivialTimetable):
     This corresponds to ``schedule=None``.
     """
 
+    can_be_scheduled = False
     description: str = "Never, external triggers only"
 
     @property
@@ -144,7 +144,7 @@ class ContinuousTimetable(_TrivialTimetable):
         return DagRunInfo.interval(start, end)
 
 
-class DatasetTriggeredTimetable(NullTimetable):
+class DatasetTriggeredTimetable(_TrivialTimetable):
     """Timetable that never schedules anything.
 
     This should not be directly used anywhere, but only set if a DAG is triggered by datasets.
@@ -188,3 +188,11 @@ class DatasetTriggeredTimetable(NullTimetable):
             events, key=operator.attrgetter("source_dag_run.data_interval_end")
         ).source_dag_run.data_interval_end
         return DataInterval(start, end)
+
+    def next_dagrun_info(
+        self,
+        *,
+        last_automated_data_interval: DataInterval | None,
+        restriction: TimeRestriction,
+    ) -> DagRunInfo | None:
+        return None

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3395,6 +3395,42 @@ class TestSchedulerJob:
             self.job_runner._send_sla_callbacks_to_processor(dag)
             scheduler_job.executor.callback_sink.send.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "schedule, number_running, excepted",
+        [
+            (None, -1, False),
+            ("*/1 * * * *", -1, False),
+            ("*/1 * * * *", 1, True),
+        ],
+        ids=["no_dag_schedule", "dag_schedule_too_many_runs", "dag_schedule_less_runs"],
+    )
+    def test_should_update_dag_next_dagruns(self, schedule, number_running, excepted, session, dag_maker):
+        """Test if really required to update next dagrun or possible to save run time"""
+
+        with dag_maker(
+            dag_id="test_should_update_dag_next_dagruns", schedule=schedule, max_active_runs=2
+        ) as dag:
+            EmptyOperator(task_id="dummy")
+
+        dag_model = dag_maker.dag_model
+
+        for index in range(2):
+            dag_maker.create_dagrun(
+                run_id=f"run_{index}",
+                execution_date=(DEFAULT_DATE + timedelta(days=index)),
+                start_date=timezone.utcnow(),
+                state=State.RUNNING,
+                session=session,
+            )
+
+        session.flush()
+        scheduler_job = Job(executor=self.null_exec)
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        assert excepted is self.job_runner._should_update_dag_next_dagruns(
+            dag, dag_model, session, number_running
+        )
+
     def test_create_dag_runs(self, dag_maker):
         """
         Test various invariants of _create_dag_runs.

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3428,7 +3428,7 @@ class TestSchedulerJob:
         self.job_runner = SchedulerJobRunner(job=scheduler_job)
 
         assert excepted is self.job_runner._should_update_dag_next_dagruns(
-            dag, dag_model, session, number_running
+            dag, dag_model, number_running, session=session
         )
 
     def test_create_dag_runs(self, dag_maker):

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3398,8 +3398,8 @@ class TestSchedulerJob:
     @pytest.mark.parametrize(
         "schedule, number_running, excepted",
         [
-            (None, -1, False),
-            ("*/1 * * * *", -1, False),
+            (None, None, False),
+            ("*/1 * * * *", None, False),
             ("*/1 * * * *", 1, True),
         ],
         ids=["no_dag_schedule", "dag_schedule_too_many_runs", "dag_schedule_less_runs"],


### PR DESCRIPTION
Hi airflow community,
this is my third PR and be happy to work on the scheduler runtime again. We faced an issue with slow scheduler execution time by having millions of queued dag_runs for one DAG.

Our DAG which runs millions of task is triggered external and has no interval or timetable. We think that DAGs which are running with interval or timetable will not create huge amount of dag_runs in queued state. But the idea is to improve the performance for the dag_runs for DAGs which have no interval or timetable by skipping the execution of calc_num_active_runs and _should_update_dag_next_dagruns if there is not timetable or interval. This also helped us to improve the scheduler execution time.

So I´m still new to Airflow coding and try to get thinks right. I hope it is possible to understand the idea behind the improvement. I´m open and looking for a nicer code to check for this, maybe you have nicer code solution to check for a DAG which has timetable or interval.

@vandonr-amz fyi, as discussed with @jens-scheffler-bosch