### PR TITLE
Fix output for `airflow providers get` command

### DIFF
--- a/airflow/cli/commands/provider_command.py
+++ b/airflow/cli/commands/provider_command.py
@@ -44,8 +44,9 @@ def provider_get(args):
                 output=args.output,
             )
         else:
-            print(f"Provider: {args.provider_name}")
-            print(f"Version: {provider_version}")
+            AirflowConsole().print_as(
+                data=[{"Provider": args.provider_name, "Version": provider_version}], output=args.output
+            )
     else:
         raise SystemExit(f"No such provider installed: {args.provider_name}")
 


### PR DESCRIPTION
If I use the `airflow provider get <provider-name> -o json/yaml` CLI command it does not respect `-o` option. It works perfectly fine when I pass the `--full` option also in the above command. The issue is currently if the `--full` option is not provided we use standard statement print to print results and not the custom AirflowConsole. In this PR I'm replacing print with `AirflowConsole().print_as`
Before
<img width="1243" alt="Screenshot 2023-05-01 at 3 07 15 AM" src="https://user-images.githubusercontent.com/98807258/235377378-a071a824-d0e7-43cc-9bc7-19e55cd9e7e5.png">


After
<img width="1134" alt="Screenshot 2023-05-01 at 3 03 27 AM" src="https://user-images.githubusercontent.com/98807258/235377260-4518b35e-e644-46db-8d91-0d9ff21037f7.png">


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
