### PR TITLE
Deprecate `delimiter` param. in GCS hook & operators, and introduce `match_glob` instead

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -18,9 +18,11 @@
 """This module contains a Google Cloud Storage operator."""
 from __future__ import annotations
 
+import warnings
+from datetime import datetime
 from typing import TYPE_CHECKING, Sequence
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 
@@ -38,44 +40,47 @@ class GCSToGCSOperator(BaseOperator):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:GCSToGCSOperator`
 
-    :param source_bucket: The source Google Cloud Storage bucket where the
-         object is. (templated)
-    :param source_object: The source name of the object to copy in the Google cloud
-        storage bucket. (templated)
-        You can use only one wildcard for objects (filenames) within your
-        bucket. The wildcard can appear inside the object name or at the
-        end of the object name. Appending a wildcard to the bucket name is
-        unsupported.
-    :param source_objects: A list of source name of the objects to copy in the Google cloud
-        storage bucket. (templated)
-    :param destination_bucket: The destination Google Cloud Storage bucket
-        where the object should be. If the destination_bucket is None, it defaults
-        to source_bucket. (templated)
-    :param destination_object: The destination name of the object in the
-        destination Google Cloud Storage bucket. (templated)
-        If a wildcard is supplied in the source_object argument, this is the
-        prefix that will be prepended to the final destination objects' paths.
-        Note that the source path's part before the wildcard will be removed;
-        if it needs to be retained it should be appended to destination_object.
-        For example, with prefix ``foo/*`` and destination_object ``blah/``, the
-        file ``foo/baz`` will be copied to ``blah/baz``; to retain the prefix write
-        the destination_object as e.g. ``blah/foo``, in which case the copied file
-        will be named ``blah/foo/baz``.
-        The same thing applies to source objects inside source_objects.
-    :param move_object: When move object is True, the object is moved instead
+    :param source_bucket: The Google Cloud Storage bucket specified as the source for the transfer operation.
+        (templated)
+    :param source_object: (Deprecated) The path to an object to copy from the source bucket.
+        This parameter is deprecated and should be replaced with ``source_objects``. (templated)
+    :param source_objects:  The path to an object or a list of paths to be copied from the source bucket.
+    Paths should be relative to the bucket's name.
+    The usage of a wildcard for source objects is deprecated.
+    Until deprecation, you can only use one wildcard for objects within your bucket.
+    The wildcard can appear inside the object name or at the end of the object name.
+    Appending a wildcard to the bucket name is not supported.
+    After the deprecation is finalized, wildcards will no longer be allowed. (templated)
+    :param destination_bucket: The Google Cloud Storage bucket where the object will be copied to.
+        If the destination_bucket is set to `None`, it will default to the source_bucket. (templated)
+    :param destination_object: The name of the object in the destination Google Cloud Storage bucket.
+        The following applies until the deprecation of wildcards in the "source_object(s)" parameter is finalized:
+        If a wildcard is provided in the source_object argument, this prefix will be added to the paths of the destination objects.
+        Note that the part of the source path before the wildcard will be removed.
+        If you need to retain it, append it to the destination_object.
+        For example, with the prefix "foo/*" and destination_object "blah/",
+        the object "foo/baz" will be copied to "blah/baz".
+        To retain the prefix, specify the destination_object as "blah/foo",
+        in which case the copied object will be named "blah/foo/baz".
+        The same applies to source objects within source_objects. (templated)
+    :param move_object: When True, the object is moved instead
         of copied to the new location. This is the equivalent of a mv command
         as opposed to a cp command.
-    :param replace: Whether you want to replace existing destination files or not.
-    :param delimiter: This is used to restrict the result to only the 'files' in a given 'folder'.
-        If source_objects = ['foo/bah/'] and delimiter = '.avro', then only the 'files' in the
-        folder 'foo/bah/' with '.avro' delimiter will be copied to the destination object.
+    :param replace: It specifies whether you want to replace existing destination objects or not.
+    :param delimiter: (Deprecated) This parameter is intended to filter the source objects based on their
+        suffix (previously referred to as delimiter, which is a mistake). When the ``source_objects``
+        parameter is set to ['foo/bah/'] and the suffix is set to '.avro', only the objects within the
+        'foo/bah/' folder that have the '.avro' suffix will be copied to the destination object.
+        This parameter is deprecated as it incorrectly utilized the delimiter parameter of the list
+        command in the GCS API. Instead, filtering of the source objects should be done using the
+        ``match_glob`` parameter.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param last_modified_time: When specified, the objects will be copied or moved,
-        only if they were modified after last_modified_time.
-        If tzinfo has not been set, UTC will be assumed.
-    :param maximum_modified_time: When specified, the objects will be copied or moved,
-        only if they were modified before maximum_modified_time.
-        If tzinfo has not been set, UTC will be assumed.
+    :param last_modified_time:  It sets a lower threshold for the objects to be copied or moved.
+        Only objects modified after the specified time will be included.
+        If the timezone information (tzinfo) has not been set, UTC will be assumed.
+    :param maximum_modified_time: It sets an upper threshold for the objects to be copied or moved.
+        Only objects modified after the specified time will be included.
+        If the timezone information (tzinfo) has not been set, UTC will be assumed.
     :param is_older_than: When specified, the objects will be copied if they are older
         than the specified time in seconds.
     :param impersonation_chain: Optional service account to impersonate using short-term
@@ -83,22 +88,24 @@ class GCSToGCSOperator(BaseOperator):
         of the last account in the list, which will be impersonated in the request.
         If set as a string, the account must grant the originating account
         the Service Account Token Creator IAM role.
-        If set as a sequence, the identities from the list must grant
-        Service Account Token Creator IAM role to the directly preceding identity, with first
+        If set as a sequence, the identities from the list must grant the
+        Service Account Token Creator IAM role to the directly preceding identity, with the first
         account from the list granting this role to the originating account (templated).
     :param source_object_required: Whether you want to raise an exception when the source object
         doesn't exist. It doesn't have any effect when the source objects are folders or patterns.
-    :param exact_match: When specified, only exact match of the source object (filename) will be
+    :param exact_match: When specified, only the exact match of the source object will be
         copied.
+    :param match_glob: (Optional) filters objects based on the glob pattern given by the string (
+        e.g, ``'**/*/.json'``)
 
     :Example:
 
-    The following Operator would copy a single file named
-    ``sales/sales-2017/january.avro`` in the ``data`` bucket to the file named
+    The following Operator would copy a single object named
+    ``sales/sales-2017/january.avro`` in the ``data`` bucket to the object named
     ``copied_sales/2017/january-backup.avro`` in the ``data_backup`` bucket ::
 
-        copy_single_file = GCSToGCSOperator(
-            task_id='copy_single_file',
+        copy_single_object = GCSToGCSOperator(
+            task_id='copy_single_object',
             source_bucket='data',
             source_objects=['sales/sales-2017/january.avro'],
             destination_bucket='data_backup',
@@ -106,41 +113,31 @@ class GCSToGCSOperator(BaseOperator):
             gcp_conn_id=google_cloud_conn_id
         )
 
-    The following Operator would copy all the Avro files from ``sales/sales-2017``
-    folder (i.e. with names starting with that prefix) in ``data`` bucket to the
+    The following Operator would copy all the Avro file objects from ``sales/sales-2017``
+    path (i.e., with names starting with that prefix) in ``data`` bucket to the
     ``copied_sales/2017`` folder in the ``data_backup`` bucket. ::
 
         copy_files = GCSToGCSOperator(
-            task_id='copy_files',
+            task_id='copy_objects',
             source_bucket='data',
             source_objects=['sales/sales-2017'],
             destination_bucket='data_backup',
             destination_object='copied_sales/2017/',
-            delimiter='.avro'
+            match_glob='**/*.avro',
             gcp_conn_id=google_cloud_conn_id
         )
 
-        Or ::
-
-        copy_files = GCSToGCSOperator(
-            task_id='copy_files',
-            source_bucket='data',
-            source_object='sales/sales-2017/*.avro',
-            destination_bucket='data_backup',
-            destination_object='copied_sales/2017/',
-            gcp_conn_id=google_cloud_conn_id
-        )
-
-    The following Operator would move all the Avro files from ``sales/sales-2017``
-    folder (i.e. with names starting with that prefix) in ``data`` bucket to the
+    The following Operator would move all the Avro objects from ``sales/sales-2017``
+    folder (i.e., with names starting with that prefix) in ``data`` bucket to the
     same folder in the ``data_backup`` bucket, deleting the original files in the
     process. ::
 
         move_files = GCSToGCSOperator(
             task_id='move_files',
             source_bucket='data',
-            source_object='sales/sales-2017/*.avro',
+            source_objects='sales/sales-2017/',
             destination_bucket='data_backup',
+            match_glob='**/*.avro',
             move_object=True,
             gcp_conn_id=google_cloud_conn_id
         )
@@ -154,7 +151,7 @@ class GCSToGCSOperator(BaseOperator):
             source_bucket='data',
             source_objects=['sales/sales-2019/*.avro', 'sales/sales-2020'],
             destination_bucket='data_backup',
-            delimiter='.avro',
+            match_glob='**/*.avro',
             move_object=True,
             gcp_conn_id=google_cloud_conn_id
         )
@@ -168,6 +165,7 @@ class GCSToGCSOperator(BaseOperator):
         "destination_bucket",
         "destination_object",
         "delimiter",
+        "match_glob",
         "impersonation_chain",
     )
     ui_color = "#f0eee4"
@@ -175,31 +173,64 @@ class GCSToGCSOperator(BaseOperator):
     def __init__(
         self,
         *,
-        source_bucket,
-        source_object=None,
-        source_objects=None,
-        destination_bucket=None,
-        destination_object=None,
-        delimiter=None,
-        move_object=False,
-        replace=True,
-        gcp_conn_id="google_cloud_default",
-        last_modified_time=None,
-        maximum_modified_time=None,
-        is_older_than=None,
+        source_bucket: str,
+        source_object: str | None = None,
+        source_objects: str | list[str] | None = None,
+        destination_bucket: str | None = None,
+        destination_object: str | None = None,
+        delimiter: str | None = None,
+        move_object: bool = False,
+        replace: bool = True,
+        gcp_conn_id: str = "google_cloud_default",
+        last_modified_time: datetime | None = None,
+        maximum_modified_time: datetime | None = None,
+        is_older_than: int | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
-        source_object_required=False,
-        exact_match=False,
+        source_object_required: bool = False,
+        exact_match: bool = False,
+        match_glob: str | None = None,
         **kwargs,
     ):
+        self.delimiter = delimiter
+        if self.delimiter:
+            warnings.warn(
+                "Usage of 'delimiter' is deprecated, please use 'match_glob' instead",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
+            match_glob = match_glob if match_glob else f"**/*{self.delimiter}"
         super().__init__(**kwargs)
-
         self.source_bucket = source_bucket
         self.source_object = source_object
-        self.source_objects = source_objects
+        if self.source_object:
+            warnings.warn(
+                "Usage of 'source_object' param is deprecated, use 'source_objects' instead",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
+            source_objects = source_objects if source_objects else self.source_object
+        if isinstance(source_objects, list) and any([WILDCARD in obj for obj in source_objects]):
+            warnings.warn(
+                "Usage of wildcard (*) in 'source_objects' is deprecated, utilize match_glob " "instead",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
+        if isinstance(source_objects, list) and not all([isinstance(item, str) for item in source_objects]):
+            raise RuntimeError("At least, one of the `objects` in the `source_objects` is not a string")
+        if not source_objects:
+            self.log.info("'source_objects' is empty. Copying all files.")
+            source_objects = [""]
+        self.source_objects = [source_objects] if isinstance(source_objects, str) else source_objects
+        if not destination_bucket:
+            self.log.info(
+                "destination_bucket is None. Defaulting it to source_bucket (%s)", self.source_bucket
+            )
+            destination_bucket = source_bucket
         self.destination_bucket = destination_bucket
         self.destination_object = destination_object
-        self.delimiter = delimiter
+        if delimiter:
+            self.match_glob: str | None = f"**/*{delimiter}"
+        self.match_glob = match_glob
         self.move_object = move_object
         self.replace = replace
         self.gcp_conn_id = gcp_conn_id
@@ -211,35 +242,10 @@ class GCSToGCSOperator(BaseOperator):
         self.exact_match = exact_match
 
     def execute(self, context: Context):
-
         hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
         )
-        if self.source_objects and self.source_object:
-            error_msg = (
-                f"You can either set source_object parameter or source_objects parameter but not both. "
-                f"Found source_object={self.source_object} and source_objects={self.source_objects}"
-            )
-            raise AirflowException(error_msg)
-
-        if not self.source_object and not self.source_objects:
-            error_msg = "You must set source_object parameter or source_objects parameter. None set"
-            raise AirflowException(error_msg)
-
-        if self.source_objects and not all(isinstance(item, str) for item in self.source_objects):
-            raise AirflowException("At least, one of the `objects` in the `source_objects` is not a string")
-
-        # If source_object is set, default it to source_objects
-        if self.source_object:
-            self.source_objects = [self.source_object]
-
-        if self.destination_bucket is None:
-            self.log.warning(
-                "destination_bucket is None. Defaulting it to source_bucket (%s)", self.source_bucket
-            )
-            self.destination_bucket = self.source_bucket
-
         # An empty source_object means to copy all files
         if len(self.source_objects) == 0:
             self.source_objects = [""]
@@ -247,45 +253,44 @@ class GCSToGCSOperator(BaseOperator):
         if self.source_objects.count("") > 1:
             raise AirflowException("You can't have two empty strings inside source_object")
 
-        # Iterate over the source_objects and do the copy
         for prefix in self.source_objects:
-            # Check if prefix contains wildcard
             if WILDCARD in prefix:
                 self._copy_source_with_wildcard(hook=hook, prefix=prefix)
-            # Now search with prefix using provided delimiter if any
             else:
                 self._copy_source_without_wildcard(hook=hook, prefix=prefix)
 
-    def _ignore_existing_files(self, hook, prefix, **kwargs):
-        # list all files in the Destination GCS bucket
-        # and only keep those files which are present in
-        # Source GCS bucket and not in Destination GCS bucket
-        delimiter = kwargs.get("delimiter")
-        objects = kwargs.get("objects")
+    def _ignore_existing_files(self, hook: GCSHook, prefix: str, objects: list[str]):
+        """
+        List all files in the Destination GCS bucket
+        and only keep those files which are present in
+        Source GCS bucket and not in Destination GCS bucket
+        """
         if self.destination_object is None:
-            existing_objects = hook.list(self.destination_bucket, prefix=prefix, delimiter=delimiter)
+            existing_objects = hook.list(
+                bucket_name=self.destination_bucket, prefix=prefix, match_glob=self.match_glob
+            )
         else:
             self.log.info("Replaced destination_object with source_object prefix.")
             destination_objects = hook.list(
-                self.destination_bucket,
+                bucket_name=self.destination_bucket,
                 prefix=self.destination_object,
-                delimiter=delimiter,
+                match_glob=self.match_glob,
             )
             existing_objects = [
                 dest_object.replace(self.destination_object, prefix, 1) for dest_object in destination_objects
             ]
 
-        objects = set(objects) - set(existing_objects)
+        objects = list(set(objects) - set(existing_objects))
         if len(objects) > 0:
             self.log.info("%s files are going to be synced: %s.", len(objects), objects)
         else:
             self.log.info("There are no new files to sync. Have a nice day!")
         return objects
 
-    def _copy_source_without_wildcard(self, hook, prefix):
+    def _copy_source_without_wildcard(self, hook: GCSHook, prefix: str):
         """
         For source_objects with no wildcard, this operator would first list
-        all files in source_objects, using provided delimiter if any. Then copy
+        all files in source_objects, using provided match_glob if any. Then copy
         files from source_objects to destination_object and rename each source
         file.
 
@@ -297,7 +302,7 @@ class GCSToGCSOperator(BaseOperator):
         the ``data_backup`` bucket (b/a.csv, b/b.csv, b/c.csv) ::
 
             copy_files = GCSToGCSOperator(
-                task_id='copy_files_without_wildcard',
+                task_id='copy_files_single_dir',
                 source_bucket='data',
                 source_objects=['a/'],
                 destination_bucket='data_backup',
@@ -318,7 +323,7 @@ class GCSToGCSOperator(BaseOperator):
                 source_objects=['a/'],
                 destination_bucket='data_backup',
                 destination_object='b/',
-                delimiter='.avro',
+                match_glob='**/*/.avro',
                 gcp_conn_id=google_cloud_conn_id
             )
 
@@ -338,16 +343,13 @@ class GCSToGCSOperator(BaseOperator):
                 gcp_conn_id=google_cloud_conn_id
             )
         """
-        objects = hook.list(self.source_bucket, prefix=prefix, delimiter=self.delimiter)
+        objects = hook.list(bucket_name=self.source_bucket, prefix=prefix, match_glob=self.match_glob)
 
         if not self.replace:
-            # If we are not replacing, ignore files already existing in source buckets
-            objects = self._ignore_existing_files(hook, prefix, objects=objects, delimiter=self.delimiter)
+            objects = self._ignore_existing_files(hook=hook, prefix=prefix, objects=objects)
 
-        # If objects is empty, and we have prefix, let's check if prefix is a blob
-        # and copy directly
         if len(objects) == 0 and prefix:
-            if hook.exists(self.source_bucket, prefix):
+            if hook.exists(bucket_name=self.source_bucket, object_name=prefix):
                 self._copy_single_object(
                     hook=hook, source_object=prefix, destination_object=self.destination_object
                 )
@@ -361,7 +363,7 @@ class GCSToGCSOperator(BaseOperator):
         elif len(objects):
             self._copy_directory(hook=hook, source_objects=objects, prefix=prefix)
 
-    def _copy_file(self, hook, source_object):
+    def _copy_file(self, hook: GCSHook, source_object: str):
         destination_object = self.destination_object or source_object
         if self.destination_object and self.destination_object[-1] == "/":
             file_name = source_object.split("/")[-1]
@@ -370,7 +372,7 @@ class GCSToGCSOperator(BaseOperator):
             hook=hook, source_object=source_object, destination_object=destination_object
         )
 
-    def _copy_directory(self, hook, source_objects, prefix):
+    def _copy_directory(self, hook: GCSHook, source_objects: Sequence[str], prefix: str):
         _prefix = prefix.rstrip("/") + "/"
         for source_obj in source_objects:
             if self.exact_match and (source_obj != prefix or not source_obj.endswith(prefix)):
@@ -385,7 +387,7 @@ class GCSToGCSOperator(BaseOperator):
                 hook=hook, source_object=source_obj, destination_object=destination_object
             )
 
-    def _copy_source_with_wildcard(self, hook, prefix):
+    def _copy_source_with_wildcard(self, hook: GCSHook, prefix: str):
         total_wildcards = prefix.count(WILDCARD)
         if total_wildcards > 1:
             error_msg = (
@@ -395,13 +397,14 @@ class GCSToGCSOperator(BaseOperator):
 
             raise AirflowException(error_msg)
         self.log.info("Delimiter ignored because wildcard is in prefix")
-        prefix_, delimiter = prefix.split(WILDCARD, 1)
-        objects = hook.list(self.source_bucket, prefix=prefix_, delimiter=delimiter)
+        prefix_, suffix = prefix.split(WILDCARD, 1)
+        match_glob = f"**/*{suffix}" if suffix else None
+        objects = hook.list(bucket_name=self.source_bucket, prefix=prefix_, match_glob=match_glob)
         if not self.replace:
             # If we are not replacing, list all files in the Destination GCS bucket
             # and only keep those files which are present in
             # Source GCS bucket and not in Destination GCS bucket
-            objects = self._ignore_existing_files(hook, prefix_, delimiter=delimiter, objects=objects)
+            objects = self._ignore_existing_files(hook=hook, prefix=prefix_, objects=objects)
 
         for source_object in objects:
             if self.destination_object is None:
@@ -413,7 +416,7 @@ class GCSToGCSOperator(BaseOperator):
                 hook=hook, source_object=source_object, destination_object=destination_object
             )
 
-    def _copy_single_object(self, hook, source_object, destination_object):
+    def _copy_single_object(self, hook: GCSHook, source_object: str, destination_object: str | None):
         if self.is_older_than:
             # Here we check if the given object is older than the given time
             # If given, last_modified_time and maximum_modified_time is ignored

--- a/airflow/providers/google/cloud/transfers/gcs_to_sftp.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_sftp.py
@@ -143,10 +143,11 @@ class GCSToSFTPOperator(BaseOperator):
                     f"Found {total_wildcards} in {self.source_object}."
                 )
 
-            prefix, delimiter = self.source_object.split(WILDCARD, 1)
+            prefix, suffix = self.source_object.split(WILDCARD, 1)
+            match_glob = f"**/*{suffix}" if suffix else None
             prefix_dirname = os.path.dirname(prefix)
 
-            objects = gcs_hook.list(self.source_bucket, prefix=prefix, delimiter=delimiter)
+            objects = gcs_hook.list(bucket_name=self.source_bucket, prefix=prefix, match_glob=match_glob)
 
             for source_object in objects:
                 destination_path = self._resolve_destination_path(source_object, prefix=prefix_dirname)

--- a/airflow/providers/google/suite/transfers/gcs_to_gdrive.py
+++ b/airflow/providers/google/suite/transfers/gcs_to_gdrive.py
@@ -130,8 +130,9 @@ class GCSToGoogleDriveOperator(BaseOperator):
 
                 raise AirflowException(error_msg)
 
-            prefix, delimiter = self.source_object.split(WILDCARD, 1)
-            objects = self.gcs_hook.list(self.source_bucket, prefix=prefix, delimiter=delimiter)
+            prefix, suffix = self.source_object.split(WILDCARD, 1)
+            match_glob = f"**/*{suffix}" if suffix else None
+            objects = self.gcs_hook.list(self.source_bucket, prefix=prefix, match_glob=match_glob)
 
             for source_object in objects:
                 if self.destination_object is None:

--- a/docs/apache-airflow-providers-google/operators/transfer/gcs_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gcs_to_gcs.rst
@@ -80,13 +80,18 @@ This operator only deletes objects in the source bucket if the file move option 
 between two different buckets, this operator never deletes data in the destination bucket.
 
 When you use this operator, you can specify whether objects should be deleted from the source after
-they are transferred to the sink. Source objects can be specified using a single wildcard, as
-well as based on the file modification date.
+they are transferred to the sink. Source objects are defined as path strings relative to the bucket,
+for example: for a bucket ``my_bucket`` and an object which its absolute path is ``my_bucket/path/to/object.txt``,
+the source object should be ``path/to/object.txt``.
 
-The way this operator works by default can be compared to the ``cp`` command. When the file move option is active, this
-operator functions like the ``mv`` command.
+Filtering objects according to their path could be done by using the `the match_glob parameter <https://cloud.google.com/storage/docs/json_api/v1/objects/list#list-object-glob>`__.
+You should avoid using a wildcard in the source object's path as it is deprecated.
+Additionally, filtering could be achieved based on the file's creation date (``is_older_than``) or modification date (``last_modified_time`` and ``maximum_modified_time``).
 
