### PR TITLE
Make sure that DAG processor job row has filed value in `job_type` column

### DIFF
--- a/airflow/jobs/backfill_job_runner.py
+++ b/airflow/jobs/backfill_job_runner.py
@@ -148,14 +148,12 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
         :param args:
         :param kwargs:
         """
-        super().__init__()
+        super().__init__(job)
         if job.job_type and job.job_type != self.job_type:
             raise Exception(
                 f"The job is already assigned a different job_type: {job.job_type}."
                 f"This is a bug and should be reported."
             )
-        self.job = job
-        self.job.job_type = self.job_type
         self.dag = dag
         self.dag_id = dag.dag_id
         self.bf_start_date = start_date

--- a/airflow/jobs/backfill_job_runner.py
+++ b/airflow/jobs/backfill_job_runner.py
@@ -149,11 +149,6 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
         :param kwargs:
         """
         super().__init__(job)
-        if job.job_type and job.job_type != self.job_type:
-            raise Exception(
-                f"The job is already assigned a different job_type: {job.job_type}."
-                f"This is a bug and should be reported."
-            )
         self.dag = dag
         self.dag_id = dag.dag_id
         self.bf_start_date = start_date

--- a/airflow/jobs/base_job_runner.py
+++ b/airflow/jobs/base_job_runner.py
@@ -33,6 +33,11 @@ class BaseJobRunner:
     job_type = "undefined"
 
     def __init__(self, job):
+        if job.job_type and job.job_type != self.job_type:
+            raise Exception(
+                f"The job is already assigned a different job_type: {job.job_type}."
+                f"This is a bug and should be reported."
+            )
         self.job = job
         self.job.job_type = self.job_type
 

--- a/airflow/jobs/base_job_runner.py
+++ b/airflow/jobs/base_job_runner.py
@@ -32,6 +32,10 @@ class BaseJobRunner:
 
     job_type = "undefined"
 
