### PR TITLE
Fix async conn for none aws_session_token

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -138,9 +138,9 @@ class BaseSessionFactory(LoggingMixin):
             or self.conn.session_kwargs.get("aws_session_token", None)
         ):
             session.set_credentials(
-                self.conn.session_kwargs["aws_access_key_id"],
-                self.conn.session_kwargs["aws_secret_access_key"],
-                self.conn.session_kwargs["aws_session_token"],
+                access_key=self.conn.session_kwargs.get("aws_access_key_id"),
+                secret_key=self.conn.session_kwargs.get("aws_secret_access_key"),
+                token=self.conn.session_kwargs.get("aws_session_token"),
             )
 
         if self.conn.session_kwargs.get("region_name", None) is not None:

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -246,6 +246,25 @@ class TestSessionFactory:
 
         assert session_profile == profile_name
 
+    @pytest.mark.asyncio
+    async def test_async_create_a_session_from_credentials_without_token(self):
+        mock_conn = Connection(
+            conn_type=MOCK_CONN_TYPE,
+            conn_id=MOCK_AWS_CONN_ID,
+            extra={
+                "aws_access_key_id": "test_aws_access_key_id",
+                "aws_secret_access_key": "test_aws_secret_access_key",
+                "region_name": "eu-central-1",
+            },
+        )
+        mock_conn_config = AwsConnectionWrapper(conn=mock_conn)
+        sf = BaseSessionFactory(conn=mock_conn_config, config=None)
+        async_session = sf.create_session(deferrable=True)
+        cred = await async_session.get_credentials()
+        assert cred.access_key == "test_aws_access_key_id"
+        assert cred.secret_key == "test_aws_secret_access_key"
+        assert cred.token is None
+
     config_for_credentials_test = [
         (
             "assume-with-initial-creds",


### PR DESCRIPTION
currently, if I'm using AWS async conn without `aws_session_token` in my extra it fails with below error
```
    async with hook.async_conn as client:
  File "/opt/***/***/providers/amazon/aws/hooks/base_aws.py", line 659, in async_conn
    return self.get_client_type(region_name=self.region_name, deferrable=True)
  File "/opt/***/***/providers/amazon/aws/hooks/base_aws.py", line 605, in get_client_type
    session = self.get_session(region_name=region_name, deferrable=deferrable)
  File "/opt/***/***/providers/amazon/aws/hooks/base_aws.py", line 578, in get_session
    ).create_session(deferrable=deferrable)
  File "/opt/***/***/providers/amazon/aws/hooks/base_aws.py", line 171, in create_session
    self._apply_session_kwargs(session)
  File "/opt/***/***/providers/amazon/aws/hooks/base_aws.py", line 143, in _apply_session_kwargs
    self.conn.session_kwargs["aws_session_token"],
```

here, I'm changing to get `aws_session_token` value using `get` on dic and not indexing

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
