### PR TITLE
Optimize deferrable mode execution for `DataprocSubmitJobOperator`

### DIFF
--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -2029,17 +2029,15 @@ class DataprocSubmitJobOperator(GoogleCloudBaseOperator):
         )
 
         self.job_id = new_job_id
-
-        job = self.hook.get_job(project_id=self.project_id, region=self.region, job_id=self.job_id)
-        state = job.status.state
-        if state == JobStatus.State.DONE:
-            return self.job_id
-        elif state == JobStatus.State.ERROR:
-            raise AirflowException(f"Job failed:\n{job}")
-        elif state == JobStatus.State.CANCELLED:
-            raise AirflowException(f"Job was cancelled:\n{job}")
-
         if self.deferrable:
+            job = self.hook.get_job(project_id=self.project_id, region=self.region, job_id=self.job_id)
+            state = job.status.state
+            if state == JobStatus.State.DONE:
+                return self.job_id
+            elif state == JobStatus.State.ERROR:
+                raise AirflowException(f"Job failed:\n{job}")
+            elif state == JobStatus.State.CANCELLED:
+                raise AirflowException(f"Job was cancelled:\n{job}")
             self.defer(
                 trigger=DataprocSubmitTrigger(
                     job_id=self.job_id,

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -2029,6 +2029,16 @@ class DataprocSubmitJobOperator(GoogleCloudBaseOperator):
         )
 
         self.job_id = new_job_id
+
+        job = self.hook.get_job(project_id=self.project_id, region=self.region, job_id=self.job_id)
+        state = job.status.state
+        if state == JobStatus.State.DONE:
+            return self.job_id
+        elif state == JobStatus.State.ERROR:
+            raise AirflowException(f"Job failed:\n{job}")
+        elif state == JobStatus.State.CANCELLED:
+            raise AirflowException(f"Job was cancelled:\n{job}")
+
         if self.deferrable:
             self.defer(
                 trigger=DataprocSubmitTrigger(

--- a/tests/providers/google/cloud/operators/test_dataproc.py
+++ b/tests/providers/google/cloud/operators/test_dataproc.py
@@ -23,7 +23,7 @@ from unittest.mock import MagicMock, Mock, call
 import pytest
 from google.api_core.exceptions import AlreadyExists, NotFound
 from google.api_core.retry import Retry
-from google.cloud.dataproc_v1 import Batch
+from google.cloud.dataproc_v1 import Batch, JobStatus
 
 from airflow.exceptions import (
     AirflowException,
@@ -134,7 +134,8 @@ VIRTUAL_CLUSTER_CONFIG = {
             "gke_cluster_target": "projects/project_id/locations/region/clusters/gke_cluster_name",
             "node_pool_target": [
                 {
-                    "node_pool": "projects/project_id/locations/region/clusters/gke_cluster_name/nodePools/dp",  # noqa
+                    "node_pool": "projects/project_id/locations/region/clusters/gke_cluster_name/nodePools/"
+                    "dp",
                     "roles": ["DEFAULT"],
                 }
             ],
@@ -1057,6 +1058,32 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
 
         assert isinstance(exc.value.trigger, DataprocSubmitTrigger)
         assert exc.value.method_name == GOOGLE_DEFAULT_DEFERRABLE_METHOD_NAME
+
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    @mock.patch("airflow.providers.google.cloud.operators.dataproc.DataprocSubmitJobOperator.defer")
+    @mock.patch("airflow.providers.google.cloud.operators.dataproc.DataprocHook.submit_job")
+    def test_dataproc_operator_execute_async_done_before_defer(self, mock_submit_job, mock_defer, mock_hook):
+        mock_submit_job.return_value.reference.job_id = TEST_JOB_ID
+        job_status = mock_hook.return_value.get_job.return_value.status
+        job_status.state = JobStatus.State.DONE
+
+        op = DataprocSubmitJobOperator(
+            task_id=TASK_ID,
+            region=GCP_REGION,
+            project_id=GCP_PROJECT,
+            job={},
+            gcp_conn_id=GCP_CONN_ID,
+            retry=RETRY,
+            asynchronous=True,
+            timeout=TIMEOUT,
+            metadata=METADATA,
+            request_id=REQUEST_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+            deferrable=True,
+        )
+
+        op.execute(context=self.mock_context)
+        assert not mock_defer.called
 
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_on_kill(self, mock_hook):

--- a/tests/providers/google/cloud/operators/test_dataproc.py
+++ b/tests/providers/google/cloud/operators/test_dataproc.py
@@ -134,8 +134,7 @@ VIRTUAL_CLUSTER_CONFIG = {
             "gke_cluster_target": "projects/project_id/locations/region/clusters/gke_cluster_name",
             "node_pool_target": [
                 {
-                    "node_pool": "projects/project_id/locations/region/clusters/gke_cluster_name/nodePools/"
-                    "dp",
+                    "node_pool": "projects/project_id/locations/region/clusters/gke_cluster_name/nodePools/dp",  # noqa
                     "roles": ["DEFAULT"],
                 }
             ],


### PR DESCRIPTION
This PR verifies if a dataproc job has already completed (or) errored out (or) cancelled before deferring the task to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
