### PR TITLE
Grid graph view clear task default should be downstream true

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/taskActions/ClearInstance.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/taskActions/ClearInstance.tsx
@@ -68,7 +68,7 @@ const ClearInstance = ({
   const [upstream, setUpstream] = useState(false);
   const onToggleUpstream = () => setUpstream(!upstream);
 
-  const [downstream, setDownstream] = useState(false);
+  const [downstream, setDownstream] = useState(true);
   const onToggleDownstream = () => setDownstream(!downstream);
 
   const [recursive, setRecursive] = useState(true);


### PR DESCRIPTION
When clearing a task from the grid view's graph view, by default we should include downstream tasks.
