### PR TITLE
Add flag apply_gcs_prefix to S3ToGCSOperator

### DIFF
--- a/tests/providers/google/cloud/transfers/test_s3_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_s3_to_gcs.py
@@ -19,17 +19,39 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
+
 from airflow.providers.google.cloud.transfers.s3_to_gcs import S3ToGCSOperator
 
 TASK_ID = "test-s3-gcs-operator"
 S3_BUCKET = "test-bucket"
 S3_PREFIX = "TEST"
 S3_DELIMITER = "/"
-GCS_PATH_PREFIX = "gs://gcs-bucket/data/"
-MOCK_FILES = ["TEST1.csv", "TEST2.csv", "TEST3.csv"]
+GCS_BUCKET = "gcs-bucket"
+GCS_BUCKET_URI = "gs://" + GCS_BUCKET
+GCS_PREFIX = "data/"
+GCS_PATH_PREFIX = GCS_BUCKET_URI + "/" + GCS_PREFIX
+MOCK_FILE_1 = "TEST1.csv"
+MOCK_FILE_2 = "TEST2.csv"
+MOCK_FILE_3 = "TEST3.csv"
+MOCK_FILES = [MOCK_FILE_1, MOCK_FILE_2, MOCK_FILE_3]
 AWS_CONN_ID = "aws_default"
 GCS_CONN_ID = "google_cloud_default"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
+APPLY_GCS_PREFIX = False
+PARAMETRIZED_OBJECT_PATHS = (
+    "apply_gcs_prefix, s3_prefix, s3_object, gcs_destination, gcs_object",
+    [
+        (False, "", MOCK_FILE_1, GCS_PATH_PREFIX, GCS_PREFIX + MOCK_FILE_1),
+        (False, S3_PREFIX, MOCK_FILE_1, GCS_PATH_PREFIX, GCS_PREFIX + S3_PREFIX + MOCK_FILE_1),
+        (False, "", MOCK_FILE_1, GCS_BUCKET_URI, MOCK_FILE_1),
+        (False, S3_PREFIX, MOCK_FILE_1, GCS_BUCKET_URI, S3_PREFIX + MOCK_FILE_1),
+        (True, "", MOCK_FILE_1, GCS_PATH_PREFIX, GCS_PREFIX + MOCK_FILE_1),
+        (True, S3_PREFIX, MOCK_FILE_1, GCS_PATH_PREFIX, GCS_PREFIX + MOCK_FILE_1),
+        (True, "", MOCK_FILE_1, GCS_BUCKET_URI, MOCK_FILE_1),
+        (True, S3_PREFIX, MOCK_FILE_1, GCS_BUCKET_URI, MOCK_FILE_1),
+    ],
+)
 
 
 class TestS3ToGoogleCloudStorageOperator:
@@ -44,6 +66,7 @@ class TestS3ToGoogleCloudStorageOperator:
             gcp_conn_id=GCS_CONN_ID,
             dest_gcs=GCS_PATH_PREFIX,
             google_impersonation_chain=IMPERSONATION_CHAIN,
+            apply_gcs_prefix=APPLY_GCS_PREFIX,
         )
 
         assert operator.task_id == TASK_ID
@@ -53,6 +76,7 @@ class TestS3ToGoogleCloudStorageOperator:
         assert operator.gcp_conn_id == GCS_CONN_ID
         assert operator.dest_gcs == GCS_PATH_PREFIX
         assert operator.google_impersonation_chain == IMPERSONATION_CHAIN
+        assert operator.apply_gcs_prefix == APPLY_GCS_PREFIX
 
     @mock.patch("airflow.providers.google.cloud.transfers.s3_to_gcs.S3Hook")
     @mock.patch("airflow.providers.amazon.aws.operators.s3.S3Hook")
@@ -73,12 +97,12 @@ class TestS3ToGoogleCloudStorageOperator:
         s3_one_mock_hook.return_value.list_keys.return_value = MOCK_FILES
         s3_two_mock_hook.return_value.list_keys.return_value = MOCK_FILES
 
