### PR TITLE
Handle temporary credentials when resource_type is used to get custom waiters

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -853,6 +853,7 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
                     region_name=self.region_name,
                     aws_access_key_id=credentials.access_key,
                     aws_secret_access_key=credentials.secret_key,
+                    aws_session_token=credentials.token,
                 )
 
             # Technically if waiter_name is in custom_waiters then self.waiter_path must


### PR DESCRIPTION
Handle temporary credentials when resource_type is used to get custom waiters.

The code implemented in #30897 does not handle temporary credentials. In other words, any custom waiter of resources of type `resource_type` (e.g. DynamoDB) does not work in environment using temporary credentials

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
