### PR TITLE
Push Spark appId to XCOM for LivyOperator with deferrable mode

### DIFF
--- a/airflow/providers/apache/livy/operators/livy.py
+++ b/airflow/providers/apache/livy/operators/livy.py
@@ -207,4 +207,5 @@ class LivyOperator(BaseOperator):
             self.task_id,
             event["response"],
         )
+        context["ti"].xcom_push(key="app_id", value=self.get_hook().get_batch(event["batch_id"])["appId"])
         return event["batch_id"]


### PR DESCRIPTION
With the change in PR #27376, we started pushing the Spark `appId` 
to `XCOM` when executing the `LivyOperator` in standard (non-defferable) 
mode. This commit now pushes the `appId` to `XCOM` in `deferrable` mode 
too to keep the expected outcome consistent for the operator so that 
subsequent tasks can fetch and use the `appId` from `XCOM`.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
