### PR TITLE
[AIP-49] Add Otel Framework and implement Counters

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1027,6 +1027,13 @@ metrics:
       type: integer
       example: ~
       default: "60000"
+    otel_debugging_on:
+      description: |
+        If True, all metrics are also emitted to the console.  Defaults to False.
+      version_added: 2.5.1
+      type: string
+      example: ~
+      default: "False"
 secrets:
   description: ~
   options:

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1030,7 +1030,7 @@ metrics:
     otel_debugging_on:
       description: |
         If True, all metrics are also emitted to the console.  Defaults to False.
-      version_added: 2.5.1
+      version_added: 2.7.0
       type: string
       example: ~
       default: "False"

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -558,6 +558,9 @@ otel_port = 8889
 otel_prefix = airflow
 otel_interval_milliseconds = 60000
 
+# If True, all metrics are also emitted to the console.  Defaults to False.
+otel_debugging_on = False
+
 [secrets]
 # Full class name of secrets backend to enable (will precede env vars and metastore in search path)
 # Example: backend = airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend

--- a/airflow/jobs/local_task_job_runner.py
+++ b/airflow/jobs/local_task_job_runner.py
@@ -299,3 +299,13 @@ class LocalTaskJobRunner(BaseJobRunner["Job | JobPydantic"], LoggingMixin):
             "local_task_job.task_exit."
             f"{self.job.id}.{self.task_instance.dag_id}.{self.task_instance.task_id}.{return_code}"
         )
+        # Same metric with tagging
+        Stats.incr(
+            "local_task_job.task_exit",
+            tags={
+                "job_id": self.job.id,
+                "dag_id": self.task_instance.dag_id,
+                "task_id": self.task_instance.task_id,
+                "return_code": return_code,
+            },
+        )

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -584,6 +584,8 @@ class SchedulerJobRunner(BaseJobRunner[Job], LoggingMixin):
 
         for pool_name, num_starving_tasks in pool_num_starving_tasks.items():
             Stats.gauge(f"pool.starving_tasks.{pool_name}", num_starving_tasks)
+            # Same metric with tagging
+            Stats.gauge("pool.starving_tasks", num_starving_tasks, tags={"pool_name": pool_name})
 
         Stats.gauge("scheduler.tasks.starving", num_starving_tasks_total)
         Stats.gauge("scheduler.tasks.executable", len(executable_tis))
@@ -1561,7 +1563,7 @@ class SchedulerJobRunner(BaseJobRunner[Job], LoggingMixin):
             Stats.gauge(f"pool.open_slots.{pool_name}", slot_stats["open"])
             Stats.gauge(f"pool.queued_slots.{pool_name}", slot_stats["queued"])
             Stats.gauge(f"pool.running_slots.{pool_name}", slot_stats["running"])
-            # tagged metrics
+            # Same metrics with tagging
             Stats.gauge("pool.open_slots", slot_stats["open"], tags={"pool_name": pool_name})
             Stats.gauge("pool.queued_slots", slot_stats["queued"], tags={"pool_name": pool_name})
             Stats.gauge("pool.running_slots", slot_stats["running"], tags={"pool_name": pool_name})

--- a/airflow/metrics/base_stats_logger.py
+++ b/airflow/metrics/base_stats_logger.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from airflow.metrics.protocols import DeltaType, Timer, TimerProtocol
 from airflow.typing_compat import Protocol
 
@@ -31,7 +33,7 @@ class StatsLogger(Protocol):
         count: int = 1,
         rate: int | float = 1,
         *,
-        tags: dict[str, str] | None = None,
+        tags: dict[str, Any] | None = None,
     ) -> None:
         """Increment stat."""
 
@@ -42,7 +44,7 @@ class StatsLogger(Protocol):
         count: int = 1,
         rate: int | float = 1,
         *,
-        tags: dict[str, str] | None = None,
+        tags: dict[str, Any] | None = None,
     ) -> None:
         """Decrement stat."""
 
@@ -54,7 +56,7 @@ class StatsLogger(Protocol):
         rate: int | float = 1,
         delta: bool = False,
         *,
-        tags: dict[str, str] | None = None,
+        tags: dict[str, Any] | None = None,
     ) -> None:
         """Gauge stat."""
 
@@ -64,7 +66,7 @@ class StatsLogger(Protocol):
         stat: str,
         dt: DeltaType | None,
         *,
-        tags: dict[str, str] | None = None,
+        tags: dict[str, Any] | None = None,
     ) -> None:
         """Stats timing."""
 

--- a/airflow/metrics/otel_logger.py
+++ b/airflow/metrics/otel_logger.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import logging
+import random
 import warnings
 from typing import Callable
 
@@ -64,20 +65,21 @@ class SafeOtelLogger:
 
         :param stat: The name of the stat to increment.
         :param count: A positive integer to add to the current value of stat.
-        :param rate: TODO: define me
+        :param rate: Value between 0 and 1 representing the "percentage" of
+            the time to emit the metric where 1 = 100%.
         :param tags: Tags to append to the stat.
         :param back_compat_name: If possible, the metric will also be emitted
             under this name for backward compatibility.
         """
         if (count < 0) or (rate < 0):
             raise ValueError("count and rate must both be positive values.")
-        # TODO: I don't think this is the right use for rate???
-        value = count * rate
+        if rate < 1 and random.random() > rate:
+            return
 
         for name in prune_dict({stat, back_compat_name}, mode="truthy"):
             if self.metrics_validator.test(name):
                 counter = self.metrics_map.get_counter(f"{self.prefix}.{name}")
-                counter.add(value, attributes=tags)
+                counter.add(count, attributes=tags)
 
         return self.metrics_map.get_counter(f"{self.prefix}.{stat}")
 
@@ -90,20 +92,21 @@ class SafeOtelLogger:
 
         :param stat: The name of the stat to decrement.
         :param count: A positive integer to subtract from current value of stat.
-        :param rate: TODO: define me
+        :param rate: Value between 0 and 1 representing the "percentage" of
+            the time to emit the metric where 1 = 100%.
         :param tags: Tags to append to the stat.
         :param back_compat_name: If possible, the metric will also be emitted
             under this name for backward compatibility.
         """
         if (count < 0) or (rate < 0):
             raise ValueError("count and rate must both be positive values.")
-        # TODO: I don't think this is the right use for rate???
-        value = count * rate
+        if rate < 1 and random.random() > rate:
+            return
 
         for name in prune_dict({stat, back_compat_name}, mode="truthy"):
             if self.metrics_validator.test(name):
                 counter = self.metrics_map.get_counter(f"{self.prefix}.{name}")
