### PR TITLE
fix bad trigger rule for EKS system tests

### DIFF
--- a/tests/system/providers/amazon/aws/example_eks_with_fargate_in_one_step.py
+++ b/tests/system/providers/amazon/aws/example_eks_with_fargate_in_one_step.py
@@ -108,7 +108,7 @@ with DAG(
         cluster_name, pod_name="{{ ti.xcom_pull(key='pod_name', task_ids='run_pod') }}"
     )
     # only describe the pod if the task above failed, to help diagnose
-    describe_pod.trigger_rule = (TriggerRule.ONE_FAILED,)
+    describe_pod.trigger_rule = TriggerRule.ONE_FAILED
 
     # An Amazon EKS cluster can not be deleted with attached resources such as nodegroups or Fargate profiles.
     # Setting the `force` to `True` will delete any attached resources before deleting the cluster.

--- a/tests/system/providers/amazon/aws/example_eks_with_fargate_profile.py
+++ b/tests/system/providers/amazon/aws/example_eks_with_fargate_profile.py
@@ -127,7 +127,7 @@ with DAG(
         cluster_name, pod_name="{{ ti.xcom_pull(key='pod_name', task_ids='run_pod') }}"
     )
     # only describe the pod if the task above failed, to help diagnose
-    describe_pod.trigger_rule = (TriggerRule.ONE_FAILED,)
+    describe_pod.trigger_rule = TriggerRule.ONE_FAILED
 
     # [START howto_operator_eks_delete_fargate_profile]
     delete_fargate_profile = EksDeleteFargateProfileOperator(

--- a/tests/system/providers/amazon/aws/example_eks_with_nodegroup_in_one_step.py
+++ b/tests/system/providers/amazon/aws/example_eks_with_nodegroup_in_one_step.py
@@ -118,7 +118,7 @@ with DAG(
         cluster_name, pod_name="{{ ti.xcom_pull(key='pod_name', task_ids='run_pod') }}"
     )
     # only describe the pod if the task above failed, to help diagnose
-    describe_pod.trigger_rule = (TriggerRule.ONE_FAILED,)
+    describe_pod.trigger_rule = TriggerRule.ONE_FAILED
 
     # [START howto_operator_eks_force_delete_cluster]
     # An Amazon EKS cluster can not be deleted with attached resources such as nodegroups or Fargate profiles.

--- a/tests/system/providers/amazon/aws/example_eks_with_nodegroups.py
+++ b/tests/system/providers/amazon/aws/example_eks_with_nodegroups.py
@@ -145,7 +145,7 @@ with DAG(
         cluster_name, pod_name="{{ ti.xcom_pull(key='pod_name', task_ids='run_pod') }}"
     )
     # only describe the pod if the task above failed, to help diagnose
-    describe_pod.trigger_rule = (TriggerRule.ONE_FAILED,)
+    describe_pod.trigger_rule = TriggerRule.ONE_FAILED
 
     # [START howto_operator_eks_delete_nodegroup]
     delete_nodegroup = EksDeleteNodegroupOperator(


### PR DESCRIPTION
I think I mistakenly pasted this with the comma, and one of the pre-commit checks helpfully added the parenthesis, and now the trigger rule is a 1 element tuple, and this creates a deadlock when we try to run the dag, for whatever reason.