### PR TITLE
Add more checks for trigger module

### DIFF
--- a/scripts/in_container/run_provider_yaml_files_check.py
+++ b/scripts/in_container/run_provider_yaml_files_check.py
@@ -306,6 +306,20 @@ def check_hook_classes(yaml_files: dict[str, dict]):
             )
 
 
+def check_trigger_classes(yaml_files: dict[str, dict]):
+    print("Checking triggers classes belong to package, exist and are classes")
+    resource_type = "triggers"
+    for yaml_file_path, provider_data in yaml_files.items():
+        provider_package = pathlib.Path(yaml_file_path).parent.as_posix().replace("/", ".")
+        trigger_classes = []
+        for trigger_class in provider_data.get(resource_type, {}):
+            trigger_classes.extend(trigger_class["class-names"])
+        if trigger_classes:
+            check_if_objects_exist_and_belong_to_package(
+                set(trigger_classes), provider_package, yaml_file_path, resource_type, ObjectType.CLASS
+            )
+
+
 def check_plugin_classes(yaml_files: dict[str, dict]):
     print("Checking plugin classes belong to package, exist and are classes")
     resource_type = "plugins"
@@ -509,6 +523,7 @@ if __name__ == "__main__":
     check_hook_classes(all_parsed_yaml_files)
     check_plugin_classes(all_parsed_yaml_files)
     check_extra_link_classes(all_parsed_yaml_files)
+    check_trigger_classes(all_parsed_yaml_files)
     check_correctness_of_list_of_sensors_operators_hook_modules(all_parsed_yaml_files)
     check_unique_provider_name(all_parsed_yaml_files)
     check_providers_have_all_documentation_files(all_parsed_yaml_files)

--- a/scripts/in_container/run_provider_yaml_files_check.py
+++ b/scripts/in_container/run_provider_yaml_files_check.py
@@ -311,12 +311,14 @@ def check_trigger_classes(yaml_files: dict[str, dict]):
     resource_type = "triggers"
     for yaml_file_path, provider_data in yaml_files.items():
         provider_package = pathlib.Path(yaml_file_path).parent.as_posix().replace("/", ".")
-        trigger_classes = []
-        for trigger_class in provider_data.get(resource_type, {}):
-            trigger_classes.extend(trigger_class["class-names"])
+        trigger_classes = {
+            name
+            for trigger_class in provider_data.get(resource_type, {})
+            for name in names in trigger_class["class-names"]
+        }
         if trigger_classes:
             check_if_objects_exist_and_belong_to_package(
-                set(trigger_classes), provider_package, yaml_file_path, resource_type, ObjectType.CLASS
+                trigger_classes, provider_package, yaml_file_path, resource_type, ObjectType.CLASS
             )
 
 

--- a/scripts/in_container/run_provider_yaml_files_check.py
+++ b/scripts/in_container/run_provider_yaml_files_check.py
@@ -314,7 +314,7 @@ def check_trigger_classes(yaml_files: dict[str, dict]):
         trigger_classes = {
             name
             for trigger_class in provider_data.get(resource_type, {})
-            for name in names in trigger_class["class-names"]
+            for name in trigger_class["class-names"]
         }
         if trigger_classes:
             check_if_objects_exist_and_belong_to_package(

--- a/scripts/in_container/verify_providers.py
+++ b/scripts/in_container/verify_providers.py
@@ -50,6 +50,7 @@ class EntityType(Enum):
     Sensors = "Sensors"
     Hooks = "Hooks"
     Secrets = "Secrets"
+    Trigger = "Trigger"
 
 
 class EntityTypeSummary(NamedTuple):
@@ -80,6 +81,7 @@ ENTITY_NAMES = {
     EntityType.Sensors: "Sensors",
     EntityType.Hooks: "Hooks",
     EntityType.Secrets: "Secrets",
+    EntityType.Trigger: "Trigger",
 }
 
 TOTALS: dict[EntityType, int] = {
@@ -88,6 +90,7 @@ TOTALS: dict[EntityType, int] = {
     EntityType.Sensors: 0,
     EntityType.Transfers: 0,
     EntityType.Secrets: 0,
+    EntityType.Trigger: 0,
 }
 
 OPERATORS_PATTERN = r".*Operator$"
@@ -96,6 +99,7 @@ HOOKS_PATTERN = r".*Hook$"
 SECRETS_PATTERN = r".*Backend$"
 TRANSFERS_PATTERN = r".*To[A-Z0-9].*Operator$"
 WRONG_TRANSFERS_PATTERN = r".*Transfer$|.*TransferOperator$"
+TRIGGER_PATTERN = r".*Trigger$"
 
 ALL_PATTERNS = {
     OPERATORS_PATTERN,
@@ -104,6 +108,7 @@ ALL_PATTERNS = {
     SECRETS_PATTERN,
     TRANSFERS_PATTERN,
     WRONG_TRANSFERS_PATTERN,
+    TRIGGER_PATTERN,
 }
 
 EXPECTED_SUFFIXES: dict[EntityType, str] = {
@@ -112,6 +117,7 @@ EXPECTED_SUFFIXES: dict[EntityType, str] = {
     EntityType.Sensors: "Sensor",
     EntityType.Secrets: "Backend",
     EntityType.Transfers: "Operator",
+    EntityType.Trigger: "Trigger",
 }
 
 
@@ -543,6 +549,7 @@ def get_package_class_summary(
     from airflow.models.baseoperator import BaseOperator
     from airflow.secrets import BaseSecretsBackend
     from airflow.sensors.base import BaseSensorOperator
+    from airflow.triggers.base import BaseTrigger
 
     all_verified_entities: dict[EntityType, VerifiedEntities] = {
         EntityType.Operators: find_all_entities(
@@ -594,6 +601,14 @@ def get_package_class_summary(
             ancestor_match=BaseOperator,
             expected_class_name_pattern=TRANSFERS_PATTERN,
             unexpected_class_name_patterns=ALL_PATTERNS - {OPERATORS_PATTERN, TRANSFERS_PATTERN},
+        ),
+        EntityType.Trigger: find_all_entities(
+            imported_classes=imported_classes,
+            base_package=full_package_name,
+            sub_package_pattern_match=r".*\.triggers\..*",
+            ancestor_match=BaseTrigger,
+            expected_class_name_pattern=TRIGGER_PATTERN,
+            unexpected_class_name_patterns=ALL_PATTERNS - {TRIGGER_PATTERN},
         ),
     }
     for entity in EntityType:

--- a/tests/always/test_providers_manager.py
+++ b/tests/always/test_providers_manager.py
@@ -340,6 +340,11 @@ class TestProviderManager:
         auth_backend_module_names = list(provider_manager.auth_backend_module_names)
         assert len(auth_backend_module_names) > 0
 
+    def test_trigger(self):
+        provider_manager = ProvidersManager()
+        trigger_class_names = list(provider_manager.trigger)
+        assert len(trigger_class_names) > 10
+
     @patch("airflow.providers_manager.import_string")
     def test_optional_feature_no_warning(self, mock_importlib_import_string):
         with self._caplog.at_level(logging.WARNING):


### PR DESCRIPTION
Let's enable more checks for provider triggers modules.
In this PR, enable the following check
- Make sure the trigger class end with Trigger
- Trigger class if in providers.yaml then make sure it exists in the module
- Add a test provider_manager.trigger return non-zero class

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
