### PR TITLE
MetastoreHivePartitionSensor

### DIFF
--- a/airflow/providers/google/cloud/sensors/dataproc_metastore.py
+++ b/airflow/providers/google/cloud/sensors/dataproc_metastore.py
@@ -1,0 +1,115 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Sequence
+
+from google.api_core.operation import Operation
+
+from airflow import AirflowException
+from airflow.providers.google.cloud.hooks.dataproc_metastore import DataprocMetastoreHook
+from airflow.providers.google.cloud.hooks.gcs import parse_json_from_gcs
+from airflow.sensors.base import BaseSensorOperator
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
+
+
+class MetastoreHivePartitionSensor(BaseSensorOperator):
+    """
+    Waits for partitions to show up in Hive.
+        This sensor uses Google Cloud SDK and passes requests via gRPC.
+
+    :param service_id: Required. Dataproc Metastore service id.
+    :param region: Required. The ID of the Google Cloud region that the service belongs to.
+    :param table: Required. Name of the partitioned table
+    :param partitions: List of table partitions to wait for.
+        A name of a partition should look like "ds=1", or "a=1/b=2" in case of nested partitions.
+        Note that you cannot use logical or comparison operators as in HivePartitionSensor.
+        If not specified then the sensor will wait for at least one partition regardless its name.
+    :param gcp_conn_id: Airflow Google Cloud connection ID.
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account.
+    """
+
+    template_fields: Sequence[str] = (
+        "service_id",
+        "region",
+        "table",
+        "partitions",
+        "impersonation_chain",
+    )
+
+    def __init__(
+        self,
+        service_id: str,
+        region: str,
+        table: str,
+        partitions: list[str] | None,
+        gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: str | Sequence[str] | None = None,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.service_id = service_id
+        self.region = region
+        self.table = table
+        self.partitions = partitions or []
+        self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
+
+    def poke(self, context: Context) -> bool:
+        hook = DataprocMetastoreHook(
+            gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain
+        )
+        operation: Operation = hook.list_hive_partitions(
+            region=self.region, service_id=self.service_id, table=self.table, partition_names=self.partitions
+        )
+        metadata = hook.wait_for_operation(timeout=self.timeout, operation=operation)
+        result_manifest_uri: str = metadata.result_manifest_uri
+        self.log.info("Received result manifest URI: %s", result_manifest_uri)
+
+        self.log.info("Extracting result manifest")
+        manifest: dict = parse_json_from_gcs(gcp_conn_id=self.gcp_conn_id, file_uri=result_manifest_uri)
+        if not (manifest and isinstance(manifest, dict)):
+            raise AirflowException(
+                f"Failed to extract result manifest. "
+                f"Expected not empty dict, but this was received: {manifest}"
+            )
+
+        if manifest.get("status", {}).get("code") != 0:
+            raise AirflowException(f"Request failed: {manifest.get('message')}")
+
+        # Extract actual query results
+        result_base_uri = result_manifest_uri.rsplit("/", 1)[0]
+        results = (f"{result_base_uri}//{filename}" for filename in manifest.get("filenames", []))
+        found_partitions = sum(
+            len(parse_json_from_gcs(gcp_conn_id=self.gcp_conn_id, file_uri=uri).get("rows", []))
+            for uri in results
+        )
+
+        # Return True if we got all requested partitions.
+        # If no partitions were given in the request, then we expect to find at least one.
+        return found_partitions > 0 and found_partitions >= len(set(self.partitions))

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -628,6 +628,9 @@ sensors:
   - integration-name: Google Dataproc
     python-modules:
       - airflow.providers.google.cloud.sensors.dataproc
+  - integration-name: Google Dataproc Metastore
+    python-modules:
+      - airflow.providers.google.cloud.sensors.dataproc_metastore
   - integration-name: Google Cloud Storage (GCS)
     python-modules:
       - airflow.providers.google.cloud.sensors.gcs

--- a/docs/apache-airflow-providers-google/operators/cloud/dataproc_metastore.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/dataproc_metastore.rst
@@ -194,3 +194,15 @@ To list backups you can use:
     :dedent: 4
     :start-after: [START how_to_cloud_dataproc_metastore_list_backups_operator]
     :end-before: [END how_to_cloud_dataproc_metastore_list_backups_operator]
+
+Check Hive partitions existence
+-------------------------------
+
+To check that Hive partitions have been created in the Metastore for a given table you can use:
+:class:`~airflow.providers.google.cloud.sensors.dataproc_metastore.MetastoreHivePartitionSensor`
+
+.. exampleinclude:: /../../tests/system/providers/google/cloud/dataproc_metastore/example_dataproc_metastore_hive_partition_sensor.py
+    :language: python
+    :dedent: 4
+    :start-after: [START how_to_cloud_dataproc_metastore_hive_partition_sensor]
+    :end-before: [END how_to_cloud_dataproc_metastore_hive_partition_sensor]

--- a/tests/providers/google/cloud/sensors/test_dataproc_metastore.py
+++ b/tests/providers/google/cloud/sensors/test_dataproc_metastore.py
@@ -1,0 +1,152 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from copy import deepcopy
+from unittest import mock
+
+import pytest
+
+from airflow import AirflowException
+from airflow.providers.google.cloud.sensors.dataproc_metastore import MetastoreHivePartitionSensor
+
+DATAPROC_METASTORE_SENSOR_PATH = "airflow.providers.google.cloud.sensors.dataproc_metastore.{}"
+TEST_TASK_ID = "test-task"
+PARTITION_1 = "column=value"
+PARTITION_2 = "column1=value1/column2=value2"
+RESULT_FILE_NAME_1 = "result-001"
+RESULT_FILE_NAME_2 = "result-002"
+MANIFEST_SUCCESS = {
+    "status": {
+        "code": 0,
+        "message": "Query results are successfully uploaded to cloud storage",
+        "details": [],
+    },
+    "filenames": [],
+}
+MANIFEST_FAIL = {"status": {"code": 1, "message": "Bad things happened", "details": []}, "filenames": []}
+RESULT_FILE_CONTENT = {"rows": [], "metadata": {}}
+ROW_1 = []
+ROW_2 = []
+TEST_SERVICE_ID = "test-service"
+TEST_REGION = "test-region"
+TEST_TABLE = "test_table"
+GCP_PROJECT = "test-project"
+GCP_CONN_ID = "test-conn"
+
+
+class TestMetastoreHivePartitionSensor:
+    @pytest.mark.parametrize(
+        "requested_partitions, result_files_with_rows, expected_result",
+        [
+            (None, [(RESULT_FILE_NAME_1, [])], False),
+            ([None], [(RESULT_FILE_NAME_1, [])], False),
+            (None, [(RESULT_FILE_NAME_1, [ROW_1])], True),
+            ([None], [(RESULT_FILE_NAME_1, [ROW_1])], True),
+            (None, [(RESULT_FILE_NAME_1, [ROW_1, ROW_2])], True),
+            ([None], [(RESULT_FILE_NAME_1, [ROW_1, ROW_2])], True),
+            ([PARTITION_1], [(RESULT_FILE_NAME_1, [])], False),
+            ([PARTITION_1], [(RESULT_FILE_NAME_1, [ROW_1])], True),
+            ([PARTITION_1, PARTITION_2], [(RESULT_FILE_NAME_1, [])], False),
+            ([PARTITION_1, PARTITION_2], [(RESULT_FILE_NAME_1, [ROW_1])], False),
+            ([PARTITION_1, PARTITION_2], [(RESULT_FILE_NAME_1, [ROW_1, ROW_2])], True),
+            ([PARTITION_1, PARTITION_1], [(RESULT_FILE_NAME_1, [])], False),
+            ([PARTITION_1, PARTITION_1], [(RESULT_FILE_NAME_1, [ROW_1])], True),
+            ([PARTITION_1, PARTITION_2], [(RESULT_FILE_NAME_1, []), (RESULT_FILE_NAME_2, [])], False),
+            ([PARTITION_1, PARTITION_2], [(RESULT_FILE_NAME_1, [ROW_1]), (RESULT_FILE_NAME_2, [])], False),
+            ([PARTITION_1, PARTITION_2], [(RESULT_FILE_NAME_1, []), (RESULT_FILE_NAME_2, [ROW_2])], False),
+            (
+                [PARTITION_1, PARTITION_2],
+                [(RESULT_FILE_NAME_1, [ROW_1]), (RESULT_FILE_NAME_2, [ROW_2])],
+                True,
+            ),
+        ],
+    )
+    @mock.patch(DATAPROC_METASTORE_SENSOR_PATH.format("DataprocMetastoreHook"))
+    @mock.patch(DATAPROC_METASTORE_SENSOR_PATH.format("parse_json_from_gcs"))
+    def test_poke_positive_manifest(
+        self,
+        mock_parse_json_from_gcs,
+        mock_hook,
+        requested_partitions,
+        result_files_with_rows,
+        expected_result,
+    ):
+        manifest = deepcopy(MANIFEST_SUCCESS)
+        parse_json_from_gcs_side_effect = []
+        for file_name, rows in result_files_with_rows:
+            manifest["filenames"].append(file_name)
+            file = deepcopy(RESULT_FILE_CONTENT)
+            file["rows"] = rows
+            parse_json_from_gcs_side_effect.append(file)
+
+        mock_parse_json_from_gcs.side_effect = [manifest, *parse_json_from_gcs_side_effect]
+
+        sensor = MetastoreHivePartitionSensor(
+            task_id=TEST_TASK_ID,
+            service_id=TEST_SERVICE_ID,
+            region=TEST_REGION,
+            table=TEST_TABLE,
+            partitions=requested_partitions,
+            gcp_conn_id=GCP_CONN_ID,
+        )
+        assert sensor.poke(context={}) == expected_result
+
+    @pytest.mark.parametrize("empty_manifest", [dict(), list(), tuple(), None, ""])
+    @mock.patch(DATAPROC_METASTORE_SENSOR_PATH.format("DataprocMetastoreHook"))
+    @mock.patch(DATAPROC_METASTORE_SENSOR_PATH.format("parse_json_from_gcs"))
+    def test_poke_empty_manifest(
+        self,
+        mock_parse_json_from_gcs,
+        mock_hook,
+        empty_manifest,
+    ):
+        mock_parse_json_from_gcs.return_value = empty_manifest
+
+        sensor = MetastoreHivePartitionSensor(
+            task_id=TEST_TASK_ID,
+            service_id=TEST_SERVICE_ID,
+            region=TEST_REGION,
+            table=TEST_TABLE,
+            partitions=[PARTITION_1],
+            gcp_conn_id=GCP_CONN_ID,
+        )
+
+        with pytest.raises(AirflowException):
+            sensor.poke(context={})
+
+    @mock.patch(DATAPROC_METASTORE_SENSOR_PATH.format("DataprocMetastoreHook"))
+    @mock.patch(DATAPROC_METASTORE_SENSOR_PATH.format("parse_json_from_gcs"))
+    def test_poke_wrong_status(
+        self,
+        mock_parse_json_from_gcs,
+        mock_hook,
+    ):
+        error_message = "Test error message"
+        mock_parse_json_from_gcs.return_value = {"code": 1, "message": error_message}
+
+        sensor = MetastoreHivePartitionSensor(
+            task_id=TEST_TASK_ID,
+            service_id=TEST_SERVICE_ID,
+            region=TEST_REGION,
+            table=TEST_TABLE,
+            partitions=[PARTITION_1],
+            gcp_conn_id=GCP_CONN_ID,
+        )
+
+        with pytest.raises(AirflowException, match=f"Request failed: {error_message}"):
+            sensor.poke(context={})

--- a/tests/system/providers/google/cloud/dataproc_metastore/example_dataproc_metastore_hive_partition_sensor.py
+++ b/tests/system/providers/google/cloud/dataproc_metastore/example_dataproc_metastore_hive_partition_sensor.py
@@ -1,0 +1,71 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Example Airflow DAG that show how to check Hive partitions existence
+using Dataproc Metastore Sensor.
+
+Note that Metastore service must be configured to use gRPC endpoints,
+"""
+from __future__ import annotations
+
+import datetime
+import os
+
+from airflow import models
+from airflow.providers.google.cloud.sensors.dataproc_metastore import MetastoreHivePartitionSensor
+
+DAG_ID = "dataproc_metastore_hive_partition_sensor"
+PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "")
+ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
+
+SERVICE_ID = f"{DAG_ID}-service-{ENV_ID}".replace("_", "-")
+REGION = "europe-west1"
+TABLE_NAME = "test_table"
+PARTITION_1 = "column1=value1"
+PARTITION_2 = "column2=value2/column3=value3"
+
+
+with models.DAG(
+    DAG_ID,
+    start_date=datetime.datetime(2021, 1, 1),
+    schedule="@once",
+    catchup=False,
+    tags=["example", "dataproc", "metastore"],
+) as dag:
+
+    # [START how_to_cloud_dataproc_metastore_hive_partition_sensor]
+    sensor = MetastoreHivePartitionSensor(
+        task_id="hive_partition_sensor",
+        service_id=SERVICE_ID,
+        region=REGION,
+        table=TABLE_NAME,
+        partitions=[PARTITION_1, PARTITION_2],
+    )
+    # [END how_to_cloud_dataproc_metastore_hive_partition_sensor]
+
+    from tests.system.utils.watcher import watcher
+
+    # This test needs watcher in order to properly mark success/failure
+    # when "teardown" task with trigger rule is part of the DAG
+    list(dag.tasks) >> watcher()
+
+
+from tests.system.utils import get_test_run  # noqa: E402
+
+# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+test_run = get_test_run(dag)


### PR DESCRIPTION
Implemented `MetastoreHivePartitionSensor` that allows users to check the existence of Hive partitions in Dataproc Metastore via gRPC requests instead of thrift.
