### PR TITLE
improve/fix glue job logs printing

### DIFF
--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -201,7 +201,7 @@ class GlueJobHook(AwsBaseHook):
         continuation_tokens: LogContinuationTokens,
     ):
         """
-        Prints the batch of logs to the Airflow task log and returns nextToken.
+        Prints the latest job logs to the Airflow task log and updates the continuation tokens.
 
         :param continuation_tokens: the tokens where to resume from when reading logs.
             The object gets updated with the new tokens by this method.

--- a/airflow/providers/amazon/aws/sensors/glue.py
+++ b/airflow/providers/amazon/aws/sensors/glue.py
@@ -60,7 +60,7 @@ class GlueJobSensor(BaseSensorOperator):
         self.aws_conn_id = aws_conn_id
         self.success_states: list[str] = ["SUCCEEDED"]
         self.errored_states: list[str] = ["FAILED", "STOPPED", "TIMEOUT"]
-        self.next_log_tokens: tuple[str | None, str | None] = (None, None)
+        self.next_log_tokens = GlueJobHook.LogContinuationTokens()
 
     @cached_property
     def hook(self):
@@ -82,7 +82,7 @@ class GlueJobSensor(BaseSensorOperator):
                 return False
         finally:
             if self.verbose:
-                self.next_log_tokens = self.hook.print_job_logs(
+                self.hook.print_job_logs(
                     job_name=self.job_name,
                     run_id=self.run_id,
                     continuation_tokens=self.next_log_tokens,

--- a/airflow/providers/amazon/aws/sensors/glue.py
+++ b/airflow/providers/amazon/aws/sensors/glue.py
@@ -60,7 +60,7 @@ class GlueJobSensor(BaseSensorOperator):
         self.aws_conn_id = aws_conn_id
         self.success_states: list[str] = ["SUCCEEDED"]
         self.errored_states: list[str] = ["FAILED", "STOPPED", "TIMEOUT"]
-        self.next_log_token: str | None = None
+        self.next_log_tokens: tuple[str | None, str | None] = (None, None)
 
     @cached_property
     def hook(self):
@@ -69,14 +69,12 @@ class GlueJobSensor(BaseSensorOperator):
     def poke(self, context: Context):
         self.log.info("Poking for job run status :for Glue Job %s and ID %s", self.job_name, self.run_id)
         job_state = self.hook.get_job_state(job_name=self.job_name, run_id=self.run_id)
-        job_failed = False
 
         try:
             if job_state in self.success_states:
                 self.log.info("Exiting Job %s Run State: %s", self.run_id, job_state)
                 return True
             elif job_state in self.errored_states:
-                job_failed = True
                 job_error_message = "Exiting Job %s Run State: %s", self.run_id, job_state
                 self.log.info(job_error_message)
                 raise AirflowException(job_error_message)
@@ -84,9 +82,8 @@ class GlueJobSensor(BaseSensorOperator):
                 return False
         finally:
             if self.verbose:
-                self.next_log_token = self.hook.print_job_logs(
+                self.next_log_tokens = self.hook.print_job_logs(
                     job_name=self.job_name,
                     run_id=self.run_id,
-                    job_failed=job_failed,
-                    next_token=self.next_log_token,
+                    continuation_tokens=self.next_log_tokens,
                 )

--- a/tests/providers/amazon/aws/hooks/test_glue.py
+++ b/tests/providers/amazon/aws/hooks/test_glue.py
@@ -19,9 +19,11 @@ from __future__ import annotations
 
 import json
 from unittest import mock
+from unittest.mock import MagicMock
 
 import boto3
 import pytest
+from botocore.exceptions import ClientError
 from moto import mock_glue, mock_iam
 
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
@@ -303,3 +305,43 @@ class TestGlueJobHook:
         glue_job_run = glue_job_hook.initialize_job(some_script_arguments, some_run_kwargs)
         glue_job_run_state = glue_job_hook.get_job_state(glue_job_run["JobName"], glue_job_run["JobRunId"])
         assert glue_job_run_state == mock_job_run_state, "Mocks but be equal"
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.glue.boto3.client")
+    @mock.patch.object(GlueJobHook, "conn")
+    def test_print_job_logs_returns_token(self, conn_mock: MagicMock, client_mock: MagicMock, caplog):
+        hook = GlueJobHook()
+        conn_mock().get_job_run.return_value = {"JobRun": {"LogGroupName": "my_log_group"}}
+        client_mock().get_paginator().paginate.return_value = [
+            # first response : 2 log lines
+            {
+                "events": [
+                    {"logStreamName": "stream", "timestamp": 123, "message": "hello\n"},
+                    {"logStreamName": "stream", "timestamp": 123, "message": "world\n"},
+                ],
+                "searchedLogStreams": [],
+                "nextToken": "my_continuation_token",
+                "ResponseMetadata": {"HTTPStatusCode": 200},
+            },
+            # second response, reached end of stream
+            {"events": [], "searchedLogStreams": [], "ResponseMetadata": {"HTTPStatusCode": 200}},
+        ]
+
+        with caplog.at_level("INFO"):
+            continuation = hook.print_job_logs("name", "run")
+
+        assert "\thello\n\tworld\n" in caplog.text
+        assert continuation == ("my_continuation_token", "my_continuation_token")
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.glue.boto3.client")
+    @mock.patch.object(GlueJobHook, "conn")
+    def test_print_job_logs_no_stream_yet(self, conn_mock: MagicMock, client_mock: MagicMock):
+        hook = GlueJobHook()
+        conn_mock().get_job_run.return_value = {"JobRun": {"LogGroupName": "my_log_group"}}
+        client_mock().get_paginator().paginate.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFoundException"}}, "op"
+        )
+
+        continuation = hook.print_job_logs("name", "run")  # should not error
+
+        assert continuation == (None, None)
+        assert client_mock().get_paginator().paginate.call_count == 2

--- a/tests/providers/amazon/aws/operators/test_glue.py
+++ b/tests/providers/amazon/aws/operators/test_glue.py
@@ -121,10 +121,7 @@ class TestGlueJobOperator:
 
         mock_initialize_job.assert_called_once_with({}, {})
         mock_print_job_logs.assert_called_once_with(
-            job_name=JOB_NAME,
-            run_id=JOB_RUN_ID,
-            job_failed=False,
-            next_token=None,
+            job_name=JOB_NAME, run_id=JOB_RUN_ID, continuation_tokens=(None, None)
         )
         assert glue.job_name == JOB_NAME
 

--- a/tests/providers/amazon/aws/operators/test_glue.py
+++ b/tests/providers/amazon/aws/operators/test_glue.py
@@ -121,7 +121,7 @@ class TestGlueJobOperator:
 
         mock_initialize_job.assert_called_once_with({}, {})
         mock_print_job_logs.assert_called_once_with(
-            job_name=JOB_NAME, run_id=JOB_RUN_ID, continuation_tokens=(None, None)
+            job_name=JOB_NAME, run_id=JOB_RUN_ID, continuation_tokens=mock.ANY
         )
         assert glue.job_name == JOB_NAME
 

--- a/tests/providers/amazon/aws/sensors/test_glue.py
+++ b/tests/providers/amazon/aws/sensors/test_glue.py
@@ -69,8 +69,7 @@ class TestGlueJobSensor:
         mock_print_job_logs.assert_called_once_with(
             job_name=job_name,
             run_id=job_run_id,
-            job_failed=False,
-            next_token=ANY,
+            continuation_tokens=ANY,
         )
 
     @mock.patch.object(GlueJobHook, "print_job_logs")
@@ -111,8 +110,7 @@ class TestGlueJobSensor:
         mock_print_job_logs.assert_called_once_with(
             job_name=job_name,
             run_id=job_run_id,
-            job_failed=False,
-            next_token=ANY,
+            continuation_tokens=ANY,
         )
 
     @mock.patch.object(GlueJobHook, "print_job_logs")

--- a/tests/system/providers/amazon/aws/example_glue.py
+++ b/tests/system/providers/amazon/aws/example_glue.py
@@ -162,9 +162,10 @@ with DAG(
         job_name=glue_job_name,
         # Job ID extracted from previous Glue Job Operator task
         run_id=submit_glue_job.output,
+        verbose=True,  # prints glue job logs in airflow logs
     )
     # [END howto_sensor_glue]
-    wait_for_job.poke_interval = 10
+    wait_for_job.poke_interval = 5
 
     delete_bucket = S3DeleteBucketOperator(
         task_id="delete_bucket",


### PR DESCRIPTION
there was several problems with the current implementation:

- it was only fetching 1 response from the logs, so if the job was producing a lot of logs, it'd lag further and further back in time (and possibly never catch up)
- if the job was marked as failed, it was jumping from one stream to an other without warning, and started filtering on exceptions and errors, providing a very weird experience to someone who'd use those to debug
- upon changing log streams, the continuation token was not reset, so that behavior was not working anyway (you cannot use a continuation token from a stream when reading from another)
- upon checking the different log streams available (/output and /error), I realized that it was not clear cut at all. A stack trace could go in /output, and some INFO logs were in /error, so I think it has value to have both streams if one wants to understand what's happening.

Regarding the fact that we now display both streams, I hesitated between interleaving messages from both, sorting by timestamp, or leaving them separated. I ended up choosing to have them separated to keep the experience consistent with what the user would see in cloudwatch, but I'd be happy to change that to chronological order if people think it's better.

Also: added it to the system test (for better visibility for users) + added utest

cc @ferruzzi 