### PR TITLE
Bump minimum Airflow version in providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -766,7 +766,7 @@ jobs:
 
   provider-airflow-compatibility-check:
     timeout-minutes: 80
-    name: "Providers Airflow 2.3 compatibility check"
+    name: "Providers Airflow 2.4 compatibility check"
     runs-on: "${{needs.build-info.outputs.runs-on}}"
     needs: [build-info, wait-for-ci-images]
     env:
@@ -789,10 +789,10 @@ jobs:
         run: >
           breeze release-management prepare-provider-packages --version-suffix-for-pypi dev0
           --package-format wheel ${{ needs.build-info.outputs.affected-providers-list-as-string }}
-      - name: "Fix incompatible 2.3 provider packages"
+      - name: "Fix incompatible 2.4 provider packages"
         run: |
-          # This step should remove the provider packages that are not compatible with 2.3
-          # or replace them with 2.3 compatible versions. Sometimes we have good reasons to bump
+          # This step should remove the provider packages that are not compatible with 2.4
+          # or replace them with 2.4 compatible versions. Sometimes we have good reasons to bump
           # the min airflow versions for some providers and then we need to add exclusions here.
           #
           # The Removal can be done with:
@@ -813,15 +813,15 @@ jobs:
           providers = json.loads(Path("generated/provider_dependencies.json").read_text())
           provider_keys = ",".join(providers.keys())
           print("AIRFLOW_EXTRAS={}".format(provider_keys))' >> $GITHUB_ENV
-      - name: "Install and verify all provider packages and airflow on Airflow 2.3 files"
+      - name: "Install and verify all provider packages and airflow on Airflow 2.4 files"
         run: >
-          breeze release-management verify-provider-packages --use-airflow-version 2.3.0
-          --use-packages-from-dist --airflow-constraints-reference constraints-2.3.0
+          breeze release-management verify-provider-packages --use-airflow-version 2.4.0
+          --use-packages-from-dist --airflow-constraints-reference constraints-2.4.0
         if: needs.build-info.outputs.affected-providers-list-as-string == ''
-      - name: "Install affected provider packages and airflow on Airflow 2.3 files"
+      - name: "Install affected provider packages and airflow on Airflow 2.4 files"
         run: >
-          breeze release-management install-provider-packages --use-airflow-version 2.3.0
-          --airflow-constraints-reference constraints-2.3.0 --run-in-parallel
+          breeze release-management install-provider-packages --use-airflow-version 2.4.0
+          --airflow-constraints-reference constraints-2.4.0 --run-in-parallel
         # Make sure to skip the run if the only provider to be installed has been removed
         # in the previous step
         if: >

--- a/PROVIDERS.rst
+++ b/PROVIDERS.rst
@@ -120,8 +120,8 @@ Airflow version to the next MINOR release, when 12 months passed since the first
 MINOR version of Airflow.
 
 For example this means that by default we upgrade the minimum version of Airflow supported by providers
-to 2.4.0 in the first Provider's release after 30th of April 2023. The 30th of April 2022 is the date when the
-first ``PATCHLEVEL`` of 2.3 (2.3.0) has been released.
+to 2.5.0 in the first Provider's release after 19th of September 2023. The 19th of September 2022 is the date when the
+first ``PATCHLEVEL`` of 2.4 (2.4.0) has been released.
 
 When we increase the minimum Airflow version, this is not a reason to bump ``MAJOR`` version of the providers
 (unless there are other breaking changes in the provider). The reason for that is that people who use

--- a/airflow/providers/airbyte/provider.yaml
+++ b/airflow/providers/airbyte/provider.yaml
@@ -36,7 +36,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-http
 
 integrations:

--- a/airflow/providers/alibaba/provider.yaml
+++ b/airflow/providers/alibaba/provider.yaml
@@ -34,7 +34,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - oss2>=2.14.0
 
 integrations:

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -57,7 +57,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - boto3>=1.24.0
   - asgiref

--- a/airflow/providers/apache/beam/provider.yaml
+++ b/airflow/providers/apache/beam/provider.yaml
@@ -41,7 +41,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-beam>=2.33.0
 
 integrations:

