### PR TITLE
Initialize plugins for cli appbuilder

### DIFF
--- a/airflow/utils/cli_app_builder.py
+++ b/airflow/utils/cli_app_builder.py
@@ -24,12 +24,15 @@ from typing import Generator
 from flask import Flask
 
 from airflow.www.extensions.init_appbuilder import AirflowAppBuilder, init_appbuilder
+from airflow.www.extensions.init_views import init_plugins
 
 
 @lru_cache(maxsize=None)
 def _return_appbuilder(app: Flask) -> AirflowAppBuilder:
     """Returns an appbuilder instance for the given app"""
-    return init_appbuilder(app)
+    init_appbuilder(app)
+    init_plugins(app)
+    return app.appbuilder  # type: ignore[attr-defined]
 
 
 @contextmanager


### PR DESCRIPTION
Plugins can provide things that need to be initialized before we can use the slim appbuilder for cli actions. For example, plugins can add menu items, which need to be loaded for sync-perm to do everything it needs to do.

Related to #28259, which broke this behavior in sync-perm.

This can easily be reproduced with this plugin:

```
from airflow.plugins_manager import AirflowPlugin

class MyPlugin(AirflowPlugin):
    name = "my_plugin"
    appbuilder_menu_items = [{"name": "MyPlugin", "href": "https://www.apache.org/"}]
```