### PR TITLE
Improve Quick Start instructions

### DIFF
--- a/docs/apache-airflow/start.rst
+++ b/docs/apache-airflow/start.rst
@@ -42,7 +42,7 @@ constraint files to enable reproducible installation, so using ``pip`` and const
 
 1. Set Airflow Home (optional):
 
-   Airflow requires a home directory, and uses `~/airflow` by default, but you can set a different location if you prefer. The `AIRFLOW_HOME` environment variable is used to inform Airflow of the desired location. This step of setting the environment variable should be done before installing Airflow so that the installation process knows where to store the necessary files.
+   Airflow requires a home directory, and uses ``~/airflow`` by default, but you can set a different location if you prefer. The ``AIRFLOW_HOME`` environment variable is used to inform Airflow of the desired location. This step of setting the environment variable should be done before installing Airflow so that the installation process knows where to store the necessary files.
 
    .. code-block:: bash
 
@@ -66,7 +66,7 @@ constraint files to enable reproducible installation, so using ``pip`` and const
 
 3. Run Airflow Standalone:
 
-   The `airflow standalone` command initializes the database, creates a user, and starts all components.
+   The ``airflow standalone`` command initializes the database, creates a user, and starts all components.
 
    .. code-block:: bash
 
@@ -74,7 +74,7 @@ constraint files to enable reproducible installation, so using ``pip`` and const
 
 4. Access the Airflow UI:
 
-   Visit `localhost:8080` in your browser and log in with the admin account details shown in the terminal. Enable the `example_bash_operator` DAG in the home page.
+   Visit ``localhost:8080`` in your browser and log in with the admin account details shown in the terminal. Enable the ``example_bash_operator`` DAG in the home page.
 
 Upon running these commands, Airflow will create the ``$AIRFLOW_HOME`` folder
 and create the "airflow.cfg" file with defaults that will get you going fast.

--- a/docs/apache-airflow/start.rst
+++ b/docs/apache-airflow/start.rst
@@ -40,28 +40,41 @@ This quick start guide will help you bootstrap an Airflow standalone instance on
 The installation of Airflow is painless if you follow the instructions below. Airflow uses
 constraint files to enable reproducible installation, so using ``pip`` and constraint files is recommended.
 
-.. code-block:: bash
-    :substitutions:
+1. Set Airflow Home (optional):
 
-    # Airflow needs a home. `~/airflow` is the default, but you can put it
-    # somewhere else if you prefer (optional)
-    export AIRFLOW_HOME=~/airflow
+   Airflow requires a home directory, and uses `~/airflow` by default, but you can set a different location if you prefer. The `AIRFLOW_HOME` environment variable is used to inform Airflow of the desired location. This step of setting the environment variable should be done before installing Airflow so that the installation process knows where to store the necessary files.
 
-    # Install Airflow using the constraints file
-    AIRFLOW_VERSION=|version|
-    PYTHON_VERSION="$(python --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
-    # For example: 3.7
-    CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt"
-    # For example: https://raw.githubusercontent.com/apache/airflow/constraints-|version|/constraints-3.7.txt
-    pip install "apache-airflow==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
+   .. code-block:: bash
 
-    # The Standalone command will initialise the database, make a user,
-    # and start all components for you.
-    airflow standalone
+      export AIRFLOW_HOME=~/airflow
 
-    # Visit localhost:8080 in the browser and use the admin account details
-    # shown on the terminal to login.
-    # Enable the example_bash_operator DAG in the home page
+2. Install Airflow using the constraints file, which is determined based on the URL we pass:
+
+   .. code-block:: bash
+      :substitutions:
+
+
+      AIRFLOW_VERSION=|version|
+
+      # Extract the version of Python you have installed. If you're currently using Python 3.11 you may want to set this manually as noted above, Python 3.11 is not yet supported.
+      PYTHON_VERSION="$(python --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
+
+      CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt"
+      # For example this would install |version| with python 3.7: https://raw.githubusercontent.com/apache/airflow/constraints-|version|/constraints-3.7.txt
+
+      pip install "apache-airflow==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
+
+3. Run Airflow Standalone:
+
+   The `airflow standalone` command initializes the database, creates a user, and starts all components.
+
+   .. code-block:: bash
+
+      airflow standalone
+
+4. Access the Airflow UI:
+
+   Visit `localhost:8080` in your browser and log in with the admin account details shown in the terminal. Enable the `example_bash_operator` DAG in the home page.
 
 Upon running these commands, Airflow will create the ``$AIRFLOW_HOME`` folder
 and create the "airflow.cfg" file with defaults that will get you going fast.


### PR DESCRIPTION
For context, I'm a pretty new developer, but I personally had a bit of a hard time parsing the [Quick Start](https://airflow.apache.org/docs/apache-airflow/stable/start.html) instructions with them in one giant code block and instead thought they were actually some sort of configuration file. 

![image](https://user-images.githubusercontent.com/85081861/232335344-a1828b47-9657-423f-8be5-ac38375e2bc9.png)

The four changes that I'm suggesting in this all relate to the instructions found in the code block, they are - 

1. Breaking the code block up by step

2. Including a note about setting the AIRFLOW_HOME variable before installation. This is pretty small but I think was part of what contributed to me being confused that this is not a config file as I'm not too used to setting environment variables for an application I haven't installed before.

3. On step two, making a note/more explicit how the URL and constraint file ties together. That language of "Install Airflow using the constraints file", once I understood what was happening made total sense, but having the text be a bit more verbose would have saved me some time. My understanding at this time, which could be wrong (in which case I think that text still needs to be updated) is that our URL being passed will determine what constraint file to use.

4. Making a note that the PYTHON_VERSION is being extracted as well as setting it manually if the user is running python 3.11 on their machine.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
