### PR TITLE
Ensure that we check worker for served logs if no local or remote logs found

### DIFF
--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -327,7 +327,7 @@ class FileTaskHandler(logging.Handler):
         elif ti.state not in State.unfinished and not (local_logs or remote_logs):
             # ordinarily we don't check served logs, with the assumption that users set up
             # remote logging or shared drive for logs for persistence, but that's not always true
-            # so even if task is done, if no local logs or remote logs found, we'll check the worker
+            # so even if task is done, if no local logs or remote logs are found, we'll check the worker
             served_messages, served_logs = self._read_from_logs_server(ti, worker_log_rel_path)
             messages_list.extend(served_messages)
 

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -303,7 +303,6 @@ class FileTaskHandler(logging.Handler):
         worker_log_rel_path = self._render_filename(ti, try_number)
         messages_list: list[str] = []
         remote_logs: list[str] = []
-        running_logs: list[str] = []
         local_logs: list[str] = []
         executor_messages: list[str] = []
         executor_logs: list[str] = []
@@ -317,18 +316,24 @@ class FileTaskHandler(logging.Handler):
                 executor_messages, executor_logs = response
             if executor_messages:
                 messages_list.extend(messages_list)
-        if ti.state in (TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED) and not executor_messages:
-            served_messages, served_logs = self._read_from_logs_server(ti, worker_log_rel_path)
-            messages_list.extend(served_messages)
         if not (remote_logs and ti.state not in State.unfinished):
             # when finished, if we have remote logs, no need to check local
             worker_log_full_path = Path(self.local_base, worker_log_rel_path)
             local_messages, local_logs = self._read_from_local(worker_log_full_path)
             messages_list.extend(local_messages)
+        if ti.state in (TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED) and not executor_messages:
+            served_messages, served_logs = self._read_from_logs_server(ti, worker_log_rel_path)
+            messages_list.extend(served_messages)
+        elif ti.state not in State.unfinished and not (local_logs or remote_logs):
+            # ordinarily we don't check served logs, with the assumption that users set up
+            # remote logging or shared drive for logs for persistence, but that's not always true
+            # so even if task is done, if no local logs or remote logs found, we'll check the worker
+            served_messages, served_logs = self._read_from_logs_server(ti, worker_log_rel_path)
+            messages_list.extend(served_messages)
+
         logs = "\n".join(
             _interleave_logs(
                 *local_logs,
-                *running_logs,
                 *remote_logs,
                 *(executor_logs or []),
                 *served_logs,

--- a/tests/providers/amazon/aws/log/test_s3_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_s3_task_handler.py
@@ -138,6 +138,7 @@ class TestS3TaskHandler:
     def test_read_when_s3_log_missing(self):
         ti = copy.copy(self.ti)
         ti.state = TaskInstanceState.SUCCESS
+        self.s3_task_handler._read_from_logs_server = mock.Mock(return_value=([], []))
         log, metadata = self.s3_task_handler.read(ti)
         assert 1 == len(log)
         assert len(log) == len(metadata)


### PR DESCRIPTION
Generally speaking when a task is done we should not read from logs server, because we assume for log persistence that users will either set up shared drive or enable remote logging.  But if they don't do that, and therefore we don't find remote or local logs, we'll check worker for served logs as a fallback.

Resolves #31059
Possibly related #30997
Resolves #31083
