### PR TITLE
Add default retry to hvac client requests

### DIFF
--- a/tests/providers/hashicorp/_internal_client/test_vault_client.py
+++ b/tests/providers/hashicorp/_internal_client/test_vault_client.py
@@ -53,10 +53,10 @@ class TestVaultClient:
         mock_client = mock.MagicMock()
         mock_hvac.Client.return_value = mock_client
         vault_client = _VaultClient(
-            auth_type="approle", role_id="role", url="http://localhost:8180", secret_id="pass"
+            auth_type="approle", role_id="role", url="http://localhost:8180", secret_id="pass", session=None
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.approle.login.assert_called_with(role_id="role", secret_id="pass")
         client.is_authenticated.assert_called_with()
         assert 2 == vault_client.kv_engine_version
@@ -71,9 +71,10 @@ class TestVaultClient:
             url="http://localhost:8180",
             secret_id="pass",
             auth_mount_point="other",
+            session=None,
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.approle.login.assert_called_with(role_id="role", secret_id="pass", mount_point="other")
         client.is_authenticated.assert_called_with()
         assert 2 == vault_client.kv_engine_version
@@ -90,10 +91,15 @@ class TestVaultClient:
         mock_client = mock.MagicMock()
         mock_hvac.Client.return_value = mock_client
         vault_client = _VaultClient(
-            auth_type="aws_iam", role_id="role", url="http://localhost:8180", key_id="user", secret_id="pass"
+            auth_type="aws_iam",
+            role_id="role",
+            url="http://localhost:8180",
+            key_id="user",
+            secret_id="pass",
+            session=None,
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.aws.iam_login.assert_called_with(
             access_key="user",
             secret_key="pass",
@@ -113,9 +119,10 @@ class TestVaultClient:
             key_id="user",
             secret_id="pass",
             auth_mount_point="other",
+            session=None,
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.aws.iam_login.assert_called_with(
             access_key="user", secret_key="pass", role="role", mount_point="other"
         )
@@ -133,9 +140,10 @@ class TestVaultClient:
             url="http://localhost:8180",
             key_id="user",
             secret_id="pass",
+            session=None,
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.azure.configure.assert_called_with(
             tenant_id="tenant_id",
             resource="resource",
@@ -157,9 +165,10 @@ class TestVaultClient:
             key_id="user",
             secret_id="pass",
             auth_mount_point="other",
+            session=None,
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.azure.configure.assert_called_with(
             tenant_id="tenant_id",
             resource="resource",
@@ -205,15 +214,19 @@ class TestVaultClient:
         mock_get_scopes.return_value = ["scope1", "scope2"]
         mock_get_credentials.return_value = ("credentials", "project_id")
         vault_client = _VaultClient(
-            auth_type="gcp", gcp_key_path="path.json", gcp_scopes="scope1,scope2", url="http://localhost:8180"
+            auth_type="gcp",
+            gcp_key_path="path.json",
+            gcp_scopes="scope1,scope2",
+            url="http://localhost:8180",
+            session=None,
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         mock_get_scopes.assert_called_with("scope1,scope2")
         mock_get_credentials.assert_called_with(
             key_path="path.json", keyfile_dict=None, scopes=["scope1", "scope2"]
         )
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.gcp.configure.assert_called_with(
             credentials="credentials",
         )
@@ -234,14 +247,15 @@ class TestVaultClient:
             gcp_scopes="scope1,scope2",
             url="http://localhost:8180",
             auth_mount_point="other",
+            session=None,
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         mock_get_scopes.assert_called_with("scope1,scope2")
         mock_get_credentials.assert_called_with(
             key_path="path.json", keyfile_dict=None, scopes=["scope1", "scope2"]
         )
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.gcp.configure.assert_called_with(credentials="credentials", mount_point="other")
         client.is_authenticated.assert_called_with()
         assert 2 == vault_client.kv_engine_version
@@ -259,14 +273,15 @@ class TestVaultClient:
             gcp_keyfile_dict={"key": "value"},
             gcp_scopes="scope1,scope2",
             url="http://localhost:8180",
+            session=None,
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         mock_get_scopes.assert_called_with("scope1,scope2")
         mock_get_credentials.assert_called_with(
             key_path=None, keyfile_dict={"key": "value"}, scopes=["scope1", "scope2"]
         )
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.gcp.configure.assert_called_with(
             credentials="credentials",
         )
@@ -278,10 +293,10 @@ class TestVaultClient:
         mock_client = mock.MagicMock()
         mock_hvac.Client.return_value = mock_client
         vault_client = _VaultClient(
-            auth_type="github", token="s.7AU0I51yv1Q1lxOIg1F3ZRAS", url="http://localhost:8180"
+            auth_type="github", token="s.7AU0I51yv1Q1lxOIg1F3ZRAS", url="http://localhost:8180", session=None
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.github.login.assert_called_with(token="s.7AU0I51yv1Q1lxOIg1F3ZRAS")
         client.is_authenticated.assert_called_with()
         assert 2 == vault_client.kv_engine_version
@@ -295,9 +310,10 @@ class TestVaultClient:
             token="s.7AU0I51yv1Q1lxOIg1F3ZRAS",
             url="http://localhost:8180",
             auth_mount_point="other",
+            session=None,
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.github.login.assert_called_with(token="s.7AU0I51yv1Q1lxOIg1F3ZRAS", mount_point="other")
         client.is_authenticated.assert_called_with()
         assert 2 == vault_client.kv_engine_version
@@ -315,12 +331,12 @@ class TestVaultClient:
         mock_client = mock.MagicMock()
         mock_hvac.Client.return_value = mock_client
         vault_client = _VaultClient(
-            auth_type="kubernetes", kubernetes_role="kube_role", url="http://localhost:8180"
+            auth_type="kubernetes", kubernetes_role="kube_role", url="http://localhost:8180", session=None
         )
         with patch("builtins.open", mock_open(read_data="data")) as mock_file:
             client = vault_client.client
         mock_file.assert_called_with("/var/run/secrets/kubernetes.io/serviceaccount/token")
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         mock_kubernetes.assert_called_with(mock_client.adapter)
         mock_kubernetes.return_value.login.assert_called_with(role="kube_role", jwt="data")
         client.is_authenticated.assert_called_with()
@@ -336,11 +352,12 @@ class TestVaultClient:
             kubernetes_role="kube_role",
             kubernetes_jwt_path="path",
             url="http://localhost:8180",
+            session=None,
         )
         with patch("builtins.open", mock_open(read_data="data")) as mock_file:
             client = vault_client.client
         mock_file.assert_called_with("path")
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         mock_kubernetes.assert_called_with(mock_client.adapter)
         mock_kubernetes.return_value.login.assert_called_with(role="kube_role", jwt="data")
         client.is_authenticated.assert_called_with()
@@ -357,11 +374,12 @@ class TestVaultClient:
             kubernetes_jwt_path="path",
             auth_mount_point="other",
             url="http://localhost:8180",
+            session=None,
         )
         with patch("builtins.open", mock_open(read_data="data")) as mock_file:
             client = vault_client.client
         mock_file.assert_called_with("path")
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         mock_kubernetes.assert_called_with(mock_client.adapter)
         mock_kubernetes.return_value.login.assert_called_with(
             role="kube_role", jwt="data", mount_point="other"
@@ -393,10 +411,10 @@ class TestVaultClient:
         mock_client = mock.MagicMock()
         mock_hvac.Client.return_value = mock_client
         vault_client = _VaultClient(
-            auth_type="ldap", username="user", password="pass", url="http://localhost:8180"
+            auth_type="ldap", username="user", password="pass", url="http://localhost:8180", session=None
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.ldap.login.assert_called_with(username="user", password="pass")
         client.is_authenticated.assert_called_with()
         assert 2 == vault_client.kv_engine_version
@@ -411,9 +429,10 @@ class TestVaultClient:
             password="pass",
             auth_mount_point="other",
             url="http://localhost:8180",
+            session=None,
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.ldap.login.assert_called_with(username="user", password="pass", mount_point="other")
         client.is_authenticated.assert_called_with()
         assert 2 == vault_client.kv_engine_version
@@ -437,10 +456,14 @@ class TestVaultClient:
         mock_client = mock.MagicMock()
         mock_hvac.Client.return_value = mock_client
         vault_client = _VaultClient(
-            auth_type="radius", radius_host="radhost", radius_secret="pass", url="http://localhost:8180"
+            auth_type="radius",
+            radius_host="radhost",
+            radius_secret="pass",
+            url="http://localhost:8180",
+            session=None,
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.radius.configure.assert_called_with(host="radhost", secret="pass", port=None)
         client.is_authenticated.assert_called_with()
         assert 2 == vault_client.kv_engine_version
@@ -455,9 +478,10 @@ class TestVaultClient:
             radius_secret="pass",
             auth_mount_point="other",
             url="http://localhost:8180",
+            session=None,
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.radius.configure.assert_called_with(
             host="radhost", secret="pass", port=None, mount_point="other"
         )
@@ -474,9 +498,10 @@ class TestVaultClient:
             radius_port=8110,
             radius_secret="pass",
             url="http://localhost:8180",
+            session=None,
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.radius.configure.assert_called_with(host="radhost", secret="pass", port=8110)
         client.is_authenticated.assert_called_with()
         assert 2 == vault_client.kv_engine_version
@@ -493,10 +518,10 @@ class TestVaultClient:
         mock_client = mock.MagicMock()
         mock_hvac.Client.return_value = mock_client
         vault_client = _VaultClient(
-            auth_type="token", token="s.7AU0I51yv1Q1lxOIg1F3ZRAS", url="http://localhost:8180"
+            auth_type="token", token="s.7AU0I51yv1Q1lxOIg1F3ZRAS", url="http://localhost:8180", session=None
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.is_authenticated.assert_called_with()
         assert "s.7AU0I51yv1Q1lxOIg1F3ZRAS" == client.token
         assert 2 == vault_client.kv_engine_version
@@ -509,10 +534,10 @@ class TestVaultClient:
         with open("/tmp/test_token.txt", "w+") as the_file:
             the_file.write("s.7AU0I51yv1Q1lxOIg1F3ZRAS")
         vault_client = _VaultClient(
-            auth_type="token", token_path="/tmp/test_token.txt", url="http://localhost:8180"
+            auth_type="token", token_path="/tmp/test_token.txt", url="http://localhost:8180", session=None
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.is_authenticated.assert_called_with()
         assert "s.7AU0I51yv1Q1lxOIg1F3ZRAS" == client.token
         assert 2 == vault_client.kv_engine_version
@@ -525,10 +550,10 @@ class TestVaultClient:
         with open("/tmp/test_token.txt", "w+") as the_file:
             the_file.write("  s.7AU0I51yv1Q1lxOIg1F3ZRAS\n")
         vault_client = _VaultClient(
-            auth_type="token", token_path="/tmp/test_token.txt", url="http://localhost:8180"
+            auth_type="token", token_path="/tmp/test_token.txt", url="http://localhost:8180", session=None
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.is_authenticated.assert_called_with()
         assert "s.7AU0I51yv1Q1lxOIg1F3ZRAS" == client.token
         assert 2 == vault_client.kv_engine_version
@@ -538,9 +563,11 @@ class TestVaultClient:
     def test_default_auth_type(self, mock_hvac):
         mock_client = mock.MagicMock()
         mock_hvac.Client.return_value = mock_client
-        vault_client = _VaultClient(token="s.7AU0I51yv1Q1lxOIg1F3ZRAS", url="http://localhost:8180")
+        vault_client = _VaultClient(
+            token="s.7AU0I51yv1Q1lxOIg1F3ZRAS", url="http://localhost:8180", session=None
+        )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.is_authenticated.assert_called_with()
         assert "s.7AU0I51yv1Q1lxOIg1F3ZRAS" == client.token
         assert "token" == vault_client.auth_type
@@ -552,10 +579,10 @@ class TestVaultClient:
         mock_client = mock.MagicMock()
         mock_hvac.Client.return_value = mock_client
         vault_client = _VaultClient(
-            auth_type="userpass", username="user", password="pass", url="http://localhost:8180"
+            auth_type="userpass", username="user", password="pass", url="http://localhost:8180", session=None
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.userpass.login.assert_called_with(username="user", password="pass")
         client.is_authenticated.assert_called_with()
         assert 2 == vault_client.kv_engine_version
@@ -570,9 +597,10 @@ class TestVaultClient:
             password="pass",
             auth_mount_point="other",
             url="http://localhost:8180",
+            session=None,
         )
         client = vault_client.client
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.userpass.login.assert_called_with(username="user", password="pass", mount_point="other")
         client.is_authenticated.assert_called_with()
         assert 2 == vault_client.kv_engine_version

--- a/tests/providers/hashicorp/hooks/test_vault.py
+++ b/tests/providers/hashicorp/hooks/test_vault.py
@@ -178,12 +178,13 @@ class TestVaultHook:
             "vault_conn_id": "vault_conn_id",
             "auth_type": "approle",
             "kv_engine_version": 2,
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url=expected_url)
+        mock_hvac.Client.assert_called_with(url=expected_url, session=None)
         test_client.auth.approle.login.assert_called_with(role_id="user", secret_id="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
@@ -210,12 +211,13 @@ class TestVaultHook:
             "vault_conn_id": "vault_conn_id",
             "auth_type": "approle",
             "kv_engine_version": 2,
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url=expected_url)
+        mock_hvac.Client.assert_called_with(url=expected_url, session=None)
         test_client.auth.approle.login.assert_called_with(role_id="user", secret_id="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
@@ -235,12 +237,13 @@ class TestVaultHook:
             "vault_conn_id": "vault_conn_id",
             "auth_type": "approle",
             "kv_engine_version": 2,
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.approle.login.assert_called_with(role_id="user", secret_id="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
@@ -258,12 +261,13 @@ class TestVaultHook:
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
         kwargs = {
             "vault_conn_id": "vault_conn_id",
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.approle.login.assert_called_with(role_id="user", secret_id="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
@@ -274,9 +278,9 @@ class TestVaultHook:
         AIRFLOW_CONN_VAULT_CONN_ID="https://role:secret@vault.example.com?auth_type=approle",
     )
     def test_approle_uri(self, mock_hvac):
-        test_hook = VaultHook(vault_conn_id="vault_conn_id")
+        test_hook = VaultHook(vault_conn_id="vault_conn_id", session=None)
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="https://vault.example.com")
+        mock_hvac.Client.assert_called_with(url="https://vault.example.com", session=None)
         test_client.auth.approle.login.assert_called_with(role_id="role", secret_id="secret")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
@@ -292,12 +296,17 @@ class TestVaultHook:
         connection_dict = {}
 
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
-        kwargs = {"vault_conn_id": "vault_conn_id", "auth_type": "aws_iam", "role_id": "role"}
+        kwargs = {
+            "vault_conn_id": "vault_conn_id",
+            "auth_type": "aws_iam",
+            "role_id": "role",
+            "session": None,
+        }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.aws.iam_login.assert_called_with(
             access_key="user",
             secret_key="pass",
@@ -319,12 +328,13 @@ class TestVaultHook:
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
         kwargs = {
             "vault_conn_id": "vault_conn_id",
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.aws.iam_login.assert_called_with(
             access_key="user",
             secret_key="pass",
@@ -337,9 +347,9 @@ class TestVaultHook:
         AIRFLOW_CONN_VAULT_CONN_ID="https://login:pass@vault.example.com?auth_type=aws_iam&role_id=role",
     )
     def test_aws_uri(self, mock_hvac):
-        test_hook = VaultHook(vault_conn_id="vault_conn_id")
+        test_hook = VaultHook(vault_conn_id="vault_conn_id", session=None)
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="https://vault.example.com")
+        mock_hvac.Client.assert_called_with(url="https://vault.example.com", session=None)
         test_client.auth.aws.iam_login.assert_called_with(
             access_key="login",
             secret_key="pass",
@@ -364,12 +374,13 @@ class TestVaultHook:
             "auth_type": "azure",
             "azure_tenant_id": "tenant_id",
             "azure_resource": "resource",
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.azure.configure.assert_called_with(
             tenant_id="tenant_id",
             resource="resource",
@@ -396,12 +407,13 @@ class TestVaultHook:
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
         kwargs = {
             "vault_conn_id": "vault_conn_id",
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.azure.configure.assert_called_with(
             tenant_id="tenant_id",
             resource="resource",
@@ -431,6 +443,7 @@ class TestVaultHook:
             "auth_type": "gcp",
             "gcp_key_path": "path.json",
             "gcp_scopes": "scope1,scope2",
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
@@ -440,7 +453,7 @@ class TestVaultHook:
         mock_get_credentials.assert_called_with(
             key_path="path.json", keyfile_dict=None, scopes=["scope1", "scope2"]
         )
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.gcp.configure.assert_called_with(
             credentials="credentials",
         )
@@ -468,6 +481,7 @@ class TestVaultHook:
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
         kwargs = {
             "vault_conn_id": "vault_conn_id",
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
@@ -477,7 +491,7 @@ class TestVaultHook:
         mock_get_credentials.assert_called_with(
             key_path="path.json", keyfile_dict=None, scopes=["scope1", "scope2"]
         )
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.gcp.configure.assert_called_with(
             credentials="credentials",
         )
@@ -505,6 +519,7 @@ class TestVaultHook:
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
         kwargs = {
             "vault_conn_id": "vault_conn_id",
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
@@ -514,7 +529,7 @@ class TestVaultHook:
         mock_get_credentials.assert_called_with(
             key_path=None, keyfile_dict={"key": "value"}, scopes=["scope1", "scope2"]
         )
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.gcp.configure.assert_called_with(
             credentials="credentials",
         )
@@ -535,12 +550,13 @@ class TestVaultHook:
         kwargs = {
             "auth_type": "github",
             "vault_conn_id": "vault_conn_id",
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.github.login.assert_called_with(token="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
@@ -560,12 +576,13 @@ class TestVaultHook:
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
         kwargs = {
             "vault_conn_id": "vault_conn_id",
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.github.login.assert_called_with(token="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
@@ -586,6 +603,7 @@ class TestVaultHook:
             "auth_type": "kubernetes",
             "kubernetes_role": "kube_role",
             "vault_conn_id": "vault_conn_id",
+            "session": None,
         }
 
         with patch("builtins.open", mock_open(read_data="data")) as mock_file:
@@ -593,7 +611,7 @@ class TestVaultHook:
             test_client = test_hook.get_conn()
         mock_get_connection.assert_called_with("vault_conn_id")
         mock_file.assert_called_with("/var/run/secrets/kubernetes.io/serviceaccount/token")
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         mock_kubernetes.assert_called_with(mock_client.adapter)
         mock_kubernetes.return_value.login.assert_called_with(role="kube_role", jwt="data")
         test_client.is_authenticated.assert_called_with()
@@ -617,13 +635,14 @@ class TestVaultHook:
         kwargs = {
             "auth_type": "kubernetes",
             "vault_conn_id": "vault_conn_id",
+            "session": None,
         }
         with patch("builtins.open", mock_open(read_data="data")) as mock_file:
             test_hook = VaultHook(**kwargs)
             test_client = test_hook.get_conn()
         mock_get_connection.assert_called_with("vault_conn_id")
         mock_file.assert_called_with("path")
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         mock_kubernetes.assert_called_with(mock_client.adapter)
         mock_kubernetes.return_value.login.assert_called_with(role="kube_role", jwt="data")
         test_client.is_authenticated.assert_called_with()
@@ -646,13 +665,14 @@ class TestVaultHook:
             "kubernetes_jwt_path": "path",
             "auth_type": "kubernetes",
             "vault_conn_id": "vault_conn_id",
+            "session": None,
         }
         with patch("builtins.open", mock_open(read_data="data")) as mock_file:
             test_hook = VaultHook(**kwargs)
             test_client = test_hook.get_conn()
         mock_get_connection.assert_called_with("vault_conn_id")
         mock_file.assert_called_with("path")
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         mock_kubernetes.assert_called_with(mock_client.adapter)
         mock_kubernetes.return_value.login.assert_called_with(role="kube_role", jwt="data")
         test_client.is_authenticated.assert_called_with()
@@ -675,12 +695,16 @@ class TestVaultHook:
         }
 
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
-        kwargs = {"vault_conn_id": "vault_conn_id", "generic_arg": "generic_val0"}
+        kwargs = {"vault_conn_id": "vault_conn_id", "generic_arg": "generic_val0", "session": None}
         test_hook = VaultHook(**kwargs)
         test_client = test_hook.get_conn()
         mock_get_connection.assert_called_with("vault_conn_id")
         mock_hvac.Client.assert_called_with(
-            url="http://localhost:8180", namespace="name", timeout=50, generic_arg="generic_val0"
+            url="http://localhost:8180",
+            namespace="name",
+            timeout=50,
+            generic_arg="generic_val0",
+            session=None,
         )
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
@@ -699,12 +723,13 @@ class TestVaultHook:
         kwargs = {
             "auth_type": "ldap",
             "vault_conn_id": "vault_conn_id",
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.ldap.login.assert_called_with(username="user", password="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
@@ -724,12 +749,13 @@ class TestVaultHook:
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
         kwargs = {
             "vault_conn_id": "vault_conn_id",
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.ldap.login.assert_called_with(username="user", password="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
@@ -749,12 +775,13 @@ class TestVaultHook:
             "auth_type": "radius",
             "radius_host": "radhost",
             "vault_conn_id": "vault_conn_id",
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.radius.configure.assert_called_with(host="radhost", secret="pass", port=None)
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
@@ -775,12 +802,13 @@ class TestVaultHook:
             "radius_host": "radhost",
             "radius_port": 8123,
             "vault_conn_id": "vault_conn_id",
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.radius.configure.assert_called_with(host="radhost", secret="pass", port=8123)
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
@@ -802,12 +830,13 @@ class TestVaultHook:
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
         kwargs = {
             "vault_conn_id": "vault_conn_id",
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.radius.configure.assert_called_with(host="radhost", secret="pass", port=8123)
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
@@ -843,12 +872,17 @@ class TestVaultHook:
         mock_get_connection.return_value = mock_connection
         connection_dict = {}
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
-        kwargs = {"vault_conn_id": "vault_conn_id", "auth_type": "token", "kv_engine_version": 2}
+        kwargs = {
+            "vault_conn_id": "vault_conn_id",
+            "auth_type": "token",
+            "kv_engine_version": 2,
+            "session": None,
+        }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.is_authenticated.assert_called_with()
         assert "pass" == test_client.token
         assert 2 == test_hook.vault_client.kv_engine_version
@@ -869,12 +903,13 @@ class TestVaultHook:
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
         kwargs = {
             "vault_conn_id": "vault_conn_id",
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.is_authenticated.assert_called_with()
         assert "pass" == test_client.token
         assert 2 == test_hook.vault_client.kv_engine_version
@@ -890,12 +925,17 @@ class TestVaultHook:
         connection_dict = {}
 
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
-        kwargs = {"vault_conn_id": "vault_conn_id", "auth_type": "userpass", "kv_engine_version": 2}
+        kwargs = {
+            "vault_conn_id": "vault_conn_id",
+            "auth_type": "userpass",
+            "kv_engine_version": 2,
+            "session": None,
+        }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.userpass.login.assert_called_with(username="user", password="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
@@ -915,12 +955,13 @@ class TestVaultHook:
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
         kwargs = {
             "vault_conn_id": "vault_conn_id",
+            "session": None,
         }
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180")
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.userpass.login.assert_called_with(username="user", password="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version


### PR DESCRIPTION
This implements a retry mechanism to the hvac client as the libraries [documentation suggests](https://hvac.readthedocs.io/en/stable/advanced_usage.html#retrying-failed-requests).

I am providing this due to a real-world case of an HTTP Connection Error causing a task to initially fail to start, after investigating I found the hvac documentation suggested adding this retry process.

Due to the docker version I have access to and the minimum requirements of Airflow dev tooling I hit limitations in the MyPy pre-commits and running the test suite, but I believe this PR should pass all tests.

Let me know if you need any additional work and/or changes to the PR to be able to review and/or land.

Finally, someone else submitted a similar PR but it is failing due import errors and they have not updated the PR since it was created three weeks ago: https://github.com/apache/airflow/pull/30628

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
