### PR TITLE
Fix `order_by` request in list DAG rest api

### DIFF
--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -1723,12 +1723,12 @@ class TestPatchDags(TestDagEndpoint):
         assert len(dags_updated.all()) == 2
 
     @provide_session
-    def test_should_respond_200_and_reverse_odering(self, session, url_safe_serializer):
+    def test_should_respond_200_and_reverse_ordering(self, session, url_safe_serializer):
         file_token = url_safe_serializer.dumps("/tmp/dag_1.py")
         self._create_dag_models(2)
         file_token10 = url_safe_serializer.dumps("/tmp/dag_2.py")
 
-        response = self.client.patch(
+        response = self.client.get(
             "/api/v1/dags?order_by=-dag_id",
             json={
                 "is_paused": True,

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -1722,6 +1722,89 @@ class TestPatchDags(TestDagEndpoint):
         dags_updated = session.query(DagModel).filter(DagModel.is_paused)
         assert len(dags_updated.all()) == 2
 
+    @provide_session
+    def test_should_respond_200_and_reverse_odering(self, session, url_safe_serializer):
+        file_token = url_safe_serializer.dumps("/tmp/dag_1.py")
+        self._create_dag_models(2)
+        file_token10 = url_safe_serializer.dumps("/tmp/dag_2.py")
+
+        response = self.client.patch(
+            "/api/v1/dags?order_by=-dag_id",
+            json={
+                "is_paused": True,
+            },
+            environ_overrides={"REMOTE_USER": "test"},
+        )
+
+        assert response.status_code == 200
+        assert {
+            "dags": [
+                {
+                    "dag_id": "TEST_DAG_2",
+                    "description": None,
+                    "fileloc": "/tmp/dag_2.py",
+                    "file_token": file_token10,
+                    "is_paused": True,
+                    "is_active": True,
+                    "is_subdag": False,
+                    "owners": [],
+                    "root_dag_id": None,
+                    "schedule_interval": {
+                        "__type": "CronExpression",
+                        "value": "2 2 * * *",
+                    },
+                    "tags": [],
+                    "next_dagrun": None,
+                    "has_task_concurrency_limits": True,
+                    "next_dagrun_data_interval_start": None,
+                    "next_dagrun_data_interval_end": None,
+                    "max_active_runs": 16,
+                    "next_dagrun_create_after": None,
+                    "last_expired": None,
+                    "max_active_tasks": 16,
+                    "last_pickled": None,
+                    "default_view": None,
+                    "last_parsed_time": None,
+                    "scheduler_lock": None,
+                    "timetable_description": None,
+                    "has_import_errors": False,
+                    "pickle_id": None,
+                },
+                {
+                    "dag_id": "TEST_DAG_1",
+                    "description": None,
+                    "fileloc": "/tmp/dag_1.py",
+                    "file_token": file_token,
+                    "is_paused": True,
+                    "is_active": True,
+                    "is_subdag": False,
+                    "owners": [],
+                    "root_dag_id": None,
+                    "schedule_interval": {
+                        "__type": "CronExpression",
+                        "value": "2 2 * * *",
+                    },
+                    "tags": [],
+                    "next_dagrun": None,
+                    "has_task_concurrency_limits": True,
+                    "next_dagrun_data_interval_start": None,
+                    "next_dagrun_data_interval_end": None,
+                    "max_active_runs": 16,
+                    "next_dagrun_create_after": None,
+                    "last_expired": None,
+                    "max_active_tasks": 16,
+                    "last_pickled": None,
+                    "default_view": None,
+                    "last_parsed_time": None,
+                    "scheduler_lock": None,
+                    "timetable_description": None,
+                    "has_import_errors": False,
+                    "pickle_id": None,
+                },
+            ],
+            "total_entries": 2,
+        } == response.json
+
     def test_should_respons_400_dag_id_pattern_missing(self):
         self._create_dag_models(1)
         response = self.client.patch(

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -1730,9 +1730,6 @@ class TestPatchDags(TestDagEndpoint):
 
         response = self.client.get(
             "/api/v1/dags?order_by=-dag_id",
-            json={
-                "is_paused": True,
-            },
             environ_overrides={"REMOTE_USER": "test"},
         )
 
@@ -1744,7 +1741,7 @@ class TestPatchDags(TestDagEndpoint):
                     "description": None,
                     "fileloc": "/tmp/dag_2.py",
                     "file_token": file_token10,
-                    "is_paused": True,
+                    "is_paused": False,
                     "is_active": True,
                     "is_subdag": False,
                     "owners": [],
@@ -1775,7 +1772,7 @@ class TestPatchDags(TestDagEndpoint):
                     "description": None,
                     "fileloc": "/tmp/dag_1.py",
                     "file_token": file_token,
-                    "is_paused": True,
+                    "is_paused": False,
                     "is_active": True,
                     "is_subdag": False,
                     "owners": [],


### PR DESCRIPTION
currently, list DAG API i.e. `GET /dags` does not use 
order_by param i.e. ignore it and because of that API returns 
unexpected results. Also, it does not throw errors when the user
passes an incorrect order_by param. In this PR, fix the broken support
for reversing ordering.

closes: https://github.com/apache/airflow/issues/30900
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