--- a/airflow/providers/apache/cassandra/provider.yaml
+++ b/airflow/providers/apache/cassandra/provider.yaml
@@ -36,7 +36,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - cassandra-driver>=3.13.0
 
 integrations:

--- a/airflow/providers/apache/drill/provider.yaml
+++ b/airflow/providers/apache/drill/provider.yaml
@@ -37,7 +37,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - sqlalchemy-drill>=1.1.0
 

--- a/airflow/providers/apache/druid/provider.yaml
+++ b/airflow/providers/apache/druid/provider.yaml
@@ -43,7 +43,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - pydruid>=0.4.1
 

--- a/airflow/providers/apache/flink/provider.yaml
+++ b/airflow/providers/apache/flink/provider.yaml
@@ -27,7 +27,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - cryptography>=2.0.0
   - apache-airflow-providers-cncf-kubernetes>=5.1.0
 

--- a/airflow/providers/apache/hdfs/provider.yaml
+++ b/airflow/providers/apache/hdfs/provider.yaml
@@ -40,7 +40,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - snakebite-py3
   - hdfs[avro,dataframe,kerberos]>=2.0.4
 

--- a/airflow/providers/apache/hive/provider.yaml
+++ b/airflow/providers/apache/hive/provider.yaml
@@ -51,7 +51,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - hmsclient>=0.1.0
   - pandas>=0.17.1

--- a/airflow/providers/apache/impala/provider.yaml
+++ b/airflow/providers/apache/impala/provider.yaml
@@ -27,7 +27,7 @@ versions:
 
 dependencies:
   - impyla>=0.18.0,<1.0
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
 
 integrations:
   - integration-name: Apache Impala

--- a/airflow/providers/apache/kafka/provider.yaml
+++ b/airflow/providers/apache/kafka/provider.yaml
@@ -26,7 +26,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - asgiref
   - confluent-kafka>=1.8.2
 

--- a/airflow/providers/apache/kylin/provider.yaml
+++ b/airflow/providers/apache/kylin/provider.yaml
@@ -34,7 +34,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - kylinpy>=2.6
 
 integrations:

--- a/airflow/providers/apache/livy/provider.yaml
+++ b/airflow/providers/apache/livy/provider.yaml
@@ -39,7 +39,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-http
   - aiohttp
   - asgiref

--- a/airflow/providers/apache/pig/provider.yaml
+++ b/airflow/providers/apache/pig/provider.yaml
@@ -34,7 +34,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
 
 integrations:
   - integration-name: Apache Pig

--- a/airflow/providers/apache/pinot/provider.yaml
+++ b/airflow/providers/apache/pinot/provider.yaml
@@ -38,7 +38,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - pinotdb>0.4.7
 

--- a/airflow/providers/apache/spark/provider.yaml
+++ b/airflow/providers/apache/spark/provider.yaml
@@ -40,7 +40,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - pyspark
 
 integrations:

--- a/airflow/providers/apache/sqoop/provider.yaml
+++ b/airflow/providers/apache/sqoop/provider.yaml
@@ -37,7 +37,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
 
 integrations:
   - integration-name: Apache Sqoop

--- a/airflow/providers/arangodb/provider.yaml
+++ b/airflow/providers/arangodb/provider.yaml
@@ -22,7 +22,7 @@ description: |
     `ArangoDB <https://www.arangodb.com/>`__
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - python-arango>=7.3.2
 
 suspended: false

--- a/airflow/providers/asana/provider.yaml
+++ b/airflow/providers/asana/provider.yaml
@@ -33,7 +33,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - asana>=0.10
 
 integrations:

--- a/airflow/providers/atlassian/jira/provider.yaml
+++ b/airflow/providers/atlassian/jira/provider.yaml
@@ -29,7 +29,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - atlassian-python-api>=1.14.2
 
 integrations:

--- a/airflow/providers/celery/provider.yaml
+++ b/airflow/providers/celery/provider.yaml
@@ -35,7 +35,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   # The Celery is known to introduce problems when upgraded to a MAJOR version. Airflow Core
   # Uses Celery for CeleryExecutor, and we also know that Kubernetes Python client follows SemVer
   # (https://docs.celeryq.dev/en/stable/contributing.html?highlight=semver#versions).

