### PR TITLE
Improve task group UI in new graph

### DIFF
--- a/airflow/www/static/js/dag/details/graph/Node.tsx
+++ b/airflow/www/static/js/dag/details/graph/Node.tsx
@@ -74,6 +74,8 @@ export const BaseNode = ({
     ? `${label} [${instance ? totalTasks : " "}]`
     : label;
 
+  const bg = isOpen ? "#cccccc40" : "white";
+
   return (
     <Tooltip
       label={
@@ -90,7 +92,7 @@ export const BaseNode = ({
         borderRadius={5}
         borderWidth={1}
         borderColor={isSelected ? "blue.400" : "gray.400"}
-        bg={isSelected ? "blue.50" : "white"}
+        bg={isSelected ? "blue.50" : bg}
         height={`${height}px`}
         width={`${width}px`}
         cursor={latestDagRunId ? "cursor" : "default"}
@@ -134,6 +136,9 @@ export const BaseNode = ({
             <Text
               color="blue.600"
               cursor="pointer"
+              // Increase the target area to expand/collapse a group
+              p={3}
+              m={-3}
               onClick={(e) => {
                 e.stopPropagation();
                 onToggleCollapse();

--- a/airflow/www/static/js/dag/details/graph/Node.tsx
+++ b/airflow/www/static/js/dag/details/graph/Node.tsx
@@ -74,7 +74,7 @@ export const BaseNode = ({
     ? `${label} [${instance ? totalTasks : " "}]`
     : label;
 
-  const bg = isOpen ? "#cccccc40" : "white";
+  const bg = isOpen ? "blackAlpha.50" : "white";
 
   return (
     <Tooltip


### PR DESCRIPTION
- Add a background opacity to task groups
- Increase the touch area for the expand/collapse button on a task group

<img width="1047" alt="Screenshot 2023-04-27 at 3 03 12 PM" src="https://user-images.githubusercontent.com/4600967/234965856-fb178b39-36a6-4069-b7e8-0dddfab97cb4.png">
<img width="642" alt="Screenshot 2023-04-27 at 3 03 25 PM" src="https://user-images.githubusercontent.com/4600967/234965860-24b1adc0-6e44-4c5b-b21e-cb71072b6aa7.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
