### PR TITLE
Fix KubernetesExecutor sending state to scheduler

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -779,7 +779,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # but that is handled by the zombie detection.
 
             ti_queued = ti.try_number == buffer_key.try_number and ti.state == TaskInstanceState.QUEUED
-            ti_requeued = ti.queued_by_job_id != self.job.id or self.job.executor.has_task(ti)
+            ti_requeued = (
+                ti.queued_by_job_id != self.job.id  # Another scheduler has queued this task again
+                or self.job.executor.has_task(ti)  # This scheduler has this task already
+            )
 
             if ti_queued and not ti_requeued:
                 Stats.incr(


### PR DESCRIPTION
It turns out the event_buffer expects the TI state, not the worker state. This changes KE to sending the proper state back to the scheduler job.

Related: #28871