### PR TITLE
Better typing for Job and JobRunners

### DIFF
--- a/airflow/jobs/backfill_job_runner.py
+++ b/airflow/jobs/backfill_job_runner.py
@@ -149,6 +149,7 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
         :param kwargs:
         """
         super().__init__(job)
+        self.job = job
         self.dag = dag
         self.dag_id = dag.dag_id
         self.bf_start_date = start_date

--- a/airflow/jobs/base_job_runner.py
+++ b/airflow/jobs/base_job_runner.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from airflow.jobs.job import Job
+    from airflow.serialization.pydantic.job import JobPydantic
 
 
 class BaseJobRunner:
@@ -32,14 +33,13 @@ class BaseJobRunner:
 
     job_type = "undefined"
 
-    def __init__(self, job):
+    def __init__(self, job: Job | JobPydantic) -> None:
         if job.job_type and job.job_type != self.job_type:
             raise Exception(
                 f"The job is already assigned a different job_type: {job.job_type}."
                 f"This is a bug and should be reported."
             )
-        self.job = job
-        self.job.job_type = self.job_type
+        job.job_type = self.job_type
 
     def _execute(self) -> int | None:
         """

--- a/airflow/jobs/dag_processor_job_runner.py
+++ b/airflow/jobs/dag_processor_job_runner.py
@@ -47,6 +47,7 @@ class DagProcessorJobRunner(BaseJobRunner, LoggingMixin):
         **kwargs,
     ):
         super().__init__(job)
+        self.job = job
         self.processor = processor
         self.processor.heartbeat = lambda: perform_heartbeat(
             job=self.job,

--- a/airflow/jobs/local_task_job_runner.py
+++ b/airflow/jobs/local_task_job_runner.py
@@ -88,6 +88,7 @@ class LocalTaskJobRunner(BaseJobRunner, LoggingMixin):
         external_executor_id: str | None = None,
     ):
         super().__init__(job)
+        self.job = job
         LoggingMixin.__init__(self, context=task_instance)
         self.task_instance = task_instance
         self.ignore_all_deps = ignore_all_deps

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -157,6 +157,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         processor_poll_interval: float | None = None,
     ):
         super().__init__(job)
+        self.job = job
         self.subdir = subdir
         self.num_runs = num_runs
         # In specific tests, we want to stop the parse loop after the _files_ have been parsed a certain

--- a/airflow/jobs/triggerer_job_runner.py
+++ b/airflow/jobs/triggerer_job_runner.py
@@ -253,6 +253,7 @@ class TriggererJobRunner(BaseJobRunner, LoggingMixin):
         capacity=None,
     ):
         super().__init__(job)
+        self.job = job
         if capacity is None:
             self.capacity = conf.getint("triggerer", "default_capacity", fallback=1000)
         elif isinstance(capacity, int) and capacity > 0:


### PR DESCRIPTION
By leveraging Generics, the typing for Runners and Job and JobPydantic is now more complete and accurate.

* Scheduler and Backfill Runners limit their code to Job and can use all the things that ORM Job allows them to do

* Other runners are limited to union of Job and JobPydantic version so that they can be run on the client side of the internal API without having all the Job features.

This is a follow up after #31182 that fixed missing job_type for DagProcessor Job and nicely extracted job to BaseRunner but broke MyPy/Typing guards implemented in the runners that should aid the AIP-44 implementation.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
