### PR TITLE
Temporarily limit botocore upgrades

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1132,7 +1132,10 @@ if [[ ${UPGRADE_BOTO=} == "true" ]]; then
     echo "${COLOR_BLUE}Upgrading boto3, botocore to latest version to run Amazon tests with them${COLOR_RESET}"
     echo
     pip uninstall aiobotocore -y || true
-    pip install --upgrade boto3 botocore
+    # Temporarily limit upgrade of botocore to be less than 1.29.127
+    # in order to avoid failing on SQS tests
+    # See https://github.com/getmoto/moto/issues/6286 and https://github.com/apache/airflow/issues/31087
+    pip install --upgrade boto3 "botocore<1.29.127"
 fi
 readonly SELECTED_TESTS CLI_TESTS API_TESTS PROVIDERS_TESTS CORE_TESTS WWW_TESTS \
     ALL_TESTS ALL_PRESELECTED_TESTS

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -562,7 +562,10 @@ if [[ ${UPGRADE_BOTO=} == "true" ]]; then
     echo "${COLOR_BLUE}Upgrading boto3, botocore to latest version to run Amazon tests with them${COLOR_RESET}"
     echo
     pip uninstall aiobotocore -y || true
-    pip install --upgrade boto3 botocore
+    # Temporarily limit upgrade of botocore to be less than 1.29.127
+    # in order to avoid failing on SQS tests
+    # See https://github.com/getmoto/moto/issues/6286 and https://github.com/apache/airflow/issues/31087
+    pip install --upgrade boto3 "botocore<1.29.127"
 fi
 readonly SELECTED_TESTS CLI_TESTS API_TESTS PROVIDERS_TESTS CORE_TESTS WWW_TESTS \
     ALL_TESTS ALL_PRESELECTED_TESTS


### PR DESCRIPTION
The latest botocore (1.29.127) breaks the way moto creates SQS queues and we need to limit it temporarily so that it will not fail our tests.

Related: https://github.com/getmoto/moto/issues/6286
Related: i#31087

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
