### PR TITLE
Update base_google hook supported credential types comments

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1,4 +1,4 @@
- .. Licensed to the Apache Software Foundation (ASF) under one
+TODO .. Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
     distributed with this work for additional information
     regarding copyright ownership.  The ASF licenses this file

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -527,7 +527,7 @@ class GoogleBaseHook(BaseHook):
 
         The gcloud tool allows you to login to Google Cloud only - ``gcloud auth login`` and
         for the needs of Application Default Credentials ``gcloud auth application-default login``.
-        In our case, we want all commands to use only the credentials from ADCm so
+        In our case, we want all commands to use only the credentials from ADC so
         we need to configure the credentials in gcloud manually.
         """
         credentials_path = _cloud_sdk.get_application_default_credentials_path()
@@ -539,7 +539,7 @@ class GoogleBaseHook(BaseHook):
             exit_stack.enter_context(patch_environ({CLOUD_SDK_CONFIG_DIR: gcloud_config_tmp}))
 
             if CREDENTIALS in os.environ:
-                # This solves most cases when we are logged in using the service key in Airflow.
+                # Use credentials of type `service_account`
                 # Don't display stdout/stderr for security reason
                 check_output(
                     [
@@ -550,9 +550,9 @@ class GoogleBaseHook(BaseHook):
                     ]
                 )
             elif os.path.exists(credentials_path):
-                # If we are logged in by `gcloud auth application-default` then we need to log in manually.
-                # This will make the `gcloud auth application-default` and `gcloud auth` credentials equals.
+                # Use credentials of type `authorized_user`
                 with open(credentials_path) as creds_file:
+                    # Make the `gcloud auth application-default` and `gcloud auth` credentials equals.
                     creds_content = json.loads(creds_file.read())
                     # Don't display stdout/stderr for security reason
                     check_output(["gcloud", "config", "set", "auth/client_id", creds_content["client_id"]])


### PR DESCRIPTION
When submitting a Python Apache Beam job using DataflowRunner with `BeamRunPythonPipelineOperator` having NO env. var. `GOOGLE_APPLICATION_CREDENTIALS` set will make the code rely on `gcloud auth application-default login` credentials.

Python documentation of the method is unclear whether `GOOGLE_APPLICATION_CREDENTIALS` should always point to the credential with type `service_account`, otherwise it shouldn't be set (e.g. it would be wrong to set it to credential of type `authorized_user`).

Current behaviour:
- code assumes when env. var. `GOOGLE_APPLICATION_CREDENTIALS` is set for the credential to be of type `service_account`, and fails otherwise.
- code assumes when env.var. `GOOGLE_APPLICATION_CREDENTIALS` is not set, and `gcloud config application-default login` is applied, the credential has to be of type `authorized_user`, and fails otherwise.

Expected behaviour:
Doc explicitly states what credentials types are supported.

Doc used:
- https://airflow.apache.org/docs/apache-airflow-providers-google/stable/connections/gcp.html
- https://cloud.google.com/docs/authentication#principal
- https://cloud.google.com/docs/authentication/application-default-credentials
----

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
