### PR TITLE
Adding asgiref requirement back into the Kafka provider docs

### DIFF
--- a/docs/apache-airflow-providers-apache-kafka/index.rst
+++ b/docs/apache-airflow-providers-apache-kafka/index.rst
@@ -90,6 +90,7 @@ Requirements
 PIP package          Version required
 ===================  ==================
 ``apache-airflow``   ``>=2.3.0``
+``asgiref``
 ``confluent-kafka``  ``>=1.8.2``
 ===================  ==================
 


### PR DESCRIPTION
I was too trigger happy with deleting duplicated content, adding `asgiref` back into the Kafka docs as a requirement, thanks and sorry @dylanbstorey.  

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
