### PR TITLE
Allow changing log level of provider import warnings

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -881,6 +881,20 @@ logging:
       type: boolean
       example: ~
       default: "False"
+    log_level_optional_feauture_disabled:
+      description: |
+        Level for messages notifying when disabled optional features are detected.
+      version_added: 2.7.0
+      type: string
+      example: info
+      default: ~
+    log_level_provider_import_error:
+      description: |
+        Level for messages notifying when disabled optional features are detected.
+      version_added: 2.7.0
+      type: string
+      example: warning
+      default: ~
 
 
 metrics:

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -881,7 +881,7 @@ logging:
       type: boolean
       example: ~
       default: "False"
-    log_level_optional_feauture_disabled:
+    log_level_optional_feature_disabled:
       description: |
         Level for messages notifying when disabled optional features are detected.
       version_added: 2.7.0

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -496,6 +496,14 @@ file_task_handler_new_file_permissions = 0o664
 # while sending higher severity logs to stderr.
 celery_stdout_stderr_separation = False
 
+# Level for messages notifying when disabled optional features are detected.
+# Example: log_level_optional_feauture_disabled = info
+# log_level_optional_feauture_disabled =
+
+# Level for messages notifying when disabled optional features are detected.
+# Example: log_level_provider_import_error = warning
+# log_level_provider_import_error =
+
 [metrics]
 
 # StatsD (https://github.com/etsy/statsd) integration settings.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -497,8 +497,8 @@ file_task_handler_new_file_permissions = 0o664
 celery_stdout_stderr_separation = False
 
 # Level for messages notifying when disabled optional features are detected.
-# Example: log_level_optional_feauture_disabled = info
-# log_level_optional_feauture_disabled =
+# Example: log_level_optional_feature_disabled = info
+# log_level_optional_feature_disabled =
 
 # Level for messages notifying when disabled optional features are detected.
 # Example: log_level_provider_import_error = warning

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -856,6 +856,7 @@ class AirflowConfigParser(ConfigParser):
             raise AirflowConfigException(f"Unable to parse [{section}] {key!r} as valid json") from e
 
     def get_log_level(self, section: str, key: str, fallback: Any = None, **kwargs) -> int:
+        """Interpret config section as log level and if successful return it."""
         val = self.get(section, key, fallback=fallback, _extra_stacklevel=1, **kwargs)
         is_empty = val is None or isinstance(val, str) and not val.strip()
         if is_empty and fallback is None:

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -230,8 +230,8 @@ T = TypeVar("T", bound=Callable)
 
 logger = logging.getLogger(__name__)
 
-LOG_LEVEL_OPTIONAL_FEAUTURE_DISABLED = conf.get_log_level(
-    "logging", "log_level_optional_feauture_disabled", fallback=logging.INFO
+LOG_LEVEL_OPTIONAL_FEATURE_DISABLED = conf.get_log_level(
+    "logging", "log_level_optional_feature_disabled", fallback=logging.INFO
 )
 LOG_LEVEL_PROVIDER_IMPORT_ERROR = conf.get_log_level(
     "logging", "log_level_provider_import_error", fallback=logging.WARNING
@@ -257,7 +257,7 @@ def log_optional_feature_disabled(class_name, e, provider_package):
         exc_info=e,
     )
     log.log(
-        LOG_LEVEL_OPTIONAL_FEAUTURE_DISABLED,
+        LOG_LEVEL_OPTIONAL_FEATURE_DISABLED,
         "Optional provider feature disabled when importing '%s' from '%s' package",
         class_name,
         provider_package,

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -387,25 +387,29 @@ no_value_set =
         # invalid and no fallback fails
         with pytest.raises(
             AirflowConfigException,
-            match='Failed to convert value Some val to log level. Please correct key "invalid_str" in section "type_validation".',
+            match="Failed to convert value Some val to log level. "
+            'Please correct key "invalid_str" in section "type_validation".',
         ):
             test_conf.get_log_level("type_validation", "invalid_str")
         # invalid fails even *with* fallback
         with pytest.raises(
             AirflowConfigException,
-            match='Failed to convert value Some val to log level. Please correct key "invalid_str" in section "type_validation".',
+            match="Failed to convert value Some val to log level. "
+            'Please correct key "invalid_str" in section "type_validation".',
         ):
             test_conf.get_log_level("type_validation", "invalid_str", fallback=10)
         # missing key no fallback fails
         with pytest.raises(
             AirflowConfigException,
-            match='No value set for key "entirely_missing_key" in section "type_validation"; please set config or supply a fallback at call site.',
+            match='No value set for key "entirely_missing_key" in section "type_validation"; '
+            "please set config or supply a fallback at call site.",
         ):
             test_conf.get_log_level("type_validation", "entirely_missing_key")
         # missing value no fallback fails
         with pytest.raises(
             AirflowConfigException,
-            match='No value set for key "no_value_set" in section "type_validation"; please set config or supply a fallback at call site.',
+            match='No value set for key "no_value_set" in section "type_validation"; '
+            "please set config or supply a fallback at call site.",
         ):
             test_conf.get_log_level("type_validation", "no_value_set")
         # when given integer, accepted


### PR DESCRIPTION
Particularly for me as a developer, I don't want to see these messages most of the time.  Reducing the noise makes it easier to see more important errors and warning messages.

Alternatives considered:
* take a list of classes / packages to ignore
* move these to a new config section `developer`