### PR TITLE
Remove deprecated "delegate_to" from GCP operators and hooks

### DIFF
--- a/airflow/providers/amazon/CHANGELOG.rst
+++ b/airflow/providers/amazon/CHANGELOG.rst
@@ -24,6 +24,16 @@
 Changelog
 ---------
 
+8.0.0
+......
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+.. warning::
+  In this version of the provider, deprecated GCS hook's parameter ``delegate_to`` is removed from the following operators: ``GCSToS3Operator``, ``GlacierToGCSOperator`` and ``GoogleApiToS3Operator``.
+  Impersonation can be achieved instead by utilizing the ``impersonation_chain`` param.
+
 7.4.1
 .....
 

--- a/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
@@ -47,9 +47,6 @@ class GCSToS3Operator(BaseOperator):
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
     :param google_cloud_storage_conn_id: (Deprecated) The connection ID used to connect to Google Cloud.
         This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
-    :param delegate_to: Google account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param dest_aws_conn_id: The destination S3 connection
     :param dest_s3_key: The base S3 key to be used to store the files. (templated)
     :param dest_verify: Whether or not to verify SSL certificates for S3 connection.
@@ -101,7 +98,6 @@ class GCSToS3Operator(BaseOperator):
         delimiter: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
         google_cloud_storage_conn_id: str | None = None,
-        delegate_to: str | None = None,
         dest_aws_conn_id: str = "aws_default",
         dest_s3_key: str,
         dest_verify: str | bool | None = None,
@@ -127,7 +123,6 @@ class GCSToS3Operator(BaseOperator):
         self.prefix = prefix
         self.delimiter = delimiter
         self.gcp_conn_id = gcp_conn_id
-        self.delegate_to = delegate_to
         self.dest_aws_conn_id = dest_aws_conn_id
         self.dest_s3_key = dest_s3_key
         self.dest_verify = dest_verify
@@ -141,7 +136,6 @@ class GCSToS3Operator(BaseOperator):
         # list all files in an Google Cloud Storage bucket
         hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.google_impersonation_chain,
         )
 

--- a/airflow/providers/amazon/aws/transfers/glacier_to_gcs.py
+++ b/airflow/providers/amazon/aws/transfers/glacier_to_gcs.py
@@ -47,10 +47,7 @@ class GlacierToGCSOperator(BaseOperator):
     :param object_name: the name of the object to check in the Google cloud
         storage bucket.
     :param gzip: option to compress local file or file data for upload
-    :param chunk_size: size of chunk in bytes the that will downloaded from Glacier vault
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
+    :param chunk_size: size of chunk in bytes the that will be downloaded from Glacier vault
     :param google_impersonation_chain: Optional Google service account to impersonate using
         short-term credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -73,7 +70,6 @@ class GlacierToGCSOperator(BaseOperator):
         object_name: str,
         gzip: bool,
         chunk_size: int = 1024,
-        delegate_to: str | None = None,
         google_impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -85,14 +81,12 @@ class GlacierToGCSOperator(BaseOperator):
         self.object_name = object_name
         self.gzip = gzip
         self.chunk_size = chunk_size
-        self.delegate_to = delegate_to
         self.impersonation_chain = google_impersonation_chain
 
     def execute(self, context: Context) -> str:
         glacier_hook = GlacierHook(aws_conn_id=self.aws_conn_id)
         gcs_hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         job_id = glacier_hook.retrieve_inventory(vault_name=self.vault_name)

--- a/airflow/providers/amazon/aws/transfers/google_api_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/google_api_to_s3.py
@@ -73,13 +73,10 @@ class GoogleApiToS3Operator(BaseOperator):
 
         .. note:: This means the response will be a list of responses.
 
-    :param google_api_num_retries: Define the number of retries for the google api requests being made
+    :param google_api_num_retries: Define the number of retries for the Google API requests being made
         if it fails.
     :param s3_overwrite: Specifies whether the s3 file will be overwritten if exists.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: Google account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param aws_conn_id: The connection id specifying the authentication information for the S3 Bucket.
     :param google_impersonation_chain: Optional Google service account to impersonate using
         short-term credentials, or chained list of accounts required to get the access_token
@@ -115,7 +112,6 @@ class GoogleApiToS3Operator(BaseOperator):
         google_api_num_retries: int = 0,
         s3_overwrite: bool = False,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         aws_conn_id: str = "aws_default",
         google_impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
@@ -133,7 +129,6 @@ class GoogleApiToS3Operator(BaseOperator):
         self.google_api_num_retries = google_api_num_retries
         self.s3_overwrite = s3_overwrite
         self.gcp_conn_id = gcp_conn_id
-        self.delegate_to = delegate_to
         self.aws_conn_id = aws_conn_id
         self.google_impersonation_chain = google_impersonation_chain
 
@@ -158,7 +153,6 @@ class GoogleApiToS3Operator(BaseOperator):
     def _retrieve_data_from_google_api(self) -> dict:
         google_discovery_api_hook = GoogleDiscoveryApiHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_service_name=self.google_api_service_name,
             api_version=self.google_api_service_version,
             impersonation_chain=self.google_impersonation_chain,

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -23,6 +23,7 @@ description: |
 
 suspended: false
 versions:
+  - 8.0.0
   - 7.4.1
   - 7.4.0
   - 7.3.0

--- a/airflow/providers/apache/beam/CHANGELOG.rst
+++ b/airflow/providers/apache/beam/CHANGELOG.rst
@@ -24,6 +24,16 @@
 Changelog
 ---------
 
+5.0.0
+......
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+.. warning::
+  In this version of the provider, deprecated GCS and Dataflow hooks' param ``delegate_to`` is removed from all Beam operators.
+  Impersonation can be achieved instead by utilizing the ``impersonation_chain`` param.
+
 4.3.0
 .....
 

--- a/airflow/providers/apache/beam/provider.yaml
+++ b/airflow/providers/apache/beam/provider.yaml
@@ -23,6 +23,7 @@ description: |
 
 suspended: false
 versions:
+  - 5.0.0
   - 4.3.0
   - 4.2.0
   - 4.1.1

--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -33,6 +33,11 @@ Google has announced sunset of Campaign Manager 360 v3.5 by Apr 20, 2023. For mo
 please check: `<https://developers.google.com/doubleclick-advertisers/deprecation>`_ . As a result, the
 default api version for Campaign Manager 360 operator was updated to the latest v4 version.
 
+.. warning::
+  In this version of the provider, deprecated ``delegate_to`` param is removed from all GCP operators, hooks, and triggers, as well as from firestore and gsuite
+  transfer operators that interact with GCS. Impersonation can be achieved instead by utilizing the ``impersonation_chain`` param.
+  The ``delegate_to`` param will still be available only in gsuite and marketing platform hooks and operators, that don't interact with Google Cloud.
+
 9.0.0
 .....
 

--- a/airflow/providers/google/cloud/hooks/automl.py
+++ b/airflow/providers/google/cloud/hooks/automl.py
@@ -24,7 +24,6 @@ This module contains a Google AutoML hook.
 """
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
 
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
@@ -65,16 +64,16 @@ class CloudAutoMLHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._client: AutoMlClient | None = None

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -74,7 +74,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
     Interact with BigQuery. This hook uses the Google Cloud connection.
 
     :param gcp_conn_id: The Airflow connection used for GCP credentials.
-    :param delegate_to: This performs a task on one host with reference to other hosts.
     :param use_legacy_sql: This specifies whether to use legacy SQL dialect.
     :param location: The location of the BigQuery resource.
     :param api_resource_configs: This contains params configuration applied for Google BigQuery jobs.
@@ -91,20 +90,20 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
     def __init__(
         self,
         gcp_conn_id: str = GoogleBaseHook.default_conn_name,
-        delegate_to: str | None = None,
         use_legacy_sql: bool = True,
         location: str | None = None,
         api_resource_configs: dict | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         labels: dict | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self.use_legacy_sql = use_legacy_sql

--- a/airflow/providers/google/cloud/hooks/bigquery_dts.py
+++ b/airflow/providers/google/cloud/hooks/bigquery_dts.py
@@ -18,7 +18,6 @@
 """This module contains a BigQuery Hook."""
 from __future__ import annotations
 
-import warnings
 from copy import copy
 from typing import Sequence
 
@@ -58,17 +57,17 @@ class BiqQueryDataTransferServiceHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         location: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self.location = location
@@ -282,13 +281,17 @@ class AsyncBiqQueryDataTransferServiceHook(GoogleBaseAsyncHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         location: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ):
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
+            )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             location=location,
             impersonation_chain=impersonation_chain,
         )

--- a/airflow/providers/google/cloud/hooks/bigtable.py
+++ b/airflow/providers/google/cloud/hooks/bigtable.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import enum
-import warnings
 from typing import Sequence
 
 from google.cloud.bigtable import Client, enums
@@ -43,16 +42,16 @@ class BigtableHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._client: Client | None = None

--- a/airflow/providers/google/cloud/hooks/cloud_build.py
+++ b/airflow/providers/google/cloud/hooks/cloud_build.py
@@ -18,7 +18,6 @@
 """Hook for Google Cloud Build service."""
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
 
 from google.api_core.client_options import ClientOptions
@@ -42,9 +41,6 @@ class CloudBuildHook(GoogleBaseHook):
     Hook for the Google Cloud Build Service.
 
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -58,16 +54,15 @@ class CloudBuildHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
-        super().__init__(
-            gcp_conn_id=gcp_conn_id, delegate_to=delegate_to, impersonation_chain=impersonation_chain
-        )
+        super().__init__(gcp_conn_id=gcp_conn_id, impersonation_chain=impersonation_chain)
         self._client: dict[str, CloudBuildClient] = {}
 
     def _get_build_id_from_operation(self, operation: Operation) -> str:
@@ -627,6 +622,14 @@ class CloudBuildHook(GoogleBaseHook):
 
 class CloudBuildAsyncHook(GoogleBaseHook):
     """Asynchronous Hook for the Google Cloud Build Service."""
+
+    def __init__(self, **kwargs):
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
+            )
+        super().__init__(**kwargs)
 
     @GoogleBaseHook.fallback_to_default_project_id
     async def get_cloud_build(

--- a/airflow/providers/google/cloud/hooks/cloud_composer.py
+++ b/airflow/providers/google/cloud/hooks/cloud_composer.py
@@ -46,6 +46,14 @@ class CloudComposerHook(GoogleBaseHook):
 
     client_options = ClientOptions(api_endpoint="composer.googleapis.com:443")
 
+    def __init__(self, **kwargs):
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
+            )
+        super().__init__(**kwargs)
+
     def get_environment_client(self) -> EnvironmentsClient:
         """Retrieves client library object that allow access Environments service."""
         return EnvironmentsClient(
@@ -283,6 +291,14 @@ class CloudComposerHook(GoogleBaseHook):
 
 class CloudComposerAsyncHook(GoogleBaseHook):
     """Hook for Google Cloud Composer async APIs."""
+
+    def __init__(self, **kwargs):
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
+            )
+        super().__init__(**kwargs)
 
     client_options = ClientOptions(api_endpoint="composer.googleapis.com:443")
 

--- a/airflow/providers/google/cloud/hooks/cloud_memorystore.py
+++ b/airflow/providers/google/cloud/hooks/cloud_memorystore.py
@@ -27,7 +27,6 @@ Hooks for Cloud Memorystore service.
 """
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
 
 from google.api_core import path_template
@@ -58,9 +57,6 @@ class CloudMemorystoreHook(GoogleBaseHook):
     keyword arguments rather than positional.
 
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -74,16 +70,16 @@ class CloudMemorystoreHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._client: CloudRedisClient | None = None
@@ -499,9 +495,6 @@ class CloudMemorystoreMemcachedHook(GoogleBaseHook):
     keyword arguments rather than positional.
 
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -515,12 +508,10 @@ class CloudMemorystoreMemcachedHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
     ) -> None:
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._client: CloudMemcacheClient | None = None

--- a/airflow/providers/google/cloud/hooks/cloud_sql.py
+++ b/airflow/providers/google/cloud/hooks/cloud_sql.py
@@ -31,7 +31,6 @@ import string
 import subprocess
 import time
 import uuid
-import warnings
 from inspect import signature
 from pathlib import Path
 from subprocess import PIPE, Popen
@@ -80,7 +79,6 @@ class CloudSQLHook(GoogleBaseHook):
 
     :param api_version: This is the version of the api.
     :param gcp_conn_id: The Airflow connection used for GCP credentials.
-    :param delegate_to: This performs a task on one host with reference to other hosts.
     :param impersonation_chain: This is the optional service account to impersonate using short term
         credentials.
     """
@@ -94,16 +92,16 @@ class CloudSQLHook(GoogleBaseHook):
         self,
         api_version: str,
         gcp_conn_id: str = default_conn_name,
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self.api_version = api_version

--- a/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
@@ -127,16 +127,16 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
         self,
         api_version: str = "v1",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self.api_version = api_version

--- a/airflow/providers/google/cloud/hooks/compute.py
+++ b/airflow/providers/google/cloud/hooks/compute.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import time
-import warnings
 from typing import Any, Sequence
 
 from google.api_core.retry import Retry
@@ -56,16 +55,16 @@ class ComputeEngineHook(GoogleBaseHook):
         self,
         api_version: str = "v1",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self.api_version = api_version

--- a/airflow/providers/google/cloud/hooks/datacatalog.py
+++ b/airflow/providers/google/cloud/hooks/datacatalog.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
 
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
@@ -44,9 +43,6 @@ class CloudDataCatalogHook(GoogleBaseHook):
     Hook for Google Cloud Data Catalog Service.
 
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -60,16 +56,16 @@ class CloudDataCatalogHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._client: DataCatalogClient | None = None

--- a/airflow/providers/google/cloud/hooks/dataflow.py
+++ b/airflow/providers/google/cloud/hooks/dataflow.py
@@ -516,26 +516,26 @@ class DataflowHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         poll_sleep: int = 10,
         impersonation_chain: str | Sequence[str] | None = None,
         drain_pipeline: bool = False,
         cancel_timeout: int | None = 5 * 60,
         wait_until_finished: bool | None = None,
+        **kwargs,
     ) -> None:
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
+            )
         self.poll_sleep = poll_sleep
         self.drain_pipeline = drain_pipeline
         self.cancel_timeout = cancel_timeout
         self.wait_until_finished = wait_until_finished
         self.job_id: str | None = None
         self.beam_hook = BeamHook(BeamRunnerType.DataflowRunner)
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
 
@@ -1188,6 +1188,14 @@ class AsyncDataflowHook(GoogleBaseAsyncHook):
     """Async hook class for dataflow service."""
 
     sync_hook_class = DataflowHook
+
+    def __init__(self, **kwargs):
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
+            )
+        super().__init__(**kwargs)
 
     async def initialize_client(self, client_class):
         """

--- a/airflow/providers/google/cloud/hooks/dataform.py
+++ b/airflow/providers/google/cloud/hooks/dataform.py
@@ -38,6 +38,14 @@ from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 class DataformHook(GoogleBaseHook):
     """Hook for Google Cloud DataForm APIs."""
 
+    def __init__(self, **kwargs):
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
+            )
+        super().__init__(**kwargs)
+
     def get_dataform_client(self) -> DataformClient:
         """Retrieves client library object that allow access to Cloud Dataform service."""
         return DataformClient(credentials=self.get_credentials())

--- a/airflow/providers/google/cloud/hooks/datafusion.py
+++ b/airflow/providers/google/cloud/hooks/datafusion.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import json
 import os
-import warnings
 from time import monotonic, sleep
 from typing import Any, Dict, Sequence
 from urllib.parse import quote, urlencode, urljoin
@@ -67,16 +66,16 @@ class DataFusionHook(GoogleBaseHook):
         self,
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self.api_version = api_version
@@ -489,6 +488,14 @@ class DataFusionAsyncHook(GoogleBaseAsyncHook):
 
     sync_hook_class = DataFusionHook
     scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+
+    def __init__(self, **kwargs):
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
+            )
+        super().__init__(**kwargs)
 
     @staticmethod
     def _base_url(instance_url: str, namespace: str) -> str:

--- a/airflow/providers/google/cloud/hooks/dataplex.py
+++ b/airflow/providers/google/cloud/hooks/dataplex.py
@@ -17,7 +17,6 @@
 """This module contains Google Dataplex hook."""
 from __future__ import annotations
 
-import warnings
 from typing import Any, Sequence
 
 from google.api_core.client_options import ClientOptions
@@ -39,8 +38,6 @@ class DataplexHook(GoogleBaseHook):
 
     :param api_version: The version of the api that will be requested for example 'v3'.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -57,16 +54,16 @@ class DataplexHook(GoogleBaseHook):
         self,
         api_version: str = "v1",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self.api_version = api_version

--- a/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/airflow/providers/google/cloud/hooks/dataproc.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import time
 import uuid
-import warnings
 from typing import Any, Sequence
 
 from google.api_core.client_options import ClientOptions
@@ -209,14 +208,15 @@ class DataprocHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
-        super().__init__(gcp_conn_id, delegate_to, impersonation_chain)
+        super().__init__(gcp_conn_id=gcp_conn_id, impersonation_chain=impersonation_chain)
 
     def get_cluster_client(self, region: str | None = None) -> ClusterControllerClient:
         """Returns ClusterControllerClient."""
@@ -1060,10 +1060,15 @@ class DataprocAsyncHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        super().__init__(gcp_conn_id, delegate_to, impersonation_chain)
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
+            )
+        super().__init__(gcp_conn_id=gcp_conn_id, impersonation_chain=impersonation_chain)
         self._cached_client: JobControllerAsyncClient | None = None
 
     def get_cluster_client(self, region: str | None = None) -> ClusterControllerAsyncClient:

--- a/airflow/providers/google/cloud/hooks/dataproc_metastore.py
+++ b/airflow/providers/google/cloud/hooks/dataproc_metastore.py
@@ -37,6 +37,14 @@ from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 class DataprocMetastoreHook(GoogleBaseHook):
     """Hook for Google Cloud Dataproc Metastore APIs."""
 
+    def __init__(self, **kwargs):
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
+            )
+        super().__init__(**kwargs)
+
     def get_dataproc_metastore_client(self) -> DataprocMetastoreClient:
         """Returns DataprocMetastoreClient."""
         client_options = ClientOptions(api_endpoint="metastore.googleapis.com:443")

--- a/airflow/providers/google/cloud/hooks/datastore.py
+++ b/airflow/providers/google/cloud/hooks/datastore.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import time
-import warnings
 from typing import Any, Sequence
 
 from googleapiclient.discovery import Resource, build
@@ -40,17 +39,17 @@ class DatastoreHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         api_version: str = "v1",
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self.connection = None

--- a/airflow/providers/google/cloud/hooks/dlp.py
+++ b/airflow/providers/google/cloud/hooks/dlp.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import re
 import time
-import warnings
 from typing import Sequence
 
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
@@ -73,9 +72,6 @@ class CloudDLPHook(GoogleBaseHook):
     on Google Cloud based data sets.
 
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -89,16 +85,16 @@ class CloudDLPHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._client: DlpServiceClient | None = None

--- a/airflow/providers/google/cloud/hooks/functions.py
+++ b/airflow/providers/google/cloud/hooks/functions.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import time
-import warnings
 from typing import Sequence
 
 import requests
@@ -46,16 +45,16 @@ class CloudFunctionsHook(GoogleBaseHook):
         self,
         api_version: str,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self.api_version = api_version

--- a/airflow/providers/google/cloud/hooks/gcs.py
+++ b/airflow/providers/google/cloud/hooks/gcs.py
@@ -23,7 +23,6 @@ import gzip as gz
 import os
 import shutil
 import time
-import warnings
 from contextlib import contextmanager
 from datetime import datetime
 from functools import partial
@@ -152,16 +151,17 @@ class GCSHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
+
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/hooks/gdm.py
+++ b/airflow/providers/google/cloud/hooks/gdm.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import Any, Sequence
 
 from googleapiclient.discovery import Resource, build
@@ -35,16 +34,16 @@ class GoogleDeploymentManagerHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/hooks/kms.py
+++ b/airflow/providers/google/cloud/hooks/kms.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import base64
-import warnings
 from typing import Sequence
 
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
@@ -45,9 +44,6 @@ class CloudKMSHook(GoogleBaseHook):
     Hook for Google Cloud Key Management service.
 
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -61,16 +57,16 @@ class CloudKMSHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._conn: KeyManagementServiceClient | None = None

--- a/airflow/providers/google/cloud/hooks/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/hooks/kubernetes_engine.py
@@ -73,13 +73,17 @@ class GKEHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         location: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
+            )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._client: ClusterManagerClient | None = None
@@ -303,13 +307,11 @@ class GKEAsyncHook(GoogleBaseAsyncHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         location: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
     ) -> None:
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._client: ClusterManagerAsyncClient | None = None

--- a/airflow/providers/google/cloud/hooks/life_sciences.py
+++ b/airflow/providers/google/cloud/hooks/life_sciences.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import time
-import warnings
 from typing import Sequence
 
 import google.api_core.path_template
@@ -41,9 +40,6 @@ class LifeSciencesHook(GoogleBaseHook):
 
     :param api_version: API version used (for example v1 or v1beta1).
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -60,16 +56,16 @@ class LifeSciencesHook(GoogleBaseHook):
         self,
         api_version: str = "v2beta",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self.api_version = api_version

--- a/airflow/providers/google/cloud/hooks/mlengine.py
+++ b/airflow/providers/google/cloud/hooks/mlengine.py
@@ -84,6 +84,14 @@ class MLEngineHook(GoogleBaseHook):
     keyword arguments rather than positional.
     """
 
+    def __init__(self, **kwargs):
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
+            )
+        super().__init__(**kwargs)
+
     def get_conn(self) -> Resource:
         """
         Retrieves the connection to MLEngine.

--- a/airflow/providers/google/cloud/hooks/natural_language.py
+++ b/airflow/providers/google/cloud/hooks/natural_language.py
@@ -18,7 +18,6 @@
 """This module contains a Google Cloud Natural Language Hook."""
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
 
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
@@ -44,9 +43,6 @@ class CloudNaturalLanguageHook(GoogleBaseHook):
     Hook for Google Cloud Natural Language Service.
 
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -60,16 +56,16 @@ class CloudNaturalLanguageHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._conn = None

--- a/airflow/providers/google/cloud/hooks/os_login.py
+++ b/airflow/providers/google/cloud/hooks/os_login.py
@@ -22,7 +22,6 @@
 """
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
 
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
@@ -44,16 +43,16 @@ class OSLoginHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._conn: OsLoginServiceClient | None = None

--- a/airflow/providers/google/cloud/hooks/pubsub.py
+++ b/airflow/providers/google/cloud/hooks/pubsub.py
@@ -67,16 +67,16 @@ class PubSubHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._client = None

--- a/airflow/providers/google/cloud/hooks/secret_manager.py
+++ b/airflow/providers/google/cloud/hooks/secret_manager.py
@@ -18,7 +18,6 @@
 """Hook for Secrets Manager service"""
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
 
 from airflow.providers.google.cloud._internal_client.secret_manager_client import _SecretManagerClient
@@ -35,9 +34,6 @@ class SecretsManagerHook(GoogleBaseHook):
     keyword arguments rather than positional.
 
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled. (Deprecated)
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -51,16 +47,16 @@ class SecretsManagerHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self.client = _SecretManagerClient(credentials=self.get_credentials())

--- a/airflow/providers/google/cloud/hooks/spanner.py
+++ b/airflow/providers/google/cloud/hooks/spanner.py
@@ -18,7 +18,6 @@
 """This module contains a Google Cloud Spanner Hook."""
 from __future__ import annotations
 
-import warnings
 from typing import Callable, Sequence
 
 from google.api_core.exceptions import AlreadyExists, GoogleAPICallError
@@ -44,16 +43,16 @@ class SpannerHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._client = None

--- a/airflow/providers/google/cloud/hooks/speech_to_text.py
+++ b/airflow/providers/google/cloud/hooks/speech_to_text.py
@@ -18,7 +18,6 @@
 """This module contains a Google Cloud Speech Hook."""
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
 
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
@@ -35,9 +34,6 @@ class CloudSpeechToTextHook(GoogleBaseHook):
     Hook for Google Cloud Speech API.
 
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -51,16 +47,16 @@ class CloudSpeechToTextHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._client = None

--- a/airflow/providers/google/cloud/hooks/stackdriver.py
+++ b/airflow/providers/google/cloud/hooks/stackdriver.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import json
-import warnings
 from typing import Any, Sequence
 
 from google.api_core.exceptions import InvalidArgument
@@ -40,16 +39,16 @@ class StackdriverHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._policy_client = None

--- a/airflow/providers/google/cloud/hooks/tasks.py
+++ b/airflow/providers/google/cloud/hooks/tasks.py
@@ -22,7 +22,6 @@ performing actions to queues or tasks.
 """
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
 
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
@@ -45,9 +44,6 @@ class CloudTasksHook(GoogleBaseHook):
     keyword arguments rather than positional.
 
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -61,16 +57,16 @@ class CloudTasksHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._client: CloudTasksClient | None = None

--- a/airflow/providers/google/cloud/hooks/text_to_speech.py
+++ b/airflow/providers/google/cloud/hooks/text_to_speech.py
@@ -18,7 +18,6 @@
 """This module contains a Google Cloud Text to Speech Hook."""
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
 
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
@@ -43,9 +42,6 @@ class CloudTextToSpeechHook(GoogleBaseHook):
     keyword arguments rather than positional.
 
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -59,16 +55,16 @@ class CloudTextToSpeechHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._client: TextToSpeechClient | None = None

--- a/airflow/providers/google/cloud/hooks/translate.py
+++ b/airflow/providers/google/cloud/hooks/translate.py
@@ -18,7 +18,6 @@
 """This module contains a Google Cloud Translate Hook."""
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
 
 from google.cloud.translate_v2 import Client
@@ -38,16 +37,16 @@ class CloudTranslateHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._client: Client | None = None

--- a/airflow/providers/google/cloud/hooks/vertex_ai/auto_ml.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/auto_ml.py
@@ -74,16 +74,16 @@ class AutoMLHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._job: None | (

--- a/airflow/providers/google/cloud/hooks/vertex_ai/batch_prediction_job.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/batch_prediction_job.py
@@ -26,7 +26,6 @@
 """
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
 
 from google.api_core.client_options import ClientOptions
@@ -47,16 +46,16 @@ class BatchPredictionJobHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._batch_prediction_job: BatchPredictionJob | None = None

--- a/airflow/providers/google/cloud/hooks/vertex_ai/custom_job.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/custom_job.py
@@ -18,7 +18,6 @@
 """This module contains a Google Cloud Vertex AI hook."""
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
 
 from google.api_core.client_options import ClientOptions
@@ -51,16 +50,16 @@ class CustomJobHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._job: None | (

--- a/airflow/providers/google/cloud/hooks/vertex_ai/dataset.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/dataset.py
@@ -41,6 +41,14 @@ from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 class DatasetHook(GoogleBaseHook):
     """Hook for Google Cloud Vertex AI Dataset APIs."""
 
+    def __init__(self, **kwargs):
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
+            )
+        super().__init__(**kwargs)
+
     def get_dataset_service_client(self, region: str | None = None) -> DatasetServiceClient:
         """Returns DatasetServiceClient."""
         if region and region != "global":

--- a/airflow/providers/google/cloud/hooks/vertex_ai/endpoint_service.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/endpoint_service.py
@@ -46,6 +46,14 @@ from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 class EndpointServiceHook(GoogleBaseHook):
     """Hook for Google Cloud Vertex AI Endpoint Service APIs."""
 
+    def __init__(self, **kwargs):
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
+            )
+        super().__init__(**kwargs)
+
     def get_endpoint_service_client(self, region: str | None = None) -> EndpointServiceClient:
         """Returns EndpointServiceClient."""
         if region and region != "global":

--- a/airflow/providers/google/cloud/hooks/vertex_ai/hyperparameter_tuning_job.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/hyperparameter_tuning_job.py
@@ -27,7 +27,6 @@
 """
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
 
 from google.api_core.client_options import ClientOptions
@@ -48,16 +47,16 @@ class HyperparameterTuningJobHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._hyperparameter_tuning_job: HyperparameterTuningJob | None = None

--- a/airflow/providers/google/cloud/hooks/vertex_ai/model_service.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/model_service.py
@@ -41,6 +41,14 @@ from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 class ModelServiceHook(GoogleBaseHook):
     """Hook for Google Cloud Vertex AI Endpoint Service APIs."""
 
+    def __init__(self, **kwargs):
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
+            )
+        super().__init__(**kwargs)
+
     def get_model_service_client(self, region: str | None = None) -> ModelServiceClient:
         """Returns ModelServiceClient."""
         if region and region != "global":

--- a/airflow/providers/google/cloud/hooks/video_intelligence.py
+++ b/airflow/providers/google/cloud/hooks/video_intelligence.py
@@ -18,7 +18,6 @@
 """This module contains a Google Cloud Video Intelligence Hook."""
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
 
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
@@ -39,9 +38,6 @@ class CloudVideoIntelligenceHook(GoogleBaseHook):
     keyword arguments rather than positional.
 
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -55,16 +51,16 @@ class CloudVideoIntelligenceHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._conn = None

--- a/airflow/providers/google/cloud/hooks/vision.py
+++ b/airflow/providers/google/cloud/hooks/vision.py
@@ -18,7 +18,6 @@
 """This module contains a Google Cloud Vision Hook."""
 from __future__ import annotations
 
-import warnings
 from copy import deepcopy
 from typing import Any, Callable, Sequence
 
@@ -127,16 +126,16 @@ class CloudVisionHook(GoogleBaseHook):
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
             )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self._client = None

--- a/airflow/providers/google/cloud/hooks/workflows.py
+++ b/airflow/providers/google/cloud/hooks/workflows.py
@@ -39,6 +39,14 @@ class WorkflowsHook(GoogleBaseHook):
     keyword arguments rather than positional.
     """
 
+    def __init__(self, **kwargs):
+        if kwargs.get("delegate_to") is not None:
+            raise RuntimeError(
+                "The `delegate_to` parameter has been deprecated before and finally removed in this version"
+                " of Google Provider. You MUST convert it to `impersonate_chain`"
+            )
+        super().__init__(**kwargs)
+
     def get_workflows_client(self) -> WorkflowsClient:
         """Returns WorkflowsClient."""
         return WorkflowsClient(credentials=self.get_credentials(), client_info=CLIENT_INFO)

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -811,9 +811,6 @@ class BigQueryGetDataOperator(GoogleCloudBaseOperator):
     :param deferrable: Run operator in the deferrable mode
     :param poll_interval: (Deferrable mode only) polling period in seconds to check for the status of job.
         Defaults to 4 seconds.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled. Deprecated.
     """
 
     template_fields: Sequence[str] = (
@@ -838,7 +835,6 @@ class BigQueryGetDataOperator(GoogleCloudBaseOperator):
         location: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         deferrable: bool = False,
-        delegate_to: str | None = None,
         poll_interval: float = 4.0,
         **kwargs,
     ) -> None:
@@ -849,11 +845,6 @@ class BigQueryGetDataOperator(GoogleCloudBaseOperator):
         self.max_results = int(max_results)
         self.selected_fields = selected_fields
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.location = location
         self.impersonation_chain = impersonation_chain
         self.project_id = project_id
@@ -892,7 +883,6 @@ class BigQueryGetDataOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context):
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         self.hook = hook
@@ -977,9 +967,6 @@ class BigQueryExecuteQueryOperator(GoogleCloudBaseOperator):
         must be ``true`` if this is set to ``false``. For standard SQL queries, this
         flag is ignored and results are never flattened.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param udf_config: The User Defined Function configuration for the query.
         See https://cloud.google.com/bigquery/user-defined-functions for details.
     :param use_legacy_sql: Whether to use legacy SQL (true) or standard SQL (false).
@@ -1060,7 +1047,6 @@ class BigQueryExecuteQueryOperator(GoogleCloudBaseOperator):
         allow_large_results: bool = False,
         flatten_results: bool | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         udf_config: list | None = None,
         use_legacy_sql: bool = True,
         maximum_billing_tier: int | None = None,
@@ -1092,7 +1078,6 @@ class BigQueryExecuteQueryOperator(GoogleCloudBaseOperator):
         self.allow_large_results = allow_large_results
         self.flatten_results = flatten_results
         self.gcp_conn_id = gcp_conn_id
-        self.delegate_to = delegate_to
         self.udf_config = udf_config
         self.use_legacy_sql = use_legacy_sql
         self.maximum_billing_tier = maximum_billing_tier
@@ -1115,7 +1100,6 @@ class BigQueryExecuteQueryOperator(GoogleCloudBaseOperator):
             self.hook = BigQueryHook(
                 gcp_conn_id=self.gcp_conn_id,
                 use_legacy_sql=self.use_legacy_sql,
-                delegate_to=self.delegate_to,
                 location=self.location,
                 impersonation_chain=self.impersonation_chain,
             )
@@ -1214,9 +1198,6 @@ class BigQueryCreateEmptyTableOperator(GoogleCloudBaseOperator):
         interact with the Bigquery service.
     :param google_cloud_storage_conn_id: [Optional] The connection ID used to connect to Google Cloud.
         and interact with the Google Cloud Storage service.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param labels: a dictionary containing labels for the table, passed to BigQuery
 
         **Example (with schema JSON in GCS)**: ::
@@ -1326,7 +1307,6 @@ class BigQueryCreateEmptyTableOperator(GoogleCloudBaseOperator):
         cluster_fields: list[str] | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         if_exists: str = "log",
-        delegate_to: str | None = None,
         bigquery_conn_id: str | None = None,
         exists_ok: bool | None = None,
         **kwargs,
@@ -1348,11 +1328,6 @@ class BigQueryCreateEmptyTableOperator(GoogleCloudBaseOperator):
         self.gcs_schema_object = gcs_schema_object
         self.gcp_conn_id = gcp_conn_id
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.time_partitioning = {} if time_partitioning is None else time_partitioning
         self.labels = labels
         self.view = view
@@ -1371,7 +1346,6 @@ class BigQueryCreateEmptyTableOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context) -> None:
         bq_hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             location=self.location,
             impersonation_chain=self.impersonation_chain,
         )
