### PR TITLE
Add postgres_conn_id to template fields in PostgresOperator

### DIFF
--- a/airflow/providers/postgres/operators/postgres.py
+++ b/airflow/providers/postgres/operators/postgres.py
@@ -42,7 +42,7 @@ class PostgresOperator(SQLExecuteQueryOperator):
         For example, you could set the schema via `{"search_path": "CUSTOM_SCHEMA"}`.
     """
 
-    template_fields: Sequence[str] = ("sql",)
+    template_fields: Sequence[str] = ("sql", "postgres_conn_id")
     template_fields_renderers = {"sql": "postgresql"}
     template_ext: Sequence[str] = (".sql",)
     ui_color = "#ededed"


### PR DESCRIPTION
Add `postgres_conn_id` to the template fields for the `PostgresOperator`

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