-        uploaded_files = operator.execute(None)
+        uploaded_files = operator.execute(context={})
         gcs_mock_hook.return_value.upload.assert_has_calls(
             [
-                mock.call("gcs-bucket", "data/TEST1.csv", mock.ANY, gzip=False),
-                mock.call("gcs-bucket", "data/TEST3.csv", mock.ANY, gzip=False),
-                mock.call("gcs-bucket", "data/TEST2.csv", mock.ANY, gzip=False),
+                mock.call(GCS_BUCKET, GCS_PREFIX + MOCK_FILE_1, mock.ANY, gzip=False),
+                mock.call(GCS_BUCKET, GCS_PREFIX + MOCK_FILE_2, mock.ANY, gzip=False),
+                mock.call(GCS_BUCKET, GCS_PREFIX + MOCK_FILE_3, mock.ANY, gzip=False),
             ],
             any_order=True,
         )
@@ -112,16 +136,118 @@ class TestS3ToGoogleCloudStorageOperator:
         s3_one_mock_hook.return_value.list_keys.return_value = MOCK_FILES
         s3_two_mock_hook.return_value.list_keys.return_value = MOCK_FILES
 
-        operator.execute(None)
+        operator.execute(context={})
         gcs_mock_hook.assert_called_once_with(
             gcp_conn_id=GCS_CONN_ID,
             impersonation_chain=None,
         )
         gcs_mock_hook.return_value.upload.assert_has_calls(
             [
-                mock.call("gcs-bucket", "data/TEST2.csv", mock.ANY, gzip=True),
-                mock.call("gcs-bucket", "data/TEST1.csv", mock.ANY, gzip=True),
-                mock.call("gcs-bucket", "data/TEST3.csv", mock.ANY, gzip=True),
+                mock.call(GCS_BUCKET, GCS_PREFIX + MOCK_FILE_1, mock.ANY, gzip=True),
+                mock.call(GCS_BUCKET, GCS_PREFIX + MOCK_FILE_2, mock.ANY, gzip=True),
+                mock.call(GCS_BUCKET, GCS_PREFIX + MOCK_FILE_3, mock.ANY, gzip=True),
             ],
             any_order=True,
         )
