### PR TITLE
Fix XCom deserialization when it contains nonprimitive values

### DIFF
--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -202,7 +202,9 @@ def deserialize(o: T | None, full=True, type_hint: Any = None) -> object:
         return col
 
     if not isinstance(o, dict):
-        raise TypeError()
+        # if o is not a dict, then it's already deserialized
+        # in this case we should return it as is
+        return o
 
     o = _convert(o)
 

--- a/tests/utils/test_json.py
+++ b/tests/utils/test_json.py
@@ -23,6 +23,7 @@ from datetime import date, datetime
 from typing import ClassVar
 
 import numpy as np
+import pandas
 import pendulum
 import pytest
 
@@ -71,6 +72,12 @@ class TestXComEncoder:
         s = json.dumps(dataset, cls=utils_json.XComEncoder)
         obj = json.loads(s, cls=utils_json.XComDecoder)
         assert dataset.uri == obj.uri
+
+    def test_encode_xcom_with_nested_dict_pandas(self):
+        data = ({"foo": 1, "bar": 2, "baz": pandas.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})},)
+        s = json.dumps(data, cls=utils_json.XComEncoder)
+        obj = json.loads(s, cls=utils_json.XComDecoder)
+        assert data == obj
 
     def test_orm_deserialize(self):
         x = 14


### PR DESCRIPTION
closes: #30797
related: #30798

Fix XCom deserialization when the serialized XCom contains nonprimitive values. The problem is that the deserialization is done by recursion on the different depth, and when we reach the last depth, we raise an exception instead of returning the deserialized value.

We don't need to check the validity of the data because they are serialized by Airflow. The deserialize method should revert the serialized data without any issue.