--- a/airflow/providers/cloudant/provider.yaml
+++ b/airflow/providers/cloudant/provider.yaml
@@ -34,7 +34,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - cloudant>=2.0
 
 integrations:

--- a/airflow/providers/cncf/kubernetes/provider.yaml
+++ b/airflow/providers/cncf/kubernetes/provider.yaml
@@ -58,7 +58,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - asgiref>=3.5.2
   - cryptography>=2.0.0
   # The Kubernetes API is known to introduce problems when upgraded to a MAJOR version. Airflow Core

--- a/airflow/providers/databricks/provider.yaml
+++ b/airflow/providers/databricks/provider.yaml
@@ -45,7 +45,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - requests>=2.27,<3
   - databricks-sql-connector>=2.0.0, <3.0.0

--- a/airflow/providers/datadog/provider.yaml
+++ b/airflow/providers/datadog/provider.yaml
@@ -35,7 +35,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - datadog>=0.14.0
 
 integrations:

--- a/airflow/providers/dbt/cloud/provider.yaml
+++ b/airflow/providers/dbt/cloud/provider.yaml
@@ -36,7 +36,7 @@ versions:
   - 1.0.1
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-http
   - asgiref
   - aiohttp

--- a/airflow/providers/dingding/provider.yaml
+++ b/airflow/providers/dingding/provider.yaml
@@ -35,7 +35,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-http
 
 integrations:

--- a/airflow/providers/discord/provider.yaml
+++ b/airflow/providers/discord/provider.yaml
@@ -35,7 +35,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-http
 
 integrations:

--- a/airflow/providers/docker/provider.yaml
+++ b/airflow/providers/docker/provider.yaml
@@ -50,7 +50,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - docker>=5.0.3
   - python-dotenv>=0.21.0
 

--- a/airflow/providers/elasticsearch/provider.yaml
+++ b/airflow/providers/elasticsearch/provider.yaml
@@ -48,7 +48,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - elasticsearch>7
   - elasticsearch-dbapi

--- a/airflow/providers/exasol/provider.yaml
+++ b/airflow/providers/exasol/provider.yaml
@@ -42,7 +42,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - pyexasol>=0.5.1
   - pandas>=0.17.1

--- a/airflow/providers/facebook/provider.yaml
+++ b/airflow/providers/facebook/provider.yaml
@@ -38,7 +38,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - facebook-business>=6.0.2
 
 integrations:

--- a/airflow/providers/github/provider.yaml
+++ b/airflow/providers/github/provider.yaml
@@ -23,7 +23,7 @@ description: |
     `GitHub <https://www.github.com/>`__
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   # There was a change introduced in version 1.58 which breaks `pickle` serialization out of the box.
   # See https://github.com/PyGithub/PyGithub/issues/2436.
   - PyGithub!=1.58

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -65,7 +65,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   # Google has very clear rules on what dependencies should be used. All the limits below
   # follow strict guidelines of Google Libraries as quoted here:

--- a/airflow/providers/grpc/provider.yaml
+++ b/airflow/providers/grpc/provider.yaml
@@ -34,7 +34,7 @@ versions:
   - 1.0.1
   - 1.0.0
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   # Google has very clear rules on what dependencies should be used. All the limits below
   # follow strict guidelines of Google Libraries as quoted here:
   # While this issue is open, dependents of google-api-core, google-cloud-core. and google-auth

--- a/airflow/providers/hashicorp/provider.yaml
+++ b/airflow/providers/hashicorp/provider.yaml
@@ -41,7 +41,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - hvac>=0.10
 
 integrations:

--- a/airflow/providers/influxdb/provider.yaml
+++ b/airflow/providers/influxdb/provider.yaml
@@ -24,7 +24,7 @@ description: |
     `InfluxDB <https://www.influxdata.com/>`__
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - influxdb-client>=1.19.0
   - requests>=2.26.0
 

