### PR TITLE
Fix webserver crash when calling get /config

### DIFF
--- a/airflow/api_connexion/endpoints/config_endpoint.py
+++ b/airflow/api_connexion/endpoints/config_endpoint.py
@@ -21,10 +21,9 @@ from http import HTTPStatus
 from flask import Response, request
 
 from airflow.api_connexion import security
-from airflow.api_connexion.exceptions import PermissionDenied
+from airflow.api_connexion.exceptions import NotFound, PermissionDenied
 from airflow.api_connexion.schemas.config_schema import Config, ConfigOption, ConfigSection, config_schema
 from airflow.configuration import conf
-from airflow.exceptions import AirflowNotFoundException
 from airflow.security import permissions
 from airflow.settings import json
 
@@ -79,7 +78,7 @@ def get_config(*, section: str | None = None) -> Response:
         return Response(status=HTTPStatus.NOT_ACCEPTABLE)
     elif conf.getboolean("webserver", "expose_config"):
         if section and not conf.has_section(section):
-            raise AirflowNotFoundException(f"section={section} not found")
+            raise NotFound("section not found.", detail=f"section={section} not found.")
         conf_dict = conf.as_dict(display_source=False, display_sensitive=True)
         if section:
             conf_section_value = conf_dict[section]

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1994,11 +1994,12 @@ paths:
                 smtp_host = localhost
                 smtp_mail_from =  airflow@example.com
 
-
         '401':
           $ref: '#/components/responses/Unauthenticated'
         '403':
           $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
   /health:
     get:

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -4194,6 +4194,7 @@ export interface operations {
       };
       401: components["responses"]["Unauthenticated"];
       403: components["responses"]["PermissionDenied"];
+      404: components["responses"]["NotFound"];
     };
   };
   /**

--- a/tests/api_connexion/endpoints/test_config_endpoint.py
+++ b/tests/api_connexion/endpoints/test_config_endpoint.py
@@ -144,6 +144,17 @@ class TestGetConfig:
         assert expected == response.json
 
     @patch("airflow.api_connexion.endpoints.config_endpoint.conf.as_dict", return_value=MOCK_CONF)
+    def test_should_respond_404_when_section_not_exist(self, mock_as_dict):
+        response = self.client.get(
+            "/api/v1/config?section=smtp1",
+            headers={"Accept": "application/json"},
+            environ_overrides={"REMOTE_USER": "test"},
+        )
+
+        assert response.status_code == 404
+        assert "section=smtp1 not found." in response.json["detail"]
+
+    @patch("airflow.api_connexion.endpoints.config_endpoint.conf.as_dict", return_value=MOCK_CONF)
     def test_should_respond_406(self, mock_as_dict):
         response = self.client.get(
             "/api/v1/config",


### PR DESCRIPTION
currently, if the section is not found we raise AirflowNotFoundException 
and that does not handle returning response gracefully and the web server crash 
I think the right expectation to raise here should be NotFound

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
