### PR TITLE
Fix operator refrence in example_sftp_to_gcs.py

### DIFF
--- a/tests/system/providers/google/cloud/gcs/example_sftp_to_gcs.py
+++ b/tests/system/providers/google/cloud/gcs/example_sftp_to_gcs.py
@@ -91,7 +91,7 @@ with models.DAG(
     # [END howto_operator_sftp_to_gcs_copy_directory]
 
     # [START howto_operator_sftp_to_gcs_move_specific_files]
-    move_specific_files_from_gcs_to_sftp = SFTPToGCSOperator(
+    move_specific_files_from_sftp_to_gcs = SFTPToGCSOperator(
         task_id="dir-move-specific-files-sftp-to-gcs",
         source_path=f"{FILE_LOCAL_PATH}/{SUBDIR}/*.bin",
         destination_bucket=BUCKET_NAME,

--- a/tests/system/providers/google/cloud/gcs/example_sftp_to_gcs.py
+++ b/tests/system/providers/google/cloud/gcs/example_sftp_to_gcs.py
@@ -112,7 +112,7 @@ with models.DAG(
         copy_file_from_sftp_to_gcs,
         move_file_from_sftp_to_gcs_destination,
         copy_directory_from_sftp_to_gcs,
-        move_specific_files_from_gcs_to_sftp,
+        move_specific_files_from_sftp_to_gcs,
         # TEST TEARDOWN
         delete_bucket,
     )


### PR DESCRIPTION
renamed the variable name move_specific_files_from_gcs_to_sftp to move_specific_files_from_sftp_to_gcs

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
