### PR TITLE
Fix grid/graph/logs scrolling (again)

### DIFF
--- a/airflow/www/static/js/dag/details/Dag.tsx
+++ b/airflow/www/static/js/dag/details/Dag.tsx
@@ -52,7 +52,7 @@ const Dag = () => {
     data: { dagRuns, groups },
   } = useGridData();
   const detailsRef = useRef<HTMLDivElement>(null);
-  const offsetTop = useOffsetTop(detailsRef);
+  const offsetTop = useOffsetTop(detailsRef, "parent");
 
   const taskSummary = getTaskSummary({ task: groups });
   const numMap = finalStatesMap();

--- a/airflow/www/static/js/dag/details/dagRun/index.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/index.tsx
@@ -62,7 +62,7 @@ const DagRun = ({ runId }: Props) => {
     data: { dagRuns },
   } = useGridData();
   const detailsRef = useRef<HTMLDivElement>(null);
-  const offsetTop = useOffsetTop(detailsRef);
+  const offsetTop = useOffsetTop(detailsRef, "parent");
 
   const run = dagRuns.find((dr) => dr.runId === runId);
   const { onCopy, hasCopied } = useClipboard(formatConf(run?.conf));

--- a/airflow/www/static/js/dag/details/graph/index.tsx
+++ b/airflow/www/static/js/dag/details/graph/index.tsx
@@ -85,7 +85,7 @@ const Graph = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
     setViewport({ x: 0, y: 0, zoom: 1 });
   }, [root, filterDownstream, filterUpstream, setViewport]);
 
-  const offsetTop = useOffsetTop(graphRef);
+  const offsetTop = useOffsetTop(graphRef, "parent", false);
 
   let nodes: ReactFlowNode<CustomNodeProps>[] = [];
 

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -150,7 +150,12 @@ const Details = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
       : group?.instances.find((ti) => ti.runId === runId);
 
   return (
-    <Flex flexDirection="column" pl={3} height="100%">
+    <Flex
+      flexDirection="column"
+      pl={3}
+      height="100%"
+      position={tab !== "logs" ? "relative" : undefined}
+    >
       <Flex alignItems="center" justifyContent="space-between" ml={6}>
         <Header />
         <Flex>
@@ -225,7 +230,7 @@ const Details = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
           )}
         </TabList>
         <TabPanels height="100%">
