### PR TITLE
Fix deprecated import in Oracle example

### DIFF
--- a/airflow/providers/oracle/example_dags/example_oracle.py
+++ b/airflow/providers/oracle/example_dags/example_oracle.py
@@ -19,7 +19,8 @@ from __future__ import annotations
 from datetime import datetime
 
 from airflow import DAG
-from airflow.providers.oracle.operators.oracle import OracleOperator, OracleStoredProcedureOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
+from airflow.providers.oracle.operators.oracle import OracleStoredProcedureOperator
 
 with DAG(
     max_active_runs=1,
@@ -31,8 +32,8 @@ with DAG(
 
     # [START howto_oracle_operator]
 
-    opr_sql = OracleOperator(
-        task_id="task_sql", oracle_conn_id="oracle", sql="SELECT 1 FROM DUAL", autocommit=True
+    opr_sql = SQLExecuteQueryOperator(
+        task_id="task_sql", conn_id="oracle", sql="SELECT 1 FROM DUAL", autocommit=True
     )
 
     # [END howto_oracle_operator]


### PR DESCRIPTION
The #30979 added examples for Oracle, but the examples used deprecated imports to OracleOperator (and it has not been caught as provider tests did not run on changing just examples).

This PR changes the import to non-deprecated SQLExecuteQueryOperator

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
