### PR TITLE
Fail ARM image preparation when instance cannot be started

### DIFF
--- a/scripts/ci/images/ci_start_arm_instance_and_connect_to_docker.sh
+++ b/scripts/ci/images/ci_start_arm_instance_and_connect_to_docker.sh
@@ -20,7 +20,7 @@ SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 WORKING_DIR="/tmp/armdocker"
 INSTANCE_INFO="${WORKING_DIR}/instance_info.json"
 ARM_AMI="ami-0e43196369d299715"  # AMI ID of latest arm-docker-ami-v*
-INSTANCE_TYPE="m6g.xlarge"  # m6g.xlarge -> 4 vCPUS 16 GB RAM
+INSTANCE_TYPE="m6g.2xlarge"  # m6g.2xlarge -> 8 vCPUS 32 GB RAM
 MARKET_OPTIONS="MarketType=spot,SpotOptions={MaxPrice=0.25,SpotInstanceType=one-time}"
 REGION="us-east-2"
 EC2_USER="ec2-user"
@@ -45,6 +45,10 @@ function start_arm_instance() {
         > "${INSTANCE_INFO}"
 
     INSTANCE_ID=$(jq < "${INSTANCE_INFO}" ".Instances[0].InstanceId" -r)
+    if [[ ${INSTANCE_ID} == "" ]]; then
+        echo "ERROR!!!! Failed to start ARM instance. Likely because it could not be allocated on spot market."
+        exit 1
+    fi
     AVAILABILITY_ZONE=$(jq < "${INSTANCE_INFO}" ".Instances[0].Placement.AvailabilityZone" -r)
     aws ec2 wait instance-status-ok --instance-ids "${INSTANCE_ID}"
     INSTANCE_PRIVATE_DNS_NAME=$(aws ec2 describe-instances \


### PR DESCRIPTION
When an ARM instance cannot be started - because most likely, the request cannot be fulfilled, we fail the job. This is better than trying to run in emulation mode

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
