### PR TITLE
Allow a user to collapse the grid view

### DIFF
--- a/airflow/www/static/js/dag/InstanceTooltip.tsx
+++ b/airflow/www/static/js/dag/InstanceTooltip.tsx
@@ -32,7 +32,7 @@ interface Props {
 
 const InstanceTooltip = ({
   group,
-  instance: { startDate, endDate, state, runId, mappedStates, note },
+  instance: { taskId, startDate, endDate, state, runId, mappedStates, note },
 }: Props) => {
   if (!group) return null;
   const isGroup = !!group.children;
@@ -60,6 +60,7 @@ const InstanceTooltip = ({
 
   return (
     <Box py="2px">
+      <Text>Task Id: {taskId}</Text>
       {group.tooltip && <Text>{group.tooltip}</Text>}
       {isMapped && totalTasks > 0 && (
         <Text>

--- a/airflow/www/static/js/dag/Main.tsx
+++ b/airflow/www/static/js/dag/Main.tsx
@@ -20,10 +20,9 @@
 /* global localStorage */
 
 import React, { useState, useRef, useEffect, useCallback } from "react";
-import { Box, Flex, useDisclosure, Divider, Spinner } from "@chakra-ui/react";
+import { Box, Flex, Divider, Spinner, useDisclosure } from "@chakra-ui/react";
 import { isEmpty, debounce } from "lodash";
 
-import useSelection from "src/dag/useSelection";
 import { useGridData } from "src/api";
 import { hoverDelay } from "src/utils";
 
@@ -32,9 +31,11 @@ import Grid from "./grid";
 import FilterBar from "./nav/FilterBar";
 import LegendRow from "./nav/LegendRow";
 import useToggleGroups from "./useToggleGroups";
+import useSelection from "./useSelection";
 
 const detailsPanelKey = "hideDetailsPanel";
 const minPanelWidth = 300;
+const collapsedWidth = "28px";
 
 const gridWidthKey = "grid-width";
 const saveWidth = debounce(
@@ -62,6 +63,7 @@ const Main = () => {
     data: { groups },
     isLoading,
   } = useGridData();
+  const [isGridCollapsed, setIsGridCollapsed] = useState(false);
   const resizeRef = useRef<HTMLDivElement>(null);
   const gridRef = useRef<HTMLDivElement>(null);
   const isPanelOpen = localStorage.getItem(detailsPanelKey) !== "true";
@@ -131,6 +133,18 @@ const Main = () => {
     return () => {};
   }, [resize, isLoading, isOpen]);
 
+  const onToggleGridCollapse = () => {
+    const gridElement = gridRef.current;
+    if (gridElement) {
+      if (isGridCollapsed) {
+        gridElement.style.width = localStorage.getItem(gridWidthKey) || "";
+      } else {
+        gridElement.style.width = collapsedWidth;
+      }
+      setIsGridCollapsed(!isGridCollapsed);
+    }
+  };
+
   return (
     <Box
       flex={1}
@@ -149,11 +163,11 @@ const Main = () => {
         ) : (
           <>
             <Box
-              minWidth={minPanelWidth}
               flex={isOpen ? undefined : 1}
+              minWidth={isGridCollapsed ? collapsedWidth : minPanelWidth}
               ref={gridRef}
               height="100%"
-              width={gridWidth}
+              width={isGridCollapsed ? collapsedWidth : gridWidth}
             >
               <Grid
                 isPanelOpen={isOpen}
@@ -161,6 +175,8 @@ const Main = () => {
                 hoveredTaskState={hoveredTaskState}
                 openGroupIds={openGroupIds}
                 onToggleGroups={onToggleGroups}
+                isGridCollapsed={isGridCollapsed}
+                setIsGridCollapsed={onToggleGridCollapse}
               />
             </Box>
             {isOpen && (

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -151,7 +151,7 @@ const Details = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
 
   return (
     <Flex flexDirection="column" pl={3} height="100%">
-      <Flex alignItems="center" justifyContent="space-between">
+      <Flex alignItems="center" justifyContent="space-between" ml={6}>
         <Header />
         <Flex>
           {runId && !taskId && (

--- a/airflow/www/static/js/dag/grid/index.tsx
+++ b/airflow/www/static/js/dag/grid/index.tsx
@@ -29,6 +29,7 @@ import { useOffsetTop } from "src/utils";
 
 import renderTaskRows from "./renderTaskRows";
 import DagRuns from "./dagRuns";
+import useSelection from "../useSelection";
 
 interface Props {
   isPanelOpen?: boolean;
@@ -36,6 +37,8 @@ interface Props {
   hoveredTaskState?: string | null;
   openGroupIds: string[];
   onToggleGroups: (groupIds: string[]) => void;
+  isGridCollapsed?: boolean;
+  setIsGridCollapsed?: (collapsed: boolean) => void;
 }
 
 const Grid = ({
@@ -44,15 +47,26 @@ const Grid = ({
   hoveredTaskState,
   openGroupIds,
   onToggleGroups,
+  isGridCollapsed,
+  setIsGridCollapsed,
 }: Props) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const tableRef = useRef<HTMLTableSectionElement>(null);
   const offsetTop = useOffsetTop(scrollRef);
+  const { selected } = useSelection();
 
   const {
     data: { groups, dagRuns },
   } = useGridData();
-  const dagRunIds = dagRuns.map((dr) => dr.runId);
+  const dagRunIds = dagRuns
+    .map((dr) => dr.runId)
+    .filter((id, i) => {
+      if (isGridCollapsed) {
+        if (selected.runId) return id === selected.runId;
+        return i === dagRuns.length - 1;
+      }
+      return true;
+    });
 
   useEffect(() => {
     const scrollOnResize = new ResizeObserver(() => {
@@ -76,25 +90,45 @@ const Grid = ({
       };
     }
     return () => {};
-  }, [tableRef, isPanelOpen]);
+  }, [tableRef, isGridCollapsed]);
 
   return (
     <Box height="100%" position="relative">
+      {isPanelOpen && (
+        <IconButton
+          fontSize="2xl"
+          variant="ghost"
+          color="gray.400"
+          size="sm"
+          position="absolute"
+          right={0}
+          zIndex={2}
+          top={-8}
+          onClick={() =>
+            setIsGridCollapsed && setIsGridCollapsed(!isGridCollapsed)
+          }
+          title={isGridCollapsed ? "Restore grid" : "Collapse grid"}
+          aria-label={isGridCollapsed ? "Restore grid" : "Collapse grid"}
+          icon={<MdDoubleArrow />}
+          transform={isGridCollapsed ? undefined : "rotateZ(180deg)"}
+          transitionProperty="none"
+        />
+      )}
       <IconButton
         fontSize="2xl"
         variant="ghost"
         color="gray.400"
         size="sm"
+        position="absolute"
+        right={isPanelOpen ? -10 : 0}
+        zIndex={2}
+        top={-8}
         onClick={onPanelToggle}
         title={`${isPanelOpen ? "Hide " : "Show "} Details Panel`}
         aria-label={isPanelOpen ? "Show Details" : "Hide Details"}
         icon={<MdDoubleArrow />}
-        transform={!isPanelOpen ? "rotateZ(180deg)" : undefined}
+        transform={isPanelOpen ? undefined : "rotateZ(180deg)"}
         transitionProperty="none"
-        position="absolute"
-        right={0}
-        zIndex={2}
-        top={-8}
       />
       <Box
         maxHeight={`calc(100% - ${offsetTop}px)`}
@@ -110,6 +144,7 @@ const Grid = ({
               groups={groups}
               openGroupIds={openGroupIds}
               onToggleGroups={onToggleGroups}
+              isGridCollapsed={isGridCollapsed}
             />
           </Thead>
           <Tbody ref={tableRef}>
@@ -119,6 +154,7 @@ const Grid = ({
               openGroupIds,
               onToggleGroups,
               hoveredTaskState,
+              isGridCollapsed,
             })}
           </Tbody>
         </Table>

--- a/airflow/www/static/js/dag/grid/renderTaskRows.tsx
+++ b/airflow/www/static/js/dag/grid/renderTaskRows.tsx
@@ -39,6 +39,7 @@ interface RowProps {
   onToggleGroups?: (groupIds: string[]) => void;
   hoveredTaskState?: string | null;
   isParentMapped?: boolean;
+  isGridCollapsed?: boolean;
 }
 
 const renderTaskRows = ({ task, level = 0, ...rest }: RowProps) => (
@@ -56,6 +57,7 @@ interface TaskInstancesProps {
   selectedRunId?: string | null;
   onSelect: (selection: SelectionProps) => void;
   hoveredTaskState?: string | null;
+  isGridCollapsed?: boolean;
 }
 
 const TaskInstances = ({
@@ -64,12 +66,13 @@ const TaskInstances = ({
   selectedRunId,
   onSelect,
   hoveredTaskState,
+  isGridCollapsed,
 }: TaskInstancesProps) => (
   <Flex justifyContent="flex-end">
     {dagRunIds.map((runId: string) => {
       // Check if an instance exists for the run, or return an empty box
       const instance = task.instances.find((ti) => ti && ti.runId === runId);
-      const isSelected = selectedRunId === runId;
+      const isSelected = selectedRunId === runId && !isGridCollapsed;
       return (
         <Box
           py="4px"
@@ -110,6 +113,7 @@ const Row = (props: RowProps) => {
     onToggleGroups = () => {},
     hoveredTaskState,
     isParentMapped,
+    isGridCollapsed,
   } = props;
   const { colors } = useTheme();
   const { selected, onSelect } = useSelection();
@@ -146,27 +150,29 @@ const Row = (props: RowProps) => {
         _hover={!isSelected ? { bg: hoverBlue } : undefined}
         transition="background-color 0.2s"
       >
-        <Td
-          bg={isSelected ? "blue.100" : "white"}
-          _groupHover={!isSelected ? { bg: "blue.50" } : undefined}
-          p={0}
-          transition="background-color 0.2s"
-          lineHeight="18px"
-          position="sticky"
-          left={0}
-          borderBottom={0}
-          width="100%"
-          zIndex={1}
-        >
-          <TaskName
-            onToggle={memoizedToggle}
-            isGroup={isGroup}
-            isMapped={task.isMapped && !isParentMapped}
-            label={task.label || task.id || ""}
-            isOpen={isOpen}
-            level={level}
-          />
-        </Td>
+        {!isGridCollapsed && (
+          <Td
+            bg={isSelected ? "blue.100" : "white"}
+            _groupHover={!isSelected ? { bg: "blue.50" } : undefined}
+            p={0}
+            transition="background-color 0.2s"
+            lineHeight="18px"
+            position="sticky"
+            left={0}
+            borderBottom={0}
+            width="100%"
+            zIndex={1}
+          >
+            <TaskName
+              onToggle={memoizedToggle}
+              isGroup={isGroup}
+              isMapped={task.isMapped && !isParentMapped}
+              label={task.label || task.id || ""}
+              isOpen={isOpen}
+              level={level}
+            />
+          </Td>
+        )}
         <Td
           p={0}
           align="right"
@@ -179,6 +185,7 @@ const Row = (props: RowProps) => {
             selectedRunId={selected.runId}
             onSelect={onSelect}
             hoveredTaskState={hoveredTaskState}
+            isGridCollapsed={isGridCollapsed}
           />
         </Td>
       </Tr>


### PR DESCRIPTION
We added a graph inside of the grid view. But for large DAGs, there may not always be enough space to see the graph. This PR adds a "collapse grid" button to only show the user-selected or latest dag run in the grid.

![Apr-18-2023 10-24-53](https://user-images.githubusercontent.com/4600967/232808894-41c84367-67f5-407c-b6aa-37ac546f905b.gif)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
