### PR TITLE
implement gcs_schema_object for BigQueryCreateExternalTableOperator

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_presto_to_gcs.py
+++ b/airflow/providers/google/cloud/example_dags/example_presto_to_gcs.py
@@ -54,6 +54,7 @@ with models.DAG(
     catchup=False,
     tags=["example"],
 ) as dag:
+
     create_dataset = BigQueryCreateEmptyDatasetOperator(task_id="create-dataset", dataset_id=DATASET_NAME)
 
     delete_dataset = BigQueryDeleteDatasetOperator(
@@ -103,7 +104,7 @@ with models.DAG(
                 "csvOptions": {"skipLeadingRows": 1},
             },
         },
-        gcs_schema_object=f"{safe_name(SOURCE_MULTIPLE_TYPES)}-schema.json",
+        schema_object=f"{safe_name(SOURCE_MULTIPLE_TYPES)}-schema.json",
     )
     # [END howto_operator_create_external_table_multiple_types]
 
@@ -112,7 +113,7 @@ with models.DAG(
         configuration={
             "query": {
                 "query": f"SELECT COUNT(*) FROM `{GCP_PROJECT_ID}.{DATASET_NAME}."
-                         f"{safe_name(SOURCE_MULTIPLE_TYPES)}`",
+                f"{safe_name(SOURCE_MULTIPLE_TYPES)}`",
                 "useLegacySql": False,
             }
         },
@@ -152,7 +153,7 @@ with models.DAG(
             },
         },
         source_objects=[f"{safe_name(SOURCE_CUSTOMER_TABLE)}.*.json"],
-        gcs_schema_object=f"{safe_name(SOURCE_CUSTOMER_TABLE)}-schema.json",
+        schema_object=f"{safe_name(SOURCE_CUSTOMER_TABLE)}-schema.json",
     )
 
     # [START howto_operator_read_data_from_gcs_many_chunks]
@@ -161,7 +162,7 @@ with models.DAG(
         configuration={
             "query": {
                 "query": f"SELECT COUNT(*) FROM `{GCP_PROJECT_ID}.{DATASET_NAME}."
-                         f"{safe_name(SOURCE_CUSTOMER_TABLE)}`",
+                f"{safe_name(SOURCE_CUSTOMER_TABLE)}`",
                 "useLegacySql": False,
             }
         },

--- a/airflow/providers/google/cloud/example_dags/example_presto_to_gcs.py
+++ b/airflow/providers/google/cloud/example_dags/example_presto_to_gcs.py
@@ -54,7 +54,6 @@ with models.DAG(
     catchup=False,
     tags=["example"],
 ) as dag:
-
     create_dataset = BigQueryCreateEmptyDatasetOperator(task_id="create-dataset", dataset_id=DATASET_NAME)
 
     delete_dataset = BigQueryDeleteDatasetOperator(
@@ -104,7 +103,7 @@ with models.DAG(
                 "csvOptions": {"skipLeadingRows": 1},
             },
         },
-        schema_object=f"{safe_name(SOURCE_MULTIPLE_TYPES)}-schema.json",
+        gcs_schema_object=f"{safe_name(SOURCE_MULTIPLE_TYPES)}-schema.json",
     )
     # [END howto_operator_create_external_table_multiple_types]
 
@@ -113,7 +112,7 @@ with models.DAG(
         configuration={
             "query": {
                 "query": f"SELECT COUNT(*) FROM `{GCP_PROJECT_ID}.{DATASET_NAME}."
-                f"{safe_name(SOURCE_MULTIPLE_TYPES)}`",
+                         f"{safe_name(SOURCE_MULTIPLE_TYPES)}`",
                 "useLegacySql": False,
             }
         },
@@ -153,7 +152,7 @@ with models.DAG(
             },
         },
         source_objects=[f"{safe_name(SOURCE_CUSTOMER_TABLE)}.*.json"],
-        schema_object=f"{safe_name(SOURCE_CUSTOMER_TABLE)}-schema.json",
+        gcs_schema_object=f"{safe_name(SOURCE_CUSTOMER_TABLE)}-schema.json",
     )
 
     # [START howto_operator_read_data_from_gcs_many_chunks]
