### PR TITLE
Use `AirflowProviderDeprecationWarning` in providers

### DIFF
--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -40,7 +40,7 @@ from uuid import uuid4
 from boto3.s3.transfer import S3Transfer, TransferConfig
 from botocore.exceptions import ClientError
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.exceptions import S3HookUriParseFailure
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.utils.tags import format_tags
@@ -74,7 +74,7 @@ def provide_bucket_name(func: T) -> T:
                     "s3 conn_type, and the associated schema field, is deprecated."
                     " Please use aws conn_type instead, and specify `bucket_name`"
                     " in `service_config.s3` within `extras`.",
-                    DeprecationWarning,
+                    AirflowProviderDeprecationWarning,
                     stacklevel=2,
                 )
                 bound_args.arguments["bucket_name"] = self.conn_config.schema

--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -29,7 +29,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, Sequence
 
 from airflow.compat.functools import cached_property
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook
 from airflow.providers.amazon.aws.links.batch import (
@@ -163,7 +163,7 @@ class BatchOperator(BaseOperator):
             self.container_overrides = overrides
             warnings.warn(
                 "Parameter `overrides` is deprecated, Please use `container_overrides` instead.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
 

--- a/airflow/providers/amazon/aws/operators/eks.py
+++ b/airflow/providers/amazon/aws/operators/eks.py
@@ -23,8 +23,7 @@ from typing import TYPE_CHECKING, Any, List, Sequence, cast
 
 from botocore.exceptions import ClientError, WaiterError
 
-from airflow import AirflowException
-from airflow.exceptions import AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.eks import EksHook
 

--- a/airflow/providers/amazon/aws/operators/eks.py
+++ b/airflow/providers/amazon/aws/operators/eks.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, List, Sequence, cast
 from botocore.exceptions import ClientError, WaiterError
 
 from airflow import AirflowException
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.eks import EksHook
 
@@ -691,7 +692,7 @@ class EksPodOperator(KubernetesPodOperator):
                 "Currently the default for this parameter is `False` but in a future release the default "
                 "will be changed to `True`. To ensure pods are not deleted in the future you will need to "
                 "set `is_delete_operator_pod=False` explicitly.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
             is_delete_operator_pod = False

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -22,7 +22,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, Sequence
 from uuid import uuid4
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.emr import EmrContainerHook, EmrHook, EmrServerlessHook
 from airflow.providers.amazon.aws.links.emr import EmrClusterLink
@@ -486,7 +486,7 @@ class EmrContainerOperator(BaseOperator):
             warnings.warn(
                 f"Parameter `{self.__class__.__name__}.max_tries` is deprecated and will be removed "
                 "in a future release.  Please use method `max_polling_attempts` instead.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
             if max_polling_attempts and max_polling_attempts != max_tries:

--- a/airflow/providers/amazon/aws/operators/sagemaker.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, Callable, Sequence
 from botocore.exceptions import ClientError
 
 from airflow.compat.functools import cached_property
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook
@@ -201,7 +201,7 @@ class SageMakerProcessingOperator(SageMakerBaseOperator):
             warnings.warn(
                 "Action 'increment' on job name conflict has been deprecated for performance reasons."
                 "The alternative to 'fail' is now 'timestamp'.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
         self.action_if_job_exists = action_if_job_exists
@@ -486,7 +486,7 @@ class SageMakerTransformOperator(SageMakerBaseOperator):
                 warnings.warn(
                     "Action 'increment' on job name conflict has been deprecated for performance reasons."
                     "The alternative to 'fail' is now 'timestamp'.",
-                    DeprecationWarning,
+                    AirflowProviderDeprecationWarning,
                     stacklevel=2,
                 )
             self.action_if_job_exists = action_if_job_exists
@@ -718,7 +718,7 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
                 warnings.warn(
                     "Action 'increment' on job name conflict has been deprecated for performance reasons."
                     "The alternative to 'fail' is now 'timestamp'.",
-                    DeprecationWarning,
+                    AirflowProviderDeprecationWarning,
                     stacklevel=2,
                 )
             self.action_if_job_exists = action_if_job_exists

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -25,6 +25,7 @@ from typing import Any
 from urllib.parse import unquote
 
 from airflow.compat.functools import cached_property
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.utils import trim_none_values
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -149,7 +150,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
                 "The `full_url_mode` kwarg is deprecated. Going forward, the `SecretsManagerBackend`"
                 " will support both URL-encoded and JSON-encoded secrets at the same time. The encoding"
                 " of the secret will be determined automatically.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
 
@@ -159,7 +160,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
                 " migrating away from URL-encoding secret values for JSON secrets."
                 " To remove this warning, make sure your JSON secrets are *NOT* URL-encoded, and then"
                 " remove this kwarg from backend_kwargs.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
             self.are_secret_values_urlencoded = kwargs.pop("are_secret_values_urlencoded", None)

--- a/airflow/providers/amazon/aws/transfers/base.py
+++ b/airflow/providers/amazon/aws/transfers/base.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import warnings
 from typing import Sequence
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.utils.types import NOTSET, ArgNotSet
@@ -60,7 +61,7 @@ class AwsToAwsBaseOperator(BaseOperator):
     ) -> None:
         super().__init__(**kwargs)
         if not isinstance(aws_conn_id, ArgNotSet):
-            warnings.warn(_DEPRECATION_MSG, DeprecationWarning, stacklevel=3)
+            warnings.warn(_DEPRECATION_MSG, AirflowProviderDeprecationWarning, stacklevel=3)
             self.source_aws_conn_id = aws_conn_id
         else:
             self.source_aws_conn_id = source_aws_conn_id

--- a/airflow/providers/amazon/aws/utils/connection_wrapper.py
+++ b/airflow/providers/amazon/aws/utils/connection_wrapper.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any
 from botocore.config import Config
 
 from airflow.compat.functools import cached_property
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.utils import trim_none_values
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.log.secrets_masker import mask_secret
@@ -168,7 +168,7 @@ class AwsConnectionWrapper(LoggingMixin):
                 f"{self.conn_repr} has connection type 's3', "
                 "which has been replaced by connection type 'aws'. "
                 "Please update your connection to have `conn_type='aws'`.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
         elif self.conn_type != "aws":
@@ -186,7 +186,7 @@ class AwsConnectionWrapper(LoggingMixin):
             warnings.warn(
                 "'session_kwargs' in extra config is deprecated and will be removed in a future releases. "
                 f"Please specify arguments passed to boto3 Session directly in {self.conn_repr} extra.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
 
@@ -242,7 +242,7 @@ class AwsConnectionWrapper(LoggingMixin):
             warnings.warn(
                 f"Host {conn.host} specified in the connection is not used."
                 " Please, set it on extra['endpoint_url'] instead",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
 
@@ -251,7 +251,7 @@ class AwsConnectionWrapper(LoggingMixin):
             warnings.warn(
                 "extra['host'] is deprecated and will be removed in a future release."
                 " Please set extra['endpoint_url'] instead",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
         else:
@@ -385,7 +385,7 @@ class AwsConnectionWrapper(LoggingMixin):
                 "Constructing 'role_arn' from extra['aws_account_id'] and extra['aws_iam_role'] is deprecated"
                 f" and will be removed in a future releases."
                 f" Please set 'role_arn' in {self.conn_repr} extra.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=3,
             )
             role_arn = f"arn:aws:iam::{aws_account_id}:role/{aws_iam_role}"
@@ -413,7 +413,7 @@ class AwsConnectionWrapper(LoggingMixin):
             warnings.warn(
                 "'external_id' in extra config is deprecated and will be removed in a future releases. "
                 f"Please set 'ExternalId' in 'assume_role_kwargs' in {self.conn_repr} extra.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=3,
             )
             assume_role_kwargs["ExternalId"] = external_id
@@ -436,7 +436,7 @@ def _parse_s3_config(
     warnings.warn(
         "Use local credentials file is never documented and well tested. "
         "Obtain credentials by this way deprecated and will be removed in a future releases.",
-        DeprecationWarning,
+        AirflowProviderDeprecationWarning,
         stacklevel=4,
     )
 

--- a/airflow/providers/apache/drill/operators/drill.py
+++ b/airflow/providers/apache/drill/operators/drill.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import warnings
 from typing import Sequence
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 
@@ -49,6 +50,6 @@ class DrillOperator(SQLExecuteQueryOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.""",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )

--- a/airflow/providers/apache/druid/operators/druid_check.py
+++ b/airflow/providers/apache/druid/operators/druid_check.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import warnings
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLCheckOperator
 
 
@@ -32,7 +33,7 @@ class DruidCheckOperator(SQLCheckOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.common.sql.operators.sql.SQLCheckOperator`.""",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         super().__init__(conn_id=druid_broker_conn_id, **kwargs)

--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -28,6 +28,8 @@ from collections import OrderedDict
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Any, Iterable, Mapping
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
+
 try:
     import pandas
 except ImportError as e:
@@ -529,7 +531,7 @@ class HiveMetastoreHook(BaseHook):
         if "authMechanism" in conn.extra_dejson:
             warnings.warn(
                 "The 'authMechanism' option is deprecated. Please use 'auth_mechanism'.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
             conn.extra_dejson["auth_mechanism"] = conn.extra_dejson["authMechanism"]
@@ -844,7 +846,7 @@ class HiveServer2Hook(DbApiHook):
         if "authMechanism" in db.extra_dejson:
             warnings.warn(
                 "The 'authMechanism' option is deprecated. Please use 'auth_mechanism'.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
             db.extra_dejson["auth_mechanism"] = db.extra_dejson["authMechanism"]

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -30,7 +30,7 @@ from kubernetes_asyncio import client as async_client, config as async_config
 from urllib3.exceptions import HTTPError
 
 from airflow.compat.functools import cached_property
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 from airflow.kubernetes.kube_client import _disable_verify_ssl, _enable_tcp_keepalive
 from airflow.utils import yaml
@@ -351,7 +351,7 @@ class KubernetesHook(BaseHook):
                 "not defined in the connection so that it's clear whether user intends 'default' or "
                 "whether namespace is unset (which is required in order to apply precedence logic in "
                 "KubernetesPodOperator).",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
             )
             return "default"
         return namespace

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -19,10 +19,11 @@ from __future__ import annotations
 
 import warnings
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.cncf.kubernetes.operators.pod import *  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.providers.cncf.kubernetes.operators.pod` instead.",
-    DeprecationWarning,
+    AirflowProviderDeprecationWarning,
     stacklevel=2,
 )

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -34,7 +34,7 @@ from slugify import slugify
 from urllib3.exceptions import HTTPError
 
 from airflow.compat.functools import cached_property
-from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
 from airflow.kubernetes import pod_generator
 from airflow.kubernetes.pod_generator import PodGenerator
 from airflow.kubernetes.secret import Secret
@@ -464,7 +464,11 @@ class KubernetesPodOperator(BaseOperator):
         return hook
 
     def get_hook(self):
-        warnings.warn("get_hook is deprecated. Please use hook instead.", DeprecationWarning, stacklevel=2)
+        warnings.warn(
+            "get_hook is deprecated. Please use hook instead.",
+            AirflowProviderDeprecationWarning,
+            stacklevel=2,
+        )
         return self.hook
 
     @cached_property
@@ -577,7 +581,7 @@ class KubernetesPodOperator(BaseOperator):
         """Converts passed config_file to dict format."""
         warnings.warn(
             "This method is deprecated and will be removed in a future version.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         config_file = self.config_file if self.config_file else os.environ.get(KUBE_CONFIG_ENV_VAR)

--- a/airflow/providers/cncf/kubernetes/triggers/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/triggers/kubernetes_pod.py
@@ -19,10 +19,11 @@ from __future__ import annotations
 
 import warnings
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.cncf.kubernetes.triggers.pod import *  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.providers.cncf.kubernetes.triggers.pod` instead.",
-    DeprecationWarning,
+    AirflowProviderDeprecationWarning,
     stacklevel=2,
 )

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -38,7 +38,7 @@ from pendulum.parsing.exceptions import ParserError
 from urllib3.exceptions import HTTPError as BaseHTTPError
 from urllib3.response import HTTPResponse
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.kubernetes.pod_generator import PodDefaults
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.timezone import utcnow
@@ -296,7 +296,7 @@ class PodManager(LoggingMixin):
         warnings.warn(
             "Method `follow_container_logs` is deprecated.  Use `fetch_container_logs` instead"
             "with option `follow=True`.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
         )
         return self.fetch_container_logs(pod=pod, container_name=container_name, follow=True)
 

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -24,7 +24,7 @@ from logging import Logger
 from typing import TYPE_CHECKING, Any, Sequence
 
 from airflow.compat.functools import cached_property
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator, BaseOperatorLink, XCom
 from airflow.providers.databricks.hooks.databricks import DatabricksHook, RunState
 from airflow.providers.databricks.triggers.databricks import DatabricksExecutionTrigger
@@ -411,7 +411,7 @@ class DatabricksSubmitRunDeferrableOperator(DatabricksSubmitRunOperator):
             "`DatabricksSubmitRunDeferrableOperator` has been deprecated. "
             "Please use `airflow.providers.databricks.operators.DatabricksSubmitRunOperator` with "
             "`deferrable=True` instead.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         super().__init__(deferrable=True, *args, **kwargs)
@@ -690,7 +690,7 @@ class DatabricksRunNowDeferrableOperator(DatabricksRunNowOperator):
             "`DatabricksRunNowDeferrableOperator` has been deprecated. "
             "Please use `airflow.providers.databricks.operators.DatabricksRunNowOperator` with "
             "`deferrable=True` instead.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         super().__init__(deferrable=True, *args, **kwargs)

--- a/airflow/providers/dbt/cloud/sensors/dbt.py
+++ b/airflow/providers/dbt/cloud/sensors/dbt.py
@@ -21,6 +21,7 @@ import warnings
 from typing import TYPE_CHECKING, Any
 
 from airflow import AirflowException
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.dbt.cloud.hooks.dbt import DbtCloudHook, DbtCloudJobRunException, DbtCloudJobRunStatus
 from airflow.providers.dbt.cloud.triggers.dbt import DbtCloudRunJobTrigger
 from airflow.sensors.base import BaseSensorOperator
@@ -62,7 +63,7 @@ class DbtCloudJobRunSensor(BaseSensorOperator):
                     warnings.warn(
                         "Argument `poll_interval` is deprecated and will be removed "
                         "in a future release.  Please use `poke_interval` instead.",
-                        DeprecationWarning,
+                        AirflowProviderDeprecationWarning,
                         stacklevel=2,
                     )
                 else:
@@ -135,7 +136,7 @@ class DbtCloudJobRunAsyncSensor(DbtCloudJobRunSensor):
         warnings.warn(
             "Class `DbtCloudJobRunAsyncSensor` is deprecated and will be removed in a future release. "
             "Please use `DbtCloudJobRunSensor` and set `deferrable` attribute to `True` instead",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         super().__init__(deferrable=True, **kwargs)

--- a/airflow/providers/dbt/cloud/sensors/dbt.py
+++ b/airflow/providers/dbt/cloud/sensors/dbt.py
@@ -20,8 +20,7 @@ import time
 import warnings
 from typing import TYPE_CHECKING, Any
 
-from airflow import AirflowException
-from airflow.exceptions import AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.dbt.cloud.hooks.dbt import DbtCloudHook, DbtCloudJobRunException, DbtCloudJobRunStatus
 from airflow.providers.dbt.cloud.triggers.dbt import DbtCloudRunJobTrigger
 from airflow.sensors.base import BaseSensorOperator

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -33,7 +33,7 @@ from docker.types import LogConfig, Mount
 from dotenv import dotenv_values
 
 from airflow.compat.functools import cached_property
-from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
 from airflow.models import BaseOperator
 from airflow.providers.docker.hooks.docker import DockerHook
 
@@ -224,7 +224,7 @@ class DockerOperator(BaseOperator):
         if type(auto_remove) == bool:
             warnings.warn(
                 "bool value for auto_remove is deprecated, please use 'never', 'success', or 'force' instead",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
         if str(auto_remove) == "False":
@@ -280,7 +280,9 @@ class DockerOperator(BaseOperator):
         self.ipc_mode = ipc_mode
         if skip_exit_code is not None:
             warnings.warn(
-                "skip_exit_code is deprecated. Please use skip_on_exit_code", DeprecationWarning, stacklevel=2
+                "skip_exit_code is deprecated. Please use skip_on_exit_code",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
             skip_on_exit_code = skip_exit_code
 

--- a/airflow/providers/elasticsearch/hooks/elasticsearch.py
+++ b/airflow/providers/elasticsearch/hooks/elasticsearch.py
@@ -24,6 +24,7 @@ from elasticsearch import Elasticsearch
 from es.elastic.api import Connection as ESConnection, connect
 
 from airflow.compat.functools import cached_property
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 from airflow.models.connection import Connection as AirflowConnection
 from airflow.providers.common.sql.hooks.sql import DbApiHook
@@ -110,7 +111,7 @@ class ElasticsearchHook(ElasticsearchSQLHook):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.elasticsearch.hooks.elasticsearch.ElasticsearchSQLHook`.""",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         super().__init__(*args, **kwargs)

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -33,6 +33,7 @@ import pendulum
 from elasticsearch_dsl import Search
 
 from airflow.configuration import conf
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.providers.elasticsearch.log.es_json_formatter import ElasticsearchJSONFormatter
@@ -105,7 +106,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
         if USE_PER_RUN_LOG_ID and log_id_template is not None:
             warnings.warn(
                 "Passing log_id_template to ElasticsearchTaskHandler is deprecated and has no effect",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
             )
 
         self.log_id_template = log_id_template  # Only used on Airflow < 2.3.2.

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -56,7 +56,7 @@ from pandas_gbq.gbq import GbqConnector  # noqa
 from requests import Session
 from sqlalchemy import create_engine
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 from airflow.providers.google.cloud.utils.bigquery import bq_cast
 from airflow.providers.google.common.consts import CLIENT_INFO
@@ -133,7 +133,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
     def get_service(self) -> Resource:
         """Returns a BigQuery service object."""
         warnings.warn(
-            "This method will be deprecated. Please use `BigQueryHook.get_client` method", DeprecationWarning
+            "This method will be deprecated. Please use `BigQueryHook.get_client` method",
+            AirflowProviderDeprecationWarning,
         )
         http_authorized = self._authorize()
         return build("bigquery", "v2", http=http_authorized, cache_discovery=False)
@@ -617,7 +618,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         warnings.warn(
             "This method is deprecated. Please use `BigQueryHook.create_empty_table` method with "
             "passing the `table_resource` object. This gives more flexibility than this method.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
         )
         location = location or self.location
         src_fmt_configs = src_fmt_configs or {}
@@ -798,7 +799,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         """
         warnings.warn(
             "This method is deprecated, please use ``BigQueryHook.update_table`` method.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
         )
         table_resource: dict[str, Any] = {}
 
@@ -950,7 +951,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets#resource
         :param project_id: The Google Cloud Project ID
         """
-        warnings.warn("This method is deprecated. Please use ``update_dataset``.", DeprecationWarning)
+        warnings.warn(
+            "This method is deprecated. Please use ``update_dataset``.", AirflowProviderDeprecationWarning
+        )
         project_id = project_id or self.project_id
         if not dataset_id or not isinstance(dataset_id, str):
             raise ValueError(
@@ -997,7 +1000,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             Leverage the page tokens to iterate through the entire collection.
         :return: List of tables associated with the dataset
         """
-        warnings.warn("This method is deprecated. Please use ``get_dataset_tables``.", DeprecationWarning)
+        warnings.warn(
+            "This method is deprecated. Please use ``get_dataset_tables``.", AirflowProviderDeprecationWarning
+        )
         project_id = project_id or self.project_id
         tables = self.get_client().list_tables(
             dataset=DatasetReference(project=project_id, dataset_id=dataset_id),
@@ -1186,7 +1191,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             requested table does not exist.
         :return:
         """
-        warnings.warn("This method is deprecated. Please use `delete_table`.", DeprecationWarning)
+        warnings.warn(
+            "This method is deprecated. Please use `delete_table`.", AirflowProviderDeprecationWarning
+        )
         return self.delete_table(table_id=deletion_dataset_table, not_found_ok=ignore_if_missing)
 
     @GoogleBaseHook.fallback_to_default_project_id
@@ -1238,7 +1245,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :param start_index: zero based index of the starting row to read.
         :return: list of rows
         """
-        warnings.warn("This method is deprecated. Please use `list_rows`.", DeprecationWarning)
+        warnings.warn("This method is deprecated. Please use `list_rows`.", AirflowProviderDeprecationWarning)
         rows = self.list_rows(
             dataset_id=dataset_id,
             table_id=table_id,
@@ -1441,7 +1448,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         """Cancel all started queries that have not yet completed"""
         warnings.warn(
             "This method is deprecated. Please use `BigQueryHook.cancel_job`.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
         )
         if self.running_job_id:
             self.cancel_job(job_id=self.running_job_id)
@@ -1603,7 +1610,10 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             https://cloud.google.com/bigquery/docs/reference/v2/jobs for
             details.
         """
-        warnings.warn("This method is deprecated. Please use `BigQueryHook.insert_job`", DeprecationWarning)
+        warnings.warn(
+            "This method is deprecated. Please use `BigQueryHook.insert_job`",
+            AirflowProviderDeprecationWarning,
+        )
         job = self.insert_job(configuration=configuration, project_id=self.project_id)
         self.running_job_id = job.job_id
         return job.job_id
@@ -1700,7 +1710,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :param description: A string containing the description for the BigQuery table.
         """
         warnings.warn(
-            "This method is deprecated. Please use `BigQueryHook.insert_job` method.", DeprecationWarning
+            "This method is deprecated. Please use `BigQueryHook.insert_job` method.",
+            AirflowProviderDeprecationWarning,
         )
 
         if not self.project_id:
@@ -1889,7 +1900,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
                 }
         """
         warnings.warn(
-            "This method is deprecated. Please use `BigQueryHook.insert_job` method.", DeprecationWarning
+            "This method is deprecated. Please use `BigQueryHook.insert_job` method.",
+            AirflowProviderDeprecationWarning,
         )
         if not self.project_id:
             raise ValueError("The project_id should be set")
@@ -1973,7 +1985,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :param return_full_job: return full job instead of job id only
         """
         warnings.warn(
-            "This method is deprecated. Please use `BigQueryHook.insert_job` method.", DeprecationWarning
+            "This method is deprecated. Please use `BigQueryHook.insert_job` method.",
+            AirflowProviderDeprecationWarning,
         )
         if not self.project_id:
             raise ValueError("The project_id should be set")
@@ -2098,7 +2111,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
                 }
         """
         warnings.warn(
-            "This method is deprecated. Please use `BigQueryHook.insert_job` method.", DeprecationWarning
+            "This method is deprecated. Please use `BigQueryHook.insert_job` method.",
+            AirflowProviderDeprecationWarning,
         )
         if not self.project_id:
             raise ValueError("The project_id should be set")
@@ -2378,7 +2392,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_table`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.create_empty_table(*args, **kwargs)
@@ -2391,7 +2405,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_dataset`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.create_empty_dataset(*args, **kwargs)
@@ -2404,7 +2418,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset_tables`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.get_dataset_tables(*args, **kwargs)
@@ -2417,7 +2431,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.delete_dataset`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.delete_dataset(*args, **kwargs)
@@ -2430,7 +2444,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_external_table`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.create_external_table(*args, **kwargs)
@@ -2443,7 +2457,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.patch_table`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.patch_table(*args, **kwargs)
@@ -2456,7 +2470,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_all`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.insert_all(*args, **kwargs)
@@ -2469,7 +2483,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.update_dataset`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return Dataset.to_api_repr(self.hook.update_dataset(*args, **kwargs))
@@ -2482,7 +2496,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.patch_dataset`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.patch_dataset(*args, **kwargs)
@@ -2495,7 +2509,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset_tables_list`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.get_dataset_tables_list(*args, **kwargs)
@@ -2508,7 +2522,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_datasets_list`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.get_datasets_list(*args, **kwargs)
@@ -2521,7 +2535,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.get_dataset(*args, **kwargs)
@@ -2535,7 +2549,7 @@ class BigQueryBaseCursor(LoggingMixin):
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks"
             ".bigquery.BigQueryHook.run_grant_dataset_view_access`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.run_grant_dataset_view_access(*args, **kwargs)
@@ -2548,7 +2562,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_table_upsert`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.run_table_upsert(*args, **kwargs)
@@ -2561,7 +2575,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_table_delete`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.run_table_delete(*args, **kwargs)
@@ -2574,7 +2588,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_tabledata`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.get_tabledata(*args, **kwargs)
@@ -2587,7 +2601,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_schema`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.get_schema(*args, **kwargs)
@@ -2600,7 +2614,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.poll_job_complete`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.poll_job_complete(*args, **kwargs)
@@ -2613,7 +2627,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.cancel_query`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.cancel_query(*args, **kwargs)  # type: ignore
@@ -2626,7 +2640,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.run_with_configuration(*args, **kwargs)
@@ -2639,7 +2653,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_load`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.run_load(*args, **kwargs)
@@ -2652,7 +2666,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_copy`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.run_copy(*args, **kwargs)
@@ -2665,7 +2679,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_extract`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.run_extract(*args, **kwargs)
@@ -2678,7 +2692,7 @@ class BigQueryBaseCursor(LoggingMixin):
         warnings.warn(
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_query`",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         return self.hook.run_query(*args, **kwargs)

--- a/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
@@ -29,7 +29,7 @@ from typing import Sequence
 from googleapiclient.discovery import Resource, build
 from googleapiclient.errors import HttpError
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 log = logging.getLogger(__name__)
@@ -233,7 +233,7 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
                 request_filter = kwargs["filter"]
                 if not isinstance(request_filter, dict):
                     raise ValueError(f"The request_filter should be dict and is {type(request_filter)}")
-                warnings.warn("Use 'request_filter' instead of 'filter'", DeprecationWarning)
+                warnings.warn("Use 'request_filter' instead of 'filter'", AirflowProviderDeprecationWarning)
             else:
                 raise TypeError("list_transfer_job missing 1 required positional argument: 'request_filter'")
 
@@ -364,7 +364,7 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
                 request_filter = kwargs["filter"]
                 if not isinstance(request_filter, dict):
                     raise ValueError(f"The request_filter should be dict and is {type(request_filter)}")
-                warnings.warn("Use 'request_filter' instead of 'filter'", DeprecationWarning)
+                warnings.warn("Use 'request_filter' instead of 'filter'", AirflowProviderDeprecationWarning)
             else:
                 raise TypeError(
                     "list_transfer_operations missing 1 required positional argument: 'request_filter'"

--- a/airflow/providers/google/cloud/hooks/dataflow.py
+++ b/airflow/providers/google/cloud/hooks/dataflow.py
@@ -32,7 +32,7 @@ from typing import Any, Callable, Generator, Sequence, TypeVar, cast
 from google.cloud.dataflow_v1beta3 import GetJobRequest, Job, JobState, JobsV1Beta3AsyncClient, JobView
 from googleapiclient.discovery import build
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.apache.beam.hooks.beam import BeamHook, BeamRunnerType, beam_options_to_args
 from airflow.providers.google.common.hooks.base_google import (
     PROVIDE_PROJECT_ID,
@@ -579,7 +579,7 @@ class DataflowHook(GoogleBaseHook):
             to start pipeline and `providers.google.cloud.hooks.dataflow.DataflowHook.wait_for_done`
             to wait for the required pipeline state.
             """,
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
 
@@ -679,7 +679,7 @@ class DataflowHook(GoogleBaseHook):
         if on_new_job_id_callback:
             warnings.warn(
                 "on_new_job_id_callback is Deprecated. Please start using on_new_job_callback",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=3,
             )
             on_new_job_id_callback(job.get("id"))
@@ -770,7 +770,7 @@ class DataflowHook(GoogleBaseHook):
         if on_new_job_id_callback:
             warnings.warn(
                 "on_new_job_id_callback is Deprecated. Please start using on_new_job_callback",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=3,
             )
             on_new_job_id_callback(job.get("id"))
@@ -844,7 +844,7 @@ class DataflowHook(GoogleBaseHook):
             to start pipeline and `providers.google.cloud.hooks.dataflow.DataflowHook.wait_for_done`
             to wait for the required pipeline state.
             """,
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
 
@@ -910,7 +910,7 @@ class DataflowHook(GoogleBaseHook):
             warnings.warn(
                 "The variables parameter has been deprecated. You should pass location using "
                 "the location parameter.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=4,
             )
         jobs_controller = _DataflowJobsController(
@@ -1039,7 +1039,7 @@ class DataflowHook(GoogleBaseHook):
         if on_new_job_id_callback:
             warnings.warn(
                 "on_new_job_id_callback is Deprecated. Please start using on_new_job_callback",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=3,
             )
             on_new_job_id_callback(cast(str, job.get("id")))

--- a/airflow/providers/google/cloud/hooks/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/hooks/kubernetes_engine.py
@@ -50,7 +50,7 @@ from urllib3.exceptions import HTTPError
 
 from airflow import version
 from airflow.compat.functools import cached_property
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.kubernetes.pod_generator_deprecated import PodDefaults
 from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import (
@@ -100,7 +100,7 @@ class GKEHook(GoogleBaseHook):
     def get_conn(self) -> container_v1.ClusterManagerClient:
         warnings.warn(
             "The get_conn method has been deprecated. You should use the get_cluster_manager_client method.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
         )
         return self.get_cluster_manager_client()
 
@@ -109,7 +109,7 @@ class GKEHook(GoogleBaseHook):
     def get_client(self) -> ClusterManagerClient:
         warnings.warn(
             "The get_client method has been deprecated. You should use the get_conn method.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
         )
         return self.get_conn()
 

--- a/airflow/providers/google/cloud/hooks/pubsub.py
+++ b/airflow/providers/google/cloud/hooks/pubsub.py
@@ -47,6 +47,7 @@ from google.cloud.pubsub_v1.types import (
 from googleapiclient.errors import HttpError
 
 from airflow.compat.functools import cached_property
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID, GoogleBaseHook
 from airflow.version import version
@@ -146,7 +147,7 @@ class PubSubHook(GoogleBaseHook):
                     warnings.warn(
                         "The base 64 encoded string as 'data' field has been deprecated. "
                         "You should pass bytestring (utf-8 encoded).",
-                        DeprecationWarning,
+                        AirflowProviderDeprecationWarning,
                         stacklevel=4,
                     )
                 except ValueError:

--- a/airflow/providers/google/cloud/hooks/vertex_ai/auto_ml.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/auto_ml.py
@@ -64,8 +64,7 @@ from google.cloud.aiplatform_v1 import JobServiceClient, PipelineServiceClient
 from google.cloud.aiplatform_v1.services.pipeline_service.pagers import ListTrainingPipelinesPager
 from google.cloud.aiplatform_v1.types import TrainingPipeline
 
-from airflow import AirflowException
-from airflow.exceptions import AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 

--- a/airflow/providers/google/cloud/hooks/vertex_ai/auto_ml.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/auto_ml.py
@@ -65,6 +65,7 @@ from google.cloud.aiplatform_v1.services.pipeline_service.pagers import ListTrai
 from google.cloud.aiplatform_v1.types import TrainingPipeline
 
 from airflow import AirflowException
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
@@ -455,7 +456,7 @@ class AutoMLHook(GoogleBaseHook):
         if column_transformations:
             warnings.warn(
                 "Consider using column_specs as column_transformations will be deprecated eventually.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
 
@@ -682,7 +683,7 @@ class AutoMLHook(GoogleBaseHook):
         if column_transformations:
             warnings.warn(
                 "Consider using column_specs as column_transformations will be deprecated eventually.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
 

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -28,7 +28,7 @@ from google.api_core.exceptions import Conflict
 from google.api_core.retry import Retry
 from google.cloud.bigquery import DEFAULT_RETRY, CopyJob, ExtractJob, LoadJob, QueryJob
 
-from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
 from airflow.models import BaseOperator, BaseOperatorLink
 from airflow.models.xcom import XCom
 from airflow.providers.common.sql.operators.sql import (
@@ -1067,7 +1067,7 @@ class BigQueryExecuteQueryOperator(GoogleCloudBaseOperator):
         super().__init__(**kwargs)
         warnings.warn(
             "This operator is deprecated. Please use `BigQueryInsertJobOperator`.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
 
@@ -1314,7 +1314,7 @@ class BigQueryCreateEmptyTableOperator(GoogleCloudBaseOperator):
         if bigquery_conn_id:
             warnings.warn(
                 "The bigquery_conn_id parameter has been deprecated. Use the gcp_conn_id parameter instead.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
             gcp_conn_id = bigquery_conn_id
@@ -1338,7 +1338,10 @@ class BigQueryCreateEmptyTableOperator(GoogleCloudBaseOperator):
         self.table_resource = table_resource
         self.impersonation_chain = impersonation_chain
         if exists_ok is not None:
-            warnings.warn("`exists_ok` parameter is deprecated, please use `if_exists`", DeprecationWarning)
+            warnings.warn(
+                "`exists_ok` parameter is deprecated, please use `if_exists`",
+                AirflowProviderDeprecationWarning,
+            )
             self.if_exists = IfExistAction.IGNORE if exists_ok else IfExistAction.LOG
         else:
             self.if_exists = IfExistAction(if_exists)
@@ -1518,7 +1521,7 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
         if bigquery_conn_id:
             warnings.warn(
                 "The bigquery_conn_id parameter has been deprecated. Use the gcp_conn_id parameter instead.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
             gcp_conn_id = bigquery_conn_id
@@ -1549,7 +1552,7 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
             warnings.warn(
                 "Passing table parameters via keywords arguments will be deprecated. "
                 "Please provide table definition using `table_resource` parameter.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
             if not bucket:
@@ -1820,7 +1823,10 @@ class BigQueryCreateEmptyDatasetOperator(GoogleCloudBaseOperator):
         self.dataset_reference = dataset_reference if dataset_reference else {}
         self.impersonation_chain = impersonation_chain
         if exists_ok is not None:
-            warnings.warn("`exists_ok` parameter is deprecated, please use `if_exists`", DeprecationWarning)
+            warnings.warn(
+                "`exists_ok` parameter is deprecated, please use `if_exists`",
+                AirflowProviderDeprecationWarning,
+            )
             self.if_exists = IfExistAction.IGNORE if exists_ok else IfExistAction.LOG
         else:
             self.if_exists = IfExistAction(if_exists)
@@ -2029,7 +2035,7 @@ class BigQueryPatchDatasetOperator(GoogleCloudBaseOperator):
     ) -> None:
         warnings.warn(
             "This operator is deprecated. Please use BigQueryUpdateDatasetOperator.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         self.dataset_id = dataset_id

--- a/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
@@ -22,7 +22,7 @@ from copy import deepcopy
 from datetime import date, time
 from typing import TYPE_CHECKING, Sequence
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.google.cloud.hooks.cloud_storage_transfer_service import (
     ACCESS_KEY_ID,
@@ -548,7 +548,9 @@ class CloudDataTransferServiceListOperationsOperator(GoogleCloudBaseOperator):
         if request_filter is None:
             if "filter" in kwargs:
                 request_filter = kwargs["filter"]
-                DeprecationWarning("Use 'request_filter' instead 'filter' to pass the argument.")
+                AirflowProviderDeprecationWarning(
+                    "Use 'request_filter' instead 'filter' to pass the argument."
+                )
             else:
                 TypeError("__init__() missing 1 required positional argument: 'request_filter'")
 

--- a/airflow/providers/google/cloud/operators/dataflow.py
+++ b/airflow/providers/google/cloud/operators/dataflow.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 from airflow import AirflowException
 from airflow.compat.functools import cached_property
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.apache.beam.hooks.beam import BeamHook, BeamRunnerType
 from airflow.providers.google.cloud.hooks.dataflow import (
     DEFAULT_DATAFLOW_LOCATION,
@@ -347,7 +348,7 @@ class DataflowCreateJavaJobOperator(GoogleCloudBaseOperator):
         warnings.warn(
             f"The `{self.__class__.__name__}` operator is deprecated, "
             f"please use `providers.apache.beam.operators.beam.BeamRunJavaPipelineOperator` instead.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         super().__init__(**kwargs)
@@ -1130,7 +1131,7 @@ class DataflowCreatePythonJobOperator(GoogleCloudBaseOperator):
         warnings.warn(
             f"The `{self.__class__.__name__}` operator is deprecated, "
             "please use `providers.apache.beam.operators.beam.BeamRunPythonPipelineOperator` instead.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         super().__init__(**kwargs)

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -36,7 +36,7 @@ from google.cloud.dataproc_v1 import Batch, Cluster, ClusterStatus, JobStatus
 from google.protobuf.duration_pb2 import Duration
 from google.protobuf.field_mask_pb2 import FieldMask
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.google.cloud.hooks.dataproc import DataprocHook, DataProcJobBuilder
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 from airflow.providers.google.cloud.links.dataproc import (
@@ -496,7 +496,7 @@ class DataprocCreateClusterOperator(GoogleCloudBaseOperator):
                 "Please provide cluster_config object using `cluster_config` parameter. "
                 "You can use `airflow.dataproc.ClusterGenerator.generate_cluster` "
                 "method to obtain cluster object.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=1,
             )
             # Remove result of apply defaults
@@ -738,7 +738,7 @@ class DataprocScaleClusterOperator(GoogleCloudBaseOperator):
         warnings.warn(
             f"The `{type(self).__name__}` operator is deprecated, "
             "please use `DataprocUpdateClusterOperator` instead.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=1,
         )
 
@@ -1164,7 +1164,7 @@ class DataprocSubmitPigJobOperator(DataprocJobBaseOperator):
             "The `{cls}` operator is deprecated, please use `DataprocSubmitJobOperator` instead. You can use"
             " `generate_job` method of `{cls}` to generate dictionary representing your job"
             " and use it with the new operator.".format(cls=type(self).__name__),
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=1,
         )
 
@@ -1238,7 +1238,7 @@ class DataprocSubmitHiveJobOperator(DataprocJobBaseOperator):
             "The `{cls}` operator is deprecated, please use `DataprocSubmitJobOperator` instead. You can use"
             " `generate_job` method of `{cls}` to generate dictionary representing your job"
             " and use it with the new operator.".format(cls=type(self).__name__),
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=1,
         )
 
@@ -1313,7 +1313,7 @@ class DataprocSubmitSparkSqlJobOperator(DataprocJobBaseOperator):
             "The `{cls}` operator is deprecated, please use `DataprocSubmitJobOperator` instead. You can use"
             " `generate_job` method of `{cls}` to generate dictionary representing your job"
             " and use it with the new operator.".format(cls=type(self).__name__),
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=1,
         )
 
@@ -1390,7 +1390,7 @@ class DataprocSubmitSparkJobOperator(DataprocJobBaseOperator):
             "The `{cls}` operator is deprecated, please use `DataprocSubmitJobOperator` instead. You can use"
             " `generate_job` method of `{cls}` to generate dictionary representing your job"
             " and use it with the new operator.".format(cls=type(self).__name__),
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=1,
         )
 
@@ -1463,7 +1463,7 @@ class DataprocSubmitHadoopJobOperator(DataprocJobBaseOperator):
             "The `{cls}` operator is deprecated, please use `DataprocSubmitJobOperator` instead. You can use"
             " `generate_job` method of `{cls}` to generate dictionary representing your job"
             " and use it with the new operator.".format(cls=type(self).__name__),
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=1,
         )
 
@@ -1561,7 +1561,7 @@ class DataprocSubmitPySparkJobOperator(DataprocJobBaseOperator):
             "The `{cls}` operator is deprecated, please use `DataprocSubmitJobOperator` instead. You can use"
             " `generate_job` method of `{cls}` to generate dictionary representing your job"
             " and use it with the new operator.".format(cls=type(self).__name__),
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=1,
         )
 

--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -26,7 +26,7 @@ from google.cloud.container_v1.types import Cluster
 from kubernetes.client.models import V1Pod
 
 from airflow.compat.functools import cached_property
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 
 try:
     from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
@@ -428,7 +428,7 @@ class GKEStartPodOperator(KubernetesPodOperator):
                 "Currently the default for this parameter is `False` but in a future release the default "
                 "will be changed to `True`. To ensure pods are not deleted in the future you will need to "
                 "set `is_delete_operator_pod=False` explicitly.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
             is_delete_operator_pod = False
@@ -438,7 +438,7 @@ class GKEStartPodOperator(KubernetesPodOperator):
                 f"You have set parameter use_internal_ip in class {self.__class__.__name__}. "
                 "In current implementation of the operator the parameter is not used and will "
                 "be deleted in future.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
 
@@ -447,7 +447,7 @@ class GKEStartPodOperator(KubernetesPodOperator):
                 f"You have set parameter regional in class {self.__class__.__name__}. "
                 "In current implementation of the operator the parameter is not used and will "
                 "be deleted in future.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
 
@@ -478,7 +478,7 @@ class GKEStartPodOperator(KubernetesPodOperator):
         warnings.warn(
             "The `get_gke_config_file` method is deprecated, "
             "please use `fetch_cluster_info` instead to get the cluster info for connecting to it.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=1,
         )
 

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 from googleapiclient.errors import HttpError
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.google.cloud.hooks.mlengine import MLEngineHook
 from airflow.providers.google.cloud.links.mlengine import (
     MLEngineJobDetailsLink,
@@ -336,7 +336,7 @@ class MLEngineManageModelOperator(GoogleCloudBaseOperator):
         warnings.warn(
             "This operator is deprecated. Consider using operators for specific operations: "
             "MLEngineCreateModelOperator, MLEngineGetModelOperator.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
 
@@ -644,7 +644,7 @@ class MLEngineManageVersionOperator(GoogleCloudBaseOperator):
         warnings.warn(
             "This operator is deprecated. Consider using operators for specific operations: "
             "MLEngineCreateVersion, MLEngineSetDefaultVersion, MLEngineListVersions, MLEngineDeleteVersion.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
 

--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -23,7 +23,7 @@ import warnings
 
 from google.auth.exceptions import DefaultCredentialsError
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.google.cloud._internal_client.secret_manager_client import _SecretManagerClient
 from airflow.providers.google.cloud.utils.credentials_provider import get_credentials_and_project_id
 from airflow.secrets import BaseSecretsBackend
@@ -153,7 +153,7 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
             warnings.warn(
                 f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
                 "in a future release.  Please use method `get_conn_value` instead.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
         return self.get_conn_value(conn_id)

--- a/airflow/providers/google/cloud/sensors/bigquery.py
+++ b/airflow/providers/google/cloud/sensors/bigquery.py
@@ -22,7 +22,7 @@ import warnings
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Sequence
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from airflow.providers.google.cloud.triggers.bigquery import (
     BigQueryTableExistenceTrigger,
@@ -81,7 +81,7 @@ class BigQueryTableExistenceSensor(BaseSensorOperator):
                 warnings.warn(
                     "Argument `poll_interval` is deprecated and will be removed "
                     "in a future release.  Please use `poke_interval` instead.",
-                    DeprecationWarning,
+                    AirflowProviderDeprecationWarning,
                     stacklevel=2,
                 )
             else:
@@ -284,7 +284,7 @@ class BigQueryTableExistenceAsyncSensor(BigQueryTableExistenceSensor):
             "will be removed in a future release. "
             "Please use `BigQueryTableExistenceSensor` and "
             "set `deferrable` attribute to `True` instead",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
         )
         super().__init__(deferrable=True, **kwargs)
 
@@ -320,6 +320,6 @@ class BigQueryTableExistencePartitionAsyncSensor(BigQueryTablePartitionExistence
             "will be removed in a future release. "
             "Please use `BigQueryTableExistencePartitionSensor` and "
             "set `deferrable` attribute to `True` instead",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
         )
         super().__init__(deferrable=True, **kwargs)

--- a/airflow/providers/google/cloud/sensors/gcs.py
+++ b/airflow/providers/google/cloud/sensors/gcs.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any, Callable, Sequence
 from google.api_core.retry import Retry
 from google.cloud.storage.retry import DEFAULT_RETRY
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 from airflow.providers.google.cloud.triggers.gcs import (
     GCSBlobTrigger,
@@ -151,7 +151,7 @@ class GCSObjectExistenceAsyncSensor(GCSObjectExistenceSensor):
         warnings.warn(
             "Class `GCSObjectExistenceAsyncSensor` is deprecated and will be removed in a future release. "
             "Please use `GCSObjectExistenceSensor` and set `deferrable` attribute to `True` instead",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
         )
         super().__init__(deferrable=True, **kwargs)
 

--- a/airflow/providers/google/cloud/transfers/bigquery_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_bigquery.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Sequence
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from airflow.providers.google.cloud.links.bigquery import BigQueryTableLink
@@ -122,7 +123,7 @@ class BigQueryToBigQueryOperator(BaseOperator):
         )
 
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
+            warnings.simplefilter("ignore", AirflowProviderDeprecationWarning)
             job_id = hook.run_copy(
                 source_project_dataset_tables=self.source_project_dataset_tables,
                 destination_project_dataset_table=self.destination_project_dataset_table,

--- a/airflow/providers/google/cloud/transfers/gcs_to_local.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_local.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Sequence
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.models.xcom import MAX_XCOM_SIZE
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
@@ -91,7 +91,7 @@ class GCSToLocalFilesystemOperator(BaseOperator):
             object_name = kwargs.get("object")
             if object_name is not None:
                 self.object_name = object_name
-                DeprecationWarning("Use 'object_name' instead of 'object'.")
+                AirflowProviderDeprecationWarning("Use 'object_name' instead of 'object'.")
             else:
                 TypeError("__init__() missing 1 required positional argument: 'object_name'")
 

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -46,7 +46,7 @@ from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseDownload, build_http, set_user_agent
 
 from airflow import version
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 from airflow.providers.google.cloud.utils.credentials_provider import (
     _get_scopes,
@@ -382,7 +382,7 @@ class GoogleBaseHook(BaseHook):
         """
         warnings.warn(
             "This method is deprecated, please use `airflow.providers.google.common.consts.CLIENT_INFO`.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         return CLIENT_INFO

--- a/airflow/providers/hashicorp/hooks/vault.py
+++ b/airflow/providers/hashicorp/hooks/vault.py
@@ -25,6 +25,7 @@ import hvac
 from hvac.exceptions import VaultError
 from requests import Response
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 from airflow.providers.hashicorp._internal_client.vault_client import (
     DEFAULT_KUBERNETES_JWT_PATH,
@@ -148,7 +149,7 @@ class VaultHook(BaseHook):
                 warnings.warn(
                     """The usage of role_id for AppRole authentication has been deprecated.
                     Please use connection login.""",
-                    DeprecationWarning,
+                    AirflowProviderDeprecationWarning,
                     stacklevel=2,
                 )
             elif self.connection.extra_dejson.get("role_id"):
@@ -156,7 +157,7 @@ class VaultHook(BaseHook):
                 warnings.warn(
                     """The usage of role_id in connection extra for AppRole authentication has been
                     deprecated. Please use connection login.""",
-                    DeprecationWarning,
+                    AirflowProviderDeprecationWarning,
                     stacklevel=2,
                 )
             elif self.connection.login:

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.hashicorp._internal_client.vault_client import _VaultClient
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -195,7 +196,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         warnings.warn(
             f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
             "in a future release.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         response = self.get_response(conn_id)

--- a/airflow/providers/jdbc/operators/jdbc.py
+++ b/airflow/providers/jdbc/operators/jdbc.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import warnings
 from typing import Sequence
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 
@@ -52,6 +53,6 @@ class JdbcOperator(SQLExecuteQueryOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.""",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )

--- a/airflow/providers/microsoft/azure/hooks/container_instance.py
+++ b/airflow/providers/microsoft/azure/hooks/container_instance.py
@@ -22,6 +22,7 @@ import warnings
 from azure.mgmt.containerinstance import ContainerInstanceManagementClient
 from azure.mgmt.containerinstance.models import ContainerGroup
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.microsoft.azure.hooks.base_azure import AzureBaseHook
 
 
@@ -69,7 +70,7 @@ class AzureContainerInstanceHook(AzureBaseHook):
         """
         warnings.warn(
             "get_state_exitcode_details() is deprecated. Related method is get_state()",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         cg_state = self.get_state(resource_group, name)
@@ -85,7 +86,9 @@ class AzureContainerInstanceHook(AzureBaseHook):
         :return: A list of the event messages
         """
         warnings.warn(
-            "get_messages() is deprecated. Related method is get_state()", DeprecationWarning, stacklevel=2
+            "get_messages() is deprecated. Related method is get_state()",
+            AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         cg_state = self.get_state(resource_group, name)
         instance_view = cg_state.containers[0].instance_view

--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -24,6 +24,7 @@ from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
 
 from airflow.compat.functools import cached_property
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.version import version as airflow_version
@@ -128,7 +129,7 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
             warnings.warn(
                 f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
                 "in a future release.  Please use method `get_conn_value` instead.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
         return self.get_conn_value(conn_id)

--- a/airflow/providers/microsoft/azure/sensors/data_factory.py
+++ b/airflow/providers/microsoft/azure/sensors/data_factory.py
@@ -20,8 +20,7 @@ import warnings
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Sequence
 
-from airflow import AirflowException
-from airflow.exceptions import AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.microsoft.azure.hooks.data_factory import (
     AzureDataFactoryHook,
     AzureDataFactoryPipelineRunException,

--- a/airflow/providers/microsoft/azure/sensors/data_factory.py
+++ b/airflow/providers/microsoft/azure/sensors/data_factory.py
@@ -21,6 +21,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Sequence
 
 from airflow import AirflowException
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.microsoft.azure.hooks.data_factory import (
     AzureDataFactoryHook,
     AzureDataFactoryPipelineRunException,
@@ -138,7 +139,7 @@ class AzureDataFactoryPipelineRunStatusAsyncSensor(AzureDataFactoryPipelineRunSt
             "will be removed in a future release. "
             "Please use `AzureDataFactoryPipelineRunStatusSensor` and "
             "set `deferrable` attribute to `True` instead",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         super().__init__(**kwargs, deferrable=True)

--- a/airflow/providers/microsoft/azure/sensors/wasb.py
+++ b/airflow/providers/microsoft/azure/sensors/wasb.py
@@ -21,7 +21,7 @@ import warnings
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Sequence
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 from airflow.providers.microsoft.azure.triggers.wasb import WasbBlobSensorTrigger, WasbPrefixSensorTrigger
 from airflow.sensors.base import BaseSensorOperator
@@ -122,7 +122,7 @@ class WasbBlobAsyncSensor(WasbBlobSensor):
             "will be removed in a future release. "
             "Please use `WasbBlobSensor` and "
             "set `deferrable` attribute to `True` instead",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         super().__init__(**kwargs, deferrable=True)

--- a/airflow/providers/microsoft/azure/transfers/local_to_adls.py
+++ b/airflow/providers/microsoft/azure/transfers/local_to_adls.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Any, Sequence
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.microsoft.azure.hooks.data_lake import AzureDataLakeHook
 
@@ -110,7 +110,7 @@ class LocalToAzureDataLakeStorageOperator(LocalFilesystemToADLSOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.microsoft.azure.transfers.local_to_adls.LocalFilesystemToADLSOperator`.""",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=3,
         )
         super().__init__(*args, **kwargs)

--- a/airflow/providers/microsoft/mssql/operators/mssql.py
+++ b/airflow/providers/microsoft/mssql/operators/mssql.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import warnings
 from typing import Sequence
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 
@@ -61,6 +62,6 @@ class MsSqlOperator(SQLExecuteQueryOperator):
             """This class is deprecated.
             Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.
             Also, you can provide `hook_params={'schema': <database>}`.""",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )

--- a/airflow/providers/microsoft/psrp/hooks/psrp.py
+++ b/airflow/providers/microsoft/psrp/hooks/psrp.py
@@ -29,7 +29,7 @@ from pypsrp.messages import MessageType
 from pypsrp.powershell import PowerShell, PSInvocationState, RunspacePool
 from pypsrp.wsman import WSMan
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 
 INFORMATIONAL_RECORD_LEVEL_MAP = {
@@ -231,7 +231,7 @@ class PsrpHook(BaseHook):
                 "Passing **kwargs to 'invoke_cmdlet' is deprecated "
                 "and will be removed in a future release. Please use 'parameters' "
                 "instead.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
             parameters = kwargs

--- a/airflow/providers/mysql/operators/mysql.py
+++ b/airflow/providers/mysql/operators/mysql.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import warnings
 from typing import Sequence
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 
@@ -64,6 +65,6 @@ class MySqlOperator(SQLExecuteQueryOperator):
             """This class is deprecated.
             Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.
             Also, you can provide `hook_params={'schema': <database>}`.""",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )

--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -23,6 +23,8 @@ from datetime import datetime
 
 import oracledb
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
+
 try:
     import numpy
 except ImportError:
@@ -205,7 +207,7 @@ class OracleHook(DbApiHook):
                     warnings.warn(
                         """Using conn.schema to pass the Oracle Service Name is deprecated.
                         Please use conn.extra.service_name instead.""",
-                        DeprecationWarning,
+                        AirflowProviderDeprecationWarning,
                         stacklevel=2,
                     )
                     dsn += "/" + conn.schema

--- a/airflow/providers/oracle/operators/oracle.py
+++ b/airflow/providers/oracle/operators/oracle.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Sequence
 
 import oracledb
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.providers.oracle.hooks.oracle import OracleHook
@@ -59,7 +60,7 @@ class OracleOperator(SQLExecuteQueryOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.""",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
 

--- a/airflow/providers/pagerduty/hooks/pagerduty.py
+++ b/airflow/providers/pagerduty/hooks/pagerduty.py
@@ -23,7 +23,7 @@ from typing import Any
 
 import pdpyras
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 from airflow.providers.pagerduty.hooks.pagerduty_events import PagerdutyEventsHook
 
@@ -140,7 +140,7 @@ class PagerdutyHook(BaseHook):
         warnings.warn(
             "This method will be deprecated. Please use the "
             "`airflow.providers.pagerduty.hooks.PagerdutyEventsHook` to interact with the Events API",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
 

--- a/airflow/providers/postgres/hooks/postgres.py
+++ b/airflow/providers/postgres/hooks/postgres.py
@@ -29,6 +29,7 @@ import psycopg2.extras
 from psycopg2.extensions import connection
 from psycopg2.extras import DictCursor, NamedTupleCursor, RealDictCursor
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models.connection import Connection
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 
@@ -72,7 +73,7 @@ class PostgresHook(DbApiHook):
             warnings.warn(
                 'The "schema" arg has been renamed to "database" as it contained the database name.'
                 'Please use "database" to set the database name.',
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
             kwargs["database"] = kwargs["schema"]
@@ -86,7 +87,7 @@ class PostgresHook(DbApiHook):
         warnings.warn(
             'The "schema" variable has been renamed to "database" as it contained the database name.'
             'Please use "database" to get the database name.',
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         return self.database
@@ -96,7 +97,7 @@ class PostgresHook(DbApiHook):
         warnings.warn(
             'The "schema" variable has been renamed to "database" as it contained the database name.'
             'Please use "database" to set the database name.',
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         self.database = value

--- a/airflow/providers/postgres/operators/postgres.py
+++ b/airflow/providers/postgres/operators/postgres.py
@@ -22,6 +22,7 @@ from typing import Mapping, Sequence
 
 from psycopg2.sql import SQL, Identifier
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 
@@ -86,6 +87,6 @@ class PostgresOperator(SQLExecuteQueryOperator):
             """This class is deprecated.
             Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.
             Also, you can provide `hook_params={'schema': <database>}`.""",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )

--- a/airflow/providers/sendgrid/utils/emailer.py
+++ b/airflow/providers/sendgrid/utils/emailer.py
@@ -38,7 +38,7 @@ from sendgrid.helpers.mail import (
     SandBoxMode,
 )
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 from airflow.utils.email import get_email_address_list
 
@@ -134,7 +134,7 @@ def _post_sendgrid_mail(mail_data: dict, conn_id: str = "sendgrid_default") -> N
         warnings.warn(
             "Fetching Sendgrid credentials from environment variables will be deprecated in a future "
             "release. Please set credentials using a connection instead.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         api_key = os.environ.get("SENDGRID_API_KEY")

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -27,7 +27,7 @@ from typing import Any, Callable
 
 import paramiko
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.ssh.hooks.ssh import SSHHook
 
 
@@ -85,7 +85,7 @@ class SFTPHook(SSHHook):
         if self.ssh_hook is not None:
             warnings.warn(
                 "Parameter `ssh_hook` is deprecated and will be removed in a future version.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
             if not isinstance(self.ssh_hook, SSHHook):
@@ -100,7 +100,7 @@ class SFTPHook(SSHHook):
         if ftp_conn_id:
             warnings.warn(
                 "Parameter `ftp_conn_id` is deprecated. Please use `ssh_conn_id` instead.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
             ssh_conn_id = ftp_conn_id

--- a/airflow/providers/sftp/operators/sftp.py
+++ b/airflow/providers/sftp/operators/sftp.py
@@ -23,7 +23,7 @@ import warnings
 from pathlib import Path
 from typing import Any, Sequence
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.sftp.hooks.sftp import SFTPHook
 from airflow.providers.ssh.hooks.ssh import SSHHook
@@ -141,7 +141,7 @@ class SFTPOperator(BaseOperator):
                     "Parameter `ssh_hook` is deprecated"
                     "Please use `sftp_hook` instead."
                     "The old parameter `ssh_hook` will be removed in a future version.",
-                    DeprecationWarning,
+                    AirflowProviderDeprecationWarning,
                     stacklevel=2,
                 )
                 self.sftp_hook = SFTPHook(ssh_hook=self.ssh_hook)

--- a/airflow/providers/slack/hooks/slack.py
+++ b/airflow/providers/slack/hooks/slack.py
@@ -27,7 +27,7 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
 from airflow.compat.functools import cached_property
-from airflow.exceptions import AirflowException, AirflowNotFoundException
+from airflow.exceptions import AirflowException, AirflowNotFoundException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 from airflow.providers.slack.utils import ConnectionExtraConfig
 from airflow.utils.helpers import exactly_one
@@ -131,7 +131,7 @@ class SlackHook(BaseHook):
             warnings.warn(
                 "Provide token as hook argument deprecated by security reason and will be removed "
                 "in a future releases. Please specify token in `Slack API` connection.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
         if not slack_conn_id:
@@ -202,7 +202,7 @@ class SlackHook(BaseHook):
     def token(self) -> str:
         warnings.warn(
             "`SlackHook.token` property deprecated and will be removed in a future releases.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         return self._get_conn_params()["token"]
@@ -210,7 +210,7 @@ class SlackHook(BaseHook):
     def __get_token(self, token: Any, slack_conn_id: Any) -> str:
         warnings.warn(
             "`SlackHook.__get_token` method deprecated and will be removed in a future releases.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         if token is not None:

--- a/airflow/providers/slack/hooks/slack_webhook.py
+++ b/airflow/providers/slack/hooks/slack_webhook.py
@@ -26,7 +26,7 @@ from urllib.parse import urlsplit
 from slack_sdk import WebhookClient
 
 from airflow.compat.functools import cached_property
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 from airflow.models import Connection
 from airflow.providers.slack.utils import ConnectionExtraConfig
@@ -151,7 +151,7 @@ class SlackWebhookHook(BaseHook):
         if http_conn_id:
             warnings.warn(
                 "Parameter `http_conn_id` is deprecated. Please use `slack_webhook_conn_id` instead.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
             if slack_webhook_conn_id:
@@ -165,7 +165,7 @@ class SlackWebhookHook(BaseHook):
             warnings.warn(
                 "Provide `webhook_token` as hook argument deprecated by security reason and will be removed "
                 "in a future releases. Please specify it in `Slack Webhook` connection.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
         if not slack_webhook_conn_id:
@@ -214,7 +214,7 @@ class SlackWebhookHook(BaseHook):
                 f"Provide {','.join(repr(a) for a in deprecated_class_attrs)} as hook argument(s) "
                 f"is deprecated and will be removed in a future releases. "
                 f"Please specify attributes in `{self.__class__.__name__}.send` method instead.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
 
@@ -234,7 +234,7 @@ class SlackWebhookHook(BaseHook):
         """Return Slack Webhook Token URL."""
         warnings.warn(
             "`SlackHook.webhook_token` property deprecated and will be removed in a future releases.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         return self._get_conn_params()["url"]
@@ -298,7 +298,7 @@ class SlackWebhookHook(BaseHook):
                     f"Found Slack Webhook Token URL in Connection {conn.conn_id!r} `host` "
                     "and `password` field is empty. This behaviour deprecated "
                     "and could expose you token in the UI and will be removed in a future releases.",
-                    DeprecationWarning,
+                    AirflowProviderDeprecationWarning,
                     stacklevel=2,
                 )
             url = (base_url.rstrip("/") + "/" + webhook_token.lstrip("/")).rstrip("/")
@@ -497,7 +497,7 @@ class SlackWebhookHook(BaseHook):
             "`SlackWebhookHook.execute` method deprecated and will be removed in a future releases. "
             "Please use `SlackWebhookHook.send` or `SlackWebhookHook.send_dict` or "
             "`SlackWebhookHook.send_text` methods instead.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         self.send()

--- a/airflow/providers/slack/operators/slack.py
+++ b/airflow/providers/slack/operators/slack.py
@@ -22,6 +22,7 @@ import warnings
 from typing import Any, Sequence
 
 from airflow.compat.functools import cached_property
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.slack.hooks.slack import SlackHook
 from airflow.utils.log.secrets_masker import mask_secret
@@ -211,7 +212,7 @@ class SlackAPIFileOperator(SlackAPIOperator):
             warnings.warn(
                 "Argument `channel` is deprecated and will removed in a future releases. "
                 "Please use `channels` instead.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
             if channels:

--- a/airflow/providers/slack/operators/slack_webhook.py
+++ b/airflow/providers/slack/operators/slack_webhook.py
@@ -21,7 +21,7 @@ import warnings
 from typing import TYPE_CHECKING, Sequence
 
 from airflow.compat.functools import cached_property
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.slack.hooks.slack_webhook import SlackWebhookHook
 
@@ -96,7 +96,7 @@ class SlackWebhookOperator(BaseOperator):
         if http_conn_id:
             warnings.warn(
                 "Parameter `http_conn_id` is deprecated. Please use `slack_webhook_conn_id` instead.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
             if slack_webhook_conn_id:
@@ -130,7 +130,7 @@ class SlackWebhookOperator(BaseOperator):
                 f"Provide {','.join(repr(a) for a in deprecated_class_attrs)} is deprecated "
                 f"and as has no affect, please remove it from {self.__class__.__name__} "
                 "constructor attributes otherwise in future version of provider it might cause an issue.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
 

--- a/airflow/providers/snowflake/operators/snowflake.py
+++ b/airflow/providers/snowflake/operators/snowflake.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import warnings
 from typing import Any, Iterable, Mapping, Sequence, SupportsAbs
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import (
     SQLCheckOperator,
     SQLExecuteQueryOperator,
@@ -97,7 +98,7 @@ class SnowflakeOperator(SQLExecuteQueryOperator):
             Also, you can provide `hook_params={'warehouse': <warehouse>, 'database': <database>,
             'role': <role>, 'schema': <schema>, 'authenticator': <authenticator>,
             'session_parameters': <session_parameters>}`.""",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
 

--- a/airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import warnings
 from typing import Any, Sequence
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 from airflow.providers.snowflake.utils.common import enclose_param
@@ -93,7 +94,7 @@ class S3ToSnowflakeOperator(BaseOperator):
             Please use
             `airflow.providers.snowflake.transfers.copy_into_snowflake.CopyFromExternalStageToSnowflakeOperator`.
             """,
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
         super().__init__(**kwargs)

--- a/airflow/providers/snowflake/transfers/snowflake_to_slack.py
+++ b/airflow/providers/snowflake/transfers/snowflake_to_slack.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import warnings
 from typing import Iterable, Mapping, Sequence
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.slack.transfers.sql_to_slack import SqlToSlackOperator
 
 
@@ -90,7 +91,7 @@ class SnowflakeToSlackOperator(SqlToSlackOperator):
             SnowflakeToSlackOperator is deprecated.
             Please use `airflow.providers.slack.transfers.sql_to_slack.SqlToSlackOperator`.
             """,
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
 

--- a/airflow/providers/sqlite/operators/sqlite.py
+++ b/airflow/providers/sqlite/operators/sqlite.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import warnings
 from typing import Sequence
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 
@@ -49,6 +50,6 @@ class SqliteOperator(SQLExecuteQueryOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.""",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -31,7 +31,7 @@ from sshtunnel import SSHTunnelForwarder
 from tenacity import Retrying, stop_after_attempt, wait_fixed, wait_random
 
 from airflow.compat.functools import cached_property
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 from airflow.utils.platform import getuser
 from airflow.utils.types import NOTSET, ArgNotSet
@@ -172,7 +172,7 @@ class SSHHook(BaseHook):
                         "Extra option `timeout` is deprecated."
                         "Please use `conn_timeout` instead."
                         "The old option `timeout` will be removed in a future version.",
-                        DeprecationWarning,
+                        AirflowProviderDeprecationWarning,
                         stacklevel=2,
                     )
                     self.timeout = int(extra_options["timeout"])
@@ -232,7 +232,7 @@ class SSHHook(BaseHook):
                 "Parameter `timeout` is deprecated."
                 "Please use `conn_timeout` instead."
                 "The old option `timeout` will be removed in a future version.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=1,
             )
 
@@ -368,7 +368,7 @@ class SSHHook(BaseHook):
             "The contextmanager of SSHHook is deprecated."
             "Please use get_conn() as a contextmanager instead."
             "This method will be removed in Airflow 2.0",
-            category=DeprecationWarning,
+            category=AirflowProviderDeprecationWarning,
         )
         return self
 
@@ -434,7 +434,7 @@ class SSHHook(BaseHook):
             "use get_tunnel() instead. But please note that the"
             "order of the parameters have changed"
             "This method will be removed in Airflow 2.0",
-            category=DeprecationWarning,
+            category=AirflowProviderDeprecationWarning,
         )
 
         return self.get_tunnel(remote_port, remote_host, local_port)

--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -22,7 +22,7 @@ from base64 import b64encode
 from typing import TYPE_CHECKING, Sequence
 
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.utils.types import NOTSET, ArgNotSet
 
@@ -139,7 +139,7 @@ class SSHOperator(BaseOperator):
         warnings.warn(
             "exec_ssh_client_command method on SSHOperator is deprecated, call "
             "`ssh_hook.exec_ssh_client_command` instead",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
         )
         assert self.ssh_hook
         return self.ssh_hook.exec_ssh_client_command(

--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -24,7 +24,7 @@ from typing import Any
 from tableauserverclient import Pager, PersonalAccessTokenAuth, Server, TableauAuth
 from tableauserverclient.server import Auth
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 
 
@@ -123,7 +123,7 @@ class TableauHook(BaseHook):
         warnings.warn(
             "Authentication via personal access token is deprecated. "
             "Please, use the password authentication to avoid inconsistencies.",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
         )
         tableau_auth = PersonalAccessTokenAuth(
             token_name=self.conn.extra_dejson["token_name"],

--- a/airflow/providers/trino/operators/trino.py
+++ b/airflow/providers/trino/operators/trino.py
@@ -23,6 +23,7 @@ from typing import Any, Sequence
 
 from trino.exceptions import TrinoQueryError
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.providers.trino.hooks.trino import TrinoHook
 
@@ -55,7 +56,7 @@ class TrinoOperator(SQLExecuteQueryOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.""",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )
 

--- a/airflow/providers/vertica/operators/vertica.py
+++ b/airflow/providers/vertica/operators/vertica.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import warnings
 from typing import Any, Sequence
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 
@@ -43,6 +44,6 @@ class VerticaOperator(SQLExecuteQueryOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.""",
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             stacklevel=2,
         )

--- a/airflow/providers/yandex/hooks/yandex.py
+++ b/airflow/providers/yandex/hooks/yandex.py
@@ -22,7 +22,7 @@ from typing import Any
 
 import yandexcloud
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 
 
@@ -120,7 +120,7 @@ class YandexCloudBaseHook(BaseHook):
         if connection_id:
             warnings.warn(
                 "Using `connection_id` is deprecated. Please use `yandex_conn_id` parameter.",
-                DeprecationWarning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
         self.connection_id = yandex_conn_id or connection_id or self.default_conn_name

--- a/tests/providers/amazon/aws/operators/test_batch.py
+++ b/tests/providers/amazon/aws/operators/test_batch.py
@@ -22,7 +22,7 @@ from unittest.mock import patch
 
 import pytest
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook
 from airflow.providers.amazon.aws.operators.batch import BatchCreateComputeEnvironmentOperator, BatchOperator
 
@@ -235,7 +235,7 @@ class TestBatchOperator:
         client_mock().submit_job.assert_called_once_with(**expected_args)
 
     def test_deprecated_override_param(self):
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(AirflowProviderDeprecationWarning):
             _ = BatchOperator(
                 task_id="task",
                 job_name=JOB_NAME,

--- a/tests/providers/amazon/aws/transfers/test_base.py
+++ b/tests/providers/amazon/aws/transfers/test_base.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import pytest
 
 from airflow import DAG
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import DagRun, TaskInstance
 from airflow.providers.amazon.aws.transfers.base import AwsToAwsBaseOperator
 from airflow.utils import timezone
@@ -47,7 +48,7 @@ class TestAwsToAwsBaseOperator:
 
     def test_deprecation(self):
         with pytest.warns(
-            DeprecationWarning,
+            AirflowProviderDeprecationWarning,
             match="The aws_conn_id parameter has been deprecated."
             " Use the source_aws_conn_id parameter instead.",
         ):

--- a/tests/providers/amazon/aws/transfers/test_dynamodb_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_dynamodb_to_s3.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from airflow import DAG
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import DagRun, TaskInstance
 from airflow.providers.amazon.aws.transfers.base import _DEPRECATION_MSG
 from airflow.providers.amazon.aws.transfers.dynamodb_to_s3 import (
@@ -169,7 +170,7 @@ class TestDynamodbToS3:
         mock_s3_hook.return_value.get_conn = s3_client
 
         aws_conn_id = "test-conn-id"
-        with pytest.warns(DeprecationWarning, match=_DEPRECATION_MSG):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=_DEPRECATION_MSG):
             dynamodb_to_s3_operator = DynamoDBToS3Operator(
                 task_id="dynamodb_to_s3",
                 dynamodb_table_name="airflow_rocks",

--- a/tests/providers/amazon/aws/utils/test_connection_wrapper.py
+++ b/tests/providers/amazon/aws/utils/test_connection_wrapper.py
@@ -22,6 +22,7 @@ from unittest import mock
 import pytest
 from botocore.config import Config
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
 from airflow.providers.amazon.aws.utils.connection_wrapper import AwsConnectionWrapper, _ConnectionMetadata
 
@@ -119,7 +120,7 @@ class TestAwsConnectionWrapper:
             r".* has connection type 's3', which has been replaced by connection type 'aws'\. "
             r"Please update your connection to have `conn_type='aws'`."
         )
-        with pytest.warns(DeprecationWarning, match=warning_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=warning_message):
             wrap_conn = AwsConnectionWrapper(conn=mock_connection_factory(conn_type=conn_type))
             assert wrap_conn.conn_type == conn_type
 
@@ -170,7 +171,9 @@ class TestAwsConnectionWrapper:
         }
         mock_conn = mock_connection_factory(login=None, password=None, extra=mock_conn_extra)
 
-        with pytest.warns(DeprecationWarning, match=r"'session_kwargs' in extra config is deprecated"):
+        with pytest.warns(
+            AirflowProviderDeprecationWarning, match=r"'session_kwargs' in extra config is deprecated"
+        ):
             wrap_conn = AwsConnectionWrapper(conn=mock_conn)
         assert wrap_conn.aws_access_key_id == aws_access_key_id
         assert wrap_conn.aws_secret_access_key == aws_secret_access_key
@@ -268,7 +271,7 @@ class TestAwsConnectionWrapper:
             r"'session_kwargs' in extra config is deprecated and will be removed in a future releases. "
             r"Please specify arguments passed to boto3 Session directly in .* extra."
         )
-        with pytest.warns(DeprecationWarning, match=warning_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=warning_message):
             wrap_conn = AwsConnectionWrapper(conn=mock_conn)
         session_kwargs = wrap_conn.session_kwargs
         assert session_kwargs == expected
@@ -376,7 +379,7 @@ class TestAwsConnectionWrapper:
                 "aws_iam_role": aws_iam_role,
             }
         )
-        with pytest.warns(DeprecationWarning, match="Please set 'role_arn' in .* extra"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="Please set 'role_arn' in .* extra"):
             wrap_conn = AwsConnectionWrapper(conn=mock_conn)
         assert wrap_conn.role_arn == expected
 
@@ -445,7 +448,7 @@ class TestAwsConnectionWrapper:
         mock_conn = mock_connection_factory(extra=mock_conn_extra)
 
         warning_message = "Please set 'ExternalId' in 'assume_role_kwargs' in .* extra."
-        with pytest.warns(DeprecationWarning, match=warning_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=warning_message):
             wrap_conn = AwsConnectionWrapper(conn=mock_conn)
         assert "ExternalId" in wrap_conn.assume_role_kwargs
         assert wrap_conn.assume_role_kwargs["ExternalId"] == mock_external_id_in_extra
@@ -501,7 +504,7 @@ class TestAwsConnectionWrapper:
             f"Host {mock_conn.host} specified in the connection is not used."
             " Please, set it on extra['endpoint_url'] instead"
         )
-        with pytest.warns(DeprecationWarning) as record:
+        with pytest.warns(AirflowProviderDeprecationWarning) as record:
             AwsConnectionWrapper(conn=mock_conn)
 
             assert str(record[0].message) == expected_deprecation_message

--- a/tests/providers/dbt/cloud/sensors/test_dbt_cloud.py
+++ b/tests/providers/dbt/cloud/sensors/test_dbt_cloud.py
@@ -22,7 +22,7 @@ from unittest.mock import patch
 import pytest
 
 from airflow import AirflowException
-from airflow.exceptions import TaskDeferred
+from airflow.exceptions import AirflowProviderDeprecationWarning, TaskDeferred
 from airflow.models.connection import Connection
 from airflow.providers.dbt.cloud.hooks.dbt import DbtCloudHook, DbtCloudJobRunException, DbtCloudJobRunStatus
 from airflow.providers.dbt.cloud.sensors.dbt import DbtCloudJobRunAsyncSensor, DbtCloudJobRunSensor
@@ -171,7 +171,7 @@ class TestDbtCloudJobRunSensorAsync:
     def test_dbt_job_run_sensor_async(self, mock_hook):
         """Assert execute method defer for Dbt cloud job run status sensors"""
 
-        with pytest.warns(DeprecationWarning, match=self.depcrecation_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = DbtCloudJobRunAsyncSensor(
                 dbt_cloud_conn_id=self.CONN_ID,
                 task_id=self.TASK_ID,
@@ -185,7 +185,7 @@ class TestDbtCloudJobRunSensorAsync:
 
     def test_dbt_job_run_sensor_async_execute_complete_success(self):
         """Assert execute_complete log success message when trigger fire with target status"""
-        with pytest.warns(DeprecationWarning, match=self.depcrecation_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = DbtCloudJobRunAsyncSensor(
                 dbt_cloud_conn_id=self.CONN_ID,
                 task_id=self.TASK_ID,
@@ -209,7 +209,7 @@ class TestDbtCloudJobRunSensorAsync:
     )
     def test_dbt_job_run_sensor_async_execute_complete_failure(self, mock_status, mock_message):
         """Assert execute_complete method to raise exception on the cancelled and error status"""
-        with pytest.warns(DeprecationWarning, match=self.depcrecation_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = DbtCloudJobRunAsyncSensor(
                 dbt_cloud_conn_id=self.CONN_ID,
                 task_id=self.TASK_ID,

--- a/tests/providers/dbt/cloud/sensors/test_dbt_cloud.py
+++ b/tests/providers/dbt/cloud/sensors/test_dbt_cloud.py
@@ -21,8 +21,7 @@ from unittest.mock import patch
 
 import pytest
 
-from airflow import AirflowException
-from airflow.exceptions import AirflowProviderDeprecationWarning, TaskDeferred
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, TaskDeferred
 from airflow.models.connection import Connection
 from airflow.providers.dbt.cloud.hooks.dbt import DbtCloudHook, DbtCloudJobRunException, DbtCloudJobRunStatus
 from airflow.providers.dbt.cloud.sensors.dbt import DbtCloudJobRunAsyncSensor, DbtCloudJobRunSensor

--- a/tests/providers/elasticsearch/hooks/test_elasticsearch.py
+++ b/tests/providers/elasticsearch/hooks/test_elasticsearch.py
@@ -22,6 +22,7 @@ from unittest import mock
 import pytest
 from elasticsearch import Elasticsearch
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
 from airflow.providers.elasticsearch.hooks.elasticsearch import (
     ElasticsearchHook,
@@ -38,7 +39,7 @@ class TestElasticsearchHook:
         conn = self.conn
         self.connection = Connection(host="localhost", port=9200, schema="http")
 
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(AirflowProviderDeprecationWarning):
 
             class UnitTestElasticsearchHook(ElasticsearchHook):
                 conn_name_attr = "test_conn_id"

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -29,7 +29,7 @@ from google.cloud.bigquery.dataset import AccessEntry, Dataset, DatasetListItem
 from google.cloud.bigquery.table import _EmptyRowIterator
 from google.cloud.exceptions import NotFound
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.google.cloud.hooks.bigquery import (
     BigQueryAsyncHook,
     BigQueryCursor,
@@ -2060,7 +2060,7 @@ class TestBigQueryBaseCursorMethodsDeprecationWarning:
         bq_cursor = BigQueryCursor(mock.MagicMock(), PROJECT_ID, mock_bq_hook)
         func = getattr(bq_cursor, func_name)
 
-        with pytest.warns(DeprecationWarning, match=message_regex):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=message_regex):
             _ = func(*args, **kwargs)
 
         mocked_func.assert_called_once_with(*args, **kwargs)

--- a/tests/providers/google/cloud/hooks/test_dataflow.py
+++ b/tests/providers/google/cloud/hooks/test_dataflow.py
@@ -29,7 +29,7 @@ from uuid import UUID
 import pytest
 from google.cloud.dataflow_v1beta3 import GetJobRequest, JobView
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.apache.beam.hooks.beam import BeamHook, run_beam_command
 from airflow.providers.google.cloud.hooks.dataflow import (
     DEFAULT_DATAFLOW_LOCATION,
@@ -210,7 +210,7 @@ class TestDataflowHook:
         py_requirements = ["pandas", "numpy"]
         job_name = f"{JOB_NAME}-{MOCK_UUID_PREFIX}"
 
-        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_python_dataflow(
                 job_name=JOB_NAME,
                 variables=DATAFLOW_VARIABLES_PY,
@@ -255,7 +255,7 @@ class TestDataflowHook:
         passed_variables = copy.deepcopy(DATAFLOW_VARIABLES_PY)
         passed_variables["region"] = TEST_LOCATION
 
-        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_python_dataflow(
                 job_name=JOB_NAME,
                 variables=passed_variables,
@@ -299,7 +299,7 @@ class TestDataflowHook:
 
         passed_variables = copy.deepcopy(DATAFLOW_VARIABLES_PY)
 
-        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_python_dataflow(
                 job_name=JOB_NAME,
                 variables=passed_variables,
@@ -345,7 +345,7 @@ class TestDataflowHook:
         passed_variables = copy.deepcopy(DATAFLOW_VARIABLES_PY)
         passed_variables["extra-package"] = ["a.whl", "b.whl"]
 
-        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_python_dataflow(
                 job_name=JOB_NAME,
                 variables=passed_variables,
@@ -388,7 +388,7 @@ class TestDataflowHook:
         on_new_job_id_callback = MagicMock()
         job_name = f"{JOB_NAME}-{MOCK_UUID_PREFIX}"
 
-        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_python_dataflow(
                 job_name=JOB_NAME,
                 variables=DATAFLOW_VARIABLES_PY,
@@ -442,7 +442,7 @@ class TestDataflowHook:
         on_new_job_id_callback = MagicMock()
         job_name = f"{JOB_NAME}-{MOCK_UUID_PREFIX}"
 
-        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_python_dataflow(
                 job_name=JOB_NAME,
                 variables=DATAFLOW_VARIABLES_PY,
@@ -482,7 +482,7 @@ class TestDataflowHook:
         mock_uuid.return_value = MOCK_UUID
         on_new_job_id_callback = MagicMock()
         with pytest.raises(AirflowException, match=r"Invalid method invocation\."):
-            with pytest.warns(DeprecationWarning, match="This method is deprecated"):
+            with pytest.warns(AirflowProviderDeprecationWarning, match="This method is deprecated"):
                 self.dataflow_hook.start_python_dataflow(
                     job_name=JOB_NAME,
                     variables=DATAFLOW_VARIABLES_PY,
@@ -504,7 +504,7 @@ class TestDataflowHook:
         on_new_job_id_callback = MagicMock()
         job_name = f"{JOB_NAME}-{MOCK_UUID_PREFIX}"
 
-        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_java_dataflow(
                 job_name=JOB_NAME,
                 variables=DATAFLOW_VARIABLES_JAVA,
@@ -544,7 +544,7 @@ class TestDataflowHook:
         passed_variables: dict[str, Any] = copy.deepcopy(DATAFLOW_VARIABLES_JAVA)
         passed_variables["mock-option"] = ["a.whl", "b.whl"]
 
-        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_java_dataflow(
                 job_name=JOB_NAME,
                 variables=passed_variables,
@@ -584,7 +584,7 @@ class TestDataflowHook:
         passed_variables: dict[str, Any] = copy.deepcopy(DATAFLOW_VARIABLES_JAVA)
         passed_variables["region"] = TEST_LOCATION
 
-        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_java_dataflow(
                 job_name=JOB_NAME,
                 variables=passed_variables,
@@ -621,7 +621,7 @@ class TestDataflowHook:
         on_new_job_id_callback = MagicMock()
         job_name = f"{JOB_NAME}-{MOCK_UUID_PREFIX}"
 
-        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_java_dataflow(
                 job_name=JOB_NAME,
                 variables=DATAFLOW_VARIABLES_JAVA,

--- a/tests/providers/google/cloud/operators/test_dataproc.py
+++ b/tests/providers/google/cloud/operators/test_dataproc.py
@@ -25,8 +25,12 @@ from google.api_core.exceptions import AlreadyExists, NotFound
 from google.api_core.retry import Retry
 from google.cloud.dataproc_v1 import Batch
 
-from airflow import AirflowException
-from airflow.exceptions import AirflowProviderDeprecationWarning, AirflowTaskTimeout, TaskDeferred
+from airflow.exceptions import (
+    AirflowException,
+    AirflowProviderDeprecationWarning,
+    AirflowTaskTimeout,
+    TaskDeferred,
+)
 from airflow.models import DAG, DagBag
 from airflow.providers.google.cloud.operators.dataproc import (
     DATAPROC_CLUSTER_LINK,

--- a/tests/providers/google/cloud/operators/test_dataproc.py
+++ b/tests/providers/google/cloud/operators/test_dataproc.py
@@ -26,7 +26,7 @@ from google.api_core.retry import Retry
 from google.cloud.dataproc_v1 import Batch
 
 from airflow import AirflowException
-from airflow.exceptions import AirflowTaskTimeout, TaskDeferred
+from airflow.exceptions import AirflowProviderDeprecationWarning, AirflowTaskTimeout, TaskDeferred
 from airflow.models import DAG, DagBag
 from airflow.providers.google.cloud.operators.dataproc import (
     DATAPROC_CLUSTER_LINK,
@@ -420,7 +420,7 @@ class TestsClusterGenerator:
 
 class TestDataprocClusterCreateOperator(DataprocClusterTestBase):
     def test_deprecation_warning(self):
-        with pytest.warns(DeprecationWarning) as warnings:
+        with pytest.warns(AirflowProviderDeprecationWarning) as warnings:
             op = DataprocCreateClusterOperator(
                 task_id=TASK_ID,
                 region=GCP_REGION,
@@ -757,7 +757,7 @@ def test_create_cluster_operator_extra_links(dag_maker, create_task_instance_of_
 
 class TestDataprocClusterScaleOperator(DataprocClusterTestBase):
     def test_deprecation_warning(self):
-        with pytest.warns(DeprecationWarning) as warnings:
+        with pytest.warns(AirflowProviderDeprecationWarning) as warnings:
             DataprocScaleClusterOperator(task_id=TASK_ID, cluster_name=CLUSTER_NAME, project_id=GCP_PROJECT)
         assert_warning("DataprocUpdateClusterOperator", warnings)
 
@@ -1549,7 +1549,7 @@ class TestDataProcHiveOperator:
 
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_deprecation_warning(self, mock_hook):
-        with pytest.warns(DeprecationWarning) as warnings:
+        with pytest.warns(AirflowProviderDeprecationWarning) as warnings:
             DataprocSubmitHiveJobOperator(task_id=TASK_ID, region=GCP_REGION, query="query")
         assert_warning("DataprocSubmitJobOperator", warnings)
 
@@ -1611,7 +1611,7 @@ class TestDataProcPigOperator:
 
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_deprecation_warning(self, mock_hook):
-        with pytest.warns(DeprecationWarning) as warnings:
+        with pytest.warns(AirflowProviderDeprecationWarning) as warnings:
             DataprocSubmitPigJobOperator(task_id=TASK_ID, region=GCP_REGION, query="query")
         assert_warning("DataprocSubmitJobOperator", warnings)
 
@@ -1679,7 +1679,7 @@ class TestDataProcSparkSqlOperator:
 
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_deprecation_warning(self, mock_hook):
-        with pytest.warns(DeprecationWarning) as warnings:
+        with pytest.warns(AirflowProviderDeprecationWarning) as warnings:
             DataprocSubmitSparkSqlJobOperator(task_id=TASK_ID, region=GCP_REGION, query="query")
         assert_warning("DataprocSubmitJobOperator", warnings)
 
@@ -1770,7 +1770,7 @@ class TestDataProcSparkOperator(DataprocJobTestBase):
 
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_deprecation_warning(self, mock_hook):
-        with pytest.warns(DeprecationWarning) as warnings:
+        with pytest.warns(AirflowProviderDeprecationWarning) as warnings:
             DataprocSubmitSparkJobOperator(
                 task_id=TASK_ID, region=GCP_REGION, main_class=self.main_class, dataproc_jars=self.jars
             )
@@ -1863,7 +1863,7 @@ class TestDataProcHadoopOperator:
 
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_deprecation_warning(self, mock_hook):
-        with pytest.warns(DeprecationWarning) as warnings:
+        with pytest.warns(AirflowProviderDeprecationWarning) as warnings:
             DataprocSubmitHadoopJobOperator(
                 task_id=TASK_ID, region=GCP_REGION, main_jar=self.jar, arguments=self.args
             )
@@ -1901,7 +1901,7 @@ class TestDataProcPySparkOperator:
 
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_deprecation_warning(self, mock_hook):
-        with pytest.warns(DeprecationWarning) as warnings:
+        with pytest.warns(AirflowProviderDeprecationWarning) as warnings:
             DataprocSubmitPySparkJobOperator(task_id=TASK_ID, region=GCP_REGION, main=self.uri)
         assert_warning("DataprocSubmitJobOperator", warnings)
 

--- a/tests/providers/google/cloud/sensors/test_bigquery.py
+++ b/tests/providers/google/cloud/sensors/test_bigquery.py
@@ -20,7 +20,7 @@ from unittest import mock
 
 import pytest
 
-from airflow.exceptions import AirflowException, TaskDeferred
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, TaskDeferred
 from airflow.providers.google.cloud.sensors.bigquery import (
     BigQueryTableExistenceAsyncSensor,
     BigQueryTableExistencePartitionAsyncSensor,
@@ -273,7 +273,7 @@ class TestBigQueryTableExistenceAsyncSensor:
         Asserts that a task is deferred and a BigQueryTableExistenceTrigger will be fired
         when the BigQueryTableExistenceAsyncSensor is executed.
         """
-        with pytest.warns(DeprecationWarning, match=self.depcrecation_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = BigQueryTableExistenceAsyncSensor(
                 task_id="check_table_exists",
                 project_id=TEST_PROJECT_ID,
@@ -289,7 +289,7 @@ class TestBigQueryTableExistenceAsyncSensor:
 
     def test_big_query_table_existence_sensor_async_execute_failure(self):
         """Tests that an AirflowException is raised in case of error event"""
-        with pytest.warns(DeprecationWarning, match=self.depcrecation_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = BigQueryTableExistenceAsyncSensor(
                 task_id="task-id",
                 project_id=TEST_PROJECT_ID,
@@ -301,7 +301,7 @@ class TestBigQueryTableExistenceAsyncSensor:
 
     def test_big_query_table_existence_sensor_async_execute_complete(self):
         """Asserts that logging occurs as expected"""
-        with pytest.warns(DeprecationWarning, match=self.depcrecation_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = BigQueryTableExistenceAsyncSensor(
                 task_id="task-id",
                 project_id=TEST_PROJECT_ID,
@@ -315,7 +315,7 @@ class TestBigQueryTableExistenceAsyncSensor:
 
     def test_big_query_sensor_async_execute_complete_event_none(self):
         """Asserts that logging occurs as expected"""
-        with pytest.warns(DeprecationWarning, match=self.depcrecation_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = BigQueryTableExistenceAsyncSensor(
                 task_id="task-id",
                 project_id=TEST_PROJECT_ID,
@@ -340,7 +340,7 @@ class TestBigQueryTableExistencePartitionAsyncSensor:
         Asserts that a task is deferred and a BigQueryTablePartitionExistenceTrigger will be fired
         when the BigQueryTableExistencePartitionAsyncSensor is executed.
         """
-        with pytest.warns(DeprecationWarning, match=self.depcrecation_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = BigQueryTableExistencePartitionAsyncSensor(
                 task_id="test_task_id",
                 project_id=TEST_PROJECT_ID,
@@ -357,7 +357,7 @@ class TestBigQueryTableExistencePartitionAsyncSensor:
 
     def test_big_query_table_existence_partition_sensor_async_execute_failure(self):
         """Tests that an AirflowException is raised in case of error event"""
-        with pytest.warns(DeprecationWarning, match=self.depcrecation_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = BigQueryTableExistencePartitionAsyncSensor(
                 task_id="test_task_id",
                 project_id=TEST_PROJECT_ID,
@@ -370,7 +370,7 @@ class TestBigQueryTableExistencePartitionAsyncSensor:
 
     def test_big_query_table_existence_partition_sensor_async_execute_complete_event_none(self):
         """Asserts that logging occurs as expected"""
-        with pytest.warns(DeprecationWarning, match=self.depcrecation_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = BigQueryTableExistencePartitionAsyncSensor(
                 task_id="task-id",
                 project_id=TEST_PROJECT_ID,
@@ -383,7 +383,7 @@ class TestBigQueryTableExistencePartitionAsyncSensor:
 
     def test_big_query_table_existence_partition_sensor_async_execute_complete(self):
         """Asserts that logging occurs as expected"""
-        with pytest.warns(DeprecationWarning, match=self.depcrecation_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = BigQueryTableExistencePartitionAsyncSensor(
                 task_id="task-id",
                 project_id=TEST_PROJECT_ID,

--- a/tests/providers/google/cloud/sensors/test_gcs.py
+++ b/tests/providers/google/cloud/sensors/test_gcs.py
@@ -24,7 +24,7 @@ import pendulum
 import pytest
 from google.cloud.storage.retry import DEFAULT_RETRY
 
-from airflow.exceptions import AirflowSensorTimeout, TaskDeferred
+from airflow.exceptions import AirflowProviderDeprecationWarning, AirflowSensorTimeout, TaskDeferred
 from airflow.models.dag import DAG, AirflowException
 from airflow.providers.google.cloud.sensors.gcs import (
     GCSObjectExistenceAsyncSensor,
@@ -168,7 +168,7 @@ class TestGoogleCloudStorageObjectSensorAsync:
         Asserts that a task is deferred and a GCSBlobTrigger will be fired
         when the GCSObjectExistenceAsyncSensor is executed.
         """
-        with pytest.warns(DeprecationWarning, match=self.depcrecation_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = GCSObjectExistenceAsyncSensor(
                 task_id="task-id",
                 bucket=TEST_BUCKET,
@@ -182,7 +182,7 @@ class TestGoogleCloudStorageObjectSensorAsync:
 
     def test_gcs_object_existence_sensor_async_execute_failure(self):
         """Tests that an AirflowException is raised in case of error event"""
-        with pytest.warns(DeprecationWarning, match=self.depcrecation_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = GCSObjectExistenceAsyncSensor(
                 task_id="task-id",
                 bucket=TEST_BUCKET,
@@ -194,7 +194,7 @@ class TestGoogleCloudStorageObjectSensorAsync:
 
     def test_gcs_object_existence_sensor_async_execute_complete(self):
         """Asserts that logging occurs as expected"""
-        with pytest.warns(DeprecationWarning, match=self.depcrecation_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = GCSObjectExistenceAsyncSensor(
                 task_id="task-id",
                 bucket=TEST_BUCKET,

--- a/tests/providers/microsoft/azure/secrets/test_azure_key_vault.py
+++ b/tests/providers/microsoft/azure/secrets/test_azure_key_vault.py
@@ -22,6 +22,7 @@ from unittest import mock
 import pytest
 from azure.core.exceptions import ResourceNotFoundError
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.microsoft.azure.secrets.key_vault import AzureKeyVaultBackend
 
 
@@ -45,7 +46,7 @@ class TestAzureKeyVaultBackend:
         )
 
         backend = AzureKeyVaultBackend(vault_url="https://example-akv-resource-name.vault.azure.net/")
-        with pytest.warns(DeprecationWarning, match="Method `.*get_conn_uri` is deprecated"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="Method `.*get_conn_uri` is deprecated"):
             returned_uri = backend.get_conn_uri(conn_id="hi")
         mock_secret_client.assert_called_once_with(
             credential=mock_cred, vault_url="https://example-akv-resource-name.vault.azure.net/"
@@ -62,7 +63,7 @@ class TestAzureKeyVaultBackend:
         mock_client.get_secret.side_effect = ResourceNotFoundError
         backend = AzureKeyVaultBackend(vault_url="https://example-akv-resource-name.vault.azure.net/")
 
-        with pytest.warns(DeprecationWarning, match="Method `.*get_conn_uri` is deprecated"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="Method `.*get_conn_uri` is deprecated"):
             assert backend.get_conn_uri(conn_id=conn_id) is None
         assert backend.get_connection(conn_id=conn_id) is None
 
@@ -120,7 +121,7 @@ class TestAzureKeyVaultBackend:
         mock_get_secret.assert_not_called()
 
         mock_get_secret.reset_mock()
-        with pytest.warns(DeprecationWarning, match="Method `.*get_conn_uri` is deprecated"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="Method `.*get_conn_uri` is deprecated"):
             assert backend.get_conn_uri("test_mysql") is None
             mock_get_secret.assert_not_called()
 

--- a/tests/providers/oracle/operators/test_oracle.py
+++ b/tests/providers/oracle/operators/test_oracle.py
@@ -23,6 +23,7 @@ from unittest import mock
 import oracledb
 import pytest
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import TaskInstance
 from airflow.providers.common.sql.hooks.sql import fetch_all_handler
 from airflow.providers.oracle.hooks.oracle import OracleHook
@@ -39,7 +40,7 @@ class TestOracleOperator:
         context = "test_context"
         task_id = "test_task_id"
 
-        with pytest.warns(DeprecationWarning, match="This class is deprecated.*"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="This class is deprecated.*"):
             operator = OracleOperator(
                 sql=sql,
                 oracle_conn_id=oracle_conn_id,

--- a/tests/providers/slack/hooks/test_slack.py
+++ b/tests/providers/slack/hooks/test_slack.py
@@ -29,7 +29,7 @@ from slack_sdk.errors import SlackApiError
 from slack_sdk.http_retry.builtin_handlers import ConnectionErrorRetryHandler, RateLimitErrorRetryHandler
 from slack_sdk.web.slack_response import SlackResponse
 
-from airflow.exceptions import AirflowException, AirflowNotFoundException
+from airflow.exceptions import AirflowException, AirflowNotFoundException, AirflowProviderDeprecationWarning
 from airflow.models.connection import Connection
 from airflow.providers.slack.hooks.slack import SlackHook
 from tests.test_utils.providers import get_provider_min_airflow_version, object_exists
@@ -82,14 +82,14 @@ class TestSlackHook:
             "Provide token as hook argument deprecated by security reason and will be removed "
             r"in a future releases. Please specify token in `Slack API` connection\."
         )
-        with pytest.warns(DeprecationWarning, match=warning_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=warning_message):
             SlackHook(slack_conn_id=SLACK_API_DEFAULT_CONN_ID, token="foo-bar")
 
     def test_token_property_deprecated(self):
         """Test deprecation warning if access to ``SlackHook.token`` property."""
         hook = SlackHook(slack_conn_id=SLACK_API_DEFAULT_CONN_ID)
         warning_message = r"`SlackHook.token` property deprecated and will be removed in a future releases\."
-        with pytest.warns(DeprecationWarning, match=warning_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=warning_message):
             assert hook.token == MOCK_SLACK_API_TOKEN
 
     def test_optional_conn_id_deprecated(self):

--- a/tests/providers/slack/hooks/test_slack_webhook.py
+++ b/tests/providers/slack/hooks/test_slack_webhook.py
@@ -30,7 +30,7 @@ from pytest import param
 from slack_sdk.http_retry.builtin_handlers import ConnectionErrorRetryHandler, RateLimitErrorRetryHandler
 from slack_sdk.webhook.webhook_response import WebhookResponse
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models.connection import Connection
 from airflow.providers.slack.hooks.slack_webhook import SlackWebhookHook, check_webhook_response
 from tests.test_utils.providers import get_provider_min_airflow_version, object_exists
@@ -188,7 +188,7 @@ class TestSlackWebhookHook:
             r"Provide `webhook_token` as hook argument deprecated by security reason and will be removed "
             r"in a future releases. Please specify it in `Slack Webhook` connection\."
         )
-        with pytest.warns(DeprecationWarning, match=warning_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=warning_message):
             SlackWebhookHook(webhook_token=webhook_token)
         mock_mask_secret.assert_called_once_with(webhook_token)
 
@@ -237,7 +237,7 @@ class TestSlackWebhookHook:
         warning_message = (
             r"Found Slack Webhook Token URL in Connection .* `host` and `password` field is empty\."
         )
-        with pytest.warns(DeprecationWarning, match=warning_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=warning_message):
             conn_params = hook._get_conn_params()
         mock_mask_secret.assert_called_once_with(mock.ANY)
         assert "url" in conn_params
@@ -505,7 +505,7 @@ class TestSlackWebhookHook:
             r"Provide .* as hook argument\(s\) is deprecated and will be removed in a future releases\. "
             r"Please specify attributes in `SlackWebhookHook\.send` method instead\."
         )
-        with pytest.warns(DeprecationWarning, match=warning_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=warning_message):
             hook = SlackWebhookHook(slack_webhook_conn_id=TEST_CONN_ID, **send_params)
         assert getattr(hook, deprecated_hook_attr) == "test-value"
         if deprecated_hook_attr == "message":
@@ -521,7 +521,7 @@ class TestSlackWebhookHook:
             "Please use `SlackWebhookHook.send` or `SlackWebhookHook.send_dict` or "
             "`SlackWebhookHook.send_text` methods instead."
         )
-        with pytest.warns(DeprecationWarning, match=warning_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=warning_message):
             hook.execute()
         mock_hook_send_dict.assert_called_once_with(body=expected_body, headers=None)
 
@@ -537,7 +537,7 @@ class TestSlackWebhookHook:
         assert str(recwarn.pop(UserWarning).message).startswith(
             "`link_names` has no affect, if you want to mention user see:"
         )
-        assert str(recwarn.pop(DeprecationWarning).message).startswith(
+        assert str(recwarn.pop(AirflowProviderDeprecationWarning).message).startswith(
             "Provide 'link_names' as hook argument(s) is deprecated and will be removed in a future releases."
         )
         hook.send()

--- a/tests/providers/slack/operators/test_slack.py
+++ b/tests/providers/slack/operators/test_slack.py
@@ -23,6 +23,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
 from airflow.providers.slack.operators.slack import (
     SlackAPIFileOperator,
@@ -271,7 +272,7 @@ class TestSlackAPIFileOperator:
             r"Argument `channel` is deprecated and will removed in a future releases\. "
             r"Please use `channels` instead\."
         )
-        with pytest.warns(DeprecationWarning, match=warning_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=warning_message):
             op = SlackAPIFileOperator(
                 task_id="slack",
                 slack_conn_id=SLACK_API_TEST_CONNECTION_ID,

--- a/tests/providers/slack/operators/test_slack_webhook.py
+++ b/tests/providers/slack/operators/test_slack_webhook.py
@@ -21,7 +21,7 @@ from unittest import mock
 
 import pytest
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
 
 
@@ -59,7 +59,7 @@ class TestSlackWebhookOperator:
         """
         kw = {simple_http_op_attr: "foo-bar"}
         warning_message = rf"Provide '{simple_http_op_attr}' is deprecated and as has no affect"
-        with pytest.warns(DeprecationWarning, match=warning_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=warning_message):
             SlackWebhookOperator(task_id="test_unused_args", **kw)
 
     def test_deprecated_http_conn_id(self):
@@ -67,7 +67,7 @@ class TestSlackWebhookOperator:
         warning_message = (
             r"Parameter `http_conn_id` is deprecated. Please use `slack_webhook_conn_id` instead."
         )
-        with pytest.warns(DeprecationWarning, match=warning_message):
+        with pytest.warns(AirflowProviderDeprecationWarning, match=warning_message):
             op = SlackWebhookOperator(
                 task_id="test_deprecated_http_conn_id", slack_webhook_conn_id=None, http_conn_id="http_conn"
             )
@@ -75,7 +75,7 @@ class TestSlackWebhookOperator:
 
         error_message = "You cannot provide both `slack_webhook_conn_id` and `http_conn_id`."
         with pytest.raises(AirflowException, match=error_message):
-            with pytest.warns(DeprecationWarning, match=warning_message):
+            with pytest.warns(AirflowProviderDeprecationWarning, match=warning_message):
                 SlackWebhookOperator(
                     task_id="test_both_conn_ids",
                     slack_webhook_conn_id="slack_webhook_conn_id",

--- a/tests/providers/trino/operators/test_trino.py
+++ b/tests/providers/trino/operators/test_trino.py
@@ -21,6 +21,7 @@ from unittest import mock
 
 import pytest
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.trino.operators.trino import TrinoOperator
 
 TRINO_CONN_ID = "test_trino"
@@ -32,7 +33,7 @@ class TestTrinoOperator:
     def test_execute(self, mock_get_db_hook):
         """Asserts that the run method is called when a TrinoOperator task is executed"""
 
-        with pytest.warns(DeprecationWarning, match="This class is deprecated.*"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="This class is deprecated.*"):
             op = TrinoOperator(
                 task_id=TASK_ID,
                 sql="SELECT 1;",


### PR DESCRIPTION
Now that Providers minimum Airflow version is 2.4.0 we can replace `DeprecationWarning` with `AirflowProviderDeprecationWarning`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
