### PR TITLE
Restore aiobotocore as optional dependency of amazon provider

### DIFF
--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -72,7 +72,6 @@ dependencies:
   - mypy-boto3-rds>=1.24.0
   - mypy-boto3-redshift-data>=1.24.0
   - mypy-boto3-appflow>=1.24.0
-  - aiobotocore[boto3]>=2.2.0
 
 integrations:
   - integration-name: Amazon Athena
@@ -610,7 +609,7 @@ additional-extras:
       - pandas>=0.17.1
   # There is conflict between boto3 and aiobotocore dependency botocore.
   # TODO: We can remove it once boto3 and aiobotocore both have compatible botocore version or
-  # boto3 have native aync support and we move away from aio aiobotocore
+  # boto3 have native async support and we move away from aio aiobotocore
   - name: aiobotocore
     dependencies:
-      - aiobotocore>=2.1.1
+      - aiobotocore[boto3]>=2.2.0

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -17,7 +17,6 @@
   },
   "amazon": {
     "deps": [
-      "aiobotocore[boto3]>=2.2.0",
       "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "asgiref",


### PR DESCRIPTION
The #30032 has been merged with aiobotore as required dependency. The aiobotocore package adds specific requirements for botocore and boto and it conflicts with older versions of Airflow, so we have to bring it back as optional dependency of the amazon provider.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
