### PR TITLE
Bring back detection of implicit single-line string concatenation

### DIFF
--- a/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -419,7 +419,7 @@ class BatchClientHook(AwsBaseHook):
             return None
         if len(all_info) > 1:
             self.log.warning(
-                f"AWS Batch job ({job_id}) has more than one log stream, " f"only returning the first one."
+                f"AWS Batch job ({job_id}) has more than one log stream, only returning the first one."
             )
         return all_info[0]
 

--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -314,7 +314,7 @@ class BatchOperator(BaseOperator):
             if len(awslogs) > 1:
                 # there can be several log streams on multi-node jobs
                 self.log.warning(
-                    "out of all those logs, we can only link to one in the UI. " "Using the first one."
+                    "out of all those logs, we can only link to one in the UI. Using the first one."
                 )
 
             CloudWatchEventsLink.persist(

--- a/airflow/providers/openlineage/plugins/adapter.py
+++ b/airflow/providers/openlineage/plugins/adapter.py
@@ -52,7 +52,7 @@ _DAG_NAMESPACE = conf.get(
     "openlineage", "namespace", fallback=os.getenv("OPENLINEAGE_NAMESPACE", _DAG_DEFAULT_NAMESPACE)
 )
 
-_PRODUCER = f"https://github.com/apache/airflow/tree/providers-openlineage/" f"{OPENLINEAGE_PROVIDER_VERSION}"
+_PRODUCER = f"https://github.com/apache/airflow/tree/providers-openlineage/{OPENLINEAGE_PROVIDER_VERSION}"
 
 set_producer(_PRODUCER)
 

--- a/airflow/providers/openlineage/utils/utils.py
+++ b/airflow/providers/openlineage/utils/utils.py
@@ -367,7 +367,7 @@ class OpenLineageRedactor(SecretsMasker):
                 return super()._redact(item, name, depth, max_depth)
         except Exception as e:
             log.warning(
-                "Unable to redact %s" "Error was: %s: %s",
+                "Unable to redact %s. Error was: %s: %s",
                 repr(item),
                 type(e).__name__,
                 str(e),

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -608,7 +608,7 @@ def install_provider_packages(
             package_format=package_format, install_selected_providers=install_selected_providers
         )
         get_console().print(
-            f"[info]Splitting {len(list_of_all_providers)} " f"providers into max {parallelism} chunks"
+            f"[info]Splitting {len(list_of_all_providers)} providers into max {parallelism} chunks"
         )
         provider_chunks = [sorted(list_of_all_providers[i::parallelism]) for i in range(parallelism)]
         # filter out empty ones

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ extend-select = [
     "UP", # Pyupgrade
     "RUF100", # Unused noqa (auto-fixable)
 
+    # impocit single-line string concatenation
+    "ISC001",
     # We ignore more pydocstyle than we enable, so be more selective at what we enable
     "D101",
     "D106",

--- a/tests/providers/google/cloud/triggers/test_gcs.py
+++ b/tests/providers/google/cloud/triggers/test_gcs.py
@@ -160,7 +160,7 @@ class TestGCSPrefixBlobTrigger:
 
     @pytest.mark.asyncio
     @async_mock.patch(
-        "airflow.providers.google.cloud.triggers.gcs.GCSPrefixBlobTrigger" "._list_blobs_with_prefix"
+        "airflow.providers.google.cloud.triggers.gcs.GCSPrefixBlobTrigger._list_blobs_with_prefix"
     )
     async def test_gcs_prefix_blob_trigger_success(self, mock_list_blobs_with_prefixs):
         """
@@ -177,7 +177,7 @@ class TestGCSPrefixBlobTrigger:
 
     @pytest.mark.asyncio
     @async_mock.patch(
-        "airflow.providers.google.cloud.triggers.gcs.GCSPrefixBlobTrigger" "._list_blobs_with_prefix"
+        "airflow.providers.google.cloud.triggers.gcs.GCSPrefixBlobTrigger._list_blobs_with_prefix"
     )
     async def test_gcs_prefix_blob_trigger_exception(self, mock_list_blobs_with_prefixs):
         """
@@ -191,7 +191,7 @@ class TestGCSPrefixBlobTrigger:
 
     @pytest.mark.asyncio
     @async_mock.patch(
-        "airflow.providers.google.cloud.triggers.gcs.GCSPrefixBlobTrigger" "._list_blobs_with_prefix"
+        "airflow.providers.google.cloud.triggers.gcs.GCSPrefixBlobTrigger._list_blobs_with_prefix"
     )
     async def test_gcs_prefix_blob_trigger_pending(self, mock_list_blobs_with_prefixs):
         """

--- a/tests/providers/microsoft/azure/log/test_wasb_task_handler.py
+++ b/tests/providers/microsoft/azure/log/test_wasb_task_handler.py
@@ -113,7 +113,7 @@ class TestWasbTaskHandler:
                 [
                     (
                         "localhost",
-                        "*** Found remote logs:\n" "***   * wasb://wasb-container/abc/hello.log\n" "Log line",
+                        "*** Found remote logs:\n***   * wasb://wasb-container/abc/hello.log\nLog line",
                     )
                 ]
             ],


### PR DESCRIPTION
When we switched to ruff we've lost one of the rules that was useful and is not enabled by default in ruff - detection of implicit single-line string concatenation.

It is often automatically introduced by black when reformatting two long strings and it is easy to miss, also it has worse readability so we should bring it back.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