-                counter.add(-value, attributes=tags)
+                counter.add(count, attributes=tags)
 
         return self.metrics_map.get_counter(f"{self.prefix}.{stat}")
 

--- a/airflow/metrics/otel_logger.py
+++ b/airflow/metrics/otel_logger.py
@@ -225,6 +225,7 @@ def get_otel_logger(cls) -> SafeOtelLogger:
     port = conf.getint("metrics", "otel_port")  # ex: 4318
     prefix = conf.get("metrics", "otel_prefix")  # ex: "airflow"
     interval = conf.getint("metrics", "otel_interval_milliseconds")  # ex: 30000
+    debug = conf.getboolean("metrics", "otel_debugging_on")
 
     allow_list = conf.get("metrics", "metrics_allow_list", fallback=None)
     allow_list_validator = AllowListValidator(allow_list)
@@ -244,8 +245,6 @@ def get_otel_logger(cls) -> SafeOtelLogger:
         )
     ]
 
-    # TODO:  remove this console exporter before launch??  It's handy for debugging maybe?
-    debug = False
     if debug:
         export_to_console = PeriodicExportingMetricReader(ConsoleMetricExporter())
         readers.append(export_to_console)

--- a/airflow/metrics/otel_logger.py
+++ b/airflow/metrics/otel_logger.py
@@ -1,0 +1,234 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import warnings
+from typing import Callable
+
+from opentelemetry import metrics
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.metrics import Instrument
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics._internal.export import ConsoleMetricExporter, PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.util.types import Attributes
+
+from airflow.configuration import conf
+from airflow.metrics.protocols import DeltaType, Timer, TimerProtocol
+from airflow.metrics.validators import AllowListValidator, validate_stat
+
+# This is currently the only UDC used.  If more are added, we should add a better system for this.
+UP_DOWN_COUNTERS = {"airflow.dag_processing.processes"}
+OTEL_NAME_MAX_LENGTH = 64
+METRIC_NAME_PREFIX = "airflow."
+
+
+def _is_up_down_counter(name):
+    return name in UP_DOWN_COUNTERS
+
+
+class SafeOtelLogger:
+    """Otel Logger"""
+
+    def __init__(self, otel_provider, prefix: str = "airflow", allow_list_validator=AllowListValidator()):
+        self.otel: Callable = otel_provider
+        self.prefix: str = prefix
+        self.metrics_validator = allow_list_validator
+        self.meter = otel_provider.get_meter(__name__)
+        self.metrics_map = MetricsMap(self.meter)
+
+    @validate_stat
+    def incr(self, stat: str, count: int = 1, rate: float = 1, tags: Attributes = None):
+        """
+        Increment stat by count.
+
+        :param stat: The name of the stat to increment.
+        :param count: A positive integer to add to the current value of stat.
+        :param rate: TODO: define me
+        :param tags: Tags to append to the stat.
+        """
+        if (count < 0) or (rate < 0):
+            raise ValueError("count and rate must both be positive values.")
+        # TODO: I don't think this is the right use for rate???
+        value = count * rate
+
+        if self.metrics_validator.test(stat):
+            counter = self.metrics_map.get_counter(f"{self.prefix}.{stat}")
+            return counter.add(value, attributes=tags)
+
+    @validate_stat
+    def decr(self, stat: str, count: int = 1, rate: float = 1, tags: Attributes = None):
+        """
+        Decrement stat by count.
+
+        :param stat: The name of the stat to increment.
+        :param count: A positive integer to subtract from current value of stat.
+        :param rate: TODO: define me
+        :param tags: Tags to append to the stat.
+        """
+        if (count < 0) or (rate < 0):
+            raise ValueError("count and rate must both be positive values.")
+        # TODO: I don't think this is the right use for rate???
+        value = count * rate
+
+        if self.metrics_validator.test(stat):
+            counter = self.metrics_map.get_counter(f"{self.prefix}.{stat}")
+            return counter.add(-value, attributes=tags)
+
+    @validate_stat
+    def gauge(
+        self,
+        stat: str,
+        value: int | float,
+        rate: float = 1,
+        delta: bool = False,
+        *,
+        tags: Attributes = None,
+    ) -> None:
+        """Gauge stat."""
+        # To be implemented
+        return None
+
+    @validate_stat
+    def timing(
+        self,
+        stat: str,
+        dt: DeltaType,
+        *,
+        tags: Attributes = None,
+    ) -> None:
+        """Stats timing."""
+        # To be implemented
+        return None
+
+    @validate_stat
+    def timer(
+        self,
+        stat: str | None = None,
+        *args,
+        tags: Attributes = None,
+        **kwargs,
+    ) -> TimerProtocol:
+        """Timer metric that can be cancelled."""
+        # To be implemented
+        return Timer()
+
+
+class BaseInstrument(Instrument):
+    """Instrument clss is abstract and must be implemented."""
+
+    def __init__(self, name: str, unit: str = "", description: str = "", attributes: Attributes = None):
+        self.name: str = name
+        self.unit: str = unit
+        self.description: str = description
+        self.attributes: Attributes = attributes
+
+
+class MetricsMap:
+    """Stores Otel Counters."""
+
+    def __init__(self, meter):
+        self.meter = meter
+        self.map = {}
+
+    def clear(self) -> None:
+        self.map.clear()
+
+    def _create_counter(self, name):
+        """Creates a new counter or up_down_counter for the provided name."""
+        otel_safe_name = name[:OTEL_NAME_MAX_LENGTH]
+        if name != otel_safe_name:
+            warnings.warn(
+                f"Metric name `{name}` exceeds OpenTelemetry's name length limit of "
+                f"{OTEL_NAME_MAX_LENGTH} characters and will be truncated to `{otel_safe_name}`."
+            )
+
+        if _is_up_down_counter(name):
+            counter = self.meter.create_up_down_counter(name=otel_safe_name)
+        else:
+            counter = self.meter.create_counter(name=otel_safe_name)
+
+        print(f"--> created {otel_safe_name} as type: {str(type(counter)).split('.')[-1][:-2]}")
+        return counter
+
+    def get_counter(self, name: str, attributes: Attributes = None):
+        """
+        Returns the value of the counter; creates a new one if it does not exist.
+
+        :param name: The name of the counter to fetch or create.
+        :param attributes:  Counter attributes, used to generate a unique key to store the counter.
+        """
+        key: str = name + str(attributes)
+        if key in self.map.keys():
+            return self.map[key]
+        else:
+            new_counter = self._create_counter(name)
+            self.map[key] = new_counter
+            return new_counter
+
+    def del_counter(self, name: str, attributes: Attributes = None) -> None:
+        """
+        Deletes a counter.
+
+        :param name: The name of the counter to fetch or create.
+        :param attributes: Counter attributes which were used to generate a unique key to store the counter.
+        """
+        key: str = name + str(attributes)
+        if key in self.map.keys():
+            del self.map[key]
+
+
+def get_otel_logger() -> SafeOtelLogger:
+    """Get Otel logger"""
+    host = conf.get("metrics", "otel_host")  # ex: "breeze-otel-collector"
+    port = conf.getint("metrics", "otel_port")  # ex: 4318
+    prefix = conf.get("metrics", "otel_prefix")  # ex: "airflow"
+    interval = conf.getint("metrics", "otel_interval_milliseconds")  # ex: 30000
+
+    allow_list = conf.get("metrics", "metrics_allow_list", fallback=None)
+    allow_list_validator = AllowListValidator(allow_list)
+
+    resource = Resource(attributes={SERVICE_NAME: "Airflow"})
+    # TODO:  figure out https instead of http ??
+    endpoint = f"http://{host}:{port}/v1/metrics"
+
+    print(f"[Metric Exporter] Connecting to OTLP at ---> {endpoint}")
+    readers = [
+        PeriodicExportingMetricReader(
+            OTLPMetricExporter(
+                endpoint=endpoint,
+                headers={"Content-Type": "application/json"},
+            ),
+            export_interval_millis=interval,
+        )
+    ]
+
+    # TODO:  remove this console exporter before launch??  It's handy for debugging maybe?
+    debug = False
+    if debug:
+        export_to_console = PeriodicExportingMetricReader(ConsoleMetricExporter())
+        readers.append(export_to_console)
+
+    metrics.set_meter_provider(
+        MeterProvider(
+            resource=resource,
+            metric_readers=readers,
+            shutdown_on_exit=False,
+        ),
+    )
+
+    return SafeOtelLogger(metrics.get_meter_provider(), prefix, allow_list_validator)

