### PR TITLE
Add providers triggers CLI command in provider discovery

### DIFF
--- a/scripts/in_container/verify_providers.py
+++ b/scripts/in_container/verify_providers.py
@@ -810,6 +810,10 @@ def verify_provider_classes():
 
 
 def run_provider_discovery():
+    import packaging.version
+
+    import airflow.version
+
     console.print("[bright_blue]List all providers[/]\n")
     subprocess.run(["airflow", "providers", "list"], check=True)
     console.print("[bright_blue]List all hooks[/]\n")
@@ -826,8 +830,12 @@ def run_provider_discovery():
     subprocess.run(["airflow", "providers", "secrets"], check=True)
     console.print("[bright_blue]List all auth backends[/]\n")
     subprocess.run(["airflow", "providers", "auth"], check=True)
-    console.print("[bright_blue]List all triggers[/]\n")
-    subprocess.run(["airflow", "providers", "triggers"], check=True)
+    if packaging.version.parse(airflow.version.version) >= packaging.version.parse("2.7.0.dev0"):
+        # CI also check if our providers are installable and discoverable in airflow older versions
+        # But the triggers command is not available till airflow-2-6-0
+        # TODO: Remove this block once airflow dependency in providers are > 2-6-0
+        console.print("[bright_blue]List all triggers[/]\n")
+        subprocess.run(["airflow", "providers", "triggers"], check=True)
 
 
 if __name__ == "__main__":

--- a/scripts/in_container/verify_providers.py
+++ b/scripts/in_container/verify_providers.py
@@ -826,6 +826,8 @@ def run_provider_discovery():
     subprocess.run(["airflow", "providers", "secrets"], check=True)
     console.print("[bright_blue]List all auth backends[/]\n")
     subprocess.run(["airflow", "providers", "auth"], check=True)
+    console.print("[bright_blue]List all triggers[/]\n")
+    subprocess.run(["airflow", "providers", "triggers"], check=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We added airflow providers triggers command recently. So let's add the same in verify-provider-packages since we run this run in CI so it would make sure that the command is remain healthy.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
