### PR TITLE
Limit Pdpyras dependency in pagerduty provider

### DIFF
--- a/airflow/providers/pagerduty/provider.yaml
+++ b/airflow/providers/pagerduty/provider.yaml
@@ -36,7 +36,8 @@ versions:
 
 dependencies:
   - apache-airflow>=2.4.0
-  - pdpyras>=4.1.2
+  # Pdpyras 5.0.0 has wrong dependencies https://github.com/PagerDuty/pdpyras/issues/100
+  - pdpyras>=4.1.2,!=5.0.0
 
 integrations:
   - integration-name: Pagerduty

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -592,7 +592,7 @@
   "pagerduty": {
     "deps": [
       "apache-airflow>=2.4.0",
-      "pdpyras>=4.1.2"
+      "pdpyras>=4.1.2,!=5.0.0"
     ],
     "cross-providers-deps": []
   },


### PR DESCRIPTION
The pdpyras 5.0.0 released an hour ago has broken install_requires (not including deprecation dependency).

When the issue is fixed: https://github.com/PagerDuty/pdpyras/issues/100 we can just replace it with != 5.0.0

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