--- a/airflow/providers/jdbc/provider.yaml
+++ b/airflow/providers/jdbc/provider.yaml
@@ -38,7 +38,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - jaydebeapi>=1.1.1
 

--- a/airflow/providers/jenkins/provider.yaml
+++ b/airflow/providers/jenkins/provider.yaml
@@ -41,7 +41,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - python-jenkins>=1.0.0
 
 integrations:

--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -55,7 +55,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - azure-batch>=8.0.0
   - azure-cosmos>=4.0.0
   - azure-datalake-store>=0.0.45

--- a/airflow/providers/microsoft/mssql/provider.yaml
+++ b/airflow/providers/microsoft/mssql/provider.yaml
@@ -41,7 +41,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - pymssql>=2.1.5
 

--- a/airflow/providers/microsoft/psrp/provider.yaml
+++ b/airflow/providers/microsoft/psrp/provider.yaml
@@ -37,6 +37,7 @@ versions:
   - 1.0.0
 
 dependencies:
+  - apache-airflow>=2.4.0
   - pypsrp>=0.8.0
 
 integrations:

--- a/airflow/providers/microsoft/winrm/provider.yaml
+++ b/airflow/providers/microsoft/winrm/provider.yaml
@@ -38,7 +38,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - pywinrm>=0.4
 
 integrations:

--- a/airflow/providers/mongo/provider.yaml
+++ b/airflow/providers/mongo/provider.yaml
@@ -37,7 +37,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - dnspython>=1.13.0
   # pymongo 4.0.0 removes connection option `ssl_cert_reqs` which is used in providers-mongo/2.2.0
   # TODO: Upgrade to pymongo 4.0.0+

--- a/airflow/providers/mysql/provider.yaml
+++ b/airflow/providers/mysql/provider.yaml
@@ -46,7 +46,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - mysqlclient>=1.3.6
 

--- a/airflow/providers/neo4j/provider.yaml
+++ b/airflow/providers/neo4j/provider.yaml
@@ -38,7 +38,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - neo4j>=4.2.1
 
 integrations:

--- a/airflow/providers/odbc/provider.yaml
+++ b/airflow/providers/odbc/provider.yaml
@@ -38,7 +38,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - pyodbc
 

--- a/airflow/providers/openfaas/provider.yaml
+++ b/airflow/providers/openfaas/provider.yaml
@@ -34,7 +34,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
 
 integrations:
   - integration-name: OpenFaaS

--- a/airflow/providers/opsgenie/provider.yaml
+++ b/airflow/providers/opsgenie/provider.yaml
@@ -37,7 +37,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - opsgenie-sdk>=2.1.5
 
 integrations:

--- a/airflow/providers/oracle/provider.yaml
+++ b/airflow/providers/oracle/provider.yaml
@@ -43,7 +43,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - oracledb>=1.0.0
 

--- a/airflow/providers/pagerduty/provider.yaml
+++ b/airflow/providers/pagerduty/provider.yaml
@@ -35,7 +35,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - pdpyras>=4.1.2
 
 integrations:

--- a/airflow/providers/papermill/provider.yaml
+++ b/airflow/providers/papermill/provider.yaml
@@ -38,7 +38,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - papermill[all]>=1.2.1
   - scrapbook[all]
 

--- a/airflow/providers/plexus/provider.yaml
+++ b/airflow/providers/plexus/provider.yaml
@@ -34,7 +34,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - arrow>=0.16.0
 
 integrations:

--- a/airflow/providers/postgres/provider.yaml
+++ b/airflow/providers/postgres/provider.yaml
@@ -45,7 +45,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - psycopg2-binary>=2.8.0
 

--- a/airflow/providers/presto/provider.yaml
+++ b/airflow/providers/presto/provider.yaml
@@ -44,7 +44,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - presto-python-client>=0.8.2
   - pandas>=0.17.1

--- a/airflow/providers/qubole/provider.yaml
+++ b/airflow/providers/qubole/provider.yaml
@@ -40,7 +40,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - qds-sdk>=1.10.4
 

