### PR TITLE
openlineage, bigquery: add openlineage method support for BigQueryInsertJobOperator

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -2245,7 +2245,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         self.running_job_id = job.job_id
         return job.job_id
 
-    def generate_job_id(self, job_id, dag_id, task_id, logical_date, configuration, force_rerun=False):
+    def generate_job_id(self, job_id, dag_id, task_id, logical_date, configuration, force_rerun=False) -> str:
         if force_rerun:
             hash_base = str(uuid.uuid4())
         else:

--- a/airflow/providers/openlineage/extractors/base.py
+++ b/airflow/providers/openlineage/extractors/base.py
@@ -86,6 +86,12 @@ class DefaultExtractor(BaseExtractor):
         # OpenLineage methods are optional - if there's no method, return None
         try:
             return self._get_openlineage_facets(self.operator.get_openlineage_facets_on_start)  # type: ignore
+        except ImportError:
+            self.log.error(
+                "OpenLineage provider method failed to import OpenLineage integration. "
+                "This should not happen. Please report this bug to developers."
+            )
+            return None
         except AttributeError:
             return None
 

--- a/airflow/providers/openlineage/utils/utils.py
+++ b/airflow/providers/openlineage/utils/utils.py
@@ -23,7 +23,7 @@ import logging
 import os
 from contextlib import suppress
 from functools import wraps
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Iterable
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import attrs
@@ -414,3 +414,10 @@ def is_source_enabled() -> bool:
 def get_filtered_unknown_operator_keys(operator: BaseOperator) -> dict:
     not_required_keys = {"dag", "task_group"}
     return {attr: value for attr, value in operator.__dict__.items() if attr not in not_required_keys}
+
+
+def normalize_sql(sql: str | Iterable[str]):
+    if isinstance(sql, str):
+        sql = [stmt for stmt in sql.split(";") if stmt != ""]
+    sql = [obj for stmt in sql for obj in stmt.split(";") if obj != ""]
+    return ";\n".join(sql)

