### PR TITLE
BREEZE: add troubleshooting section to cover ETIMEDOUT during start-airflow

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -766,7 +766,7 @@ ETIMEOUT when ``npm`` command is trying to install required packages:
     npm ERR! network request to https://registry.npmjs.org/yarn failed, reason: connect ETIMEDOUT 2606:4700::6810:1723:443
     npm ERR! network This is a problem related to network connectivity.
     npm ERR! network In most cases you are behind a proxy or have bad network settings.
-    npm ERR! network 
+    npm ERR! network
     npm ERR! network If you are behind a proxy, please make sure that the
     npm ERR! network 'proxy' config is set properly.  See: 'npm help config'
 

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -715,6 +715,68 @@ describe your problem.
     stated in `This comment <https://github.com/moby/moby/issues/43361#issuecomment-1227617516>`_ and allows to
     run Breeze with no problems.
 
+
+ETIMEOUT Error
+--------------
+
+When running `breeze start-airflow`, the following output might be observed:
+
+.. code-block:: bash
+
+    Skip fixing ownership of generated files as Host OS is darwin
+
+
+    Waiting for asset compilation to complete in the background.
+
+    Still waiting .....
+    Still waiting .....
+    Still waiting .....
+    Still waiting .....
+    Still waiting .....
+    Still waiting .....
+
+    The asset compilation is taking too long.
+
+    If it does not complete soon, you might want to stop it and remove file lock:
+      * press Ctrl-C
+      * run 'rm /opt/airflow/.build/www/.asset_compile.lock'
+
+    Still waiting .....
+    Still waiting .....
+    Still waiting .....
+    Still waiting .....
+    Still waiting .....
+    Still waiting .....
+    Still waiting .....
+
+    The asset compilation failed. Exiting.
+
+    [INFO] Locking pre-commit directory
+
+    Error 1 returned
+
+This error is actually caused by the following error during the asset compilation which resulted in
+ETIMEOUT when ``npm`` command is trying to install required packages:
+
+.. code-block:: bash
+
+    npm ERR! code ETIMEDOUT
+    npm ERR! syscall connect
+    npm ERR! errno ETIMEDOUT
+    npm ERR! network request to https://registry.npmjs.org/yarn failed, reason: connect ETIMEDOUT 2606:4700::6810:1723:443
+    npm ERR! network This is a problem related to network connectivity.
+    npm ERR! network In most cases you are behind a proxy or have bad network settings.
+    npm ERR! network 
+    npm ERR! network If you are behind a proxy, please make sure that the
+    npm ERR! network 'proxy' config is set properly.  See: 'npm help config'
+
+In this situation, notice that the IP address ``2606:4700::6810:1723:443`` is in IPv6 format, which was the
+reason why the connection did not go through the router, as the router did not support IPv6 addresses in its DNS lookup.
+In this case, disabling IPv6 in the host machine and using IPv4 instead resolved the issue.
+
+The similar issue could happen if you are behind an HTTP/HTTPS proxy and your access to required websites are
+blocked by it, or your proxy setting has not been done properly.
+
 Advanced commands
 =================
 

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -719,7 +719,7 @@ describe your problem.
 ETIMEOUT Error
 --------------
 
-When running `breeze start-airflow`, the following output might be observed:
+When running ``breeze start-airflow``, the following output might be observed:
 
 .. code-block:: bash
 


### PR DESCRIPTION
closes: #30947
related: #30947

- Adds section under `troubleshooting` to describe a potential ETIMEDOUT condition when running breeze to start airflow, and inform readers of potential symptoms , reasons, and way to avoid it.