### PR TITLE
`StepFunctionStartExecutionOperator`: get logs in case of failure

### DIFF
--- a/airflow/providers/amazon/aws/operators/step_function.py
+++ b/airflow/providers/amazon/aws/operators/step_function.py
@@ -113,8 +113,12 @@ class StepFunctionGetExecutionOutputOperator(BaseOperator):
         hook = StepFunctionHook(aws_conn_id=self.aws_conn_id, region_name=self.region_name)
 
         execution_status = hook.describe_execution(self.execution_arn)
-        execution_output = json.loads(execution_status["output"]) if "output" in execution_status else None
+        response = None
+        if "output" in execution_status:
+            response = json.loads(execution_status["output"])
+        elif "error" in execution_status:
+            response = json.loads(execution_status["error"])
 
         self.log.info("Got State Machine Execution output for %s", self.execution_arn)
 
-        return execution_output
+        return response

--- a/tests/providers/amazon/aws/operators/test_step_function.py
+++ b/tests/providers/amazon/aws/operators/test_step_function.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 from unittest import mock
 from unittest.mock import MagicMock
 
+import pytest
+
 from airflow.providers.amazon.aws.operators.step_function import (
     StepFunctionGetExecutionOutputOperator,
     StepFunctionStartExecutionOperator,
@@ -58,9 +60,10 @@ class TestStepFunctionGetExecutionOutputOperator:
         assert REGION_NAME == operator.region_name
 
     @mock.patch("airflow.providers.amazon.aws.operators.step_function.StepFunctionHook")
-    def test_execute(self, mock_hook):
+    @pytest.mark.parametrize("response", ["output", "error"])
+    def test_execute(self, mock_hook, response):
         # Given
-        hook_response = {"output": "{}"}
+        hook_response = {response: "{}"}
 
         hook_instance = mock_hook.return_value
         hook_instance.describe_execution.return_value = hook_response


### PR DESCRIPTION
In case of unsuccessful execution `output` is not set. Instead `error` is set.
this is explained in [Step Function docs](https://docs.aws.amazon.com/step-functions/latest/apireference/API_DescribeExecution.html#API_DescribeExecution_ResponseSyntax).


![Screenshot 2023-05-04 at 22 41 09](https://user-images.githubusercontent.com/45845474/236312359-a611bd5e-6ab5-4cca-b429-f0397aa3d739.png)


![Screenshot 2023-05-04 at 22 41 16](https://user-images.githubusercontent.com/45845474/236312364-932824c9-a489-4be9-866a-e53d4275b2a1.png)
