### PR TITLE
Add deferrable param in EmrStepSensor

### DIFF
--- a/airflow/providers/amazon/aws/triggers/emr.py
+++ b/airflow/providers/amazon/aws/triggers/emr.py
@@ -1,0 +1,90 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Iterable
+
+from airflow.compat.functools import cached_property
+from airflow.providers.amazon.aws.hooks.emr import EmrHook
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+
+class EmrStepSensorTrigger(BaseTrigger):
+    """
+    Poll for the status of EMR container until reaches terminal state
+
+    :param virtual_cluster_id: Reference Emr cluster id
+    :param job_id:  job_id to check the state
+    :param max_tries: maximum try attempts for polling the status
+    :param aws_conn_id: Reference to AWS connection id
+    :param poll_interval: polling period in seconds to check for the status
+    """
+
+    def __init__(
+        self,
+        job_flow_id: str,
+        step_id: str,
+        target_states: Iterable[str],
+        aws_conn_id: str = "aws_default",
+        poll_interval: int = 30,
+        max_attempts: int = 60,
+        **kwargs: Any,
+    ):
+        self.job_flow_id = job_flow_id
+        self.step_id = step_id
+        self.target_states = target_states
+        self.aws_conn_id = aws_conn_id
+        self.poll_interval = poll_interval
+        self.max_attempts = max_attempts
+        super().__init__(**kwargs)
+
+    @cached_property
+    def hook(self) -> EmrHook:
+        return EmrHook(self.aws_conn_id)
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        return (
+            "airflow.providers.amazon.aws.triggers.emr.EmrStepSensorTrigger",
+            {
+                "job_flow_id": self.job_flow_id,
+                "step_id": self.step_id,
+                "target_states": self.target_states,
+                "aws_conn_id": self.aws_conn_id,
+                "max_attempts": self.max_attempts,
+                "poll_interval": self.poll_interval,
+            },
+        )
+
+    async def run(self) -> AsyncIterator[TriggerEvent]:
+        async with self.hook.async_conn as client:
+            waiter = self.hook.get_waiter("job_step_wait_for_terminal", deferrable=True, client=client)
+            await waiter.wait(
+                ClusterId=self.job_flow_id,
+                StepId=self.step_id,
+                WaiterConfig={
+                    "Delay": self.poll_interval,
+                    "MaxAttempts": self.max_attempts,
+                },
+            )
+
+        response = self.hook.conn.describe_step(ClusterId=self.job_flow_id, StepId=self.step_id)
+        state = response["Step"]["Status"]["State"]
+        if state in self.target_states:
+            yield TriggerEvent({"status": "success"})
+        else:
+            yield TriggerEvent({"status": "failed", "response": response})

--- a/airflow/providers/amazon/aws/waiters/emr.json
+++ b/airflow/providers/amazon/aws/waiters/emr.json
@@ -75,6 +75,37 @@
                     "state": "failure"
                 }
             ]
+        },
+        "job_step_wait_for_terminal": {
+            "operation": "DescribeStep",
+            "delay": 30,
+            "maxAttempts": 60,
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "argument": "step.status",
+                    "expected": "COMPLETED",
+                    "state": "success"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "step.status",
+                    "expected": "CANCELLED",
+                    "state": "success"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "step.status",
+                    "expected": "FAILED",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "step.status",
+                    "expected": "INTERRUPTED",
+                    "state": "failure"
+                }
+            ]
         }
     }
 }

--- a/tests/providers/amazon/aws/triggers/test_emr.py
+++ b/tests/providers/amazon/aws/triggers/test_emr.py
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import PropertyMock
+
+import pytest
+
+from airflow.providers.amazon.aws.triggers.emr import EmrStepSensorTrigger
+from tests.providers.amazon.aws.utils.compat import AsyncMock, async_mock
+
+JOB__FLOW_ID = "job-1234"
+STEP_ID = "s-1234"
+TARGET_STATE = ["TERMINATED"]
+AWS_CONN_ID = "aws_emr_conn"
+POLL_INTERVAL = 60
+MAX_ATTEMPTS = 5
+
+
+class TestEmrStepSensorTrigger:
+    def test_emr_job_step_sensor_trigger_serialize(self):
+        emr_trigger = EmrStepSensorTrigger(
+            job_flow_id=JOB__FLOW_ID,
+            step_id=STEP_ID,
+            target_states=TARGET_STATE,
+            aws_conn_id=AWS_CONN_ID,
+            poll_interval=POLL_INTERVAL,
+            max_attempts=MAX_ATTEMPTS,
+        )
+        class_path, args = emr_trigger.serialize()
+        assert class_path == "airflow.providers.amazon.aws.triggers.emr.EmrStepSensorTrigger"
+        assert args["job_flow_id"] == JOB__FLOW_ID
+        assert args["step_id"] == STEP_ID
+        assert args["target_states"] == TARGET_STATE
+        assert args["aws_conn_id"] == AWS_CONN_ID
+        assert args["poll_interval"] == POLL_INTERVAL
+        assert args["max_attempts"] == MAX_ATTEMPTS
+
+    @pytest.mark.asyncio
+    @async_mock.patch(
+        "airflow.providers.amazon.aws.hooks.base_aws.AwsGenericHook.conn", new_callable=PropertyMock
+    )
+    @async_mock.patch("airflow.providers.amazon.aws.hooks.emr.EmrHook.get_waiter")
+    @async_mock.patch("airflow.providers.amazon.aws.hooks.emr.EmrHook.async_conn")
+    async def test_emr_step_sensor_trigger_run(self, mock_async_conn, mock_get_waiter, mock_conn):
+        mock = async_mock.MagicMock()
+        mock_async_conn.__aenter__.return_value = mock
+
+        mock_get_waiter().wait = AsyncMock()
+
+        emr_trigger = EmrStepSensorTrigger(
+            job_flow_id=JOB__FLOW_ID,
+            target_states=TARGET_STATE,
+            step_id=STEP_ID,
+            aws_conn_id=AWS_CONN_ID,
+            poll_interval=POLL_INTERVAL,
+            max_attempts=MAX_ATTEMPTS,
+        )
+
+        generator = emr_trigger.run()
+        await generator.asend(None)
+
+        assert mock_conn.return_value.describe_step.called


### PR DESCRIPTION
Add the deferrable param in EmrStepSensor.
This will allow running EmrStepSensor in an async way
that means we only submit a job from the worker to run a job
then defer to the trigger for polling and wait for a job the job status
and the worker slot won't be occupied for the whole period of task execution.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
