### PR TITLE
Update to Latest Service Bus Library

### DIFF
--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -66,7 +66,7 @@ dependencies:
   - azure-storage-blob>=12.14.0
   - azure-storage-common>=2.1.0
   - azure-storage-file>=2.1.0
-  - azure-servicebus>=7.6.1
+  - azure-servicebus>=7.10.0
   - azure-synapse-spark
   - adal>=1.2.7
   - azure-storage-file-datalake>=12.9.1

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -480,7 +480,7 @@
       "azure-mgmt-datafactory>=1.0.0,<2.0",
       "azure-mgmt-datalake-store>=0.5.0",
       "azure-mgmt-resource>=2.2.0",
-      "azure-servicebus>=7.6.1",
+      "azure-servicebus>=7.10.0",
       "azure-storage-blob>=12.14.0",
       "azure-storage-common>=2.1.0",
       "azure-storage-file-datalake>=12.9.1",


### PR DESCRIPTION
This PR updates the azure-service version to 7.10.0. The new version is now using a new all python based AMQP stack, which means uamqp is no longer required and opens up the library overall to be run in a wide variety of architectures, OSes etc. There are some performance improvements when receiving messages from queues & topics. 

I had seen an old issue yall had mentioned and this version bump will help with that :)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
