### PR TITLE
Fix Pool schema OpenAPI spec

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3070,7 +3070,7 @@ components:
           type: integer
           readOnly: true
           description: The number of slots used by running/queued tasks at the moment.
-        used_slots:
+        running_slots:
           type: integer
           readOnly: true
           description: The number of slots used by running tasks at the moment.
@@ -3082,6 +3082,10 @@ components:
           type: integer
           readOnly: true
           description: The number of free slots at the moment.
+        scheduled_slots:
+          type: integer
+          readOnly: true
+          description: The number of slots used by scheduled tasks at the moment.
         description:
           type: string
           description: |

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -97,12 +97,14 @@ info:
     - Field names are in snake_case.
     ```json
     {
+        "description": "string",
         "name": "string",
-        "slots": 0,
         "occupied_slots": 0,
-        "used_slots": 0,
-        "queued_slots": 0,
         "open_slots": 0
+        "queued_slots": 0,
+        "running_slots": 0,
+        "scheduled_slots": 0,
+        "slots": 0,
     }
     ```
 

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1211,11 +1211,13 @@ export interface components {
       /** @description The number of slots used by running/queued tasks at the moment. */
       occupied_slots?: number;
       /** @description The number of slots used by running tasks at the moment. */
-      used_slots?: number;
+      running_slots?: number;
       /** @description The number of slots used by queued tasks at the moment. */
       queued_slots?: number;
       /** @description The number of free slots at the moment. */
       open_slots?: number;
+      /** @description The number of slots used by scheduled tasks at the moment. */
+      scheduled_slots?: number;
       /**
        * @description The description of the pool.
        *


### PR DESCRIPTION
In OpenAPI the spec for the Pool schema is not correct and does not match the actual response.

Actual response:
![image](https://user-images.githubusercontent.com/14861206/235359670-658c59bb-6f6e-4d1a-9675-88537a2c6afa.png)
