### PR TITLE
Add missing fields in DynamoDBToS3Operator system test

### DIFF
--- a/tests/system/providers/amazon/aws/example_dynamodb_to_s3.py
+++ b/tests/system/providers/amazon/aws/example_dynamodb_to_s3.py
@@ -135,6 +135,7 @@ with DAG(
         file_size=1000,
         s3_bucket_name=bucket_name,
         export_time=datetime(year=2023, month=4, day=10),
+        s3_key_prefix=f"{S3_KEY_PREFIX}-3-",
     )
     # [END howto_transfer_dynamodb_to_s3_in_some_point_in_time]
 

--- a/tests/system/providers/amazon/aws/example_dynamodb_to_s3.py
+++ b/tests/system/providers/amazon/aws/example_dynamodb_to_s3.py
@@ -134,7 +134,7 @@ with DAG(
         dynamodb_table_name=table_name,
         file_size=1000,
         s3_bucket_name=bucket_name,
-        export_time=datetime(year=2023, month=4, day=10),
+        export_time=datetime.now(),
         s3_key_prefix=f"{S3_KEY_PREFIX}-3-",
     )
     # [END howto_transfer_dynamodb_to_s3_in_some_point_in_time]


### PR DESCRIPTION
There was a missing `s3_key_prefix` in the system test for `DynamoDBToS3Operator` and the `export_time` date format was not correct.