### PR TITLE
Parameterize whether input is required for AirflowDateTimePickerWidget

### DIFF
--- a/airflow/www/widgets.py
+++ b/airflow/www/widgets.py
@@ -40,6 +40,9 @@ class AirflowDateTimePickerWidget:
         "</div>"
     )
 
+    def __init__(self, input_required: bool = True):
+        self.input_required = input_required
+
     def __call__(self, field, **kwargs):
         kwargs.setdefault("id", field.id)
         kwargs.setdefault("name", field.name)
@@ -48,7 +51,8 @@ class AirflowDateTimePickerWidget:
         template = self.data_template
 
         return Markup(
-            template % {"text": html_params(type="text", value=field.data, required=True, **kwargs)}
+            template
+            % {"text": html_params(type="text", value=field.data, required=self.input_required, **kwargs)}
         )
 
 


### PR DESCRIPTION
I'd like to use Airflow's own datetime picker widget, especially when writing web view plugins with FAB. With the existing implementation, the input is always required, but sometimes I have use cases where a datetime value is optional. This pull request made a simple change that parameterize whether the input tag will have the `required` attribute when instantiating an instance of this widget.

A default `True` is assigned so that the original behavior is preserved.