### PR TITLE
Fix Spacing for DagBag.dagbag_report()'s Output

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -605,8 +605,7 @@ class DagBag(LoggingMixin):
         -------------------------------------------------------------------
         Number of DAGs: {dag_num}
         Total task number: {task_num}
-        DagBag parsing time: {duration}
-        {table}
+        DagBag parsing time: {duration}\n{table}
         """
         )
         return report


### PR DESCRIPTION
The whitespace before `{table}` is throwing off the headers when printing `DagBag.dagbag_report()`


![image](https://user-images.githubusercontent.com/101577043/236491604-0e7f0aae-1ce9-438a-a357-a7ac7d602b72.png)
