### PR TITLE
Add deferrable param in SageMakerTrainingOperator

### DIFF
--- a/airflow/providers/amazon/aws/operators/sagemaker.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker.py
@@ -28,6 +28,7 @@ from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarni
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook
+from airflow.providers.amazon.aws.triggers.sagemaker import SageMakerTrigger
 from airflow.providers.amazon.aws.utils import trim_none_values
 from airflow.providers.amazon.aws.utils.sagemaker import ApprovalStatus
 from airflow.providers.amazon.aws.utils.tags import format_tags
@@ -683,6 +684,8 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
     :param print_log: if the operator should print the cloudwatch log during training
     :param check_interval: if wait is set to be true, this is the time interval
         in seconds which the operator will check the status of the training job
+    :param max_retries: Number of times to poll for query state before returning the current state,
+        defaults to None.
     :param max_ingestion_time: If wait is set to True, the operation fails if the training job
         doesn't finish within max_ingestion_time seconds. If you set this parameter to None,
         the operation does not timeout.
@@ -691,6 +694,8 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
     :param action_if_job_exists: Behaviour if the job name already exists. Possible options are "timestamp"
         (default), "increment" (deprecated) and "fail".
         This is only relevant if check_if_job_exists is True.
+    :param deferrable: Run operator in the deferrable mode. This is only effective if wait_for_completion is
+        set to True.
     :return Dict: Returns The ARN of the training job created in Amazon SageMaker.
     """
 
@@ -702,15 +707,18 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
         wait_for_completion: bool = True,
         print_log: bool = True,
         check_interval: int = CHECK_INTERVAL_SECOND,
+        max_retries: int | None = None,
         max_ingestion_time: int | None = None,
         check_if_job_exists: bool = True,
         action_if_job_exists: str = "timestamp",
+        deferrable: bool = False,
         **kwargs,
     ):
         super().__init__(config=config, aws_conn_id=aws_conn_id, **kwargs)
         self.wait_for_completion = wait_for_completion
         self.print_log = print_log
         self.check_interval = check_interval
+        self.max_retries = max_retries or 60
         self.max_ingestion_time = max_ingestion_time
         self.check_if_job_exists = check_if_job_exists
         if action_if_job_exists in {"timestamp", "increment", "fail"}:
@@ -727,6 +735,7 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
                 f"Argument action_if_job_exists accepts only 'timestamp', 'increment' and 'fail'. \
                 Provided value: '{action_if_job_exists}'."
             )
+        self.deferrable = deferrable
 
     def expand_role(self) -> None:
         """Expands an IAM role name into an ARN."""
@@ -753,17 +762,50 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
             )
 
         self.log.info("Creating SageMaker training job %s.", self.config["TrainingJobName"])
+
+        if self.deferrable and not self.wait_for_completion:
+            self.log.warning(
+                "Setting deferrable to True does not have effect when wait_for_completion is set to False."
+            )
+
+        wait_for_completion = self.wait_for_completion
+        if self.deferrable and self.wait_for_completion:
+            # Set wait_for_completion to False so that it waits for the status in the deferred task.
+            wait_for_completion = False
+
         response = self.hook.create_training_job(
             self.config,
-            wait_for_completion=self.wait_for_completion,
+            wait_for_completion=wait_for_completion,
             print_log=self.print_log,
             check_interval=self.check_interval,
             max_ingestion_time=self.max_ingestion_time,
         )
         if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
             raise AirflowException(f"Sagemaker Training Job creation failed: {response}")
+
+        if self.deferrable and self.wait_for_completion:
+            self.defer(
+                timeout=self.execution_timeout,
+                trigger=SageMakerTrigger(
+                    job_name=self.config["TrainingJobName"],
+                    job_type="Training",
+                    poke_interval=self.check_interval,
+                    max_retries=self.max_retries,
+                    aws_conn_id=self.aws_conn_id,
+                ),
+                method_name="execute_complete",
+            )
+
+        result = {"Training": serialize(self.hook.describe_training_job(self.config["TrainingJobName"]))}
+        return result
+
+    def execute_complete(self, context, event=None):
+        if event["status"] != "success":
+            raise AirflowException(f"Error while running job: {event}")
         else:
-            return {"Training": serialize(self.hook.describe_training_job(self.config["TrainingJobName"]))}
+            self.log.info(event["message"])
+        result = {"Training": serialize(self.hook.describe_training_job(self.config["TrainingJobName"]))}
+        return result
 
 
 class SageMakerDeleteModelOperator(SageMakerBaseOperator):

--- a/airflow/providers/amazon/aws/operators/sagemaker.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker.py
@@ -684,7 +684,7 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
     :param print_log: if the operator should print the cloudwatch log during training
     :param check_interval: if wait is set to be true, this is the time interval
         in seconds which the operator will check the status of the training job
-    :param max_retries: Number of times to poll for query state before returning the current state,
+    :param max_attempts: Number of times to poll for query state before returning the current state,
         defaults to None.
     :param max_ingestion_time: If wait is set to True, the operation fails if the training job
         doesn't finish within max_ingestion_time seconds. If you set this parameter to None,
@@ -707,7 +707,7 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
         wait_for_completion: bool = True,
         print_log: bool = True,
         check_interval: int = CHECK_INTERVAL_SECOND,
-        max_retries: int | None = None,
+        max_attempts: int | None = None,
         max_ingestion_time: int | None = None,
         check_if_job_exists: bool = True,
         action_if_job_exists: str = "timestamp",
@@ -718,7 +718,7 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
         self.wait_for_completion = wait_for_completion
         self.print_log = print_log
         self.check_interval = check_interval
-        self.max_retries = max_retries or 60
+        self.max_attempts = max_attempts or 60
         self.max_ingestion_time = max_ingestion_time
         self.check_if_job_exists = check_if_job_exists
         if action_if_job_exists in {"timestamp", "increment", "fail"}:
@@ -790,7 +790,7 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
                     job_name=self.config["TrainingJobName"],
                     job_type="Training",
                     poke_interval=self.check_interval,
-                    max_retries=self.max_retries,
+                    max_attempts=self.max_attempts,
                     aws_conn_id=self.aws_conn_id,
                 ),
                 method_name="execute_complete",

--- a/airflow/providers/amazon/aws/triggers/sagemaker.py
+++ b/airflow/providers/amazon/aws/triggers/sagemaker.py
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import Any
+
+from airflow.compat.functools import cached_property
+from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+
+class SageMakerTrigger(BaseTrigger):
+    """
+    SageMakerTrigger is common trigger for both transform and training sagemaker job, and it is
+     fired as deferred class with params to run the task in triggerer.
+
+    :param job_name: name of the job to check status
+    :param job_type: Type of the sagemaker job whether it is Transform or Training
+    :param poke_interval:  polling period in seconds to check for the status
+    :param max_retries: Number of times to poll for query state before returning the current state,
+        defaults to None.
+    :param aws_conn_id: AWS connection ID for sagemaker
+    """
+
+    def __init__(
+        self,
+        job_name: str,
+        job_type: str,
+        poke_interval: int = 30,
+        max_retries: int | None = None,
+        aws_conn_id: str = "aws_default",
+    ):
+        super().__init__()
+        self.job_name = job_name
+        self.job_type = job_type
+        self.poke_interval = poke_interval
+        self.max_retries = max_retries
+        self.aws_conn_id = aws_conn_id
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        """Serializes SagemakerTrigger arguments and classpath."""
+        return (
+            "airflow.providers.amazon.aws.triggers.sagemaker.SagemakerTrigger",
+            {
+                "job_name": self.job_name,
+                "job_type": self.job_type,
+                "poke_interval": self.poke_interval,
+                "max_retries": self.max_retries,
+                "aws_conn_id": self.aws_conn_id,
+            },
+        )
+
+    @cached_property
+    def hook(self) -> SageMakerHook:
+        return SageMakerHook(aws_conn_id=self.aws_conn_id)
+
+    async def run(self):
+        self.log.info("job name is %s", self.job_name)
+        async with self.hook.async_conn as client:
+            waiter = self.hook.get_waiter("TrainingJobComplete", deferrable=True, client=client)
+            await waiter.wait(
+                TrainingJobName=self.job_name,
+                WaiterConfig={
+                    "Delay": self.poke_interval,
+                    "MaxAttempts": self.max_retries,
+                },
+            )
+        yield TriggerEvent({"status": "success", "message": "Job completed."})

--- a/airflow/providers/amazon/aws/triggers/sagemaker.py
+++ b/airflow/providers/amazon/aws/triggers/sagemaker.py
@@ -32,7 +32,7 @@ class SageMakerTrigger(BaseTrigger):
     :param job_name: name of the job to check status
     :param job_type: Type of the sagemaker job whether it is Transform or Training
     :param poke_interval:  polling period in seconds to check for the status
-    :param max_retries: Number of times to poll for query state before returning the current state,
+    :param max_attempts: Number of times to poll for query state before returning the current state,
         defaults to None.
     :param aws_conn_id: AWS connection ID for sagemaker
     """