--- a/airflow/metrics/otel_logger.py
+++ b/airflow/metrics/otel_logger.py
@@ -66,8 +66,6 @@ class SafeOtelLogger:
         count: int = 1,
         rate: float = 1,
         tags: Attributes = None,
-        *,
-        back_compat_name: str = "",
     ):
         """
         Increment stat by count.
@@ -77,17 +75,11 @@ class SafeOtelLogger:
         :param rate: value between 0 and 1 that represents the sampled rate at
             which the metric is going to be emitted.
         :param tags: Tags to append to the stat.
-        :param back_compat_name: If possible, the metric will also be emitted
-            under this name for backward compatibility.
         """
         if (count < 0) or (rate < 0):
             raise ValueError("count and rate must both be positive values.")
         if rate < 1 and random.random() > rate:
             return
-
-        if back_compat_name and self.metrics_validator.test(back_compat_name):
-            counter = self.metrics_map.get_counter(f"{self.prefix}.{back_compat_name}")
-            counter.add(count, attributes=tags)
 
         if self.metrics_validator.test(stat):
             counter = self.metrics_map.get_counter(f"{self.prefix}.{stat}")
@@ -101,8 +93,6 @@ class SafeOtelLogger:
         count: int = 1,
         rate: float = 1,
         tags: Attributes = None,
-        *,
-        back_compat_name: str = "",
     ):
         """
         Decrement stat by count.
@@ -112,17 +102,11 @@ class SafeOtelLogger:
         :param rate: value between 0 and 1 that represents the sampled rate at
             which the metric is going to be emitted.
         :param tags: Tags to append to the stat.
-        :param back_compat_name: If possible, the metric will also be emitted
-            under this name for backward compatibility.
         """
         if (count < 0) or (rate < 0):
             raise ValueError("count and rate must both be positive values.")
         if rate < 1 and random.random() > rate:
             return
-
-        if back_compat_name and self.metrics_validator.test(back_compat_name):
-            counter = self.metrics_map.get_counter(f"{self.prefix}.{back_compat_name}")
-            counter.add(-count, attributes=tags)
 
         if self.metrics_validator.test(stat):
             counter = self.metrics_map.get_counter(f"{self.prefix}.{stat}")

--- a/airflow/metrics/otel_logger.py
+++ b/airflow/metrics/otel_logger.py
@@ -36,7 +36,20 @@ from airflow.metrics.validators import AllowListValidator, stat_name_default_han
 log = logging.getLogger(__name__)
 
 
-# This is currently the only UDC used.  If more are added, we should add a better system for this.
+# "airflow.dag_processing.processes" is currently the only UDC used in Airflow.  If more are added,
+# we should add a better system for this.
+#
+# Generally in OTel a Counter is monotonic (can only go up) and there is an UpDownCounter which,
+# as you can guess, is non-monotonic; it can go up or down. The choice here is to either drop
+# this one metric and implement the rest as monotonic Counters, implement all counters as
+# UpDownCounters, or add a bit of logic to do it intelligently. The catch is that the Collector
+# which transmits these metrics to the upstream dashboard tools (Prometheus, Grafana, etc.) assigns
+# the type of Gauge to any UDC instead of Counter. Adding this logic feels like the best compromise
+# where normal Counters still get typed correctly, and we don't lose an existing metric.
+# See:
+# https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#counter-creation
+# https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#updowncounter
+
 UP_DOWN_COUNTERS = {"airflow.dag_processing.processes"}
 OTEL_NAME_MAX_LENGTH = 63
 METRIC_NAME_PREFIX = "airflow."

--- a/airflow/metrics/otel_logger.py
+++ b/airflow/metrics/otel_logger.py
@@ -60,7 +60,14 @@ def _is_up_down_counter(name):
 
 
 def _generate_key_name(name: str, attributes: Attributes = None):
-    return f"{name}{'_' + str(attributes) if attributes else ''}"
+    if attributes:
+        key = name
+        for item in attributes.items():
+            key += f"_{item[0]}_{item[1]}"
+    else:
+        key = name
+
+    return key
 
 
 def name_is_otel_safe(prefix: str, name: str) -> bool:
@@ -121,7 +128,7 @@ class SafeOtelLogger:
             return
 
         if self.metrics_validator.test(stat) and name_is_otel_safe(self.prefix, stat):
