### PR TITLE
Fix static_folder for cli app

### DIFF
--- a/airflow/utils/cli_app_builder.py
+++ b/airflow/utils/cli_app_builder.py
@@ -17,12 +17,14 @@
 
 from __future__ import annotations
 
+import os
 from contextlib import contextmanager
 from functools import lru_cache
 from typing import Generator
 
 from flask import Flask
 
+import airflow
 from airflow.www.extensions.init_appbuilder import AirflowAppBuilder, init_appbuilder
 from airflow.www.extensions.init_views import init_plugins
 
@@ -37,6 +39,7 @@ def _return_appbuilder(app: Flask) -> AirflowAppBuilder:
 
 @contextmanager
 def get_application_builder() -> Generator[AirflowAppBuilder, None, None]:
-    flask_app = Flask(__name__)
+    static_folder = os.path.join(os.path.dirname(airflow.__file__), "www", "static")
+    flask_app = Flask(__name__, static_folder=static_folder)
     with flask_app.app_context():
         yield _return_appbuilder(flask_app)


### PR DESCRIPTION
This make sure that `static_folder` is consistent between the normal app and the slim cli app.