--- a/airflow/providers/redis/provider.yaml
+++ b/airflow/providers/redis/provider.yaml
@@ -34,7 +34,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   # Redis 4 introduced a number of changes that likely need testing including mixins in redis commands
   # as well as unquoting URLS with `urllib.parse.unquote`:
   # https://github.com/redis/redis-py/blob/master/CHANGES

--- a/airflow/providers/salesforce/provider.yaml
+++ b/airflow/providers/salesforce/provider.yaml
@@ -42,7 +42,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - simple-salesforce>=1.0.0
   - pandas>=0.17.1
 

--- a/airflow/providers/samba/provider.yaml
+++ b/airflow/providers/samba/provider.yaml
@@ -35,7 +35,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - smbprotocol>=1.5.0
 
 integrations:

--- a/airflow/providers/segment/provider.yaml
+++ b/airflow/providers/segment/provider.yaml
@@ -34,7 +34,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - analytics-python>=1.2.9
 
 integrations:

--- a/airflow/providers/sendgrid/provider.yaml
+++ b/airflow/providers/sendgrid/provider.yaml
@@ -22,7 +22,7 @@ description: |
     `Sendgrid <https://sendgrid.com/>`__
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - sendgrid>=6.0.0
 
 suspended: false

--- a/airflow/providers/sftp/provider.yaml
+++ b/airflow/providers/sftp/provider.yaml
@@ -48,7 +48,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-ssh>=2.1.0
 
 integrations:

--- a/airflow/providers/singularity/provider.yaml
+++ b/airflow/providers/singularity/provider.yaml
@@ -35,7 +35,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - spython>=0.0.56
 
 integrations:

--- a/airflow/providers/slack/provider.yaml
+++ b/airflow/providers/slack/provider.yaml
@@ -42,7 +42,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - slack_sdk>=3.0.0
 

--- a/airflow/providers/smtp/provider.yaml
+++ b/airflow/providers/smtp/provider.yaml
@@ -28,7 +28,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
 
 integrations:
   - integration-name: Simple Mail Transfer Protocol (SMTP)

--- a/airflow/providers/snowflake/provider.yaml
+++ b/airflow/providers/snowflake/provider.yaml
@@ -52,7 +52,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - snowflake-connector-python>=2.4.1
   - snowflake-sqlalchemy>=1.1.0

--- a/airflow/providers/ssh/provider.yaml
+++ b/airflow/providers/ssh/provider.yaml
@@ -46,7 +46,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - paramiko>=2.6.0
   - sshtunnel>=0.3.2
 

--- a/airflow/providers/tableau/provider.yaml
+++ b/airflow/providers/tableau/provider.yaml
@@ -40,7 +40,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - tableauserverclient
 
 integrations:

--- a/airflow/providers/tabular/provider.yaml
+++ b/airflow/providers/tabular/provider.yaml
@@ -28,7 +28,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
 
 integrations:
   - integration-name: Tabular

--- a/airflow/providers/telegram/provider.yaml
+++ b/airflow/providers/telegram/provider.yaml
@@ -37,7 +37,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - python-telegram-bot>=20.0.0
 
 integrations:

--- a/airflow/providers/trino/provider.yaml
+++ b/airflow/providers/trino/provider.yaml
@@ -44,7 +44,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - pandas>=0.17.1
   - trino>=0.318.0

--- a/airflow/providers/vertica/provider.yaml
+++ b/airflow/providers/vertica/provider.yaml
@@ -39,7 +39,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - vertica-python>=0.5.1
 

--- a/airflow/providers/yandex/provider.yaml
+++ b/airflow/providers/yandex/provider.yaml
@@ -36,7 +36,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - yandexcloud>=0.173.0
 
 integrations:

--- a/airflow/providers/zendesk/provider.yaml
+++ b/airflow/providers/zendesk/provider.yaml
@@ -36,7 +36,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.3.0
+  - apache-airflow>=2.4.0
   - zenpy>=2.0.24
 
 integrations:

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -2,7 +2,7 @@
   "airbyte": {
     "deps": [
       "apache-airflow-providers-http",
-      "apache-airflow>=2.3.0"
+      "apache-airflow>=2.4.0"
     ],
     "cross-providers-deps": [
       "http"
@@ -10,7 +10,7 @@
   },
   "alibaba": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "oss2>=2.14.0"
     ],
     "cross-providers-deps": []