@@ -1380,7 +1354,6 @@ class BigQueryCreateEmptyTableOperator(GoogleCloudBaseOperator):
             gcs_bucket, gcs_object = _parse_gcs_url(self.gcs_schema_object)
             gcs_hook = GCSHook(
                 gcp_conn_id=self.google_cloud_storage_conn_id,
-                delegate_to=self.delegate_to,
                 impersonation_chain=self.impersonation_chain,
             )
             schema_fields_string = gcs_hook.download_as_byte_array(gcs_bucket, gcs_object).decode("utf-8")
@@ -1482,9 +1455,6 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
         interact with the Bigquery service.
     :param google_cloud_storage_conn_id: (Optional) The connection ID used to connect to Google Cloud
         and interact with the Google Cloud Storage service.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param src_fmt_configs: configure optional fields specific to the source format
     :param labels: a dictionary containing labels for the table, passed to BigQuery
     :param encryption_configuration: [Optional] Custom encryption configuration (e.g., Cloud KMS keys).
@@ -1542,7 +1512,6 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
         encryption_configuration: dict | None = None,
         location: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         bigquery_conn_id: str | None = None,
         **kwargs,
     ) -> None:
@@ -1625,11 +1594,6 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
         self.allow_jagged_rows = allow_jagged_rows
         self.gcp_conn_id = gcp_conn_id
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.autodetect = autodetect
 
         self.src_fmt_configs = src_fmt_configs or {}
@@ -1641,7 +1605,6 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context) -> None:
         bq_hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             location=self.location,
             impersonation_chain=self.impersonation_chain,
         )
@@ -1661,7 +1624,6 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
         if not self.schema_fields and self.schema_object and self.source_format != "DATASTORE_BACKUP":
             gcs_hook = GCSHook(
                 gcp_conn_id=self.google_cloud_storage_conn_id,
-                delegate_to=self.delegate_to,
                 impersonation_chain=self.impersonation_chain,
             )
             schema_fields = json.loads(gcs_hook.download(self.bucket, self.schema_object).decode("utf-8"))
@@ -1730,9 +1692,6 @@ class BigQueryDeleteDatasetOperator(GoogleCloudBaseOperator):
         Will raise HttpError 400: "{dataset_id} is still in use" if set to False and dataset is not empty.
         The default value is False.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -1768,18 +1727,12 @@ class BigQueryDeleteDatasetOperator(GoogleCloudBaseOperator):
         delete_contents: bool = False,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         **kwargs,
     ) -> None:
         self.dataset_id = dataset_id
         self.project_id = project_id
         self.delete_contents = delete_contents
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
         super().__init__(**kwargs)
@@ -1789,7 +1742,6 @@ class BigQueryDeleteDatasetOperator(GoogleCloudBaseOperator):
 
         bq_hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -1814,9 +1766,6 @@ class BigQueryCreateEmptyDatasetOperator(GoogleCloudBaseOperator):
         More info:
         https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets#resource
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -1860,7 +1809,6 @@ class BigQueryCreateEmptyDatasetOperator(GoogleCloudBaseOperator):
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
         if_exists: str = "log",
-        delegate_to: str | None = None,
         exists_ok: bool | None = None,
         **kwargs,
     ) -> None:
@@ -1870,11 +1818,6 @@ class BigQueryCreateEmptyDatasetOperator(GoogleCloudBaseOperator):
         self.location = location
         self.gcp_conn_id = gcp_conn_id
         self.dataset_reference = dataset_reference if dataset_reference else {}
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         if exists_ok is not None:
             warnings.warn("`exists_ok` parameter is deprecated, please use `if_exists`", DeprecationWarning)
@@ -1887,7 +1830,6 @@ class BigQueryCreateEmptyDatasetOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context) -> None:
         bq_hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             location=self.location,
             impersonation_chain=self.impersonation_chain,
         )
@@ -1930,9 +1872,6 @@ class BigQueryGetDatasetOperator(GoogleCloudBaseOperator):
     :param project_id: The name of the project where we want to create the dataset.
         Don't need to provide, if projectId in dataset_reference.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -1958,24 +1897,17 @@ class BigQueryGetDatasetOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         **kwargs,
     ) -> None:
         self.dataset_id = dataset_id
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def execute(self, context: Context):
         bq_hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -2005,9 +1937,6 @@ class BigQueryGetDatasetTablesOperator(GoogleCloudBaseOperator):
         self.project_id will be used.
     :param max_results: (Optional) the maximum number of tables to return.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -2033,25 +1962,18 @@ class BigQueryGetDatasetTablesOperator(GoogleCloudBaseOperator):
         max_results: int | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         **kwargs,
     ) -> None:
         self.dataset_id = dataset_id
         self.project_id = project_id
         self.max_results = max_results
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def execute(self, context: Context):
         bq_hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -2077,9 +1999,6 @@ class BigQueryPatchDatasetOperator(GoogleCloudBaseOperator):
     :param project_id: The name of the project where we want to create the dataset.
         Don't need to provide, if projectId in dataset_reference.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -2106,7 +2025,6 @@ class BigQueryPatchDatasetOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         **kwargs,
     ) -> None:
         warnings.warn(
@@ -2118,18 +2036,12 @@ class BigQueryPatchDatasetOperator(GoogleCloudBaseOperator):
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id
         self.dataset_resource = dataset_resource
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def execute(self, context: Context):
         bq_hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -2161,9 +2073,6 @@ class BigQueryUpdateTableOperator(GoogleCloudBaseOperator):
     :param project_id: The name of the project where we want to create the table.
         Don't need to provide, if projectId in table_reference.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -2194,7 +2103,6 @@ class BigQueryUpdateTableOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         **kwargs,
     ) -> None:
         self.dataset_id = dataset_id
@@ -2203,18 +2111,12 @@ class BigQueryUpdateTableOperator(GoogleCloudBaseOperator):
         self.fields = fields
         self.gcp_conn_id = gcp_conn_id
         self.table_resource = table_resource
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def execute(self, context: Context):
         bq_hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -2257,9 +2159,6 @@ class BigQueryUpdateDatasetOperator(GoogleCloudBaseOperator):
     :param project_id: The name of the project where we want to create the dataset.
         Don't need to provide, if projectId in dataset_reference.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -2288,7 +2187,6 @@ class BigQueryUpdateDatasetOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         **kwargs,
     ) -> None:
         self.dataset_id = dataset_id
@@ -2296,18 +2194,12 @@ class BigQueryUpdateDatasetOperator(GoogleCloudBaseOperator):
         self.fields = fields
         self.gcp_conn_id = gcp_conn_id
         self.dataset_resource = dataset_resource
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def execute(self, context: Context):
         bq_hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         fields = self.fields or list(self.dataset_resource.keys())
@@ -2341,9 +2233,6 @@ class BigQueryDeleteTableOperator(GoogleCloudBaseOperator):
         ``(<project>.|<project>:)<dataset>.<table>`` that indicates which table
         will be deleted. (templated)
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param ignore_if_missing: if True, then return success even if the
         requested table does not exist.
     :param location: The location used for the operation.
@@ -2371,18 +2260,12 @@ class BigQueryDeleteTableOperator(GoogleCloudBaseOperator):
         ignore_if_missing: bool = False,
         location: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
 
         self.deletion_dataset_table = deletion_dataset_table
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.ignore_if_missing = ignore_if_missing
         self.location = location
         self.impersonation_chain = impersonation_chain
@@ -2391,7 +2274,6 @@ class BigQueryDeleteTableOperator(GoogleCloudBaseOperator):
         self.log.info("Deleting: %s", self.deletion_dataset_table)
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             location=self.location,
             impersonation_chain=self.impersonation_chain,
         )
@@ -2414,9 +2296,6 @@ class BigQueryUpsertTableOperator(GoogleCloudBaseOperator):
     :param project_id: The name of the project where we want to update the dataset.
         Don't need to provide, if projectId in dataset_reference.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide
-        delegation enabled.
     :param location: The location used for the operation.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -2447,7 +2326,6 @@ class BigQueryUpsertTableOperator(GoogleCloudBaseOperator):
         gcp_conn_id: str = "google_cloud_default",
         location: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -2456,11 +2334,6 @@ class BigQueryUpsertTableOperator(GoogleCloudBaseOperator):
         self.table_resource = table_resource
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.location = location
         self.impersonation_chain = impersonation_chain
 
@@ -2468,7 +2341,6 @@ class BigQueryUpsertTableOperator(GoogleCloudBaseOperator):
         self.log.info("Upserting Dataset: %s with table_resource: %s", self.dataset_id, self.table_resource)
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             location=self.location,
             impersonation_chain=self.impersonation_chain,
         )
@@ -2522,9 +2394,6 @@ class BigQueryUpdateTableSchemaOperator(GoogleCloudBaseOperator):
     :param project_id: The name of the project where we want to update the dataset.
         Don't need to provide, if projectId in dataset_reference.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide
-        delegation enabled.
     :param location: The location used for the operation.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -2557,7 +2426,6 @@ class BigQueryUpdateTableSchemaOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         **kwargs,
     ) -> None:
         self.schema_fields_updates = schema_fields_updates
@@ -2566,18 +2434,12 @@ class BigQueryUpdateTableSchemaOperator(GoogleCloudBaseOperator):
         self.dataset_id = dataset_id
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def execute(self, context: Context):
         bq_hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -2636,9 +2498,6 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator):
     :param project_id: Google Cloud Project where the job is running
     :param location: location the job is running
     :param gcp_conn_id: The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -2684,7 +2543,6 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator):
         result_timeout: float | None = None,
         deferrable: bool = False,
         poll_interval: float = 4.0,
-        delegate_to: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -2693,11 +2551,6 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator):
         self.job_id = job_id
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.force_rerun = force_rerun
         self.reattach_states: set[str] = reattach_states or set()
         self.impersonation_chain = impersonation_chain
@@ -2738,7 +2591,6 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator):
     def execute(self, context: Any):
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         self.hook = hook

--- a/airflow/providers/google/cloud/operators/cloud_build.py
+++ b/airflow/providers/google/cloud/operators/cloud_build.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import json
 import re
-import warnings
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Sequence
 from urllib.parse import unquote, urlsplit
@@ -155,9 +154,6 @@ class CloudBuildCreateBuildOperator(GoogleCloudBaseOperator):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param retry: Designation of what errors, if any, should be retried.
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
@@ -179,7 +175,6 @@ class CloudBuildCreateBuildOperator(GoogleCloudBaseOperator):
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         poll_interval: float = 4.0,
         deferrable: bool = False,
         location: str = "global",
@@ -196,11 +191,6 @@ class CloudBuildCreateBuildOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.poll_interval = poll_interval
         self.deferrable = deferrable
         self.location = location
@@ -219,7 +209,6 @@ class CloudBuildCreateBuildOperator(GoogleCloudBaseOperator):
         hook = CloudBuildHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
-            delegate_to=self.delegate_to,
         )
         build = BuildProcessor(build=self.build).process_body()
 
@@ -244,7 +233,6 @@ class CloudBuildCreateBuildOperator(GoogleCloudBaseOperator):
                     project_id=self.project_id,
                     gcp_conn_id=self.gcp_conn_id,
                     impersonation_chain=self.impersonation_chain,
-                    delegate_to=self.delegate_to,
                     poll_interval=self.poll_interval,
                     location=self.location,
                 ),
@@ -270,7 +258,6 @@ class CloudBuildCreateBuildOperator(GoogleCloudBaseOperator):
             hook = CloudBuildHook(
                 gcp_conn_id=self.gcp_conn_id,
                 impersonation_chain=self.impersonation_chain,
-                delegate_to=self.delegate_to,
             )
             self.log.info("Cloud Build completed with response %s ", event["message"])
             project_id = self.project_id or hook.project_id

--- a/airflow/providers/google/cloud/operators/cloud_composer.py
+++ b/airflow/providers/google/cloud/operators/cloud_composer.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from google.api_core.exceptions import AlreadyExists
@@ -106,9 +105,6 @@ class CloudComposerCreateEnvironmentOperator(GoogleCloudBaseOperator):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param retry: Designation of what errors, if any, should be retried.
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
@@ -136,7 +132,6 @@ class CloudComposerCreateEnvironmentOperator(GoogleCloudBaseOperator):
         environment: Environment | dict,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         retry: Retry | _MethodDefault = DEFAULT,
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
@@ -154,11 +149,6 @@ class CloudComposerCreateEnvironmentOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.deferrable = deferrable
         self.pooling_period_seconds = pooling_period_seconds
 
@@ -166,7 +156,6 @@ class CloudComposerCreateEnvironmentOperator(GoogleCloudBaseOperator):
         hook = CloudComposerHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
-            delegate_to=self.delegate_to,
         )
 
         name = hook.get_environment_name(self.project_id, self.region, self.environment_id)
@@ -198,7 +187,6 @@ class CloudComposerCreateEnvironmentOperator(GoogleCloudBaseOperator):
                         operation_name=result.operation.name,
                         gcp_conn_id=self.gcp_conn_id,
                         impersonation_chain=self.impersonation_chain,
-                        delegate_to=self.delegate_to,
                         pooling_period_seconds=self.pooling_period_seconds,
                     ),
                     method_name=GOOGLE_DEFAULT_DEFERRABLE_METHOD_NAME,
