### PR TITLE
Fix pymongo tests to be forward-compatible

### DIFF
--- a/tests/providers/mongo/hooks/test_mongo.py
+++ b/tests/providers/mongo/hooks/test_mongo.py
@@ -241,7 +241,7 @@ class TestMongoHook:
 
         self.hook.delete_one(collection, {"_id": "1"})
 
-        assert 0 == collection.count()
+        assert 0 == collection.count_documents({})
 
     def test_delete_many(self):
         collection = mongomock.MongoClient().db.collection
@@ -251,12 +251,12 @@ class TestMongoHook:
 
         self.hook.delete_many(collection, {"field": "value"})
 
-        assert 0 == collection.count()
+        assert 0 == collection.count_documents({})
 
     def test_find_one(self):
         collection = mongomock.MongoClient().db.collection
         obj = {"test_find_one": "test_value"}
-        collection.insert(obj)
+        collection.insert_one(obj)
 
         result_obj = self.hook.find(collection, {}, find_one=True)
         result_obj = {result: result_obj[result] for result in result_obj}
@@ -265,7 +265,7 @@ class TestMongoHook:
     def test_find_many(self):
         collection = mongomock.MongoClient().db.collection
         objs = [{"_id": 1, "test_find_many_1": "test_value"}, {"_id": 2, "test_find_many_2": "test_value"}]
-        collection.insert(objs)
+        collection.insert_many(objs)
 
         result_objs = self.hook.find(mongo_collection=collection, query={}, projection={}, find_one=False)
 
@@ -277,7 +277,7 @@ class TestMongoHook:
             {"_id": "1", "test_find_many_1": "test_value", "field_3": "a"},
             {"_id": "2", "test_find_many_2": "test_value", "field_3": "b"},
         ]
-        collection.insert(objs)
+        collection.insert_many(objs)
 
         projection = {"_id": 0}
         result_objs = self.hook.find(
@@ -293,7 +293,7 @@ class TestMongoHook:
             {"test_id": "3", "test_status": "success"},
         ]
 
-        collection.insert(objs)
+        collection.insert_many(objs)
 
         aggregate_query = [{"$match": {"test_status": "success"}}]
 


### PR DESCRIPTION
The pymongo tests used count() and insert() methods that have been deprecated and their usage was replaced with future compatible count_documents(), insert_one() and insert_many().

As we are preparing (as part of google SDK migration in #30067 to allow migration to pymongo 4.*, we should replace the usage of those methods with the future-compatible ones.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