@@ -18,7 +18,7 @@
   "amazon": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "asgiref",
       "boto3>=1.24.0",
       "jsonpath_ng>=1.5.3",
@@ -44,7 +44,7 @@
   },
   "apache.beam": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "apache-beam>=2.33.0"
     ],
     "cross-providers-deps": [
@@ -53,7 +53,7 @@
   },
   "apache.cassandra": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "cassandra-driver>=3.13.0"
     ],
     "cross-providers-deps": []
@@ -61,7 +61,7 @@
   "apache.drill": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "sqlalchemy-drill>=1.1.0"
     ],
     "cross-providers-deps": [
@@ -71,7 +71,7 @@
   "apache.druid": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "pydruid>=0.4.1"
     ],
     "cross-providers-deps": [
@@ -82,7 +82,7 @@
   "apache.flink": {
     "deps": [
       "apache-airflow-providers-cncf-kubernetes>=5.1.0",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "cryptography>=2.0.0"
     ],
     "cross-providers-deps": [
@@ -91,7 +91,7 @@
   },
   "apache.hdfs": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "hdfs[avro,dataframe,kerberos]>=2.0.4",
       "snakebite-py3"
     ],
@@ -100,7 +100,7 @@
   "apache.hive": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "hmsclient>=0.1.0",
       "pandas>=0.17.1",
       "pyhive[hive]>=0.6.0",
@@ -119,7 +119,7 @@
   },
   "apache.impala": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "impyla>=0.18.0,<1.0"
     ],
     "cross-providers-deps": [
@@ -128,7 +128,7 @@
   },
   "apache.kafka": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "asgiref",
       "confluent-kafka>=1.8.2"
     ],
@@ -136,7 +136,7 @@
   },
   "apache.kylin": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "kylinpy>=2.6"
     ],
     "cross-providers-deps": []
@@ -145,7 +145,7 @@
     "deps": [
       "aiohttp",
       "apache-airflow-providers-http",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "asgiref"
     ],
     "cross-providers-deps": [
@@ -154,14 +154,14 @@
   },
   "apache.pig": {
     "deps": [
-      "apache-airflow>=2.3.0"
+      "apache-airflow>=2.4.0"
     ],
     "cross-providers-deps": []
   },
   "apache.pinot": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "pinotdb>0.4.7"
     ],
     "cross-providers-deps": [
@@ -170,41 +170,41 @@
   },
   "apache.spark": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "pyspark"
     ],
     "cross-providers-deps": []
   },
   "apache.sqoop": {
     "deps": [
-      "apache-airflow>=2.3.0"
+      "apache-airflow>=2.4.0"
     ],
     "cross-providers-deps": []
   },
   "arangodb": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "python-arango>=7.3.2"
     ],
     "cross-providers-deps": []
   },
   "asana": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "asana>=0.10"
     ],
     "cross-providers-deps": []
   },
   "atlassian.jira": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "atlassian-python-api>=1.14.2"
     ],
     "cross-providers-deps": []
   },
   "celery": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "celery>=5.2.3,<6",
       "flower>=1.0.0"
     ],
@@ -212,14 +212,14 @@
   },
   "cloudant": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "cloudant>=2.0"
     ],
     "cross-providers-deps": []
   },
   "cncf.kubernetes": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "asgiref>=3.5.2",
       "cryptography>=2.0.0",
       "kubernetes>=21.7.0,<24",
@@ -237,7 +237,7 @@
     "deps": [
       "aiohttp>=3.6.3, <4",
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "databricks-sql-connector>=2.0.0, <3.0.0",
       "requests>=2.27,<3"
     ],
@@ -247,7 +247,7 @@
   },
   "datadog": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "datadog>=0.14.0"
     ],
     "cross-providers-deps": []