@@ -42,14 +42,14 @@ class SageMakerTrigger(BaseTrigger):
         job_name: str,
         job_type: str,
         poke_interval: int = 30,
-        max_retries: int | None = None,
+        max_attempts: int | None = None,
         aws_conn_id: str = "aws_default",
     ):
         super().__init__()
         self.job_name = job_name
         self.job_type = job_type
         self.poke_interval = poke_interval
-        self.max_retries = max_retries
+        self.max_attempts = max_attempts
         self.aws_conn_id = aws_conn_id
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
@@ -60,7 +60,7 @@ class SageMakerTrigger(BaseTrigger):
                 "job_name": self.job_name,
                 "job_type": self.job_type,
                 "poke_interval": self.poke_interval,
-                "max_retries": self.max_retries,
+                "max_attempts": self.max_attempts,
                 "aws_conn_id": self.aws_conn_id,
             },
         )
@@ -77,7 +77,7 @@ class SageMakerTrigger(BaseTrigger):
                 TrainingJobName=self.job_name,
                 WaiterConfig={
                     "Delay": self.poke_interval,
-                    "MaxAttempts": self.max_retries,
+                    "MaxAttempts": self.max_attempts,
                 },
             )
         yield TriggerEvent({"status": "success", "message": "Job completed."})

