### PR TITLE
Support for sorting DAGs by Last Run Date in the web UI

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -207,7 +207,7 @@
                   title="Status of all previous DAG runs.">info</span>
           </th>
           <th>Schedule</th>
-          <th style="width:180px;">Last Run
+          <th style="width:180px;">{{ sortable_column("Last Run", "last_dagrun") }}
             <span class="material-icons text-muted js-tooltip" aria-hidden="true"
                   title="Date/Time of the latest Dag Run.">info</span>
           </th>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -70,7 +70,7 @@ from pendulum.datetime import DateTime
 from pendulum.parsing.exceptions import ParserError
 from pygments import highlight, lexers
 from pygments.formatters import HtmlFormatter
-from sqlalchemy import Date, and_, case, desc, func, inspect, nullslast, union_all
+from sqlalchemy import Date, and_, case, desc, func, inspect, union_all
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 from wtforms import SelectField, validators
@@ -790,16 +790,20 @@ class Airflow(AirflowBaseView):
                 )
                 if arg_sorting_direction == "desc":
                     current_dags = current_dags.order_by(
-                        nullslast(dag_run_subquery.c.max_execution_date.desc())
+                        dag_run_subquery.c.max_execution_date.is_(None),
+                        dag_run_subquery.c.max_execution_date.desc(),
                     )
                 else:
-                    current_dags = current_dags.order_by(nullslast(dag_run_subquery.c.max_execution_date))
+                    current_dags = current_dags.order_by(
+                        dag_run_subquery.c.max_execution_date.is_(None), dag_run_subquery.c.max_execution_date
+                    )
             else:
                 sort_column = DagModel.__table__.c.get(arg_sorting_key)
                 if sort_column is not None:
                     if arg_sorting_direction == "desc":
-                        sort_column = sort_column.desc()
-                    current_dags = current_dags.order_by(nullslast(sort_column))
+                        current_dags = current_dags.order_by(sort_column.is_(None), sort_column.desc())
+                    else:
+                        current_dags = current_dags.order_by(sort_column.is_(None), sort_column)
 
             dags = current_dags.options(joinedload(DagModel.tags)).offset(start).limit(dags_per_page).all()
             user_permissions = g.user.perms

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -776,11 +776,28 @@ class Airflow(AirflowBaseView):
                 current_dags = all_dags
                 num_of_all_dags = all_dags_count
 
-            sort_column = DagModel.__table__.c.get(arg_sorting_key)
-            if sort_column is not None:
+            if arg_sorting_key == "last_dagrun":
+                dag_run_subquery = (
+                    session.query(
+                        DagRun.dag_id,
+                        sqla.func.max(DagRun.execution_date).label("max_execution_date"),
+                    )
+                    .group_by(DagRun.dag_id)
+                    .subquery()
+                )
+                current_dags = current_dags.outerjoin(
+                    dag_run_subquery, and_(dag_run_subquery.c.dag_id == DagModel.dag_id)
+                )
                 if arg_sorting_direction == "desc":
-                    sort_column = sort_column.desc()
-                current_dags = current_dags.order_by(sort_column)
+                    current_dags = current_dags.order_by(dag_run_subquery.c.max_execution_date.desc())
+                else:
+                    current_dags = current_dags.order_by(dag_run_subquery.c.max_execution_date)
+            else:
+                sort_column = DagModel.__table__.c.get(arg_sorting_key)
+                if sort_column is not None:
+                    if arg_sorting_direction == "desc":
+                        sort_column = sort_column.desc()
+                    current_dags = current_dags.order_by(sort_column)
 
             dags = current_dags.options(joinedload(DagModel.tags)).offset(start).limit(dags_per_page).all()
             user_permissions = g.user.perms


### PR DESCRIPTION
closes: #30838

Based on the closed PR https://github.com/apache/airflow/pull/11652, adds support for sorting dag list by last_run_date in the home page.

![image](https://user-images.githubusercontent.com/1306697/235058231-7446c919-2637-4cf5-802e-d826230fb7a3.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