-Below are examples of using the GCSToGCSOperator to copy a single file, to copy multiple files with a wild card,
+The way this operator works by default can be compared to the ``gsutil cp`` `command <https://cloud.google.com/storage/docs/gsutil/commands/cp>`__.
+When the ``move_object`` parameter is set to ``True``, this operator functions like the ``gsutil mv`` `command <https://cloud.google.com/storage/docs/gsutil/commands/mv>`__.
+
+Below are examples of using the ``GCSToGCSOperator`` to copy a single file, to copy multiple files with a wild card,
 to copy multiple files, to move a single file, and to move multiple files.
 
 Copy single file
@@ -118,8 +123,8 @@ folder in ``BUCKET_1_DST``, with file names unchanged.
 .. exampleinclude:: /../../tests/system/providers/google/cloud/gcs/example_gcs_to_gcs.py
     :language: python
     :dedent: 4
-    :start-after: [START howto_operator_gcs_to_gcs_delimiter]
-    :end-before: [END howto_operator_gcs_to_gcs_delimiter]
+    :start-after: [START howto_operator_gcs_to_gcs_match_glob]
+    :end-before: [END howto_operator_gcs_to_gcs_match_glob]
 
 For source_objects with no wildcard, all files in source_objects would be listed, using provided delimiter if any.
 Then copy files from source_objects to destination_object and rename each source file.