--- a/airflow/providers/amazon/aws/waiters/sagemaker.json
+++ b/airflow/providers/amazon/aws/waiters/sagemaker.json
@@ -1,0 +1,31 @@
+{
+    "version": 2,
+    "waiters": {
+        "TrainingJobComplete": {
+            "delay": 30,
+            "operation": "DescribeTrainingJob",
+            "maxAttempts": 60,
+            "description": "Wait until job is SUCCEEDED",
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "argument": "TrainingJobStatus",
+                    "expected": "Completed",
+                    "state": "success"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "TrainingJobStatus",
+                    "expected": "Failed",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "TrainingJobStatus",
+                    "expected": "Stopped",
+                    "state": "failure"
+                }
+            ]
+        }
+    }
+}

--- a/airflow/providers/amazon/aws/waiters/sagemaker.json
+++ b/airflow/providers/amazon/aws/waiters/sagemaker.json
@@ -5,7 +5,7 @@
             "delay": 30,
             "operation": "DescribeTrainingJob",
             "maxAttempts": 60,
-            "description": "Wait until job is SUCCEEDED",
+            "description": "Wait until job is COMPLETED",
             "acceptors": [
                 {
                     "matcher": "path",
@@ -22,6 +22,58 @@
                 {
                     "matcher": "path",
                     "argument": "TrainingJobStatus",
+                    "expected": "Stopped",
+                    "state": "failure"
+                }
+            ]
+        },
+        "TransformJobComplete": {
+            "delay": 30,
+            "operation": "DescribeTransformJob",
+            "maxAttempts": 60,
+            "description": "Wait until job is COMPLETED",
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "argument": "TransformJobStatus",
+                    "expected": "Completed",
+                    "state": "success"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "TransformJobStatus",
+                    "expected": "Failed",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "TransformJobStatus",
+                    "expected": "Stopped",
+                    "state": "failure"
+                }
+            ]
+        },
+        "ProcessingJobComplete": {
+            "delay": 30,
+            "operation": "DescribeProcessingJob",
+            "maxAttempts": 60,
+            "description": "Wait until job is COMPLETED",
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "argument": "ProcessingJobStatus",
+                    "expected": "Completed",
+                    "state": "success"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "ProcessingJobStatus",
+                    "expected": "Failed",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "ProcessingJobStatus",
                     "expected": "Stopped",
                     "state": "failure"
                 }

