### PR TITLE
Add deferrable param in SageMakerProcessingOperator

### DIFF
--- a/airflow/providers/amazon/aws/triggers/sagemaker.py
+++ b/airflow/providers/amazon/aws/triggers/sagemaker.py
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import Any
+
+from airflow.compat.functools import cached_property
+from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+
+class SageMakerTrigger(BaseTrigger):
+    """
+    SageMakerTrigger is fired as deferred class with params to run the task in triggerer.
+
+    :param job_name: name of the job to check status
+    :param job_type: Type of the sagemaker job whether it is Transform or Training
+    :param poke_interval:  polling period in seconds to check for the status
+    :param max_attempts: Number of times to poll for query state before returning the current state,
+        defaults to None.
+    :param aws_conn_id: AWS connection ID for sagemaker
+    """
+
+    def __init__(
+        self,
+        job_name: str,
+        job_type: str,
+        poke_interval: int = 30,
+        max_attempts: int | None = None,
+        aws_conn_id: str = "aws_default",
+    ):
+        super().__init__()
+        self.job_name = job_name
+        self.job_type = job_type
+        self.poke_interval = poke_interval
+        self.max_attempts = max_attempts
+        self.aws_conn_id = aws_conn_id
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        """Serializes SagemakerTrigger arguments and classpath."""
+        return (
+            "airflow.providers.amazon.aws.triggers.sagemaker.SageMakerTrigger",
+            {
+                "job_name": self.job_name,
+                "job_type": self.job_type,
+                "poke_interval": self.poke_interval,
+                "max_attempts": self.max_attempts,
+                "aws_conn_id": self.aws_conn_id,
+            },
+        )
+
+    @cached_property
+    def hook(self) -> SageMakerHook:
+        return SageMakerHook(aws_conn_id=self.aws_conn_id)
+
+    @staticmethod
+    def _get_job_type_waiter(job_type: str) -> str:
+        return {
+            "training": "TrainingJobComplete",
+            "transform": "TransformJobComplete",
+            "processing": "ProcessingJobComplete",
+        }[job_type.lower()]
+
+    @staticmethod
+    def _get_job_type_waiter_job_name_arg(job_type: str) -> str:
+        return {
+            "training": "TrainingJobName",
+            "transform": "TransformJobName",
+            "processing": "ProcessingJobName",
+        }[job_type.lower()]
+
+    async def run(self):
+        self.log.info("job name is %s and job type is %s", self.job_name, self.job_type)
+        async with self.hook.async_conn as client:
+            waiter = self.hook.get_waiter(
+                self._get_job_type_waiter(self.job_type), deferrable=True, client=client
+            )
+            waiter_args = {
+                self._get_job_type_waiter_job_name_arg(self.job_type): self.job_name,
+                "WaiterConfig": {
+                    "Delay": self.poke_interval,
+                    "MaxAttempts": self.max_attempts,
+                },
+            }
+            await waiter.wait(**waiter_args)
+        yield TriggerEvent({"status": "success", "message": "Job completed."})

--- a/airflow/providers/amazon/aws/waiters/sagemaker.json
+++ b/airflow/providers/amazon/aws/waiters/sagemaker.json
@@ -1,0 +1,83 @@
+{
+    "version": 2,
+    "waiters": {
+        "TrainingJobComplete": {
+            "delay": 30,
+            "operation": "DescribeTrainingJob",
+            "maxAttempts": 60,
+            "description": "Wait until job is COMPLETED",
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "argument": "TrainingJobStatus",
+                    "expected": "Completed",
+                    "state": "success"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "TrainingJobStatus",
+                    "expected": "Failed",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "TrainingJobStatus",
+                    "expected": "Stopped",
+                    "state": "failure"
+                }
+            ]
+        },
+        "TransformJobComplete": {
+            "delay": 30,
+            "operation": "DescribeTransformJob",
+            "maxAttempts": 60,
+            "description": "Wait until job is COMPLETED",
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "argument": "TransformJobStatus",
+                    "expected": "Completed",
+                    "state": "success"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "TransformJobStatus",
+                    "expected": "Failed",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "TransformJobStatus",
+                    "expected": "Stopped",
+                    "state": "failure"
+                }
+            ]
+        },
+        "ProcessingJobComplete": {
+            "delay": 30,
+            "operation": "DescribeProcessingJob",
+            "maxAttempts": 60,
+            "description": "Wait until job is COMPLETED",
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "argument": "ProcessingJobStatus",
+                    "expected": "Completed",
+                    "state": "success"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "ProcessingJobStatus",
+                    "expected": "Failed",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "ProcessingJobStatus",
+                    "expected": "Stopped",
+                    "state": "failure"
+                }
+            ]
+        }
+    }
+}

--- a/tests/providers/amazon/aws/operators/test_sagemaker_processing.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_processing.py
@@ -238,14 +238,11 @@ class TestSageMakerProcessingOperator:
                 action_if_job_exists="not_fail_or_increment",
             )
 
-    @mock.patch.object(SageMakerHook, "describe_processing_job")
     @mock.patch.object(SageMakerHook, "create_processing_job")
-    @mock.patch.object(sagemaker, "serialize", return_value="")
-    @mock.patch("airflow.providers.amazon.aws.hooks.sagemaker.AwsBaseHook.get_client_type")
     @mock.patch("airflow.providers.amazon.aws.operators.sagemaker.SageMakerBaseOperator._check_if_job_exists")
-    def test_operator_defer(self, mock_job_exists, mock_client, _, mock_processing, mock_desc):
+    def test_operator_defer(self, mock_job_exists, mock_processing):
         mock_processing.return_value = {
-            "TrainingJobArn": "test_arn",
+            "ProcessingJobArn": "test_arn",
             "ResponseMetadata": {"HTTPStatusCode": 200},
         }
         mock_job_exists.return_value = False


### PR DESCRIPTION
This will allow running SageMakerProcessingOperator in an async 
fashion meaning that we only submit a job from the worker to run 
a job and then defer to the trigger for polling to wait for the job 
status to reach a terminal state. This way, the worker slot won't be 
occupied for the whole period of task execution.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
