### PR TITLE
Use material icons for dag import error banner

### DIFF
--- a/airflow/www/static/css/flash.css
+++ b/airflow/www/static/css/flash.css
@@ -18,17 +18,11 @@
  */
 
 .panel-heading #alerts-accordion-toggle::after {
-  /* symbol for "opening" panels */
-  font-family: FontAwesome; /* stylelint-disable-line font-family-no-missing-generic-family-keyword */
-  content: "\f077";
   float: right;
   color: grey;
 }
 
 .panel-heading #alerts-accordion-toggle.collapsed::after {
-  /* symbol for "closing" panels */
-  font-family: FontAwesome; /* stylelint-disable-line font-family-no-missing-generic-family-keyword */
-  content: "\f078";
   float: right;
   color: grey;
 }
@@ -51,9 +45,6 @@
 }
 
 .dag-import-error::after {
-  /* symbol for "opening" panels */
-  font-family: FontAwesome; /* stylelint-disable-line font-family-no-missing-generic-family-keyword */
-  content: "\f078";
   float: right;
   color: #e43921;
   position: absolute;
@@ -61,7 +52,6 @@
   right: 0;
 }
 
-.dag-import-error.expanded-error::after {
-  /* symbol for "closing" panels */
-  content: "\f077";
+.expanded-error .toggle-direction {
+  transform: rotate(180deg);
 }

--- a/airflow/www/templates/appbuilder/flash.html
+++ b/airflow/www/templates/appbuilder/flash.html
@@ -55,7 +55,7 @@
           <div class="panel-body">
             {% for category, m in dag_import_errors %}
               <div class="alert alert-error">
-                <div class="dag-import-error" onclick="toggleErrorMessage.call(this)"><span class="material-icons pull-right toggle-direction" aria-hidden="true">expand_less</span>{{ m }}</div>
+                <div class="dag-import-error" onclick="toggleErrorMessage.call(this)"><span class="material-icons pull-right toggle-direction" aria-hidden="true">expand_more</span>{{ m }}</div>
               </div>
             {% endfor %}
           </div>

--- a/airflow/www/templates/appbuilder/flash.html
+++ b/airflow/www/templates/appbuilder/flash.html
@@ -41,21 +41,21 @@
   {% endif %}
 
   {% if dag_import_errors %}
-    <div class="panel-group" id="accordion">
+    <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true" style="margin-top: 16px;">
       <div class="panel panel-default">
-        <div class="panel-heading" id="errorHeading">
+        <div class="panel-heading" role="tab" id="errorHeading">
           <h4 class="panel-title">
-            <a id="alerts-accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#alerts" aria-expanded="false" class="collapsed">
+            <a role="button" data-toggle="collapse" data-parent="#accordion" href="#errorCollapse" aria-expanded="true" aria-controls="errorCollapse" class="accordion-toggle collapsed">
               <span class="text-danger"><span class="material-icons" aria-hidden="true">error</span> DAG Import Errors ({{ dag_import_errors|length }})</span>
+              <span class="material-icons pull-right toggle-direction" aria-hidden="true">expand_less</span>
             </a>
           </h4>
         </div>
-
-        <div id="alerts" class="panel-collapse collapse">
+        <div id="errorCollapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="errorHeading">
           <div class="panel-body">
             {% for category, m in dag_import_errors %}
               <div class="alert alert-error">
-                <div class="dag-import-error" onclick="toggleErrorMessage.call(this)">{{ m }}</div>
+                <div class="dag-import-error" onclick="toggleErrorMessage.call(this)"><span class="material-icons pull-right toggle-direction" aria-hidden="true">expand_less</span>{{ m }}</div>
               </div>
             {% endfor %}
           </div>


### PR DESCRIPTION
Something broke the import of font awesome icons. But we only used them in one place. Instead of putting them back in, we should just use the material icons we already exist across the UI.

Before:
<img width="1107" alt="Screenshot 2023-04-20 at 12 02 33 PM" src="https://user-images.githubusercontent.com/4600967/233423992-e941a528-e158-4511-93be-bec990f8bb64.png">


After:
<img width="1088" alt="Screenshot 2023-04-20 at 1 07 25 PM" src="https://user-images.githubusercontent.com/4600967/233438354-cdafe5f2-11f1-4cda-8905-f1138edd7511.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
