### PR TITLE
Optimize deferrable mode execution in `GCSObjectsWithPrefixExistenceSensor`

### DIFF
--- a/airflow/providers/google/cloud/sensors/gcs.py
+++ b/airflow/providers/google/cloud/sensors/gcs.py
@@ -323,19 +323,20 @@ class GCSObjectsWithPrefixExistenceSensor(BaseSensorOperator):
             super().execute(context)
             return self._matches
         else:
-            self.defer(
-                timeout=timedelta(seconds=self.timeout),
-                trigger=GCSPrefixBlobTrigger(
-                    bucket=self.bucket,
-                    prefix=self.prefix,
-                    poke_interval=self.poke_interval,
-                    google_cloud_conn_id=self.google_cloud_conn_id,
-                    hook_params={
-                        "impersonation_chain": self.impersonation_chain,
-                    },
-                ),
-                method_name="execute_complete",
-            )
+            if not self.poke(context=context):
+                self.defer(
+                    timeout=timedelta(seconds=self.timeout),
+                    trigger=GCSPrefixBlobTrigger(
+                        bucket=self.bucket,
+                        prefix=self.prefix,
+                        poke_interval=self.poke_interval,
+                        google_cloud_conn_id=self.google_cloud_conn_id,
+                        hook_params={
+                            "impersonation_chain": self.impersonation_chain,
+                        },
+                    ),
+                    method_name="execute_complete",
+                )
 
     def execute_complete(self, context: dict[str, Any], event: dict[str, str | list[str]]) -> str | list[str]:
         """

--- a/tests/providers/google/cloud/sensors/test_gcs.py
+++ b/tests/providers/google/cloud/sensors/test_gcs.py
@@ -369,6 +369,21 @@ class TestGoogleCloudStoragePrefixSensor:
             task.execute(mock.MagicMock)
             mock_hook.return_value.list.assert_called_once_with(TEST_BUCKET, prefix=TEST_PREFIX)
 
+    @mock.patch("airflow.providers.google.cloud.sensors.gcs.GCSHook")
+    @mock.patch("airflow.providers.google.cloud.sensors.gcs.GCSObjectsWithPrefixExistenceSensor.defer")
+    def test_gcs_object_prefix_existence_sensor_finish_before_deferred(self, mock_defer, mock_hook):
+        task = GCSObjectsWithPrefixExistenceSensor(
+            task_id="task-id",
+            bucket=TEST_BUCKET,
+            prefix=TEST_PREFIX,
+            google_cloud_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+            deferrable=True,
+        )
+        mock_hook.return_value.list.return_value = True
+        task.execute(mock.MagicMock())
+        assert not mock_defer.called
+
 
 class TestGCSObjectsWithPrefixExistenceSensorAsync:
     OPERATOR = GCSObjectsWithPrefixExistenceSensor(
@@ -379,14 +394,15 @@ class TestGCSObjectsWithPrefixExistenceSensorAsync:
         deferrable=True,
     )
 
-    def test_gcs_object_with_prefix_existence_sensor_async(self, context):
+    @mock.patch("airflow.providers.google.cloud.sensors.gcs.GCSHook")
+    def test_gcs_object_with_prefix_existence_sensor_async(self, mock_hook):
         """
         Asserts that a task is deferred and a GCSPrefixBlobTrigger will be fired
         when the GCSObjectsWithPrefixExistenceSensorAsync is executed.
         """
-
+        mock_hook.return_value.list.return_value = False
         with pytest.raises(TaskDeferred) as exc:
-            self.OPERATOR.execute(context)
+            self.OPERATOR.execute(mock.MagicMock())
         assert isinstance(exc.value.trigger, GCSPrefixBlobTrigger), "Trigger is not a GCSPrefixBlobTrigger"
 
     def test_gcs_object_with_prefix_existence_sensor_async_execute_failure(self, context):


### PR DESCRIPTION
In deferrable mode for GCSObjectsWithPrefixExistenceSensor, we should first check if file with given prefix is available or not in the execute method and only defer if that results in False. This way we don’t run an unnecessary deferral cycle if the condition is already true.

cc @dstandish

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
