### PR TITLE
Improve Description of dag_processing.processes Metric in Docs

### DIFF
--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
@@ -94,7 +94,7 @@ Name                                                                   Descripti
 ``zombies_killed``                                                     Zombie tasks killed
 ``scheduler_heartbeat``                                                Scheduler heartbeats
 ``dag_processing.processes``                                           Relative number of currently running DAG parsing processes (ie this delta
-                                                                       negative when, since the last metric was sent, processes have completed)
+                                                                       is negative when, since the last metric was sent, processes have completed)
 ``dag_processing.processor_timeouts``                                  Number of file processors that have been killed due to taking too long
 ``dag_processing.sla_callback_count``                                  Number of SLA callbacks received
 ``dag_processing.other_callback_count``                                Number of non-SLA callbacks received

--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
@@ -93,7 +93,8 @@ Name                                                                   Descripti
 ``previously_succeeded``                                               Number of previously succeeded task instances
 ``zombies_killed``                                                     Zombie tasks killed
 ``scheduler_heartbeat``                                                Scheduler heartbeats
-``dag_processing.processes``                                           Relative number of currently running DAG parsing processes
+``dag_processing.processes``                                           Relative number of currently running DAG parsing processes (ie this delta
+                                                                       negative when, since the last metric was sent, processes have completed)
 ``dag_processing.processor_timeouts``                                  Number of file processors that have been killed due to taking too long
 ``dag_processing.sla_callback_count``                                  Number of SLA callbacks received
 ``dag_processing.other_callback_count``                                Number of non-SLA callbacks received

--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
@@ -93,7 +93,7 @@ Name                                                                   Descripti
 ``previously_succeeded``                                               Number of previously succeeded task instances
 ``zombies_killed``                                                     Zombie tasks killed
 ``scheduler_heartbeat``                                                Scheduler heartbeats
-``dag_processing.processes``                                           Number of currently running DAG parsing processes
+``dag_processing.processes``                                           Relative number of currently running DAG parsing processes
 ``dag_processing.processor_timeouts``                                  Number of file processors that have been killed due to taking too long
 ``dag_processing.sla_callback_count``                                  Number of SLA callbacks received
 ``dag_processing.other_callback_count``                                Number of non-SLA callbacks received


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
Hey folks; this is a very very small proposal regarding the description of the dag_processing.processes metric emitted by airflow. It is a delta value, not the absolute value, and that can lead to _very_ difficult interpretation of what this metric actually means.

If you look at the data this metric emits, it's sometimes negative (which doesn't seem to make a huge amount of sense since it's the "count" of dag processing processes spun off by `processor.py`). I don't claim this change to be the best rephrasing, but I thought it'd make sense to have a convo on this pull itself to figure out the best solution.