### PR TITLE
Fix mappedStates case

### DIFF
--- a/airflow/www/static/js/dag/InstanceTooltip.tsx
+++ b/airflow/www/static/js/dag/InstanceTooltip.tsx
@@ -19,6 +19,7 @@
 
 import React from "react";
 import { Box, Text } from "@chakra-ui/react";
+import { snakeCase } from "lodash";
 
 import { getGroupAndMapSummary } from "src/utils";
 import { formatDuration, getDuration } from "src/datetime_utils";
@@ -46,11 +47,11 @@ const InstanceTooltip = ({
   });
 
   childTaskMap.forEach((key, val) => {
+    const childState = snakeCase(val);
     if (key > 0) {
       summary.push(
-        // eslint-disable-next-line react/no-array-index-key
-        <Text key={val} ml="10px">
-          {val}
+        <Text key={childState} ml="10px">
+          {childState}
           {": "}
           {key}
         </Text>

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -59,8 +59,6 @@ const Details = ({ instance, group, dagId }: Props) => {
     mappedStates,
   });
 
-  console.log(mappedStates);
-
   childTaskMap.forEach((key, val) => {
     const childState = snakeCase(val);
     if (key > 0) {

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -19,6 +19,7 @@
 
 import React from "react";
 import { Text, Flex, Table, Tbody, Tr, Td, Divider } from "@chakra-ui/react";
+import { snakeCase } from "lodash";
 
 import { getGroupAndMapSummary } from "src/utils";
 import { getDuration, formatDuration } from "src/datetime_utils";
@@ -58,16 +59,18 @@ const Details = ({ instance, group, dagId }: Props) => {
     mappedStates,
   });
 
+  console.log(mappedStates);
+
   childTaskMap.forEach((key, val) => {
+    const childState = snakeCase(val);
     if (key > 0) {
       summary.push(
-        // eslint-disable-next-line react/no-array-index-key
-        <Tr key={val}>
+        <Tr key={childState}>
           <Td />
           <Td>
             <Flex alignItems="center">
-              <SimpleStatus state={val as TaskState} mx={2} />
-              {val}
+              <SimpleStatus state={childState as TaskState} mx={2} />
+              {childState}
               {": "}
               {key}
             </Flex>


### PR DESCRIPTION
Our camelCasing was messing with the `mappedStates` summary. We should set it back to snake_case to work with all our task state logic.

Before:
<img width="637" alt="Screenshot 2023-04-27 at 11 06 44 AM" src="https://user-images.githubusercontent.com/4600967/234908218-2bbd3f3d-149e-4e84-a28f-04bfeae71068.png">


After:
<img width="584" alt="Screenshot 2023-04-27 at 11 06 30 AM" src="https://user-images.githubusercontent.com/4600967/234908248-6659310b-2441-4bf8-acff-e7d30746e96c.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