-            counter = self.metrics_map.get_counter(f"{self.prefix}.{stat}")
+            counter = self.metrics_map.get_counter(f"{self.prefix}.{stat}", attributes=tags)
             counter.add(count, attributes=tags)
             return counter
 

--- a/airflow/metrics/otel_logger.py
+++ b/airflow/metrics/otel_logger.py
@@ -190,7 +190,7 @@ class MetricsMap:
             counter = self.meter.create_counter(name=otel_safe_name)
 
         counter_type = str(type(counter)).split(".")[-1][:-2]
-        logging.debug("--> created %s as type: %", otel_safe_name, counter_type)
+        logging.debug("--> created %s as type: %s", otel_safe_name, counter_type)
         return counter
 
     def get_counter(self, name: str, attributes: Attributes = None):
@@ -233,7 +233,7 @@ def get_otel_logger(cls) -> SafeOtelLogger:
     # TODO:  figure out https instead of http ??
     endpoint = f"http://{host}:{port}/v1/metrics"
 
-    logging.info("[Metric Exporter] Connecting to OTLP at ---> %", endpoint)
+    logging.info("[Metric Exporter] Connecting to OTLP at ---> %s", endpoint)
     readers = [
         PeriodicExportingMetricReader(
             OTLPMetricExporter(

--- a/airflow/metrics/otel_logger.py
+++ b/airflow/metrics/otel_logger.py
@@ -33,7 +33,7 @@ from airflow.metrics.validators import AllowListValidator, validate_stat
 
 # This is currently the only UDC used.  If more are added, we should add a better system for this.
 UP_DOWN_COUNTERS = {"airflow.dag_processing.processes"}
-OTEL_NAME_MAX_LENGTH = 64
+OTEL_NAME_MAX_LENGTH = 63
 METRIC_NAME_PREFIX = "airflow."
 
 
@@ -192,7 +192,7 @@ class MetricsMap:
             del self.map[key]
 
 
-def get_otel_logger() -> SafeOtelLogger:
+def get_otel_logger(cls) -> SafeOtelLogger:
     """Get Otel logger"""
     host = conf.get("metrics", "otel_host")  # ex: "breeze-otel-collector"
     port = conf.getint("metrics", "otel_port")  # ex: 4318

--- a/airflow/metrics/otel_logger.py
+++ b/airflow/metrics/otel_logger.py
@@ -72,7 +72,7 @@ def _generate_key_name(name: str, attributes: Attributes = None):
 
 def name_is_otel_safe(prefix: str, name: str) -> bool:
     """
-    Returns true if the provided name and prefix would result in a name compatible with Open Telemetry.
+    Returns True if the provided name and prefix would result in a name compatible with Open Telemetry.
     Legal names are defined here:
     https://opentelemetry.io/docs/reference/specification/metrics/api/#instrument-name-syntax
     """
@@ -88,7 +88,7 @@ def name_is_otel_safe(prefix: str, name: str) -> bool:
         # `stat_name_default_handler` throws InvalidStatsNameException if the
         # provided value is not valid or returns the value if it is.  We don't
         # need the return value but will make use of the validation checks. If
-        # no exception is thrown, then the name is safe for OTel.
+        # no exception is thrown, then the proposed name meets OTel requirements.
         stat_name_default_handler(proposed_stat_name, max_length=OTEL_NAME_MAX_LENGTH)
         return True
     except InvalidStatsNameException:

--- a/airflow/metrics/validators.py
+++ b/airflow/metrics/validators.py
@@ -50,6 +50,8 @@ ALLOWED_CHARACTERS = frozenset(string.ascii_letters + string.digits + "_.-")
 # OpenTelemetry and should be deprecated over time. This is implemented to
 # ensure that any new metrics we introduce have names which meet the OTel
 # standard while also allowing us time to deprecate the old names.
+# NOTE:  No new names should be added to this list.  This list should
+#        only ever shorten over time as we deprecate these names.
 BACK_COMPAT_METRIC_NAME_PATTERNS: set[str] = {
     r"^(?P<job_name>.*)_start$",
     r"^(?P<job_name>.*)_end$",

--- a/airflow/metrics/validators.py
+++ b/airflow/metrics/validators.py
@@ -21,20 +21,66 @@ from __future__ import annotations
 
 import abc
 import logging
+import re
 import string
+import warnings
 from functools import partial, wraps
-from typing import Callable, Iterable, TypeVar, cast
+from typing import Callable, Iterable, Pattern, TypeVar, cast
 
 from airflow.configuration import conf
 from airflow.exceptions import InvalidStatsNameException
+
+# TODO: replace
+T = TypeVar("T", bound=Callable)
+
+log = logging.getLogger(__name__)
+
+
+class MetricNameLengthExemptionWarning(Warning):
+    """
+    A Warning class to be used for the metric name length exemption notice.
+    Using a custom Warning class allows us to easily test that it is used.
+    """
+
+    ...
+
 
 # Only characters in the character set are considered valid
 # for the stat_name if stat_name_default_handler is used.
 ALLOWED_CHARACTERS = frozenset(string.ascii_letters + string.digits + "_.-")
 
-T = TypeVar("T", bound=Callable)
+# The following set contains existing metrics whose names are too long for
+# OpenTelemetry and should be deprecated over time. This is implemented to
+# ensure that any new metrics we introduce have names which meet the OTel
+# standard while also allowing us time to deprecate the old names.
+BACK_COMPAT_METRIC_NAME_PATTERNS: set[str] = {
+    r"^(?P<job_name>.*)_start$",
+    r"^(?P<job_name>.*)_end$",
+    r"^(?P<job_name>.*)_heartbeat_failure$",
+    r"^local_task_job.task_exit\.(?P<job_id>.*)\.(?P<dag_id>.*)\.(?P<task_id>.*)\.(?P<return_code>.*)$",
+    r"^operator_failures_(?P<operator_name>.*)$",
+    r"^operator_successes_(?P<operator_name>.*)$",
+    r"^ti.start.(?P<dag_id>.*)\.(?P<task_id>.*)$",
+    r"^ti.finish.(?P<dag_id>.*)\.(?P<task_id>.*)\.(?P<state>.*)$",
+    r"^task_removed_from_dag\.(?P<dag_id>.*)$",
+    r"^task_restored_to_dag\.(?P<dag_id>.*)$",
+    r"^task_instance_created-(?P<operator_name>.*)$",
+    r"^dag_processing\.last_run\.seconds_ago\.(?P<dag_file>.*)$",
+    r"^pool\.open_slots\.(?P<pool_name>.*)$",
+    r"^pool\.queued_slots\.(?P<pool_name>.*)$",
+    r"^pool\.running_slots\.(?P<pool_name>.*)$",
+    r"^pool\.starving_tasks\.(?P<pool_name>.*)$",
+    r"^dagrun\.dependency-check\.(?P<dag_id>.*)$",
+    r"^dag\.(?P<dag_id>.*)\.(?P<task_id>.*)\.duration$",
+    r"^dag_processing\.last_duration\.(?P<dag_file>.*)$",
+    r"^dagrun\.duration\.success\.(?P<dag_id>.*)$",
+    r"^dagrun\.duration\.failed\.(?P<dag_id>.*)$",
+    r"^dagrun\.schedule_delay\.(?P<dag_id>.*)$",
+    r"^dagrun\.(?P<dag_id>.*)\.first_task_scheduling_delay$",
+}
+BACK_COMPAT_METRIC_NAMES: set[Pattern[str]] = {re.compile(name) for name in BACK_COMPAT_METRIC_NAME_PATTERNS}
 
-log = logging.getLogger(__name__)
+OTEL_NAME_MAX_LENGTH = 63
 
 
 def validate_stat(fn: T) -> T:
@@ -55,6 +101,68 @@ def validate_stat(fn: T) -> T:
             return None
 
     return cast(T, wrapper)
+
+
+def stat_name_otel_handler(
+    stat_prefix: str,
+    stat_name: str,
+    max_length: int = OTEL_NAME_MAX_LENGTH,
+) -> str:
+    """
+    Verifies that a proposed prefix and name combination will meet OpenTelemetry naming standards.
+    See: https://opentelemetry.io/docs/reference/specification/metrics/api/#instrument-name-syntax
+
+    :param stat_prefix: The proposed prefix applied to all metric names.
+    :param stat_name: The proposed name.
+    :param max_length: The max length of the combined prefix and name; defaults to the max length
+        as defined in the OpenTelemetry standard, but can be overridden.
+
+    :returns: Returns the approved combined name or raises an InvalidStatsNameException.
+    """
+    proposed_stat_name: str = f"{stat_prefix}.{stat_name}"
+    name_length_exemption: bool = False
+    matched_exemption: str = ""
+
+    # This test case is here to enforce that the values can not be None and
+    # must be a valid String.  Without this test here, those values get cast
+    # to a string and pass when they should not, potentially resulting in
+    # metrics named "airflow.None", "airflow.42", or "None.42" for example.
+    if not (isinstance(stat_name, str) and isinstance(stat_prefix, str)):
+        raise InvalidStatsNameException("Stat name and prefix must both be strings.")
+
+    if len(proposed_stat_name) > OTEL_NAME_MAX_LENGTH:
+        # If the name is in the exceptions list, do not fail it for being too long.
+        # It may still be deemed invalid for other reasons below.
+        for exemption in BACK_COMPAT_METRIC_NAMES:
+            if re.match(exemption, stat_name):
+                # There is a back-compat exception for this name; proceed
+                name_length_exemption = True
+                matched_exemption = exemption.pattern
+                break
+        else:
+            raise InvalidStatsNameException(
+                f"Invalid stat name: {proposed_stat_name}.  Please see "
+                f"https://opentelemetry.io/docs/reference/specification/metrics/api/#instrument-name-syntax"
+            )
+
+    # `stat_name_default_handler` throws InvalidStatsNameException if the
+    # provided value is not valid or returns the value if it is.  We don't
+    # need the return value but will make use of the validation checks. If
+    # no exception is thrown, then the proposed name meets OTel requirements.
+    stat_name_default_handler(proposed_stat_name, max_length=999 if name_length_exemption else max_length)
+
+    # This warning is down here instead of up above because the exemption only
+    # applies to the length and a name may still be invalid for other reasons.
+    if name_length_exemption:
+        warnings.warn(
+            f"Stat name {stat_name} matches exemption {matched_exemption} and "
+            f"will be truncated to {proposed_stat_name[:OTEL_NAME_MAX_LENGTH]}. "
+            f"This stat name will be deprecated in the future and replaced with "
+            f"a shorter name combined with Attributes/Tags.",
+            MetricNameLengthExemptionWarning,
+        )
+
+    return proposed_stat_name
 
 
 def stat_name_default_handler(

--- a/airflow/metrics/validators.py
+++ b/airflow/metrics/validators.py
@@ -25,13 +25,10 @@ import re
 import string
 import warnings
 from functools import partial, wraps
-from typing import Callable, Iterable, Pattern, TypeVar, cast
+from typing import Callable, Iterable, Pattern, cast
 
 from airflow.configuration import conf
 from airflow.exceptions import InvalidStatsNameException
-
-# TODO: replace
-T = TypeVar("T", bound=Callable)
 
 log = logging.getLogger(__name__)
 
@@ -83,14 +80,14 @@ BACK_COMPAT_METRIC_NAMES: set[Pattern[str]] = {re.compile(name) for name in BACK
 OTEL_NAME_MAX_LENGTH = 63
 
 
-def validate_stat(fn: T) -> T:
+def validate_stat(fn: Callable) -> Callable:
     """
     Check if stat name contains invalid characters.
     Log and not emit stats if name is invalid.
     """
 
     @wraps(fn)
-    def wrapper(self, stat: str | None = None, *args, **kwargs) -> T | None:
+    def wrapper(self, stat: str | None = None, *args, **kwargs) -> Callable | None:
         try:
             if stat is not None:
                 handler_stat_name_func = get_current_handler_stat_name_func()
@@ -100,7 +97,7 @@ def validate_stat(fn: T) -> T:
             log.exception("Invalid stat name: %s.", stat)
             return None
 
-    return cast(T, wrapper)
+    return cast(Callable, wrapper)
 
 
 def stat_name_otel_handler(

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1009,6 +1009,8 @@ class DagRun(Base, LoggingMixin):
                 if should_restore_task:
                     self.log.info("Restoring task '%s' which was previously removed from DAG '%s'", ti, dag)
                     Stats.incr(f"task_restored_to_dag.{dag.dag_id}", tags=self.stats_tags)
+                    # Same metric with tagging
+                    Stats.incr("task_restored_to_dag", tags={**self.stats_tags, "dag_id": dag.dag_id})
                     ti.state = State.NONE
             except AirflowException:
                 if ti.state == State.REMOVED:
@@ -1016,6 +1018,8 @@ class DagRun(Base, LoggingMixin):
                 elif self.state != State.RUNNING and not dag.partial:
                     self.log.warning("Failed to get task '%s' for dag '%s'. Marking it as removed.", ti, dag)
                     Stats.incr(f"task_removed_from_dag.{dag.dag_id}", tags=self.stats_tags)
+                    # Same metric with tagging
+                    Stats.incr("task_removed_from_dag", tags={**self.stats_tags, "dag_id": dag.dag_id})
                     ti.state = State.REMOVED
                 continue
 
@@ -1172,6 +1176,8 @@ class DagRun(Base, LoggingMixin):
 
             for task_type, count in created_counts.items():
                 Stats.incr(f"task_instance_created-{task_type}", count, tags=self.stats_tags)
+                # Same metric with tagging
+                Stats.incr("task_instance_created", count, tags={**self.stats_tags, "task_type": task_type})
             session.flush()
         except IntegrityError:
             self.log.info(

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1468,12 +1468,20 @@ class TaskInstance(Base, LoggingMixin):
             session.commit()
         actual_start_date = timezone.utcnow()
         Stats.incr(f"ti.start.{self.task.dag_id}.{self.task.task_id}", tags=self.stats_tags)
+        # Same metric with tagging
+        Stats.incr("ti.start", tags=self.stats_tags)
         # Initialize final state counters at zero
         for state in State.task_states:
             Stats.incr(
                 f"ti.finish.{self.task.dag_id}.{self.task.task_id}.{state}",
                 count=0,
                 tags=self.stats_tags,
+            )
+            # Same metric with tagging
+            Stats.incr(
+                "ti.finish",
+                count=0,
+                tags={**self.stats_tags, "state": str(state)},
             )
 
         self.task = self.task.prepare_for_execution()
@@ -1545,6 +1553,8 @@ class TaskInstance(Base, LoggingMixin):
             raise
         finally:
             Stats.incr(f"ti.finish.{self.dag_id}.{self.task_id}.{self.state}", tags=self.stats_tags)
+            # Same metric with tagging
+            Stats.incr("ti.finish", tags={**self.stats_tags, "state": str(self.state)})
 
         # Recording SKIPPED or SUCCESS
         self.clear_next_method_args()
@@ -1642,6 +1652,8 @@ class TaskInstance(Base, LoggingMixin):
             self.task.post_execute(context=context, result=result)
 
         Stats.incr(f"operator_successes_{self.task.task_type}", tags=self.stats_tags)
+        # Same metric with tagging
+        Stats.incr("operator_successes", tags={**self.stats_tags, "task_type": self.task.task_type})
         Stats.incr("ti_successes", tags=self.stats_tags)
 
     def _run_finished_callback(
@@ -1911,6 +1923,8 @@ class TaskInstance(Base, LoggingMixin):
         self.set_duration()
 
         Stats.incr(f"operator_failures_{self.operator}", tags=self.stats_tags)
+        # Same metric with tagging
+        Stats.incr("operator_failures", tags={**self.stats_tags, "operator": self.operator})
         Stats.incr("ti_failures", tags=self.stats_tags)
 
         if not test_mode:

--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -22,7 +22,7 @@ import socket
 from typing import TYPE_CHECKING, Callable
 
 from airflow.configuration import conf
-from airflow.metrics import datadog_logger, statsd_logger
+from airflow.metrics import datadog_logger, otel_logger, statsd_logger
 from airflow.metrics.base_stats_logger import NoStatsLogger, StatsLogger
 
 log = logging.getLogger(__name__)
@@ -49,6 +49,8 @@ class _Stats(type):
                 cls.__class__.factory = datadog_logger.get_dogstatsd_logger
             elif conf.getboolean("metrics", "statsd_on"):
                 cls.__class__.factory = statsd_logger.get_statsd_logger
+            elif conf.getboolean("metrics", "otel_on"):
+                cls.__class__.factory = otel_logger.get_otel_logger
             else:
                 cls.__class__.factory = NoStatsLogger
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,6 +117,8 @@ install_requires =
     markupsafe>=1.1.1
     marshmallow-oneofschema>=2.0.1
     mdit-py-plugins>=0.3.0
+    # Pip can not find a version that satisfies constraints if opentelemetry-api is not pinned.
+    opentelemetry-api==1.15.0
     packaging>=14.0
     pathspec~=0.9.0
     pendulum>=2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -119,6 +119,7 @@ install_requires =
     mdit-py-plugins>=0.3.0
     # Pip can not find a version that satisfies constraints if opentelemetry-api is not pinned.
     opentelemetry-api==1.15.0
+    opentelemetry-exporter-otlp
     packaging>=14.0
     pathspec~=0.9.0
     pendulum>=2.0

--- a/setup.py
+++ b/setup.py
@@ -309,7 +309,7 @@ ldap = [
     "python-ldap",
 ]
 leveldb = ["plyvel"]
-otel = ["opentelemetry-exporter-otlp", "opentelemetry-exporter-prometheus"]
+otel = ["opentelemetry-exporter-prometheus"]
 pandas = ["pandas>=0.17.1", "pyarrow>=9.0.0"]
 password = [
     "bcrypt>=2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -309,7 +309,7 @@ ldap = [
     "python-ldap",
 ]
 leveldb = ["plyvel"]
-otel = ["opentelemetry-api==1.15.0", "opentelemetry-exporter-otlp", "opentelemetry-exporter-prometheus"]
+otel = ["opentelemetry-exporter-otlp", "opentelemetry-exporter-prometheus"]
 pandas = ["pandas>=0.17.1", "pyarrow>=9.0.0"]
 password = [
     "bcrypt>=2.0.0",

--- a/tests/core/test_otel_logger.py
+++ b/tests/core/test_otel_logger.py
@@ -27,6 +27,7 @@ from airflow.metrics.otel_logger import (
     OTEL_NAME_MAX_LENGTH,
     UP_DOWN_COUNTERS,
     SafeOtelLogger,
+    _generate_key_name,
     _is_up_down_counter,
 )
 
@@ -77,11 +78,12 @@ class TestOtelMetrics:
 
     def test_incr_new_metric_with_tags(self, name):
         tags = {"hello": "world"}
+        key = _generate_key_name(full_name(name), tags)
 
         self.stats.incr(name, tags=tags)
 
         self.meter.get_meter().create_counter.assert_called_once_with(name=full_name(name))
-        self.map[full_name(name)].add.assert_called_once_with(1, attributes=tags)
+        self.map[key].add.assert_called_once_with(1, attributes=tags)
 
     def test_incr_existing_metric(self, name):
         # Create the metric and set value to 1

--- a/tests/core/test_otel_logger.py
+++ b/tests/core/test_otel_logger.py
@@ -97,6 +97,9 @@ class TestOtelMetrics:
         self.stats.incr(name, rate=0.5)
         # This one should not increment because random() will return a value higher than `rate`
         self.stats.incr(name, rate=0.5)
+        # This one should raise an exception for a negative `rate` value
+        with pytest.raises(ValueError):
+            self.stats.incr(name, rate=-0.5)
 
         assert mock_random.call_count == 2
         assert self.map[full_name(name)].add.call_count == 1
@@ -128,6 +131,9 @@ class TestOtelMetrics:
         self.stats.decr(name, rate=0.5)
         # This one should not decrement because random() will return a value higher than `rate`
         self.stats.decr(name, rate=0.5)
+        # This one should raise an exception for a negative `rate` value
+        with pytest.raises(ValueError):
+            self.stats.decr(name, rate=-0.5)
 
         assert mock_random.call_count == 2
         # add() is called once in the initial stats.incr and once for the decr that passed the rate check.

--- a/tests/core/test_otel_logger.py
+++ b/tests/core/test_otel_logger.py
@@ -1,0 +1,156 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from opentelemetry.metrics import MeterProvider
+
+from airflow.metrics.otel_logger import (
+    METRIC_NAME_PREFIX,
+    OTEL_NAME_MAX_LENGTH,
+    UP_DOWN_COUNTERS,
+    SafeOtelLogger,
+    _is_up_down_counter,
+)
+
+
+def full_name(name: str):
+    return f"{METRIC_NAME_PREFIX}{name}"
+
+
+@pytest.fixture
+def name():
+    return "test_stats_run"
+
+
+class TestOtelMetrics:
+    def setup_method(self):
+        self.meter = mock.Mock(MeterProvider)
+        self.stats = SafeOtelLogger(otel_provider=self.meter)
+        self.map = self.stats.metrics_map.map
+
+    def test_is_up_down_counter_positive(self):
+        udc = next(iter(UP_DOWN_COUNTERS))
+
+        assert _is_up_down_counter(udc)
+
+    def test_is_up_down_counter_negative(self):
+        assert not _is_up_down_counter("this_is_not_a_udc")
+
+    def test_stat_name_must_be_a_string(self):
+        self.stats.incr(42)
+
+        self.meter.assert_not_called()
+
+    def test_stat_name_must_not_exceed_max_length(self):
+        self.stats.incr("X" * OTEL_NAME_MAX_LENGTH)
+
+        self.meter.assert_not_called()
+
+    def test_stat_name_must_only_include_allowed_characters(self):
+        self.stats.incr("test/$tats")
+
+        self.meter.assert_not_called()
+
+    def test_incr_new_metric(self, name):
+        self.stats.incr(name)
+
+        self.meter.get_meter().create_counter.assert_called_once_with(name=full_name(name))
+
+    def test_incr_new_metric_with_tags(self, name):
+        tags = {"hello": "world"}
+
+        self.stats.incr(name, tags=tags)
+
+        self.meter.get_meter().create_counter.assert_called_once_with(name=full_name(name))
+        self.map[full_name(name)].add.assert_called_once_with(1, attributes=tags)
+
+    def test_incr_existing_metric(self, name):
+        # Create the metric and set value to 1
+        self.stats.incr(name)
+        # Increment value to 2
+        self.stats.incr(name)
+
+        assert self.map[full_name(name)].add.call_count == 2
+
+    def test_incr_with_back_compat_name(self, name):
+        back_compat_name = f"back_compat_{name}"
+        expected_calls = [
+            mock.call(name=full_name(back_compat_name)),
+            mock.call(name=full_name(name)),
+        ]
+
+        self.stats.incr(name, back_compat_name=back_compat_name)
+
+        self.meter.get_meter().create_counter.assert_has_calls(expected_calls, any_order=True)
+        assert self.meter.get_meter().create_counter.call_count == len(expected_calls)
+
+    @mock.patch("random.random", side_effect=[0.1, 0.9])
+    def test_incr_with_rate_limit_works(self, mock_random, name):
+        # Create the counter and set the value to 1
+        self.stats.incr(name, rate=0.5)
+        # This one should not increment because random() will return a value higher than `rate`
+        self.stats.incr(name, rate=0.5)
+
+        assert mock_random.call_count == 2
+        assert self.map[full_name(name)].add.call_count == 1
+
+    def test_decr_existing_metric(self, name):
+        expected_calls = [
+            mock.call(1, attributes=None),
+            mock.call(-1, attributes=None),
+        ]
+        # Create the metric and set value to 1
+        self.stats.incr(name)
+
+        # Decrement value to 0
+        self.stats.decr(name)
+
+        self.map[full_name(name)].add.assert_has_calls(expected_calls)
+        assert self.map[full_name(name)].add.call_count == len(expected_calls)
+
+    @mock.patch("random.random", side_effect=[0.1, 0.9])
+    def test_decr_with_rate_limit_works(self, mock_random, name):
+        expected_calls = [
+            mock.call(1, attributes=None),
+            mock.call(-1, attributes=None),
+        ]
+        # Create the metric and set value to 1
+        self.stats.incr(name)
+
+        # Decrement the counter to 0
+        self.stats.decr(name, rate=0.5)
+        # This one should not decrement because random() will return a value higher than `rate`
+        self.stats.decr(name, rate=0.5)
+
+        assert mock_random.call_count == 2
+        # add() is called once in the initial stats.incr and once for the decr that passed the rate check.
+        self.map[full_name(name)].add.assert_has_calls(expected_calls)
+        self.map[full_name(name)].add.call_count == 2
+
+    @mock.patch("warnings.warn")
+    def test_timer_warns_not_implemented(self, mock_warn):
+        with self.stats.timer():
+            mock_warn.assert_called_once_with("OpenTelemetry Timers are not yet implemented.")
+
+    @mock.patch("warnings.warn")
+    def test_gauge_warns_not_implemented(self, mock_warn):
+        self.stats.gauge("test_gauge", 1)
+
+        mock_warn.assert_called_once_with("OpenTelemetry Gauges are not yet implemented.")

--- a/tests/core/test_otel_logger.py
+++ b/tests/core/test_otel_logger.py
@@ -89,18 +89,6 @@ class TestOtelMetrics:
 
         assert self.map[full_name(name)].add.call_count == 2
 
-    def test_incr_with_back_compat_name(self, name):
-        back_compat_name = f"back_compat_{name}"
-        expected_calls = [
-            mock.call(name=full_name(back_compat_name)),
-            mock.call(name=full_name(name)),
-        ]
-
-        self.stats.incr(name, back_compat_name=back_compat_name)
-
-        self.meter.get_meter().create_counter.assert_has_calls(expected_calls, any_order=True)
-        assert self.meter.get_meter().create_counter.call_count == len(expected_calls)
-
     @mock.patch("random.random", side_effect=[0.1, 0.9])
     def test_incr_with_rate_limit_works(self, mock_random, name):
         # Create the counter and set the value to 1

--- a/tests/core/test_otel_logger.py
+++ b/tests/core/test_otel_logger.py
@@ -32,7 +32,7 @@ from airflow.metrics.otel_logger import (
     _generate_key_name,
     _is_up_down_counter,
 )
-from airflow.metrics.validators import MetricNameLengthExemptionWarning
+from airflow.metrics.validators import BACK_COMPAT_METRIC_NAMES, MetricNameLengthExemptionWarning
 
 INVALID_STAT_NAME_CASES = [
     (None, "can not be None"),
@@ -65,6 +65,14 @@ class TestOtelMetrics:
 
     def test_is_up_down_counter_negative(self):
         assert not _is_up_down_counter("this_is_not_a_udc")
+
+    def test_exemption_list_has_not_grown(self):
+        assert len(BACK_COMPAT_METRIC_NAMES) <= 23, (
+            "This test exists solely to ensure that nobody is adding names to the exemption list. "
+            "There are 23 names which are potentially too long for OTel and that number should "
+            "only ever go down as these names are deprecated.  If this test is failing, please "
+            "adjust your new stat's name; do not add as exemption without a very good reason."
+        )
 
     @pytest.mark.parametrize(
         "invalid_stat_combo",

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -407,6 +407,15 @@ class TestLocalTaskJob:
         mock_stats_incr.assert_has_calls(
             [
                 mock.call("local_task_job.task_exit.95.test_localtaskjob_code.op1.-9"),
+                mock.call(
+                    "local_task_job.task_exit",
+                    tags={
+                        "job_id": 95,
+                        "dag_id": "test_localtaskjob_code",
+                        "task_id": "op1",
+                        "return_code": -9,
+                    },
+                ),
             ]
         )
 

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1386,6 +1386,7 @@ class TestSchedulerJob:
             [
                 mock.call("scheduler.tasks.starving", 1),
                 mock.call(f"pool.starving_tasks.{Pool.DEFAULT_POOL_NAME}", 1),
+                mock.call("pool.starving_tasks", 1, tags={"pool_name": Pool.DEFAULT_POOL_NAME}),
             ],
             any_order=True,
         )
@@ -1401,6 +1402,7 @@ class TestSchedulerJob:
             [
                 mock.call("scheduler.tasks.starving", 0),
                 mock.call(f"pool.starving_tasks.{Pool.DEFAULT_POOL_NAME}", 0),
+                mock.call("pool.starving_tasks", 0, tags={"pool_name": Pool.DEFAULT_POOL_NAME}),
             ],
             any_order=True,
         )

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -982,8 +982,13 @@ def test_verify_integrity_task_start_and_end_date(Stats_incr, session, run_type,
     tis = dag_run.task_instances
     assert len(tis) == expected_tis
 
-    Stats_incr.assert_called_with(
+    Stats_incr.assert_any_call(
         "task_instance_created-EmptyOperator", expected_tis, tags={"dag_id": "test", "run_type": run_type}
+    )
+    Stats_incr.assert_any_call(
+        "task_instance_created",
+        expected_tis,
+        tags={"dag_id": "test", "run_type": run_type, "task_type": "EmptyOperator"},
     )
 
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2690,6 +2690,9 @@ class TestTaskInstance:
 
         Stats_incr.assert_any_call("ti_failures", tags=expected_stats_tags)
         Stats_incr.assert_any_call("operator_failures_EmptyOperator", tags=expected_stats_tags)
+        Stats_incr.assert_any_call(
+            "operator_failures", tags={**expected_stats_tags, "operator": "EmptyOperator"}
+        )
 
     def test_handle_failure_task_undefined(self, create_task_instance):
         """
@@ -2853,9 +2856,13 @@ class TestTaskInstance:
         session.commit()
         ti._run_raw_task()
         ti.refresh_from_db()
-        stats_mock.assert_called_with(
+        stats_mock.assert_any_call(
             f"ti.finish.{ti.dag_id}.{ti.task_id}.{ti.state}",
             tags={"dag_id": ti.dag_id, "task_id": ti.task_id},
+        )
+        stats_mock.assert_any_call(
+            "ti.finish",
+            tags={"dag_id": ti.dag_id, "task_id": ti.task_id, "state": ti.state},
         )
         for state in State.task_states:
             assert (
@@ -2866,11 +2873,20 @@ class TestTaskInstance:
                 )
                 in stats_mock.mock_calls
             )
+            assert (
+                call(
+                    "ti.finish",
+                    count=0,
+                    tags={"dag_id": ti.dag_id, "task_id": ti.task_id, "state": str(state)},
+                )
+                in stats_mock.mock_calls
+            )
         assert (
             call(f"ti.start.{ti.dag_id}.{ti.task_id}", tags={"dag_id": ti.dag_id, "task_id": ti.task_id})
             in stats_mock.mock_calls
         )
-        assert stats_mock.call_count == len(State.task_states) + 4
+        assert call("ti.start", tags={"dag_id": ti.dag_id, "task_id": ti.task_id}) in stats_mock.mock_calls
+        assert stats_mock.call_count == (2 * len(State.task_states)) + 7
 
     def test_command_as_list(self, create_task_instance):
         ti = create_task_instance()


### PR DESCRIPTION
AIP-49: Implement OpenTelemetry

**Overview**
Adds the support framework for OpenTelemetry support and implements Counters and UpDownCounters.  Gauges and Timers build on this and are Coming Soon :tm:

**Testing**
Passes `breeze static-checks --all-files`, `breeze build-docs`, and `breeze testing tests --run-in-parallel` locally.

cc: @o-nikolas @vincbeck @vandonr-amz @syedahsn @howardyoo @potiuk 
