### PR TITLE
Add support for disable automountServiceAccountToken at template level

### DIFF
--- a/chart/newsfragments/30759.improvement.rst
+++ b/chart/newsfragments/30759.improvement.rst
@@ -1,0 +1,1 @@
+Add support from disabling automountServiceAccountToken at ServiceAccount creation

--- a/chart/templates/cleanup/cleanup-serviceaccount.yaml
+++ b/chart/templates/cleanup/cleanup-serviceaccount.yaml
@@ -21,6 +21,9 @@
 {{- if and .Values.cleanup.serviceAccount.create .Values.cleanup.enabled }}
 kind: ServiceAccount
 apiVersion: v1
+{{- if hasKey .Values.cleanup.serviceAccount "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ .Values.cleanup.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 metadata:
   name: {{ include "cleanup.serviceAccountName" . }}
   labels:

--- a/chart/templates/dag-processor/dag-processor-serviceaccount.yaml
+++ b/chart/templates/dag-processor/dag-processor-serviceaccount.yaml
@@ -22,6 +22,9 @@
 {{- if and .Values.dagProcessor.serviceAccount.create .Values.dagProcessor.enabled }}
 kind: ServiceAccount
 apiVersion: v1
+{{- if hasKey .Values.dagProcessor.serviceAccount "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ .Values.dagProcessor.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 metadata:
   name: {{ include "dagProcessor.serviceAccountName" . }}
   labels:

--- a/chart/templates/flower/flower-serviceaccount.yaml
+++ b/chart/templates/flower/flower-serviceaccount.yaml
@@ -21,6 +21,9 @@
 {{- if and .Values.flower.enabled (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")) .Values.flower.serviceAccount.create }}
 kind: ServiceAccount
 apiVersion: v1
+{{- if hasKey .Values.flower.serviceAccount "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ .Values.flower.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 metadata:
   name: {{ include "flower.serviceAccountName" . }}
   labels:

--- a/chart/templates/jobs/create-user-job-serviceaccount.yaml
+++ b/chart/templates/jobs/create-user-job-serviceaccount.yaml
@@ -21,6 +21,9 @@
 {{- if and .Values.createUserJob.serviceAccount.create .Values.webserver.defaultUser.enabled }}
 kind: ServiceAccount
 apiVersion: v1
+{{- if hasKey .Values.createUserJob.serviceAccount "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ .Values.createUserJob.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 metadata:
   name: {{ include "createUserJob.serviceAccountName" . }}
   labels:

--- a/chart/templates/jobs/migrate-database-job-serviceaccount.yaml
+++ b/chart/templates/jobs/migrate-database-job-serviceaccount.yaml
@@ -21,6 +21,9 @@
 {{- if .Values.migrateDatabaseJob.serviceAccount.create }}
 kind: ServiceAccount
 apiVersion: v1
+{{- if hasKey .Values.migrateDatabaseJob.serviceAccount "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ .Values.migrateDatabaseJob.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 metadata:
   name: {{ include "migrateDatabaseJob.serviceAccountName" . }}
   labels:

--- a/chart/templates/pgbouncer/pgbouncer-serviceaccount.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-serviceaccount.yaml
@@ -21,6 +21,9 @@
 {{- if and .Values.pgbouncer.serviceAccount.create .Values.pgbouncer.enabled }}
 kind: ServiceAccount
 apiVersion: v1
+{{- if hasKey .Values.pgbouncer.serviceAccount "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ .Values.pgbouncer.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 metadata:
   name: {{ include "pgbouncer.serviceAccountName" . }}
   labels:

--- a/chart/templates/redis/redis-serviceaccount.yaml
+++ b/chart/templates/redis/redis-serviceaccount.yaml
@@ -21,6 +21,9 @@
 {{- if and .Values.redis.enabled .Values.redis.serviceAccount.create (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")) }}
 kind: ServiceAccount
 apiVersion: v1
+{{- if hasKey .Values.redis.serviceAccount "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ .Values.redis.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 metadata:
   name: {{ include "redis.serviceAccountName" . }}
   labels:

--- a/chart/templates/scheduler/scheduler-serviceaccount.yaml
+++ b/chart/templates/scheduler/scheduler-serviceaccount.yaml
@@ -21,6 +21,9 @@
 {{- if .Values.scheduler.serviceAccount.create }}
 kind: ServiceAccount
 apiVersion: v1
+{{- if hasKey .Values.scheduler.serviceAccount "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ .Values.scheduler.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 metadata:
   name: {{ include "scheduler.serviceAccountName" . }}
   labels:

--- a/chart/templates/statsd/statsd-serviceaccount.yaml
+++ b/chart/templates/statsd/statsd-serviceaccount.yaml
@@ -21,6 +21,9 @@
 {{- if and .Values.statsd.enabled .Values.statsd.serviceAccount.create }}
 kind: ServiceAccount
 apiVersion: v1
+{{- if hasKey .Values.statsd.serviceAccount "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ .Values.statsd.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 metadata:
   name: {{ include "statsd.serviceAccountName" . }}
   labels:

--- a/chart/templates/triggerer/triggerer-serviceaccount.yaml
+++ b/chart/templates/triggerer/triggerer-serviceaccount.yaml
@@ -22,6 +22,9 @@
 {{- if and .Values.triggerer.serviceAccount.create .Values.triggerer.enabled }}
 kind: ServiceAccount
 apiVersion: v1
+{{- if hasKey .Values.triggerer.serviceAccount "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ .Values.triggerer.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 metadata:
   name: {{ include "triggerer.serviceAccountName" . }}
   labels:

--- a/chart/templates/webserver/webserver-serviceaccount.yaml
+++ b/chart/templates/webserver/webserver-serviceaccount.yaml
@@ -21,6 +21,9 @@
 {{- if .Values.webserver.serviceAccount.create }}
 kind: ServiceAccount
 apiVersion: v1
+{{- if hasKey .Values.webserver.serviceAccount "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ .Values.webserver.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 metadata:
   name: {{ include "webserver.serviceAccountName" . }}
   labels:

--- a/chart/templates/workers/worker-serviceaccount.yaml
+++ b/chart/templates/workers/worker-serviceaccount.yaml
@@ -21,6 +21,9 @@
 {{- if and .Values.workers.serviceAccount.create (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") (eq .Values.executor "KubernetesExecutor") (eq .Values.executor "LocalKubernetesExecutor")) }}
 kind: ServiceAccount
 apiVersion: v1
+{{- if hasKey .Values.worker.serviceAccount "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ .Values.worker.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 metadata:
   name: {{ include "worker.serviceAccountName" . }}
   labels:


### PR DESCRIPTION
closes: #30722
Add support to disable automountServiceAccountToken when creating ServiceAccounts via helm chart templates.

With this change you can add line below in `serviceAccount` section your `values.yaml`


```
serviceAccount:

    # Specifies whether a ServiceAccount should be created
    create: true
    # The name of the ServiceAccount to use.
    # If not set and create is true, a name is generated using the release name
    name: ~
   
    automountServiceAccountToken: false

    # Annotations to add to webserver kubernetes service account.
    annotations: { }

```

If not set in values.yaml the ServiceAccount will be created with default value for ~ `automountServiceAccountToken`, which is currently `true`