@@ -162,7 +161,7 @@ with models.DAG(
         configuration={
             "query": {
                 "query": f"SELECT COUNT(*) FROM `{GCP_PROJECT_ID}.{DATASET_NAME}."
-                f"{safe_name(SOURCE_CUSTOMER_TABLE)}`",
+                         f"{safe_name(SOURCE_CUSTOMER_TABLE)}`",
                 "useLegacySql": False,
             }
         },

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1481,7 +1481,8 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
     template_fields: Sequence[str] = (
         "bucket",
         "source_objects",
-        "schema_object" "gcs_schema_bucket",
+        "schema_object",
+        "gcs_schema_bucket",
         "destination_project_dataset_table",
         "labels",
         "table_resource",

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1481,8 +1481,7 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
     template_fields: Sequence[str] = (
         "bucket",
         "source_objects",
-        "schema_object"
-        "gcs_schema_bucket",
+        "schema_object" "gcs_schema_bucket",
         "destination_project_dataset_table",
         "labels",
         "table_resource",

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1431,9 +1431,10 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
     :param table_resource: Table resource as described in documentation:
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#Table
         If provided all other parameters are ignored. External schema from object will be resolved.
-    :param gcs_schema_object: Full path to the JSON file containing
-        schema (templated). For
-        example: ``gs://test-bucket/dir1/dir2/employee_schema.json``
+    :param schema_object: If set, a GCS object path pointing to a .json file that
+        contains the schema for the table. (templated)
+    :param gcs_schema_bucket: GCS bucket name where the schema JSON is stored (templated).
+        The default value is self.bucket.
     :param source_format: File format of the data.
     :param autodetect: Try to detect schema and format options automatically.
         The schema_fields and schema_object options will be honored when specified explicitly.
@@ -1480,7 +1481,8 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
     template_fields: Sequence[str] = (
         "bucket",
         "source_objects",
-        "gcs_schema_object",
+        "schema_object"
+        "gcs_schema_bucket",
         "destination_project_dataset_table",
         "labels",
         "table_resource",
@@ -1498,7 +1500,8 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
         destination_project_dataset_table: str | None = None,
         table_resource: dict[str, Any] | None = None,
         schema_fields: list | None = None,
-        gcs_schema_object: str | None = None,
+        schema_object: str | None = None,
+        gcs_schema_bucket: str | None = None,
         source_format: str | None = None,
         autodetect: bool = False,
         compression: str | None = None,
@@ -1557,6 +1560,8 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
             )
             if not bucket:
                 raise ValueError("`bucket` is required when not using `table_resource`.")
+            if not gcs_schema_bucket:
+                gcs_schema_bucket = bucket
             if not source_objects:
                 raise ValueError("`source_objects` is required when not using `table_resource`.")
             if not source_format:
@@ -1573,7 +1578,8 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
                 )
             self.bucket = bucket
             self.source_objects = source_objects
-            self.gcs_schema_object = gcs_schema_object
+            self.schema_object = schema_object
+            self.gcs_schema_bucket = gcs_schema_bucket
             self.destination_project_dataset_table = destination_project_dataset_table
             self.schema_fields = schema_fields
             self.source_format = source_format
@@ -1585,7 +1591,8 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
             self.table_resource = table_resource
             self.bucket = ""
             self.source_objects = []
-            self.gcs_schema_object = None
+            self.schema_object = None
+            self.gcs_schema_bucket = ""
             self.destination_project_dataset_table = ""
 
         if table_resource and kwargs_passed:
@@ -1624,14 +1631,14 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
             )
             return
 
-        if not self.schema_fields and self.gcs_schema_object and self.source_format != "DATASTORE_BACKUP":
-            gcs_bucket, gcs_object = _parse_gcs_url(self.gcs_schema_object)
+        if not self.schema_fields and self.schema_object and self.source_format != "DATASTORE_BACKUP":
             gcs_hook = GCSHook(
                 gcp_conn_id=self.google_cloud_storage_conn_id,
                 impersonation_chain=self.impersonation_chain,
             )
-            schema_fields_string = gcs_hook.download_as_byte_array(gcs_bucket, gcs_object).decode("utf-8")
-            schema_fields = json.loads(schema_fields_string)
+            schema_fields = json.loads(
+                gcs_hook.download(self.gcs_schema_bucket, self.schema_object).decode("utf-8")
+            )
         else:
             schema_fields = self.schema_fields
 

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -237,6 +237,7 @@ class TestBigQueryCreateExternalTableOperator:
             destination_project_dataset_table=f"{TEST_GCP_PROJECT_ID}.{TEST_DATASET}.{TEST_TABLE_ID}",
             schema_fields=[],
             bucket=TEST_GCS_BUCKET,
+            gcs_schema_bucket=TEST_GCS_BUCKET,
             source_objects=TEST_GCS_DATA,
             source_format=TEST_SOURCE_FORMAT,
             autodetect=True,


### PR DESCRIPTION
Before this PR:

The BigQueryCreateExternalTableOperator can work with the schema object if the JSON file is in the same bucket as the data source objects.

After this PR:

The developers have the ability to define a different bucket where the schema object is located like the implementation of the BigQueryCreateEmptyTableOperator.

