### PR TITLE
`CreateBatchPredictionJobOperator` Add batch_size param for Vertex AI BatchPredictionJob objects

### DIFF
--- a/airflow/providers/google/cloud/hooks/vertex_ai/batch_prediction_job.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/batch_prediction_job.py
@@ -216,7 +216,7 @@ class BatchPredictionJobHook(GoogleBaseHook):
             when setting this parameter, higher value speeds up the batch operation's execution,
             but too high value will result in a whole batch not fitting in a machine's memory,
             and the whole operation will fail.
-            The default value is 64.
+            The default value is same as in the aiplatform's BatchPredictionJob.
         """
         self._batch_prediction_job = BatchPredictionJob.create(
             job_display_name=job_display_name,

--- a/airflow/providers/google/cloud/hooks/vertex_ai/batch_prediction_job.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/batch_prediction_job.py
@@ -210,7 +210,8 @@ class BatchPredictionJobHook(GoogleBaseHook):
             concurrent Future and any downstream object will be immediately returned and synced when the
             Future has completed.
         :param create_request_timeout: Optional. The timeout for the create request in seconds.
-        :param batch_size: Optional. The number of the records (e.g. instances) of the operation given in each batch
+        :param batch_size: Optional. The number of the records (e.g. instances)
+            of the operation given in each batch
             to a machine replica. Machine type, and size of a single record should be considered
             when setting this parameter, higher value speeds up the batch operation's execution,
             but too high value will result in a whole batch not fitting in a machine's memory,

--- a/airflow/providers/google/cloud/hooks/vertex_ai/batch_prediction_job.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/batch_prediction_job.py
@@ -209,8 +209,8 @@ class BatchPredictionJobHook(GoogleBaseHook):
         :param sync: Whether to execute this method synchronously. If False, this method will be executed in
             concurrent Future and any downstream object will be immediately returned and synced when the
             Future has completed.
-        :param create_request_timeout: The timeout for the create request in seconds.
-        :param batch_size: The number of the records (e.g. instances) of the operation given in each batch
+        :param create_request_timeout: Optional. The timeout for the create request in seconds.
+        :param batch_size: Optional. The number of the records (e.g. instances) of the operation given in each batch
             to a machine replica. Machine type, and size of a single record should be considered
             when setting this parameter, higher value speeds up the batch operation's execution,
             but too high value will result in a whole batch not fitting in a machine's memory,

--- a/airflow/providers/google/cloud/hooks/vertex_ai/batch_prediction_job.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/batch_prediction_job.py
@@ -114,6 +114,8 @@ class BatchPredictionJobHook(GoogleBaseHook):
         labels: dict[str, str] | None = None,
         encryption_spec_key_name: str | None = None,
         sync: bool = True,
+        create_request_timeout: float | None = None,
+        batch_size: int | None = None,
     ) -> BatchPredictionJob:
         """
         Create a batch prediction job.
@@ -207,6 +209,13 @@ class BatchPredictionJobHook(GoogleBaseHook):
         :param sync: Whether to execute this method synchronously. If False, this method will be executed in
             concurrent Future and any downstream object will be immediately returned and synced when the
             Future has completed.