--- a/tests/providers/google/cloud/operators/job_details.json
+++ b/tests/providers/google/cloud/operators/job_details.json
@@ -1,0 +1,240 @@
+{
+    "kind": "bigquery#job",
+    "etag": "vd2aBaVVX6a4bUJW13+Tqg==",
+    "id": "airflow:US.job_IDnbVW6NACdFDkermznYm9o4mcVH",
+    "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/airflow-openlineage/jobs/job_IDnbVW6NACdFDkermznYm9o4mcVH?location=US",
+    "user_email": "svc-account@airflow-openlineage.iam.gserviceaccount.com",
+    "configuration": {
+        "query": {
+            "query": "Select * from test_table",
+            "destinationTable": {
+                "projectId": "airflow-openlineage",
+                "datasetId": "new_dataset",
+                "tableId": "output_table"
+            },
+            "createDisposition": "CREATE_IF_NEEDED",
+            "writeDisposition": "WRITE_TRUNCATE",
+            "priority": "INTERACTIVE",
+            "allowLargeResults": false,
+            "useLegacySql": false
+        },
+        "jobType": "QUERY"
+    },
+    "jobReference": {
+        "projectId": "airflow-openlineage",
+        "jobId": "job_IDnbVW6NACdFDkermznYm9o4mcVH",
+        "location": "US"
+    },
+    "statistics": {
+        "creationTime": 1.60390893E12,
+        "startTime": 1.60390893E12,
+        "endTime": 1.60390893E12,
+        "totalBytesProcessed": "110355534",
+        "query": {
+            "queryPlan": [{
+                    "name": "S00: Input",
+                    "id": "0",
+                    "startMs": "1603908925668",
+                    "endMs": "1603908925880",
+                    "waitRatioAvg": 0.0070422534,
+                    "waitMsAvg": "2",
+                    "waitRatioMax": 0.0070422534,
+                    "waitMsMax": "2",
+                    "readRatioAvg": 0.14084508,
+                    "readMsAvg": "40",
+                    "readRatioMax": 0.14084508,
+                    "readMsMax": "40",
+                    "computeRatioAvg": 1,
+                    "computeMsAvg": "284",
+                    "computeRatioMax": 1,
+                    "computeMsMax": "284",
+                    "writeRatioAvg": 0.017605634,
+                    "writeMsAvg": "5",
+                    "writeRatioMax": 0.017605634,
+                    "writeMsMax": "5",
+                    "shuffleOutputBytes": "439409",
+                    "shuffleOutputBytesSpilled": "0",
+                    "recordsRead": "5552452",
+                    "recordsWritten": "16142",
+                    "parallelInputs": "1",
+                    "completedParallelInputs": "1",
+                    "status": "COMPLETE",
+                    "steps": [{
+                            "kind": "READ",
+                            "substeps": [
+                                "$1:state, $2:name, $3:number",
+                                "FROM bigquery-public-data.usa_names.usa_1910_2013",
+                                "WHERE equal($1, 'TX')"
+                            ]
+                        },
+                        {
+                            "kind": "AGGREGATE",
+                            "substeps": [
+                                "GROUP BY $30 := $2, $31 := $1",
+                                "$20 := SUM($3)"
+                            ]
+                        },
+                        {
+                            "kind": "WRITE",
+                            "substeps": [
+                                "$31, $30, $20",
+                                "TO __stage00_output",
+                                "BY HASH($30, $31)"
+                            ]
+                        }
+                    ],
+                    "slotMs": "448"
+                },
+                {
+                    "name": "S01: Sort+",
+                    "id": "1",
+                    "startMs": "1603908925891",
+                    "endMs": "1603908925911",
+                    "inputStages": [
+                        "0"
+                    ],
+                    "waitRatioAvg": 0.0070422534,
+                    "waitMsAvg": "2",
+                    "waitRatioMax": 0.0070422534,
+                    "waitMsMax": "2",
+                    "readRatioAvg": 0,
+                    "readMsAvg": "0",
+                    "readRatioMax": 0,
+                    "readMsMax": "0",
+                    "computeRatioAvg": 0.049295776,
+                    "computeMsAvg": "14",
+                    "computeRatioMax": 0.049295776,
+                    "computeMsMax": "14",
+                    "writeRatioAvg": 0.0070422534,
+                    "writeMsAvg": "2",
+                    "writeRatioMax": 0.0070422534,
+                    "writeMsMax": "2",
+                    "shuffleOutputBytes": "401",
+                    "shuffleOutputBytesSpilled": "0",
+                    "recordsRead": "16142",
+                    "recordsWritten": "20",
+                    "parallelInputs": "1",
+                    "completedParallelInputs": "1",
+                    "status": "COMPLETE",
+                    "steps": [{
+                            "kind": "READ",
+                            "substeps": [
+                                "$31, $30, $20",
+                                "FROM __stage00_output"
+                            ]
+                        },
+                        {
+                            "kind": "SORT",
+                            "substeps": [
+                                "$10 DESC",
+                                "LIMIT 20"
+                            ]
+                        },
+                        {
+                            "kind": "AGGREGATE",
+                            "substeps": [
+                                "GROUP BY $40 := $30, $41 := $31",
+                                "$10 := SUM($20)"
+                            ]
+                        },
+                        {
+                            "kind": "WRITE",
+                            "substeps": [
+                                "$50, $51",
+                                "TO __stage01_output"
+                            ]
+                        }
+                    ],
+                    "slotMs": "33"
+                },
+                {
+                    "name": "S02: Output",
+                    "id": "2",
+                    "startMs": "1603908926017",
+                    "endMs": "1603908926191",
+                    "inputStages": [
+                        "1"
+                    ],
+                    "waitRatioAvg": 0.4471831,
+                    "waitMsAvg": "127",
+                    "waitRatioMax": 0.4471831,
+                    "waitMsMax": "127",
+                    "readRatioAvg": 0,
+                    "readMsAvg": "0",
+                    "readRatioMax": 0,
+                    "readMsMax": "0",
+                    "computeRatioAvg": 0.03169014,
+                    "computeMsAvg": "9",
+                    "computeRatioMax": 0.03169014,
+                    "computeMsMax": "9",
+                    "writeRatioAvg": 0.5633803,
+                    "writeMsAvg": "160",
+                    "writeRatioMax": 0.5633803,
+                    "writeMsMax": "160",
+                    "shuffleOutputBytes": "321",
+                    "shuffleOutputBytesSpilled": "0",
+                    "recordsRead": "20",
+                    "recordsWritten": "20",
+                    "parallelInputs": "1",
+                    "completedParallelInputs": "1",
+                    "status": "COMPLETE",
+                    "steps": [{
+                            "kind": "READ",
+                            "substeps": [
+                                "$50, $51",
+                                "FROM __stage01_output"
+                            ]
+                        },
+                        {
+                            "kind": "SORT",
+                            "substeps": [
+                                "$51 DESC",
+                                "LIMIT 20"
+                            ]
+                        },
+                        {
+                            "kind": "WRITE",
+                            "substeps": [
+                                "$60, $61",
+                                "TO __stage02_output"
+                            ]
+                        }
+                    ],
+                    "slotMs": "342"
+                }
+            ],
+            "estimatedBytesProcessed": "110355534",
+            "timeline": [{
+                    "elapsedMs": "736",
+                    "totalSlotMs": "482",
+                    "pendingUnits": "1",
+                    "completedUnits": "2",
+                    "activeUnits": "1"
+                },
+                {
+                    "elapsedMs": "1045",
+                    "totalSlotMs": "825",
+                    "pendingUnits": "0",
+                    "completedUnits": "3",
+                    "activeUnits": "1"
+                }
+            ],
+            "totalPartitionsProcessed": "0",
+            "totalBytesProcessed": "110355534",
+            "totalBytesBilled": "111149056",
+            "billingTier": 1,
+            "totalSlotMs": "825",
+            "cacheHit": false,
+            "referencedTables": [{
+                "projectId": "airflow-openlineage",
+                "datasetId": "new_dataset",
+                "tableId": "test_table"
+            }],
+            "statementType": "SELECT"
+        },
+        "totalSlotMs": "825"
+    },
+    "status": {
+        "state": "DONE"
+    }
+}


### PR DESCRIPTION
This PR adds OpenLineage support for BigQueryInsertJobOperator.

Despite being SQL-based, this does not use SQL parsing due to the fact that BigQuery has an API that allows us to get the lineage data directly from it. Code that does that is implemented in OpenLineage Common library: https://github.com/OpenLineage/OpenLineage/blob/main/integration/common/openlineage/common/provider/bigquery.py
the method merely uses it.