### PR TITLE
Fix missing line in index.rst

### DIFF
--- a/docs/apache-airflow-providers-airbyte/index.rst
+++ b/docs/apache-airflow-providers-airbyte/index.rst
@@ -83,6 +83,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =================================  ==================
 PIP package                        Version required
 =================================  ==================

--- a/docs/apache-airflow-providers-alibaba/index.rst
+++ b/docs/apache-airflow-providers-alibaba/index.rst
@@ -84,6 +84,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-amazon/index.rst
+++ b/docs/apache-airflow-providers-amazon/index.rst
@@ -93,6 +93,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-apache-beam/index.rst
+++ b/docs/apache-airflow-providers-apache-beam/index.rst
@@ -82,6 +82,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-apache-cassandra/index.rst
+++ b/docs/apache-airflow-providers-apache-cassandra/index.rst
@@ -83,6 +83,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ====================  ==================
 PIP package           Version required
 ====================  ==================

--- a/docs/apache-airflow-providers-apache-drill/index.rst
+++ b/docs/apache-airflow-providers-apache-drill/index.rst
@@ -83,6 +83,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-apache-druid/index.rst
+++ b/docs/apache-airflow-providers-apache-druid/index.rst
@@ -83,6 +83,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-apache-flink/index.rst
+++ b/docs/apache-airflow-providers-apache-flink/index.rst
@@ -76,6 +76,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ============================================  ==================
 PIP package                                   Version required
 ============================================  ==================

--- a/docs/apache-airflow-providers-apache-hdfs/index.rst
+++ b/docs/apache-airflow-providers-apache-hdfs/index.rst
@@ -73,6 +73,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =================================  ==================
 PIP package                        Version required
 =================================  ==================

--- a/docs/apache-airflow-providers-apache-hive/index.rst
+++ b/docs/apache-airflow-providers-apache-hive/index.rst
@@ -85,6 +85,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================================
 PIP package                              Version required
 =======================================  ==================================

--- a/docs/apache-airflow-providers-apache-impala/index.rst
+++ b/docs/apache-airflow-providers-apache-impala/index.rst
@@ -82,6 +82,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-apache-kafka/index.rst
+++ b/docs/apache-airflow-providers-apache-kafka/index.rst
@@ -89,6 +89,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ===================  ==================
 PIP package          Version required
 ===================  ==================

--- a/docs/apache-airflow-providers-apache-kylin/index.rst
+++ b/docs/apache-airflow-providers-apache-kylin/index.rst
@@ -77,6 +77,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-apache-livy/index.rst
+++ b/docs/apache-airflow-providers-apache-livy/index.rst
@@ -82,6 +82,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =================================  ==================
 PIP package                        Version required
 =================================  ==================

--- a/docs/apache-airflow-providers-apache-pig/index.rst
+++ b/docs/apache-airflow-providers-apache-pig/index.rst
@@ -82,6 +82,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-apache-pinot/index.rst
+++ b/docs/apache-airflow-providers-apache-pinot/index.rst
@@ -76,6 +76,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-apache-spark/index.rst
+++ b/docs/apache-airflow-providers-apache-spark/index.rst
@@ -83,6 +83,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-apache-sqoop/index.rst
+++ b/docs/apache-airflow-providers-apache-sqoop/index.rst
@@ -70,6 +70,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-arangodb/index.rst
+++ b/docs/apache-airflow-providers-arangodb/index.rst
@@ -83,6 +83,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-asana/index.rst
+++ b/docs/apache-airflow-providers-asana/index.rst
@@ -84,6 +84,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-atlassian-jira/index.rst
+++ b/docs/apache-airflow-providers-atlassian-jira/index.rst
@@ -70,6 +70,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ========================  ==================
 PIP package               Version required
 ========================  ==================

--- a/docs/apache-airflow-providers-celery/index.rst
+++ b/docs/apache-airflow-providers-celery/index.rst
@@ -65,6 +65,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-cloudant/index.rst
+++ b/docs/apache-airflow-providers-cloudant/index.rst
@@ -65,6 +65,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-cncf-kubernetes/index.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/index.rst
@@ -84,6 +84,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ======================  ==================
 PIP package             Version required
 ======================  ==================

