### PR TITLE
Fix missing aws default

### DIFF
--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -138,7 +138,7 @@ class BatchOperator(BaseOperator):
         waiters: Any | None = None,
         max_retries: int | None = None,
         status_retries: int | None = None,
-        aws_conn_id: str | None = None,
+        aws_conn_id: str | None = 'aws_default',
         region_name: str | None = None,
         tags: dict | None = None,
         wait_for_completion: bool = True,

--- a/airflow/providers/amazon/aws/operators/cloud_formation.py
+++ b/airflow/providers/amazon/aws/operators/cloud_formation.py
@@ -37,7 +37,7 @@ class CloudFormationCreateStackOperator(BaseOperator):
 
     :param stack_name: stack name (templated)
     :param cloudformation_parameters: parameters to be passed to CloudFormation.
-    :param aws_conn_id: aws connection to uses
+    :param aws_conn_id: aws connection to use.
     """
 
     template_fields: Sequence[str] = ("stack_name", "cloudformation_parameters")
@@ -70,7 +70,7 @@ class CloudFormationDeleteStackOperator(BaseOperator):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:CloudFormationDeleteStackOperator`
 
-    :param aws_conn_id: aws connection to uses
+    :param aws_conn_id: aws connection to use.
     """
 
     template_fields: Sequence[str] = ("stack_name",)


### PR DESCRIPTION
I scanned through other AWS Operators, but Batch is the only Operator that uses None for default aws_conn_id.

This commit is to fix it to make it consistent.