### PR TITLE
Remove print from dag trigger command

### DIFF
--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -153,7 +153,6 @@ def dag_trigger(args) -> None:
             execution_date=args.exec_date,
             replace_microseconds=args.replace_microseconds,
         )
-        print(message)
         AirflowConsole().print_as(
             data=[message] if message is not None else [],
             output=args.output,


### PR DESCRIPTION
Recently, we added output format arg in `airflow dag trigger <dag_id>` command
because of that, we are getting the result twice in the console.
first because of old print statements and  2nd because of AirflowConsole().print_as.
I feel we should remove the print statement now.

before
<img width="1338" alt="Screenshot 2023-04-27 at 11 44 13 PM" src="https://user-images.githubusercontent.com/98807258/234956387-dea2d5ec-ee3c-4330-a996-b06d3571ce3b.png">

after
<img width="1332" alt="Screenshot 2023-04-27 at 11 44 40 PM" src="https://user-images.githubusercontent.com/98807258/234956438-62a51fe4-ec8f-4dec-931e-f6c7654331e4.png">
 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