--- a/docs/apache-airflow-providers-databricks/index.rst
+++ b/docs/apache-airflow-providers-databricks/index.rst
@@ -84,6 +84,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ===================
 PIP package                              Version required
 =======================================  ===================

--- a/docs/apache-airflow-providers-datadog/index.rst
+++ b/docs/apache-airflow-providers-datadog/index.rst
@@ -76,6 +76,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-dbt-cloud/index.rst
+++ b/docs/apache-airflow-providers-dbt-cloud/index.rst
@@ -88,6 +88,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =================================  ==================
 PIP package                        Version required
 =================================  ==================

--- a/docs/apache-airflow-providers-dingding/index.rst
+++ b/docs/apache-airflow-providers-dingding/index.rst
@@ -83,6 +83,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =================================  ==================
 PIP package                        Version required
 =================================  ==================

--- a/docs/apache-airflow-providers-discord/index.rst
+++ b/docs/apache-airflow-providers-discord/index.rst
@@ -65,6 +65,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =================================  ==================
 PIP package                        Version required
 =================================  ==================

--- a/docs/apache-airflow-providers-docker/index.rst
+++ b/docs/apache-airflow-providers-docker/index.rst
@@ -78,6 +78,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-elasticsearch/index.rst
+++ b/docs/apache-airflow-providers-elasticsearch/index.rst
@@ -85,6 +85,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-exasol/index.rst
+++ b/docs/apache-airflow-providers-exasol/index.rst
@@ -70,6 +70,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-facebook/index.rst
+++ b/docs/apache-airflow-providers-facebook/index.rst
@@ -70,6 +70,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =====================  ==================
 PIP package            Version required
 =====================  ==================

--- a/docs/apache-airflow-providers-github/index.rst
+++ b/docs/apache-airflow-providers-github/index.rst
@@ -90,6 +90,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-google/index.rst
+++ b/docs/apache-airflow-providers-google/index.rst
@@ -95,6 +95,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ======================================
 PIP package                              Version required
 =======================================  ======================================

--- a/docs/apache-airflow-providers-grpc/index.rst
+++ b/docs/apache-airflow-providers-grpc/index.rst
@@ -76,6 +76,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ========================  ===================
 PIP package               Version required
 ========================  ===================

--- a/docs/apache-airflow-providers-hashicorp/index.rst
+++ b/docs/apache-airflow-providers-hashicorp/index.rst
@@ -77,6 +77,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-influxdb/index.rst
+++ b/docs/apache-airflow-providers-influxdb/index.rst
@@ -90,6 +90,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ===================  ==================
 PIP package          Version required
 ===================  ==================

--- a/docs/apache-airflow-providers-jdbc/index.rst
+++ b/docs/apache-airflow-providers-jdbc/index.rst
@@ -84,6 +84,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-jenkins/index.rst
+++ b/docs/apache-airflow-providers-jenkins/index.rst
@@ -82,6 +82,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-microsoft-azure/index.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/index.rst
@@ -86,6 +86,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ================================  ==================
 PIP package                       Version required
 ================================  ==================

--- a/docs/apache-airflow-providers-microsoft-mssql/index.rst
+++ b/docs/apache-airflow-providers-microsoft-mssql/index.rst
@@ -84,6 +84,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-microsoft-psrp/index.rst
+++ b/docs/apache-airflow-providers-microsoft-psrp/index.rst
@@ -78,6 +78,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-microsoft-winrm/index.rst
+++ b/docs/apache-airflow-providers-microsoft-winrm/index.rst
@@ -83,6 +83,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-mongo/index.rst
+++ b/docs/apache-airflow-providers-mongo/index.rst
@@ -71,6 +71,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-mysql/index.rst
+++ b/docs/apache-airflow-providers-mysql/index.rst
@@ -84,6 +84,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-neo4j/index.rst
+++ b/docs/apache-airflow-providers-neo4j/index.rst
@@ -84,6 +84,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-odbc/index.rst
+++ b/docs/apache-airflow-providers-odbc/index.rst
@@ -72,6 +72,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-openfaas/index.rst
+++ b/docs/apache-airflow-providers-openfaas/index.rst
@@ -70,6 +70,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-opsgenie/index.rst
+++ b/docs/apache-airflow-providers-opsgenie/index.rst
@@ -83,6 +83,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-oracle/index.rst
+++ b/docs/apache-airflow-providers-oracle/index.rst
@@ -78,6 +78,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-pagerduty/index.rst
+++ b/docs/apache-airflow-providers-pagerduty/index.rst
@@ -70,6 +70,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-papermill/index.rst
+++ b/docs/apache-airflow-providers-papermill/index.rst
@@ -83,6 +83,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-plexus/index.rst
+++ b/docs/apache-airflow-providers-plexus/index.rst
@@ -77,6 +77,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-postgres/index.rst
+++ b/docs/apache-airflow-providers-postgres/index.rst
@@ -84,6 +84,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-presto/index.rst
+++ b/docs/apache-airflow-providers-presto/index.rst
@@ -83,6 +83,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-qubole/index.rst
+++ b/docs/apache-airflow-providers-qubole/index.rst
@@ -83,6 +83,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-redis/index.rst
+++ b/docs/apache-airflow-providers-redis/index.rst
@@ -77,6 +77,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-salesforce/index.rst
+++ b/docs/apache-airflow-providers-salesforce/index.rst
@@ -84,6 +84,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =====================  ==================
 PIP package            Version required
 =====================  ==================

