### PR TITLE
Optimize deferrable execution mode `AzureDataFactoryPipelineRunStatusSensor`

### DIFF
--- a/airflow/providers/microsoft/azure/sensors/data_factory.py
+++ b/airflow/providers/microsoft/azure/sensors/data_factory.py
@@ -94,17 +94,18 @@ class AzureDataFactoryPipelineRunStatusSensor(BaseSensorOperator):
         if not self.deferrable:
             super().execute(context=context)
         else:
-            self.defer(
-                timeout=timedelta(seconds=self.timeout),
-                trigger=ADFPipelineRunStatusSensorTrigger(
-                    run_id=self.run_id,
-                    azure_data_factory_conn_id=self.azure_data_factory_conn_id,
-                    resource_group_name=self.resource_group_name,
-                    factory_name=self.factory_name,
-                    poke_interval=self.poke_interval,
-                ),
-                method_name="execute_complete",
-            )
+            if not self.poke(context=context):
+                self.defer(
+                    timeout=timedelta(seconds=self.timeout),
+                    trigger=ADFPipelineRunStatusSensorTrigger(
+                        run_id=self.run_id,
+                        azure_data_factory_conn_id=self.azure_data_factory_conn_id,
+                        resource_group_name=self.resource_group_name,
+                        factory_name=self.factory_name,
+                        poke_interval=self.poke_interval,
+                    ),
+                    method_name="execute_complete",
+                )
 
     def execute_complete(self, context: Context, event: dict[str, str]) -> None:
         """

--- a/tests/providers/microsoft/azure/sensors/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/sensors/test_azure_data_factory.py
@@ -84,14 +84,27 @@ class TestPipelineRunStatusSensor:
             with pytest.raises(AzureDataFactoryPipelineRunException, match=error_message):
                 self.sensor.poke({})
 
-    def test_adf_pipeline_status_sensor_async(self):
+    @mock.patch("airflow.providers.microsoft.azure.sensors.data_factory.AzureDataFactoryHook")
+    def test_adf_pipeline_status_sensor_async(self, mock_hook):
         """Assert execute method defer for Azure Data factory pipeline run status sensor"""
-
+        mock_hook.return_value.get_pipeline_run_status.return_value = AzureDataFactoryPipelineRunStatus.QUEUED
         with pytest.raises(TaskDeferred) as exc:
-            self.defered_sensor.execute({})
+            self.defered_sensor.execute(mock.MagicMock())
         assert isinstance(
             exc.value.trigger, ADFPipelineRunStatusSensorTrigger
         ), "Trigger is not a ADFPipelineRunStatusSensorTrigger"
+
+    @mock.patch("airflow.providers.microsoft.azure.sensors.data_factory.AzureDataFactoryHook")
+    @mock.patch(
+        "airflow.providers.microsoft.azure.sensors.data_factory"
+        ".AzureDataFactoryPipelineRunStatusSensor.defer"
+    )
+    def test_gcs_object_existence_sensor_finish_before_deferred(self, mock_defer, mock_hook):
+        mock_hook.return_value.get_pipeline_run_status.return_value = (
+            AzureDataFactoryPipelineRunStatus.SUCCEEDED
+        )
+        self.defered_sensor.execute(mock.MagicMock())
+        assert not mock_defer.called
 
     def test_adf_pipeline_status_sensor_execute_complete_success(self):
         """Assert execute_complete log success message when trigger fire with target status"""
@@ -115,9 +128,10 @@ class TestAzureDataFactoryPipelineRunStatusAsyncSensor:
         run_id=RUN_ID,
     )
 
-    def test_adf_pipeline_status_sensor_async(self):
+    @mock.patch("airflow.providers.microsoft.azure.sensors.data_factory.AzureDataFactoryHook")
+    def test_adf_pipeline_status_sensor_async(self, mock_hook):
         """Assert execute method defer for Azure Data factory pipeline run status sensor"""
-
+        mock_hook.return_value.get_pipeline_run_status.return_value = AzureDataFactoryPipelineRunStatus.QUEUED
         with pytest.raises(TaskDeferred) as exc:
             self.SENSOR.execute({})
         assert isinstance(

--- a/tests/providers/microsoft/azure/sensors/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/sensors/test_azure_data_factory.py
@@ -99,7 +99,7 @@ class TestPipelineRunStatusSensor:
         "airflow.providers.microsoft.azure.sensors.data_factory"
         ".AzureDataFactoryPipelineRunStatusSensor.defer"
     )
-    def test_gcs_object_existence_sensor_finish_before_deferred(self, mock_defer, mock_hook):
+    def test_adf_pipeline_status_sensor_finish_before_deferred(self, mock_defer, mock_hook):
         mock_hook.return_value.get_pipeline_run_status.return_value = (
             AzureDataFactoryPipelineRunStatus.SUCCEEDED
         )


### PR DESCRIPTION
In deferrable mode for AzureDataFactoryPipelineRunStatusSensor, we should first check if job is successful or not in the execute method and only defer if that is not successful. This way we don’t run an unnecessary deferral cycle if the condition is already true.

cc @dstandish

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
