### PR TITLE
Upper-bind elasticearch integration

### DIFF
--- a/airflow/providers/elasticsearch/provider.yaml
+++ b/airflow/providers/elasticsearch/provider.yaml
@@ -52,7 +52,7 @@ dependencies:
   - apache-airflow-providers-common-sql>=1.3.1
   # We cannot use elasticsearch 8 yet. The elasticsearch-dsl is not compatible with it.
   # elasticsearch>=7.15.0 breaks our tests.The eleasticsearch 7 is an old version that is not
-  # supported anymore.We should move to elasticsearch 8 as
+  # supported anymore. We should move to elasticsearch 8 as
   # likely requires getting rid of elasticsearch-dsl or waiting until there is a compatible version
   # We can also try to replace the <7.15.0 with <8.0.0 but we need to solve the test failures first
   - elasticsearch>7,<7.15.0

--- a/airflow/providers/elasticsearch/provider.yaml
+++ b/airflow/providers/elasticsearch/provider.yaml
@@ -50,7 +50,12 @@ versions:
 dependencies:
   - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
-  - elasticsearch>7
+  # We cannot use elasticsearch 8 yet. The elasticsearch-dsl is not compatible with it.
+  # elasticsearch>=7.15.0 breaks our tests.The eleasticsearch 7 is an old version that is not
+  # supported anymore.We should move to elasticsearch 8 as
+  # likely requires getting rid of elasticsearch-dsl or waiting until there is a compatible version
+  # We can also try to replace the <7.15.0 with <8.0.0 but we need to solve the test failures first
+  - elasticsearch>7,<7.15.0
   - elasticsearch-dbapi
   - elasticsearch-dsl>=5.0.0
 

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -296,7 +296,7 @@
       "apache-airflow>=2.4.0",
       "elasticsearch-dbapi",
       "elasticsearch-dsl>=5.0.0",
-      "elasticsearch>7"
+      "elasticsearch>7,<7.15.0"
     ],
     "cross-providers-deps": [
       "common.sql"


### PR DESCRIPTION
During bumping the dependencies of Google Provider we found out that elasticsearch >= 7.15.0 (which we never tested before because of other constraints) breaks our tests. Since there is an 8 version of eleastic search available as of 2021, we should - rather than solve the tests in 7, likely migrate to version 8, which should likely involve getting rid of elastisearch-dsl, because it has limitations of elasticsearch <8.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