@@ -256,7 +256,7 @@
     "deps": [
       "aiohttp",
       "apache-airflow-providers-http",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "asgiref"
     ],
     "cross-providers-deps": [
@@ -266,7 +266,7 @@
   "dingding": {
     "deps": [
       "apache-airflow-providers-http",
-      "apache-airflow>=2.3.0"
+      "apache-airflow>=2.4.0"
     ],
     "cross-providers-deps": [
       "http"
@@ -275,7 +275,7 @@
   "discord": {
     "deps": [
       "apache-airflow-providers-http",
-      "apache-airflow>=2.3.0"
+      "apache-airflow>=2.4.0"
     ],
     "cross-providers-deps": [
       "http"
@@ -283,7 +283,7 @@
   },
   "docker": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "docker>=5.0.3",
       "python-dotenv>=0.21.0"
     ],
@@ -292,7 +292,7 @@
   "elasticsearch": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "elasticsearch-dbapi",
       "elasticsearch-dsl>=5.0.0",
       "elasticsearch>7"
@@ -304,7 +304,7 @@
   "exasol": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "pandas>=0.17.1",
       "pyexasol>=0.5.1"
     ],
@@ -314,7 +314,7 @@
   },
   "facebook": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "facebook-business>=6.0.2"
     ],
     "cross-providers-deps": []
@@ -326,7 +326,7 @@
   "github": {
     "deps": [
       "PyGithub!=1.58",
-      "apache-airflow>=2.3.0"
+      "apache-airflow>=2.4.0"
     ],
     "cross-providers-deps": []
   },
@@ -335,7 +335,7 @@
       "PyOpenSSL",
       "PyYAML<7.0,>=5.1",
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "asgiref>=3.5.2",
       "gcloud-aio-auth>=4.0.0,<5.0.0",
       "gcloud-aio-bigquery>=6.1.2",
@@ -412,7 +412,7 @@
   },
   "grpc": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "google-auth-httplib2>=0.0.1",
       "google-auth>=1.0.0, <3.0.0",
       "grpcio>=1.15.0"
@@ -421,7 +421,7 @@
   },
   "hashicorp": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "hvac>=0.10"
     ],
     "cross-providers-deps": [
@@ -443,7 +443,7 @@
   },
   "influxdb": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "influxdb-client>=1.19.0",
       "requests>=2.26.0"
     ],
@@ -452,7 +452,7 @@
   "jdbc": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "jaydebeapi>=1.1.1"
     ],
     "cross-providers-deps": [
@@ -461,7 +461,7 @@
   },
   "jenkins": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "python-jenkins>=1.0.0"
     ],
     "cross-providers-deps": []
@@ -469,7 +469,7 @@
   "microsoft.azure": {
     "deps": [
       "adal>=1.2.7",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "azure-batch>=8.0.0",
       "azure-cosmos>=4.0.0",
       "azure-datalake-store>=0.0.45",
@@ -496,7 +496,7 @@
   "microsoft.mssql": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "pymssql>=2.1.5"
     ],
     "cross-providers-deps": [
@@ -505,20 +505,21 @@
   },
   "microsoft.psrp": {
     "deps": [
+      "apache-airflow>=2.4.0",
       "pypsrp>=0.8.0"
     ],
     "cross-providers-deps": []
   },
   "microsoft.winrm": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "pywinrm>=0.4"
     ],
     "cross-providers-deps": []
   },
   "mongo": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "dnspython>=1.13.0",
       "pymongo>=3.6.0,<4.0.0"
     ],
@@ -527,7 +528,7 @@
   "mysql": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "mysqlclient>=1.3.6"
     ],
     "cross-providers-deps": [
@@ -540,7 +541,7 @@
   },
   "neo4j": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "neo4j>=4.2.1"
     ],
     "cross-providers-deps": []
@@ -548,7 +549,7 @@
   "odbc": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "pyodbc"
     ],
     "cross-providers-deps": [
@@ -557,7 +558,7 @@
   },
   "openfaas": {
     "deps": [
-      "apache-airflow>=2.3.0"
+      "apache-airflow>=2.4.0"
     ],
     "cross-providers-deps": []
   },
@@ -573,7 +574,7 @@
   },
   "opsgenie": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "opsgenie-sdk>=2.1.5"
     ],
     "cross-providers-deps": []