--- a/tests/providers/amazon/aws/operators/test_sagemaker_training.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_training.py
@@ -21,10 +21,11 @@ from unittest import mock
 import pytest
 from botocore.exceptions import ClientError
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook
 from airflow.providers.amazon.aws.operators import sagemaker
 from airflow.providers.amazon.aws.operators.sagemaker import SageMakerTrainingOperator
+from airflow.providers.amazon.aws.triggers.sagemaker import SageMakerTrigger
 
 EXPECTED_INTEGER_FIELDS: list[list[str]] = [
     ["ResourceConfig", "InstanceCount"],
@@ -113,3 +114,19 @@ class TestSageMakerTrainingOperator:
         }
         with pytest.raises(AirflowException):
             self.sagemaker.execute(None)
+
+    @mock.patch.object(SageMakerHook, "describe_training_job")
+    @mock.patch.object(SageMakerHook, "create_training_job")
+    @mock.patch.object(sagemaker, "serialize", return_value="")
+    @mock.patch("airflow.providers.amazon.aws.hooks.sagemaker.AwsBaseHook.get_client_type")
+    def test_operator_defer(self, mock_client, _, mock_training, mock_desc):
+        mock_training.return_value = {
+            "TrainingJobArn": "test_arn",
+            "ResponseMetadata": {"HTTPStatusCode": 200},
+        }
+        self.sagemaker.deferrable = True
+        self.sagemaker.wait_for_completion = True
+        self.sagemaker.check_if_job_exists = False
+        with pytest.raises(TaskDeferred) as exc:
+            self.sagemaker.execute(context=None)
+        assert isinstance(exc.value.trigger, SageMakerTrigger), "Trigger is not a SagemakerTrigger"

--- a/tests/providers/amazon/aws/operators/test_sagemaker_training.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_training.py
@@ -115,11 +115,8 @@ class TestSageMakerTrainingOperator:
         with pytest.raises(AirflowException):
             self.sagemaker.execute(None)
 
-    @mock.patch.object(SageMakerHook, "describe_training_job")
     @mock.patch.object(SageMakerHook, "create_training_job")
