### PR TITLE
Add explicit information about how to write task logs

### DIFF
--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/logging-tasks.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/logging-tasks.rst
@@ -54,6 +54,39 @@ These patterns can be adjusted by :ref:`config:logging__log_filename_template`.
 
 In addition, you can supply a remote location to store current logs and backups.
 
+Writing to task logs from your code
+-----------------------------------
+
+Most operators will write logs to the task log automatically. This is because they derive from they
+have a ``log`` logger that you can use to write to the task log.
+This logger is created and configured by :class:`~airflow.utils.log.LoggingMixin` that all classic
+operators derive from.
+
+If you want to log to the task log from a custom class of yours you can do the following:
+
+* make sure your class extends from :class:`~airflow.utils.log.LoggingMixin`
+* just use standard print statements to print to stdout
+* use the ``airflow.task`` logger that is configured by default or create logger where ``airflow.task`` is
+  the parent logger
+
+The last option is the most flexible, as you can create your own logger and configure it as you see fit
+via advanced configuration options below.
+
+Using task logger directly:
+
+.. code-block:: python
+
+  logger = logging.getLogger("airflow.task")
+  logger.info("This is a log message")
+
+Using child logger of task logger:
+
+.. code-block:: python
+
+  child_logger = logging.getLogger("airflow.task.child")
+  child_logger.info("This is a child log message")
+
+
 Interleaving of logs
 --------------------
 


### PR DESCRIPTION
There was no explicit information in our documentation on how to write logs from your tasks. While for classic operators, that is easy and straightforward as they all have log property which is the right logger coming from LoggingMixin, for taskflow code and custom classes it is is not straightforward that you have to use `airflow.task` logger (or a child of it) or that you have extend LoggingMixin to use the built-in logging configuration.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
