### PR TITLE
Speed up package wheel job in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -741,13 +741,52 @@ jobs:
           --package-format wheel --use-airflow-version wheel
         env:
           SKIP_CONSTRAINTS: "${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}"
-      - name: "Remove airflow whl package"
+      - name: "Fix ownership"
+        run: breeze ci fix-ownership
+        if: always()
+
+  provider-airflow-compatibility-check:
+    timeout-minutes: 80
+    name: "Providers Airflow 2.3 compatibility check"
+    runs-on: "${{needs.build-info.outputs.runs-on}}"
+    needs: [build-info, wait-for-ci-images]
+    env:
+      RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
+      PYTHON_MAJOR_MINOR_VERSION: "${{needs.build-info.outputs.default-python-version}}"
+    if: >
+      needs.build-info.outputs.image-build == 'true' && needs.build-info.outputs.default-branch == 'main'
+    steps:
+      - name: Cleanup repo
+        run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: >
+          Prepare breeze & CI image: ${{needs.build-info.outputs.default-python-version}}:${{env.IMAGE_TAG}}
+        uses: ./.github/actions/prepare_breeze_and_image
+      - name: "Cleanup dist files"
+        run: rm -fv ./dist/*
+      - name: "Prepare provider packages: wheel"
+        run: >
+          breeze release-management prepare-provider-packages --version-suffix-for-pypi dev0
+          --package-format wheel
+      - name: "Fix incompatible 2.3 provider packages"
         run: |
-          rm -vf dist/apache_airflow-*.whl
-          # remove the provider packages that are not compatible with 2.3
+          # This step should remove the provider packages that are not compatible with 2.3
+          # or replace them with 2.3 compatible versions. Sometimes we have good reasons to bump
+          # the min airflow versions for some providers and then we need to add exclusions here.
+          #
+          # The Removal can be done with:
+          #
+          # rm -vf dist/apache_airflow_providers_<PROVIDER>*.whl
+          #
+          # Then it can be followed by downloading a compatible version from PyPI in case other
+          # providers depend on it and fail with import errors (you need to download compatible version):
+          #
+          # pip download --no-deps --dest dist apache-airflow-providers-<PROVIDER>==3.1.0
+          #
           rm -vf dist/apache_airflow_providers_openlineage*.whl
-          # rm -vf dist/apache_airflow_providers_docker*.whl
-          # pip download --no-deps --dest dist apache-airflow-providers-docker==3.1.0
       - name: "Get all provider extras as AIRFLOW_EXTRAS env variable"
         # Extras might be different on S3 so rather than relying on "all" we should get the list of
         # packages to be installed from the current provider_dependencies.json file


### PR DESCRIPTION
After recent improvements, package wheel job has become one
of the longest jobs to run. So far it sequentially build airlfow,
prepared documentation for packages, build the packages
installed both airflow and packages and tested imports for them, then it
was removing installed airlfow, removed airflow and run the same tests
with 2.3 airflow version to check for compatibility.

This change splits it into two parallel jobs. There is a small
duplication (3 minutes of preparing the whl packages) but then
the "compatibility" job does not need Airflow and few other
steps to be run (such as preparing docs or airlfow) and overall
we just get few minutes longer to repeate the wheel package
preparation but then each of the two jobs will take a bit more
than half the time of the original way, which will greately improve
feedback time for the users (in most cases the two jobs will complete
under 12 minutes, where the original job needed 21 minutes to complete.

Based on #29223 so only last commit counts

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
