### PR TITLE
Add pod status phase to KPO test mock, otherwise the test will not be valid

### DIFF
--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -1096,7 +1096,7 @@ class TestKubernetesPodOperator:
             ({"skip_on_exit_code": (100, 101)}, 100, AirflowSkipException),
             ({"skip_on_exit_code": 100}, 101, AirflowException),
             ({"skip_on_exit_code": [100, 102]}, 101, AirflowException),
-            ({"skip_on_exit_code": None}, 0, AirflowException),
+            ({"skip_on_exit_code": None}, 0, None),
         ],
     )
     @patch(f"{POD_MANAGER_CLASS}.await_pod_completion")
@@ -1115,6 +1115,7 @@ class TestKubernetesPodOperator:
         sidecar_container.name = "airflow-xcom-sidecar"
         sidecar_container.last_state.terminated.exit_code = 0
         remote_pod.return_value.status.container_statuses = [base_container, sidecar_container]
+        remote_pod.return_value.status.phase = "Succeeded" if actual_exit_code == 0 else "Failed"
 
         if expected_exc is None:
             self.run_pod(k)


### PR DESCRIPTION
related: #30769

Add `Succeeded` and `Failed` pod status phases to `KubernetesPodOperator` test mock, otherwise the test will not be valid.

cc: @eladkal @potiuk 
