### PR TITLE
Remove the upper version bound on pymongo

### DIFF
--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -82,7 +82,12 @@ class MongoHook(BaseHook):
 
         # If we are using SSL disable requiring certs from specific hostname
         if options.get("ssl", False):
-            options.update({"ssl_cert_reqs": CERT_NONE})
+            if pymongo.__version__ >= "4.0.0":
+                # In pymongo 4.0.0+ `tlsAllowInvalidCertificates=True`
+                # replaces `ssl_cert_reqs=CERT_NONE`
+                options.update({"tlsAllowInvalidCertificates": True})
+            else:
+                options.update({"ssl_cert_reqs": CERT_NONE})
 
         self.client = MongoClient(self.uri, **options)
         return self.client

--- a/airflow/providers/mongo/provider.yaml
+++ b/airflow/providers/mongo/provider.yaml
@@ -39,9 +39,7 @@ versions:
 dependencies:
   - apache-airflow>=2.4.0
   - dnspython>=1.13.0
-  # pymongo 4.0.0 removes connection option `ssl_cert_reqs` which is used in providers-mongo/2.2.0
-  # TODO: Upgrade to pymongo 4.0.0+
-  - pymongo>=3.6.0,<4.0.0
+  - pymongo>=3.6.0
 
 integrations:
   - integration-name: MongoDB

--- a/docs/apache-airflow-providers-mongo/index.rst
+++ b/docs/apache-airflow-providers-mongo/index.rst
@@ -75,7 +75,7 @@ PIP package         Version required
 ==================  ==================
 ``apache-airflow``  ``>=2.3.0``
 ``dnspython``       ``>=1.13.0``
-``pymongo``         ``>=3.6.0,<4.0.0``
+``pymongo``         ``>=3.6.0``
 ==================  ==================
 
 .. include:: ../../airflow/providers/mongo/CHANGELOG.rst

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -522,7 +522,7 @@
     "deps": [
       "apache-airflow>=2.4.0",
       "dnspython>=1.13.0",
-      "pymongo>=3.6.0,<4.0.0"
+      "pymongo>=3.6.0"
     ],
     "cross-providers-deps": []
   },


### PR DESCRIPTION
There was an upper version bound on pymongo of `<4.0.0` because versions 4.0.0+ removed the `ssl_cert_reqs` parameter from client connection options. However, comparing the pymongo 3.7.0 docs (https://pymongo.readthedocs.io/en/3.7.0/examples/tls.html#certificate-verification-policy) to the 4.3.3 docs
(https://pymongo.readthedocs.io/en/4.3.3/examples/tls.html#certificate-verification-policy) it seems that `ssl_cert_reqs` has been effectively renamed to `tlsAllowInvalidCertificates`.

This PR removes upper version bound on pymongo, and adds a test to set `tlsAllowInvalidCertificates` for pymongo 4.0.0 and later, while continuing to use `ssl_cert_reqs` for earlier versions of pymongo.