+        :param create_request_timeout: The timeout for the create request in seconds.
+        :param batch_size: The number of the records (e.g. instances) of the operation given in each batch
+            to a machine replica. Machine type, and size of a single record should be considered
+            when setting this parameter, higher value speeds up the batch operation's execution,
+            but too high value will result in a whole batch not fitting in a machine's memory,
+            and the whole operation will fail.
+            The default value is 64.
         """
         self._batch_prediction_job = BatchPredictionJob.create(
             job_display_name=job_display_name,
@@ -232,6 +241,8 @@ class BatchPredictionJobHook(GoogleBaseHook):
             credentials=self.get_credentials(),
             encryption_spec_key_name=encryption_spec_key_name,
             sync=sync,
+            create_request_timeout=create_request_timeout,
+            batch_size=batch_size,
         )
         return self._batch_prediction_job
 

--- a/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
@@ -139,6 +139,13 @@ class CreateBatchPredictionJobOperator(GoogleCloudBaseOperator):
     :param sync: Whether to execute this method synchronously. If False, this method will be executed in
         concurrent Future and any downstream object will be immediately returned and synced when the
         Future has completed.
+    :param create_request_timeout: The timeout for the create request in seconds.
+    :param batch_size: The number of the records (e.g. instances) of the operation given in each batch
+        to a machine replica. Machine type, and size of a single record should be considered
+        when setting this parameter, higher value speeds up the batch operation's execution,
+        but too high value will result in a whole batch not fitting in a machine's memory,
+        and the whole operation will fail.
+        The default value is 64.
     :param retry: Designation of what errors, if any, should be retried.
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
@@ -181,6 +188,8 @@ class CreateBatchPredictionJobOperator(GoogleCloudBaseOperator):
         labels: dict[str, str] | None = None,
         encryption_spec_key_name: str | None = None,
         sync: bool = True,
+        create_request_timeout: float | None = None,
+        batch_size: int | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
@@ -208,6 +217,8 @@ class CreateBatchPredictionJobOperator(GoogleCloudBaseOperator):
         self.labels = labels
         self.encryption_spec_key_name = encryption_spec_key_name
         self.sync = sync
+        self.create_request_timeout = create_request_timeout
+        self.batch_size = batch_size
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
         self.hook: BatchPredictionJobHook | None = None
@@ -241,6 +252,8 @@ class CreateBatchPredictionJobOperator(GoogleCloudBaseOperator):
             labels=self.labels,
             encryption_spec_key_name=self.encryption_spec_key_name,
             sync=self.sync,
+            create_request_timeout=self.create_request_timeout,
+            batch_size=self.batch_size,
         )
 
         batch_prediction_job = result.to_dict()

--- a/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
@@ -139,8 +139,8 @@ class CreateBatchPredictionJobOperator(GoogleCloudBaseOperator):
     :param sync: Whether to execute this method synchronously. If False, this method will be executed in
         concurrent Future and any downstream object will be immediately returned and synced when the
         Future has completed.
-    :param create_request_timeout: The timeout for the create request in seconds.
-    :param batch_size: The number of the records (e.g. instances) of the operation given in each batch
+    :param create_request_timeout: Optional. The timeout for the create request in seconds.
+    :param batch_size: Optional. The number of the records (e.g. instances) of the operation given in each batch
         to a machine replica. Machine type, and size of a single record should be considered
         when setting this parameter, higher value speeds up the batch operation's execution,
         but too high value will result in a whole batch not fitting in a machine's memory,

--- a/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
@@ -146,7 +146,7 @@ class CreateBatchPredictionJobOperator(GoogleCloudBaseOperator):
         when setting this parameter, higher value speeds up the batch operation's execution,
         but too high value will result in a whole batch not fitting in a machine's memory,
         and the whole operation will fail.
-        The default value is 64.
+        The default value is same as in the aiplatform's BatchPredictionJob.
     :param retry: Designation of what errors, if any, should be retried.
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.

--- a/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
@@ -140,7 +140,8 @@ class CreateBatchPredictionJobOperator(GoogleCloudBaseOperator):
         concurrent Future and any downstream object will be immediately returned and synced when the
         Future has completed.
     :param create_request_timeout: Optional. The timeout for the create request in seconds.
-    :param batch_size: Optional. The number of the records (e.g. instances) of the operation given in each batch
+    :param batch_size: Optional. The number of the records (e.g. instances)
+        of the operation given in each batch
         to a machine replica. Machine type, and size of a single record should be considered
         when setting this parameter, higher value speeds up the batch operation's execution,
         but too high value will result in a whole batch not fitting in a machine's memory,

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -95,7 +95,7 @@ dependencies:
   - google-api-python-client>=1.6.0,<2.0.0
   - google-auth>=1.0.0
   - google-auth-httplib2>=0.0.1
-  - google-cloud-aiplatform>=1.7.1,<2.0.0
+  - google-cloud-aiplatform>=1.13.1,<2.0.0
   - google-cloud-automl>=2.1.0
   - google-cloud-bigquery-datatransfer>=3.0.0
   - google-cloud-bigtable>=2.0.0,<3.0.0

--- a/docs/apache-airflow-providers-google/index.rst
+++ b/docs/apache-airflow-providers-google/index.rst
@@ -115,7 +115,7 @@ PIP package                              Version required
 ``google-api-python-client``             ``>=1.6.0,<2.0.0``
 ``google-auth``                          ``>=1.0.0``
 ``google-auth-httplib2``                 ``>=0.0.1``
-``google-cloud-aiplatform``              ``>=1.7.1,<2.0.0``
+``google-cloud-aiplatform``              ``>=1.13.1,<2.0.0``
 ``google-cloud-automl``                  ``>=2.1.0``
 ``google-cloud-bigquery-datatransfer``   ``>=3.0.0``
 ``google-cloud-bigtable``                ``>=2.0.0,<3.0.0``

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -346,7 +346,7 @@
       "google-auth-httplib2>=0.0.1",
       "google-auth-oauthlib<1.0.0,>=0.3.0",
       "google-auth>=1.0.0",
-      "google-cloud-aiplatform>=1.7.1,<2.0.0",
+      "google-cloud-aiplatform>=1.13.1,<2.0.0",
       "google-cloud-automl>=2.1.0",
       "google-cloud-bigquery-datatransfer>=3.0.0",
       "google-cloud-bigtable>=2.0.0,<3.0.0",

--- a/tests/providers/google/cloud/operators/test_vertex_ai.py
+++ b/tests/providers/google/cloud/operators/test_vertex_ai.py
@@ -165,6 +165,9 @@ TEST_OUTPUT_CONFIG = {
     "export_format_id": "tf-saved-model",
 }
 
+TEST_CREATE_REQUEST_TIMEOUT = 100.5
+TEST_BATCH_SIZE = 4000
+
 
 class TestVertexAICreateCustomContainerTrainingJobOperator:
     @mock.patch(VERTEX_AI_PATH.format("custom_job.CustomJobHook"))
@@ -989,6 +992,8 @@ class TestVertexAICreateBatchPredictionJobOperator:
             model_name=TEST_MODEL_NAME,
             instances_format="jsonl",
             predictions_format="jsonl",
+            create_request_timeout=TEST_CREATE_REQUEST_TIMEOUT,
+            batch_size=TEST_BATCH_SIZE,
         )
         op.execute(context={"ti": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
@@ -1015,6 +1020,8 @@ class TestVertexAICreateBatchPredictionJobOperator:
             labels=None,
             encryption_spec_key_name=None,
             sync=True,
+            create_request_timeout=TEST_CREATE_REQUEST_TIMEOUT,
+            batch_size=TEST_BATCH_SIZE,
         )
 
 


### PR DESCRIPTION
# Add batch_size param for Vertex AI BatchPredictionJob objects.

Vertex AI python sdk has [BatchPredictionJob.create method](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform.BatchPredictionJob#google_cloud_aiplatform_BatchPredictionJob_create), introduced with [the 1.13.1 version](https://github.com/googleapis/python-aiplatform/pull/1194/files). So the PR updates with passing `batch_size` param:

- Reference to the SDK (locally on my machine the project from scratch takes 1.16, the update should be safe)
- `CreateBatchPredictionJobOperator`
- `BatchPredictionJobHook`
- Unit tests

When the `batch_size` is [introduced in 1.13](https://github.com/googleapis/python-aiplatform/commit/50bdb01504740ed31de788d8a160f3e2be7f55df),  `create_request_timeout` had already been there, so this param is also added to avoid any confuse.

The change itself is pretty simple.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
<!-- **^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
-->