@@ -219,7 +207,6 @@ class CloudComposerCreateEnvironmentOperator(GoogleCloudBaseOperator):
             hook = CloudComposerHook(
                 gcp_conn_id=self.gcp_conn_id,
                 impersonation_chain=self.impersonation_chain,
-                delegate_to=self.delegate_to,
             )
 
             env = hook.get_environment(
@@ -254,12 +241,9 @@ class CloudComposerDeleteEnvironmentOperator(GoogleCloudBaseOperator):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param deferrable: Run operator in the deferrable mode
     :param pooling_period_seconds: Optional: Control the rate of the poll for the result of deferrable run.
-        By default the trigger will poll every 30 seconds.
+        By default, the trigger will poll every 30 seconds.
     """
 
     template_fields = (
@@ -280,7 +264,6 @@ class CloudComposerDeleteEnvironmentOperator(GoogleCloudBaseOperator):
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         deferrable: bool = False,
         pooling_period_seconds: int = 30,
         **kwargs,
@@ -294,11 +277,6 @@ class CloudComposerDeleteEnvironmentOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.deferrable = deferrable
         self.pooling_period_seconds = pooling_period_seconds
 
@@ -306,7 +284,6 @@ class CloudComposerDeleteEnvironmentOperator(GoogleCloudBaseOperator):
         hook = CloudComposerHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
-            delegate_to=self.delegate_to,
         )
         result = hook.delete_environment(
             project_id=self.project_id,
@@ -326,7 +303,6 @@ class CloudComposerDeleteEnvironmentOperator(GoogleCloudBaseOperator):
                     operation_name=result.operation.name,
                     gcp_conn_id=self.gcp_conn_id,
                     impersonation_chain=self.impersonation_chain,
-                    delegate_to=self.delegate_to,
                     pooling_period_seconds=self.pooling_period_seconds,
                 ),
                 method_name=GOOGLE_DEFAULT_DEFERRABLE_METHOD_NAME,
@@ -355,9 +331,6 @@ class CloudComposerGetEnvironmentOperator(GoogleCloudBaseOperator):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     """
 
     template_fields = (
@@ -380,7 +353,6 @@ class CloudComposerGetEnvironmentOperator(GoogleCloudBaseOperator):
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -392,17 +364,11 @@ class CloudComposerGetEnvironmentOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
 
     def execute(self, context: Context):
         hook = CloudComposerHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
-            delegate_to=self.delegate_to,
         )
 
         result = hook.get_environment(
@@ -439,9 +405,6 @@ class CloudComposerListEnvironmentsOperator(GoogleCloudBaseOperator):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     """
 
     template_fields = (
@@ -464,7 +427,6 @@ class CloudComposerListEnvironmentsOperator(GoogleCloudBaseOperator):
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -477,17 +439,11 @@ class CloudComposerListEnvironmentsOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
 
     def execute(self, context: Context):
         hook = CloudComposerHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
-            delegate_to=self.delegate_to,
         )
         CloudComposerEnvironmentsLink.persist(operator_instance=self, context=context)
         result = hook.list_environments(
@@ -526,12 +482,9 @@ class CloudComposerUpdateEnvironmentOperator(GoogleCloudBaseOperator):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param deferrable: Run operator in the deferrable mode
     :param pooling_period_seconds: Optional: Control the rate of the poll for the result of deferrable run.
-        By default the trigger will poll every 30 seconds.
+        By default, the trigger will poll every 30 seconds.
     """
 
     template_fields = (
@@ -556,7 +509,6 @@ class CloudComposerUpdateEnvironmentOperator(GoogleCloudBaseOperator):
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         deferrable: bool = False,
         pooling_period_seconds: int = 30,
         **kwargs,
@@ -572,11 +524,6 @@ class CloudComposerUpdateEnvironmentOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.deferrable = deferrable
         self.pooling_period_seconds = pooling_period_seconds
 
@@ -584,7 +531,6 @@ class CloudComposerUpdateEnvironmentOperator(GoogleCloudBaseOperator):
         hook = CloudComposerHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
-            delegate_to=self.delegate_to,
         )
 
         result = hook.update_environment(
@@ -610,7 +556,6 @@ class CloudComposerUpdateEnvironmentOperator(GoogleCloudBaseOperator):
                     operation_name=result.operation.name,
                     gcp_conn_id=self.gcp_conn_id,
                     impersonation_chain=self.impersonation_chain,
-                    delegate_to=self.delegate_to,
                     pooling_period_seconds=self.pooling_period_seconds,
                 ),
                 method_name=GOOGLE_DEFAULT_DEFERRABLE_METHOD_NAME,
@@ -621,7 +566,6 @@ class CloudComposerUpdateEnvironmentOperator(GoogleCloudBaseOperator):
             hook = CloudComposerHook(
                 gcp_conn_id=self.gcp_conn_id,
                 impersonation_chain=self.impersonation_chain,
-                delegate_to=self.delegate_to,
             )
 
             env = hook.get_environment(
@@ -654,9 +598,6 @@ class CloudComposerListImageVersionsOperator(GoogleCloudBaseOperator):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     """
 
     template_fields = (
@@ -678,7 +619,6 @@ class CloudComposerListImageVersionsOperator(GoogleCloudBaseOperator):
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -692,17 +632,11 @@ class CloudComposerListImageVersionsOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
 
     def execute(self, context: Context):
         hook = CloudComposerHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
-            delegate_to=self.delegate_to,
         )
         result = hook.list_image_versions(
             project_id=self.project_id,

--- a/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
@@ -18,7 +18,6 @@
 """This module contains Google Cloud Transfer operators."""
 from __future__ import annotations
 
-import warnings
 from copy import deepcopy
 from datetime import date, time
 from typing import TYPE_CHECKING, Sequence
@@ -795,9 +794,6 @@ class CloudDataTransferServiceS3ToGCSOperator(GoogleCloudBaseOperator):
     :param aws_conn_id: The source S3 connection
     :param gcp_conn_id: The destination connection ID to use
         when connecting to Google Cloud Storage.
-    :param delegate_to: Google account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param description: Optional transfer service job description
     :param schedule: Optional transfer service schedule;
         If not set, run transfer job once as soon as the operator runs
@@ -849,7 +845,6 @@ class CloudDataTransferServiceS3ToGCSOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         aws_conn_id: str = "aws_default",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         description: str | None = None,
         schedule: dict | None = None,
         object_conditions: dict | None = None,
@@ -869,11 +864,6 @@ class CloudDataTransferServiceS3ToGCSOperator(GoogleCloudBaseOperator):
         self.project_id = project_id
         self.aws_conn_id = aws_conn_id
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.description = description
         self.schedule = schedule
         self.object_conditions = object_conditions
@@ -891,7 +881,6 @@ class CloudDataTransferServiceS3ToGCSOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context) -> None:
         hook = CloudDataTransferServiceHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.google_impersonation_chain,
         )
         body = self._create_body()
@@ -971,9 +960,6 @@ class CloudDataTransferServiceGCSToGCSOperator(GoogleCloudBaseOperator):
         owns the job
     :param gcp_conn_id: Optional connection ID to use when connecting to Google Cloud
         Storage.
-    :param delegate_to: Google account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param description: Optional transfer service job description
     :param schedule: Optional transfer service schedule;
         If not set, run transfer job once as soon as the operator runs
@@ -1024,7 +1010,6 @@ class CloudDataTransferServiceGCSToGCSOperator(GoogleCloudBaseOperator):
         destination_path: str | None = None,
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         description: str | None = None,
         schedule: dict | None = None,
         object_conditions: dict | None = None,
@@ -1043,11 +1028,6 @@ class CloudDataTransferServiceGCSToGCSOperator(GoogleCloudBaseOperator):
         self.destination_path = destination_path
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.description = description
         self.schedule = schedule
         self.object_conditions = object_conditions
@@ -1065,7 +1045,6 @@ class CloudDataTransferServiceGCSToGCSOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context) -> None:
         hook = CloudDataTransferServiceHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.google_impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/operators/dataform.py
+++ b/airflow/providers/google/cloud/operators/dataform.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from airflow.providers.google.cloud.links.dataform import (
@@ -56,8 +55,6 @@ class DataformCreateCompilationResultOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -78,7 +75,6 @@ class DataformCreateCompilationResultOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -92,17 +88,11 @@ class DataformCreateCompilationResultOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = DataformHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         result = hook.create_compilation_result(
@@ -129,8 +119,6 @@ class DataformGetCompilationResultOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -141,7 +129,7 @@ class DataformGetCompilationResultOperator(GoogleCloudBaseOperator):
         account from the list granting this role to the originating account (templated).
     """
 
-    template_fields = ("repository_id", "compilation_result_id", "delegate_to", "impersonation_chain")
+    template_fields = ("repository_id", "compilation_result_id", "impersonation_chain")
 
     def __init__(
         self,
@@ -153,7 +141,6 @@ class DataformGetCompilationResultOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -167,17 +154,11 @@ class DataformGetCompilationResultOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = DataformHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         result = hook.get_compilation_result(
@@ -204,8 +185,6 @@ class DataformCreateWorkflowInvocationOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -215,12 +194,12 @@ class DataformCreateWorkflowInvocationOperator(GoogleCloudBaseOperator):
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
     :param asynchronous: Flag to return workflow_invocation_id from the Dataform API.
-        This is useful for submitting long running workflows and
+        This is useful for submitting long-running workflows and
         waiting on them asynchronously using the DataformWorkflowInvocationStateSensor
     :param wait_time: Number of seconds between checks
     """
 
-    template_fields = ("workflow_invocation", "delegate_to", "impersonation_chain")
+    template_fields = ("workflow_invocation", "impersonation_chain")
     operator_extra_links = (DataformWorkflowInvocationLink(),)
 
     def __init__(
@@ -233,7 +212,6 @@ class DataformCreateWorkflowInvocationOperator(GoogleCloudBaseOperator):
         timeout: int | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         asynchronous: bool = False,
         wait_time: int = 10,
@@ -249,11 +227,6 @@ class DataformCreateWorkflowInvocationOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.asynchronous = asynchronous
         self.wait_time = wait_time
@@ -261,7 +234,6 @@ class DataformCreateWorkflowInvocationOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context):
         hook = DataformHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         result = hook.create_workflow_invocation(
@@ -306,8 +278,6 @@ class DataformGetWorkflowInvocationOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -318,7 +288,7 @@ class DataformGetWorkflowInvocationOperator(GoogleCloudBaseOperator):
         account from the list granting this role to the originating account (templated).
     """
 
-    template_fields = ("repository_id", "workflow_invocation_id", "delegate_to", "impersonation_chain")
+    template_fields = ("repository_id", "workflow_invocation_id", "impersonation_chain")
     operator_extra_links = (DataformWorkflowInvocationLink(),)
 
     def __init__(
@@ -331,7 +301,6 @@ class DataformGetWorkflowInvocationOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -345,17 +314,11 @@ class DataformGetWorkflowInvocationOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = DataformHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         result = hook.get_workflow_invocation(
@@ -382,8 +345,6 @@ class DataformCancelWorkflowInvocationOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -394,7 +355,7 @@ class DataformCancelWorkflowInvocationOperator(GoogleCloudBaseOperator):
         account from the list granting this role to the originating account (templated).
     """
 
-    template_fields = ("repository_id", "workflow_invocation_id", "delegate_to", "impersonation_chain")
+    template_fields = ("repository_id", "workflow_invocation_id", "impersonation_chain")
     operator_extra_links = (DataformWorkflowInvocationLink(),)
 
     def __init__(
@@ -407,7 +368,6 @@ class DataformCancelWorkflowInvocationOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -421,17 +381,11 @@ class DataformCancelWorkflowInvocationOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = DataformHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         hook.cancel_workflow_invocation(
@@ -456,8 +410,6 @@ class DataformCreateRepositoryOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -472,7 +424,6 @@ class DataformCreateRepositoryOperator(GoogleCloudBaseOperator):
     template_fields = (
         "project_id",
         "repository_id",
-        "delegate_to",
         "impersonation_chain",
     )
 
@@ -485,7 +436,6 @@ class DataformCreateRepositoryOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -501,17 +451,11 @@ class DataformCreateRepositoryOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
 
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> dict:
         hook = DataformHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -546,8 +490,6 @@ class DataformDeleteRepositoryOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -561,7 +503,6 @@ class DataformDeleteRepositoryOperator(GoogleCloudBaseOperator):
     template_fields = (
         "project_id",
         "repository_id",
-        "delegate_to",
         "impersonation_chain",
     )
 
@@ -575,7 +516,6 @@ class DataformDeleteRepositoryOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -592,17 +532,11 @@ class DataformDeleteRepositoryOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
 
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
         hook = DataformHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -629,8 +563,6 @@ class DataformCreateWorkspaceOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -645,7 +577,6 @@ class DataformCreateWorkspaceOperator(GoogleCloudBaseOperator):
     template_fields = (
         "project_id",
         "repository_id",
-        "delegate_to",
         "impersonation_chain",
     )
 
@@ -659,7 +590,6 @@ class DataformCreateWorkspaceOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -676,17 +606,11 @@ class DataformCreateWorkspaceOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
 
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> dict:
         hook = DataformHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -724,8 +648,6 @@ class DataformDeleteWorkspaceOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -740,7 +662,6 @@ class DataformDeleteWorkspaceOperator(GoogleCloudBaseOperator):
         "project_id",
         "repository_id",
         "workspace_id",
-        "delegate_to",
         "impersonation_chain",
     )
 
@@ -754,7 +675,6 @@ class DataformDeleteWorkspaceOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -771,17 +691,11 @@ class DataformDeleteWorkspaceOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
 
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
         hook = DataformHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -810,8 +724,6 @@ class DataformWriteFileOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -826,7 +738,6 @@ class DataformWriteFileOperator(GoogleCloudBaseOperator):
         "project_id",
         "repository_id",
         "workspace_id",
-        "delegate_to",
         "impersonation_chain",
     )
 
@@ -842,7 +753,6 @@ class DataformWriteFileOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -861,17 +771,11 @@ class DataformWriteFileOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
 
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> dict:
         hook = DataformHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         write_file_response = hook.write_file(
@@ -901,8 +805,6 @@ class DataformMakeDirectoryOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -917,7 +819,6 @@ class DataformMakeDirectoryOperator(GoogleCloudBaseOperator):
         "project_id",
         "repository_id",
         "workspace_id",
-        "delegate_to",
         "impersonation_chain",
     )
 
@@ -932,7 +833,6 @@ class DataformMakeDirectoryOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -950,17 +850,11 @@ class DataformMakeDirectoryOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
 
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> dict:
         hook = DataformHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -991,8 +885,6 @@ class DataformRemoveFileOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -1007,7 +899,6 @@ class DataformRemoveFileOperator(GoogleCloudBaseOperator):
         "project_id",
         "repository_id",
         "workspace_id",
-        "delegate_to",
         "impersonation_chain",
     )
 
@@ -1022,7 +913,6 @@ class DataformRemoveFileOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -1040,17 +930,11 @@ class DataformRemoveFileOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
 
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
         hook = DataformHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -1079,8 +963,6 @@ class DataformRemoveDirectoryOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -1095,7 +977,6 @@ class DataformRemoveDirectoryOperator(GoogleCloudBaseOperator):
         "project_id",
         "repository_id",
         "workspace_id",
-        "delegate_to",
         "impersonation_chain",
     )
 
@@ -1110,7 +991,6 @@ class DataformRemoveDirectoryOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -1128,17 +1008,11 @@ class DataformRemoveDirectoryOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
 
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
         hook = DataformHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -1166,8 +1040,6 @@ class DataformInstallNpmPackagesOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -1182,7 +1054,6 @@ class DataformInstallNpmPackagesOperator(GoogleCloudBaseOperator):
         "project_id",
         "repository_id",
         "workspace_id",
-        "delegate_to",
         "impersonation_chain",
     )
 
@@ -1196,7 +1067,6 @@ class DataformInstallNpmPackagesOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -1213,17 +1083,11 @@ class DataformInstallNpmPackagesOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
 
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> dict:
         hook = DataformHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/operators/datafusion.py
+++ b/airflow/providers/google/cloud/operators/datafusion.py
@@ -17,7 +17,6 @@
 """This module contains Google DataFusion operators."""
 from __future__ import annotations
 
-import warnings
 from time import sleep
 from typing import TYPE_CHECKING, Any, Sequence
 
@@ -62,9 +61,6 @@ class CloudDataFusionRestartInstanceOperator(GoogleCloudBaseOperator):
     :param project_id: The ID of the Google Cloud project that the instance belongs to.
     :param api_version: The version of the api that will be requested for example 'v3'.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -89,7 +85,6 @@ class CloudDataFusionRestartInstanceOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -99,17 +94,11 @@ class CloudDataFusionRestartInstanceOperator(GoogleCloudBaseOperator):
         self.project_id = project_id
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )
@@ -145,9 +134,6 @@ class CloudDataFusionDeleteInstanceOperator(GoogleCloudBaseOperator):
     :param project_id: The ID of the Google Cloud project that the instance belongs to.
     :param api_version: The version of the api that will be requested for example 'v3'.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -171,7 +157,6 @@ class CloudDataFusionDeleteInstanceOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -181,17 +166,11 @@ class CloudDataFusionDeleteInstanceOperator(GoogleCloudBaseOperator):
         self.project_id = project_id
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )
@@ -220,9 +199,6 @@ class CloudDataFusionCreateInstanceOperator(GoogleCloudBaseOperator):
     :param project_id: The ID of the Google Cloud project that the instance belongs to.
     :param api_version: The version of the api that will be requested for example 'v3'.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -249,7 +225,6 @@ class CloudDataFusionCreateInstanceOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -260,17 +235,11 @@ class CloudDataFusionCreateInstanceOperator(GoogleCloudBaseOperator):
         self.project_id = project_id
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> dict:
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )
@@ -332,9 +301,6 @@ class CloudDataFusionUpdateInstanceOperator(GoogleCloudBaseOperator):
     :param project_id: The ID of the Google Cloud project that the instance belongs to.
     :param api_version: The version of the api that will be requested for example 'v3'.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -362,7 +328,6 @@ class CloudDataFusionUpdateInstanceOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -374,17 +339,11 @@ class CloudDataFusionUpdateInstanceOperator(GoogleCloudBaseOperator):
         self.project_id = project_id
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )
@@ -422,9 +381,6 @@ class CloudDataFusionGetInstanceOperator(GoogleCloudBaseOperator):
     :param project_id: The ID of the Google Cloud project that the instance belongs to.
     :param api_version: The version of the api that will be requested for example 'v3'.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -449,7 +405,6 @@ class CloudDataFusionGetInstanceOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -459,17 +414,11 @@ class CloudDataFusionGetInstanceOperator(GoogleCloudBaseOperator):
         self.project_id = project_id
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> dict:
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )
@@ -509,9 +458,6 @@ class CloudDataFusionCreatePipelineOperator(GoogleCloudBaseOperator):
         can create a namespace.
     :param api_version: The version of the api that will be requested for example 'v3'.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -541,7 +487,6 @@ class CloudDataFusionCreatePipelineOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -554,17 +499,11 @@ class CloudDataFusionCreatePipelineOperator(GoogleCloudBaseOperator):
         self.project_id = project_id
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )
@@ -607,9 +546,6 @@ class CloudDataFusionDeletePipelineOperator(GoogleCloudBaseOperator):
         can create a namespace.
     :param api_version: The version of the api that will be requested for example 'v3'.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -638,7 +574,6 @@ class CloudDataFusionDeletePipelineOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -651,17 +586,11 @@ class CloudDataFusionDeletePipelineOperator(GoogleCloudBaseOperator):
         self.project_id = project_id
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )
@@ -699,9 +628,6 @@ class CloudDataFusionListPipelinesOperator(GoogleCloudBaseOperator):
         can create a namespace.
     :param api_version: The version of the api that will be requested for example 'v3'.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -731,7 +657,6 @@ class CloudDataFusionListPipelinesOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -744,17 +669,11 @@ class CloudDataFusionListPipelinesOperator(GoogleCloudBaseOperator):
         self.project_id = project_id
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> dict:
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )
@@ -799,9 +718,6 @@ class CloudDataFusionStartPipelineOperator(GoogleCloudBaseOperator):
         can create a namespace.
     :param api_version: The version of the api that will be requested for example 'v3'.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -841,7 +757,6 @@ class CloudDataFusionStartPipelineOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         asynchronous=False,
         deferrable=False,
@@ -857,11 +772,6 @@ class CloudDataFusionStartPipelineOperator(GoogleCloudBaseOperator):
         self.project_id = project_id
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.asynchronous = asynchronous
         self.pipeline_timeout = pipeline_timeout
@@ -876,7 +786,6 @@ class CloudDataFusionStartPipelineOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context) -> str:
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )
@@ -917,7 +826,6 @@ class CloudDataFusionStartPipelineOperator(GoogleCloudBaseOperator):
                     poll_interval=self.poll_interval,
                     gcp_conn_id=self.gcp_conn_id,
                     impersonation_chain=self.impersonation_chain,
-                    delegate_to=self.delegate_to,
                 ),
                 method_name="execute_complete",
             )
@@ -969,9 +877,6 @@ class CloudDataFusionStopPipelineOperator(GoogleCloudBaseOperator):
         can create a namespace.
     :param api_version: The version of the api that will be requested for example 'v3'.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -999,7 +904,6 @@ class CloudDataFusionStopPipelineOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -1011,17 +915,11 @@ class CloudDataFusionStopPipelineOperator(GoogleCloudBaseOperator):
         self.project_id = project_id
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )

--- a/airflow/providers/google/cloud/operators/dataplex.py
+++ b/airflow/providers/google/cloud/operators/dataplex.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 
-import warnings
 from time import sleep
 from typing import TYPE_CHECKING, Any, Sequence
 
@@ -57,8 +56,6 @@ class DataplexCreateTaskOperator(GoogleCloudBaseOperator):
         Note that if `retry` is specified, the timeout applies to each individual attempt.
     :param metadata: Additional metadata that is provided to the method.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -77,7 +74,6 @@ class DataplexCreateTaskOperator(GoogleCloudBaseOperator):
         "dataplex_task_id",
         "body",
         "validate_only",
-        "delegate_to",
         "impersonation_chain",
     )
     template_fields_renderers = {"body": "json"}
@@ -96,7 +92,6 @@ class DataplexCreateTaskOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         asynchronous: bool = False,
         *args,
@@ -114,18 +109,12 @@ class DataplexCreateTaskOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.asynchronous = asynchronous
 
     def execute(self, context: Context) -> dict:
         hook = DataplexHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )
@@ -189,8 +178,6 @@ class DataplexDeleteTaskOperator(GoogleCloudBaseOperator):
         Note that if `retry` is specified, the timeout applies to each individual attempt.
     :param metadata: Additional metadata that is provided to the method.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -201,7 +188,7 @@ class DataplexDeleteTaskOperator(GoogleCloudBaseOperator):
         account from the list granting this role to the originating account (templated).
     """
 
-    template_fields = ("project_id", "dataplex_task_id", "delegate_to", "impersonation_chain")
+    template_fields = ("project_id", "dataplex_task_id", "impersonation_chain")
 
     def __init__(
         self,
@@ -214,7 +201,6 @@ class DataplexDeleteTaskOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -229,17 +215,11 @@ class DataplexDeleteTaskOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
         hook = DataplexHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )
@@ -280,8 +260,6 @@ class DataplexListTasksOperator(GoogleCloudBaseOperator):
         Note that if `retry` is specified, the timeout applies to each individual attempt.
     :param metadata: Additional metadata that is provided to the method.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -298,7 +276,6 @@ class DataplexListTasksOperator(GoogleCloudBaseOperator):
         "page_token",
         "filter",
         "order_by",
-        "delegate_to",
         "impersonation_chain",
     )
     operator_extra_links = (DataplexTasksLink(),)
@@ -317,7 +294,6 @@ class DataplexListTasksOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -335,17 +311,11 @@ class DataplexListTasksOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> list[dict]:
         hook = DataplexHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )
@@ -382,8 +352,6 @@ class DataplexGetTaskOperator(GoogleCloudBaseOperator):
         Note that if `retry` is specified, the timeout applies to each individual attempt.
     :param metadata: Additional metadata that is provided to the method.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -394,7 +362,7 @@ class DataplexGetTaskOperator(GoogleCloudBaseOperator):
         account from the list granting this role to the originating account (templated).
     """
 
-    template_fields = ("project_id", "dataplex_task_id", "delegate_to", "impersonation_chain")
+    template_fields = ("project_id", "dataplex_task_id", "impersonation_chain")
     operator_extra_links = (DataplexTaskLink(),)
 
     def __init__(
@@ -408,7 +376,6 @@ class DataplexGetTaskOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -423,17 +390,11 @@ class DataplexGetTaskOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> dict:
         hook = DataplexHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )
@@ -470,8 +431,6 @@ class DataplexCreateLakeOperator(GoogleCloudBaseOperator):
         Note that if `retry` is specified, the timeout applies to each individual attempt.
     :param metadata: Additional metadata that is provided to the method.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service account making the
-        request must have domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -490,7 +449,6 @@ class DataplexCreateLakeOperator(GoogleCloudBaseOperator):
         "lake_id",
         "body",
         "validate_only",
-        "delegate_to",
         "impersonation_chain",
     )
     template_fields_renderers = {"body": "json"}
@@ -508,7 +466,6 @@ class DataplexCreateLakeOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         asynchronous: bool = False,
         *args,
@@ -525,18 +482,12 @@ class DataplexCreateLakeOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.asynchronous = asynchronous
 
     def execute(self, context: Context) -> dict:
         hook = DataplexHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )
@@ -599,8 +550,6 @@ class DataplexDeleteLakeOperator(GoogleCloudBaseOperator):
         Note that if `retry` is specified, the timeout applies to each individual attempt.
     :param metadata: Additional metadata that is provided to the method.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service account making the
-        request must have domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -611,7 +560,7 @@ class DataplexDeleteLakeOperator(GoogleCloudBaseOperator):
         account from the list granting this role to the originating account (templated).
     """
 
-    template_fields = ("project_id", "lake_id", "delegate_to", "impersonation_chain")
+    template_fields = ("project_id", "lake_id", "impersonation_chain")
     operator_extra_links = (DataplexLakeLink(),)
 
     def __init__(
@@ -624,7 +573,6 @@ class DataplexDeleteLakeOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -639,18 +587,12 @@ class DataplexDeleteLakeOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
 
         hook = DataplexHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -927,9 +927,6 @@ class DataprocJobBaseOperator(GoogleCloudBaseOperator):
     :param dataproc_jars: HCFS URIs of jar files to add to the CLASSPATH of the Hive server and Hadoop
         MapReduce (MR) tasks. Can contain Hive SerDes and UDFs. (templated)
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param labels: The labels to associate with this job. Label keys must contain 1 to 63 characters,
         and must conform to RFC 1035. Label values may be empty, but, if present, must contain 1 to 63
         characters, and must conform to RFC 1035. No more than 32 labels can be associated with a job.
@@ -975,7 +972,6 @@ class DataprocJobBaseOperator(GoogleCloudBaseOperator):
         dataproc_properties: dict | None = None,
         dataproc_jars: list[str] | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         labels: dict | None = None,
         job_error_states: set[str] | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
@@ -988,11 +984,6 @@ class DataprocJobBaseOperator(GoogleCloudBaseOperator):
         if deferrable and polling_interval_seconds <= 0:
             raise ValueError("Invalid value for polling_interval_seconds. Expected value greater than 0")
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.labels = labels
         self.job_name = job_name
         self.cluster_name = cluster_name
@@ -1060,7 +1051,6 @@ class DataprocJobBaseOperator(GoogleCloudBaseOperator):
                         job_id=job_id,
                         project_id=self.project_id,
                         region=self.region,
-                        delegate_to=self.delegate_to,
                         gcp_conn_id=self.gcp_conn_id,
                         impersonation_chain=self.impersonation_chain,
                         polling_interval_seconds=self.polling_interval_seconds,

--- a/airflow/providers/google/cloud/operators/datastore.py
+++ b/airflow/providers/google/cloud/operators/datastore.py
@@ -18,7 +18,6 @@
 """This module contains Google Datastore operators."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any, Sequence
 
 from airflow.exceptions import AirflowException
@@ -46,15 +45,12 @@ class CloudDatastoreExportEntitiesOperator(GoogleCloudBaseOperator):
     .. seealso::
         https://cloud.google.com/datastore/docs/export-import-entities
 
-    :param bucket: name of the cloud storage bucket to backup data
+    :param bucket: name of the cloud storage bucket to back up data
     :param namespace: optional namespace path in the specified Cloud Storage bucket
-        to backup data. If this namespace does not exist in GCS, it will be created.
+        to back up data. If this namespace does not exist in GCS, it will be created.
     :param datastore_conn_id: the name of the Datastore connection id to use
     :param cloud_storage_conn_id: the name of the cloud storage connection id to
         force-write backup
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param entity_filter: description of what data from the project is included in the
         export, refer to
         https://cloud.google.com/datastore/docs/reference/rest/Shared.Types/EntityFilter
@@ -89,7 +85,6 @@ class CloudDatastoreExportEntitiesOperator(GoogleCloudBaseOperator):
         namespace: str | None = None,
         datastore_conn_id: str = "google_cloud_default",
         cloud_storage_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         entity_filter: dict | None = None,
         labels: dict | None = None,
         polling_interval_in_seconds: int = 10,
@@ -101,11 +96,6 @@ class CloudDatastoreExportEntitiesOperator(GoogleCloudBaseOperator):
         super().__init__(**kwargs)
         self.datastore_conn_id = datastore_conn_id
         self.cloud_storage_conn_id = cloud_storage_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.bucket = bucket
         self.namespace = namespace
         self.entity_filter = entity_filter
@@ -126,7 +116,6 @@ class CloudDatastoreExportEntitiesOperator(GoogleCloudBaseOperator):
 
         ds_hook = DatastoreHook(
             gcp_conn_id=self.datastore_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         result = ds_hook.export_to_storage_bucket(
@@ -172,9 +161,6 @@ class CloudDatastoreImportEntitiesOperator(GoogleCloudBaseOperator):
         https://cloud.google.com/datastore/docs/reference/rest/Shared.Types/EntityFilter
     :param labels: client-assigned labels for cloud storage
     :param datastore_conn_id: the name of the connection id to use
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param polling_interval_in_seconds: number of seconds to wait before polling for
         execution status again
     :param impersonation_chain: Optional service account to impersonate using short-term
@@ -206,7 +192,6 @@ class CloudDatastoreImportEntitiesOperator(GoogleCloudBaseOperator):
         entity_filter: dict | None = None,
         labels: dict | None = None,
         datastore_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         polling_interval_in_seconds: float = 10,
         project_id: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
@@ -214,11 +199,6 @@ class CloudDatastoreImportEntitiesOperator(GoogleCloudBaseOperator):
     ) -> None:
         super().__init__(**kwargs)
         self.datastore_conn_id = datastore_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.bucket = bucket
         self.file = file
         self.namespace = namespace
@@ -232,7 +212,6 @@ class CloudDatastoreImportEntitiesOperator(GoogleCloudBaseOperator):
         self.log.info("Importing data from Cloud Storage bucket %s", self.bucket)
         ds_hook = DatastoreHook(
             self.datastore_conn_id,
-            self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         result = ds_hook.import_from_storage_bucket(
@@ -267,9 +246,6 @@ class CloudDatastoreAllocateIdsOperator(GoogleCloudBaseOperator):
 
     :param partial_keys: a list of partial keys.
     :param project_id: Google Cloud project ID against which to make the request.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -292,7 +268,6 @@ class CloudDatastoreAllocateIdsOperator(GoogleCloudBaseOperator):
         *,
         partial_keys: list,
         project_id: str | None = None,
-        delegate_to: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
@@ -302,11 +277,6 @@ class CloudDatastoreAllocateIdsOperator(GoogleCloudBaseOperator):
         self.partial_keys = partial_keys
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> list:
@@ -335,9 +305,6 @@ class CloudDatastoreBeginTransactionOperator(GoogleCloudBaseOperator):
 
     :param transaction_options: Options for a new transaction.
     :param project_id: Google Cloud project ID against which to make the request.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -359,7 +326,6 @@ class CloudDatastoreBeginTransactionOperator(GoogleCloudBaseOperator):
         *,
         transaction_options: dict[str, Any],
         project_id: str | None = None,
-        delegate_to: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
@@ -369,11 +335,6 @@ class CloudDatastoreBeginTransactionOperator(GoogleCloudBaseOperator):
         self.transaction_options = transaction_options
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> str:
@@ -401,9 +362,6 @@ class CloudDatastoreCommitOperator(GoogleCloudBaseOperator):
 
     :param body: the body of the commit request.
     :param project_id: Google Cloud project ID against which to make the request.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -426,7 +384,6 @@ class CloudDatastoreCommitOperator(GoogleCloudBaseOperator):
         *,
         body: dict[str, Any],
         project_id: str | None = None,
-        delegate_to: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
@@ -436,11 +393,6 @@ class CloudDatastoreCommitOperator(GoogleCloudBaseOperator):
         self.body = body
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> dict:
@@ -469,9 +421,6 @@ class CloudDatastoreRollbackOperator(GoogleCloudBaseOperator):
 
     :param transaction: the transaction to roll back.
     :param project_id: Google Cloud project ID against which to make the request.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -493,7 +442,6 @@ class CloudDatastoreRollbackOperator(GoogleCloudBaseOperator):
         *,
         transaction: str,
         project_id: str | None = None,
-        delegate_to: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
@@ -503,11 +451,6 @@ class CloudDatastoreRollbackOperator(GoogleCloudBaseOperator):
         self.transaction = transaction
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
@@ -534,9 +477,6 @@ class CloudDatastoreRunQueryOperator(GoogleCloudBaseOperator):
 
     :param body: the body of the query request.
     :param project_id: Google Cloud project ID against which to make the request.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -558,7 +498,6 @@ class CloudDatastoreRunQueryOperator(GoogleCloudBaseOperator):
         *,
         body: dict[str, Any],
         project_id: str | None = None,
-        delegate_to: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
@@ -568,11 +507,6 @@ class CloudDatastoreRunQueryOperator(GoogleCloudBaseOperator):
         self.body = body
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> dict:
@@ -599,9 +533,6 @@ class CloudDatastoreGetOperationOperator(GoogleCloudBaseOperator):
         https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects.operations/get
 
     :param name: the name of the operation resource.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -622,7 +553,6 @@ class CloudDatastoreGetOperationOperator(GoogleCloudBaseOperator):
         self,
         *,
         name: str,
-        delegate_to: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
@@ -631,11 +561,6 @@ class CloudDatastoreGetOperationOperator(GoogleCloudBaseOperator):
 
         self.name = name
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
@@ -659,9 +584,6 @@ class CloudDatastoreDeleteOperationOperator(GoogleCloudBaseOperator):
         https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects.operations/delete
 
     :param name: the name of the operation resource.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -682,7 +604,6 @@ class CloudDatastoreDeleteOperationOperator(GoogleCloudBaseOperator):
         self,
         *,
         name: str,
-        delegate_to: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
@@ -691,11 +612,6 @@ class CloudDatastoreDeleteOperationOperator(GoogleCloudBaseOperator):
 
         self.name = name
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:

--- a/airflow/providers/google/cloud/operators/gcs.py
+++ b/airflow/providers/google/cloud/operators/gcs.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import datetime
 import subprocess
 import sys
-import warnings
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import TYPE_CHECKING, Sequence
@@ -74,9 +73,6 @@ class GCSCreateBucketOperator(GoogleCloudBaseOperator):
     :param project_id: The ID of the Google Cloud Project. (templated)
     :param labels: User-provided labels, in key/value pairs.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -122,7 +118,6 @@ class GCSCreateBucketOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         labels: dict | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -134,17 +129,11 @@ class GCSCreateBucketOperator(GoogleCloudBaseOperator):
         self.project_id = project_id
         self.labels = labels
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
         hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         StorageLink.persist(
@@ -177,12 +166,9 @@ class GCSListObjectsOperator(GoogleCloudBaseOperator):
     :param prefix: Prefix string which filters objects whose name begin with
            this prefix. (templated)
     :param delimiter: The delimiter by which you want to filter the objects. (templated)
-        For e.g to lists the CSV files from in a directory in GCS you would use
+        For example, to lists the CSV files from in a directory in GCS you would use
         delimiter='.csv'.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -223,7 +209,6 @@ class GCSListObjectsOperator(GoogleCloudBaseOperator):
         prefix: str | None = None,
         delimiter: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -232,18 +217,12 @@ class GCSListObjectsOperator(GoogleCloudBaseOperator):
         self.prefix = prefix
         self.delimiter = delimiter
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> list:
 
         hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -276,9 +255,6 @@ class GCSDeleteObjectsOperator(GoogleCloudBaseOperator):
     :param prefix: Prefix of objects to delete. All objects matching this
         prefix in the bucket will be deleted.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -303,7 +279,6 @@ class GCSDeleteObjectsOperator(GoogleCloudBaseOperator):
         objects: list[str] | None = None,
         prefix: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -312,11 +287,6 @@ class GCSDeleteObjectsOperator(GoogleCloudBaseOperator):
         self.objects = objects
         self.prefix = prefix
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
         if objects is None and prefix is None:
@@ -330,7 +300,6 @@ class GCSDeleteObjectsOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context) -> None:
         hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -944,9 +913,6 @@ class GCSSynchronizeBucketsOperator(GoogleCloudBaseOperator):
             This option can delete data quickly if you specify the wrong source/destination combination.
 
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -966,7 +932,6 @@ class GCSSynchronizeBucketsOperator(GoogleCloudBaseOperator):
         "delete_extra_files",
         "allow_overwrite",
         "gcp_conn_id",
-        "delegate_to",
         "impersonation_chain",
     )
     operator_extra_links = (StorageLink(),)
@@ -982,7 +947,6 @@ class GCSSynchronizeBucketsOperator(GoogleCloudBaseOperator):
         delete_extra_files: bool = False,
         allow_overwrite: bool = False,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -995,17 +959,11 @@ class GCSSynchronizeBucketsOperator(GoogleCloudBaseOperator):
         self.delete_extra_files = delete_extra_files
         self.allow_overwrite = allow_overwrite
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
         hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         StorageLink.persist(

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -145,9 +145,6 @@ class MLEngineStartBatchPredictionJobOperator(GoogleCloudBaseOperator):
         (templated)
     :param gcp_conn_id: The connection ID used for connection to Google
         Cloud Platform.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param labels: a dictionary containing labels for the job; passed to BigQuery
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -190,7 +187,6 @@ class MLEngineStartBatchPredictionJobOperator(GoogleCloudBaseOperator):
         signature_name: str | None = None,
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         labels: dict[str, str] | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
@@ -210,11 +206,6 @@ class MLEngineStartBatchPredictionJobOperator(GoogleCloudBaseOperator):
         self._runtime_version = runtime_version
         self._signature_name = signature_name
         self._gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self._delegate_to = delegate_to
         self._labels = labels
         self._impersonation_chain = impersonation_chain
 
@@ -274,9 +265,7 @@ class MLEngineStartBatchPredictionJobOperator(GoogleCloudBaseOperator):
         if self._signature_name:
             prediction_request["predictionInput"]["signatureName"] = self._signature_name
 
-        hook = MLEngineHook(
-            self._gcp_conn_id, self._delegate_to, impersonation_chain=self._impersonation_chain
-        )
+        hook = MLEngineHook(gcp_conn_id=self._gcp_conn_id, impersonation_chain=self._impersonation_chain)
 
         # Helper method to check if the existing job's prediction input is the
         # same as the request we get here.
@@ -316,9 +305,6 @@ class MLEngineManageModelOperator(GoogleCloudBaseOperator):
         If set to None or missing, the default project_id from the Google Cloud connection is used.
         (templated)
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -342,7 +328,6 @@ class MLEngineManageModelOperator(GoogleCloudBaseOperator):
         operation: str = "create",
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -359,17 +344,11 @@ class MLEngineManageModelOperator(GoogleCloudBaseOperator):
         self._model = model
         self._operation = operation
         self._gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self._delegate_to = delegate_to
         self._impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = MLEngineHook(
             gcp_conn_id=self._gcp_conn_id,
-            delegate_to=self._delegate_to,
             impersonation_chain=self._impersonation_chain,
         )
         if self._operation == "create":
@@ -395,9 +374,6 @@ class MLEngineCreateModelOperator(GoogleCloudBaseOperator):
         If set to None or missing, the default project_id from the Google Cloud connection is used.
         (templated)
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -421,7 +397,6 @@ class MLEngineCreateModelOperator(GoogleCloudBaseOperator):
         model: dict,
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -429,17 +404,11 @@ class MLEngineCreateModelOperator(GoogleCloudBaseOperator):
         self._project_id = project_id
         self._model = model
         self._gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self._delegate_to = delegate_to
         self._impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = MLEngineHook(
             gcp_conn_id=self._gcp_conn_id,
-            delegate_to=self._delegate_to,
             impersonation_chain=self._impersonation_chain,
         )
 
@@ -470,9 +439,6 @@ class MLEngineGetModelOperator(GoogleCloudBaseOperator):
         If set to None or missing, the default project_id from the Google Cloud connection is used.
         (templated)
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -496,7 +462,6 @@ class MLEngineGetModelOperator(GoogleCloudBaseOperator):
         model_name: str,
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -504,17 +469,11 @@ class MLEngineGetModelOperator(GoogleCloudBaseOperator):
         self._project_id = project_id
         self._model_name = model_name
         self._gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self._delegate_to = delegate_to
         self._impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = MLEngineHook(
             gcp_conn_id=self._gcp_conn_id,
-            delegate_to=self._delegate_to,
             impersonation_chain=self._impersonation_chain,
         )
         project_id = self._project_id or hook.project_id
@@ -547,9 +506,6 @@ class MLEngineDeleteModelOperator(GoogleCloudBaseOperator):
         If set to None or missing, the default project_id from the Google Cloud connection is used.
         (templated)
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -574,7 +530,6 @@ class MLEngineDeleteModelOperator(GoogleCloudBaseOperator):
         delete_contents: bool = False,
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -583,17 +538,11 @@ class MLEngineDeleteModelOperator(GoogleCloudBaseOperator):
         self._model_name = model_name
         self._delete_contents = delete_contents
         self._gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self._delegate_to = delegate_to
         self._impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = MLEngineHook(
             gcp_conn_id=self._gcp_conn_id,
-            delegate_to=self._delegate_to,
             impersonation_chain=self._impersonation_chain,
         )
 
@@ -653,9 +602,6 @@ class MLEngineManageVersionOperator(GoogleCloudBaseOperator):
         If set to None or missing, the default project_id from the Google Cloud connection is used.
         (templated)
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -683,7 +629,6 @@ class MLEngineManageVersionOperator(GoogleCloudBaseOperator):
         operation: str = "create",
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -694,11 +639,6 @@ class MLEngineManageVersionOperator(GoogleCloudBaseOperator):
         self._version = version or {}
         self._operation = operation
         self._gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self._delegate_to = delegate_to
         self._impersonation_chain = impersonation_chain
 
         warnings.warn(
@@ -714,7 +654,6 @@ class MLEngineManageVersionOperator(GoogleCloudBaseOperator):
 
         hook = MLEngineHook(
             gcp_conn_id=self._gcp_conn_id,
-            delegate_to=self._delegate_to,
             impersonation_chain=self._impersonation_chain,
         )
 
@@ -755,9 +694,6 @@ class MLEngineCreateVersionOperator(GoogleCloudBaseOperator):
         If set to None or missing, the default project_id from the Google Cloud connection is used.
         (templated)
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -783,7 +719,6 @@ class MLEngineCreateVersionOperator(GoogleCloudBaseOperator):
         version: dict,
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -793,11 +728,6 @@ class MLEngineCreateVersionOperator(GoogleCloudBaseOperator):
         self._model_name = model_name
         self._version = version
         self._gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self._delegate_to = delegate_to
         self._impersonation_chain = impersonation_chain
         self._validate_inputs()
 
@@ -811,7 +741,6 @@ class MLEngineCreateVersionOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context):
         hook = MLEngineHook(
             gcp_conn_id=self._gcp_conn_id,
-            delegate_to=self._delegate_to,
             impersonation_chain=self._impersonation_chain,
         )
 
@@ -847,9 +776,6 @@ class MLEngineSetDefaultVersionOperator(GoogleCloudBaseOperator):
         If set to None or missing, the default project_id from the Google Cloud connection is used.
         (templated)
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -875,7 +801,6 @@ class MLEngineSetDefaultVersionOperator(GoogleCloudBaseOperator):
         version_name: str,
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -885,11 +810,6 @@ class MLEngineSetDefaultVersionOperator(GoogleCloudBaseOperator):
         self._model_name = model_name
         self._version_name = version_name
         self._gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self._delegate_to = delegate_to
         self._impersonation_chain = impersonation_chain
         self._validate_inputs()
 
@@ -903,7 +823,6 @@ class MLEngineSetDefaultVersionOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context):
         hook = MLEngineHook(
             gcp_conn_id=self._gcp_conn_id,
-            delegate_to=self._delegate_to,
             impersonation_chain=self._impersonation_chain,
         )
 
@@ -938,9 +857,6 @@ class MLEngineListVersionsOperator(GoogleCloudBaseOperator):
     :param project_id: The Google Cloud project name to which MLEngine model belongs.
         If set to None or missing, the default project_id from the Google Cloud connection is used.
         (templated)
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -964,7 +880,6 @@ class MLEngineListVersionsOperator(GoogleCloudBaseOperator):
         model_name: str,
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -973,11 +888,6 @@ class MLEngineListVersionsOperator(GoogleCloudBaseOperator):
         self._project_id = project_id
         self._model_name = model_name
         self._gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self._delegate_to = delegate_to
         self._impersonation_chain = impersonation_chain
         self._validate_inputs()
 
@@ -988,7 +898,6 @@ class MLEngineListVersionsOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context):
         hook = MLEngineHook(
             gcp_conn_id=self._gcp_conn_id,
-            delegate_to=self._delegate_to,
             impersonation_chain=self._impersonation_chain,
         )
 
@@ -1024,9 +933,6 @@ class MLEngineDeleteVersionOperator(GoogleCloudBaseOperator):
     :param project_id: The Google Cloud project name to which MLEngine
         model belongs.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -1052,7 +958,6 @@ class MLEngineDeleteVersionOperator(GoogleCloudBaseOperator):
         version_name: str,
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -1062,11 +967,6 @@ class MLEngineDeleteVersionOperator(GoogleCloudBaseOperator):
         self._model_name = model_name
         self._version_name = version_name
         self._gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self._delegate_to = delegate_to
         self._impersonation_chain = impersonation_chain
         self._validate_inputs()
 
@@ -1080,7 +980,6 @@ class MLEngineDeleteVersionOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context):
         hook = MLEngineHook(
             gcp_conn_id=self._gcp_conn_id,
-            delegate_to=self._delegate_to,
             impersonation_chain=self._impersonation_chain,
         )
 
@@ -1139,9 +1038,6 @@ class MLEngineStartTrainingJobOperator(GoogleCloudBaseOperator):
         If set to None or missing, the Google-managed Cloud ML Engine service account will be used.
     :param project_id: The Google Cloud project name within which MLEngine training job should run.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param mode: Can be one of 'DRY_RUN'/'CLOUD'. In 'DRY_RUN' mode, no real
         training job will be launched, but the MLEngine training job request
         will be printed out. In 'CLOUD' mode, a real MLEngine training job
@@ -1198,7 +1094,6 @@ class MLEngineStartTrainingJobOperator(GoogleCloudBaseOperator):
         job_dir: str | None = None,
         service_account: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         mode: str = "PRODUCTION",
         labels: dict[str, str] | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
@@ -1222,11 +1117,6 @@ class MLEngineStartTrainingJobOperator(GoogleCloudBaseOperator):
         self._job_dir = job_dir
         self._service_account = service_account
         self._gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self._delegate_to = delegate_to
         self._mode = mode
         self._labels = labels
         self._hyperparameters = hyperparameters
@@ -1316,7 +1206,6 @@ class MLEngineStartTrainingJobOperator(GoogleCloudBaseOperator):
 
         hook = MLEngineHook(
             gcp_conn_id=self._gcp_conn_id,
-            delegate_to=self._delegate_to,
             impersonation_chain=self._impersonation_chain,
         )
         self.hook = hook
@@ -1363,7 +1252,6 @@ class MLEngineStartTrainingJobOperator(GoogleCloudBaseOperator):
                     labels=self._labels,
                     gcp_conn_id=self._gcp_conn_id,
                     impersonation_chain=self._impersonation_chain,
-                    delegate_to=self._delegate_to,
                 ),
                 method_name="execute_complete",
             )
@@ -1446,9 +1334,6 @@ class MLEngineTrainingCancelJobOperator(GoogleCloudBaseOperator):
         If set to None or missing, the default project_id from the Google Cloud connection is used.
         (templated)
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -1472,7 +1357,6 @@ class MLEngineTrainingCancelJobOperator(GoogleCloudBaseOperator):
         job_id: str,
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -1480,11 +1364,6 @@ class MLEngineTrainingCancelJobOperator(GoogleCloudBaseOperator):
         self._project_id = project_id
         self._job_id = job_id
         self._gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self._delegate_to = delegate_to
         self._impersonation_chain = impersonation_chain
 
         if not self._project_id:
@@ -1494,7 +1373,6 @@ class MLEngineTrainingCancelJobOperator(GoogleCloudBaseOperator):
 
         hook = MLEngineHook(
             gcp_conn_id=self._gcp_conn_id,
-            delegate_to=self._delegate_to,
             impersonation_chain=self._impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/operators/pubsub.py
+++ b/airflow/providers/google/cloud/operators/pubsub.py
@@ -24,7 +24,6 @@ This module contains Google PubSub operators.
 """
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
@@ -85,9 +84,6 @@ class PubSubCreateTopicOperator(GoogleCloudBaseOperator):
         ``{topic}``. (templated)
     :param gcp_conn_id: The connection ID to use connecting to
         Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param labels: Client-assigned labels; see
         https://cloud.google.com/pubsub/docs/labels
     :param message_storage_policy: Policy constraining the set
@@ -130,7 +126,6 @@ class PubSubCreateTopicOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         fail_if_exists: bool = False,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         labels: dict[str, str] | None = None,
         message_storage_policy: dict | MessageStoragePolicy = None,
         kms_key_name: str | None = None,
@@ -146,11 +141,6 @@ class PubSubCreateTopicOperator(GoogleCloudBaseOperator):
         self.topic = topic
         self.fail_if_exists = fail_if_exists
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.labels = labels
         self.message_storage_policy = message_storage_policy
         self.kms_key_name = kms_key_name
@@ -162,7 +152,6 @@ class PubSubCreateTopicOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context) -> None:
         hook = PubSubHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -256,9 +245,6 @@ class PubSubCreateSubscriptionOperator(GoogleCloudBaseOperator):
         acknowledge each message pulled from the subscription
     :param gcp_conn_id: The connection ID to use connecting to
         Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param push_config: If push delivery is used with this subscription,
         this field is used to configure it. An empty ``pushConfig`` signifies
         that the subscriber will pull and ack messages using API methods.
@@ -332,7 +318,6 @@ class PubSubCreateSubscriptionOperator(GoogleCloudBaseOperator):
         ack_deadline_secs: int = 10,
         fail_if_exists: bool = False,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         push_config: dict | PushConfig | None = None,
         retain_acked_messages: bool | None = None,
         message_retention_duration: dict | Duration | None = None,
@@ -356,11 +341,6 @@ class PubSubCreateSubscriptionOperator(GoogleCloudBaseOperator):
         self.ack_deadline_secs = ack_deadline_secs
         self.fail_if_exists = fail_if_exists
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.push_config = push_config
         self.retain_acked_messages = retain_acked_messages
         self.message_retention_duration = message_retention_duration
@@ -378,7 +358,6 @@ class PubSubCreateSubscriptionOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context) -> str:
         hook = PubSubHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -446,9 +425,6 @@ class PubSubDeleteTopicOperator(GoogleCloudBaseOperator):
         the task
     :param gcp_conn_id: The connection ID to use connecting to
         Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param retry: (Optional) A retry object used to retry requests.
         If None is specified, requests will not be retried.
     :param timeout: (Optional) The amount of time, in seconds, to wait for the request
@@ -479,7 +455,6 @@ class PubSubDeleteTopicOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         fail_if_not_exists: bool = False,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         retry: Retry | _MethodDefault = DEFAULT,
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
@@ -491,11 +466,6 @@ class PubSubDeleteTopicOperator(GoogleCloudBaseOperator):
         self.topic = topic
         self.fail_if_not_exists = fail_if_not_exists
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.retry = retry
         self.timeout = timeout
         self.metadata = metadata
@@ -504,7 +474,6 @@ class PubSubDeleteTopicOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context) -> None:
         hook = PubSubHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -554,9 +523,6 @@ class PubSubDeleteSubscriptionOperator(GoogleCloudBaseOperator):
         fail the task
     :param gcp_conn_id: The connection ID to use connecting to
         Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param retry: (Optional) A retry object used to retry requests.
         If None is specified, requests will not be retried.
     :param timeout: (Optional) The amount of time, in seconds, to wait for the request
@@ -587,7 +553,6 @@ class PubSubDeleteSubscriptionOperator(GoogleCloudBaseOperator):
         project_id: str | None = None,
         fail_if_not_exists: bool = False,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         retry: Retry | _MethodDefault = DEFAULT,
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
@@ -599,11 +564,6 @@ class PubSubDeleteSubscriptionOperator(GoogleCloudBaseOperator):
         self.subscription = subscription
         self.fail_if_not_exists = fail_if_not_exists
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.retry = retry
         self.timeout = timeout
         self.metadata = metadata
@@ -612,7 +572,6 @@ class PubSubDeleteSubscriptionOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context) -> None:
         hook = PubSubHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -672,9 +631,6 @@ class PubSubPublishMessageOperator(GoogleCloudBaseOperator):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage
     :param gcp_conn_id: The connection ID to use connecting to
         Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -700,7 +656,6 @@ class PubSubPublishMessageOperator(GoogleCloudBaseOperator):
         messages: list,
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -709,17 +664,11 @@ class PubSubPublishMessageOperator(GoogleCloudBaseOperator):
         self.topic = topic
         self.messages = messages
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
         hook = PubSubHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -757,9 +706,6 @@ class PubSubPullOperator(GoogleCloudBaseOperator):
         immediately rather than by any downstream tasks
     :param gcp_conn_id: The connection ID to use connecting to
         Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param messages_callback: (Optional) Callback to process received messages.
         It's return value will be saved to XCom.
         If you are pulling large messages, you probably want to provide a custom callback.
@@ -790,17 +736,11 @@ class PubSubPullOperator(GoogleCloudBaseOperator):
         ack_messages: bool = False,
         messages_callback: Callable[[list[ReceivedMessage], Context], Any] | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.project_id = project_id
         self.subscription = subscription
         self.max_messages = max_messages
@@ -811,7 +751,6 @@ class PubSubPullOperator(GoogleCloudBaseOperator):
     def execute(self, context: Context) -> list:
         hook = PubSubHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/operators/stackdriver.py
+++ b/airflow/providers/google/cloud/operators/stackdriver.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
@@ -71,9 +70,6 @@ class StackdriverListAlertPoliciesOperator(GoogleCloudBaseOperator):
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google
         Cloud Platform.
     :param project_id: The project to fetch alerts from.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -103,7 +99,6 @@ class StackdriverListAlertPoliciesOperator(GoogleCloudBaseOperator):
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
         project_id: str | None = None,
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -117,11 +112,6 @@ class StackdriverListAlertPoliciesOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.hook: StackdriverHook | None = None
 
@@ -137,7 +127,6 @@ class StackdriverListAlertPoliciesOperator(GoogleCloudBaseOperator):
         if self.hook is None:
             self.hook = StackdriverHook(
                 gcp_conn_id=self.gcp_conn_id,
-                delegate_to=self.delegate_to,
                 impersonation_chain=self.impersonation_chain,
             )
 
@@ -180,9 +169,6 @@ class StackdriverEnableAlertPoliciesOperator(GoogleCloudBaseOperator):
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google
         Cloud Platform.
     :param project_id: The project in which alert needs to be enabled.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -209,18 +195,12 @@ class StackdriverEnableAlertPoliciesOperator(GoogleCloudBaseOperator):
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
         project_id: str | None = None,
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.filter_ = filter_
         self.retry = retry
         self.timeout = timeout
@@ -233,7 +213,6 @@ class StackdriverEnableAlertPoliciesOperator(GoogleCloudBaseOperator):
         if self.hook is None:
             self.hook = StackdriverHook(
                 gcp_conn_id=self.gcp_conn_id,
-                delegate_to=self.delegate_to,
                 impersonation_chain=self.impersonation_chain,
             )
         self.hook.enable_alert_policies(
@@ -272,9 +251,6 @@ class StackdriverDisableAlertPoliciesOperator(GoogleCloudBaseOperator):
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google
         Cloud Platform.
     :param project_id: The project in which alert needs to be disabled.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -301,18 +277,12 @@ class StackdriverDisableAlertPoliciesOperator(GoogleCloudBaseOperator):
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
         project_id: str | None = None,
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.filter_ = filter_
         self.retry = retry
         self.timeout = timeout
@@ -325,7 +295,6 @@ class StackdriverDisableAlertPoliciesOperator(GoogleCloudBaseOperator):
         if self.hook is None:
             self.hook = StackdriverHook(
                 gcp_conn_id=self.gcp_conn_id,
-                delegate_to=self.delegate_to,
                 impersonation_chain=self.impersonation_chain,
             )
         self.hook.disable_alert_policies(
@@ -364,9 +333,6 @@ class StackdriverUpsertAlertOperator(GoogleCloudBaseOperator):
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google
         Cloud Platform.
     :param project_id: The project in which alert needs to be created/updated.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -395,7 +361,6 @@ class StackdriverUpsertAlertOperator(GoogleCloudBaseOperator):
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
         project_id: str | None = None,
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -406,11 +371,6 @@ class StackdriverUpsertAlertOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.hook: StackdriverHook | None = None
 
@@ -419,7 +379,6 @@ class StackdriverUpsertAlertOperator(GoogleCloudBaseOperator):
         if self.hook is None:
             self.hook = StackdriverHook(
                 gcp_conn_id=self.gcp_conn_id,
-                delegate_to=self.delegate_to,
                 impersonation_chain=self.impersonation_chain,
             )
         self.hook.upsert_alert(
@@ -455,9 +414,6 @@ class StackdriverDeleteAlertOperator(GoogleCloudBaseOperator):
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google
         Cloud Platform.
     :param project_id: The project from which alert needs to be deleted.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -484,7 +440,6 @@ class StackdriverDeleteAlertOperator(GoogleCloudBaseOperator):
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
         project_id: str | None = None,
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -495,11 +450,6 @@ class StackdriverDeleteAlertOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.hook: StackdriverHook | None = None
 
@@ -508,7 +458,6 @@ class StackdriverDeleteAlertOperator(GoogleCloudBaseOperator):
         if self.hook is None:
             self.hook = StackdriverHook(
                 gcp_conn_id=self.gcp_conn_id,
-                delegate_to=self.delegate_to,
                 impersonation_chain=self.impersonation_chain,
             )
         self.hook.delete_alert_policy(
@@ -555,9 +504,6 @@ class StackdriverListNotificationChannelsOperator(GoogleCloudBaseOperator):
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google
         Cloud Platform.
     :param project_id: The project to fetch notification channels from.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -588,7 +534,6 @@ class StackdriverListNotificationChannelsOperator(GoogleCloudBaseOperator):
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
         project_id: str | None = None,
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -602,11 +547,6 @@ class StackdriverListNotificationChannelsOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.hook: StackdriverHook | None = None
 
@@ -622,7 +562,6 @@ class StackdriverListNotificationChannelsOperator(GoogleCloudBaseOperator):
         if self.hook is None:
             self.hook = StackdriverHook(
                 gcp_conn_id=self.gcp_conn_id,
-                delegate_to=self.delegate_to,
                 impersonation_chain=self.impersonation_chain,
             )
         channels = self.hook.list_notification_channels(
@@ -664,9 +603,6 @@ class StackdriverEnableNotificationChannelsOperator(GoogleCloudBaseOperator):
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google
         Cloud Platform.
     :param project_id: The location used for the operation.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -694,7 +630,6 @@ class StackdriverEnableNotificationChannelsOperator(GoogleCloudBaseOperator):
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
         project_id: str | None = None,
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -705,11 +640,6 @@ class StackdriverEnableNotificationChannelsOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.hook: StackdriverHook | None = None
 
@@ -720,7 +650,6 @@ class StackdriverEnableNotificationChannelsOperator(GoogleCloudBaseOperator):
         if self.hook is None:
             self.hook = StackdriverHook(
                 gcp_conn_id=self.gcp_conn_id,
-                delegate_to=self.delegate_to,
                 impersonation_chain=self.impersonation_chain,
             )
         self.hook.enable_notification_channels(
@@ -758,9 +687,6 @@ class StackdriverDisableNotificationChannelsOperator(GoogleCloudBaseOperator):
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google
         Cloud Platform.
     :param project_id: The project in which notification channels needs to be enabled.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -788,7 +714,6 @@ class StackdriverDisableNotificationChannelsOperator(GoogleCloudBaseOperator):
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
         project_id: str | None = None,
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -799,11 +724,6 @@ class StackdriverDisableNotificationChannelsOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.hook: StackdriverHook | None = None
 
@@ -814,7 +734,6 @@ class StackdriverDisableNotificationChannelsOperator(GoogleCloudBaseOperator):
         if self.hook is None:
             self.hook = StackdriverHook(
                 gcp_conn_id=self.gcp_conn_id,
-                delegate_to=self.delegate_to,
                 impersonation_chain=self.impersonation_chain,
             )
         self.hook.disable_notification_channels(
@@ -853,9 +772,6 @@ class StackdriverUpsertNotificationChannelOperator(GoogleCloudBaseOperator):
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google
         Cloud Platform.
     :param project_id: The project in which notification channels needs to be created/updated.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -884,7 +800,6 @@ class StackdriverUpsertNotificationChannelOperator(GoogleCloudBaseOperator):
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
         project_id: str | None = None,
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -895,11 +810,6 @@ class StackdriverUpsertNotificationChannelOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.hook: StackdriverHook | None = None
 
@@ -910,7 +820,6 @@ class StackdriverUpsertNotificationChannelOperator(GoogleCloudBaseOperator):
         if self.hook is None:
             self.hook = StackdriverHook(
                 gcp_conn_id=self.gcp_conn_id,
-                delegate_to=self.delegate_to,
                 impersonation_chain=self.impersonation_chain,
             )
         self.hook.upsert_channel(
@@ -946,9 +855,6 @@ class StackdriverDeleteNotificationChannelOperator(GoogleCloudBaseOperator):
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google
         Cloud Platform.
     :param project_id: The project from which notification channel needs to be deleted.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -975,7 +881,6 @@ class StackdriverDeleteNotificationChannelOperator(GoogleCloudBaseOperator):
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
         project_id: str | None = None,
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -986,11 +891,6 @@ class StackdriverDeleteNotificationChannelOperator(GoogleCloudBaseOperator):
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.hook: StackdriverHook | None = None
 
@@ -999,7 +899,6 @@ class StackdriverDeleteNotificationChannelOperator(GoogleCloudBaseOperator):
         if self.hook is None:
             self.hook = StackdriverHook(
                 gcp_conn_id=self.gcp_conn_id,
-                delegate_to=self.delegate_to,
                 impersonation_chain=self.impersonation_chain,
             )
         self.hook.delete_notification_channel(

--- a/airflow/providers/google/cloud/operators/vertex_ai/auto_ml.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/auto_ml.py
@@ -18,7 +18,6 @@
 """This module contains Google Vertex AI operators."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from google.api_core.exceptions import NotFound
@@ -59,7 +58,6 @@ class AutoMLTrainingJobBaseOperator(GoogleCloudBaseOperator):
         model_labels: dict[str, str] | None = None,
         sync: bool = True,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -78,11 +76,6 @@ class AutoMLTrainingJobBaseOperator(GoogleCloudBaseOperator):
         self.sync = sync
         # END Run param
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.hook: AutoMLHook | None = None
 
@@ -165,7 +158,6 @@ class CreateAutoMLForecastingTrainingJobOperator(AutoMLTrainingJobBaseOperator):
     def execute(self, context: Context):
         self.hook = AutoMLHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         model, training_id = self.hook.create_auto_ml_forecasting_training_job(
@@ -262,7 +254,6 @@ class CreateAutoMLImageTrainingJobOperator(AutoMLTrainingJobBaseOperator):
     def execute(self, context: Context):
         self.hook = AutoMLHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         model, training_id = self.hook.create_auto_ml_image_training_job(
@@ -359,7 +350,6 @@ class CreateAutoMLTabularTrainingJobOperator(AutoMLTrainingJobBaseOperator):
     def execute(self, context: Context):
         self.hook = AutoMLHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         model, training_id = self.hook.create_auto_ml_tabular_training_job(
@@ -444,7 +434,6 @@ class CreateAutoMLTextTrainingJobOperator(AutoMLTrainingJobBaseOperator):
     def execute(self, context: Context):
         self.hook = AutoMLHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         model, training_id = self.hook.create_auto_ml_text_training_job(
@@ -510,7 +499,6 @@ class CreateAutoMLVideoTrainingJobOperator(AutoMLTrainingJobBaseOperator):
     def execute(self, context: Context):
         self.hook = AutoMLHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         model, training_id = self.hook.create_auto_ml_video_training_job(
@@ -560,7 +548,6 @@ class DeleteAutoMLTrainingJobOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -572,17 +559,11 @@ class DeleteAutoMLTrainingJobOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = AutoMLHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         try:
@@ -628,7 +609,6 @@ class ListAutoMLTrainingJobOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -643,17 +623,11 @@ class ListAutoMLTrainingJobOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = AutoMLHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         results = hook.list_training_pipelines(

--- a/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
@@ -26,7 +26,6 @@
 """
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from google.api_core.exceptions import NotFound
@@ -144,9 +143,6 @@ class CreateBatchPredictionJobOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -186,7 +182,6 @@ class CreateBatchPredictionJobOperator(GoogleCloudBaseOperator):
         encryption_spec_key_name: str | None = None,
         sync: bool = True,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -214,11 +209,6 @@ class CreateBatchPredictionJobOperator(GoogleCloudBaseOperator):
         self.encryption_spec_key_name = encryption_spec_key_name
         self.sync = sync
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.hook: BatchPredictionJobHook | None = None
 
@@ -226,7 +216,6 @@ class CreateBatchPredictionJobOperator(GoogleCloudBaseOperator):
         self.log.info("Creating Batch prediction job")
         self.hook = BatchPredictionJobHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         result = self.hook.create_batch_prediction_job(
@@ -284,9 +273,6 @@ class DeleteBatchPredictionJobOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -309,7 +295,6 @@ class DeleteBatchPredictionJobOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -321,17 +306,11 @@ class DeleteBatchPredictionJobOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = BatchPredictionJobHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -362,9 +341,6 @@ class GetBatchPredictionJobOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -388,7 +364,6 @@ class GetBatchPredictionJobOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -400,17 +375,11 @@ class GetBatchPredictionJobOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = BatchPredictionJobHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -456,9 +425,6 @@ class ListBatchPredictionJobsOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -485,7 +451,6 @@ class ListBatchPredictionJobsOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -500,17 +465,11 @@ class ListBatchPredictionJobsOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = BatchPredictionJobHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         results = hook.list_batch_prediction_jobs(

--- a/airflow/providers/google/cloud/operators/vertex_ai/custom_job.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/custom_job.py
@@ -18,7 +18,6 @@
 """This module contains Google Vertex AI operators."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from google.api_core.exceptions import NotFound
@@ -93,7 +92,6 @@ class CustomTrainingJobBaseOperator(GoogleCloudBaseOperator):
         tensorboard: str | None = None,
         sync=True,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -148,11 +146,6 @@ class CustomTrainingJobBaseOperator(GoogleCloudBaseOperator):
         self.sync = sync
         # END Run param
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
 
@@ -402,9 +395,6 @@ class CreateCustomContainerTrainingJobOperator(CustomTrainingJobBaseOperator):
             will be executed in concurrent Future and any downstream object will
             be immediately returned and synced when the Future has completed.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -435,7 +425,6 @@ class CreateCustomContainerTrainingJobOperator(CustomTrainingJobBaseOperator):
     def execute(self, context: Context):
         self.hook = CustomJobHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         model, training_id, custom_job_id = self.hook.create_custom_container_training_job(
@@ -754,9 +743,6 @@ class CreateCustomPythonPackageTrainingJobOperator(CustomTrainingJobBaseOperator
             will be executed in concurrent Future and any downstream object will
             be immediately returned and synced when the Future has completed.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -788,7 +774,6 @@ class CreateCustomPythonPackageTrainingJobOperator(CustomTrainingJobBaseOperator
     def execute(self, context: Context):
         self.hook = CustomJobHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         model, training_id, custom_job_id = self.hook.create_custom_python_package_training_job(
@@ -1108,9 +1093,6 @@ class CreateCustomTrainingJobOperator(CustomTrainingJobBaseOperator):
             will be executed in concurrent Future and any downstream object will
             be immediately returned and synced when the Future has completed.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -1144,7 +1126,6 @@ class CreateCustomTrainingJobOperator(CustomTrainingJobBaseOperator):
     def execute(self, context: Context):
         self.hook = CustomJobHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         model, training_id, custom_job_id = self.hook.create_custom_training_job(
@@ -1229,9 +1210,6 @@ class DeleteCustomTrainingJobOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -1255,7 +1233,6 @@ class DeleteCustomTrainingJobOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -1268,17 +1245,11 @@ class DeleteCustomTrainingJobOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = CustomJobHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         try:
@@ -1342,9 +1313,6 @@ class ListCustomTrainingJobOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -1377,7 +1345,6 @@ class ListCustomTrainingJobOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -1392,17 +1359,11 @@ class ListCustomTrainingJobOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = CustomJobHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         results = hook.list_training_pipelines(

--- a/airflow/providers/google/cloud/operators/vertex_ai/dataset.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/dataset.py
@@ -18,7 +18,6 @@
 """This module contains Google Vertex AI operators."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from google.api_core.exceptions import NotFound
@@ -47,9 +46,6 @@ class CreateDatasetOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -73,7 +69,6 @@ class CreateDatasetOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -85,17 +80,11 @@ class CreateDatasetOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = DatasetHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -130,9 +119,6 @@ class GetDatasetOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -157,7 +143,6 @@ class GetDatasetOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -170,17 +155,11 @@ class GetDatasetOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = DatasetHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -213,9 +192,6 @@ class DeleteDatasetOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -238,7 +214,6 @@ class DeleteDatasetOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -250,17 +225,11 @@ class DeleteDatasetOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = DatasetHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -292,9 +261,6 @@ class ExportDataOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -318,7 +284,6 @@ class ExportDataOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -331,17 +296,11 @@ class ExportDataOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = DatasetHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -372,9 +331,6 @@ class ImportDataOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -398,7 +354,6 @@ class ImportDataOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -411,17 +366,11 @@ class ImportDataOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = DatasetHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -455,9 +404,6 @@ class ListDatasetsOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -485,7 +431,6 @@ class ListDatasetsOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -501,17 +446,11 @@ class ListDatasetsOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = DatasetHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         results = hook.list_datasets(
@@ -543,9 +482,6 @@ class UpdateDatasetOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -570,7 +506,6 @@ class UpdateDatasetOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -584,17 +519,11 @@ class UpdateDatasetOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = DatasetHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         self.log.info("Updating dataset: %s", self.dataset_id)

--- a/airflow/providers/google/cloud/operators/vertex_ai/endpoint_service.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/endpoint_service.py
@@ -28,7 +28,6 @@
 """
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from google.api_core.exceptions import NotFound
@@ -62,9 +61,6 @@ class CreateEndpointOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -89,7 +85,6 @@ class CreateEndpointOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -102,17 +97,11 @@ class CreateEndpointOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = EndpointServiceHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -148,9 +137,6 @@ class DeleteEndpointOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -173,7 +159,6 @@ class DeleteEndpointOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -185,17 +170,11 @@ class DeleteEndpointOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = EndpointServiceHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -242,9 +221,6 @@ class DeployModelOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -270,7 +246,6 @@ class DeployModelOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -284,17 +259,11 @@ class DeployModelOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = EndpointServiceHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -331,9 +300,6 @@ class GetEndpointOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -357,7 +323,6 @@ class GetEndpointOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -369,17 +334,11 @@ class GetEndpointOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = EndpointServiceHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -432,9 +391,6 @@ class ListEndpointsOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -462,7 +418,6 @@ class ListEndpointsOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -478,17 +433,11 @@ class ListEndpointsOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = EndpointServiceHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         results = hook.list_endpoints(
@@ -527,9 +476,6 @@ class UndeployModelOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -554,7 +500,6 @@ class UndeployModelOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -568,17 +513,11 @@ class UndeployModelOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = EndpointServiceHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -611,9 +550,6 @@ class UpdateEndpointOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -639,7 +575,6 @@ class UpdateEndpointOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -653,17 +588,11 @@ class UpdateEndpointOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = EndpointServiceHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         self.log.info("Updating endpoint: %s", self.endpoint_id)

--- a/airflow/providers/google/cloud/operators/vertex_ai/hyperparameter_tuning_job.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/hyperparameter_tuning_job.py
@@ -27,7 +27,6 @@
 """
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from google.api_core.exceptions import NotFound
@@ -134,9 +133,6 @@ class CreateHyperparameterTuningJobOperator(GoogleCloudBaseOperator):
     :param sync: Whether to execute this method synchronously. If False, this method will unblock and it
         will be executed in a concurrent Future.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -186,7 +182,6 @@ class CreateHyperparameterTuningJobOperator(GoogleCloudBaseOperator):
         sync: bool = True,
         # END: run param
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -218,11 +213,6 @@ class CreateHyperparameterTuningJobOperator(GoogleCloudBaseOperator):
         self.tensorboard = tensorboard
         self.sync = sync
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.hook: HyperparameterTuningJobHook | None = None
 
@@ -230,7 +220,6 @@ class CreateHyperparameterTuningJobOperator(GoogleCloudBaseOperator):
         self.log.info("Creating Hyperparameter Tuning job")
         self.hook = HyperparameterTuningJobHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         result = self.hook.create_hyperparameter_tuning_job(
@@ -294,9 +283,6 @@ class GetHyperparameterTuningJobOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -320,7 +306,6 @@ class GetHyperparameterTuningJobOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -332,17 +317,11 @@ class GetHyperparameterTuningJobOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = HyperparameterTuningJobHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -392,7 +371,6 @@ class DeleteHyperparameterTuningJobOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -404,17 +382,11 @@ class DeleteHyperparameterTuningJobOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = HyperparameterTuningJobHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         try:
@@ -479,7 +451,6 @@ class ListHyperparameterTuningJobOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -494,17 +465,11 @@ class ListHyperparameterTuningJobOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = HyperparameterTuningJobHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         results = hook.list_hyperparameter_tuning_jobs(

--- a/airflow/providers/google/cloud/operators/vertex_ai/model_service.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/model_service.py
@@ -24,7 +24,6 @@
 """
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from google.api_core.exceptions import NotFound
@@ -55,9 +54,6 @@ class DeleteModelOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -80,7 +76,6 @@ class DeleteModelOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -92,17 +87,11 @@ class DeleteModelOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = ModelServiceHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -134,9 +123,6 @@ class ExportModelOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -161,7 +147,6 @@ class ExportModelOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -174,17 +159,11 @@ class ExportModelOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = ModelServiceHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -234,9 +213,6 @@ class ListModelsOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -264,7 +240,6 @@ class ListModelsOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -280,17 +255,11 @@ class ListModelsOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = ModelServiceHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         results = hook.list_models(
@@ -320,9 +289,6 @@ class UploadModelOperator(GoogleCloudBaseOperator):
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -346,7 +312,6 @@ class UploadModelOperator(GoogleCloudBaseOperator):
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -358,17 +323,11 @@ class UploadModelOperator(GoogleCloudBaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         hook = ModelServiceHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         self.log.info("Upload model")

--- a/airflow/providers/google/cloud/sensors/bigquery.py
+++ b/airflow/providers/google/cloud/sensors/bigquery.py
@@ -45,9 +45,6 @@ class BigQueryTableExistenceSensor(BaseSensorOperator):
         storage bucket.
     :param table_id: The name of the table to check the existence of.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -73,7 +70,6 @@ class BigQueryTableExistenceSensor(BaseSensorOperator):
         dataset_id: str,
         table_id: str,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         deferrable: bool = False,
         **kwargs,
@@ -97,11 +93,6 @@ class BigQueryTableExistenceSensor(BaseSensorOperator):
         self.dataset_id = dataset_id
         self.table_id = table_id
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
         self.deferrable = deferrable
@@ -111,7 +102,6 @@ class BigQueryTableExistenceSensor(BaseSensorOperator):
         self.log.info("Sensor checks existence of table: %s", table_uri)
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         return hook.table_exists(
@@ -129,7 +119,6 @@ class BigQueryTableExistenceSensor(BaseSensorOperator):
                 poll_interval=self.poke_interval,
                 gcp_conn_id=self.gcp_conn_id,
                 hook_params={
-                    "delegate_to": self.delegate_to,
                     "impersonation_chain": self.impersonation_chain,
                 },
             ),
@@ -163,9 +152,6 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
     :param table_id: The name of the table to check the existence of.
     :param partition_id: The name of the partition to check the existence of.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must
-        have domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -193,7 +179,6 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
         table_id: str,
         partition_id: str,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         deferrable: bool = False,
         **kwargs,
@@ -207,11 +192,6 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
         self.table_id = table_id
         self.partition_id = partition_id
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
         self.deferrable = deferrable
@@ -221,7 +201,6 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
         self.log.info('Sensor checks existence of partition: "%s" in table: %s', self.partition_id, table_uri)
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         return hook.table_partition_exists(
@@ -283,9 +262,6 @@ class BigQueryTableExistenceAsyncSensor(BigQueryTableExistenceSensor):
     :param gcp_conn_id: The connection ID used to connect to Google Cloud.
     :param bigquery_conn_id: (Deprecated) The connection ID used to connect to Google Cloud.
        This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-       if any. For this to work, the service account making the request must have
-       domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
        credentials, or chained list of accounts required to get the access_token
        of the last account in the list, which will be impersonated in the request.

--- a/airflow/providers/google/cloud/sensors/cloud_composer.py
+++ b/airflow/providers/google/cloud/sensors/cloud_composer.py
@@ -19,7 +19,6 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any, Sequence
 
 from airflow.exceptions import AirflowException
@@ -38,8 +37,6 @@ class CloudComposerEnvironmentSensor(BaseSensorOperator):
     :param region: Required. The ID of the Google Cloud region that the service belongs to.
     :param operation_name: The name of the operation resource
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service account making the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -58,7 +55,6 @@ class CloudComposerEnvironmentSensor(BaseSensorOperator):
         region: str,
         operation_name: str,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         pooling_period_seconds: int = 30,
         **kwargs,
@@ -69,11 +65,6 @@ class CloudComposerEnvironmentSensor(BaseSensorOperator):
         self.operation_name = operation_name
         self.pooling_period_seconds = pooling_period_seconds
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
@@ -85,7 +76,6 @@ class CloudComposerEnvironmentSensor(BaseSensorOperator):
                 operation_name=self.operation_name,
                 gcp_conn_id=self.gcp_conn_id,
                 impersonation_chain=self.impersonation_chain,
-                delegate_to=self.delegate_to,
                 pooling_period_seconds=self.pooling_period_seconds,
             ),
             method_name="execute_complete",

--- a/airflow/providers/google/cloud/sensors/dataflow.py
+++ b/airflow/providers/google/cloud/sensors/dataflow.py
@@ -18,7 +18,6 @@
 """This module contains a Google Cloud Dataflow sensor."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Callable, Sequence
 
 from airflow.exceptions import AirflowException
@@ -50,10 +49,6 @@ class DataflowJobStatusSensor(BaseSensorOperator):
     :param location: The location of the Dataflow job (for example europe-west1). See:
         https://cloud.google.com/dataflow/docs/concepts/regional-endpoints
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled. See:
-        https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -74,7 +69,6 @@ class DataflowJobStatusSensor(BaseSensorOperator):
         project_id: str | None = None,
         location: str = DEFAULT_DATAFLOW_LOCATION,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -86,11 +80,6 @@ class DataflowJobStatusSensor(BaseSensorOperator):
         self.project_id = project_id
         self.location = location
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.hook: DataflowHook | None = None
 
@@ -102,7 +91,6 @@ class DataflowJobStatusSensor(BaseSensorOperator):
         )
         self.hook = DataflowHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -142,9 +130,6 @@ class DataflowJobMetricsSensor(BaseSensorOperator):
     :param location: The location of the Dataflow job (for example europe-west1). See:
         https://cloud.google.com/dataflow/docs/concepts/regional-endpoints
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -166,7 +151,6 @@ class DataflowJobMetricsSensor(BaseSensorOperator):
         project_id: str | None = None,
         location: str = DEFAULT_DATAFLOW_LOCATION,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -177,18 +161,12 @@ class DataflowJobMetricsSensor(BaseSensorOperator):
         self.fail_on_terminal_state = fail_on_terminal_state
         self.location = location
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.hook: DataflowHook | None = None
 
     def poke(self, context: Context) -> bool:
         self.hook = DataflowHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -231,9 +209,6 @@ class DataflowJobMessagesSensor(BaseSensorOperator):
         If set to None or missing, the default project_id from the Google Cloud connection is used.
     :param location: Job location.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -255,7 +230,6 @@ class DataflowJobMessagesSensor(BaseSensorOperator):
         project_id: str | None = None,
         location: str = DEFAULT_DATAFLOW_LOCATION,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -266,18 +240,12 @@ class DataflowJobMessagesSensor(BaseSensorOperator):
         self.fail_on_terminal_state = fail_on_terminal_state
         self.location = location
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.hook: DataflowHook | None = None
 
     def poke(self, context: Context) -> bool:
         self.hook = DataflowHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -320,9 +288,6 @@ class DataflowJobAutoScalingEventsSensor(BaseSensorOperator):
         If set to None or missing, the default project_id from the Google Cloud connection is used.
     :param location: Job location.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -344,7 +309,6 @@ class DataflowJobAutoScalingEventsSensor(BaseSensorOperator):
         project_id: str | None = None,
         location: str = DEFAULT_DATAFLOW_LOCATION,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -355,18 +319,12 @@ class DataflowJobAutoScalingEventsSensor(BaseSensorOperator):
         self.fail_on_terminal_state = fail_on_terminal_state
         self.location = location
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.hook: DataflowHook | None = None
 
     def poke(self, context: Context) -> bool:
         self.hook = DataflowHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/sensors/dataform.py
+++ b/airflow/providers/google/cloud/sensors/dataform.py
@@ -18,7 +18,6 @@
 """This module contains a Google Cloud Dataform sensor."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Iterable, Sequence
 
 from airflow.exceptions import AirflowException
@@ -43,10 +42,6 @@ class DataformWorkflowInvocationStateSensor(BaseSensorOperator):
         https://cloud.google.com/python/docs/reference/dataform/latest/google.cloud.dataform_v1beta1.types.WorkflowInvocation.State
     :param failure_statuses: State that will terminate the sensor with an exception
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled. See:
-        https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -69,7 +64,6 @@ class DataformWorkflowInvocationStateSensor(BaseSensorOperator):
         expected_statuses: set[int] | int,
         failure_statuses: Iterable[int] | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -83,18 +77,12 @@ class DataformWorkflowInvocationStateSensor(BaseSensorOperator):
         self.project_id = project_id
         self.region = region
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.hook: DataformHook | None = None
 
     def poke(self, context: Context) -> bool:
         self.hook = DataformHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/sensors/datafusion.py
+++ b/airflow/providers/google/cloud/sensors/datafusion.py
@@ -18,7 +18,6 @@
 """This module contains a Google Cloud Data Fusion sensors."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Iterable, Sequence
 
 from airflow.exceptions import AirflowException, AirflowNotFoundException
@@ -44,9 +43,6 @@ class CloudDataFusionPipelineStateSensor(BaseSensorOperator):
         is always default. If your pipeline belongs to an Enterprise edition instance, you
         can create a namespace.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -71,7 +67,6 @@ class CloudDataFusionPipelineStateSensor(BaseSensorOperator):
         project_id: str | None = None,
         namespace: str = "default",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -85,11 +80,6 @@ class CloudDataFusionPipelineStateSensor(BaseSensorOperator):
         self.project_id = project_id
         self.namespace = namespace
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def poke(self, context: Context) -> bool:
@@ -100,7 +90,6 @@ class CloudDataFusionPipelineStateSensor(BaseSensorOperator):
         )
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/sensors/dataplex.py
+++ b/airflow/providers/google/cloud/sensors/dataplex.py
@@ -17,7 +17,6 @@
 """This module contains Google Dataplex sensors."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 if TYPE_CHECKING:
@@ -54,8 +53,6 @@ class DataplexTaskStateSensor(BaseSensorOperator):
         will not be retried.
     :param metadata: Additional metadata that is provided to the method.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -78,7 +75,6 @@ class DataplexTaskStateSensor(BaseSensorOperator):
         retry: Retry | _MethodDefault = DEFAULT,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         *args,
         **kwargs,
@@ -92,18 +88,12 @@ class DataplexTaskStateSensor(BaseSensorOperator):
         self.retry = retry
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def poke(self, context: Context) -> bool:
         self.log.info("Waiting for task %s to be %s", self.dataplex_task_id, TaskState.ACTIVE)
         hook = DataplexHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )

--- a/airflow/providers/google/cloud/sensors/gcs.py
+++ b/airflow/providers/google/cloud/sensors/gcs.py
@@ -45,9 +45,6 @@ class GCSObjectExistenceSensor(BaseSensorOperator):
         storage bucket.
     :param google_cloud_conn_id: The connection ID to use when
         connecting to Google Cloud Storage.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -72,7 +69,6 @@ class GCSObjectExistenceSensor(BaseSensorOperator):
         bucket: str,
         object: str,
         google_cloud_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         retry: Retry = DEFAULT_RETRY,
         deferrable: bool = False,
@@ -83,11 +79,6 @@ class GCSObjectExistenceSensor(BaseSensorOperator):
         self.bucket = bucket
         self.object = object
         self.google_cloud_conn_id = google_cloud_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.retry = retry
 
@@ -97,7 +88,6 @@ class GCSObjectExistenceSensor(BaseSensorOperator):
         self.log.info("Sensor checks existence of : %s, %s", self.bucket, self.object)
         hook = GCSHook(
             gcp_conn_id=self.google_cloud_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         return hook.exists(self.bucket, self.object, self.retry)
@@ -115,7 +105,6 @@ class GCSObjectExistenceSensor(BaseSensorOperator):
                     poke_interval=self.poke_interval,
                     google_cloud_conn_id=self.google_cloud_conn_id,
                     hook_params={
-                        "delegate_to": self.delegate_to,
                         "impersonation_chain": self.impersonation_chain,
                     },
                 ),
@@ -143,9 +132,6 @@ class GCSObjectExistenceAsyncSensor(GCSObjectExistenceSensor):
     :param bucket: The Google Cloud Storage bucket where the object is.
     :param object: The name of the object to check in the Google cloud storage bucket.
     :param google_cloud_conn_id: The connection ID to use when connecting to Google Cloud Storage.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -190,9 +176,6 @@ class GCSObjectUpdateSensor(BaseSensorOperator):
         as parameter.
     :param google_cloud_conn_id: The connection ID to use when
         connecting to Google Cloud Storage.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -216,7 +199,6 @@ class GCSObjectUpdateSensor(BaseSensorOperator):
         object: str,
         ts_func: Callable = ts_function,
         google_cloud_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -226,18 +208,12 @@ class GCSObjectUpdateSensor(BaseSensorOperator):
         self.object = object
         self.ts_func = ts_func
         self.google_cloud_conn_id = google_cloud_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def poke(self, context: Context) -> bool:
         self.log.info("Sensor checks existence of : %s, %s", self.bucket, self.object)
         hook = GCSHook(
             gcp_conn_id=self.google_cloud_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         return hook.is_updated_after(self.bucket, self.object, self.ts_func(context))
@@ -256,9 +232,6 @@ class GCSObjectsWithPrefixExistenceSensor(BaseSensorOperator):
         storage bucket.
     :param google_cloud_conn_id: The connection ID to use when
         connecting to Google Cloud Storage.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -281,7 +254,6 @@ class GCSObjectsWithPrefixExistenceSensor(BaseSensorOperator):
         bucket: str,
         prefix: str,
         google_cloud_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -289,11 +261,6 @@ class GCSObjectsWithPrefixExistenceSensor(BaseSensorOperator):
         self.bucket = bucket
         self.prefix = prefix
         self.google_cloud_conn_id = google_cloud_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self._matches: list[str] = []
         self.impersonation_chain = impersonation_chain
 
@@ -301,7 +268,6 @@ class GCSObjectsWithPrefixExistenceSensor(BaseSensorOperator):
         self.log.info("Sensor checks existence of objects: %s, %s", self.bucket, self.prefix)
         hook = GCSHook(
             gcp_conn_id=self.google_cloud_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         self._matches = hook.list(self.bucket, prefix=self.prefix)
@@ -346,9 +312,6 @@ class GCSUploadSessionCompleteSensor(BaseSensorOperator):
         when this happens. If false an error will be raised.
     :param google_cloud_conn_id: The connection ID to use when connecting
         to Google Cloud Storage.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -375,7 +338,6 @@ class GCSUploadSessionCompleteSensor(BaseSensorOperator):
         previous_objects: set[str] | None = None,
         allow_delete: bool = True,
         google_cloud_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -392,11 +354,6 @@ class GCSUploadSessionCompleteSensor(BaseSensorOperator):
         self.inactivity_seconds = 0
         self.allow_delete = allow_delete
         self.google_cloud_conn_id = google_cloud_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.last_activity_time = None
         self.impersonation_chain = impersonation_chain
         self.hook: GCSHook | None = None
@@ -405,7 +362,6 @@ class GCSUploadSessionCompleteSensor(BaseSensorOperator):
         if not self.hook:
             self.hook = GCSHook(
                 gcp_conn_id=self.google_cloud_conn_id,
-                delegate_to=self.delegate_to,
                 impersonation_chain=self.impersonation_chain,
             )
         return self.hook

--- a/airflow/providers/google/cloud/sensors/pubsub.py
+++ b/airflow/providers/google/cloud/sensors/pubsub.py
@@ -18,7 +18,6 @@
 """This module contains a Google PubSub sensor."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 from google.cloud.pubsub_v1.types import ReceivedMessage
@@ -67,9 +66,6 @@ class PubSubPullSensor(BaseSensorOperator):
         immediately rather than by any downstream tasks
     :param gcp_conn_id: The connection ID to use connecting to
         Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param messages_callback: (Optional) Callback to process received messages.
         It's return value will be saved to XCom.
         If you are pulling large messages, you probably want to provide a custom callback.
@@ -101,18 +97,12 @@ class PubSubPullSensor(BaseSensorOperator):
         ack_messages: bool = False,
         gcp_conn_id: str = "google_cloud_default",
         messages_callback: Callable[[list[ReceivedMessage], Context], Any] | None = None,
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
 
         super().__init__(**kwargs)
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.project_id = project_id
         self.subscription = subscription
         self.max_messages = max_messages
@@ -130,7 +120,6 @@ class PubSubPullSensor(BaseSensorOperator):
     def poke(self, context: Context) -> bool:
         hook = PubSubHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/transfers/adls_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/adls_to_gcs.py
@@ -22,7 +22,6 @@ Google Cloud Storage operator.
 from __future__ import annotations
 
 import os
-import warnings
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Sequence
 
@@ -46,9 +45,6 @@ class ADLSToGCSOperator(ADLSListOperator):
     :param azure_data_lake_conn_id: The connection ID to use when
         connecting to Azure Data Lake Storage.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: Google account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param google_impersonation_chain: Optional Google service account to impersonate using
         short-term credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -111,7 +107,6 @@ class ADLSToGCSOperator(ADLSListOperator):
         dest_gcs: str,
         azure_data_lake_conn_id: str,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         replace: bool = False,
         gzip: bool = False,
         google_impersonation_chain: str | Sequence[str] | None = None,
@@ -124,12 +119,6 @@ class ADLSToGCSOperator(ADLSListOperator):
         self.dest_gcs = dest_gcs
         self.replace = replace
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'google_impersonation_chain'",
-                DeprecationWarning,
-            )
-        self.delegate_to = delegate_to
         self.gzip = gzip
         self.google_impersonation_chain = google_impersonation_chain
 
@@ -138,7 +127,6 @@ class ADLSToGCSOperator(ADLSListOperator):
         files = super().execute(context)
         g_hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.google_impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/transfers/azure_fileshare_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/azure_fileshare_to_gcs.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Sequence
 
@@ -44,9 +43,6 @@ class AzureFileShareToGCSOperator(BaseOperator):
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
     :param dest_gcs: The destination Google Cloud Storage bucket and prefix
         where you want to store the files. (templated)
-    :param delegate_to: Google account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param replace: Whether you want to replace existing destination files
         or not.
     :param gzip: Option to compress file for upload
@@ -79,7 +75,6 @@ class AzureFileShareToGCSOperator(BaseOperator):
         prefix: str = "",
         azure_fileshare_conn_id: str = "azure_fileshare_default",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         replace: bool = False,
         gzip: bool = False,
         google_impersonation_chain: str | Sequence[str] | None = None,
@@ -93,12 +88,6 @@ class AzureFileShareToGCSOperator(BaseOperator):
         self.azure_fileshare_conn_id = azure_fileshare_conn_id
         self.gcp_conn_id = gcp_conn_id
         self.dest_gcs = dest_gcs
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'google_impersonation_chain'",
-                DeprecationWarning,
-            )
-        self.delegate_to = delegate_to
         self.replace = replace
         self.gzip = gzip
         self.google_impersonation_chain = google_impersonation_chain
@@ -123,7 +112,6 @@ class AzureFileShareToGCSOperator(BaseOperator):
 
         gcs_hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.google_impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/transfers/bigquery_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_bigquery.py
@@ -50,9 +50,6 @@ class BigQueryToBigQueryOperator(BaseOperator):
     :param write_disposition: The write disposition if the table already exists.
     :param create_disposition: The create disposition if the table doesn't exist.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param labels: a dictionary containing labels for the job/query,
         passed to BigQuery
     :param encryption_configuration: [Optional] Custom encryption configuration (e.g., Cloud KMS keys).
@@ -94,7 +91,6 @@ class BigQueryToBigQueryOperator(BaseOperator):
         write_disposition: str = "WRITE_EMPTY",
         create_disposition: str = "CREATE_IF_NEEDED",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         labels: dict | None = None,
         encryption_configuration: dict | None = None,
         location: str | None = None,
@@ -108,11 +104,6 @@ class BigQueryToBigQueryOperator(BaseOperator):
         self.write_disposition = write_disposition
         self.create_disposition = create_disposition
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.labels = labels
         self.encryption_configuration = encryption_configuration
         self.location = location
@@ -126,7 +117,6 @@ class BigQueryToBigQueryOperator(BaseOperator):
         )
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             location=self.location,
             impersonation_chain=self.impersonation_chain,
         )

--- a/airflow/providers/google/cloud/transfers/bigquery_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_gcs.py
@@ -18,7 +18,6 @@
 """This module contains Google BigQuery to Google Cloud Storage operator."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any, Sequence
 
 from google.api_core.exceptions import Conflict
@@ -60,9 +59,6 @@ class BigQueryToGCSOperator(BaseOperator):
     :param field_delimiter: The delimiter to use when extracting to a CSV.
     :param print_header: Whether to print a header for a CSV file extract.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param labels: a dictionary containing labels for the job/query,
         passed to BigQuery
     :param location: The location used for the operation.
@@ -110,7 +106,6 @@ class BigQueryToGCSOperator(BaseOperator):
         field_delimiter: str = ",",
         print_header: bool = True,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         labels: dict | None = None,
         location: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
@@ -131,11 +126,6 @@ class BigQueryToGCSOperator(BaseOperator):
         self.field_delimiter = field_delimiter
         self.print_header = print_header
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.labels = labels
         self.location = location
         self.impersonation_chain = impersonation_chain
@@ -209,7 +199,6 @@ class BigQueryToGCSOperator(BaseOperator):
         )
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             location=self.location,
             impersonation_chain=self.impersonation_chain,
         )

--- a/airflow/providers/google/cloud/transfers/bigquery_to_mssql.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_mssql.py
@@ -18,7 +18,6 @@
 """This module contains Google BigQuery to MSSQL operator."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from airflow.models import BaseOperator
@@ -63,9 +62,6 @@ class BigQueryToMsSqlOperator(BaseOperator):
     :param selected_fields: List of fields to return (comma-separated). If
         unspecified, all fields are returned.
     :param gcp_conn_id: reference to a specific Google Cloud hook.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param mssql_conn_id: reference to a specific mssql hook
     :param database: name of database which overwrite defined one in connection
     :param replace: Whether to replace instead of insert
@@ -93,7 +89,6 @@ class BigQueryToMsSqlOperator(BaseOperator):
         gcp_conn_id: str = "google_cloud_default",
         mssql_conn_id: str = "mssql_default",
         database: str | None = None,
-        delegate_to: str | None = None,
         replace: bool = False,
         batch_size: int = 1000,
         location: str | None = None,
@@ -107,11 +102,6 @@ class BigQueryToMsSqlOperator(BaseOperator):
         self.database = database
         self.mssql_table = mssql_table
         self.replace = replace
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.batch_size = batch_size
         self.location = location
         self.impersonation_chain = impersonation_chain
@@ -126,7 +116,6 @@ class BigQueryToMsSqlOperator(BaseOperator):
     def execute(self, context: Context) -> None:
         big_query_hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             location=self.location,
             impersonation_chain=self.impersonation_chain,
         )

--- a/airflow/providers/google/cloud/transfers/bigquery_to_mysql.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_mysql.py
@@ -18,7 +18,6 @@
 """This module contains Google BigQuery to MySQL operator."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from airflow.models import BaseOperator
@@ -63,9 +62,6 @@ class BigQueryToMySqlOperator(BaseOperator):
     :param selected_fields: List of fields to return (comma-separated). If
         unspecified, all fields are returned.
     :param gcp_conn_id: reference to a specific Google Cloud hook.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param mysql_conn_id: Reference to :ref:`mysql connection id <howto/connection:mysql>`.
     :param database: name of database which overwrite defined one in connection
     :param replace: Whether to replace instead of insert
@@ -97,7 +93,6 @@ class BigQueryToMySqlOperator(BaseOperator):
         gcp_conn_id: str = "google_cloud_default",
         mysql_conn_id: str = "mysql_default",
         database: str | None = None,
-        delegate_to: str | None = None,
         replace: bool = False,
         batch_size: int = 1000,
         location: str | None = None,
@@ -111,11 +106,6 @@ class BigQueryToMySqlOperator(BaseOperator):
         self.database = database
         self.mysql_table = mysql_table
         self.replace = replace
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.batch_size = batch_size
         self.location = location
         self.impersonation_chain = impersonation_chain
@@ -127,7 +117,6 @@ class BigQueryToMySqlOperator(BaseOperator):
     def execute(self, context: Context) -> None:
         big_query_hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             location=self.location,
             impersonation_chain=self.impersonation_chain,
         )

--- a/airflow/providers/google/cloud/transfers/calendar_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/calendar_to_gcs.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import json
-import warnings
 from datetime import datetime
 from tempfile import NamedTemporaryFile
 from typing import Any, Sequence
@@ -65,9 +64,6 @@ class GoogleCalendarToGCSOperator(BaseOperator):
     :param destination_path: The Google Cloud Storage URI array for the object created by the operator.
         For example: ``path/to/my/files``.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -108,7 +104,6 @@ class GoogleCalendarToGCSOperator(BaseOperator):
         updated_min: datetime | None = None,
         destination_path: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -133,11 +128,6 @@ class GoogleCalendarToGCSOperator(BaseOperator):
         self.updated_min = updated_min
         self.destination_bucket = destination_bucket
         self.destination_path = destination_path
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def _upload_data(
@@ -146,7 +136,6 @@ class GoogleCalendarToGCSOperator(BaseOperator):
     ) -> str:
         gcs_hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 
@@ -173,7 +162,6 @@ class GoogleCalendarToGCSOperator(BaseOperator):
         calendar_hook = GoogleCalendarHook(
             api_version=self.api_version,
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/transfers/cassandra_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/cassandra_to_gcs.py
@@ -22,7 +22,6 @@ data from Cassandra to Google Cloud Storage in JSON format.
 from __future__ import annotations
 
 import json
-import warnings
 from base64 import b64encode
 from datetime import datetime
 from decimal import Decimal
@@ -67,9 +66,6 @@ class CassandraToGCSOperator(BaseOperator):
     :param cassandra_conn_id: Reference to a specific Cassandra hook.
     :param gzip: Option to compress file for upload
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -106,7 +102,6 @@ class CassandraToGCSOperator(BaseOperator):
         gzip: bool = False,
         cassandra_conn_id: str = "cassandra_default",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         query_timeout: float | None | NotSetType = NOT_SET,
         encode_uuid: bool = True,
@@ -121,11 +116,6 @@ class CassandraToGCSOperator(BaseOperator):
         self.approx_max_file_size_bytes = approx_max_file_size_bytes
         self.cassandra_conn_id = cassandra_conn_id
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'mpersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.gzip = gzip
         self.impersonation_chain = impersonation_chain
         self.query_timeout = query_timeout
@@ -255,7 +245,6 @@ class CassandraToGCSOperator(BaseOperator):
         """Upload a file (data split or schema .json file) to Google Cloud Storage."""
         hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         hook.upload(

--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import json
-import warnings
 from typing import TYPE_CHECKING, Any, Sequence
 
 from google.api_core.exceptions import BadRequest, Conflict
@@ -128,9 +127,6 @@ class GCSToBigQueryOperator(BaseOperator):
         execute() command, which in turn gets stored in XCom for future
         operators to use. This can be helpful with incremental loads--during
         future executions, you can pick up from the max ID.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param schema_update_options: Allows the schema of the destination
         table to be updated as a side effect of the load job.
     :param src_fmt_configs: configure optional fields specific to the source format
@@ -208,7 +204,6 @@ class GCSToBigQueryOperator(BaseOperator):
         encoding="UTF-8",
         max_id_key=None,
         gcp_conn_id="google_cloud_default",
-        delegate_to=None,
         schema_update_options=(),
         src_fmt_configs=None,
         external_table=False,
@@ -274,11 +269,6 @@ class GCSToBigQueryOperator(BaseOperator):
 
         self.max_id_key = max_id_key
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
 
         self.schema_update_options = schema_update_options
         self.src_fmt_configs = src_fmt_configs
@@ -324,7 +314,6 @@ class GCSToBigQueryOperator(BaseOperator):
     def execute(self, context: Context):
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             location=self.location,
             impersonation_chain=self.impersonation_chain,
         )
@@ -356,7 +345,6 @@ class GCSToBigQueryOperator(BaseOperator):
             if self.schema_object and self.source_format != "DATASTORE_BACKUP":
                 gcs_hook = GCSHook(
                     gcp_conn_id=self.gcp_conn_id,
-                    delegate_to=self.delegate_to,
                     impersonation_chain=self.impersonation_chain,
                 )
                 self.schema_fields = json.loads(
@@ -467,7 +455,6 @@ class GCSToBigQueryOperator(BaseOperator):
     def _find_max_value_in_column(self):
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             location=self.location,
             impersonation_chain=self.impersonation_chain,
         )

--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -18,7 +18,6 @@
 """This module contains a Google Cloud Storage operator."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from airflow.exceptions import AirflowException
@@ -71,9 +70,6 @@ class GCSToGCSOperator(BaseOperator):
         If source_objects = ['foo/bah/'] and delimiter = '.avro', then only the 'files' in the
         folder 'foo/bah/' with '.avro' delimiter will be copied to the destination object.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param last_modified_time: When specified, the objects will be copied or moved,
         only if they were modified after last_modified_time.
         If tzinfo has not been set, UTC will be assumed.
@@ -188,7 +184,6 @@ class GCSToGCSOperator(BaseOperator):
         move_object=False,
         replace=True,
         gcp_conn_id="google_cloud_default",
-        delegate_to=None,
         last_modified_time=None,
         maximum_modified_time=None,
         is_older_than=None,
@@ -208,11 +203,6 @@ class GCSToGCSOperator(BaseOperator):
         self.move_object = move_object
         self.replace = replace
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.last_modified_time = last_modified_time
         self.maximum_modified_time = maximum_modified_time
         self.is_older_than = is_older_than
@@ -224,7 +214,6 @@ class GCSToGCSOperator(BaseOperator):
 
         hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         if self.source_objects and self.source_object:

--- a/airflow/providers/google/cloud/transfers/gcs_to_local.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_local.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from airflow.exceptions import AirflowException
@@ -52,9 +51,6 @@ class GCSToLocalFilesystemOperator(BaseOperator):
         the contents of the downloaded file to XCom with the key set in this
         parameter. If not set, the downloaded data will not be pushed to XCom. (templated)
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -85,7 +81,6 @@ class GCSToLocalFilesystemOperator(BaseOperator):
         filename: str | None = None,
         store_to_xcom_key: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         file_encoding: str = "utf-8",
         **kwargs,
@@ -109,11 +104,6 @@ class GCSToLocalFilesystemOperator(BaseOperator):
         self.object_name = object_name
         self.store_to_xcom_key = store_to_xcom_key
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.file_encoding = file_encoding
 
@@ -121,7 +111,6 @@ class GCSToLocalFilesystemOperator(BaseOperator):
         self.log.info("Executing download: %s, %s, %s", self.bucket, self.object_name, self.filename)
         hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/transfers/gcs_to_sftp.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_sftp.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import os
-import warnings
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Sequence
 
@@ -85,9 +84,6 @@ class GCSToSFTPOperator(BaseOperator):
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
     :param sftp_conn_id: The sftp connection id. The name or identifier for
         establishing a connection to the SFTP server.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -116,7 +112,6 @@ class GCSToSFTPOperator(BaseOperator):
         move_object: bool = False,
         gcp_conn_id: str = "google_cloud_default",
         sftp_conn_id: str = "ssh_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -129,18 +124,12 @@ class GCSToSFTPOperator(BaseOperator):
         self.move_object = move_object
         self.gcp_conn_id = gcp_conn_id
         self.sftp_conn_id = sftp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.sftp_dirs = None
 
     def execute(self, context: Context):
         gcs_hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/transfers/gdrive_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gdrive_to_gcs.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from airflow.models import BaseOperator
@@ -43,9 +42,6 @@ class GoogleDriveToGCSOperator(BaseOperator):
     :param file_name: The name of the file residing in Google Drive
     :param drive_id: Optional. The id of the shared Google Drive in which the file resides.
     :param gcp_conn_id: The GCP connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -74,7 +70,6 @@ class GoogleDriveToGCSOperator(BaseOperator):
         folder_id: str,
         drive_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -85,22 +80,15 @@ class GoogleDriveToGCSOperator(BaseOperator):
         self.drive_id = drive_id
         self.file_name = file_name
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         gdrive_hook = GoogleDriveHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         gcs_hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         file_metadata = gdrive_hook.get_file_id(

--- a/airflow/providers/google/cloud/transfers/gdrive_to_local.py
+++ b/airflow/providers/google/cloud/transfers/gdrive_to_local.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from airflow.models import BaseOperator
@@ -39,9 +38,6 @@ class GoogleDriveToLocalOperator(BaseOperator):
     :param file_name: The name of the file residing in Google Drive
     :param gcp_conn_id: The GCP connection ID to use when fetching connection info.
     :param drive_id: Optional. The id of the shared Google Drive in which the file resides.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -68,7 +64,6 @@ class GoogleDriveToLocalOperator(BaseOperator):
         folder_id: str,
         drive_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -78,18 +73,12 @@ class GoogleDriveToLocalOperator(BaseOperator):
         self.drive_id = drive_id
         self.file_name = file_name
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context):
         self.log.info("Executing download: %s into %s", self.file_name, self.output_file)
         gdrive_hook = GoogleDriveHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         file_metadata = gdrive_hook.get_file_id(

--- a/airflow/providers/google/cloud/transfers/local_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/local_to_gcs.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import os
-import warnings
 from glob import glob
 from typing import TYPE_CHECKING, Sequence
 
@@ -47,7 +46,6 @@ class LocalFilesystemToGCSOperator(BaseOperator):
     :param bucket: The bucket to upload to. (templated)
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
     :param mime_type: The mime-type string
-    :param delegate_to: The account to impersonate, if any
     :param gzip: Allows for file to be compressed and uploaded as gzip
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -74,7 +72,6 @@ class LocalFilesystemToGCSOperator(BaseOperator):
         bucket,
         gcp_conn_id="google_cloud_default",
         mime_type="application/octet-stream",
-        delegate_to=None,
         gzip=False,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
@@ -86,11 +83,6 @@ class LocalFilesystemToGCSOperator(BaseOperator):
         self.bucket = bucket
         self.gcp_conn_id = gcp_conn_id
         self.mime_type = mime_type
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.gzip = gzip
         self.impersonation_chain = impersonation_chain
 
@@ -98,7 +90,6 @@ class LocalFilesystemToGCSOperator(BaseOperator):
         """Uploads a file or list of files to Google Cloud Storage"""
         hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/transfers/s3_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/s3_to_gcs.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Sequence
 
@@ -61,9 +60,6 @@ class S3ToGCSOperator(S3ListOperator):
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
     :param dest_gcs: The destination Google Cloud Storage bucket and prefix
         where you want to store the files. (templated)
-    :param delegate_to: Google account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param replace: Whether you want to replace existing destination files
         or not.
     :param gzip: Option to compress file for upload
@@ -115,7 +111,6 @@ class S3ToGCSOperator(S3ListOperator):
         verify=None,
         gcp_conn_id="google_cloud_default",
         dest_gcs=None,
-        delegate_to=None,
         replace=False,
         gzip=False,
         google_impersonation_chain: str | Sequence[str] | None = None,
@@ -125,11 +120,6 @@ class S3ToGCSOperator(S3ListOperator):
         super().__init__(bucket=bucket, prefix=prefix, delimiter=delimiter, aws_conn_id=aws_conn_id, **kwargs)
         self.gcp_conn_id = gcp_conn_id
         self.dest_gcs = dest_gcs
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.replace = replace
         self.verify = verify
         self.gzip = gzip
@@ -153,7 +143,6 @@ class S3ToGCSOperator(S3ListOperator):
 
         gcs_hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.google_impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/transfers/sftp_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/sftp_to_gcs.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import os
-import warnings
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Sequence
 
@@ -57,9 +56,6 @@ class SFTPToGCSOperator(BaseOperator):
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
     :param sftp_conn_id: The sftp connection id. The name or identifier for
         establishing a connection to the SFTP server.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param mime_type: The mime-type string
     :param gzip: Allows for file to be compressed and uploaded as gzip
     :param move_object: When move object is True, the object is moved instead
@@ -90,7 +86,6 @@ class SFTPToGCSOperator(BaseOperator):
         destination_path: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
         sftp_conn_id: str = "ssh_default",
-        delegate_to: str | None = None,
         mime_type: str = "application/octet-stream",
         gzip: bool = False,
         move_object: bool = False,
@@ -104,11 +99,6 @@ class SFTPToGCSOperator(BaseOperator):
         self.destination_bucket = self._set_bucket_name(destination_bucket)
         self.gcp_conn_id = gcp_conn_id
         self.mime_type = mime_type
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.gzip = gzip
         self.sftp_conn_id = sftp_conn_id
         self.move_object = move_object
@@ -117,7 +107,6 @@ class SFTPToGCSOperator(BaseOperator):
     def execute(self, context: Context):
         gcs_hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/transfers/sheets_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/sheets_to_gcs.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import csv
-import warnings
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Any, Sequence
 
@@ -45,9 +44,6 @@ class GoogleSheetsToGCSOperator(BaseOperator):
     :param destination_path: The Google cloud storage URI array for the object created by the operator.
         For example: ``path/to/my/files``.
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -74,7 +70,6 @@ class GoogleSheetsToGCSOperator(BaseOperator):
         sheet_filter: list[str] | None = None,
         destination_path: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -84,11 +79,6 @@ class GoogleSheetsToGCSOperator(BaseOperator):
         self.sheet_filter = sheet_filter
         self.destination_bucket = destination_bucket
         self.destination_path = destination_path
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def _upload_data(
@@ -122,12 +112,10 @@ class GoogleSheetsToGCSOperator(BaseOperator):
     def execute(self, context: Context):
         sheet_hook = GSheetsHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         gcs_hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 

--- a/airflow/providers/google/cloud/transfers/sql_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/sql_to_gcs.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import abc
 import json
 import os
-import warnings
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Sequence
 
@@ -65,9 +64,6 @@ class BaseSQLToGCSOperator(BaseOperator):
         dict. Examples could be seen: https://cloud.google.com/bigquery/docs
         /schemas#specifying_a_json_schema_file
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param parameters: a parameters dict that is substituted at query runtime.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -118,7 +114,6 @@ class BaseSQLToGCSOperator(BaseOperator):
         schema: str | list | None = None,
         parameters: dict | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         upload_metadata: bool = False,
         exclude_columns: set | None = None,
@@ -143,11 +138,6 @@ class BaseSQLToGCSOperator(BaseOperator):
         self.schema = schema
         self.parameters = parameters
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.upload_metadata = upload_metadata
         self.exclude_columns = exclude_columns
@@ -459,7 +449,6 @@ class BaseSQLToGCSOperator(BaseOperator):
         """Upload a file (data split or schema .json file) to Google Cloud Storage."""
         hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         is_data_file = file_to_upload.get("file_name") != self.schema_filename

--- a/airflow/providers/google/cloud/triggers/bigquery_dts.py
+++ b/airflow/providers/google/cloud/triggers/bigquery_dts.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import asyncio
-import warnings
 from typing import Any, AsyncIterator, Sequence
 
 from google.cloud.bigquery_datatransfer_v1 import TransferRun, TransferState
@@ -34,9 +33,6 @@ class BigQueryDataTransferRunTrigger(BaseTrigger):
     :param run_id: ID of the Transfer Run which should be watched.
     :param poll_interval: Optional. Interval which defines how often triggers check status of the job.
     :param gcp_conn_id: The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-    if any. For this to work, the service account making the request must have
-    domain-wide delegation enabled.
     :param location: BigQuery Transfer Service location for regional transfers.
     :param impersonation_chain: Optional service account to impersonate using short-term
     credentials, or chained list of accounts required to get the access_token
@@ -55,7 +51,6 @@ class BigQueryDataTransferRunTrigger(BaseTrigger):
         run_id: str,
         poll_interval: int = 10,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         location: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
     ):
@@ -65,11 +60,6 @@ class BigQueryDataTransferRunTrigger(BaseTrigger):
         self.run_id = run_id
         self.poll_interval = poll_interval
         self.gcp_conn_id = gcp_conn_id
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.location = location
         self.impersonation_chain = impersonation_chain
 
@@ -83,7 +73,6 @@ class BigQueryDataTransferRunTrigger(BaseTrigger):
                 "run_id": self.run_id,
                 "poll_interval": self.poll_interval,
                 "gcp_conn_id": self.gcp_conn_id,
-                "delegate_to": self.delegate_to,
                 "location": self.location,
                 "impersonation_chain": self.impersonation_chain,
             },
@@ -157,7 +146,6 @@ class BigQueryDataTransferRunTrigger(BaseTrigger):
     def _get_async_hook(self) -> AsyncBiqQueryDataTransferServiceHook:
         return AsyncBiqQueryDataTransferServiceHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             location=self.location,
             impersonation_chain=self.impersonation_chain,
         )

--- a/airflow/providers/google/cloud/triggers/cloud_build.py
+++ b/airflow/providers/google/cloud/triggers/cloud_build.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import asyncio
-import warnings
 from typing import Any, AsyncIterator, Sequence
 
 from google.cloud.devtools.cloudbuild_v1.types import Build
@@ -41,9 +40,6 @@ class CloudBuildCreateBuildTrigger(BaseTrigger):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param poll_interval: polling period in seconds to check for the status
     :param location: The location of the project.
     """
@@ -54,7 +50,6 @@ class CloudBuildCreateBuildTrigger(BaseTrigger):
         project_id: str | None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         poll_interval: float = 4.0,
         location: str = "global",
     ):
@@ -63,11 +58,6 @@ class CloudBuildCreateBuildTrigger(BaseTrigger):
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.poll_interval = poll_interval
         self.location = location
 
@@ -80,7 +70,6 @@ class CloudBuildCreateBuildTrigger(BaseTrigger):
                 "project_id": self.project_id,
                 "gcp_conn_id": self.gcp_conn_id,
                 "impersonation_chain": self.impersonation_chain,
-                "delegate_to": self.delegate_to,
                 "poll_interval": self.poll_interval,
                 "location": self.location,
             },

--- a/airflow/providers/google/cloud/triggers/cloud_composer.py
+++ b/airflow/providers/google/cloud/triggers/cloud_composer.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import asyncio
-import warnings
 from typing import Any, Sequence
 
 from airflow import AirflowException
@@ -37,7 +36,6 @@ class CloudComposerExecutionTrigger(BaseTrigger):
         operation_name: str,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         pooling_period_seconds: int = 30,
     ):
         super().__init__()
@@ -46,17 +44,11 @@ class CloudComposerExecutionTrigger(BaseTrigger):
         self.operation_name = operation_name
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.pooling_period_seconds = pooling_period_seconds
 
         self.gcp_hook = CloudComposerAsyncHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
-            delegate_to=self.delegate_to,
         )
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
@@ -68,7 +60,6 @@ class CloudComposerExecutionTrigger(BaseTrigger):
                 "operation_name": self.operation_name,
                 "gcp_conn_id": self.gcp_conn_id,
                 "impersonation_chain": self.impersonation_chain,
-                "delegate_to": self.delegate_to,
                 "pooling_period_seconds": self.pooling_period_seconds,
             },
         )

--- a/airflow/providers/google/cloud/triggers/dataflow.py
+++ b/airflow/providers/google/cloud/triggers/dataflow.py
@@ -36,9 +36,6 @@ class TemplateJobStartTrigger(BaseTrigger):
     :param location: Optional. the location where job is executed. If set to None then
         the value of DEFAULT_DATAFLOW_LOCATION will be used
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional. Service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -57,7 +54,6 @@ class TemplateJobStartTrigger(BaseTrigger):
         project_id: str | None,
         location: str = DEFAULT_DATAFLOW_LOCATION,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         poll_sleep: int = 10,
         impersonation_chain: str | Sequence[str] | None = None,
         cancel_timeout: int | None = 5 * 60,
@@ -68,7 +64,6 @@ class TemplateJobStartTrigger(BaseTrigger):
         self.job_id = job_id
         self.location = location
         self.gcp_conn_id = gcp_conn_id
-        self.delegate_to = delegate_to
         self.poll_sleep = poll_sleep
         self.impersonation_chain = impersonation_chain
         self.cancel_timeout = cancel_timeout
@@ -82,7 +77,6 @@ class TemplateJobStartTrigger(BaseTrigger):
                 "job_id": self.job_id,
                 "location": self.location,
                 "gcp_conn_id": self.gcp_conn_id,
-                "delegate_to": self.delegate_to,
                 "poll_sleep": self.poll_sleep,
                 "impersonation_chain": self.impersonation_chain,
                 "cancel_timeout": self.cancel_timeout,
@@ -143,7 +137,6 @@ class TemplateJobStartTrigger(BaseTrigger):
     def _get_async_hook(self) -> AsyncDataflowHook:
         return AsyncDataflowHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             poll_sleep=self.poll_sleep,
             impersonation_chain=self.impersonation_chain,
             cancel_timeout=self.cancel_timeout,

--- a/airflow/providers/google/cloud/triggers/datafusion.py
+++ b/airflow/providers/google/cloud/triggers/datafusion.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import asyncio
-import warnings
 from typing import Any, AsyncIterator, Sequence
 
 from airflow.providers.google.cloud.hooks.datafusion import DataFusionAsyncHook
@@ -36,9 +35,6 @@ class DataFusionStartPipelineTrigger(BaseTrigger):
        can create a namespace.
     :param gcp_conn_id: Reference to google cloud connection id
     :param poll_interval: polling period in seconds to check for the status
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -58,7 +54,6 @@ class DataFusionStartPipelineTrigger(BaseTrigger):
         poll_interval: float = 3.0,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
         success_states: list[str] | None = None,
     ):
         super().__init__()
@@ -69,11 +64,6 @@ class DataFusionStartPipelineTrigger(BaseTrigger):
         self.poll_interval = poll_interval
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.success_states = success_states
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
@@ -131,6 +121,5 @@ class DataFusionStartPipelineTrigger(BaseTrigger):
             pipeline_name=self.pipeline_name,
             pipeline_id=self.pipeline_id,
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )

--- a/airflow/providers/google/cloud/triggers/dataproc.py
+++ b/airflow/providers/google/cloud/triggers/dataproc.py
@@ -38,7 +38,6 @@ class DataprocBaseTrigger(BaseTrigger):
         region: str,
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         polling_interval_seconds: int = 30,
     ):
@@ -48,13 +47,11 @@ class DataprocBaseTrigger(BaseTrigger):
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
         self.polling_interval_seconds = polling_interval_seconds
-        self.delegate_to = delegate_to
 
     def get_async_hook(self):
         return DataprocAsyncHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
-            delegate_to=self.delegate_to,
         )
 
 
@@ -77,10 +74,9 @@ class DataprocSubmitTrigger(DataprocBaseTrigger):
     :param polling_interval_seconds: polling period in seconds to check for the status
     """
 
-    def __init__(self, job_id: str, delegate_to: str | None = None, **kwargs):
+    def __init__(self, job_id: str, **kwargs):
         self.job_id = job_id
-        self.delegate_to = delegate_to
-        super().__init__(delegate_to=self.delegate_to, **kwargs)
+        super().__init__(**kwargs)
 
     def serialize(self):
         return (
@@ -90,7 +86,6 @@ class DataprocSubmitTrigger(DataprocBaseTrigger):
                 "project_id": self.project_id,
                 "region": self.region,
                 "gcp_conn_id": self.gcp_conn_id,
-                "delegate_to": self.delegate_to,
                 "impersonation_chain": self.impersonation_chain,
                 "polling_interval_seconds": self.polling_interval_seconds,
             },
@@ -309,7 +304,6 @@ class DataprocWorkflowTrigger(DataprocBaseTrigger):
                 "project_id": self.project_id,
                 "region": self.region,
                 "gcp_conn_id": self.gcp_conn_id,
-                "delegate_to": self.delegate_to,
                 "impersonation_chain": self.impersonation_chain,
                 "polling_interval_seconds": self.polling_interval_seconds,
             },

--- a/airflow/providers/google/cloud/triggers/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/triggers/kubernetes_engine.py
@@ -129,7 +129,6 @@ class GKEOperationTrigger(BaseTrigger):
         project_id: str | None,
         location: str,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         poll_interval: int = 10,
     ):
@@ -139,7 +138,6 @@ class GKEOperationTrigger(BaseTrigger):
         self.project_id = project_id
         self.location = location
         self.gcp_conn_id = gcp_conn_id
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.poll_interval = poll_interval
 
@@ -154,7 +152,6 @@ class GKEOperationTrigger(BaseTrigger):
                 "project_id": self.project_id,
                 "location": self.location,
                 "gcp_conn_id": self.gcp_conn_id,
-                "delegate_to": self.delegate_to,
                 "impersonation_chain": self.impersonation_chain,
                 "poll_interval": self.poll_interval,
             },
@@ -209,7 +206,6 @@ class GKEOperationTrigger(BaseTrigger):
             self._hook = GKEAsyncHook(
                 gcp_conn_id=self.gcp_conn_id,
                 location=self.location,
-                delegate_to=self.delegate_to,
                 impersonation_chain=self.impersonation_chain,
             )
         return self._hook

--- a/airflow/providers/google/cloud/triggers/mlengine.py
+++ b/airflow/providers/google/cloud/triggers/mlengine.py
@@ -49,7 +49,6 @@ class MLEngineStartTrainingJobTrigger(BaseTrigger):
         labels: dict[str, str] | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        delegate_to: str | None = None,
     ):
         super().__init__()
         self.log.info("Using the connection  %s .", conn_id)
@@ -68,7 +67,6 @@ class MLEngineStartTrainingJobTrigger(BaseTrigger):
         self.labels = labels
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
-        self.delegate_to = delegate_to
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serializes MLEngineStartTrainingJobTrigger arguments and classpath."""
@@ -119,6 +117,5 @@ class MLEngineStartTrainingJobTrigger(BaseTrigger):
     def _get_async_hook(self) -> MLEngineAsyncHook:
         return MLEngineAsyncHook(
             gcp_conn_id=self.conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )

--- a/airflow/providers/google/common/hooks/discovery_api.py
+++ b/airflow/providers/google/common/hooks/discovery_api.py
@@ -18,7 +18,6 @@
 """This module allows you to connect to the Google Discovery API Service and query it."""
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
 
 from googleapiclient.discovery import Resource, build
@@ -54,16 +53,10 @@ class GoogleDiscoveryApiHook(GoogleBaseHook):
         api_service_name: str,
         api_version: str,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self.api_service_name = api_service_name

--- a/airflow/providers/google/firebase/hooks/firestore.py
+++ b/airflow/providers/google/firebase/hooks/firestore.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import time
-import warnings
 from typing import Sequence
 
 from googleapiclient.discovery import build, build_from_document
@@ -40,9 +39,6 @@ class CloudFirestoreHook(GoogleBaseHook):
 
     :param api_version: API version used (for example v1 or v1beta1).
     :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -59,16 +55,10 @@ class CloudFirestoreHook(GoogleBaseHook):
         self,
         api_version: str = "v1",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
     ) -> None:
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
         super().__init__(
             gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
         self.api_version = api_version

--- a/airflow/providers/google/suite/transfers/gcs_to_gdrive.py
+++ b/airflow/providers/google/suite/transfers/gcs_to_gdrive.py
@@ -95,7 +95,6 @@ class GCSToGoogleDriveOperator(BaseOperator):
         destination_object: str | None = None,
         move_object: bool = False,
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -106,7 +105,6 @@ class GCSToGoogleDriveOperator(BaseOperator):
         self.destination_object = destination_object
         self.move_object = move_object
         self.gcp_conn_id = gcp_conn_id
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.gcs_hook: GCSHook | None = None
         self.gdrive_hook: GoogleDriveHook | None = None
@@ -115,12 +113,10 @@ class GCSToGoogleDriveOperator(BaseOperator):
 
         self.gcs_hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         self.gdrive_hook = GoogleDriveHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 

--- a/airflow/providers/google/suite/transfers/gcs_to_sheets.py
+++ b/airflow/providers/google/suite/transfers/gcs_to_sheets.py
@@ -67,7 +67,6 @@ class GCSToGoogleSheetsOperator(BaseOperator):
         object_name: str,
         spreadsheet_range: str = "Sheet1",
         gcp_conn_id: str = "google_cloud_default",
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -78,18 +77,15 @@ class GCSToGoogleSheetsOperator(BaseOperator):
         self.spreadsheet_range = spreadsheet_range
         self.bucket_name = bucket_name
         self.object_name = object_name
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Any) -> None:
         sheet_hook = GSheetsHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         gcs_hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         with NamedTemporaryFile("w+") as temp_file:

--- a/airflow/providers/microsoft/azure/CHANGELOG.rst
+++ b/airflow/providers/microsoft/azure/CHANGELOG.rst
@@ -24,6 +24,16 @@
 Changelog
 ---------
 
+6.0.0
+......
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+.. warning::
+  In this version of the provider, deprecated GCS hook's param ``delegate_to`` is removed from ``AzureBlobStorageToGCSOperator``.
+  Impersonation can be achieved instead by utilizing the ``impersonation_chain`` param.
+
 5.3.1
 .....
 

--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Microsoft Azure <https://azure.microsoft.com/>`__
 suspended: false
 versions:
+  - 6.0.0
   - 5.3.1
   - 5.3.0
   - 5.2.1

--- a/airflow/providers/microsoft/azure/transfers/azure_blob_to_gcs.py
+++ b/airflow/providers/microsoft/azure/transfers/azure_blob_to_gcs.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import tempfile
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from airflow.models import BaseOperator
@@ -46,9 +45,6 @@ class AzureBlobStorageToGCSOperator(BaseOperator):
     :param object_name: The object name to set when uploading the file
     :param filename: The local file path to the file to be uploaded
     :param gzip: Option to compress local file or file data for upload
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -71,7 +67,6 @@ class AzureBlobStorageToGCSOperator(BaseOperator):
         object_name: str,
         filename: str,
         gzip: bool,
-        delegate_to: str | None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -85,11 +80,6 @@ class AzureBlobStorageToGCSOperator(BaseOperator):
         self.object_name = object_name
         self.filename = filename
         self.gzip = gzip
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     template_fields: Sequence[str] = (
@@ -105,7 +95,6 @@ class AzureBlobStorageToGCSOperator(BaseOperator):
         azure_hook = WasbHook(wasb_conn_id=self.wasb_conn_id)
         gcs_hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 

--- a/airflow/providers/presto/CHANGELOG.rst
+++ b/airflow/providers/presto/CHANGELOG.rst
@@ -24,6 +24,17 @@
 Changelog
 ---------
 
+5.0.0
+......
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+.. warning::
+  In this version of the provider, deprecated GCS hook's param ``delegate_to`` is removed from ``GCSToPrestoOperator``.
+  Impersonation can be achieved instead by utilizing the ``impersonation_chain`` param.
+
+
 4.2.2
 .....
 

--- a/airflow/providers/presto/provider.yaml
+++ b/airflow/providers/presto/provider.yaml
@@ -23,6 +23,7 @@ description: |
 
 suspended: false
 versions:
+  - 5.0.0
   - 4.2.2
   - 4.2.1
   - 4.2.0

--- a/airflow/providers/presto/transfers/gcs_to_presto.py
+++ b/airflow/providers/presto/transfers/gcs_to_presto.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import csv
 import json
-import warnings
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Iterable, Sequence
 
@@ -46,9 +45,6 @@ class GCSToPrestoOperator(BaseOperator):
     :param presto_conn_id: destination presto connection
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud and
         interact with the Google Cloud Storage service.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -75,7 +71,6 @@ class GCSToPrestoOperator(BaseOperator):
         gcp_conn_id: str = "google_cloud_default",
         schema_fields: Iterable[str] | None = None,
         schema_object: str | None = None,
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -87,17 +82,11 @@ class GCSToPrestoOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.schema_fields = schema_fields
         self.schema_object = schema_object
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
         gcs_hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 

--- a/airflow/providers/trino/CHANGELOG.rst
+++ b/airflow/providers/trino/CHANGELOG.rst
@@ -24,6 +24,16 @@
 Changelog
 ---------
 
+5.0.0
+......
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+.. warning::
+  In this version of the provider, deprecated GCS hook's param ``delegate_to`` is removed from ``GCSToPrestoOperator``.
+  Impersonation can be achieved instead by utilizing the ``impersonation_chain`` param.
+
 4.3.2
 .....
 

--- a/airflow/providers/trino/provider.yaml
+++ b/airflow/providers/trino/provider.yaml
@@ -23,6 +23,7 @@ description: |
 
 suspended: false
 versions:
+  - 5.0.0
   - 4.3.2
   - 4.3.1
   - 4.3.0

--- a/airflow/providers/trino/transfers/gcs_to_trino.py
+++ b/airflow/providers/trino/transfers/gcs_to_trino.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import csv
 import json
-import warnings
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Iterable, Sequence
 
@@ -49,9 +48,6 @@ class GCSToTrinoOperator(BaseOperator):
     :param schema_fields: The names of the columns to fill in the table. If schema_fields is
         provided, any path provided in the schema object will be
     :param schema_object: JSON file with schema fields
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -78,7 +74,6 @@ class GCSToTrinoOperator(BaseOperator):
         gcp_conn_id: str = "google_cloud_default",
         schema_fields: Iterable[str] | None = None,
         schema_object: str | None = None,
-        delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
@@ -90,17 +85,11 @@ class GCSToTrinoOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.schema_fields = schema_fields
         self.schema_object = schema_object
-        if delegate_to:
-            warnings.warn(
-                "'delegate_to' parameter is deprecated, please use 'impersonation_chain'", DeprecationWarning
-            )
-        self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
         gcs_hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
 

--- a/tests/integration/providers/google/cloud/transfers/test_trino_to_gcs.py
+++ b/tests/integration/providers/google/cloud/transfers/test_trino_to_gcs.py
@@ -104,7 +104,6 @@ class TestTrinoToGCSOperator:
 
         mock_trino_hook.assert_called_once_with(trino_conn_id=TRINO_CONN_ID)
         mock_gcs_hook.assert_called_once_with(
-            delegate_to=None,
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
@@ -241,7 +240,6 @@ class TestTrinoToGCSOperator:
 
         mock_trino_hook.assert_called_once_with(trino_conn_id=TRINO_CONN_ID)
         mock_gcs_hook.assert_called_once_with(
-            delegate_to=None,
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )

--- a/tests/providers/amazon/aws/transfers/test_glacier_to_gcs.py
+++ b/tests/providers/amazon/aws/transfers/test_glacier_to_gcs.py
@@ -40,7 +40,6 @@ class TestGlacierToGCSOperator:
             aws_conn_id=AWS_CONN_ID,
             vault_name=VAULT_NAME,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=None,
             google_impersonation_chain=None,
             bucket_name=BUCKET_NAME,
             object_name=OBJECT_NAME,
@@ -55,9 +54,7 @@ class TestGlacierToGCSOperator:
             vault_name=VAULT_NAME, job_id=hook_aws_mock.return_value.retrieve_inventory.return_value[JOB_ID]
         )
 
-        hook_gcs_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None, impersonation_chain=None
-        )
+        hook_gcs_mock.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=None)
         hook_gcs_mock.return_value.upload.assert_called_once_with(
             bucket_name=BUCKET_NAME,
             object_name=OBJECT_NAME,

--- a/tests/providers/apache/beam/operators/test_beam.py
+++ b/tests/providers/apache/beam/operators/test_beam.py
@@ -118,7 +118,6 @@ class TestBeamRunPythonPipelineOperator:
         job_name = dataflow_hook_mock.build_dataflow_job_name.return_value
         dataflow_hook_mock.assert_called_once_with(
             gcp_conn_id=dataflow_config.gcp_conn_id,
-            delegate_to=dataflow_config.delegate_to,
             poll_sleep=dataflow_config.poll_sleep,
             impersonation_chain=dataflow_config.impersonation_chain,
             drain_pipeline=dataflow_config.drain_pipeline,
@@ -239,7 +238,6 @@ class TestBeamRunJavaPipelineOperator:
         job_name = dataflow_hook_mock.build_dataflow_job_name.return_value
         dataflow_hook_mock.assert_called_once_with(
             gcp_conn_id=dataflow_config.gcp_conn_id,
-            delegate_to=dataflow_config.delegate_to,
             poll_sleep=dataflow_config.poll_sleep,
             impersonation_chain=dataflow_config.impersonation_chain,
             drain_pipeline=dataflow_config.drain_pipeline,
@@ -539,7 +537,6 @@ class TestBeamRunGoPipelineOperator:
         job_name = dataflow_hook_mock.build_dataflow_job_name.return_value
         dataflow_hook_mock.assert_called_once_with(
             gcp_conn_id=dataflow_config.gcp_conn_id,
-            delegate_to=dataflow_config.delegate_to,
             poll_sleep=dataflow_config.poll_sleep,
             impersonation_chain=dataflow_config.impersonation_chain,
             drain_pipeline=dataflow_config.drain_pipeline,
@@ -649,7 +646,6 @@ class TestBeamRunGoPipelineOperator:
 
         mock_dataflow_hook.assert_called_once_with(
             gcp_conn_id=dataflow_config.gcp_conn_id,
-            delegate_to=dataflow_config.delegate_to,
             poll_sleep=dataflow_config.poll_sleep,
             impersonation_chain=dataflow_config.impersonation_chain,
             drain_pipeline=dataflow_config.drain_pipeline,

--- a/tests/providers/google/cloud/hooks/test_automl.py
+++ b/tests/providers/google/cloud/hooks/test_automl.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 from google.cloud.automl_v1beta1 import AutoMlClient
 
@@ -50,7 +51,11 @@ DATASET = {"dataset_id": "data"}
 MASK = {"field": "mask"}
 
 
-class TestAuoMLHook:
+class TestAutoMLHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudAutoMLHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.automl.GoogleBaseHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -69,6 +69,11 @@ class _BigQueryBaseTestClass:
         self.hook = MockedBigQueryHook()
 
 
+def test_delegate_to_runtime_error():
+    with pytest.raises(RuntimeError):
+        BigQueryHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
+
 class TestBigQueryHookMethods(_BigQueryBaseTestClass):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryConnection")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook._authorize")

--- a/tests/providers/google/cloud/hooks/test_bigquery_dts.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery_dts.py
@@ -55,6 +55,10 @@ RUN_ID = "id1234"
 
 
 class TestBigQueryDataTransferHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            BiqQueryDataTransferServiceHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with async_mock.patch(
             "airflow.providers.google.cloud.hooks.bigquery_dts.GoogleBaseHook.__init__",
@@ -127,6 +131,10 @@ class TestBigQueryDataTransferHook:
 
 class TestAsyncBiqQueryDataTransferServiceHook:
     HOOK_MODULE_PATH = "airflow.providers.google.cloud.hooks.bigquery_dts"
+
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            AsyncBiqQueryDataTransferServiceHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
 
     @pytest.fixture()
     def mock_client(self):

--- a/tests/providers/google/cloud/hooks/test_bigtable.py
+++ b/tests/providers/google/cloud/hooks/test_bigtable.py
@@ -21,6 +21,7 @@ from unittest import mock
 from unittest.mock import PropertyMock
 
 import google
+import pytest
 from google.cloud.bigtable import Client, enums
 from google.cloud.bigtable.instance import Instance
 
@@ -49,6 +50,10 @@ CBT_REPLICATE_CLUSTERS = [
 
 
 class TestBigtableHookNoDefaultProjectId:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            BigtableHook(gcp_conn_id="test", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_cloud_build.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_build.py
@@ -60,6 +60,10 @@ TRIGGER_ID = "32488e7f-09d6-4fe9-a5fb-4ca1419a6e7a"
 
 
 class TestCloudBuildHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudBuildHook(gcp_conn_id="test", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
@@ -322,6 +326,10 @@ class TestCloudBuildHook:
 
 
 class TestAsyncHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudBuildAsyncHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     @pytest.fixture
     def hook(self):
         return CloudBuildAsyncHook(

--- a/tests/providers/google/cloud/hooks/test_cloud_composer.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_composer.py
@@ -29,7 +29,6 @@ from tests.providers.google.cloud.utils.compat import AsyncMock, async_mock
 TEST_GCP_REGION = "global"
 TEST_GCP_PROJECT = "test-project"
 TEST_GCP_CONN_ID = "test-gcp-conn-id"
-TEST_DELEGATE_TO = "test-delegate-to"
 TEST_ENVIRONMENT_ID = "testenvname"
 TEST_ENVIRONMENT = {
     "name": TEST_ENVIRONMENT_ID,
@@ -60,6 +59,10 @@ def mock_init(*args, **kwargs):
 
 
 class TestCloudComposerHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudComposerHook(gcp_conn_id="test", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_init):
             self.hook = CloudComposerHook(gcp_conn_id="test")
@@ -196,6 +199,10 @@ class TestCloudComposerHook:
 
 
 class TestCloudComposerAsyncHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudComposerAsyncHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self, method):
         with async_mock.patch(BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_init):
             self.hook = CloudComposerAsyncHook(gcp_conn_id="test")

--- a/tests/providers/google/cloud/hooks/test_cloud_memorystore.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_memorystore.py
@@ -39,7 +39,6 @@ from tests.providers.google.cloud.utils.base_gcp_mock import (
 )
 
 TEST_GCP_CONN_ID = "test-gcp-conn-id"
-TEST_DELEGATE_TO = "test-delegate-to"
 TEST_LOCATION = "test-location"
 TEST_INSTANCE_ID = "test-instance-id"
 TEST_PROJECT_ID = "test-project-id"
@@ -58,6 +57,10 @@ TEST_NAME_DEFAULT_PROJECT_ID = (
 
 
 class TestCloudMemorystoreWithDefaultProjectIdHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudMemorystoreHook(gcp_conn_id="test", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.cloud_memorystore.CloudMemorystoreHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_cloud_sql.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_sql.py
@@ -42,6 +42,10 @@ from tests.providers.google.cloud.utils.base_gcp_mock import (
 
 
 class TestGcpSqlHookDefaultProjectId:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudSQLHook(api_version="v1", gcp_conn_id="test", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_cloud_storage_transfer_service.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_storage_transfer_service.py
@@ -107,6 +107,10 @@ class GCPRequestMock:
 
 
 class TestGCPTransferServiceHookWithPassedName:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudDataTransferServiceHook(gcp_conn_id="test", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_compute.py
+++ b/tests/providers/google/cloud/hooks/test_compute.py
@@ -55,6 +55,10 @@ COMPUTE_ENGINE_HOOK_PATH = "airflow.providers.google.cloud.hooks.compute.{}"
 
 
 class TestGcpComputeHookApiCall:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            ComputeEngineHook(api_version=API_VERSION, gcp_conn_id=GCP_CONN_ID, delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"),

--- a/tests/providers/google/cloud/hooks/test_compute_ssh.py
+++ b/tests/providers/google/cloud/hooks/test_compute_ssh.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import json
 from unittest import mock
 
+import pytest
+
 from airflow.models import Connection
 from airflow.providers.google.cloud.hooks.compute_ssh import ComputeEngineSSHHook
 
@@ -33,6 +35,10 @@ TEST_PUB_KEY2 = "root:NAME MNJ root"
 
 
 class TestComputeEngineHookWithPassedProjectId:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            ComputeEngineSSHHook(gcp_conn_id="gcpssh", delegate_to="delegate_to")
+
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.OSLoginHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.paramiko")
@@ -59,7 +65,7 @@ class TestComputeEngineHookWithPassedProjectId:
         mock_paramiko.RSAKey.generate.assert_called_once_with(2048)
         mock_compute_hook.assert_has_calls(
             [
-                mock.call(delegate_to=None, gcp_conn_id="google_cloud_default"),
+                mock.call(gcp_conn_id="google_cloud_default"),
                 mock.call().get_instance_address(
                     project_id=TEST_PROJECT_ID,
                     resource_id=TEST_INSTANCE_NAME,
@@ -70,7 +76,7 @@ class TestComputeEngineHookWithPassedProjectId:
         )
         mock_os_login_hook.assert_has_calls(
             [
-                mock.call(delegate_to=None, gcp_conn_id="google_cloud_default"),
+                mock.call(gcp_conn_id="google_cloud_default"),
                 mock.call()._get_credentials_email(),
                 mock.call().import_ssh_public_key(
                     ssh_public_key={"key": "NAME AYZ root", "expiration_time_usec": mock.ANY},
@@ -118,7 +124,7 @@ class TestComputeEngineHookWithPassedProjectId:
         mock_paramiko.RSAKey.generate.assert_called_once_with(2048)
         mock_compute_hook.assert_has_calls(
             [
-                mock.call(delegate_to=None, gcp_conn_id="google_cloud_default"),
+                mock.call(gcp_conn_id="google_cloud_default"),
                 mock.call().get_instance_address(
                     project_id=TEST_PROJECT_ID,
                     resource_id=TEST_INSTANCE_NAME,

--- a/tests/providers/google/cloud/hooks/test_datacatalog.py
+++ b/tests/providers/google/cloud/hooks/test_datacatalog.py
@@ -35,7 +35,6 @@ from tests.providers.google.cloud.utils.base_gcp_mock import (
 )
 
 TEST_GCP_CONN_ID: str = "test-gcp-conn-id"
-TEST_DELEGATE_TO: str = "test-delegate-to"
 TEST_LOCATION: str = "europe-west-3b"
 TEST_ENTRY_ID: str = "test-entry-id"
 TEST_ENTRY: dict = {}
@@ -83,6 +82,10 @@ TEST_CREDENTIALS = mock.MagicMock()
 
 
 class TestCloudDataCatalog:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudDataCatalogHook(gcp_conn_id="test", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.datacatalog.CloudDataCatalogHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_dataflow.py
+++ b/tests/providers/google/cloud/hooks/test_dataflow.py
@@ -183,6 +183,10 @@ class TestFallbackToVariables:
 
 
 class TestDataflowHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            DataflowHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         self.dataflow_hook = DataflowHook(gcp_conn_id="google_cloud_default")
         self.dataflow_hook.beam_hook = MagicMock()
@@ -1910,6 +1914,10 @@ def make_mock_awaitable():
 
 
 class TestAsyncHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            AsyncDataflowHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     @pytest.fixture
     def hook(self):
         return AsyncDataflowHook(

--- a/tests/providers/google/cloud/hooks/test_dataform.py
+++ b/tests/providers/google/cloud/hooks/test_dataform.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 
 from airflow.providers.google.cloud.hooks.dataform import DataformHook
@@ -31,7 +32,6 @@ REGION = "region"
 REPOSITORY_ID = "test_repository"
 WORKSPACE_ID = "test_workspace"
 GCP_CONN_ID = "google_cloud_default"
-DELEGATE_TO = "test-delegate-to"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 COMPILATION_RESULT = {
     "git_commitish": "main",
@@ -53,6 +53,10 @@ FILE_CONTENTS = b"test content"
 
 
 class TestDataflowHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            DataformHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"),
@@ -60,7 +64,6 @@ class TestDataflowHook:
         ):
             self.hook = DataformHook(
                 gcp_conn_id=GCP_CONN_ID,
-                delegate_to=DELEGATE_TO,
                 impersonation_chain=IMPERSONATION_CHAIN,
             )
 

--- a/tests/providers/google/cloud/hooks/test_datafusion.py
+++ b/tests/providers/google/cloud/hooks/test_datafusion.py
@@ -80,6 +80,10 @@ def session():
 
 
 class TestDataFusionHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            DataFusionHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     @staticmethod
     def mock_endpoint(get_conn_mock):
         return get_conn_mock.return_value.projects.return_value.locations.return_value.instances.return_value
@@ -434,6 +438,10 @@ class TestDataFusionHook:
 
 
 class TestDataFusionHookAsynch:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            DataFusionAsyncHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     @pytest.mark.asyncio
     @mock.patch(HOOK_STR.format("DataFusionAsyncHook._get_link"))
     async def test_async_get_pipeline_should_execute_successfully(self, mocked_link, hook_async):

--- a/tests/providers/google/cloud/hooks/test_dataplex.py
+++ b/tests/providers/google/cloud/hooks/test_dataplex.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 
 from airflow.providers.google.cloud.operators.dataplex import DataplexHook
@@ -33,11 +34,14 @@ BODY = {"body": "test"}
 DATAPLEX_TASK_ID = "testTask001"
 
 GCP_CONN_ID = "google_cloud_default"
-DELEGATE_TO = "test-delegate-to"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
 class TestDataplexHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            DataplexHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"),
@@ -45,7 +49,6 @@ class TestDataplexHook:
         ):
             self.hook = DataplexHook(
                 gcp_conn_id=GCP_CONN_ID,
-                delegate_to=DELEGATE_TO,
                 impersonation_chain=IMPERSONATION_CHAIN,
             )
 

--- a/tests/providers/google/cloud/hooks/test_dataproc.py
+++ b/tests/providers/google/cloud/hooks/test_dataproc.py
@@ -71,6 +71,10 @@ async def mock_awaitable(*args, **kwargs):
 
 
 class TestDataprocHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            DataprocHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_init):
             self.hook = DataprocHook(gcp_conn_id="test")
@@ -496,6 +500,10 @@ class TestDataprocHook:
 
 
 class TestDataprocAsyncHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            DataprocAsyncHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_init):
             self.hook = DataprocAsyncHook(gcp_conn_id="test")
@@ -756,9 +764,7 @@ class TestDataprocAsyncHook:
     @async_mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_operation"))
     async def test_get_operation(self, mock_client):
         mock_client.return_value = None
-        hook = DataprocAsyncHook(
-            gcp_conn_id="google_cloud_default", delegate_to=None, impersonation_chain=None
-        )
+        hook = DataprocAsyncHook(gcp_conn_id="google_cloud_default", impersonation_chain=None)
         await hook.get_operation(region=GCP_LOCATION, operation_name="operation_name")
         mock_client.assert_called_once()
         mock_client.assert_called_with(region=GCP_LOCATION, operation_name="operation_name")

--- a/tests/providers/google/cloud/hooks/test_dataproc_metastore.py
+++ b/tests/providers/google/cloud/hooks/test_dataproc_metastore.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 
 from airflow.providers.google.cloud.hooks.dataproc_metastore import DataprocMetastoreHook
@@ -60,6 +61,10 @@ DATAPROC_METASTORE_STRING = "airflow.providers.google.cloud.hooks.dataproc_metas
 
 
 class TestDataprocMetastoreWithDefaultProjectIdHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            DataprocMetastoreHook(gcp_conn_id=TEST_GCP_CONN_ID, delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id

--- a/tests/providers/google/cloud/hooks/test_datastore.py
+++ b/tests/providers/google/cloud/hooks/test_datastore.py
@@ -31,13 +31,16 @@ GCP_PROJECT_ID = "test"
 def mock_init(
     self,
     gcp_conn_id,
-    delegate_to=None,
     impersonation_chain=None,
 ):
     pass
 
 
 class TestDatastoreHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            DatastoreHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__", new=mock_init

--- a/tests/providers/google/cloud/hooks/test_dlp.py
+++ b/tests/providers/google/cloud/hooks/test_dlp.py
@@ -54,6 +54,10 @@ JOB_TRIGGER_PATH = f"projects/{PROJECT_ID}/jobTriggers/{TRIGGER_ID}"
 
 
 class TestCloudDLPHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudDLPHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_functions.py
+++ b/tests/providers/google/cloud/hooks/test_functions.py
@@ -36,6 +36,10 @@ GCF_FUNCTION = "function"
 
 
 class TestFunctionHookNoDefaultProjectId:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudFunctionsHook(api_version="v1", gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_gcs.py
+++ b/tests/providers/google/cloud/hooks/test_gcs.py
@@ -129,6 +129,10 @@ class TestFallbackObjectUrlToObjectNameAndBucketName:
 
 
 class TestGCSHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            gcs.GCSHook(api_version="v1", gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             GCS_STRING.format("GoogleBaseHook.__init__"),

--- a/tests/providers/google/cloud/hooks/test_gdm.py
+++ b/tests/providers/google/cloud/hooks/test_gdm.py
@@ -28,7 +28,6 @@ from airflow.providers.google.cloud.hooks.gdm import GoogleDeploymentManagerHook
 def mock_init(
     self,
     gcp_conn_id,
-    delegate_to=None,
     impersonation_chain=None,
 ):
     pass
@@ -39,6 +38,10 @@ TEST_DEPLOYMENT = "my-deployment"
 
 
 class TestDeploymentManagerHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            GoogleDeploymentManagerHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_kms.py
+++ b/tests/providers/google/cloud/hooks/test_kms.py
@@ -21,6 +21,7 @@ from base64 import b64decode, b64encode
 from collections import namedtuple
 from unittest import mock
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 
 from airflow.providers.google.cloud.hooks.kms import CloudKMSHook
@@ -50,13 +51,16 @@ RESPONSE = Response(PLAINTEXT, PLAINTEXT)
 def mock_init(
     self,
     gcp_conn_id,
-    delegate_to=None,
     impersonation_chain=None,
 ):
     pass
 
 
 class TestCloudKMSHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudKMSHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
@@ -47,12 +47,15 @@ POD_NAME = "test-pod-name"
 POD_NAMESPACE = "test"
 ASYNC_HOOK_STRING = GKE_STRING.format("GKEAsyncHook")
 GCP_CONN_ID = "test-gcp-conn-id"
-DELEGATE_TO = "test-delegate-to"
 IMPERSONATE_CHAIN = ["impersonate", "this", "test"]
 OPERATION_NAME = "test-operation-name"
 
 
 class TestGKEHookClient:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            GKEHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         self.gke_hook = GKEHook(location=GKE_ZONE)
 
@@ -366,7 +369,6 @@ class TestGKEPodAsyncHook:
 def async_gke_hook():
     return GKEAsyncHook(
         gcp_conn_id=GCP_CONN_ID,
-        delegate_to=DELEGATE_TO,
         location=GKE_ZONE,
         impersonation_chain=IMPERSONATE_CHAIN,
     )

--- a/tests/providers/google/cloud/hooks/test_life_sciences.py
+++ b/tests/providers/google/cloud/hooks/test_life_sciences.py
@@ -48,6 +48,10 @@ TEST_LOCATION = "test-location"
 
 
 class TestLifeSciencesHookWithPassedProjectId:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            LifeSciencesHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_mlengine.py
+++ b/tests/providers/google/cloud/hooks/test_mlengine.py
@@ -47,6 +47,10 @@ pytest.JOB_ID = "test-job-id"
 
 
 class TestMLEngineHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            hook.MLEngineHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         self.hook = hook.MLEngineHook()
 

--- a/tests/providers/google/cloud/hooks/test_natural_language.py
+++ b/tests/providers/google/cloud/hooks/test_natural_language.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from typing import Any
 from unittest import mock
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 from google.cloud.language_v1.proto.language_service_pb2 import Document
 
@@ -35,6 +36,10 @@ ENCODING_TYPE = "UTF32"
 
 
 class TestCloudNaturalLanguageHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudNaturalLanguageHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_os_login.py
+++ b/tests/providers/google/cloud/hooks/test_os_login.py
@@ -32,7 +32,6 @@ from tests.providers.google.cloud.utils.base_gcp_mock import (
 )
 
 TEST_GCP_CONN_ID: str = "test-gcp-conn-id"
-TEST_DELEGATE_TO: str = "test-delegate-to"
 TEST_PROJECT_ID: str = "test-project-id"
 TEST_PROJECT_ID_2: str = "test-project-id-2"
 
@@ -46,6 +45,10 @@ TEST_PARENT: str = "users/test-user"
 
 
 class TestOSLoginHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            OSLoginHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.os_login.OSLoginHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_pubsub.py
+++ b/tests/providers/google/cloud/hooks/test_pubsub.py
@@ -53,7 +53,6 @@ LABELS = {"airflow-version": "v" + version.replace(".", "-").replace("+", "-")}
 def mock_init(
     self,
     gcp_conn_id,
-    delegate_to=None,
     impersonation_chain=None,
 ):
     pass
@@ -73,6 +72,10 @@ def _generate_messages(count) -> list[ReceivedMessage]:
 
 
 class TestPubSubHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            PubSubHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_init):
             self.pubsub_hook = PubSubHook(gcp_conn_id="test")

--- a/tests/providers/google/cloud/hooks/test_secret_manager.py
+++ b/tests/providers/google/cloud/hooks/test_secret_manager.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from google.api_core.exceptions import NotFound
 from google.cloud.secretmanager_v1.proto.service_pb2 import AccessSecretVersionResponse
 
@@ -34,6 +35,10 @@ INTERNAL_CLIENT_PACKAGE = "airflow.providers.google.cloud._internal_client.secre
 
 
 class TestSecretsManagerHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            SecretsManagerHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     @patch(INTERNAL_CLIENT_PACKAGE + "._SecretManagerClient.client", return_value=MagicMock())
     @patch(
         SECRETS_HOOK_PACKAGE + "SecretsManagerHook.get_credentials_and_project_id",

--- a/tests/providers/google/cloud/hooks/test_spanner.py
+++ b/tests/providers/google/cloud/hooks/test_spanner.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 from unittest import mock
 from unittest.mock import PropertyMock
 
+import pytest
+
 from airflow.providers.google.cloud.hooks.spanner import SpannerHook
 from airflow.providers.google.common.consts import CLIENT_INFO
 from tests.providers.google.cloud.utils.base_gcp_mock import (
@@ -34,6 +36,10 @@ SPANNER_DATABASE = "database-name"
 
 
 class TestGcpSpannerHookDefaultProjectId:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            SpannerHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_speech_to_text.py
+++ b/tests/providers/google/cloud/hooks/test_speech_to_text.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 
 from airflow.providers.google.cloud.hooks.speech_to_text import CloudSpeechToTextHook
@@ -31,6 +32,10 @@ AUDIO = {"uri": "gs://bucket/object"}
 
 
 class TestTextToSpeechOperator:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudSpeechToTextHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_stackdriver.py
+++ b/tests/providers/google/cloud/hooks/test_stackdriver.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 from unittest import mock
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 from google.cloud.monitoring_v3 import AlertPolicy, NotificationChannel
 from google.protobuf.field_mask_pb2 import FieldMask
@@ -81,6 +82,10 @@ TEST_NOTIFICATION_CHANNEL_2 = {
 
 
 class TestStackdriverHookMethods:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            stackdriver.StackdriverHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     @mock.patch(
         "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.get_credentials_and_project_id",
         return_value=(CREDENTIALS, PROJECT_ID),

--- a/tests/providers/google/cloud/hooks/test_tasks.py
+++ b/tests/providers/google/cloud/hooks/test_tasks.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from typing import Any
 from unittest import mock
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 from google.cloud.tasks_v2.types import Queue, Task
 
@@ -47,6 +48,10 @@ def mock_patch_return_object(attribute: str, return_value: Any) -> object:
 
 
 class TestCloudTasksHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudTasksHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_text_to_speech.py
+++ b/tests/providers/google/cloud/hooks/test_text_to_speech.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 
 from airflow.providers.google.cloud.hooks.text_to_speech import CloudTextToSpeechHook
@@ -31,6 +32,10 @@ AUDIO_CONFIG = {"audio_encoding": "MP3"}
 
 
 class TestTextToSpeechHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudTextToSpeechHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_translate.py
+++ b/tests/providers/google/cloud/hooks/test_translate.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
+
 from airflow.providers.google.cloud.hooks.translate import CloudTranslateHook
 from airflow.providers.google.common.consts import CLIENT_INFO
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
@@ -27,6 +29,10 @@ PROJECT_ID_TEST = "project-id"
 
 
 class TestCloudTranslateHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudTranslateHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.translate.CloudTranslateHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_video_intelligence.py
+++ b/tests/providers/google/cloud/hooks/test_video_intelligence.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 from google.cloud.videointelligence_v1 import enums
 
@@ -35,6 +36,10 @@ ANNOTATE_VIDEO_RESPONSE = {"test": "test"}
 
 
 class TestCloudVideoIntelligenceHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudVideoIntelligenceHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.video_intelligence.CloudVideoIntelligenceHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_vision.py
+++ b/tests/providers/google/cloud/hooks/test_vision.py
@@ -84,6 +84,10 @@ LOCATION_PRODUCT_ID_TEST_PARAMS = [
 
 
 class TestGcpVisionHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CloudVisionHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.vision.CloudVisionHook.__init__",

--- a/tests/providers/google/cloud/hooks/test_workflows.py
+++ b/tests/providers/google/cloud/hooks/test_workflows.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
+
 from airflow.providers.google.cloud.hooks.workflows import WorkflowsHook
 from airflow.providers.google.common.consts import CLIENT_INFO
 
@@ -50,6 +52,10 @@ def mock_init(*args, **kwargs):
 
 
 class TestWorkflowsHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            WorkflowsHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
+
     def setup_method(self, _):
         with mock.patch(BASE_PATH.format("GoogleBaseHook.__init__"), new=mock_init):
             self.hook = WorkflowsHook(gcp_conn_id="test")

--- a/tests/providers/google/cloud/hooks/vertex_ai/test_auto_ml.py
+++ b/tests/providers/google/cloud/hooks/vertex_ai/test_auto_ml.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 
 from airflow.providers.google.cloud.hooks.vertex_ai.auto_ml import AutoMLHook
@@ -109,6 +110,10 @@ class TestAutoMLWithDefaultProjectIdHook:
 
 
 class TestAutoMLWithoutDefaultProjectIdHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            AutoMLHook(gcp_conn_id=TEST_GCP_CONN_ID, delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_no_default_project_id

--- a/tests/providers/google/cloud/hooks/vertex_ai/test_batch_prediction_job.py
+++ b/tests/providers/google/cloud/hooks/vertex_ai/test_batch_prediction_job.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 
 from airflow.providers.google.cloud.hooks.vertex_ai.batch_prediction_job import BatchPredictionJobHook
@@ -41,6 +42,10 @@ BATCH_PREDICTION_JOB_STRING = "airflow.providers.google.cloud.hooks.vertex_ai.ba
 
 
 class TestBatchPredictionJobWithDefaultProjectIdHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            BatchPredictionJobHook(gcp_conn_id=TEST_GCP_CONN_ID, delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id

--- a/tests/providers/google/cloud/hooks/vertex_ai/test_custom_job.py
+++ b/tests/providers/google/cloud/hooks/vertex_ai/test_custom_job.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 
 from airflow.providers.google.cloud.hooks.vertex_ai.custom_job import CustomJobHook
@@ -40,6 +41,10 @@ CUSTOM_JOB_STRING = "airflow.providers.google.cloud.hooks.vertex_ai.custom_job.{
 
 
 class TestCustomJobWithDefaultProjectIdHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            CustomJobHook(gcp_conn_id=TEST_GCP_CONN_ID, delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id

--- a/tests/providers/google/cloud/hooks/vertex_ai/test_dataset.py
+++ b/tests/providers/google/cloud/hooks/vertex_ai/test_dataset.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 
 from airflow.providers.google.cloud.hooks.vertex_ai.dataset import DatasetHook
@@ -47,6 +48,10 @@ DATASET_STRING = "airflow.providers.google.cloud.hooks.vertex_ai.dataset.{}"
 
 
 class TestVertexAIWithDefaultProjectIdHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            DatasetHook(gcp_conn_id=TEST_GCP_CONN_ID, delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id

--- a/tests/providers/google/cloud/hooks/vertex_ai/test_endpoint_service.py
+++ b/tests/providers/google/cloud/hooks/vertex_ai/test_endpoint_service.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 
 from airflow.providers.google.cloud.hooks.vertex_ai.endpoint_service import EndpointServiceHook
@@ -43,6 +44,10 @@ ENDPOINT_SERVICE_STRING = "airflow.providers.google.cloud.hooks.vertex_ai.endpoi
 
 
 class TestEndpointServiceWithDefaultProjectIdHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            EndpointServiceHook(gcp_conn_id=TEST_GCP_CONN_ID, delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id

--- a/tests/providers/google/cloud/hooks/vertex_ai/test_hyperparameter_tuning_job.py
+++ b/tests/providers/google/cloud/hooks/vertex_ai/test_hyperparameter_tuning_job.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 
 from airflow.providers.google.cloud.hooks.vertex_ai.hyperparameter_tuning_job import (
@@ -42,6 +43,10 @@ HYPERPARAMETER_TUNING_JOB_STRING = (
 
 
 class TestHyperparameterTuningJobWithDefaultProjectIdHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            HyperparameterTuningJobHook(gcp_conn_id=TEST_GCP_CONN_ID, delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id

--- a/tests/providers/google/cloud/hooks/vertex_ai/test_model_service.py
+++ b/tests/providers/google/cloud/hooks/vertex_ai/test_model_service.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 
 from airflow.providers.google.cloud.hooks.vertex_ai.model_service import ModelServiceHook
@@ -39,6 +40,10 @@ MODEL_SERVICE_STRING = "airflow.providers.google.cloud.hooks.vertex_ai.model_ser
 
 
 class TestModelServiceWithDefaultProjectIdHook:
+    def test_delegate_to_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            ModelServiceHook(gcp_conn_id=TEST_GCP_CONN_ID, delegate_to="delegate_to")
+
     def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id

--- a/tests/providers/google/cloud/operators/test_cloud_build.py
+++ b/tests/providers/google/cloud/operators/test_cloud_build.py
@@ -123,7 +123,7 @@ class TestCloudBuildOperator:
         operator = CloudBuildCreateBuildOperator(build=BUILD, task_id="id")
         operator.execute(context=mock.MagicMock())
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=None, delegate_to=None)
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=None)
         build = Build(BUILD)
         mock_hook.return_value.create_build_without_waiting_for_result.assert_called_once_with(
             build=build, project_id=None, retry=DEFAULT, timeout=None, metadata=(), location="global"
@@ -434,7 +434,7 @@ def test_async_create_build_without_wait_should_execute_successfully(mock_hook):
     )
     operator.execute(context=mock.MagicMock())
 
-    mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=None, delegate_to=None)
+    mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=None)
     build = Build(BUILD)
     mock_hook.return_value.create_build_without_waiting_for_result.assert_called_once_with(
         build=build, project_id=None, retry=DEFAULT, timeout=None, metadata=(), location="global"

--- a/tests/providers/google/cloud/operators/test_cloud_composer.py
+++ b/tests/providers/google/cloud/operators/test_cloud_composer.py
@@ -37,7 +37,6 @@ TASK_ID = "task-id"
 TEST_GCP_REGION = "global"
 TEST_GCP_PROJECT = "test-project"
 TEST_GCP_CONN_ID = "test-gcp-conn-id"
-TEST_DELEGATE_TO = None
 TEST_IMPERSONATION_CHAIN = None
 TEST_ENVIRONMENT_ID = "testenvname"
 TEST_ENVIRONMENT = {
@@ -83,7 +82,6 @@ class TestCloudComposerCreateEnvironmentOperator:
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
-            delegate_to=TEST_DELEGATE_TO,
         )
         mock_hook.return_value.create_environment.assert_called_once_with(
             project_id=TEST_GCP_PROJECT,
@@ -135,7 +133,6 @@ class TestCloudComposerDeleteEnvironmentOperator:
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
-            delegate_to=TEST_DELEGATE_TO,
         )
         mock_hook.return_value.delete_environment.assert_called_once_with(
             project_id=TEST_GCP_PROJECT,
@@ -187,7 +184,6 @@ class TestCloudComposerUpdateEnvironmentOperator:
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
-            delegate_to=TEST_DELEGATE_TO,
         )
         mock_hook.return_value.update_environment.assert_called_once_with(
             project_id=TEST_GCP_PROJECT,
@@ -243,7 +239,6 @@ class TestCloudComposerGetEnvironmentOperator:
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
-            delegate_to=TEST_DELEGATE_TO,
         )
         mock_hook.return_value.get_environment.assert_called_once_with(
             project_id=TEST_GCP_PROJECT,
@@ -271,7 +266,6 @@ class TestCloudComposerListEnvironmentsOperator:
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
-            delegate_to=TEST_DELEGATE_TO,
         )
         mock_hook.return_value.list_environments.assert_called_once_with(
             project_id=TEST_GCP_PROJECT,
@@ -300,7 +294,6 @@ class TestCloudComposerListImageVersionsOperator:
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
-            delegate_to=TEST_DELEGATE_TO,
         )
         mock_hook.return_value.list_image_versions.assert_called_once_with(
             project_id=TEST_GCP_PROJECT,

--- a/tests/providers/google/cloud/operators/test_dataflow.py
+++ b/tests/providers/google/cloud/operators/test_dataflow.py
@@ -95,7 +95,6 @@ GROUP BY sales_region;
 """
 TEST_SQL_JOB = {"id": "test-job-id"}
 GCP_CONN_ID = "test_gcp_conn_id"
-DELEGATE_TO = "delegating_to_something"
 IMPERSONATION_CHAIN = ["impersonate", "this"]
 CANCEL_TIMEOUT = 10 * 420
 
@@ -147,7 +146,6 @@ class TestDataflowPythonOperator:
         mock_callback_on_job_id.assert_called_once_with(on_new_job_id_callback=mock.ANY)
         dataflow_hook_mock.assert_called_once_with(
             gcp_conn_id="google_cloud_default",
-            delegate_to=mock.ANY,
             poll_sleep=POLL_SLEEP,
             impersonation_chain=None,
             drain_pipeline=False,
@@ -481,7 +479,6 @@ class TestDataflowTemplateOperator:
             environment={"maxWorkers": 2},
             deferrable=True,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             cancel_timeout=CANCEL_TIMEOUT,
         )
@@ -531,7 +528,6 @@ class TestDataflowTemplateOperator:
             "wait_until_finished": True,
             "deferrable": True,
             "gcp_conn_id": GCP_CONN_ID,
-            "delegate_to": DELEGATE_TO,
             "impersonation_chain": IMPERSONATION_CHAIN,
             "cancel_timeout": CANCEL_TIMEOUT,
         }
@@ -566,7 +562,6 @@ class TestDataflowStartFlexTemplateOperator:
         sync_operator.execute(mock.MagicMock())
         mock_dataflow.assert_called_once_with(
             gcp_conn_id="google_cloud_default",
-            delegate_to=None,
             drain_pipeline=False,
             cancel_timeout=600,
             wait_until_finished=None,
@@ -629,7 +624,6 @@ class TestDataflowSqlOperator:
         start_sql.execute(mock.MagicMock())
         mock_hook.assert_called_once_with(
             gcp_conn_id="google_cloud_default",
-            delegate_to=None,
             drain_pipeline=False,
             impersonation_chain=None,
         )

--- a/tests/providers/google/cloud/operators/test_dataform.py
+++ b/tests/providers/google/cloud/operators/test_dataform.py
@@ -55,7 +55,6 @@ WORKSPACE_ID = "test_workspace_id"
 WORKSPACE = f"projects/{PROJECT_ID}/locations/{REGION}/repositories/{REPOSITORY_ID}/workspaces/{WORKSPACE_ID}"
 COMPILATION_RESULT_ID = "test_compilation_result_id"
 GCP_CONN_ID = "google_cloud_default"
-DELEGATE_TO = "test-delegate-to"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 FILEPATH = "path/to/file.txt"
 FILE_CONTENT = b"test content"

--- a/tests/providers/google/cloud/operators/test_dataplex.py
+++ b/tests/providers/google/cloud/operators/test_dataplex.py
@@ -46,7 +46,6 @@ BODY_LAKE = {
 DATAPLEX_TASK_ID = "testTask001"
 
 GCP_CONN_ID = "google_cloud_default"
-DELEGATE_TO = "test-delegate-to"
 API_VERSION = "v1"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
@@ -65,7 +64,6 @@ class TestDataplexCreateTaskOperator:
             validate_only=None,
             api_version=API_VERSION,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         hook_mock.return_value.wait_for_operation.return_value = None
@@ -73,7 +71,6 @@ class TestDataplexCreateTaskOperator:
         op.execute(context=mock.MagicMock())
         hook_mock.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             api_version=API_VERSION,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
@@ -101,13 +98,11 @@ class TestDataplexDeleteTaskOperator:
             task_id="delete_dataplex_task",
             api_version=API_VERSION,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context=None)
         hook_mock.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             api_version=API_VERSION,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
@@ -132,13 +127,11 @@ class TestDataplexListTasksOperator:
             task_id="list_dataplex_task",
             api_version=API_VERSION,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context=mock.MagicMock())
         hook_mock.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             api_version=API_VERSION,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
@@ -168,7 +161,6 @@ class TestDataplexGetTaskOperator:
             task_id="get_dataplex_task",
             api_version=API_VERSION,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         hook_mock.return_value.wait_for_operation.return_value = None
@@ -176,7 +168,6 @@ class TestDataplexGetTaskOperator:
         op.execute(context=mock.MagicMock())
         hook_mock.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             api_version=API_VERSION,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
@@ -201,13 +192,11 @@ class TestDataplexDeleteLakeOperator:
             task_id="delete_dataplex_lake",
             api_version=API_VERSION,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context=mock.MagicMock())
         hook_mock.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             api_version=API_VERSION,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
@@ -234,7 +223,6 @@ class TestDataplexCreateLakeOperator:
             validate_only=None,
             api_version=API_VERSION,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         hook_mock.return_value.wait_for_operation.return_value = None
@@ -242,7 +230,6 @@ class TestDataplexCreateLakeOperator:
         op.execute(context=mock.MagicMock())
         hook_mock.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             api_version=API_VERSION,
             impersonation_chain=IMPERSONATION_CHAIN,
         )

--- a/tests/providers/google/cloud/operators/test_datastore.py
+++ b/tests/providers/google/cloud/operators/test_datastore.py
@@ -60,7 +60,7 @@ class TestCloudDatastoreExportEntitiesOperator:
         )
         op.execute(context={"ti": mock.MagicMock()})
 
