### PR TITLE
BaseAWS - Override client when resource_type is user to get custom waiters

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -846,7 +846,7 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
                 credentials = self.get_credentials()
                 client = boto3.client(
                     self.resource_type,
-                    region_name=self._region_name,
+                    region_name=self.region_name,
                     aws_access_key_id=credentials.access_key,
                     aws_secret_access_key=credentials.secret_key,
                 )

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -841,6 +841,16 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
             raise ValueError("client must be provided for a deferrable waiter.")
         client = client or self.conn
         if self.waiter_path and (waiter_name in self._list_custom_waiters()):
+            # Currently, the custom waiter doesn't work with resource_type, only client_type is supported.
+            if self.resource_type:
+                credentials = self.get_credentials()
+                client = boto3.client(
+                    self.resource_type,
+                    region_name=self._region_name,
+                    aws_access_key_id=credentials.access_key,
+                    aws_secret_access_key=credentials.secret_key,
+                )
+
             # Technically if waiter_name is in custom_waiters then self.waiter_path must
             # exist but MyPy doesn't like the fact that self.waiter_path could be None.
             with open(self.waiter_path) as config_file:

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -1092,4 +1092,4 @@ def test_custom_waiter_with_resource_type(waiter_path_mock: MagicMock):
     with mock.patch("airflow.providers.amazon.aws.waiters.base_waiter.BaseBotoWaiter") as BaseBotoWaiter:
         hook.get_waiter("other_wait")
 
-    assert isinstance(BaseBotoWaiter.call_args.kwargs["client"], botocore.client.BaseClient)
+    assert isinstance(BaseBotoWaiter.call_args[1]["client"], botocore.client.BaseClient)

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock, PropertyMock, mock_open
 from uuid import UUID
 
 import boto3
+import botocore
 import jinja2
 import pytest
 from botocore.config import Config
@@ -1081,3 +1082,14 @@ def test_waiter_config_param_wrong_format(waiter_path_mock: MagicMock):
 
     with pytest.raises(jinja2.TemplateSyntaxError):
         hook.get_waiter("bad_param_wait")
+
+
+@mock.patch.object(AwsGenericHook, "waiter_path", new_callable=PropertyMock)
+def test_custom_waiter_with_resource_type(waiter_path_mock: MagicMock):
+    waiter_path_mock.return_value = TEST_WAITER_CONFIG_LOCATION
+    hook = AwsBaseHook(resource_type="dynamodb")  # needs to be a real client type
+
+    with mock.patch("airflow.providers.amazon.aws.waiters.base_waiter.BaseBotoWaiter") as BaseBotoWaiter:
+        hook.get_waiter("other_wait")
+
+    assert isinstance(BaseBotoWaiter.call_args.kwargs["client"], botocore.client.BaseClient)


### PR DESCRIPTION
Currently, in the BaseAWS hook, the custom waiter doesn't work with resource_type, only client_type is supported. In this PR we are overriding the client when the user uses resource_type's hooks with boto3.client(). This PR temporarily fixes the issue on the Airflow side, until it is not fixed in Botocore.
