### PR TITLE
Add tags param in RedshiftCreateClusterSnapshotOperator

### DIFF
--- a/airflow/providers/amazon/aws/hooks/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/hooks/redshift_cluster.py
@@ -156,7 +156,11 @@ class RedshiftHook(AwsBaseHook):
         return response["Cluster"] if response["Cluster"] else None
 
     def create_cluster_snapshot(
-        self, snapshot_identifier: str, cluster_identifier: str, retention_period: int = -1
+        self,
+        snapshot_identifier: str,
+        cluster_identifier: str,
+        retention_period: int = -1,
+        tags: list[Any] | None = None,
     ) -> str:
         """
         Creates a snapshot of a cluster
@@ -168,11 +172,15 @@ class RedshiftHook(AwsBaseHook):
         :param cluster_identifier: unique identifier of a cluster
         :param retention_period: The number of days that a manual snapshot is retained.
             If the value is -1, the manual snapshot is retained indefinitely.
+        :param tags: A list of tag instances
         """
+        if tags is None:
+            tags = []
         response = self.get_conn().create_cluster_snapshot(
             SnapshotIdentifier=snapshot_identifier,
             ClusterIdentifier=cluster_identifier,
             ManualSnapshotRetentionPeriod=retention_period,
+            Tags=tags,
         )
         return response["Snapshot"] if response["Snapshot"] else None
 

--- a/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -298,6 +298,7 @@ class RedshiftCreateClusterSnapshotOperator(BaseOperator):
     :param cluster_identifier: The cluster identifier for which you want a snapshot
     :param retention_period: The number of days that a manual snapshot is retained.
         If the value is -1, the manual snapshot is retained indefinitely.
+    :parma tags: A list of tag instances
     :param wait_for_completion: Whether wait for the cluster snapshot to be in ``available`` state
     :param poll_interval: Time (in seconds) to wait between two consecutive calls to check state
     :param max_attempt: The maximum number of attempts to be made to check the state
@@ -316,6 +317,7 @@ class RedshiftCreateClusterSnapshotOperator(BaseOperator):
         snapshot_identifier: str,
         cluster_identifier: str,
         retention_period: int = -1,
+        tags: list[Any] | None = None,
         wait_for_completion: bool = False,
         poll_interval: int = 15,
         max_attempt: int = 20,
@@ -326,6 +328,7 @@ class RedshiftCreateClusterSnapshotOperator(BaseOperator):
         self.snapshot_identifier = snapshot_identifier
         self.cluster_identifier = cluster_identifier
         self.retention_period = retention_period
+        self.tags = tags
         self.wait_for_completion = wait_for_completion
         self.poll_interval = poll_interval
         self.max_attempt = max_attempt
@@ -343,6 +346,7 @@ class RedshiftCreateClusterSnapshotOperator(BaseOperator):
             cluster_identifier=self.cluster_identifier,
             snapshot_identifier=self.snapshot_identifier,
             retention_period=self.retention_period,
+            tags=self.tags,
         )
 
         if self.wait_for_completion:

--- a/tests/providers/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_cluster.py
@@ -144,12 +144,24 @@ class TestRedshiftCreateClusterSnapshotOperator:
             cluster_identifier="test_cluster",
             snapshot_identifier="test_snapshot",
             retention_period=1,
+            tags=[
+                {
+                    "Key": "user",
+                    "Value": "airflow",
+                }
+            ],
         )
         create_snapshot.execute(None)
         mock_get_conn.return_value.create_cluster_snapshot.assert_called_once_with(
             ClusterIdentifier="test_cluster",
             SnapshotIdentifier="test_snapshot",
             ManualSnapshotRetentionPeriod=1,
+            Tags=[
+                {
+                    "Key": "user",
+                    "Value": "airflow",
+                }
+            ],
         )
 
         mock_get_conn.return_value.get_waiter.assert_not_called()


### PR DESCRIPTION
Add tags param in RedshiftCreateClusterSnapshotOperator. This will help to group cluster snapshot based on tags.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
