### PR TITLE
Chart: add custom volumemounts to dag processor waitForMigrations init container

### DIFF
--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -115,7 +115,14 @@ spec:
           resources: {{- toYaml .Values.dagProcessor.resources | nindent 12 }}
           image: {{ template "airflow_image_for_migrations" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
-          volumeMounts: {{- include "airflow_config_mount" . | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.volumeMounts }}
+              {{- toYaml .Values.volumeMounts | nindent 12 }}
+            {{- end }}
+            {{- if .Values.dagProcessor.extraVolumeMounts }}
+              {{- toYaml .Values.dagProcessor.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+            {{- include "airflow_config_mount" . | nindent 12 }}
           args: {{- include "wait-for-migrations-command" . | indent 10 }}
           envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env:

--- a/tests/charts/airflow_core/test_dag_processor.py
+++ b/tests/charts/airflow_core/test_dag_processor.py
@@ -118,6 +118,9 @@ class TestDagProcessor:
         assert "test-volume" == jmespath.search(
             "spec.template.spec.containers[0].volumeMounts[0].name", docs[0]
         )
+        assert "test-volume" == jmespath.search(
+            "spec.template.spec.initContainers[0].volumeMounts[0].name", docs[0]
+        )
 
     def test_should_add_global_volume_and_global_volume_mount(self):
         docs = render_chart(
@@ -132,6 +135,9 @@ class TestDagProcessor:
         assert "test-volume" == jmespath.search("spec.template.spec.volumes[1].name", docs[0])
         assert "test-volume" == jmespath.search(
             "spec.template.spec.containers[0].volumeMounts[0].name", docs[0]
+        )
+        assert "test-volume" == jmespath.search(
+            "spec.template.spec.initContainers[0].volumeMounts[0].name", docs[0]
         )
 
     def test_should_add_extraEnvs(self):


### PR DESCRIPTION
For some reason global volumemounts are missing from dag processor waitForMigrations init container (while all other waitForMigrations init containers have it) . This PR fixes it.  Also I decided to add `dagProcessor.extraVolumeMounts` to dag processor waitForMigrations init container, since this is common behavior for all other waitForMigrations init containers.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