-          <TabPanel height="100%">
+          <TabPanel height="100%" p={0} m={4}>
             {isDag && <DagContent />}
             {isDagRun && <DagRunContent runId={runId} />}
             {isTaskInstance && (
@@ -250,10 +255,7 @@ const Details = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
             />
           </TabPanel>
           {showLogs && run && (
-            <TabPanel
-              pt={mapIndex !== undefined ? "0px" : undefined}
-              height="100%"
-            >
+            <TabPanel p={0} m={4} height="100%">
               <BackToTaskSummary
                 isMapIndexDefined={mapIndex !== undefined}
                 onClick={() => onSelect({ runId, taskId })}
@@ -270,7 +272,7 @@ const Details = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
             </TabPanel>
           )}
           {showMappedTasks && (
-            <TabPanel height="100%">
+            <TabPanel height="100%" p={0} m={4}>
               <MappedInstances
                 dagId={dagId}
                 runId={runId}

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -110,9 +110,9 @@ const Details = ({ instance, group, dagId }: Props) => {
           </Table>
         </>
       )}
-
-      <Text as="strong">Task Instance Details</Text>
-      <Divider my={2} />
+      <Text as="strong" mb={2}>
+        Task Instance Details
+      </Text>
       <Table variant="striped">
         <Tbody>
           {tooltip && (

--- a/airflow/www/static/js/dag/details/taskInstance/ExtraLinks.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/ExtraLinks.tsx
@@ -43,10 +43,9 @@ const ExtraLinks = ({ dagId, taskId, executionDate, extraLinks }: Props) => {
     url && /^(?:[a-z]+:)?\/\//.test(url);
 
   return (
-    <Box mb={3}>
+    <Box my={3}>
       <Text as="strong">Extra Links</Text>
-      <Divider my={2} />
-      <Flex flexWrap="wrap">
+      <Flex flexWrap="wrap" my={2}>
         {links.map(({ name, url }) => (
           <Button
             key={name}

--- a/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
@@ -38,7 +38,7 @@ interface Props {
 
 const MappedInstances = ({ dagId, runId, taskId, onRowClicked }: Props) => {
   const mappedTasksRef = useRef<HTMLDivElement>(null);
-  const offsetTop = useOffsetTop(mappedTasksRef);
+  const offsetTop = useOffsetTop(mappedTasksRef, "child", true);
   const limit = 25;
   const [offset, setOffset] = useState(0);
   const [sortBy, setSortBy] = useState<SortingRule<object>[]>([]);
@@ -121,7 +121,7 @@ const MappedInstances = ({ dagId, runId, taskId, onRowClicked }: Props) => {
   return (
     <Box
       ref={mappedTasksRef}
-      maxHeight={`calc(100% - ${offsetTop}px)`}
+      maxHeight={offsetTop ? `${offsetTop}px` : "100%"}
       overflowY="auto"
     >
       <Table

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -39,7 +39,7 @@ interface Props {
 
 const TaskInstance = ({ taskId, runId, mapIndex }: Props) => {
   const taskInstanceRef = useRef<HTMLDivElement>(null);
-  const offsetTop = useOffsetTop(taskInstanceRef);
+  const offsetTop = useOffsetTop(taskInstanceRef, "parent");
   const isMapIndexDefined = !(mapIndex === undefined);
   const {
     data: { dagRuns, groups },

--- a/airflow/www/static/js/dag/grid/index.tsx
+++ b/airflow/www/static/js/dag/grid/index.tsx
@@ -52,7 +52,7 @@ const Grid = ({
 }: Props) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const tableRef = useRef<HTMLTableSectionElement>(null);
-  const offsetTop = useOffsetTop(scrollRef);
+  const offsetTop = useOffsetTop(tableRef, "parent", true);
   const { selected } = useSelection();
 
   const {
@@ -131,7 +131,7 @@ const Grid = ({
         transitionProperty="none"
       />
       <Box
-        maxHeight={`calc(100% - ${offsetTop}px)`}
+        maxHeight={offsetTop ? `${offsetTop - 20}px` : "100%"}
         ref={scrollRef}
         overflow="auto"
         position="relative"

--- a/airflow/www/static/js/utils/useOffsetTop.ts
+++ b/airflow/www/static/js/utils/useOffsetTop.ts
@@ -20,8 +20,14 @@
 import { debounce } from "lodash";
 import React, { useEffect, useState } from "react";
 
+const footer = document.getElementsByTagName("footer")[0];
+
 // For an html element, keep it within view height by calculating the top offset and footer height
-const useOffsetTop = (contentRef: React.RefObject<HTMLElement>) => {
+const useOffsetTop = (
+  contentRef: React.RefObject<HTMLElement>,
+  offsetType: "child" | "parent" | "calculate" = "calculate",
+  withFooter: boolean = false
+) => {
   const [top, setTop] = useState(0);
 
   useEffect(() => {
@@ -31,12 +37,23 @@ const useOffsetTop = (contentRef: React.RefObject<HTMLElement>) => {
       // Note: offsetParent() will get the highest level parent with position: static;
       const parentOffset =
         contentRef.current?.offsetParent?.getBoundingClientRect().top || 0;
-      const childOffset = offset - parentOffset;
-      if (childOffset) setTop(childOffset);
+
+      let fullOffset = offset;
+      if (offsetType === "parent") fullOffset = parentOffset;
+      else if (offsetType === "calculate") fullOffset = offset - parentOffset;
+      if (withFooter) {
+        setTop(footer.getBoundingClientRect().top - fullOffset);
+      } else {
+        setTop(fullOffset);
+      }
     }, 25);
-    // set height on load
+
     calculateHeight();
-  }, [contentRef]);
+    window.addEventListener("resize", calculateHeight);
+    return () => {
+      window.removeEventListener("resize", calculateHeight);
+    };
+  }, [contentRef, offsetType, withFooter]);
 
   return top;
 };


### PR DESCRIPTION
After testing again, there are a few different ways we need to calculate the allowable area for elements in the grid view. This PR tries to merge that into a few different strategies we can reuse.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
