### PR TITLE
Fix timestamp parse failure for k8s executor pod tailing

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 import json
 import logging
 import multiprocessing
-import re
 import time
 from collections import defaultdict
 from contextlib import suppress
@@ -49,7 +48,7 @@ from airflow.kubernetes.kubernetes_helper_functions import annotations_to_key, c
 from airflow.kubernetes.pod_generator import PodGenerator
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils.event_scheduler import EventScheduler
-from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.log.logging_mixin import LoggingMixin, remove_escape_codes
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import State, TaskInstanceState
 
@@ -821,9 +820,8 @@ class KubernetesExecutor(BaseExecutor):
                 tail_lines=100,
                 _preload_content=False,
             )
-            ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
             for line in res:
-                log.append(ansi_escape.sub("", line.decode()))
+                log.append(remove_escape_codes(line.decode()))
             if log:
                 messages.append("Found logs through kube API")
         except Exception as e:

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -315,7 +315,7 @@ class FileTaskHandler(logging.Handler):
             if response:
                 executor_messages, executor_logs = response
             if executor_messages:
-                messages_list.extend(messages_list)
+                messages_list.extend(executor_messages)
         if not (remote_logs and ti.state not in State.unfinished):
             # when finished, if we have remote logs, no need to check local
             worker_log_full_path = Path(self.local_base, worker_log_rel_path)

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -1140,7 +1140,11 @@ class TestKubernetesExecutor:
         messages, logs = executor.get_task_log(ti=ti, try_number=1)
 
         mock_kube_client.read_namespaced_pod_log.assert_called_once()
-        assert "Trying to get logs (last 100 lines) from worker pod " in messages
+        expected_messages = [
+            "Attempting to fetch logs from pod  through kube API",
+            "Found logs through kube API",
+        ]
+        assert messages == expected_messages
         assert logs[0] == "a_\nb_\nc_"
 
         mock_kube_client.reset_mock()

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -1140,11 +1140,7 @@ class TestKubernetesExecutor:
         messages, logs = executor.get_task_log(ti=ti, try_number=1)
 
         mock_kube_client.read_namespaced_pod_log.assert_called_once()
-        expected_messages = [
-            "Attempting to fetch logs from pod  through kube API",
-            "Found logs through kube API",
-        ]
-        assert messages == expected_messages
+        assert "Attempting to fetch logs from pod  through kube API" in messages
         assert logs[0] == "a_\nb_\nc_"
 
         mock_kube_client.reset_mock()

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -1148,10 +1148,7 @@ class TestKubernetesExecutor:
 
         messages, logs = executor.get_task_log(ti=ti, try_number=1)
         assert logs == [""]
-        assert messages == [
-            "Trying to get logs (last 100 lines) from worker pod ",
-            "Reading from k8s pod logs failed: error_fetching_pod_log",
-        ]
+        assert "Attempting to fetch logs from pod  through kube API" in messages
 
     def test_supports_pickling(self):
         assert KubernetesExecutor.supports_pickling

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -1140,7 +1140,10 @@ class TestKubernetesExecutor:
         messages, logs = executor.get_task_log(ti=ti, try_number=1)
 
         mock_kube_client.read_namespaced_pod_log.assert_called_once()
-        assert "Attempting to fetch logs from pod  through kube API" in messages
+        assert messages == [
+            "Attempting to fetch logs from pod  through kube API",
+            "Found logs through kube API",
+        ]
         assert logs[0] == "a_\nb_\nc_"
 
         mock_kube_client.reset_mock()
@@ -1148,7 +1151,10 @@ class TestKubernetesExecutor:
 
         messages, logs = executor.get_task_log(ti=ti, try_number=1)
         assert logs == [""]
-        assert "Attempting to fetch logs from pod  through kube API" in messages
+        assert messages == [
+            "Attempting to fetch logs from pod  through kube API",
+            "Reading from k8s pod logs failed: error_fetching_pod_log",
+        ]
 
     def test_supports_pickling(self):
         assert KubernetesExecutor.supports_pickling


### PR DESCRIPTION
When we tail stdout over kube API, we get ansi color codes which must be escaped in order for timestamps to be properly parsed so that messages can be properly interleaved by the file task handler (i.e. / a.k.a. the web UI task log reader).

While at it, fixed an issue with improper appending of "messages" (e.g. "fetching logs from kube API") and added one such message for good measure.

Before:
![image](https://github.com/apache/airflow/assets/15932138/e310d937-036c-482d-92d2-dd909a165251)

After:
![image](https://github.com/apache/airflow/assets/15932138/ba1e05ab-c906-4ac5-9b78-b28216dd77e9)


