### PR TITLE
Only run mssql tests on self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1127,7 +1127,7 @@ jobs:
       BACKEND_VERSION: "${{matrix.mssql-version}}"
       JOB_ID: "mssql-${{matrix.mssql-version}}-${{matrix.python-version}}"
       COVERAGE: "${{needs.build-info.outputs.run-coverage}}"
-    if: needs.build-info.outputs.run-tests == 'true'
+    if: needs.build-info.outputs.run-tests == 'true' && needs.build-info.outputs.runs-on == 'self-hosted'
     steps:
       - name: Cleanup repo
         shell: bash
@@ -1334,7 +1334,6 @@ jobs:
       - tests-postgres
       - tests-sqlite
       - tests-mysql
-      - tests-mssql
       - tests-quarantined
       - tests-integration-postgres
       - tests-integration-mysql
@@ -1499,7 +1498,6 @@ jobs:
       - static-checks
       - tests-sqlite
       - tests-mysql
-      - tests-mssql
       - tests-postgres
       - tests-integration-postgres
       - tests-integration-mysql
@@ -1662,7 +1660,6 @@ jobs:
       - static-checks
       - tests-sqlite
       - tests-mysql
-      - tests-mssql
       - tests-postgres
       - tests-integration-postgres
       - tests-integration-mysql


### PR DESCRIPTION
The MSSQL tests are rather flaky on public runners. They also almost never bring any extra value when fail usually those are flaky behaviour of MSSQL database for those runners due to resource constraints.

This PR changes MSSQL tests to be only run for self-hosted runners, which means that they will be run for PRs of committers and in canary builds.

This should be enough to find out potentially mssql-only breaking changes and fix them - without disturbing regular contributors.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
