### PR TITLE
Remove worrying log message about redaction caused by OpenLineage plugin

### DIFF
--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -207,7 +207,9 @@ class SecretsMasker(logging.Filter):
 
         return True
 
-    def _redact_all(self, item: Redactable, depth: int, max_depth: int) -> Redacted:
+    # Default on `max_depth` is to support versions of the OpenLineage plugin (not the provider) which called
+    # this function directly. New versions of that provider, and this class itself call it with a value
+    def _redact_all(self, item: Redactable, depth: int, max_depth: int = MAX_RECURSION_DEPTH) -> Redacted:
         if depth > max_depth or isinstance(item, str):
             return "***"
         if isinstance(item, dict):


### PR DESCRIPTION
The current published plugin calls `_redact_all` directly, so when we
added the `max_depth` parameter in 2.6 (precisely so it didn't need to
call this private function directly!) we broke that.

This change leads to some worrying logs appearing in task logs for
anyone with the plugin installed:

```
[2023-05-05, 11:56:17 BST] {utils.py:490} WARNING - Unable to redact []Error was: TypeError: SecretsMasker._redact_all() missing 1 required positional argument: 'max_depth'
[2023-05-05, 11:56:17 BST] {utils.py:490} WARNING - Unable to redact []Error was: TypeError: SecretsMasker._redact_all() missing 1 required positional argument: 'max_depth'
[2023-05-05, 11:56:17 BST] {utils.py:490} WARNING - Unable to redact NoneError was: TypeError: SecretsMasker._redact_all() missing 1 required positional argument: 'max_depth'
```

This patch makes that previous change backwards compatible for that with
no change in behaviour for new code.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