--- a/docs/apache-airflow-providers-samba/index.rst
+++ b/docs/apache-airflow-providers-samba/index.rst
@@ -70,6 +70,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-segment/index.rst
+++ b/docs/apache-airflow-providers-segment/index.rst
@@ -70,6 +70,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ====================  ==================
 PIP package           Version required
 ====================  ==================

--- a/docs/apache-airflow-providers-sendgrid/index.rst
+++ b/docs/apache-airflow-providers-sendgrid/index.rst
@@ -70,6 +70,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-sftp/index.rst
+++ b/docs/apache-airflow-providers-sftp/index.rst
@@ -71,6 +71,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ================================  ==================
 PIP package                       Version required
 ================================  ==================

--- a/docs/apache-airflow-providers-singularity/index.rst
+++ b/docs/apache-airflow-providers-singularity/index.rst
@@ -77,6 +77,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-slack/index.rst
+++ b/docs/apache-airflow-providers-slack/index.rst
@@ -84,6 +84,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-smtp/index.rst
+++ b/docs/apache-airflow-providers-smtp/index.rst
@@ -71,6 +71,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-snowflake/index.rst
+++ b/docs/apache-airflow-providers-snowflake/index.rst
@@ -84,6 +84,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-ssh/index.rst
+++ b/docs/apache-airflow-providers-ssh/index.rst
@@ -76,6 +76,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-tableau/index.rst
+++ b/docs/apache-airflow-providers-tableau/index.rst
@@ -79,6 +79,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================  ==================
 PIP package              Version required
 =======================  ==================

--- a/docs/apache-airflow-providers-tabular/index.rst
+++ b/docs/apache-airflow-providers-tabular/index.rst
@@ -79,6 +79,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================

--- a/docs/apache-airflow-providers-telegram/index.rst
+++ b/docs/apache-airflow-providers-telegram/index.rst
@@ -83,6 +83,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================  ==================
 PIP package              Version required
 =======================  ==================

--- a/docs/apache-airflow-providers-trino/index.rst
+++ b/docs/apache-airflow-providers-trino/index.rst
@@ -85,6 +85,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-vertica/index.rst
+++ b/docs/apache-airflow-providers-vertica/index.rst
@@ -70,6 +70,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 =======================================  ==================
 PIP package                              Version required
 =======================================  ==================

--- a/docs/apache-airflow-providers-zendesk/index.rst
+++ b/docs/apache-airflow-providers-zendesk/index.rst
@@ -77,6 +77,7 @@ Requirements
 ------------
 
 The minimum Apache Airflow version supported by this provider package is ``2.4.0``.
+
 ==================  ==================
 PIP package         Version required
 ==================  ==================


### PR DESCRIPTION
This was "once a blue moon" case. It was really a result of improvement
ew weeks ago to improve the "min-airflow-version" automation
(which happens every 12 months or so).

The change was to modify index.rst to include the information
about "minimum required airflow version" in #30994 (and
added full automation for it) but the templated missed a single line.

This one fixes the template: #31323 but we need the follow up with
those empty lines updated in index.rst files in order to correct
the documentation generated in the PR for documentation for the
new wave of providers: https://github.com/apache/airflow-site/pull/787

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
