### PR TITLE
feat(airflow-API): add logical_date to list of allowed field to sort …

### DIFF
--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -176,6 +176,7 @@ def _fetch_dag_runs(
         "updated_at",
         "external_trigger",
         "conf",
+        "logical_date",
     ]
     query = apply_sorting(query, order_by, to_replace, allowed_filter_attrs)
     return query.offset(offset).limit(limit).all(), total_entries


### PR DESCRIPTION
…result

Official documentation mention that for this [endpoint](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#operation/get_dag_runs_batch).
You should be able to sort using fields of the returned DagRuns like `logical_date` that is (if I understand correctly) "The logical date (previously called execution date). This is the time or interval covered by this DAG run, according to the DAG definition." what we want to use.
 But there is an hardcoded filter in the code and if you sort using `logical_date` you get this response
responses {'detail': "Ordering with 'logical_date' is disallowed or the attribute does not exist on the model", 'status': 400, 'title': 'Bad Request', 'type': 'https://airflow.apache.org/docs/apache-airflow/2.5.2/stable-rest-api-ref.html#section/Errors/BadRequest'}.
So I added the field in the API after checking that is was present in the json returned.