### PR TITLE
K8s hook should still work with missing default conn

### DIFF
--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -39,6 +39,14 @@ Features
    * ``Deprecate 'skip_exit_code' in 'DockerOperator' and 'KubernetesPodOperator' (#30733)``
   * ``Remove skip_exit_code from KubernetesPodOperator (#30788)``
 
+6.1.0
+.....
+
+Features
+~~~~~~~~
+
+If ``kubernetes_default`` connection is not defined, then KubernetesHook / KubernetesPodOperator will behave as though given ``conn_id=None``.
+
 6.0.0
 .....
 

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -152,11 +152,11 @@ class KubernetesHook(BaseHook):
         """
         try:
             return super().get_connection(conn_id)
-        except AirflowNotFoundException as e:
+        except AirflowNotFoundException:
             if conn_id == cls.default_conn_name:
                 return Connection(conn_id=cls.default_conn_name)
             else:
-                raise e
+                raise
 
     @cached_property
     def conn_extras(self):

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -144,6 +144,12 @@ class KubernetesHook(BaseHook):
 
     @classmethod
     def get_connection(cls, conn_id: str) -> Connection:
+        """
+        Return requested connection.
+
+        If missing and conn_id is "kubernetes_default", will return empty connection so that hook will
+        default to cluster-derived creds.
+        """
         try:
             return super().get_connection(conn_id)
         except AirflowNotFoundException as e:

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -148,7 +148,7 @@ class KubernetesHook(BaseHook):
         Return requested connection.
 
         If missing and conn_id is "kubernetes_default", will return empty connection so that hook will
-        default to cluster-derived creds.
+        default to cluster-derived credentials.
         """
         try:
             return super().get_connection(conn_id)

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -30,9 +30,10 @@ from kubernetes_asyncio import client as async_client, config as async_config
 from urllib3.exceptions import HTTPError
 
 from airflow.compat.functools import cached_property
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException, AirflowNotFoundException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 from airflow.kubernetes.kube_client import _disable_verify_ssl, _enable_tcp_keepalive
+from airflow.models import Connection
 from airflow.utils import yaml
 
 LOADING_KUBE_CONFIG_FILE_RESOURCE = "Loading Kubernetes configuration file kube_config from {}..."
@@ -140,6 +141,16 @@ class KubernetesHook(BaseHook):
         for param in params:
             if param is not None:
                 return param
+
+    @classmethod
+    def get_connection(cls, conn_id: str) -> Connection:
+        try:
+            return super().get_connection(conn_id)
+        except AirflowNotFoundException as e:
+            if conn_id == cls.default_conn_name:
+                return Connection(conn_id=cls.default_conn_name)
+            else:
+                raise e
 
     @cached_property
     def conn_extras(self):

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -419,7 +419,7 @@ class TestKubernetesHook:
         hook = KubernetesHook()
         assert hook.conn_extras == {}
 
-        # meanwhile, asking for non-default should still fail if no exist
+        # meanwhile, asking for non-default should still fail if it doesn't exist
         hook = KubernetesHook("some_conn")
         with pytest.raises(AirflowNotFoundException, match="The conn_id `some_conn` isn't defined"):
             hook.conn_extras

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -27,8 +27,11 @@ from unittest.mock import MagicMock, patch
 import kubernetes
 import pytest
 from kubernetes.config import ConfigException
+from sqlalchemy.orm import make_transient
 
 from airflow import AirflowException
+from airflow.exceptions import AirflowNotFoundException
+from airflow.hooks.base import BaseHook
 from airflow.models import Connection
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import AsyncKubernetesHook, KubernetesHook
 from airflow.utils import db
@@ -52,6 +55,22 @@ NAMESPACE = "test-namespace"
 
 class DeprecationRemovalRequired(AirflowException):
     ...
+
+
+DEFAULT_CONN_ID = "kubernetes_default"
+
+
+@pytest.fixture()
+def remove_default_conn(session):
+    before_conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).one_or_none()
+    if before_conn:
+        session.delete(before_conn)
+        session.commit()
+    yield
+    if before_conn:
+        make_transient(before_conn)
+        session.add(before_conn)
+        session.commit()
 
 
 class TestKubernetesHook:
@@ -390,6 +409,20 @@ class TestKubernetesHook:
             kubernetes_hook.get_conn()
             mock_get_client.assert_called_with(cluster_context="test")
             assert kubernetes_hook.get_namespace() == "test"
+
+    def test_missing_default_connection_is_ok(self, remove_default_conn):
+        # prove to ourselves that the default conn no exist
+        with pytest.raises(AirflowNotFoundException):
+            BaseHook.get_connection(DEFAULT_CONN_ID)
+
+        # verify K8sHook still works
+        hook = KubernetesHook()
+        assert hook.conn_extras == {}
+
+        # meanwhile, asking for non-default should still fail if no exist
+        hook = KubernetesHook("some_conn")
+        with pytest.raises(AirflowNotFoundException, match="The conn_id `some_conn` isn't defined"):
+            hook.conn_extras
 
     @patch("kubernetes.config.kube_config.KubeConfigLoader")
     @patch("kubernetes.config.kube_config.KubeConfigMerger")

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -411,7 +411,7 @@ class TestKubernetesHook:
             assert kubernetes_hook.get_namespace() == "test"
 
     def test_missing_default_connection_is_ok(self, remove_default_conn):
-        # prove to ourselves that the default conn no exist
+        # prove to ourselves that the default conn doesn't exist
         with pytest.raises(AirflowNotFoundException):
             BaseHook.get_connection(DEFAULT_CONN_ID)
 


### PR DESCRIPTION
It's common when using KPO / K8s hook to want to simply use the RBAC of the cluster.  This was the default behavior prior to #28848.  After that change, users are forced to add a k8s connection or their dags will break.

To fix this, in the special case where conn_id=="kubernetes_default", if the conn is missing, we ignore the failure.