### PR TITLE
Update the error message for invalid use of poke-only sensors

### DIFF
--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -322,7 +322,7 @@ def poke_mode_only(cls):
 
         def mode_setter(_, value):
             if value != "poke":
-                raise ValueError("cannot set mode to 'poke'.")
+                raise ValueError(f"Cannot set mode to '{value}'. Only 'poke' is acceptable")
 
         if not issubclass(cls_type, BaseSensorOperator):
             raise ValueError(

--- a/tests/sensors/test_base.py
+++ b/tests/sensors/test_base.py
@@ -862,14 +862,14 @@ class TestPokeModeOnly:
 
     def test_poke_mode_only_bad_class_method(self):
         sensor = DummyPokeOnlySensor(task_id="foo", mode="poke", poke_changes_mode=False)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Cannot set mode to 'reschedule'. Only 'poke' is acceptable"):
             sensor.change_mode("reschedule")
 
     def test_poke_mode_only_bad_init(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Cannot set mode to 'reschedule'. Only 'poke' is acceptable"):
             DummyPokeOnlySensor(task_id="foo", mode="reschedule", poke_changes_mode=False)
 
     def test_poke_mode_only_bad_poke(self):
         sensor = DummyPokeOnlySensor(task_id="foo", mode="poke", poke_changes_mode=True)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Cannot set mode to 'reschedule'. Only 'poke' is acceptable"):
             sensor.poke({})


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Update the error message in the assertion thrown when there's an attempt to change the mode of a poke-only sensor.

A minor change, but it's something that caused me to do a double-take while writing a DAG. So thought I'd submit a patch 😄 

