### PR TITLE
Fix when OpenLineage plugins has listener disabled.

### DIFF
--- a/airflow/providers/openlineage/extractors/manager.py
+++ b/airflow/providers/openlineage/extractors/manager.py
@@ -37,13 +37,13 @@ class ExtractorManager(LoggingMixin):
 
         # Comma-separated extractors in OPENLINEAGE_EXTRACTORS variable.
         # Extractors should implement BaseExtractor
-        from airflow.providers.openlineage.utils import import_from_string
+        from airflow.utils.module_loading import import_string
 
         # TODO: use airflow config with OL backup
         env_extractors = os.getenv("OPENLINEAGE_EXTRACTORS")
         if env_extractors is not None:
             for extractor in env_extractors.split(";"):
-                extractor: type[BaseExtractor] = import_from_string(extractor.strip())
+                extractor: type[BaseExtractor] = import_string(extractor.strip())
                 for operator_class in extractor.get_operator_classnames():
                     self.extractors[operator_class] = extractor
 

--- a/airflow/providers/openlineage/plugins/openlineage.py
+++ b/airflow/providers/openlineage/plugins/openlineage.py
@@ -33,7 +33,7 @@ class OpenLineageProviderPlugin(AirflowPlugin):
 
     name = "OpenLineageProviderPlugin"
     macros = [lineage_run_id, lineage_parent_id]
-    if _is_disabled():
+    if not _is_disabled():
         from airflow.providers.openlineage.plugins.listener import OpenLineageListener
 
         listeners = [OpenLineageListener()]

--- a/tests/providers/openlineage/plugins/test_openlineage.py
+++ b/tests/providers/openlineage/plugins/test_openlineage.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+class TestOpenLineageProviderPlugin:
+    def setup_method(self):
+        self.old_modules = dict(sys.modules)
+
+    def teardown_method(self):
+        # Remove any new modules imported during the test run. This lets us
+        # import the same source files for more than one test.
+        for mod in [m for m in sys.modules if m not in self.old_modules]:
+            del sys.modules[mod]
+
+    @pytest.mark.parametrize(
+        "mocks, expected",
+        [([patch.dict(os.environ, {"OPENLINEAGE_DISABLED": "true"}, 0)], 0), ([], 1)],
+    )
+    def test_plugin_disablements(self, mocks, expected):
+        with contextlib.ExitStack() as stack:
+            for mock in mocks:
+                stack.enter_context(mock)
+            from airflow.providers.openlineage.plugins.openlineage import OpenLineageProviderPlugin
+
+            plugin = OpenLineageProviderPlugin()
+            assert len(plugin.listeners) == expected


### PR DESCRIPTION
Recently, the first PR for AIP-53 (#29940) was merged. However, the logic for disabling the OpenLineage listener is currently opposite to what is intended.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->