-        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID, delegate_to=None, impersonation_chain=None)
+        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID, impersonation_chain=None)
         mock_hook.return_value.export_to_storage_bucket.assert_called_once_with(
             project_id=PROJECT_ID,
             bucket=BUCKET,
@@ -89,7 +89,7 @@ class TestCloudDatastoreImportEntitiesOperator:
         )
         op.execute(context={"ti": mock.MagicMock()})
 
-        mock_hook.assert_called_once_with(CONN_ID, None, impersonation_chain=None)
+        mock_hook.assert_called_once_with(CONN_ID, impersonation_chain=None)
         mock_hook.return_value.import_from_storage_bucket.assert_called_once_with(
             project_id=PROJECT_ID,
             bucket=BUCKET,

--- a/tests/providers/google/cloud/operators/test_gcs.py
+++ b/tests/providers/google/cloud/operators/test_gcs.py
@@ -413,13 +413,11 @@ class TestGoogleCloudStorageSync:
             delete_extra_files=True,
             allow_overwrite=True,
             gcp_conn_id="GCP_CONN_ID",
-            delegate_to="DELEGATE_TO",
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
         mock_hook.assert_called_once_with(
             gcp_conn_id="GCP_CONN_ID",
-            delegate_to="DELEGATE_TO",
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.sync.assert_called_once_with(

--- a/tests/providers/google/cloud/operators/test_mlengine.py
+++ b/tests/providers/google/cloud/operators/test_mlengine.py
@@ -54,7 +54,6 @@ TEST_PROJECT_ID = "test-project-id"
 TEST_MODEL_NAME = "test-model-name"
 TEST_VERSION_NAME = "test-version"
 TEST_GCP_CONN_ID = "test-gcp-conn-id"
-TEST_DELEGATE_TO = "test-delegate-to"
 TEST_IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 TEST_MODEL = {
     "name": TEST_MODEL_NAME,
@@ -135,8 +134,7 @@ class TestMLEngineBatchPredictionOperator:
         prediction_output = prediction_task.execute(None)
 
         mock_hook.assert_called_once_with(
-            "google_cloud_default",
-            None,
+            gcp_conn_id="google_cloud_default",
             impersonation_chain=None,
         )
         hook_instance.create_job.assert_called_once_with(
@@ -178,8 +176,7 @@ class TestMLEngineBatchPredictionOperator:
         prediction_output = prediction_task.execute(None)
 
         mock_hook.assert_called_once_with(
-            "google_cloud_default",
-            None,
+            gcp_conn_id="google_cloud_default",
             impersonation_chain=None,
         )
         hook_instance.create_job.assert_called_once_with(
@@ -216,8 +213,7 @@ class TestMLEngineBatchPredictionOperator:
         prediction_output = prediction_task.execute(None)
 
         mock_hook.assert_called_once_with(
-            "google_cloud_default",
-            None,
+            gcp_conn_id="google_cloud_default",
             impersonation_chain=None,
         )
         hook_instance.create_job.assert_called_once_with(
@@ -290,8 +286,7 @@ class TestMLEngineBatchPredictionOperator:
             prediction_task.execute(None)
 
             mock_hook.assert_called_once_with(
-                "google_cloud_default",
-                None,
+                gcp_conn_id="google_cloud_default",
                 impersonation_chain=None,
             )
             hook_instance.create_job.assert_called_once_with(
@@ -332,7 +327,6 @@ class TestMLEngineTrainingCancelJobOperator:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id="google_cloud_default",
-            delegate_to=None,
             impersonation_chain=None,
         )
         # Make sure only 'cancel_job' is invoked on hook instance
@@ -355,7 +349,6 @@ class TestMLEngineTrainingCancelJobOperator:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id="google_cloud_default",
-            delegate_to=None,
             impersonation_chain=None,
         )
         # Make sure only 'cancel_job' is invoked on hook instance
@@ -375,14 +368,12 @@ class TestMLEngineModelOperator:
             model=TEST_MODEL,
             operation="create",
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
 
         task.execute(context=MagicMock())
 
         mock_hook.assert_called_once_with(
-            delegate_to=TEST_DELEGATE_TO,
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
@@ -398,14 +389,12 @@ class TestMLEngineModelOperator:
             model=TEST_MODEL,
             operation="get",
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
 
         result = task.execute(context=MagicMock())
 
         mock_hook.assert_called_once_with(
-            delegate_to=TEST_DELEGATE_TO,
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
@@ -422,7 +411,6 @@ class TestMLEngineModelOperator:
             model=TEST_MODEL,
             operation="invalid",
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
         )
         with pytest.raises(ValueError):
             task.execute(None)
@@ -436,14 +424,12 @@ class TestMLEngineCreateModelOperator:
             project_id=TEST_PROJECT_ID,
             model=TEST_MODEL,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
 
         task.execute(context=MagicMock())
 
         mock_hook.assert_called_once_with(
-            delegate_to=TEST_DELEGATE_TO,
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
@@ -460,14 +446,12 @@ class TestMLEngineGetModelOperator:
             project_id=TEST_PROJECT_ID,
             model_name=TEST_MODEL_NAME,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
 
         result = task.execute(context=MagicMock())
 
         mock_hook.assert_called_once_with(
-            delegate_to=TEST_DELEGATE_TO,
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
@@ -485,7 +469,6 @@ class TestMLEngineDeleteModelOperator:
             project_id=TEST_PROJECT_ID,
             model_name=TEST_MODEL_NAME,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
             delete_contents=True,
         )
@@ -493,7 +476,6 @@ class TestMLEngineDeleteModelOperator:
         task.execute(context=MagicMock())
 
         mock_hook.assert_called_once_with(
-            delegate_to=TEST_DELEGATE_TO,
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
@@ -520,7 +502,6 @@ class TestMLEngineVersionOperator:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id="google_cloud_default",
-            delegate_to=None,
             impersonation_chain=None,
         )
         # Make sure only 'create_version' is invoked on hook instance
@@ -539,14 +520,12 @@ class TestMLEngineCreateVersion:
             model_name=TEST_MODEL_NAME,
             version=TEST_VERSION,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
 
         task.execute(context=MagicMock())
 
         mock_hook.assert_called_once_with(
-            delegate_to=TEST_DELEGATE_TO,
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
@@ -562,7 +541,6 @@ class TestMLEngineCreateVersion:
                 model_name=None,
                 version=TEST_VERSION,
                 gcp_conn_id=TEST_GCP_CONN_ID,
-                delegate_to=TEST_DELEGATE_TO,
             )
 
     def test_missing_version(self):
@@ -573,7 +551,6 @@ class TestMLEngineCreateVersion:
                 model_name=TEST_MODEL_NAME,
                 version=None,
                 gcp_conn_id=TEST_GCP_CONN_ID,
-                delegate_to=TEST_DELEGATE_TO,
             )
 
 
@@ -586,14 +563,12 @@ class TestMLEngineSetDefaultVersion:
             model_name=TEST_MODEL_NAME,
             version_name=TEST_VERSION_NAME,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
 
         task.execute(context=MagicMock())
 
         mock_hook.assert_called_once_with(
-            delegate_to=TEST_DELEGATE_TO,
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
@@ -609,7 +584,6 @@ class TestMLEngineSetDefaultVersion:
                 model_name=None,
                 version_name=TEST_VERSION_NAME,
                 gcp_conn_id=TEST_GCP_CONN_ID,
-                delegate_to=TEST_DELEGATE_TO,
             )
 
     def test_missing_version_name(self):
@@ -620,7 +594,6 @@ class TestMLEngineSetDefaultVersion:
                 model_name=TEST_MODEL_NAME,
                 version_name=None,
                 gcp_conn_id=TEST_GCP_CONN_ID,
-                delegate_to=TEST_DELEGATE_TO,
             )
 
 
@@ -632,14 +605,12 @@ class TestMLEngineListVersions:
             project_id=TEST_PROJECT_ID,
             model_name=TEST_MODEL_NAME,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
 
         task.execute(context=MagicMock())
 
         mock_hook.assert_called_once_with(
-            delegate_to=TEST_DELEGATE_TO,
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
@@ -655,7 +626,6 @@ class TestMLEngineListVersions:
                 project_id=TEST_PROJECT_ID,
                 model_name=None,
                 gcp_conn_id=TEST_GCP_CONN_ID,
-                delegate_to=TEST_DELEGATE_TO,
             )
 
 
@@ -668,14 +638,12 @@ class TestMLEngineDeleteVersion:
             model_name=TEST_MODEL_NAME,
             version_name=TEST_VERSION_NAME,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
 
         task.execute(context=MagicMock())
 
         mock_hook.assert_called_once_with(
-            delegate_to=TEST_DELEGATE_TO,
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
@@ -691,7 +659,6 @@ class TestMLEngineDeleteVersion:
                 model_name=TEST_MODEL_NAME,
                 version_name=None,
                 gcp_conn_id=TEST_GCP_CONN_ID,
-                delegate_to=TEST_DELEGATE_TO,
             )
 
     def test_missing_model_name(self):
@@ -702,7 +669,6 @@ class TestMLEngineDeleteVersion:
                 model_name=None,
                 version_name=TEST_VERSION_NAME,
                 gcp_conn_id=TEST_GCP_CONN_ID,
-                delegate_to=TEST_DELEGATE_TO,
             )
 
 
@@ -741,7 +707,6 @@ class TestMLEngineStartTrainingJobOperator:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id="google_cloud_default",
-            delegate_to=None,
             impersonation_chain=None,
         )
         mock_hook.return_value.create_job_without_waiting_result.assert_called_once_with(
@@ -785,7 +750,6 @@ class TestMLEngineStartTrainingJobOperator:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id="google_cloud_default",
-            delegate_to=None,
             impersonation_chain=None,
         )
         mock_hook.return_value.create_job_without_waiting_result.assert_called_once_with(
@@ -831,7 +795,6 @@ class TestMLEngineStartTrainingJobOperator:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id="google_cloud_default",
-            delegate_to=None,
             impersonation_chain=None,
         )
         mock_hook.return_value.create_job_without_waiting_result.assert_called_once_with(
@@ -906,7 +869,6 @@ class TestMLEngineStartTrainingJobOperator:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id="google_cloud_default",
-            delegate_to=None,
             impersonation_chain=None,
         )
         mock_hook.return_value.create_job_without_waiting_result.assert_called_once_with(
@@ -929,7 +891,6 @@ class TestMLEngineStartTrainingJobOperator:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id="google_cloud_default",
-            delegate_to=None,
             impersonation_chain=None,
         )
 
@@ -945,7 +906,6 @@ class TestMLEngineStartTrainingJobOperator:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id="google_cloud_default",
-            delegate_to=None,
             impersonation_chain=None,
         )
 
@@ -963,7 +923,6 @@ class TestMLEngineStartTrainingJobOperator:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id="google_cloud_default",
-            delegate_to=None,
             impersonation_chain=None,
         )
         mock_hook.return_value.create_job_without_waiting_result.assert_called_once_with(
@@ -1111,7 +1070,6 @@ def test_async_create_training_job_with_conflict_should_execute_successfully(moc
 
     mock_hook.assert_called_once_with(
         gcp_conn_id="google_cloud_default",
-        delegate_to=None,
         impersonation_chain=None,
     )
     mock_hook.return_value.create_job_without_waiting_result.assert_called_once()

--- a/tests/providers/google/cloud/operators/test_vertex_ai.py
+++ b/tests/providers/google/cloud/operators/test_vertex_ai.py
@@ -79,7 +79,6 @@ TASK_ID = "test_task_id"
 GCP_PROJECT = "test-project"
 GCP_LOCATION = "test-location"
 GCP_CONN_ID = "test-conn"
-DELEGATE_TO = "test-delegate-to"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 STAGING_BUCKET = "gs://test-vertex-ai-bucket"
 DISPLAY_NAME = "display_name_1"  # Create random display name
@@ -178,7 +177,6 @@ class TestVertexAICreateCustomContainerTrainingJobOperator:
         op = CreateCustomContainerTrainingJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             staging_bucket=STAGING_BUCKET,
             display_name=DISPLAY_NAME,
@@ -198,9 +196,7 @@ class TestVertexAICreateCustomContainerTrainingJobOperator:
             project_id=GCP_PROJECT,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.create_custom_container_training_job.assert_called_once_with(
             staging_bucket=STAGING_BUCKET,
             display_name=DISPLAY_NAME,
@@ -263,7 +259,6 @@ class TestVertexAICreateCustomPythonPackageTrainingJobOperator:
         op = CreateCustomPythonPackageTrainingJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             staging_bucket=STAGING_BUCKET,
             display_name=DISPLAY_NAME,
@@ -284,9 +279,7 @@ class TestVertexAICreateCustomPythonPackageTrainingJobOperator:
             project_id=GCP_PROJECT,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.create_custom_python_package_training_job.assert_called_once_with(
             staging_bucket=STAGING_BUCKET,
             display_name=DISPLAY_NAME,
@@ -350,7 +343,6 @@ class TestVertexAICreateCustomTrainingJobOperator:
         op = CreateCustomTrainingJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             staging_bucket=STAGING_BUCKET,
             display_name=DISPLAY_NAME,
@@ -364,9 +356,7 @@ class TestVertexAICreateCustomTrainingJobOperator:
             project_id=GCP_PROJECT,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.create_custom_training_job.assert_called_once_with(
             staging_bucket=STAGING_BUCKET,
             display_name=DISPLAY_NAME,
@@ -432,13 +422,10 @@ class TestVertexAIDeleteCustomTrainingJobOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.delete_training_pipeline.assert_called_once_with(
             training_pipeline=TRAINING_PIPELINE_ID,
             region=GCP_LOCATION,
@@ -468,7 +455,6 @@ class TestVertexAIListCustomTrainingJobOperator:
         op = ListCustomTrainingJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -481,9 +467,7 @@ class TestVertexAIListCustomTrainingJobOperator:
             metadata=METADATA,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_training_pipelines.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -504,7 +488,6 @@ class TestVertexAICreateDatasetOperator:
         op = CreateDatasetOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -514,9 +497,7 @@ class TestVertexAICreateDatasetOperator:
             metadata=METADATA,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.create_dataset.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -534,7 +515,6 @@ class TestVertexAIDeleteDatasetOperator:
         op = DeleteDatasetOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -544,9 +524,7 @@ class TestVertexAIDeleteDatasetOperator:
             metadata=METADATA,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.delete_dataset.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -564,7 +542,6 @@ class TestVertexAIExportDataOperator:
         op = ExportDataOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -575,9 +552,7 @@ class TestVertexAIExportDataOperator:
             metadata=METADATA,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.export_data.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -596,7 +571,6 @@ class TestVertexAIImportDataOperator:
         op = ImportDataOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -607,9 +581,7 @@ class TestVertexAIImportDataOperator:
             metadata=METADATA,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.import_data.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -634,7 +606,6 @@ class TestVertexAIListDatasetsOperator:
         op = ListDatasetsOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -648,9 +619,7 @@ class TestVertexAIListDatasetsOperator:
             metadata=METADATA,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_datasets.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -672,7 +641,6 @@ class TestVertexAIUpdateDatasetOperator:
         op = UpdateDatasetOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             project_id=GCP_PROJECT,
             region=GCP_LOCATION,
@@ -684,9 +652,7 @@ class TestVertexAIUpdateDatasetOperator:
             metadata=METADATA,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.update_dataset.assert_called_once_with(
             project_id=GCP_PROJECT,
             region=GCP_LOCATION,
@@ -707,7 +673,6 @@ class TestVertexAICreateAutoMLForecastingTrainingJobOperator:
         op = CreateAutoMLForecastingTrainingJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             display_name=DISPLAY_NAME,
             dataset_id=TEST_DATASET_ID,
@@ -724,9 +689,7 @@ class TestVertexAICreateAutoMLForecastingTrainingJobOperator:
             project_id=GCP_PROJECT,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_dataset.assert_called_once_with(dataset_name=TEST_DATASET_ID)
         mock_hook.return_value.create_auto_ml_forecasting_training_job.assert_called_once_with(
             project_id=GCP_PROJECT,
@@ -774,7 +737,6 @@ class TestVertexAICreateAutoMLImageTrainingJobOperator:
         op = CreateAutoMLImageTrainingJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             display_name=DISPLAY_NAME,
             dataset_id=TEST_DATASET_ID,
@@ -786,9 +748,7 @@ class TestVertexAICreateAutoMLImageTrainingJobOperator:
             project_id=GCP_PROJECT,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_dataset.assert_called_once_with(dataset_name=TEST_DATASET_ID)
         mock_hook.return_value.create_auto_ml_image_training_job.assert_called_once_with(
             project_id=GCP_PROJECT,
@@ -824,7 +784,6 @@ class TestVertexAICreateAutoMLTabularTrainingJobOperator:
         op = CreateAutoMLTabularTrainingJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             display_name=DISPLAY_NAME,
             dataset_id=TEST_DATASET_ID,
@@ -835,9 +794,7 @@ class TestVertexAICreateAutoMLTabularTrainingJobOperator:
             project_id=GCP_PROJECT,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_dataset.assert_called_once_with(dataset_name=TEST_DATASET_ID)
         mock_hook.return_value.create_auto_ml_tabular_training_job.assert_called_once_with(
             project_id=GCP_PROJECT,
@@ -879,7 +836,6 @@ class TestVertexAICreateAutoMLTextTrainingJobOperator:
         op = CreateAutoMLTextTrainingJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             display_name=DISPLAY_NAME,
             dataset_id=TEST_DATASET_ID,
@@ -891,9 +847,7 @@ class TestVertexAICreateAutoMLTextTrainingJobOperator:
             project_id=GCP_PROJECT,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_dataset.assert_called_once_with(dataset_name=TEST_DATASET_ID)
         mock_hook.return_value.create_auto_ml_text_training_job.assert_called_once_with(
             project_id=GCP_PROJECT,
@@ -926,7 +880,6 @@ class TestVertexAICreateAutoMLVideoTrainingJobOperator:
         op = CreateAutoMLVideoTrainingJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             display_name=DISPLAY_NAME,
             dataset_id=TEST_DATASET_ID,
@@ -937,9 +890,7 @@ class TestVertexAICreateAutoMLVideoTrainingJobOperator:
             project_id=GCP_PROJECT,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_dataset.assert_called_once_with(dataset_name=TEST_DATASET_ID)
         mock_hook.return_value.create_auto_ml_video_training_job.assert_called_once_with(
             project_id=GCP_PROJECT,
@@ -973,13 +924,10 @@ class TestVertexAIDeleteAutoMLTrainingJobOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.delete_training_pipeline.assert_called_once_with(
             training_pipeline=TRAINING_PIPELINE_ID,
             region=GCP_LOCATION,
@@ -1001,7 +949,6 @@ class TestVertexAIListAutoMLTrainingJobOperator:
         op = ListAutoMLTrainingJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1014,9 +961,7 @@ class TestVertexAIListAutoMLTrainingJobOperator:
             metadata=METADATA,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_training_pipelines.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1037,7 +982,6 @@ class TestVertexAICreateBatchPredictionJobOperator:
         op = CreateBatchPredictionJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1047,9 +991,7 @@ class TestVertexAICreateBatchPredictionJobOperator:
             predictions_format="jsonl",
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.create_batch_prediction_job.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1082,7 +1024,6 @@ class TestVertexAIDeleteBatchPredictionJobOperator:
         op = DeleteBatchPredictionJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1092,9 +1033,7 @@ class TestVertexAIDeleteBatchPredictionJobOperator:
             metadata=METADATA,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.delete_batch_prediction_job.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1116,7 +1055,6 @@ class TestVertexAIListBatchPredictionJobsOperator:
         op = ListBatchPredictionJobsOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1129,9 +1067,7 @@ class TestVertexAIListBatchPredictionJobsOperator:
             metadata=METADATA,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_batch_prediction_jobs.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1152,7 +1088,6 @@ class TestVertexAICreateEndpointOperator:
         op = CreateEndpointOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1163,9 +1098,7 @@ class TestVertexAICreateEndpointOperator:
             metadata=METADATA,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.create_endpoint.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1183,7 +1116,6 @@ class TestVertexAIDeleteEndpointOperator:
         op = DeleteEndpointOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1193,9 +1125,7 @@ class TestVertexAIDeleteEndpointOperator:
             metadata=METADATA,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.delete_endpoint.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1213,7 +1143,6 @@ class TestVertexAIDeployModelOperator:
         op = DeployModelOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1225,9 +1154,7 @@ class TestVertexAIDeployModelOperator:
             metadata=METADATA,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.deploy_model.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1252,7 +1179,6 @@ class TestVertexAIListEndpointsOperator:
         op = ListEndpointsOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1266,9 +1192,7 @@ class TestVertexAIListEndpointsOperator:
             metadata=METADATA,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_endpoints.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1289,7 +1213,6 @@ class TestVertexAIUndeployModelOperator:
         op = UndeployModelOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1301,9 +1224,7 @@ class TestVertexAIUndeployModelOperator:
             metadata=METADATA,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.undeploy_model.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1323,7 +1244,6 @@ class TestVertexAICreateHyperparameterTuningJobOperator:
         op = CreateHyperparameterTuningJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1337,9 +1257,7 @@ class TestVertexAICreateHyperparameterTuningJobOperator:
             parallel_trial_count=3,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.create_hyperparameter_tuning_job.assert_called_once_with(
             project_id=GCP_PROJECT,
             region=GCP_LOCATION,
@@ -1375,16 +1293,13 @@ class TestVertexAIGetHyperparameterTuningJobOperator:
         op = GetHyperparameterTuningJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
             hyperparameter_tuning_job_id=TEST_HYPERPARAMETER_TUNING_JOB_ID,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.get_hyperparameter_tuning_job.assert_called_once_with(
             project_id=GCP_PROJECT,
             region=GCP_LOCATION,
@@ -1401,16 +1316,13 @@ class TestVertexAIDeleteHyperparameterTuningJobOperator:
         op = DeleteHyperparameterTuningJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
             hyperparameter_tuning_job_id=TEST_HYPERPARAMETER_TUNING_JOB_ID,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.delete_hyperparameter_tuning_job.assert_called_once_with(
             project_id=GCP_PROJECT,
             region=GCP_LOCATION,
@@ -1432,7 +1344,6 @@ class TestVertexAIListHyperparameterTuningJobOperator:
         op = ListHyperparameterTuningJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1445,9 +1356,7 @@ class TestVertexAIListHyperparameterTuningJobOperator:
             metadata=METADATA,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_hyperparameter_tuning_jobs.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1467,7 +1376,6 @@ class TestVertexAIExportModelOperator:
         op = ExportModelOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1478,9 +1386,7 @@ class TestVertexAIExportModelOperator:
             metadata=METADATA,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.export_model.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1498,7 +1404,6 @@ class TestVertexAIDeleteModelOperator:
         op = DeleteModelOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1508,9 +1413,7 @@ class TestVertexAIDeleteModelOperator:
             metadata=METADATA,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.delete_model.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1534,7 +1437,6 @@ class TestVertexAIListModelsOperator:
         op = ListModelsOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1548,9 +1450,7 @@ class TestVertexAIListModelsOperator:
             metadata=METADATA,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_models.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1572,7 +1472,6 @@ class TestVertexAIUploadModelOperator:
         op = UploadModelOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -1582,9 +1481,7 @@ class TestVertexAIUploadModelOperator:
             metadata=METADATA,
         )
         op.execute(context={"ti": mock.MagicMock()})
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
-        )
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.upload_model.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,

--- a/tests/providers/google/cloud/sensors/test_bigquery.py
+++ b/tests/providers/google/cloud/sensors/test_bigquery.py
@@ -35,7 +35,6 @@ from airflow.providers.google.cloud.triggers.bigquery import (
 TEST_PROJECT_ID = "test_project"
 TEST_DATASET_ID = "test_dataset"
 TEST_TABLE_ID = "test_table"
-TEST_DELEGATE_TO = "test_delegate_to"
 TEST_GCP_CONN_ID = "test_gcp_conn_id"
 TEST_PARTITION_ID = "20200101"
 TEST_IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
@@ -50,7 +49,6 @@ class TestBigqueryTableExistenceSensor:
             dataset_id=TEST_DATASET_ID,
             table_id=TEST_TABLE_ID,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.table_exists.return_value = True
@@ -60,7 +58,6 @@ class TestBigqueryTableExistenceSensor:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.table_exists.assert_called_once_with(
@@ -133,7 +130,6 @@ class TestBigqueryTablePartitionExistenceSensor:
             table_id=TEST_TABLE_ID,
             partition_id=TEST_PARTITION_ID,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.table_partition_exists.return_value = True
@@ -143,7 +139,6 @@ class TestBigqueryTablePartitionExistenceSensor:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.table_partition_exists.assert_called_once_with(

--- a/tests/providers/google/cloud/sensors/test_dataflow.py
+++ b/tests/providers/google/cloud/sensors/test_dataflow.py
@@ -34,7 +34,6 @@ TEST_TASK_ID = "task_id"
 TEST_JOB_ID = "test_job_id"
 TEST_PROJECT_ID = "test_project"
 TEST_LOCATION = "us-central1"
-TEST_DELEGATE_TO = "test_delegate_to"
 TEST_GCP_CONN_ID = "test_gcp_conn_id"
 TEST_IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
@@ -57,7 +56,6 @@ class TestDataflowJobStatusSensor:
             location=TEST_LOCATION,
             project_id=TEST_PROJECT_ID,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_get_job.return_value = {"id": TEST_JOB_ID, "currentState": current_status}
@@ -67,7 +65,6 @@ class TestDataflowJobStatusSensor:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_get_job.assert_called_once_with(
@@ -84,7 +81,6 @@ class TestDataflowJobStatusSensor:
             location=TEST_LOCATION,
             project_id=TEST_PROJECT_ID,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_get_job.return_value = {"id": TEST_JOB_ID, "currentState": DataflowJobStatus.JOB_STATE_CANCELLED}
@@ -98,7 +94,6 @@ class TestDataflowJobStatusSensor:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_get_job.assert_called_once_with(
@@ -129,7 +124,6 @@ class TestDataflowJobMetricsSensor:
             location=TEST_LOCATION,
             project_id=TEST_PROJECT_ID,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_get_job.return_value = {"id": TEST_JOB_ID, "currentState": job_current_state}
@@ -139,7 +133,6 @@ class TestDataflowJobMetricsSensor:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_fetch_job_metrics_by_id.assert_called_once_with(
@@ -172,7 +165,6 @@ class DataflowJobMessagesSensorTest:
             location=TEST_LOCATION,
             project_id=TEST_PROJECT_ID,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_get_job.return_value = {"id": TEST_JOB_ID, "currentState": job_current_state}
@@ -183,7 +175,6 @@ class DataflowJobMessagesSensorTest:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_fetch_job_messages_by_id.assert_called_once_with(
@@ -205,7 +196,6 @@ class DataflowJobMessagesSensorTest:
             location=TEST_LOCATION,
             project_id=TEST_PROJECT_ID,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_get_job.return_value = {"id": TEST_JOB_ID, "currentState": DataflowJobStatus.JOB_STATE_DONE}
@@ -219,7 +209,6 @@ class DataflowJobMessagesSensorTest:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_fetch_job_messages_by_id.assert_not_called()
@@ -249,7 +238,6 @@ class DataflowJobAutoScalingEventsSensorTest:
             location=TEST_LOCATION,
             project_id=TEST_PROJECT_ID,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_get_job.return_value = {"id": TEST_JOB_ID, "currentState": job_current_state}
@@ -260,7 +248,6 @@ class DataflowJobAutoScalingEventsSensorTest:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_fetch_job_autoscaling_events_by_id.assert_called_once_with(
@@ -282,7 +269,6 @@ class DataflowJobAutoScalingEventsSensorTest:
             location=TEST_LOCATION,
             project_id=TEST_PROJECT_ID,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_get_job.return_value = {"id": TEST_JOB_ID, "currentState": DataflowJobStatus.JOB_STATE_DONE}
@@ -296,7 +282,6 @@ class DataflowJobAutoScalingEventsSensorTest:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_fetch_job_autoscaling_events_by_id.assert_not_called()

--- a/tests/providers/google/cloud/sensors/test_datafusion.py
+++ b/tests/providers/google/cloud/sensors/test_datafusion.py
@@ -32,7 +32,6 @@ PIPELINE_NAME = "shrubberyPipeline"
 PIPELINE_ID = "test_pipeline_id"
 PROJECT_ID = "test_project_id"
 GCP_CONN_ID = "test_conn_id"
-DELEGATE_TO = "test_delegate_to"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 FAILURE_STATUSES = {"FAILED"}
 
@@ -58,7 +57,6 @@ class TestCloudDataFusionPipelineStateSensor:
             instance_name=INSTANCE_NAME,
             location=LOCATION,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 
@@ -69,7 +67,6 @@ class TestCloudDataFusionPipelineStateSensor:
 
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 
@@ -91,7 +88,6 @@ class TestCloudDataFusionPipelineStateSensor:
             instance_name=INSTANCE_NAME,
             location=LOCATION,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 
@@ -117,7 +113,6 @@ class TestCloudDataFusionPipelineStateSensor:
             instance_name=INSTANCE_NAME,
             location=LOCATION,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 

--- a/tests/providers/google/cloud/sensors/test_dataplex.py
+++ b/tests/providers/google/cloud/sensors/test_dataplex.py
@@ -34,7 +34,6 @@ BODY = {"body": "test"}
 DATAPLEX_TASK_ID = "testTask001"
 
 GCP_CONN_ID = "google_cloud_default"
-DELEGATE_TO = "test-delegate-to"
 API_VERSION = "v1"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
@@ -58,7 +57,6 @@ class TestDataplexTaskStateSensor:
             dataplex_task_id=DATAPLEX_TASK_ID,
             api_version=API_VERSION,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         result = sensor.poke(context={})
@@ -87,7 +85,6 @@ class TestDataplexTaskStateSensor:
             dataplex_task_id=DATAPLEX_TASK_ID,
             api_version=API_VERSION,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 

--- a/tests/providers/google/cloud/sensors/test_gcs.py
+++ b/tests/providers/google/cloud/sensors/test_gcs.py
@@ -40,8 +40,6 @@ TEST_BUCKET = "TEST_BUCKET"
 
 TEST_OBJECT = "TEST_OBJECT"
 
-TEST_DELEGATE_TO = "TEST_DELEGATE_TO"
-
 TEST_GCP_CONN_ID = "TEST_GCP_CONN_ID"
 
 TEST_IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
@@ -83,7 +81,6 @@ class TestGoogleCloudStorageObjectSensor:
             bucket=TEST_BUCKET,
             object=TEST_OBJECT,
             google_cloud_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.exists.return_value = True
@@ -92,7 +89,6 @@ class TestGoogleCloudStorageObjectSensor:
 
         assert result is True
         mock_hook.assert_called_once_with(
-            delegate_to=TEST_DELEGATE_TO,
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
@@ -216,14 +212,12 @@ class TestGoogleCloudStorageObjectUpdatedSensor:
             bucket=TEST_BUCKET,
             object=TEST_OBJECT,
             google_cloud_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.is_updated_after.return_value = True
         result = task.poke(mock.MagicMock())
 
         mock_hook.assert_called_once_with(
-            delegate_to=TEST_DELEGATE_TO,
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
@@ -239,14 +233,12 @@ class TestGoogleCloudStoragePrefixSensor:
             bucket=TEST_BUCKET,
             prefix=TEST_PREFIX,
             google_cloud_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.list.return_value = ["NOT_EMPTY_LIST"]
         result = task.poke(mock.MagicMock)
 
         mock_hook.assert_called_once_with(
-            delegate_to=TEST_DELEGATE_TO,
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
@@ -260,7 +252,6 @@ class TestGoogleCloudStoragePrefixSensor:
             bucket=TEST_BUCKET,
             prefix=TEST_PREFIX,
             google_cloud_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
         )
         mock_hook.return_value.list.return_value = []
         result = task.poke(mock.MagicMock)
@@ -274,7 +265,6 @@ class TestGoogleCloudStoragePrefixSensor:
             bucket=TEST_BUCKET,
             prefix=TEST_PREFIX,
             google_cloud_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
             poke_interval=0,
         )
@@ -284,7 +274,6 @@ class TestGoogleCloudStoragePrefixSensor:
         response = task.execute(None)
 
         mock_hook.assert_called_once_with(
-            delegate_to=TEST_DELEGATE_TO,
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
@@ -319,7 +308,6 @@ class TestGCSUploadSessionCompleteSensor:
             min_objects=1,
             allow_delete=False,
             google_cloud_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
             dag=self.dag,
         )
@@ -331,7 +319,6 @@ class TestGCSUploadSessionCompleteSensor:
         self.sensor._get_gcs_hook()
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         assert mock_hook.return_value == self.sensor.hook

--- a/tests/providers/google/cloud/transfers/test_adls_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_adls_to_gcs.py
@@ -96,7 +96,6 @@ class TestAdlsToGoogleCloudStorageOperator:
         adls_two_mock_hook.assert_called_once_with(azure_data_lake_conn_id=AZURE_CONN_ID)
         gcs_mock_hook.assert_called_once_with(
             gcp_conn_id=GCS_CONN_ID,
-            delegate_to=None,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 

--- a/tests/providers/google/cloud/transfers/test_azure_fileshare_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_azure_fileshare_to_gcs.py
@@ -84,7 +84,6 @@ class TestAzureFileShareToGCSOperator:
 
         gcs_mock_hook.assert_called_once_with(
             gcp_conn_id=GCS_CONN_ID,
-            delegate_to=None,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 

--- a/tests/providers/google/cloud/transfers/test_calendar_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_calendar_to_gcs.py
@@ -71,7 +71,6 @@ class TestGoogleCalendarToGCSOperator:
         # Test GCS Hook
         mock_gcs_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=None,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 
@@ -102,7 +101,6 @@ class TestGoogleCalendarToGCSOperator:
         mock_calendar_hook.assert_called_once_with(
             api_version=API_VERSION,
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=None,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 

--- a/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
@@ -29,7 +29,6 @@ from airflow.providers.google.cloud.transfers.gcs_to_sftp import GCSToSFTPOperat
 TASK_ID = "test-gcs-to-sftp-operator"
 GCP_CONN_ID = "GCP_CONN_ID"
 SFTP_CONN_ID = "SFTP_CONN_ID"
-DELEGATE_TO = "DELEGATE_TO"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 TEST_BUCKET = "test-bucket"
 DESTINATION_SFTP = "destination_path"
@@ -59,13 +58,11 @@ class TestGoogleCloudStorageToSFTPOperator:
             move_object=False,
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         task.execute({})
         gcs_hook_mock.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         sftp_hook_mock.assert_called_once_with(SFTP_CONN_ID)
@@ -103,13 +100,11 @@ class TestGoogleCloudStorageToSFTPOperator:
             move_object=True,
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         task.execute(None)
         gcs_hook_mock.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         sftp_hook_mock.assert_called_once_with(SFTP_CONN_ID)
@@ -196,7 +191,6 @@ class TestGoogleCloudStorageToSFTPOperator:
             move_object=False,
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
-            delegate_to=DELEGATE_TO,
         )
         operator.execute(None)
 
@@ -289,7 +283,6 @@ class TestGoogleCloudStorageToSFTPOperator:
             move_object=True,
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
-            delegate_to=DELEGATE_TO,
         )
         operator.execute(None)
 
@@ -323,7 +316,6 @@ class TestGoogleCloudStorageToSFTPOperator:
             move_object=False,
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
-            delegate_to=DELEGATE_TO,
         )
         with pytest.raises(AirflowException):
             operator.execute(None)

--- a/tests/providers/google/cloud/transfers/test_gdrive_to_local.py
+++ b/tests/providers/google/cloud/transfers/test_gdrive_to_local.py
@@ -43,9 +43,7 @@ class TestGoogleDriveToLocalOperator:
             hook_mock.return_value.get_file_id.return_value = meta
 
             op.execute(context=None)
-            hook_mock.assert_called_once_with(
-                delegate_to=None, gcp_conn_id=GCP_CONN_ID, impersonation_chain=None
-            )
+            hook_mock.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=None)
 
             hook_mock.return_value.download_file.assert_called_once_with(
                 file_id=meta["id"], file_handle=mock.ANY

--- a/tests/providers/google/cloud/transfers/test_s3_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_s3_to_gcs.py
@@ -87,7 +87,6 @@ class TestS3ToGoogleCloudStorageOperator:
         s3_two_mock_hook.assert_called_once_with(aws_conn_id=AWS_CONN_ID, verify=None)
         gcs_mock_hook.assert_called_once_with(
             gcp_conn_id=GCS_CONN_ID,
-            delegate_to=None,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 
@@ -116,7 +115,6 @@ class TestS3ToGoogleCloudStorageOperator:
         operator.execute(None)
         gcs_mock_hook.assert_called_once_with(
             gcp_conn_id=GCS_CONN_ID,
-            delegate_to=None,
             impersonation_chain=None,
         )
         gcs_mock_hook.return_value.upload.assert_has_calls(

--- a/tests/providers/google/cloud/transfers/test_sftp_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_sftp_to_gcs.py
@@ -29,7 +29,6 @@ from airflow.providers.google.cloud.transfers.sftp_to_gcs import SFTPToGCSOperat
 TASK_ID = "test-gcs-to-sftp-operator"
 GCP_CONN_ID = "GCP_CONN_ID"
 SFTP_CONN_ID = "SFTP_CONN_ID"
-DELEGATE_TO = "DELEGATE_TO"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 DEFAULT_MIME_TYPE = "application/octet-stream"
@@ -64,13 +63,11 @@ class TestSFTPToGCSOperator:
             move_object=False,
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         task.execute(None)
         gcs_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         sftp_hook.assert_called_once_with(SFTP_CONN_ID)
@@ -100,14 +97,12 @@ class TestSFTPToGCSOperator:
             move_object=False,
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             gzip=True,
         )
         task.execute(None)
         gcs_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         sftp_hook.assert_called_once_with(SFTP_CONN_ID)
@@ -137,13 +132,11 @@ class TestSFTPToGCSOperator:
             move_object=True,
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         task.execute(None)
         gcs_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         sftp_hook.assert_called_once_with(SFTP_CONN_ID)
@@ -179,7 +172,6 @@ class TestSFTPToGCSOperator:
             move_object=True,
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
-            delegate_to=DELEGATE_TO,
         )
         task.execute(None)
 
@@ -231,7 +223,6 @@ class TestSFTPToGCSOperator:
             move_object=True,
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
-            delegate_to=DELEGATE_TO,
         )
         task.execute(None)
 
@@ -253,7 +244,6 @@ class TestSFTPToGCSOperator:
             move_object=False,
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
-            delegate_to=DELEGATE_TO,
         )
         with pytest.raises(AirflowException) as ctx:
             task.execute(None)

--- a/tests/providers/google/cloud/transfers/test_sheets_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_sheets_to_gcs.py
@@ -101,12 +101,10 @@ class TestGoogleSheetsToGCSOperator:
 
         mock_sheet_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=None,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         mock_gcs_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=None,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 

--- a/tests/providers/google/cloud/triggers/test_bigquery_dts.py
+++ b/tests/providers/google/cloud/triggers/test_bigquery_dts.py
@@ -32,7 +32,6 @@ CONFIG_ID = "test-config-id"
 RUN_ID = "test-run-id"
 POLL_INTERVAL = 10
 GCP_CONN_ID = "google-cloud-default-id"
-DELEGATE_TO = "test-delegate-to"
 LOCATION = "us-central1"
 IMPERSONATION_CHAIN = ["test", "chain"]
 
@@ -45,7 +44,6 @@ def trigger():
         run_id=RUN_ID,
         poll_interval=POLL_INTERVAL,
         gcp_conn_id=GCP_CONN_ID,
-        delegate_to=DELEGATE_TO,
         location=LOCATION,
         impersonation_chain=IMPERSONATION_CHAIN,
     )
@@ -65,7 +63,6 @@ class TestBigQueryDataTransferRunTrigger:
             "run_id": RUN_ID,
             "poll_interval": POLL_INTERVAL,
             "gcp_conn_id": GCP_CONN_ID,
-            "delegate_to": DELEGATE_TO,
             "location": LOCATION,
             "impersonation_chain": IMPERSONATION_CHAIN,
         }
@@ -74,7 +71,6 @@ class TestBigQueryDataTransferRunTrigger:
         "attr, expected_value",
         [
             ("gcp_conn_id", GCP_CONN_ID),
-            ("delegate_to", DELEGATE_TO),
             ("location", LOCATION),
             ("impersonation_chain", IMPERSONATION_CHAIN),
         ],

--- a/tests/providers/google/cloud/triggers/test_cloud_build.py
+++ b/tests/providers/google/cloud/triggers/test_cloud_build.py
@@ -86,7 +86,6 @@ def trigger():
         project_id=TEST_PROJECT_ID,
         gcp_conn_id=TEST_CONN_ID,
         impersonation_chain=None,
-        delegate_to=None,
         poll_interval=TEST_POLL_INTERVAL,
         location=TEST_LOCATION,
     )
@@ -112,7 +111,6 @@ class TestCloudBuildCreateBuildTrigger:
             "project_id": TEST_PROJECT_ID,
             "gcp_conn_id": TEST_CONN_ID,
             "impersonation_chain": None,
-            "delegate_to": None,
             "poll_interval": TEST_POLL_INTERVAL,
             "location": TEST_LOCATION,
         }

--- a/tests/providers/google/cloud/triggers/test_dataflow.py
+++ b/tests/providers/google/cloud/triggers/test_dataflow.py
@@ -33,7 +33,6 @@ PROJECT_ID = "test-project-id"
 JOB_ID = "test_job_id_2012-12-23-10:00"
 LOCATION = "us-central1"
 GCP_CONN_ID = "test_gcp_conn_id"
-DELEGATE_TO = "delegating_to_something"
 POLL_SLEEP = 20
 IMPERSONATION_CHAIN = ["impersonate", "this"]
 CANCEL_TIMEOUT = 10 * 420
@@ -46,7 +45,6 @@ def trigger():
         job_id=JOB_ID,
         location=LOCATION,
         gcp_conn_id=GCP_CONN_ID,
-        delegate_to=DELEGATE_TO,
         poll_sleep=POLL_SLEEP,
         impersonation_chain=IMPERSONATION_CHAIN,
         cancel_timeout=CANCEL_TIMEOUT,
@@ -77,7 +75,6 @@ class TestTemplateJobStartTrigger:
                 "job_id": JOB_ID,
                 "location": LOCATION,
                 "gcp_conn_id": GCP_CONN_ID,
-                "delegate_to": DELEGATE_TO,
                 "poll_sleep": POLL_SLEEP,
                 "impersonation_chain": IMPERSONATION_CHAIN,
                 "cancel_timeout": CANCEL_TIMEOUT,
@@ -89,7 +86,6 @@ class TestTemplateJobStartTrigger:
         "attr, expected",
         [
             ("gcp_conn_id", GCP_CONN_ID),
-            ("delegate_to", DELEGATE_TO),
             ("poll_sleep", POLL_SLEEP),
             ("impersonation_chain", IMPERSONATION_CHAIN),
             ("cancel_timeout", CANCEL_TIMEOUT),

--- a/tests/providers/google/cloud/triggers/test_dataproc.py
+++ b/tests/providers/google/cloud/triggers/test_dataproc.py
@@ -296,7 +296,6 @@ class TestDataprocWorkflowTrigger:
             "project_id": TEST_PROJECT_ID,
             "region": TEST_REGION,
             "gcp_conn_id": TEST_GCP_CONN_ID,
-            "delegate_to": None,
             "impersonation_chain": None,
             "polling_interval_seconds": TEST_POLL_INTERVAL,
         }

--- a/tests/providers/google/cloud/triggers/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/triggers/test_kubernetes_engine.py
@@ -58,7 +58,6 @@ OPERATION_NAME = "test-operation-name"
 PROJECT_ID = "test-project-id"
 LOCATION = "us-central1-c"
 GCP_CONN_ID = "test-non-existing-project-id"
-DELEGATE_TO = "test-delegate-to"
 IMPERSONATION_CHAIN = ["impersonate", "this", "test"]
 TRIGGER_PATH = "airflow.providers.google.cloud.triggers.kubernetes_engine.GKEOperationTrigger"
 EXC_MSG = "test error msg"
@@ -302,7 +301,6 @@ def operation_trigger():
         project_id=PROJECT_ID,
         location=LOCATION,
         gcp_conn_id=GCP_CONN_ID,
-        delegate_to=DELEGATE_TO,
         impersonation_chain=IMPERSONATION_CHAIN,
         poll_interval=POLL_INTERVAL,
     )
@@ -329,7 +327,6 @@ class TestGKEOperationTrigger:
             "project_id": PROJECT_ID,
             "location": LOCATION,
             "gcp_conn_id": GCP_CONN_ID,
-            "delegate_to": DELEGATE_TO,
             "impersonation_chain": IMPERSONATION_CHAIN,
             "poll_interval": POLL_INTERVAL,
         }

--- a/tests/providers/google/cloud/utils/base_gcp_mock.py
+++ b/tests/providers/google/cloud/utils/base_gcp_mock.py
@@ -28,33 +28,33 @@ GCP_PROJECT_ID_HOOK_UNIT_TEST = "example-project"
 def mock_base_gcp_hook_default_project_id(
     self,
     gcp_conn_id="google_cloud_default",
-    delegate_to=None,
     impersonation_chain=None,
+    delegate_to=None,
 ):
     self.extras_list = {"project": GCP_PROJECT_ID_HOOK_UNIT_TEST}
     self._conn = gcp_conn_id
-    self.delegate_to = delegate_to
     self.impersonation_chain = impersonation_chain
     self._client = None
     self._conn = None
     self._cached_credentials = None
     self._cached_project_id = None
+    self.delegate_to = delegate_to
 
 
 def mock_base_gcp_hook_no_default_project_id(
     self,
     gcp_conn_id="google_cloud_default",
-    delegate_to=None,
     impersonation_chain=None,
+    delegate_to=None,
 ):
     self.extras_list = {}
     self._conn = gcp_conn_id
-    self.delegate_to = delegate_to
     self.impersonation_chain = impersonation_chain
     self._client = None
     self._conn = None
     self._cached_credentials = None
     self._cached_project_id = None
+    self.delegate_to = delegate_to
 
 
 GCP_CONNECTION_WITH_PROJECT_ID = Connection(extra=json.dumps({"project": GCP_PROJECT_ID_HOOK_UNIT_TEST}))

--- a/tests/providers/google/suite/transfers/test_gcs_to_gdrive.py
+++ b/tests/providers/google/suite/transfers/test_gcs_to_gdrive.py
@@ -48,7 +48,6 @@ class TestGcsToGDriveOperator:
         mock_gcs_hook.assert_has_calls(
             [
                 mock.call(
-                    delegate_to=None,
                     gcp_conn_id="google_cloud_default",
                     impersonation_chain=None,
                 ),
@@ -61,7 +60,6 @@ class TestGcsToGDriveOperator:
         mock_gdrive.assert_has_calls(
             [
                 mock.call(
-                    delegate_to=None,
                     gcp_conn_id="google_cloud_default",
                     impersonation_chain=None,
                 ),
@@ -93,7 +91,6 @@ class TestGcsToGDriveOperator:
         mock_gcs_hook.assert_has_calls(
             [
                 mock.call(
-                    delegate_to=None,
                     gcp_conn_id="google_cloud_default",
                     impersonation_chain=IMPERSONATION_CHAIN,
                 ),
@@ -107,7 +104,6 @@ class TestGcsToGDriveOperator:
         mock_gdrive.assert_has_calls(
             [
                 mock.call(
-                    delegate_to=None,
                     gcp_conn_id="google_cloud_default",
                     impersonation_chain=IMPERSONATION_CHAIN,
                 ),
@@ -137,7 +133,6 @@ class TestGcsToGDriveOperator:
         mock_gcs_hook.assert_has_calls(
             [
                 mock.call(
-                    delegate_to=None,
                     gcp_conn_id="google_cloud_default",
                     impersonation_chain=IMPERSONATION_CHAIN,
                 ),
@@ -154,7 +149,6 @@ class TestGcsToGDriveOperator:
         mock_gdrive.assert_has_calls(
             [
                 mock.call(
-                    delegate_to=None,
                     gcp_conn_id="google_cloud_default",
                     impersonation_chain=IMPERSONATION_CHAIN,
                 ),

--- a/tests/providers/google/suite/transfers/test_gcs_to_sheets.py
+++ b/tests/providers/google/suite/transfers/test_gcs_to_sheets.py
@@ -52,12 +52,10 @@ class TestGCSToGoogleSheets:
 
         mock_sheet_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=None,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         mock_gcs_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=None,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 

--- a/tests/providers/microsoft/azure/transfers/test_azure_blob_to_gcs.py
+++ b/tests/providers/microsoft/azure/transfers/test_azure_blob_to_gcs.py
@@ -29,7 +29,6 @@ BUCKET_NAME = "airflow"
 OBJECT_NAME = "file.txt"
 FILENAME = "file.txt"
 GZIP = False
-DELEGATE_TO = None
 IMPERSONATION_CHAIN = None
 TASK_ID = "transfer_file"
 
@@ -46,7 +45,6 @@ class TestAzureBlobStorageToGCSTransferOperator:
             object_name=OBJECT_NAME,
             filename=FILENAME,
             gzip=GZIP,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             task_id=TASK_ID,
         )
@@ -59,7 +57,6 @@ class TestAzureBlobStorageToGCSTransferOperator:
         assert operator.object_name == OBJECT_NAME
         assert operator.filename == FILENAME
         assert operator.gzip == GZIP
-        assert operator.delegate_to == DELEGATE_TO
         assert operator.impersonation_chain == IMPERSONATION_CHAIN
         assert operator.task_id == TASK_ID
 
@@ -77,7 +74,6 @@ class TestAzureBlobStorageToGCSTransferOperator:
             object_name=OBJECT_NAME,
             filename=FILENAME,
             gzip=GZIP,
-            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
             task_id=TASK_ID,
         )
@@ -91,7 +87,7 @@ class TestAzureBlobStorageToGCSTransferOperator:
             blob_name=BLOB_NAME,
         )
         mock_hook_gcs.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO, impersonation_chain=IMPERSONATION_CHAIN
+            gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN
         )
         mock_hook_gcs.return_value.upload.assert_called_once_with(
             bucket_name=BUCKET_NAME,

--- a/tests/providers/presto/transfers/test_gcs_presto.py
+++ b/tests/providers/presto/transfers/test_gcs_presto.py
@@ -55,7 +55,6 @@ class TestGCSToPrestoOperator:
 
         mock_gcs_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=None,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 
@@ -92,7 +91,6 @@ class TestGCSToPrestoOperator:
 
         mock_gcs_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=None,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 
@@ -131,7 +129,6 @@ class TestGCSToPrestoOperator:
 
         mock_gcs_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=None,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 

--- a/tests/providers/trino/transfers/test_gcs_trino.py
+++ b/tests/providers/trino/transfers/test_gcs_trino.py
@@ -55,7 +55,6 @@ class TestGCSToTrinoOperator:
 
         mock_gcs_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=None,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 
@@ -92,7 +91,6 @@ class TestGCSToTrinoOperator:
 
         mock_gcs_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=None,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 
@@ -131,7 +129,6 @@ class TestGCSToTrinoOperator:
 
         mock_gcs_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
-            delegate_to=None,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 

--- a/tests/system/providers/microsoft/azure/example_azure_blob_to_gcs.py
+++ b/tests/system/providers/microsoft/azure/example_azure_blob_to_gcs.py
@@ -57,7 +57,6 @@ with DAG(
         object_name=GCP_OBJECT_NAME,
         filename=GCP_BUCKET_FILE_PATH,
         gzip=False,
-        delegate_to=None,
         impersonation_chain=None,
     )
     # [END how_to_azure_blob_to_gcs]


### PR DESCRIPTION
related: #9461, #29088
---
- This PR removes the deprecated `delegate_to` parameter from GCP operators, hooks, sensors, transfers, and triggers, as well as from firebase hook. 
- It also removes the parameter from Microsoft Azure, Presto, Trino, and gsuite transfers that interact with Google Cloud.
- The `delegate_to` param will still be available only in gsuite and marketing platform hooks, operators, sensors, and transfers that don't interact with Google Cloud (see reasoning in #9461).


**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
