### PR TITLE
Fix problem with displaying graph

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -197,8 +197,6 @@ def get_date_time_num_runs_dag_runs_form_data(www_request, session, dag):
     base_date = www_request.args.get("base_date")
     if base_date:
         base_date = _safe_parse_datetime(base_date)
-    elif run_id:
-        base_date = (timezone.utcnow() + datetime.timedelta(seconds=1)).replace(microsecond=0)
     else:
         # The DateTimeField widget truncates milliseconds and would loose
         # the first dag run. Round to next second.


### PR DESCRIPTION
If _run_id_ is presented in the graph URL for example: http://localhost:8080/dags/simple_dag/graph?run_id=scheduled__2023-03-14T12%3A47%3A00%2B00%3A00&execution_date=2023-03-14+12%3A47%3A00%2B00%3A00 
_query_date_ will be equal to _base_date_ which set as:
`(timezone.utcnow() + timedelta(seconds=1)).replace(microsecond=0) ` 
And drs will contain only recent _num_runs_ results which may not include _dag_run_ with desirable _execution_date_, instead of this you will have the latest one.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
