### PR TITLE
Allow to run suspended provider changes PRs if proper label is set

### DIFF
--- a/dev/breeze/SELECTIVE_CHECKS.md
+++ b/dev/breeze/SELECTIVE_CHECKS.md
@@ -109,6 +109,11 @@ The logic implements the following rules:
   changed, also providers docs are built because all providers depend on airflow docs. If any of the docs
   build python files changed or when build is "canary" type in main - all docs packages are built.
 
+
+The selective checks will fail in PR if it contains changes to a suspended provider unless you set the
+label `allow suspended provider changes` in the PR. This is to prevent accidental changes to suspended
+providers.
+
 The selective check outputs available are described below. In case of `list-as-string` values,
 empty string means `everything`, where lack of the output means `nothing` and list elements are
 separated by spaces. This is to accommodate for the wau how outputs of this kind can be easily used by

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -241,7 +241,7 @@ def add_dependent_providers(
 
 
 def find_all_providers_affected(
-    changed_files: tuple[str, ...], include_docs: bool
+    changed_files: tuple[str, ...], include_docs: bool, fail_if_suspended_providers_affected: bool
 ) -> list[str] | Literal["ALL_PROVIDERS"] | None:
     all_providers: set[str] = set()
     dependencies = json.loads((AIRFLOW_SOURCES_ROOT / "generated" / "provider_dependencies.json").read_text())
@@ -266,7 +266,7 @@ def find_all_providers_affected(
         # potential escape hatch if someone would like to modify suspended provider,
         # but it can be found at the review time and is anyway harmless as the provider will not be
         # released nor tested nor used in CI anyway.
-        get_console().print("[error]You are modifying suspended providers.\n")
+        get_console().print("[yellow]You are modifying suspended providers.\n")
         get_console().print(
             "[info]Some providers modified by this change have been suspended, "
             "and before attempting such changes you should fix the reason for suspension."
@@ -276,7 +276,15 @@ def find_all_providers_affected(
             "to make changes to the provider."
         )
         get_console().print(f"Suspended providers: {suspended_providers}")
-        sys.exit(1)
+        if fail_if_suspended_providers_affected:
+            get_console().print(
+                "[error]This PR did not have `allow suspended provider changes` " "label set so it will fail."
+            )
+            sys.exit(1)
+        else:
+            get_console().print(
+                "[info]This PR had `allow suspended provider changes` label set so it will " "continue"
+            )
     if len(all_providers) == 0:
         return None
     for provider in list(all_providers):
@@ -563,6 +571,9 @@ class SelectiveChecks:
         # prepare all providers packages and build all providers documentation
         return "Providers" in self._get_test_types_to_run()
 
+    def _fail_if_suspended_providers_affected(self):
+        return "allow suspended provider changes" not in self._pr_labels
+
     def _get_test_types_to_run(self) -> list[str]:
         candidate_test_types: set[str] = {"Always"}
         matched_files: set[str] = set()
@@ -597,7 +608,9 @@ class SelectiveChecks:
         else:
             if "Providers" in candidate_test_types:
                 affected_providers = find_all_providers_affected(
-                    changed_files=self._files, include_docs=False
+                    changed_files=self._files,
+                    include_docs=False,
+                    fail_if_suspended_providers_affected=self._fail_if_suspended_providers_affected(),
                 )
                 if affected_providers != "ALL_PROVIDERS" and affected_providers is not None:
                     candidate_test_types.remove("Providers")
@@ -697,7 +710,11 @@ class SelectiveChecks:
             return "--package-filter apache-airflow --package-filter docker-stack"
         if self.full_tests_needed:
             return _ALL_DOCS_LIST
-        providers_affected = find_all_providers_affected(changed_files=self._files, include_docs=True)
+        providers_affected = find_all_providers_affected(
+            changed_files=self._files,
+            include_docs=True,
+            fail_if_suspended_providers_affected=self._fail_if_suspended_providers_affected(),
+        )
         if (
             providers_affected == "ALL_PROVIDERS"
             or "docs/conf.py" in self._files
@@ -746,7 +763,11 @@ class SelectiveChecks:
             return _ALL_PROVIDERS_LIST
         if self._are_all_providers_affected():
             return _ALL_PROVIDERS_LIST
-        affected_providers = find_all_providers_affected(changed_files=self._files, include_docs=True)
+        affected_providers = find_all_providers_affected(
+            changed_files=self._files,
+            include_docs=True,
+            fail_if_suspended_providers_affected=self._fail_if_suspended_providers_affected(),
+        )
         if not affected_providers:
             return None
         if affected_providers == "ALL_PROVIDERS":

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -278,12 +278,12 @@ def find_all_providers_affected(
         get_console().print(f"Suspended providers: {suspended_providers}")
         if fail_if_suspended_providers_affected:
             get_console().print(
-                "[error]This PR did not have `allow suspended provider changes` " "label set so it will fail."
+                "[error]This PR did not have `allow suspended provider changes` label set so it will fail."
             )
             sys.exit(1)
         else:
             get_console().print(
-                "[info]This PR had `allow suspended provider changes` label set so it will " "continue"
+                "[info]This PR had `allow suspended provider changes` label set so it will continue"
             )
     if len(all_providers) == 0:
         return None

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1071,3 +1071,50 @@ def test_docs_filter(files: tuple[str, ...], expected_outputs: dict[str, str]):
         default_branch="main",
     )
     assert_outputs_are_printed(expected_outputs, str(stderr))
+
+
+@pytest.mark.parametrize(
+    "files, labels, expected_outputs, should_fail",
+    [
+        pytest.param(
+            ("airflow/providers/yandex/test.py",),
+            (),
+            None,
+            True,
+            id="Suspended provider changes should fail",
+        ),
+        pytest.param(
+            ("airflow/providers/yandex/test.py",),
+            ("allow suspended provider changes",),
+            {"affected-providers-list-as-string": ALL_PROVIDERS_AFFECTED},
+            False,
+            id="Suspended provider changes should not fail if appropriate label is set",
+        ),
+        pytest.param(
+            ("airflow/providers/yandex/test.py", "airflow/providers/airbyte/test.py"),
+            ("allow suspended provider changes",),
+            {"affected-providers-list-as-string": "airbyte http"},
+            False,
+            id="Only non-suspended provider changes should be listed",
+        ),
+    ],
+)
+def test_suspended_providers(
+    files: tuple[str, ...], labels: tuple[str], expected_outputs: dict[str, str], should_fail: bool
+):
+    failed = False
+    try:
+        stderr = str(
+            SelectiveChecks(
+                files=files,
+                commit_ref="HEAD",
+                github_event=GithubEvents.PULL_REQUEST,
+                pr_labels=labels,
+                default_branch="main",
+            )
+        )
+    except SystemExit:
+        failed = True
+    assert failed == should_fail
+    if not failed:
+        assert_outputs_are_printed(expected_outputs, str(stderr))


### PR DESCRIPTION
The changes to suspended providers should cause build changes in general, but there are cases where we still want to merge such changes. In this case maintainer should be able to set `allow suspended provider changes` and the PR should be allowed to run.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
