### PR TITLE
Fix missing models in API documentation.

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -214,7 +214,7 @@ def clear_task_instances(
     :param tis: a list of task instances
     :param session: current session
     :param dag_run_state: state to set finished DagRuns to.
-    If set to False, DagRuns state will not be changed.
+        If set to False, DagRuns state will not be changed.
     :param dag: DAG object
     :param activate_dag_runs: Deprecated parameter, do not pass
     """

--- a/docs/apache-airflow/public-airflow-interface.rst
+++ b/docs/apache-airflow/public-airflow-interface.rst
@@ -58,7 +58,9 @@ DAGs
 ----
 
 The DAG is Airflow's core entity that represents a recurring workflow. You can create a DAG by
-instantiating the :class:`~airflow.models.dag.DAG` class in your DAG file.
+instantiating the :class:`~airflow.models.dag.DAG` class in your DAG file. You can also instantiate
+them via :class::`~airflow.models.dagbag.DagBag` class that reads DAGs from a file or a folder. DAGs
+can also have parameters specified via :class::`~airflow.models.param.Param` class.
 
 Airflow has a set of example DAGs that you can use to learn how to write DAGs
 
@@ -72,6 +74,17 @@ Airflow has a set of example DAGs that you can use to learn how to write DAGs
 You can read more about DAGs in :doc:`DAGs <core-concepts/dags>`.
 
 .. _pythonapi:operators:
+
+References for the modules used in DAGs are here:
+
+.. toctree::
+  :includehidden:
+  :glob:
+  :maxdepth: 1
+
+  _api/airflow/models/dag/index
+  _api/airflow/models/dagbag/index
+  _api/airflow/models/param/index
 
 Operators
 ---------
@@ -114,6 +127,30 @@ Also you can learn how to write a custom operator in :doc:`howto/custom-operator
 
 .. _pythonapi:hooks:
 
+References for the modules used in for operators are here:
+
+.. toctree::
+  :includehidden:
+  :glob:
+  :maxdepth: 1
+
+  _api/airflow/models/baseoperator/index
+
+
+Task Instances
+--------------
+
+Task instances are the individual runs of a single task in a DAG (in a DAG Run). They are available in the context
+passed to the execute method of the operators via the :class:`~airflow.models.taskinstance.TaskInstance` class.
+
+.. toctree::
+  :includehidden:
+  :glob:
+  :maxdepth: 1
+
+  _api/airflow/models/taskinstance/index
+
+
 Hooks
 -----
 
@@ -143,6 +180,19 @@ use the following classes:
 
 You can read more about the public Airflow utilities in :doc:`howto/connection`,
 :doc:`core-concepts/variables`, :doc:`core-concepts/xcoms`
+
+
+Reference for classes used for the utilities are here:
+
+.. toctree::
+  :includehidden:
+  :glob:
+  :maxdepth: 1
+
+  _api/airflow/models/connection/index
+  _api/airflow/models/variable/index
+  _api/airflow/models/xcom/index
+
 
 Public Exceptions
 -----------------
@@ -346,6 +396,8 @@ Lineage
 
 Airflow can help track origins of data, what happens to it and where it moves over time. You can read more
 about lineage in :doc:`administration-and-deployment/lineage`.
+
+
 
 
 What is not part of the Public Interface of Apache Airflow?

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -228,6 +228,7 @@ if PACKAGE_NAME == "apache-airflow":
         "decorators",
         "example_dags",
         "executors",
+        "models",
         "operators",
         "providers",
         "secrets",
@@ -237,6 +238,17 @@ if PACKAGE_NAME == "apache-airflow":
         "utils",
     }
     browsable_utils: set[str] = set()
+
+    models_included: set[str] = {
+        "baseoperator.py",
+        "connection.py",
+        "dag.py",
+        "dagbag.py",
+        "param.py",
+        "taskinstance.py",
+        "variable.py",
+        "xcom.py",
+    }
 
     root = ROOT_DIR / "airflow"
     for path in root.iterdir():
@@ -249,6 +261,12 @@ if PACKAGE_NAME == "apache-airflow":
     for path in (root / "utils").iterdir():
         if path.name not in browsable_utils:
             exclude_patterns.append(_get_rst_filepath_from_path(path))
+
+    for path in (root / "models").iterdir():
+        if path.name not in models_included:
+            exclude_patterns.append(_get_rst_filepath_from_path(path))
+
+
 elif PACKAGE_NAME != "docker-stack":
     exclude_patterns.extend(
         _get_rst_filepath_from_path(f) for f in pathlib.Path(PACKAGE_DIR).glob("**/example_dags")

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -331,6 +331,7 @@ dagbags
 DagCallbackRequest
 DagFileProcessorManager
 dagmodel
+DagParam
 Dagre
 dagre
 DagRun


### PR DESCRIPTION
The Airflow models have been accidentally removed from the docs when #28300 was implemented. The whole models documentation have been removed accidentally, even if there were references to the actual classes and packages used as the models package was entirely excluded.

This PR fixes it by selectively including the models that should be included and by linking the package indexes directly in the public interface documentation.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
