### PR TITLE
Fix `url_for_asset` fallback and 404 on DAG Audit Log

### DIFF
--- a/airflow/www/extensions/init_manifest_files.py
+++ b/airflow/www/extensions/init_manifest_files.py
@@ -46,7 +46,7 @@ def configure_manifest_files(app):
     def get_asset_url(filename):
         if app.debug:
             parse_manifest_json()
-        return url_for("static", filename=manifest.get(filename, ""))
+        return url_for("static", filename=manifest.get(filename, filename))
 
     parse_manifest_json()
 

--- a/airflow/www/templates/airflow/dag_audit_log.html
+++ b/airflow/www/templates/airflow/dag_audit_log.html
@@ -49,7 +49,6 @@
 {% block head_css %}
 {{ super() }}
 <link href="{{ url_for_asset('dataTables.bootstrap.min.css') }}" rel="stylesheet" type="text/css" >
-<link href="{{ url_for_asset('bootstrap-toggle.min.css') }}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
There was a 404 on the DAG Audit Log for bootstrap toggle css, which as far as I can tell, we aren't even trying to use. So we will no longer try and add it to the page.

This highlighted the fact that if we don't have an asset in the manifest, `url_for_asset` would just leave off the filename completely. This resulted in the href being just `/static/`, with no filename as a breadcrumb in the eventual 404. Now we will just use the filename as-is so the 404 is more meaningful.