### PR TITLE
Fix Kubernetes executor set wrong task status

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -220,13 +220,13 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
         resource_version: str,
         event: Any,
     ) -> None:
-        kube_pod = event["object"]
+        pod = event["object"]
         annotations_string = annotations_for_logging_task_metadata(annotations)
         """Process status response."""
         if status == "Pending":
             # deletion_timestamp is set by kube server when a graceful deletion is requested.
             # since kube server have received request to delete pod set TI state failed
-            if event["type"] == "DELETED" and kube_pod.metadata.deletion_timestamp is not None:
+            if event["type"] == "DELETED" and pod.metadata.deletion_timestamp:
                 self.log.info("Event: Failed to start pod %s, annotations: %s", pod_name, annotations_string)
                 self.watcher_queue.put((pod_name, namespace, State.FAILED, annotations, resource_version))
             else:
@@ -240,7 +240,6 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
             # If our event type is DELETED, we have the POD_EXECUTOR_DONE_KEY, or the pod has
             # a deletion timestamp, we've already seen the initial Succeeded event and sent it
             # along to the scheduler.
-            pod = event["object"]
             if (
                 event["type"] == "DELETED"
                 or POD_EXECUTOR_DONE_KEY in pod.metadata.labels
@@ -256,7 +255,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
         elif status == "Running":
             # deletion_timestamp is set by kube server when a graceful deletion is requested.
             # since kube server have received request to delete pod set TI state failed
-            if event["type"] == "DELETED" and kube_pod.metadata.deletion_timestamp is not None:
+            if event["type"] == "DELETED" and pod.metadata.deletion_timestamp:
                 self.log.info(
                     "Event: Pod %s deleted before it could complete, annotations: %s",
                     pod_name,

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -1261,6 +1261,7 @@ class TestKubernetesJobWatcher:
 
     def test_process_status_pending_deleted(self):
         self.events.append({"type": "DELETED", "object": self.pod})
+        self.pod.metadata.deletion_timestamp = datetime.utcnow()
 
         self._run()
         self.assert_watcher_queue_called_once_with_state(State.FAILED)
@@ -1305,6 +1306,7 @@ class TestKubernetesJobWatcher:
 
     def test_process_status_running_deleted(self):
         self.pod.status.phase = "Running"
+        self.pod.metadata.deletion_timestamp = datetime.utcnow()
         self.events.append({"type": "DELETED", "object": self.pod})
 
         self._run()


### PR DESCRIPTION
In the case of multiple schedulers lots of tasks running
If schedulers restart a bit quickly some cases it sets the wrong task status.
In this PR, I'm changing some checks so that if the pod status is non-terminal 
then set the task status to Failed only if the deletion_timestamp (metadata.deletion_timestamp) is set for the pod. This gets set when server receive the deletion request https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/#ObjectMeta

**Example screenshot before changes** 
<img width="1374" alt="Screenshot 2023-05-14 at 2 55 02 AM" src="https://github.com/apache/airflow/assets/98807258/960ece72-af58-4677-895c-ee88b6abb17e">

**Example screenshot after changes** 
<img width="1224" alt="Screenshot 2023-05-14 at 2 49 30 AM" src="https://github.com/apache/airflow/assets/98807258/d0d5a5f8-d2d5-42a1-8228-8b28f6ba8acc">



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
