### PR TITLE
restore fallback to empty connection behavior

### DIFF
--- a/airflow/providers/amazon/CHANGELOG.rst
+++ b/airflow/providers/amazon/CHANGELOG.rst
@@ -38,8 +38,6 @@ Breaking changes
 
   Removed deprecated parameter ``max_tries`` from the Athena & EMR hook & operators in favor of ``max_polling_attempts``.
 
-  Disabled deprecated behavior of switching to an empty aws connection ID on error. You can set it to None explicitly.
-
   Removed deprecated method ``waiter`` from emr hook in favor of the more generic ``airflow.providers.amazon.aws.utils.waiter.waiter``
 
   Removed deprecated unused parameter ``cluster_identifier`` from Redshift Cluster's hook method ``get_cluster_snapshot_status``


### PR DESCRIPTION
this was removed as part of a big PR (#30755) to get rid of all old code that was marked obsolete, but this specific thing is pretty tricky to fix if it breaks customer code.

Also, doing this fallback does not prevent us from moving forward with other things, so I think we should better keep it around, and even not treat it as a deprecated behavior.