### PR TITLE
Add missing priorityClassName to K8S worker pod template

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -80,6 +80,9 @@ spec:
     {{- if .Values.workers.extraContainers }}
       {{- toYaml .Values.workers.extraContainers | nindent 4 }}
     {{- end }}
+  {{- if .Values.workers.priorityClassName }}
+  priorityClassName: {{ .Values.workers.priorityClassName }}
+  {{- end }}
   {{- if or .Values.registry.secretName .Values.registry.connection }}
   imagePullSecrets:
     - name: {{ template "registry_secret" . }}

--- a/tests/charts/airflow_aux/test_pod_template_file.py
+++ b/tests/charts/airflow_aux/test_pod_template_file.py
@@ -733,3 +733,16 @@ class TestPodTemplateFile:
 
         assert "127.0.0.2" == jmespath.search("spec.hostAliases[0].ip", docs[0])
         assert "test.hostname" == jmespath.search("spec.hostAliases[0].hostnames[0]", docs[0])
+
+    def test_workers_priority_class_name(self):
+        docs = render_chart(
+            values={
+                "workers": {
+                    "priorityClassName": "test-priority",
+                },
+            },
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert "test-priority" == jmespath.search("spec.priorityClassName", docs[0])


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #31311

This PR adds `priorityClassName` to the pod template of the KubernetesExecutor workers when it is provided to `Values.workers.priorityClassName`

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
