### PR TITLE
Optimize deferred mode execution for wasb sensors

### DIFF
--- a/airflow/providers/microsoft/azure/sensors/wasb.py
+++ b/airflow/providers/microsoft/azure/sensors/wasb.py
@@ -78,17 +78,18 @@ class WasbBlobSensor(BaseSensorOperator):
         if not self.deferrable:
             super().execute(context=context)
         else:
-            self.defer(
-                timeout=timedelta(seconds=self.timeout),
-                trigger=WasbBlobSensorTrigger(
-                    container_name=self.container_name,
-                    blob_name=self.blob_name,
-                    wasb_conn_id=self.wasb_conn_id,
-                    public_read=self.public_read,
-                    poke_interval=self.poke_interval,
-                ),
-                method_name="execute_complete",
-            )
+            if not self.poke(context=context):
+                self.defer(
+                    timeout=timedelta(seconds=self.timeout),
+                    trigger=WasbBlobSensorTrigger(
+                        container_name=self.container_name,
+                        blob_name=self.blob_name,
+                        wasb_conn_id=self.wasb_conn_id,
+                        public_read=self.public_read,
+                        poke_interval=self.poke_interval,
+                    ),
+                    method_name="execute_complete",
+                )
 
     def execute_complete(self, context: Context, event: dict[str, str]) -> None:
         """
@@ -172,16 +173,17 @@ class WasbPrefixSensor(BaseSensorOperator):
         if not self.deferrable:
             super().execute(context=context)
         else:
-            self.defer(
-                timeout=timedelta(seconds=self.timeout),
-                trigger=WasbPrefixSensorTrigger(
-                    container_name=self.container_name,
-                    prefix=self.prefix,
-                    wasb_conn_id=self.wasb_conn_id,
-                    poke_interval=self.poke_interval,
-                ),
-                method_name="execute_complete",
-            )
+            if not self.poke(context=context):
+                self.defer(
+                    timeout=timedelta(seconds=self.timeout),
+                    trigger=WasbPrefixSensorTrigger(
+                        container_name=self.container_name,
+                        prefix=self.prefix,
+                        wasb_conn_id=self.wasb_conn_id,
+                        poke_interval=self.poke_interval,
+                    ),
+                    method_name="execute_complete",
+                )
 
     def execute_complete(self, context: Context, event: dict[str, str]) -> None:
         """

--- a/tests/providers/microsoft/azure/sensors/test_wasb.py
+++ b/tests/providers/microsoft/azure/sensors/test_wasb.py
@@ -128,9 +128,17 @@ class TestWasbBlobAsyncSensor:
         deferrable=True,
     )
 
-    def test_wasb_blob_sensor_async(self):
-        """Assert execute method defer for wasb blob sensor"""
+    @mock.patch("airflow.providers.microsoft.azure.sensors.wasb.WasbHook")
+    @mock.patch("airflow.providers.microsoft.azure.sensors.wasb.WasbBlobSensor.defer")
+    def test_wasb_blob_sensor_finish_before_deferred(self, mock_defer, mock_hook):
+        mock_hook.return_value.check_for_blob.return_value = True
+        self.SENSOR.execute(mock.MagicMock())
+        assert not mock_defer.called
 
+    @mock.patch("airflow.providers.microsoft.azure.sensors.wasb.WasbHook")
+    def test_wasb_blob_sensor_async(self, mock_hook):
+        """Assert execute method defer for wasb blob sensor"""
+        mock_hook.return_value.check_for_blob.return_value = False
         with pytest.raises(TaskDeferred) as exc:
             self.SENSOR.execute(self.create_context(self.SENSOR))
         assert isinstance(exc.value.trigger, WasbBlobSensorTrigger), "Trigger is not a WasbBlobSensorTrigger"
@@ -244,9 +252,17 @@ class TestWasbPrefixAsyncSensor:
         deferrable=True,
     )
 
-    def test_wasb_prefix_sensor_async(self):
-        """Assert execute method defer for wasb prefix sensor"""
+    @mock.patch("airflow.providers.microsoft.azure.sensors.wasb.WasbHook")
+    @mock.patch("airflow.providers.microsoft.azure.sensors.wasb.WasbPrefixSensor.defer")
+    def test_wasb_prefix_sensor_finish_before_deferred(self, mock_defer, mock_hook):
+        mock_hook.return_value.check_for_prefix.return_value = True
+        self.SENSOR.execute(mock.MagicMock())
+        assert not mock_defer.called
 
+    @mock.patch("airflow.providers.microsoft.azure.sensors.wasb.WasbHook")
+    def test_wasb_prefix_sensor_async(self, mock_hook):
+        """Assert execute method defer for wasb prefix sensor"""
+        mock_hook.return_value.check_for_prefix.return_value = False
         with pytest.raises(TaskDeferred) as exc:
             self.SENSOR.execute(self.create_context(self.SENSOR))
         assert isinstance(

--- a/tests/providers/microsoft/azure/sensors/test_wasb.py
+++ b/tests/providers/microsoft/azure/sensors/test_wasb.py
@@ -133,7 +133,7 @@ class TestWasbBlobAsyncSensor:
     def test_wasb_blob_sensor_finish_before_deferred(self, mock_defer, mock_hook):
         mock_hook.return_value.check_for_blob.return_value = True
         self.SENSOR.execute(mock.MagicMock())
-        assert mock_defer.assert_not_called()
+        assert not mock_defer.called
 
     @mock.patch("airflow.providers.microsoft.azure.sensors.wasb.WasbHook")
     def test_wasb_blob_sensor_async(self, mock_hook):

--- a/tests/providers/microsoft/azure/sensors/test_wasb.py
+++ b/tests/providers/microsoft/azure/sensors/test_wasb.py
@@ -133,7 +133,7 @@ class TestWasbBlobAsyncSensor:
     def test_wasb_blob_sensor_finish_before_deferred(self, mock_defer, mock_hook):
         mock_hook.return_value.check_for_blob.return_value = True
         self.SENSOR.execute(mock.MagicMock())
-        assert not mock_defer.called
+        assert mock_defer.assert_not_called()
 
     @mock.patch("airflow.providers.microsoft.azure.sensors.wasb.WasbHook")
     def test_wasb_blob_sensor_async(self, mock_hook):


### PR DESCRIPTION
In deferrable mode for wasb sensors, we should first check if blob is available or not in the execute method and only defer if that is not successful. This way we don’t run an unnecessary deferral cycle if the condition is already true.

cc @dstandish

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
