### PR TITLE
Fix dev index building for suspended providers

### DIFF
--- a/docs/exts/docs_build/dev_index_generator.py
+++ b/docs/exts/docs_build/dev_index_generator.py
@@ -58,7 +58,7 @@ def _render_content():
             )
             providers.append(current_provider)
         except StopIteration:
-            raise Exception(f"Could not find provider.yaml file for package: {package_name}")
+            print(f"WARNING! Could not find provider.yaml file for package: {package_name}")
 
     content = _render_template(
         "dev_index_template.html.jinja2", providers=sorted(providers, key=lambda k: k["package-name"])


### PR DESCRIPTION
This is a follow-up after #30422 and #30763 - it turns out that locally building index of providers failed when some providers are suspended. It only impacts dev workflow locally.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
