### PR TITLE
Adding example to clarify usage of --file flag in STATIC_CHECKS.md document

### DIFF
--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -428,7 +428,7 @@ Run the ``mypy`` check for all files:
 
      breeze static-checks --type mypy-core --all-files
 
-Run the ``ruff`` check for the ``tests.core.py`` file with verbose output:
+Run the ``ruff`` check for the ``tests/core.py`` file with verbose output:
 
 .. code-block:: bash
 
@@ -439,6 +439,14 @@ Run the ``ruff for the ``tests.core`` package with verbose output:
 .. code-block:: bash
 
      breeze static-checks --type ruff --file tests/core/* --verbose
+
+Run the ``black`` check for the files ``airflow/example_dags/example_bash_operator.py`` and
+``airflow/example_dags/example_python_operator.py``:
+
+.. code-block:: bash
+
+     breeze static-checks --type black --file airflow/example_dags/example_bash_operator.py \
+         airflow/example_dags/example_python_operator.py
 
 Run all checks for the currently staged files:
 


### PR DESCRIPTION
This PR adds a small example to `STATIC_CODE_CHECKS.rst` about how to specify two or more specific files using the `--file` flag. `breeze static-checks --help` shows that `--files` accepts a list of files, but the documentation did not have an example of this, so I add one.