+    def __init__(self, job):
+        self.job = job
+        self.job.job_type = self.job_type
+
     def _execute(self) -> int | None:
         """
         Executes the logic connected to the runner. This method should be

--- a/airflow/jobs/dag_processor_job_runner.py
+++ b/airflow/jobs/dag_processor_job_runner.py
@@ -53,6 +53,7 @@ class DagProcessorJobRunner(BaseJobRunner, LoggingMixin):
                 f"The job is already assigned a different job_type: {job.job_type}."
                 f"This is a bug and should be reported."
             )
+        self.job.job_type = self.job_type
         self.processor = processor
         self.processor.heartbeat = lambda: perform_heartbeat(
             job=self.job,

--- a/airflow/jobs/dag_processor_job_runner.py
+++ b/airflow/jobs/dag_processor_job_runner.py
@@ -47,11 +47,6 @@ class DagProcessorJobRunner(BaseJobRunner, LoggingMixin):
         **kwargs,
     ):
         super().__init__(job)
-        if job.job_type and job.job_type != self.job_type:
-            raise Exception(
-                f"The job is already assigned a different job_type: {job.job_type}."
-                f"This is a bug and should be reported."
-            )
         self.processor = processor
         self.processor.heartbeat = lambda: perform_heartbeat(
             job=self.job,

--- a/airflow/jobs/dag_processor_job_runner.py
+++ b/airflow/jobs/dag_processor_job_runner.py
@@ -46,14 +46,12 @@ class DagProcessorJobRunner(BaseJobRunner, LoggingMixin):
         *args,
         **kwargs,
     ):
-        super().__init__(*args, **kwargs)
-        self.job = job
+        super().__init__(job)
         if job.job_type and job.job_type != self.job_type:
             raise Exception(
                 f"The job is already assigned a different job_type: {job.job_type}."
                 f"This is a bug and should be reported."
             )
-        self.job.job_type = self.job_type
         self.processor = processor
         self.processor.heartbeat = lambda: perform_heartbeat(
             job=self.job,

--- a/airflow/jobs/local_task_job_runner.py
+++ b/airflow/jobs/local_task_job_runner.py
@@ -87,15 +87,13 @@ class LocalTaskJobRunner(BaseJobRunner, LoggingMixin):
         pool: str | None = None,
         external_executor_id: str | None = None,
     ):
-        BaseJobRunner.__init__(self)
+        super().__init__(job)
         LoggingMixin.__init__(self, context=task_instance)
         if job.job_type and job.job_type != self.job_type:
             raise Exception(
                 f"The job is already assigned a different job_type: {job.job_type}."
                 f"This is a bug and should be reported."
             )
-        self.job = job
-        self.job.job_type = self.job_type
         self.task_instance = task_instance
         self.ignore_all_deps = ignore_all_deps
         self.ignore_depends_on_past = ignore_depends_on_past

--- a/airflow/jobs/local_task_job_runner.py
+++ b/airflow/jobs/local_task_job_runner.py
@@ -89,11 +89,6 @@ class LocalTaskJobRunner(BaseJobRunner, LoggingMixin):
     ):
         super().__init__(job)
         LoggingMixin.__init__(self, context=task_instance)
-        if job.job_type and job.job_type != self.job_type:
-            raise Exception(
-                f"The job is already assigned a different job_type: {job.job_type}."
-                f"This is a bug and should be reported."
-            )
         self.task_instance = task_instance
         self.ignore_all_deps = ignore_all_deps
         self.ignore_depends_on_past = ignore_depends_on_past

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -156,14 +156,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         log: logging.Logger | None = None,
         processor_poll_interval: float | None = None,
     ):
-        super().__init__()
+        super().__init__(job)
         if job.job_type and job.job_type != self.job_type:
             raise Exception(
                 f"The job is already assigned a different job_type: {job.job_type}."
                 f"This is a bug and should be reported."
             )
-        self.job = job
-        self.job.job_type = self.job_type
         self.subdir = subdir
         self.num_runs = num_runs
         # In specific tests, we want to stop the parse loop after the _files_ have been parsed a certain

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -157,11 +157,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         processor_poll_interval: float | None = None,
     ):
         super().__init__(job)
-        if job.job_type and job.job_type != self.job_type:
-            raise Exception(
-                f"The job is already assigned a different job_type: {job.job_type}."
-                f"This is a bug and should be reported."
-            )
         self.subdir = subdir
         self.num_runs = num_runs
         # In specific tests, we want to stop the parse loop after the _files_ have been parsed a certain

--- a/airflow/jobs/triggerer_job_runner.py
+++ b/airflow/jobs/triggerer_job_runner.py
@@ -252,14 +252,12 @@ class TriggererJobRunner(BaseJobRunner, LoggingMixin):
         job: Job | JobPydantic,
         capacity=None,
     ):
-        super().__init__()
+        super().__init__(job)
         if job.job_type and job.job_type != self.job_type:
             raise Exception(
                 f"The job is already assigned a different job_type: {job.job_type}."
                 f"This is a bug and should be reported."
             )
-        self.job = job
-        self.job.job_type = self.job_type
         if capacity is None:
             self.capacity = conf.getint("triggerer", "default_capacity", fallback=1000)
         elif isinstance(capacity, int) and capacity > 0:

--- a/airflow/jobs/triggerer_job_runner.py
+++ b/airflow/jobs/triggerer_job_runner.py
@@ -253,11 +253,6 @@ class TriggererJobRunner(BaseJobRunner, LoggingMixin):
         capacity=None,
     ):
         super().__init__(job)
-        if job.job_type and job.job_type != self.job_type:
-            raise Exception(
-                f"The job is already assigned a different job_type: {job.job_type}."
-                f"This is a bug and should be reported."
-            )
         if capacity is None:
             self.capacity = conf.getint("triggerer", "default_capacity", fallback=1000)
         elif isinstance(capacity, int) and capacity > 0:

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -332,7 +332,7 @@ class MockJobRunner(BaseJobRunner):
     job_type = "MockJob"
 
     def __init__(self, job: Job | JobPydantic, func=None):
-        super().__init__()
+        super().__init__(job)
         self.job = job
         self.job.job_type = self.job_type
         self.func = func


### PR DESCRIPTION
## Description

We're running custom probes on the dag processor component.

Since the DagProcessor component is represented as a `job_runner`, we're running SQL queries to check the latest_heartbeat for the associated job object.

To speed up queries in big deployments, we're using a the index on `job_type`:
```sql
SELECT latest_heartbeat FROM job
  WHERE
    job_type = 'DagProcessorJob'
  AND
    hostname = '%s';
```
 (hostname being the IP address of the k8s pod).

The problem is that there's a bug currently, and the job_type is always NULL for dag processor job_runners.

I added the missing line of code that should fix this issue.