-    @mock.patch.object(sagemaker, "serialize", return_value="")
-    @mock.patch("airflow.providers.amazon.aws.hooks.sagemaker.AwsBaseHook.get_client_type")
-    def test_operator_defer(self, mock_client, _, mock_training, mock_desc):
+    def test_operator_defer(self, mock_training):
         mock_training.return_value = {
             "TrainingJobArn": "test_arn",
             "ResponseMetadata": {"HTTPStatusCode": 200},

--- a/tests/providers/amazon/aws/triggers/test_sagemaker.py
+++ b/tests/providers/amazon/aws/triggers/test_sagemaker.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.providers.amazon.aws.triggers.sagemaker import SageMakerTrigger
+from airflow.triggers.base import TriggerEvent
+from tests.providers.amazon.aws.utils.compat import AsyncMock, async_mock
+
+JOB_NAME = "job_name"
+JOB_TYPE = "job_type"
+AWS_CONN_ID = "aws_sagemaker_conn"
+POKE_INTERVAL = 30
+MAX_RETRIES = 60
+
+
+class TestSagemakerTrigger:
+    def test_sagemaker_trigger_serialize(self):
+        sagemaker_trigger = SageMakerTrigger(
+            job_name=JOB_NAME,
+            job_type=JOB_TYPE,
+            poke_interval=POKE_INTERVAL,
+            max_retries=MAX_RETRIES,
+            aws_conn_id=AWS_CONN_ID,
+        )
+        class_path, args = sagemaker_trigger.serialize()
+        assert class_path == "airflow.providers.amazon.aws.triggers.sagemaker.SagemakerTrigger"
+        assert args["job_name"] == JOB_NAME
+        assert args["job_type"] == JOB_TYPE
+        assert args["poke_interval"] == POKE_INTERVAL
+        assert args["max_retries"] == MAX_RETRIES
+        assert args["aws_conn_id"] == AWS_CONN_ID
+
+    @pytest.mark.asyncio
+    @async_mock.patch("airflow.providers.amazon.aws.hooks.sagemaker.SageMakerHook.get_waiter")
+    @async_mock.patch("airflow.providers.amazon.aws.hooks.sagemaker.SageMakerHook.async_conn")
+    async def test_sagemaker_trigger_run(self, mock_async_conn, mock_get_waiter):
+        mock = async_mock.MagicMock()
+        mock_async_conn.__aenter__.return_value = mock
+
+        mock_get_waiter().wait = AsyncMock()
+
+        sagemaker_trigger = SageMakerTrigger(
+            job_name=JOB_NAME,
+            job_type=JOB_TYPE,
+            poke_interval=POKE_INTERVAL,
+            max_retries=MAX_RETRIES,
+            aws_conn_id=AWS_CONN_ID,
+        )
+
+        generator = sagemaker_trigger.run()
+        response = await generator.asend(None)
+
+        assert response == TriggerEvent({"status": "success", "message": "Job completed."})

--- a/tests/providers/amazon/aws/triggers/test_sagemaker.py
+++ b/tests/providers/amazon/aws/triggers/test_sagemaker.py
@@ -16,8 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import mock
-
 import pytest
 
 from airflow.providers.amazon.aws.triggers.sagemaker import SageMakerTrigger
@@ -51,8 +49,8 @@ class TestSagemakerTrigger:
     @pytest.mark.asyncio
     @async_mock.patch("airflow.providers.amazon.aws.hooks.sagemaker.SageMakerHook.get_waiter")
     @async_mock.patch("airflow.providers.amazon.aws.hooks.sagemaker.SageMakerHook.async_conn")
-    @mock.patch("airflow.providers.amazon.aws.triggers.sagemaker.SageMakerTrigger._get_job_type_waiter")
-    @mock.patch(
+    @async_mock.patch("airflow.providers.amazon.aws.triggers.sagemaker.SageMakerTrigger._get_job_type_waiter")
+    @async_mock.patch(
         "airflow.providers.amazon.aws.triggers.sagemaker.SageMakerTrigger._get_job_type_waiter_job_name_arg"
     )
     async def test_sagemaker_trigger_run(

--- a/tests/providers/amazon/aws/triggers/test_sagemaker.py
+++ b/tests/providers/amazon/aws/triggers/test_sagemaker.py
@@ -26,7 +26,7 @@ JOB_NAME = "job_name"
 JOB_TYPE = "job_type"
 AWS_CONN_ID = "aws_sagemaker_conn"
 POKE_INTERVAL = 30
-MAX_RETRIES = 60
+MAX_ATTEMPTS = 60
 
 
 class TestSagemakerTrigger:
@@ -35,7 +35,7 @@ class TestSagemakerTrigger:
             job_name=JOB_NAME,
             job_type=JOB_TYPE,
             poke_interval=POKE_INTERVAL,
-            max_retries=MAX_RETRIES,
+            max_attempts=MAX_ATTEMPTS,
             aws_conn_id=AWS_CONN_ID,
         )
         class_path, args = sagemaker_trigger.serialize()
@@ -43,7 +43,7 @@ class TestSagemakerTrigger:
         assert args["job_name"] == JOB_NAME
         assert args["job_type"] == JOB_TYPE
         assert args["poke_interval"] == POKE_INTERVAL
-        assert args["max_retries"] == MAX_RETRIES
+        assert args["max_attempts"] == MAX_ATTEMPTS
         assert args["aws_conn_id"] == AWS_CONN_ID
 
     @pytest.mark.asyncio
@@ -59,7 +59,7 @@ class TestSagemakerTrigger:
             job_name=JOB_NAME,
             job_type=JOB_TYPE,
             poke_interval=POKE_INTERVAL,
-            max_retries=MAX_RETRIES,
+            max_attempts=MAX_ATTEMPTS,
             aws_conn_id=AWS_CONN_ID,
         )
 


### PR DESCRIPTION
This will allow running SageMakerTrainingOperator in an async 
fashion meaning that we only submit a job from the worker to 
run a job and then defer to the trigger for polling to wait for the 
job status to reach a terminal state. This way, the worker slot 
won't be occupied for the whole period of task execution.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
