### PR TITLE
Update AWS EMR Cluster Link to use the new dashboard

### DIFF
--- a/airflow/providers/amazon/aws/links/emr.py
+++ b/airflow/providers/amazon/aws/links/emr.py
@@ -24,9 +24,7 @@ class EmrClusterLink(BaseAwsLink):
 
     name = "EMR Cluster"
     key = "emr_cluster"
-    format_str = (
-        BASE_AWS_CONSOLE_LINK + "/elasticmapreduce/home?region={region_name}#cluster-details:{job_flow_id}"
-    )
+    format_str = BASE_AWS_CONSOLE_LINK + "/emr/home?region={region_name}#/clusterDetails/{job_flow_id}"
 
 
 class EmrLogsLink(BaseAwsLink):

--- a/tests/providers/amazon/aws/links/test_links.py
+++ b/tests/providers/amazon/aws/links/test_links.py
@@ -65,8 +65,7 @@ AWS_LINKS = [
     (
         EmrClusterLink,
         {"job_flow_id": "j-TEST-FLOW-ID"},
-        f"https://console.{AWS_DOMAIN}/elasticmapreduce/home?region={REGION_NAME}"
-        f"#cluster-details:j-TEST-FLOW-ID",
+        f"https://console.{AWS_DOMAIN}/emr/home?region={REGION_NAME}#/clusterDetails/j-TEST-FLOW-ID",
     ),
     (
         CloudWatchEventsLink,


### PR DESCRIPTION
AWS has deprecated the EMR console located at `/elasticmapreduce/` in favour of a new one, hosted at `/emr/`

This updates the URL generated by the AWS Operator link to use the new dashboard.

Link to AWS Documentation for the changed URL:
https://docs.aws.amazon.com/emr/latest/ManagementGuide/whats-new-in-console.html

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