+
+    @pytest.mark.parametrize(
+        "source_objects, existing_objects, objects_expected",
+        [
+            (MOCK_FILES, [], MOCK_FILES),
+            (MOCK_FILES, [MOCK_FILE_1], [MOCK_FILE_2, MOCK_FILE_3]),
+            (MOCK_FILES, [MOCK_FILE_1, MOCK_FILE_2], [MOCK_FILE_3]),
+            (MOCK_FILES, [MOCK_FILE_3, MOCK_FILE_2], [MOCK_FILE_1]),
+            (MOCK_FILES, MOCK_FILES, []),
+        ],
+    )
+    @mock.patch("airflow.providers.google.cloud.transfers.s3_to_gcs.GCSHook")
+    def test_exclude_existing_objects(
+        self, mock_gcs_hook, source_objects, existing_objects, objects_expected
+    ):
+        operator = S3ToGCSOperator(
+            task_id=TASK_ID,
+            bucket=S3_BUCKET,
+            prefix=S3_PREFIX,
+            delimiter=S3_DELIMITER,
+            gcp_conn_id=GCS_CONN_ID,
+            dest_gcs=GCS_PATH_PREFIX,
+            gzip=True,
+        )
+        mock_gcs_hook.list.return_value = existing_objects
+        files_reduced = operator.exclude_existing_objects(s3_objects=source_objects, gcs_hook=mock_gcs_hook)
+        assert set(files_reduced) == set(objects_expected)
+
+    @pytest.mark.parametrize(*PARAMETRIZED_OBJECT_PATHS)
+    def test_s3_to_gcs_object(self, apply_gcs_prefix, s3_prefix, s3_object, gcs_destination, gcs_object):
+        operator = S3ToGCSOperator(
+            task_id=TASK_ID,
+            bucket=S3_BUCKET,
+            prefix=s3_prefix,
+            delimiter=S3_DELIMITER,
+            gcp_conn_id=GCS_CONN_ID,
+            dest_gcs=gcs_destination,
+            gzip=True,
+            apply_gcs_prefix=apply_gcs_prefix,
+        )
+        assert operator.s3_to_gcs_object(s3_object=s3_prefix + s3_object) == gcs_object
+
+    @pytest.mark.parametrize(*PARAMETRIZED_OBJECT_PATHS)
+    def test_gcs_to_s3_object(self, apply_gcs_prefix, s3_prefix, s3_object, gcs_destination, gcs_object):
+        operator = S3ToGCSOperator(
+            task_id=TASK_ID,
+            bucket=S3_BUCKET,
+            prefix=s3_prefix,
+            delimiter=S3_DELIMITER,
+            gcp_conn_id=GCS_CONN_ID,
+            dest_gcs=gcs_destination,
+            gzip=True,
+            apply_gcs_prefix=apply_gcs_prefix,
+        )
+        assert operator.gcs_to_s3_object(gcs_object=gcs_object) == s3_prefix + s3_object
+
+    @pytest.mark.parametrize(*PARAMETRIZED_OBJECT_PATHS)
+    @mock.patch("airflow.providers.google.cloud.transfers.s3_to_gcs.S3Hook")
+    @mock.patch("airflow.providers.amazon.aws.operators.s3.S3Hook")
+    @mock.patch("airflow.providers.google.cloud.transfers.s3_to_gcs.GCSHook")
+    def test_execute_apply_gcs_prefix(
+        self,
+        gcs_mock_hook,
+        s3_one_mock_hook,
+        s3_two_mock_hook,
+        apply_gcs_prefix,
+        s3_prefix,
+        s3_object,
+        gcs_destination,
+        gcs_object,
+    ):
+
+        operator = S3ToGCSOperator(
+            task_id=TASK_ID,
+            bucket=S3_BUCKET,
+            prefix=s3_prefix,
+            delimiter=S3_DELIMITER,
+            gcp_conn_id=GCS_CONN_ID,
+            dest_gcs=gcs_destination,
+            google_impersonation_chain=IMPERSONATION_CHAIN,
+            apply_gcs_prefix=apply_gcs_prefix,
+        )
+
+        s3_one_mock_hook.return_value.list_keys.return_value = [s3_prefix + s3_object]
+        s3_two_mock_hook.return_value.list_keys.return_value = [s3_prefix + s3_object]
+
+        uploaded_files = operator.execute(context={})
+        gcs_mock_hook.return_value.upload.assert_has_calls(
+            [
+                mock.call(GCS_BUCKET, gcs_object, mock.ANY, gzip=False),
+            ],
+            any_order=True,
+        )
+
+        s3_one_mock_hook.assert_called_once_with(aws_conn_id=AWS_CONN_ID, verify=None)
+        s3_two_mock_hook.assert_called_once_with(aws_conn_id=AWS_CONN_ID, verify=None)
+        gcs_mock_hook.assert_called_once_with(
+            gcp_conn_id=GCS_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+
+        assert sorted([s3_prefix + s3_object]) == sorted(uploaded_files)

--- a/tests/system/providers/google/cloud/gcs/example_s3_to_gcs.py
+++ b/tests/system/providers/google/cloud/gcs/example_s3_to_gcs.py
@@ -62,7 +62,11 @@ with models.DAG(
     )
     # [START howto_transfer_s3togcs_operator]
     transfer_to_gcs = S3ToGCSOperator(
-        task_id="s3_to_gcs_task", bucket=BUCKET_NAME, prefix=PREFIX, dest_gcs=GCS_BUCKET_URL
+        task_id="s3_to_gcs_task",
+        bucket=BUCKET_NAME,
+        prefix=PREFIX,
+        dest_gcs=GCS_BUCKET_URL,
+        apply_gcs_prefix=True,
     )
     # [END howto_transfer_s3togcs_operator]
 


### PR DESCRIPTION
Added parameter `apply_gcs_prefix=False`.

If it is set `True`, then objects will be copied from S3 to GCS without copying their full source path. Instead, a new destination path will be constructed as a source path, where S3 prefix is replaced by a GCS prefix. It allows users to copy files from S3 into a specific folder in GCS.

The default value is `apply_gcs_prefix=False` which refers to the old operators behavior, therefore merging this PR won't affect existing users, unless they change the value for this parameter in their DAGs.