### PR TITLE
Add repair job functionality to databricks hook

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -44,6 +44,7 @@ SUBMIT_RUN_ENDPOINT = ("POST", "api/2.1/jobs/runs/submit")
 GET_RUN_ENDPOINT = ("GET", "api/2.1/jobs/runs/get")
 CANCEL_RUN_ENDPOINT = ("POST", "api/2.1/jobs/runs/cancel")
 DELETE_RUN_ENDPOINT = ("POST", "api/2.1/jobs/runs/delete")
+REPAIR_RUN_ENDPOINT = ("POST", "api/2.1/jobs/runs/repair")
 OUTPUT_RUNS_JOB_ENDPOINT = ("GET", "api/2.1/jobs/runs/get-output")
 
 INSTALL_LIBS_ENDPOINT = ("POST", "api/2.0/libraries/install")
@@ -360,6 +361,14 @@ class DatabricksHook(BaseDatabricksHook):
         """
         json = {"run_id": run_id}
         self._do_api_call(DELETE_RUN_ENDPOINT, json)
+
+    def repair_run(self, json: dict) -> None:
+        """
+        Re-run one or more tasks.
+
+        :param json: repair a job run.
+        """
+        self._do_api_call(REPAIR_RUN_ENDPOINT, json)
 
     def restart_cluster(self, json: dict) -> None:
         """

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -150,6 +150,13 @@ def delete_run_endpoint(host):
     return f"https://{host}/api/2.1/jobs/runs/delete"
 
 
+def repair_run_endpoint(host):
+    """
+    Utility function to generate delete run endpoint given the host.
+    """
+    return f"https://{host}/api/2.1/jobs/runs/repair"
+
+
 def start_cluster_endpoint(host):
     """
     Utility function to generate the get run endpoint given the host.
@@ -537,6 +544,37 @@ class TestDatabricksHook:
         mock_requests.post.assert_called_once_with(
             delete_run_endpoint(HOST),
             json={"run_id": RUN_ID},
+            params=None,
+            auth=HTTPBasicAuth(LOGIN, PASSWORD),
+            headers=self.hook.user_agent_header,
+            timeout=self.hook.timeout_seconds,
+        )
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests")
+    def test_repair_run(self, mock_requests):
+        mock_requests.post.return_value.json.return_value = {"repair_id": 734650698524280}
+        json = (
+            {
+                "run_id": 455644833,
+                "rerun_tasks": ["task0", "task1"],
+                "latest_repair_id": 734650698524280,
+                "rerun_all_failed_tasks": False,
+                "jar_params": ["john", "doe", "35"],
+                "notebook_params": {"name": "john doe", "age": "35"},
+                "python_params": ["john doe", "35"],
+                "spark_submit_params": ["--class", "org.apache.spark.examples.SparkPi"],
+                "python_named_params": {"name": "task", "data": "dbfs:/path/to/data.json"},
+                "pipeline_params": {"full_refresh": True},
+                "sql_params": {"name": "john doe", "age": "35"},
+                "dbt_commands": ["dbt deps", "dbt seed", "dbt run"],
+            },
+        )
+
+        self.hook.repair_run(json)
+
+        mock_requests.post.assert_called_once_with(
+            repair_run_endpoint(HOST),
+            json=json,
             params=None,
             auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=self.hook.user_agent_header,


### PR DESCRIPTION
Closes: #29250 

This PR adds repair job functionality to databricks hook in order to be able to repair and resubmit Databricks jobs from Airflow

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
