### PR TITLE
Add more instructive message in case CI gets expired/wrong credentials

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -265,7 +265,7 @@ def check_remote_ghcr_io_commands():
     """
     Checks if you have permissions to pull an empty image from ghcr.io. Unfortunately, GitHub packages
     treat expired login as "no-access" even on public repos. We need to detect that situation and suggest
-    user to log-out.
+    user to log-out or if they are in CI environment to re-push their PR/close or reopen the PR.
     :return:
     """
     response = run_command(
@@ -281,12 +281,24 @@ def check_remote_ghcr_io_commands():
                 "[error]\nYou seem to be offline. This command requires access to network.[/]\n"
             )
             sys.exit(2)
-        get_console().print(
-            "[error]\nYou seem to have expired permissions on ghcr.io.[/]\n"
-            "[warning]Please logout. Run this command:[/]\n\n"
-            "   docker logout ghcr.io\n\n"
-        )
-        sys.exit(1)
+        if os.environ.get("CI"):
+            get_console().print(
+                "\n[error]We are extremely sorry but you've hit the rare case that the "
+                "credentials you got from GitHub Actions to run are expired, and we cannot do much.[/]"
+                "\n¯\_(ツ)_/¯\n\n"
+                "[warning]You have the following options now:\n\n"
+                "  * Close and reopen the Pull Request of yours\n"
+                "  * Rebase or amend your commit and push your branch again\n"
+                "  * Ask in the PR to re-run the failed job\n\n"
+            )
+            sys.exit(1)
+        else:
+            get_console().print(
+                "[error]\nYou seem to have expired permissions on ghcr.io.[/]\n"
+                "[warning]Please logout. Run this command:[/]\n\n"
+                "   docker logout ghcr.io\n\n"
+            )
+            sys.exit(1)
 
 
 DOCKER_COMPOSE_COMMAND = ["docker-compose"]


### PR DESCRIPTION
When the CI job gets expired/wrong credentials we cannot do much. Unfortunately in this case the only thing we can do is to fail the job, so that next time the job will be restarted, it will get new credentials.

This PR adds specially crafted message that instucts contributor to what can be done in this case.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