@@ -133,7 +138,7 @@ the ``BUCKET_1_SRC`` GCS bucket to the ``backup/`` folder in ``BUCKET_1_DST`` bu
     :start-after: [START howto_operator_gcs_to_gcs_without_wildcard]
     :end-before: [END howto_operator_gcs_to_gcs_without_wildcard]
 
-The delimiter filed may be specified to select any source files starting with ``source_object`` and ending with the
+The delimiter field may be specified to select any source files starting with ``source_object`` and ending with the
 value supplied to ``delimiter``. This example uses the ``delimiter`` value to implement the same functionality as the
 prior example.
 

--- a/tests/providers/google/cloud/hooks/test_gcs.py
+++ b/tests/providers/google/cloud/hooks/test_gcs.py
@@ -763,16 +763,32 @@ class TestGCSHook:
         (
             (
                 "prefix",
-                [mock.call(delimiter=",", prefix="prefix", versions=None, max_results=None, page_token=None)],
+                [
+                    mock.call(
+                        match_glob="**/*.json",
+                        prefix="prefix",
+                        versions=None,
+                        max_results=None,
+                        page_token=None,
+                    )
+                ],
             ),
             (
                 ["prefix", "prefix_2"],
                 [
                     mock.call(
-                        delimiter=",", prefix="prefix", versions=None, max_results=None, page_token=None
+                        match_glob="**/*.json",
+                        prefix="prefix",
+                        versions=None,
+                        max_results=None,
+                        page_token=None,
                     ),
                     mock.call(
-                        delimiter=",", prefix="prefix_2", versions=None, max_results=None, page_token=None
+                        match_glob="**/*.json",
+                        prefix="prefix_2",
+                        versions=None,
+                        max_results=None,
+                        page_token=None,
                     ),
                 ],
             ),
@@ -784,8 +800,55 @@ class TestGCSHook:
         self.gcs_hook.list(
             bucket_name="test_bucket",
             prefix=prefix,
-            delimiter=",",
+            match_glob="**/*.json",
         )
+        assert mock_service.return_value.bucket.return_value.list_blobs.call_args_list == result
+
+    @pytest.mark.parametrize(
+        "prefix, result",
+        (
+            (
+                "prefix",
+                [
+                    mock.call(
+                        match_glob="**/*.json",
+                        prefix="prefix",
+                        versions=None,
+                        max_results=None,
+                        page_token=None,
+                    )
+                ],
+            ),
+            (
+                ["prefix", "prefix_2"],
+                [
+                    mock.call(
+                        match_glob="**/*.json",
+                        prefix="prefix",
+                        versions=None,
+                        max_results=None,
+                        page_token=None,
+                    ),
+                    mock.call(
+                        match_glob="**/*.json",
+                        prefix="prefix_2",
+                        versions=None,
+                        max_results=None,
+                        page_token=None,
+                    ),
+                ],
+            ),
+        ),
+    )
+    @mock.patch(GCS_STRING.format("GCSHook.get_conn"))
+    def test_list__deprecated_delimiter(self, mock_service, prefix, result):
+        mock_service.return_value.bucket.return_value.list_blobs.return_value.next_page_token = None
+        with pytest.deprecated_call():
+            self.gcs_hook.list(
+                bucket_name="test_bucket",
+                prefix=prefix,
+                delimiter=".json",
+            )
         assert mock_service.return_value.bucket.return_value.list_blobs.call_args_list == result
 
     @mock.patch(GCS_STRING.format("GCSHook.get_conn"))

--- a/tests/providers/google/cloud/operators/test_gcs.py
+++ b/tests/providers/google/cloud/operators/test_gcs.py
@@ -36,7 +36,7 @@ from airflow.providers.google.cloud.operators.gcs import (
 TASK_ID = "test-gcs-operator"
 TEST_BUCKET = "test-bucket"
 TEST_PROJECT = "test-project"
-DELIMITER = ".csv"
+SUFFIX = ".csv"
 PREFIX = "TEST"
 PREFIX_2 = "TEST2"
 MOCK_FILES = ["TEST1.csv", "TEST2.csv", "TEST3.csv", "OTHERTEST1.csv"]
@@ -162,11 +162,11 @@ class TestGoogleCloudStorageListOperator:
     def test_execute(self, mock_hook):
         mock_hook.return_value.list.return_value = MOCK_FILES
         operator = GCSListObjectsOperator(
-            task_id=TASK_ID, bucket=TEST_BUCKET, prefix=PREFIX, delimiter=DELIMITER
+            task_id=TASK_ID, bucket=TEST_BUCKET, prefix=PREFIX, match_glob=f"**/*{SUFFIX}"
         )
         files = operator.execute(context=mock.MagicMock())
         mock_hook.return_value.list.assert_called_once_with(
-            bucket_name=TEST_BUCKET, prefix=PREFIX, delimiter=DELIMITER
+            bucket_name=TEST_BUCKET, prefix=PREFIX, match_glob=f"**/*{SUFFIX}"
         )
         assert sorted(files) == sorted(MOCK_FILES)
 

--- a/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
@@ -120,12 +120,12 @@ class TestGoogleCloudStorageToSFTPOperator:
         gcs_hook_mock.return_value.delete.assert_called_once_with(TEST_BUCKET, source_object)
 
     @pytest.mark.parametrize(
-        "source_object, prefix, delimiter, gcs_files_list, target_objects, keep_directory_structure",
+        "source_object, prefix, match_glob, gcs_files_list, target_objects, keep_directory_structure",
         [
             (
                 "folder/test_object*.txt",
                 "folder/test_object",
-                ".txt",
+                "**/*.txt",
                 [
                     "folder/test_object/file1.txt",
                     "folder/test_object/file2.txt",
@@ -136,7 +136,7 @@ class TestGoogleCloudStorageToSFTPOperator:
             (
                 "folder/test_object/*",
                 "folder/test_object/",
-                "",
+                None,
                 [
                     "folder/test_object/file1.txt",
                     "folder/test_object/file2.txt",
@@ -147,7 +147,7 @@ class TestGoogleCloudStorageToSFTPOperator:
             (
                 "folder/test_object*.txt",
                 "folder/test_object",
-                ".txt",
+                "**/*.txt",
                 [
                     "folder/test_object/file1.txt",
                     "folder/test_object/file2.txt",
@@ -158,7 +158,7 @@ class TestGoogleCloudStorageToSFTPOperator:
             (
                 "folder/test_object/*",
                 "folder/test_object/",
-                "",
+                None,
                 [
                     "folder/test_object/file1.txt",
                     "folder/test_object/file2.txt",
@@ -176,7 +176,7 @@ class TestGoogleCloudStorageToSFTPOperator:
         gcs_hook_mock,
         source_object,
         prefix,
-        delimiter,
+        match_glob,
         gcs_files_list,
         target_objects,
         keep_directory_structure,
@@ -194,7 +194,9 @@ class TestGoogleCloudStorageToSFTPOperator:
         )
         operator.execute(None)
 
-        gcs_hook_mock.return_value.list.assert_called_with(TEST_BUCKET, delimiter=delimiter, prefix=prefix)
+        gcs_hook_mock.return_value.list.assert_called_with(
+            bucket_name=TEST_BUCKET, match_glob=match_glob, prefix=prefix
+        )
 
         gcs_hook_mock.return_value.download.assert_has_calls(
             [
@@ -212,12 +214,12 @@ class TestGoogleCloudStorageToSFTPOperator:
         gcs_hook_mock.return_value.delete.assert_not_called()
 
     @pytest.mark.parametrize(
-        "source_object, prefix, delimiter, gcs_files_list, target_objects, keep_directory_structure",
+        "source_object, prefix, match_glob, gcs_files_list, target_objects, keep_directory_structure",
         [
             (
                 "folder/test_object*.txt",
                 "folder/test_object",
-                ".txt",
+                "**/*.txt",
                 [
                     "folder/test_object/file1.txt",
                     "folder/test_object/file2.txt",
@@ -228,7 +230,7 @@ class TestGoogleCloudStorageToSFTPOperator:
             (
                 "folder/test_object/*",
                 "folder/test_object/",
-                "",
+                None,
                 [
                     "folder/test_object/file1.txt",
                     "folder/test_object/file2.txt",
@@ -239,7 +241,7 @@ class TestGoogleCloudStorageToSFTPOperator:
             (
                 "folder/test_object*.txt",
                 "folder/test_object",
-                ".txt",
+                "**/*.txt",
                 [
                     "folder/test_object/file1.txt",
                     "folder/test_object/file2.txt",
@@ -250,7 +252,7 @@ class TestGoogleCloudStorageToSFTPOperator:
             (
                 "folder/test_object/*",
                 "folder/test_object/",
-                "",
+                None,
                 [
                     "folder/test_object/file1.txt",
                     "folder/test_object/file2.txt",
@@ -268,7 +270,7 @@ class TestGoogleCloudStorageToSFTPOperator:
         gcs_hook_mock,
         source_object,
         prefix,
-        delimiter,
+        match_glob,
         gcs_files_list,
         target_objects,
         keep_directory_structure,
@@ -286,7 +288,9 @@ class TestGoogleCloudStorageToSFTPOperator:
         )
         operator.execute(None)
 
-        gcs_hook_mock.return_value.list.assert_called_with(TEST_BUCKET, delimiter=delimiter, prefix=prefix)
+        gcs_hook_mock.return_value.list.assert_called_with(
+            bucket_name=TEST_BUCKET, match_glob=match_glob, prefix=prefix
+        )
 
         gcs_hook_mock.return_value.download.assert_has_calls(
             [

--- a/tests/system/providers/google/cloud/gcs/example_gcs_to_gcs.py
+++ b/tests/system/providers/google/cloud/gcs/example_gcs_to_gcs.py
@@ -142,42 +142,32 @@ with models.DAG(
     )
     # [END howto_operator_gcs_to_gcs_single_file]
 
-    # [START howto_operator_gcs_to_gcs_wildcard]
-    copy_files_with_wildcard = GCSToGCSOperator(
-        task_id="copy_files_with_wildcard",
-        source_bucket=BUCKET_NAME_SRC,
-        source_object="data/*.txt",
-        destination_bucket=BUCKET_NAME_DST,
-        destination_object="backup/",
-    )
-    # [END howto_operator_gcs_to_gcs_wildcard]
-
-    # [START howto_operator_gcs_to_gcs_without_wildcard]
-    copy_files_without_wildcard = GCSToGCSOperator(
-        task_id="copy_files_without_wildcard",
+    # [START howto_operator_gcs_to_gcs_single_dir]
+    copy_files = GCSToGCSOperator(
+        task_id="copy_files_gcs_dir",
         source_bucket=BUCKET_NAME_SRC,
         source_object="subdir/",
         destination_bucket=BUCKET_NAME_DST,
         destination_object="backup/",
     )
-    # [END howto_operator_gcs_to_gcs_without_wildcard]
+    # [END howto_operator_gcs_to_gcs_single_dir]
 
-    # [START howto_operator_gcs_to_gcs_delimiter]
-    copy_files_with_delimiter = GCSToGCSOperator(
-        task_id="copy_files_with_delimiter",
+    # [START howto_operator_gcs_to_gcs_match_glob]
+    copy_files_with_match_glob = GCSToGCSOperator(
+        task_id="copy_files_with_match_glob",
         source_bucket=BUCKET_NAME_SRC,
         source_object="data/",
         destination_bucket=BUCKET_NAME_DST,
         destination_object="backup/",
-        delimiter=".txt",
+        match_glob="**/*.txt",
     )
-    # [END howto_operator_gcs_to_gcs_delimiter]
+    # [END howto_operator_gcs_to_gcs_match_glob]
 
     # [START howto_operator_gcs_to_gcs_list]
     copy_files_with_list = GCSToGCSOperator(
         task_id="copy_files_with_list",
         source_bucket=BUCKET_NAME_SRC,
-        source_objects=[OBJECT_1, OBJECT_2],  # Instead of files each element could be a wildcard expression
+        source_objects=[OBJECT_1, OBJECT_2],
         destination_bucket=BUCKET_NAME_DST,
         destination_object="backup/",
     )
@@ -223,9 +213,8 @@ with models.DAG(
         sync_to_subdirectory,
         sync_from_subdirectory,
         copy_single_file,
-        copy_files_with_wildcard,
-        copy_files_without_wildcard,
-        copy_files_with_delimiter,
+        copy_files,
+        copy_files_with_match_glob,
         copy_files_with_list,
         move_single_file,
         move_files_with_list,


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
---
closes: #29115
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
