### PR TITLE
Make connection id validation consistent across interface

### DIFF
--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -39,6 +39,7 @@ from airflow.api_connexion.types import APIResponse, UpdateMask
 from airflow.models import Connection
 from airflow.secrets.environment_variables import CONN_ENV_PREFIX
 from airflow.security import permissions
+from airflow.utils import helpers
 from airflow.utils.log.action_logger import action_event_from_permission
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.strings import get_random_string
@@ -157,6 +158,10 @@ def post_connection(*, session: Session = NEW_SESSION) -> APIResponse:
     except ValidationError as err:
         raise BadRequest(detail=str(err.messages))
     conn_id = data["conn_id"]
+    try:
+        helpers.validate_key(conn_id, max_length=200)
+    except Exception as e:
+        raise BadRequest(detail=str(e))
     query = session.query(Connection)
     connection = query.filter_by(conn_id=conn_id).first()
     if not connection:

--- a/airflow/cli/commands/connection_command.py
+++ b/airflow/cli/commands/connection_command.py
@@ -35,7 +35,7 @@ from airflow.hooks.base import BaseHook
 from airflow.models import Connection
 from airflow.providers_manager import ProvidersManager
 from airflow.secrets.local_filesystem import load_connections_dict
-from airflow.utils import cli as cli_utils, yaml
+from airflow.utils import cli as cli_utils, helpers, yaml
 from airflow.utils.cli import suppress_logs_and_warning
 from airflow.utils.session import create_session
 
@@ -203,6 +203,12 @@ def connections_add(args):
     has_json = bool(args.conn_json)
     has_type = bool(args.conn_type)
 
+    # Validate connection-id
+    try:
+        helpers.validate_key(args.conn_id, max_length=200)
+    except Exception as e:
+        raise SystemExit(f"Could not create connection. {str(e)}")
+
     if not has_type and not (has_json or has_uri):
         raise SystemExit("Must supply either conn-uri or conn-json if not supplying conn-type")
 
@@ -313,6 +319,13 @@ def _import_helper(file_path: str, overwrite: bool) -> None:
     connections_dict = load_connections_dict(file_path)
     with create_session() as session:
         for conn_id, conn in connections_dict.items():
+            try:
+                helpers.validate_key(conn["conn_id"], max_length=200)
+            except Exception as e:
+                print(f"Could not import invalid connection. {str(e)}")
+                del connections_dict["conn_id"]
+                continue
+
             existing_conn_id = session.query(Connection.id).filter(Connection.conn_id == conn_id).scalar()
             if existing_conn_id is not None:
                 if not overwrite:

--- a/airflow/cli/commands/connection_command.py
+++ b/airflow/cli/commands/connection_command.py
@@ -207,7 +207,7 @@ def connections_add(args):
     try:
         helpers.validate_key(args.conn_id, max_length=200)
     except Exception as e:
-        raise SystemExit(f"Could not create connection. {str(e)}")
+        raise SystemExit(f"Could not create connection. {e}")
 
     if not has_type and not (has_json or has_uri):
         raise SystemExit("Must supply either conn-uri or conn-json if not supplying conn-type")
@@ -322,8 +322,7 @@ def _import_helper(file_path: str, overwrite: bool) -> None:
             try:
                 helpers.validate_key(conn["conn_id"], max_length=200)
             except Exception as e:
-                print(f"Could not import invalid connection. {str(e)}")
-                del connections_dict["conn_id"]
+                print(f"Could not import connection. {e}")
                 continue
 
             existing_conn_id = session.query(Connection.id).filter(Connection.conn_id == conn_id).scalar()

--- a/airflow/cli/commands/connection_command.py
+++ b/airflow/cli/commands/connection_command.py
@@ -320,7 +320,7 @@ def _import_helper(file_path: str, overwrite: bool) -> None:
     with create_session() as session:
         for conn_id, conn in connections_dict.items():
             try:
-                helpers.validate_key(conn["conn_id"], max_length=200)
+                helpers.validate_key(conn_id, max_length=200)
             except Exception as e:
                 print(f"Could not import connection. {e}")
                 continue

--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -562,6 +562,20 @@ class TestPostConnection(TestConnectionEndpoint):
             "type": EXCEPTIONS_LINK_MAP[400],
         }
 
+    def test_post_should_respond_400_for_invalid_conn_id(self):
+        payload = {"connection_id": "****", "conn_type": "test_type"}
+        response = self.client.post(
+            "/api/v1/connections", json=payload, environ_overrides={"REMOTE_USER": "test"}
+        )
+        assert response.status_code == 400
+        assert response.json == {
+            "detail": "The key '****' has to be made of "
+            "alphanumeric characters, dashes, dots and underscores exclusively",
+            "status": 400,
+            "title": "Bad Request",
+            "type": EXCEPTIONS_LINK_MAP[400],
+        }
+
     def test_post_should_respond_409_already_exist(self):
         payload = {"connection_id": "test-connection-id", "conn_type": "test_type"}
         response = self.client.post(

--- a/tests/cli/commands/test_connection_command.py
+++ b/tests/cli/commands/test_connection_command.py
@@ -635,6 +635,17 @@ class TestCliAddConnections:
                 )
             )
 
+    def test_cli_connections_add_invalid_conn_id(self):
+        conn_id = "a***a"
+        with pytest.raises(
+            SystemExit,
+            match=r"The key 'a***a' has to be made of alphanumeric characters, "
+            r"dashes, dots and underscores exclusively",
+        ):
+            connection_command.connections_add(
+                self.parser.parse_args(["connections", "add", conn_id, f"--conn-uri={TEST_URL}"])
+            )
+
 
 class TestCliDeleteConnections:
     parser = cli_parser.get_parser()

--- a/tests/cli/commands/test_connection_command.py
+++ b/tests/cli/commands/test_connection_command.py
@@ -636,15 +636,14 @@ class TestCliAddConnections:
             )
 
     def test_cli_connections_add_invalid_conn_id(self):
-        conn_id = "a***a"
-        with pytest.raises(
-            SystemExit,
-            match=r"The key 'a***a' has to be made of alphanumeric characters, "
-            r"dashes, dots and underscores exclusively",
-        ):
+        with pytest.raises(SystemExit) as e:
             connection_command.connections_add(
-                self.parser.parse_args(["connections", "add", conn_id, f"--conn-uri={TEST_URL}"])
+                self.parser.parse_args(["connections", "add", "Test$", f"--conn-uri={TEST_URL}"])
             )
+        assert (
+            e.value.args[0] == "Could not create connection. The key 'Test$' has to be made of "
+            "alphanumeric characters, dashes, dots and underscores exclusively"
+        )
 
 
 class TestCliDeleteConnections:


### PR DESCRIPTION
recently, we added the connection id validation
if the user creates a connection from UI but 
this improvement is missing in CLI and API. 
This PR make sure that connection id validation is consistent 
across interfaces like CLI, API, and UI.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
