### PR TITLE
GKEPodHook needs to have all methods KPO calls

### DIFF
--- a/airflow/providers/google/cloud/hooks/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/hooks/kubernetes_engine.py
@@ -51,7 +51,6 @@ from urllib3.exceptions import HTTPError
 from airflow import version
 from airflow.compat.functools import cached_property
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
-from airflow.kubernetes.pod_generator_deprecated import PodDefaults
 from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import (
     PROVIDE_PROJECT_ID,
@@ -373,10 +372,22 @@ class GKEPodHook(GoogleBaseHook):
     def is_in_cluster(self) -> bool:
         return False
 
-    @staticmethod
-    def get_xcom_sidecar_container_image():
-        """Returns the xcom sidecar image that defined in the connection"""
-        return PodDefaults.SIDECAR_CONTAINER.image
+    def _get_namespace(self):
+        """Implemented for compatibility with KubernetesHook.  Deprecated; do not use."""
+
+    def get_xcom_sidecar_container_image(self):
+        """
+        Returns the xcom sidecar image defined in the connection.
+
+        Implemented for compatibility with KubernetesHook.
+        """
+
+    def get_xcom_sidecar_container_resources(self):
+        """
+        Returns the xcom sidecar resources defined in the connection.
+
+        Implemented for compatibility with KubernetesHook.
+        """
 
     def get_conn(self) -> client.ApiClient:
         configuration = self._get_config()

--- a/tests/ast_helpers.py
+++ b/tests/ast_helpers.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import ast
+from collections import deque
+
+
+class FuncCallVisitor(ast.NodeVisitor):
+    def __init__(self):
+        self._name = deque()
+
+    @property
+    def name(self):
+        return ".".join(self._name)
+
+    @name.deleter
+    def name(self):
+        self._name.clear()
+
+    def visit_Name(self, node):
+        self._name.appendleft(node.id)
+
+    def visit_Attribute(self, node):
+        try:
+            self._name.appendleft(node.attr)
+            self._name.appendleft(node.value.id)
+        except AttributeError:
+            self.generic_visit(node)
+
+
+def get_func_calls(tree):
+    func_calls = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            callvisitor = FuncCallVisitor()
+            callvisitor.visit(node.func)
+            func_calls.append(callvisitor.name)
+
+    return func_calls
+
+
+def extract_ast_class_def_by_name(content, class_name):
+    """
+    Extracts class definition by name
+
+    :param content: python file content
+    :param class_name: name of the class.
+    :return: class node found
+    """
+
+    ast_tree = ast.parse(content)
+    for node in ast.walk(ast_tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return node
+
+    return None

--- a/tests/ast_helpers.py
+++ b/tests/ast_helpers.py
@@ -17,41 +17,6 @@
 from __future__ import annotations
 
 import ast
-from collections import deque
-
-
-class FuncCallVisitor(ast.NodeVisitor):
-    def __init__(self):
-        self._name = deque()
-
-    @property
-    def name(self):
-        return ".".join(self._name)
-
-    @name.deleter
-    def name(self):
-        self._name.clear()
-
-    def visit_Name(self, node):
-        self._name.appendleft(node.id)
-
-    def visit_Attribute(self, node):
-        try:
-            self._name.appendleft(node.attr)
-            self._name.appendleft(node.value.id)
-        except AttributeError:
-            self.generic_visit(node)
-
-
-def get_func_calls(tree):
-    func_calls = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Call):
-            callvisitor = FuncCallVisitor()
-            callvisitor.visit(node.func)
-            func_calls.append(callvisitor.name)
-
-    return func_calls
 
 
 def extract_ast_class_def_by_name(content, class_name):

--- a/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import ast
 import sys
 from asyncio import Future
 
@@ -34,7 +35,7 @@ from airflow.providers.google.cloud.hooks.kubernetes_engine import (
 )
 from airflow.providers.google.common.consts import CLIENT_INFO
 from tests import REPO_ROOT
-from tests.ast_helpers import extract_ast_class_def_by_name, get_func_calls
+from tests.ast_helpers import extract_ast_class_def_by_name
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
 
 if sys.version_info < (3, 8):
@@ -421,6 +422,26 @@ def test_hook_has_methods_required_by_kpo():
     kpo_file = REPO_ROOT / "airflow/providers/cncf/kubernetes/operators/pod.py"
     class_def = extract_ast_class_def_by_name(kpo_file.read_text(), "KubernetesPodOperator")
 
-    pattern = "self.hook."
-    methods = {x.replace(pattern, "") for x in get_func_calls(class_def) if pattern in x}
+    def get_hook_attr_refs(tree, attr):
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute):
+                if isinstance(node.value, ast.Attribute) and node.value.attr == attr:
+                    yield node.attr
+
+    # use AST to find all hook attr references in KPO
+    methods = set(get_hook_attr_refs(class_def, "hook"))
+    # actually verify that GKE has all attrs referenced by KPO
     assert methods.intersection(GKEPodHook.__dict__) == methods
+
+    # sanity check below
+    # the list here is not strictly required but it's helpful to verify that the test is working
+    # will need to be updated when new hook method / attr references added to KPO
+    expected = {
+        "core_v1_client",
+        "get_pod",
+        "_get_namespace",
+        "is_in_cluster",
+        "get_xcom_sidecar_container_image",
+        "get_xcom_sidecar_container_resources",
+    }
+    assert methods == expected

--- a/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
@@ -26,8 +26,15 @@ from google.cloud.container_v1 import ClusterManagerAsyncClient
 from google.cloud.container_v1.types import Cluster
 
 from airflow.exceptions import AirflowException
-from airflow.providers.google.cloud.hooks.kubernetes_engine import GKEAsyncHook, GKEHook, GKEPodAsyncHook
+from airflow.providers.google.cloud.hooks.kubernetes_engine import (
+    GKEAsyncHook,
+    GKEHook,
+    GKEPodAsyncHook,
+    GKEPodHook,
+)
 from airflow.providers.google.common.consts import CLIENT_INFO
+from tests import REPO_ROOT
+from tests.ast_helpers import extract_ast_class_def_by_name, get_func_calls
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
 
 if sys.version_info < (3, 8):
@@ -408,3 +415,12 @@ class TestGKEAsyncHook:
         mock_async_gke_cluster_client.get_operation.assert_called_once_with(
             name=operation_path,
         )
+
+
+def test_hook_has_methods_required_by_kpo():
+    kpo_file = REPO_ROOT / "airflow/providers/cncf/kubernetes/operators/pod.py"
+    class_def = extract_ast_class_def_by_name(kpo_file.read_text(), "KubernetesPodOperator")
+
+    pattern = "self.hook."
+    methods = {x.replace(pattern, "") for x in get_func_calls(class_def) if pattern in x}
+    assert methods.intersection(GKEPodHook.__dict__) == methods


### PR DESCRIPTION
From time to time methods are added to KubernetesHook for use with KPO and we neglect to add them to GKEPodHook, thus breaking GKEStartPodOperator.  Here I add missing methods and a test to ensure that the two classes stay consistent in the ways necessary.

It might be nice to make a common interface such as KubernetesPodOperatorHookInterface which would define the necessary methods, but that is deferred for another day.  For now we simply update GKEPodHook and at an easy test to verify consistency.
