### PR TITLE
Not preload workers with reload_on_plugin_change

### DIFF
--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -424,7 +424,8 @@ def webserver(args):
         # all writing to the database at the same time, we use the --preload option.
         # With the preload option, the app is loaded before the workers are forked, and each worker will
         # then have a copy of the app
-        run_args += ["--preload"]
+        if not conf.getboolean("webserver", "reload_on_plugin_change", fallback=False):
+            run_args += ["--preload"]
 
         gunicorn_master_proc: psutil.Process | subprocess.Popen
 


### PR DESCRIPTION
Do not add --preload option to gunicorn in development where reload_on_plugin_change=True ensure reloading plugins.

closes: https://github.com/apache/airflow/issues/30910.
