### PR TITLE
Optimize away pytest collection steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,6 +547,7 @@ jobs:
           DEBUG_RESOURCES: ${{needs.build-info.outputs.debug-resources}}
       - name: "Tests Pytest collection"
         run: breeze testing tests --run-in-parallel --collect-only
+        if: needs.build-info.outputs.run-tests == 'true'
         env:
           PYTHON_MAJOR_MINOR_VERSION: "${{needs.build-info.outputs.default-python-version}}"
           BACKEND: sqlite
@@ -964,6 +965,7 @@ jobs:
         run: breeze testing tests --run-in-parallel
       - name: "Tests ARM Pytest collection: ${{matrix.python-version}}"
         run: breeze testing tests --run-in-parallel --collect-only --remove-arm-packages
+        if: matrix.postgres-version == needs.build-info.outputs.default-postgres-version
       - name: "Post Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         uses: ./.github/actions/post_tests
 
@@ -1097,9 +1099,6 @@ jobs:
         uses: ./.github/actions/migration_tests
       - name: "Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         run: breeze testing tests --run-in-parallel
-      - name: "Tests ARM Pytest collection: ${{matrix.python-version}}"
-        if: env.MYSQL_VERSION != '5.7'
-        run: breeze testing tests --run-in-parallel --collect-only --remove-arm-packages
       - name: "Post Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         uses: ./.github/actions/post_tests
 
@@ -1183,8 +1182,6 @@ jobs:
         uses: ./.github/actions/migration_tests
       - name: "Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         run: breeze testing tests --run-in-parallel
-      - name: "Tests ARM Pytest collection: ${{matrix.python-version}}"
-        run: breeze testing tests --run-in-parallel --collect-only --remove-arm-packages
       - name: "Post Tests: ${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types}}"
         uses: ./.github/actions/post_tests
 


### PR DESCRIPTION
The Pytest collection steps are only needed if there are any tests about to be run. There are cases where we build CI images but we do not expect to run any tests (for doc-only changes). This should save about 3 minutes of build time.

Also ARM pytest collection should only be executed once for every build after all "regular" tests passed - there is no need to run them for different backends/versions. It is enough to run them for default single backend version (Postgres).

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