@@ -581,7 +582,7 @@
   "oracle": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "oracledb>=1.0.0"
     ],
     "cross-providers-deps": [
@@ -590,14 +591,14 @@
   },
   "pagerduty": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "pdpyras>=4.1.2"
     ],
     "cross-providers-deps": []
   },
   "papermill": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "papermill[all]>=1.2.1",
       "scrapbook[all]"
     ],
@@ -605,7 +606,7 @@
   },
   "plexus": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "arrow>=0.16.0"
     ],
     "cross-providers-deps": []
@@ -613,7 +614,7 @@
   "postgres": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "psycopg2-binary>=2.8.0"
     ],
     "cross-providers-deps": [
@@ -624,7 +625,7 @@
   "presto": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "pandas>=0.17.1",
       "presto-python-client>=0.8.2"
     ],
@@ -636,7 +637,7 @@
   "qubole": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "qds-sdk>=1.10.4"
     ],
     "cross-providers-deps": [
@@ -645,14 +646,14 @@
   },
   "redis": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "redis~=3.2"
     ],
     "cross-providers-deps": []
   },
   "salesforce": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "pandas>=0.17.1",
       "simple-salesforce>=1.0.0"
     ],
@@ -660,7 +661,7 @@
   },
   "samba": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "smbprotocol>=1.5.0"
     ],
     "cross-providers-deps": []
@@ -668,13 +669,13 @@
   "segment": {
     "deps": [
       "analytics-python>=1.2.9",
-      "apache-airflow>=2.3.0"
+      "apache-airflow>=2.4.0"
     ],
     "cross-providers-deps": []
   },
   "sendgrid": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "sendgrid>=6.0.0"
     ],
     "cross-providers-deps": []
@@ -682,7 +683,7 @@
   "sftp": {
     "deps": [
       "apache-airflow-providers-ssh>=2.1.0",
-      "apache-airflow>=2.3.0"
+      "apache-airflow>=2.4.0"
     ],
     "cross-providers-deps": [
       "ssh"
@@ -690,7 +691,7 @@
   },
   "singularity": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "spython>=0.0.56"
     ],
     "cross-providers-deps": []
@@ -698,7 +699,7 @@
   "slack": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "slack_sdk>=3.0.0"
     ],
     "cross-providers-deps": [
@@ -707,14 +708,14 @@
   },
   "smtp": {
     "deps": [
-      "apache-airflow>=2.3.0"
+      "apache-airflow>=2.4.0"
     ],
     "cross-providers-deps": []
   },
   "snowflake": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "snowflake-connector-python>=2.4.1",
       "snowflake-sqlalchemy>=1.1.0"
     ],
@@ -733,7 +734,7 @@
   },
   "ssh": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "paramiko>=2.6.0",
       "sshtunnel>=0.3.2"
     ],
@@ -741,20 +742,20 @@
   },
   "tableau": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "tableauserverclient"
     ],
     "cross-providers-deps": []
   },
   "tabular": {
     "deps": [
-      "apache-airflow>=2.3.0"
+      "apache-airflow>=2.4.0"
     ],
     "cross-providers-deps": []
   },
   "telegram": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "python-telegram-bot>=20.0.0"
     ],
     "cross-providers-deps": []
@@ -762,7 +763,7 @@
   "trino": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "pandas>=0.17.1",
       "trino>=0.318.0"
     ],
@@ -774,7 +775,7 @@
   "vertica": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "vertica-python>=0.5.1"
     ],
     "cross-providers-deps": [
@@ -783,7 +784,7 @@
   },
   "zendesk": {
     "deps": [
-      "apache-airflow>=2.3.0",
+      "apache-airflow>=2.4.0",
       "zenpy>=2.0.24"
     ],
     "cross-providers-deps": []


### PR DESCRIPTION
~**DO NOT MERGE BEFORE 30-APR**~

According to our policy https://github.com/apache/airflow/blob/main/PROVIDERS.rst#minimum-supported-version-of-airflow-for-community-managed-providers

Note for reviewers:
Providers that are pre-installed with Airflow (Sqlite, common.sql etc..) do not have minimum Airflow version thus left out of this PR.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
