### PR TITLE
Extend EMR System Test waiter timeout

### DIFF
--- a/tests/system/providers/amazon/aws/example_emr.py
+++ b/tests/system/providers/amazon/aws/example_emr.py
@@ -164,10 +164,14 @@ with DAG(
         task_id="add_steps",
         job_flow_id=create_job_flow.output,
         steps=SPARK_STEPS,
-        wait_for_completion=True,
         execution_role_arn=execution_role_arn,
     )
     # [END howto_operator_emr_add_steps]
+    add_steps.wait_for_completion = True
+    # On rare occasion (1 in 50ish?) this system test times out.  Extending
+    # the delay and max_attempts to attempt to mitigate the flaky test.
+    add_steps.waiter_delay = 60
+    add_steps.waiter_max_attempts = 90
 
     # [START howto_sensor_emr_step]
     wait_for_step = EmrStepSensor(

--- a/tests/system/providers/amazon/aws/example_emr.py
+++ b/tests/system/providers/amazon/aws/example_emr.py
@@ -168,9 +168,8 @@ with DAG(
     )
     # [END howto_operator_emr_add_steps]
     add_steps.wait_for_completion = True
-    # On rare occasion (1 in 50ish?) this system test times out.  Extending
-    # the delay and max_attempts to attempt to mitigate the flaky test.
-    add_steps.waiter_delay = 60
+    # On rare occasion (1 in 50ish?) this system test times out.  Extending the
+    # max_attempts from the default 60 to attempt to mitigate the flaky test.
     add_steps.waiter_max_attempts = 90
 
     # [START howto_sensor_emr_step]


### PR DESCRIPTION
On rare occasion this system test has timed out.  Extending the max wait to try to mitigate that.

cc: @o-nikolas @vincbeck @vandonr-amz @syedahsn