### PR TITLE
Add deferrable param in EmrContainerOperator

### DIFF
--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import ast
 import warnings
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Sequence
 from uuid import uuid4
 
@@ -518,12 +519,16 @@ class EmrContainerOperator(BaseOperator):
             self.tags,
         )
         if self.deferrable:
+            timeout = (
+                timedelta(seconds=self.max_polling_attempts * self.poll_interval + 60)
+                if self.max_polling_attempts
+                else self.execution_timeout
+            )
             self.defer(
-                timeout=self.execution_timeout,
+                timeout=timeout,
                 trigger=EmrContainerOperatorTrigger(
                     virtual_cluster_id=self.virtual_cluster_id,
                     job_id=self.job_id,
-                    max_attempts=self.max_polling_attempts,
                     aws_conn_id=self.aws_conn_id,
                     poll_interval=self.poll_interval,
                 ),

--- a/airflow/providers/amazon/aws/triggers/emr.py
+++ b/airflow/providers/amazon/aws/triggers/emr.py
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator
+
+from airflow.compat.functools import cached_property
+from airflow.providers.amazon.aws.hooks.emr import EmrContainerHook
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+
+class EmrContainerOperatorTrigger(BaseTrigger):
+    """
+    Poll for the status of EMR container until reaches terminal state
+
+    :param virtual_cluster_id: Reference Emr cluster id
+    :param job_id:  job_id to check the state
+    :param max_attempts: maximum try attempts for polling the status
+    :param aws_conn_id: Reference to AWS connection id
+    :param poll_interval: polling period in seconds to check for the status
+    """
+
+    def __init__(
+        self,
+        virtual_cluster_id: str,
+        job_id: str,
+        aws_conn_id: str = "aws_default",
+        poll_interval: int = 10,
+        max_attempts: int | None = None,
+        **kwargs: Any,
+    ):
+        self.virtual_cluster_id = virtual_cluster_id
+        self.job_id = job_id
+        self.aws_conn_id = aws_conn_id
+        self.poll_interval = poll_interval
+        self.max_attempts = max_attempts
+        super().__init__(**kwargs)
+
+    @cached_property
+    def hook(self) -> EmrContainerHook:
+        return EmrContainerHook(self.aws_conn_id, virtual_cluster_id=self.virtual_cluster_id)
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        """Serializes EmrContainerSensorTrigger arguments and classpath."""
+        return (
+            "airflow.providers.amazon.aws.triggers.emr.EmrContainerOperatorTrigger",
+            {
+                "virtual_cluster_id": self.virtual_cluster_id,
+                "job_id": self.job_id,
+                "aws_conn_id": self.aws_conn_id,
+                "max_attempts": self.max_attempts,
+                "poll_interval": self.poll_interval,
+            },
+        )
+
+    async def run(self) -> AsyncIterator[TriggerEvent]:
+        async with self.hook.async_conn as client:
+            waiter = self.hook.get_waiter("container_job_complete", deferrable=True, client=client)
+            await waiter.wait(
+                id=self.job_id,
+                virtualClusterId=self.virtual_cluster_id,
+                WaiterConfig={
+                    "Delay": self.poll_interval,
+                    "MaxAttempts": self.max_attempts,
+                },
+            )
+        yield TriggerEvent({"status": "success", "message": "Job completed."})

--- a/airflow/providers/amazon/aws/triggers/emr.py
+++ b/airflow/providers/amazon/aws/triggers/emr.py
@@ -17,7 +17,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, AsyncIterator
+
+from botocore.exceptions import WaiterError
 
 from airflow.compat.functools import cached_property
 from airflow.providers.amazon.aws.hooks.emr import EmrContainerHook
@@ -30,7 +33,6 @@ class EmrContainerOperatorTrigger(BaseTrigger):
 
     :param virtual_cluster_id: Reference Emr cluster id
     :param job_id:  job_id to check the state
-    :param max_attempts: maximum try attempts for polling the status
     :param aws_conn_id: Reference to AWS connection id
     :param poll_interval: polling period in seconds to check for the status
     """
@@ -41,14 +43,12 @@ class EmrContainerOperatorTrigger(BaseTrigger):
         job_id: str,
         aws_conn_id: str = "aws_default",
         poll_interval: int = 10,
-        max_attempts: int | None = None,
         **kwargs: Any,
     ):
         self.virtual_cluster_id = virtual_cluster_id
         self.job_id = job_id
         self.aws_conn_id = aws_conn_id
         self.poll_interval = poll_interval
-        self.max_attempts = max_attempts
         super().__init__(**kwargs)
 
     @cached_property
@@ -56,14 +56,13 @@ class EmrContainerOperatorTrigger(BaseTrigger):
         return EmrContainerHook(self.aws_conn_id, virtual_cluster_id=self.virtual_cluster_id)
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
-        """Serializes EmrContainerSensorTrigger arguments and classpath."""
+        """Serializes EmrContainerOperatorTrigger arguments and classpath."""
         return (
             "airflow.providers.amazon.aws.triggers.emr.EmrContainerOperatorTrigger",
             {
                 "virtual_cluster_id": self.virtual_cluster_id,
                 "job_id": self.job_id,
                 "aws_conn_id": self.aws_conn_id,
-                "max_attempts": self.max_attempts,
                 "poll_interval": self.poll_interval,
             },
         )
@@ -71,12 +70,28 @@ class EmrContainerOperatorTrigger(BaseTrigger):
     async def run(self) -> AsyncIterator[TriggerEvent]:
         async with self.hook.async_conn as client:
             waiter = self.hook.get_waiter("container_job_complete", deferrable=True, client=client)
-            await waiter.wait(
-                id=self.job_id,
-                virtualClusterId=self.virtual_cluster_id,
-                WaiterConfig={
-                    "Delay": self.poll_interval,
-                    "MaxAttempts": self.max_attempts,
-                },
-            )
-        yield TriggerEvent({"status": "success", "message": "Job completed."})
+            attempt = 0
+            while True:
+                attempt = attempt + 1
+                try:
+                    await waiter.wait(
+                        id=self.job_id,
+                        virtualClusterId=self.virtual_cluster_id,
+                        WaiterConfig={
+                            "Delay": self.poll_interval,
+                            "MaxAttempts": 1,
+                        },
+                    )
+                    break
+                except WaiterError as error:
+                    if "terminal failure" in str(error):
+                        yield TriggerEvent({"status": "failure", "message": f"Job Failed: {error}"})
+                        break
+                    self.log.info(
+                        "Job status is %s. Retrying attempt %s",
+                        error.last_response["jobRun"]["state"],
+                        attempt,
+                    )
+                    await asyncio.sleep(int(self.poll_interval))
+
+            yield TriggerEvent({"status": "success", "job_id": self.job_id})

--- a/airflow/providers/amazon/aws/waiters/emr-containers.json
+++ b/airflow/providers/amazon/aws/waiters/emr-containers.json
@@ -1,0 +1,18 @@
+{
+    "version": 2,
+    "waiters": {
+        "container_job_complete": {
+            "operation": "DescribeJobRun",
+            "delay": 30,
+            "maxAttempts": 60,
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "argument": "jobRun.state",
+                    "expected": "COMPLETED",
+                    "state": "success"
+                }
+            ]
+        }
+    }
+}

--- a/airflow/providers/amazon/aws/waiters/emr-containers.json
+++ b/airflow/providers/amazon/aws/waiters/emr-containers.json
@@ -11,6 +11,18 @@
                     "argument": "jobRun.state",
                     "expected": "COMPLETED",
                     "state": "success"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "jobRun.state",
+                    "expected": "FAILED",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "jobRun.state",
+                    "expected": "CANCELLED",
+                    "state": "failure"
                 }
             ]
         }

--- a/tests/providers/amazon/aws/triggers/test_emr_containers.py
+++ b/tests/providers/amazon/aws/triggers/test_emr_containers.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.providers.amazon.aws.triggers.emr import EmrContainerOperatorTrigger
+from airflow.triggers.base import TriggerEvent
+from tests.providers.amazon.aws.utils.compat import AsyncMock, async_mock
+
+VIRTUAL_CLUSTER_ID = "vzwemreks"
+JOB_ID = "job-1234"
+AWS_CONN_ID = "aws_emr_conn"
+POLL_INTERVAL = 60
+MAX_ATTEMPTS = 5
+
+
+class TestEmrContainerSensorTrigger:
+    def test_emr_container_operator_trigger_serialize(self):
+        emr_trigger = EmrContainerOperatorTrigger(
+            virtual_cluster_id=VIRTUAL_CLUSTER_ID,
+            job_id=JOB_ID,
+            aws_conn_id=AWS_CONN_ID,
+            poll_interval=POLL_INTERVAL,
+            max_attempts=MAX_ATTEMPTS,
+        )
+        class_path, args = emr_trigger.serialize()
+        assert class_path == "airflow.providers.amazon.aws.triggers.emr.EmrContainerOperatorTrigger"
+        assert args["virtual_cluster_id"] == VIRTUAL_CLUSTER_ID
+        assert args["job_id"] == JOB_ID
+        assert args["aws_conn_id"] == AWS_CONN_ID
+        assert args["poll_interval"] == POLL_INTERVAL
+        assert args["max_attempts"] == MAX_ATTEMPTS
+
+    @pytest.mark.asyncio
+    @async_mock.patch("airflow.providers.amazon.aws.hooks.emr.EmrContainerHook.get_waiter")
+    @async_mock.patch("airflow.providers.amazon.aws.hooks.emr.EmrContainerHook.async_conn")
+    async def test_emr_container_trigger_run(self, mock_async_conn, mock_get_waiter):
+        mock = async_mock.MagicMock()
+        mock_async_conn.__aenter__.return_value = mock
+
+        mock_get_waiter().wait = AsyncMock()
+
+        emr_trigger = EmrContainerOperatorTrigger(
+            virtual_cluster_id=VIRTUAL_CLUSTER_ID,
+            job_id=JOB_ID,
+            aws_conn_id=AWS_CONN_ID,
+            poll_interval=POLL_INTERVAL,
+            max_attempts=MAX_ATTEMPTS,
+        )
+
+        generator = emr_trigger.run()
+        response = await generator.asend(None)
+
+        assert response == TriggerEvent({"status": "success", "message": "Job completed."})


### PR DESCRIPTION
Add the deferrable param in EmrContainerOperator.
This will allow running EmrContainerOperator in an async way
that means we only submit a job from the worker to run a job 
then defer to the trigger for polling and wait for a job the job status
and the worker slot won't be occupied for the whole period of task execution.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
