### PR TITLE
Fix removed delegate_to parameter in deferrable GCS sensor

### DIFF
--- a/airflow/providers/google/cloud/sensors/gcs.py
+++ b/airflow/providers/google/cloud/sensors/gcs.py
@@ -235,7 +235,6 @@ class GCSObjectUpdateSensor(BaseSensorOperator):
                     poke_interval=self.poke_interval,
                     google_cloud_conn_id=self.google_cloud_conn_id,
                     hook_params={
-                        "delegate_to": self.delegate_to,
                         "impersonation_chain": self.impersonation_chain,
                     },
                 ),


### PR DESCRIPTION
Two PRs crossed and the result of #30748 caused the #30579 to fail as delegate_to parameter has been removed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
