### PR TITLE
Add broad-strokes 'security model'

### DIFF
--- a/.github/SECURITY.rst
+++ b/.github/SECURITY.rst
@@ -15,6 +15,21 @@
     specific language governing permissions and limitations
     under the License.
 
+Security Model
+--------------
+
+In the Airflow security model, the system administrators are fully trusted.
+They are the only ones who can upload new DAGs, which gives them the ability
+to execute any code on the server.
+
+Authenticated web interface and API users with Admin/Op permissions are trusted,
+but to a lesser extent: they can configure the DAGs which gives them some control,
+but not arbitrary code execution.
+
+Authenticated Web interface and API users with 'regular' permissions are trusted
+to the point where they can impact resource consumption and pause/unpause configured DAGs,
+but not otherwise influence their functionality.
+
 Reporting Vulnerabilities
 -------------------------
 


### PR DESCRIPTION
Add a broad-strokes description of the security expectations operator should expect. This will get included into https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/security/index.html

I'm no Airflow expert so help definitely welcome.

I would like this section to be a bit more prominent rather than hidden away under 'Administration and Deployment', but it looks like the structure was carefully considered in https://github.com/apache/airflow/pull/27235 so this is probably fine.

Eventually we could point the 'Security' link on the main pages like https://airflow.apache.org/ to this page.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
