### PR TITLE
Add rest endpoint to get option of configuration

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2000,6 +2000,51 @@ paths:
         '403':
           $ref: '#/components/responses/PermissionDenied'
 
+  /config/section/{section}/option/{option}:
+    get:
+      summary: Get a option from configuration
+      x-openapi-router-controller: airflow.api_connexion.endpoints.config_endpoint
+      operationId: get_value
+      tags: [Config]
+      parameters:
+        - name: section
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: option
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Config'
+              example:
+                sections:
+                  - name: core
+                    options:
+                      - key: dags_folder
+                        value: /home/user/my-dags-folder
+            text/plain:
+              schema:
+                type: string
+              example: |
+                [core]
+                dags_folder = /home/user/my-dags-folder
+
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+           $ref: '#/components/responses/NotFound'
+
+
   /health:
     get:
       summary: Get instance status

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -641,6 +641,9 @@ export interface paths {
   "/config": {
     get: operations["get_config"];
   };
+  "/config/section/{section}/option/{option}": {
+    get: operations["get_value"];
+  };
   "/health": {
     /**
      * Get the status of Airflow's metadatabase and scheduler. It includes info about
@@ -4196,6 +4199,26 @@ export interface operations {
       403: components["responses"]["PermissionDenied"];
     };
   };
+  get_value: {
+    parameters: {
+      path: {
+        section: string;
+        option: string;
+      };
+    };
+    responses: {
+      /** Success. */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Config"];
+          "text/plain": string;
+        };
+      };
+      401: components["responses"]["Unauthenticated"];
+      403: components["responses"]["PermissionDenied"];
+      404: components["responses"]["NotFound"];
+    };
+  };
   /**
    * Get the status of Airflow's metadatabase and scheduler. It includes info about
    * metadatabase and last heartbeat of scheduler.
@@ -4999,6 +5022,9 @@ export type GetDatasetEventsVariables = CamelCasedPropertiesDeep<
 >;
 export type GetConfigVariables = CamelCasedPropertiesDeep<
   operations["get_config"]["parameters"]["query"]
+>;
+export type GetValueVariables = CamelCasedPropertiesDeep<
+  operations["get_value"]["parameters"]["path"]
 >;
 export type GetPluginsVariables = CamelCasedPropertiesDeep<
   operations["get_plugins"]["parameters"]["query"]


### PR DESCRIPTION
Currently, getting a single configuration option is missing in the rest API.
This PR add an endpoint `/config/section/{section}/option/{option}` to Return a single option. 
If the option is not found, the API returns 404. 
Also, if `expose_config` is not set in the configuration then it would return 403.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
