### PR TITLE
Fix Scheduler crash when clear a previous run of a normal task that is now a mapped task.

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2834,7 +2834,7 @@ class TaskInstance(Base, LoggingMixin):
         """
         from airflow.models.renderedtifields import RenderedTaskInstanceFields
 
-        tables = [TaskFail, XCom, RenderedTaskInstanceFields]
+        tables = [TaskFail, TaskInstanceNote, TaskReschedule, XCom, RenderedTaskInstanceFields]
         for table in tables:
             session.execute(
                 delete(table).where(

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2826,7 +2826,7 @@ class TaskInstance(Base, LoggingMixin):
 
     def clear_db_references(self, session):
         """
-        Clear db tables what have a reference to this instance.
+        Clear db tables that have a reference to this instance.
 
         :param session: ORM Session
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2826,7 +2826,8 @@ class TaskInstance(Base, LoggingMixin):
 
     def clear_db_references(self, session):
         """
-        Clear DB references to XCom, TaskFail and RenderedTaskInstanceFields.
+        Clear DB references to XCom, TaskFail, TaskInstanceNote,
+        TaskReschedule and RenderedTaskInstanceFields.
 
         :param session: ORM Session
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2826,8 +2826,7 @@ class TaskInstance(Base, LoggingMixin):
 
     def clear_db_references(self, session):
         """
-        Clear DB references to XCom, TaskFail, TaskInstanceNote,
-        TaskReschedule and RenderedTaskInstanceFields.
+        Clear db tables what have a reference to this instance.
 
         :param session: ORM Session
 

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -40,7 +40,9 @@ from airflow.models import (
 )
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dagrun import DagRunNote
+from airflow.models.taskinstance import TaskInstanceNote
 from airflow.models.taskmap import TaskMap
+from airflow.models.taskreschedule import TaskReschedule
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import ShortCircuitOperator
 from airflow.serialization.serialized_objects import SerializedDAG
@@ -2273,20 +2275,34 @@ def test_clearing_task_and_moving_from_non_mapped_to_mapped(dag_maker, session):
 
     dr1: DagRun = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
     ti = dr1.get_task_instances()[0]
+    filter_kwargs = dict(dag_id=ti.dag_id, task_id=ti.task_id, run_id=ti.run_id, map_index=ti.map_index)
+    ti = session.query(TaskInstance).filter_by(**filter_kwargs).one()
+
+    tr = TaskReschedule(
+        task=ti,
+        run_id=ti.run_id,
+        try_number=ti.run_id,
+        start_date=timezone.datetime(2017, 1, 1),
+        end_date=timezone.datetime(2017, 1, 2),
+        reschedule_date=timezone.datetime(2017, 1, 1),
+    )
+
     # mimicking a case where task moved from non-mapped to mapped
     # in that case, it would have map_index of -1 even though mapped
     ti.map_index = -1
+    ti.note = "sample note"
     session.merge(ti)
     session.flush()
     # Purposely omitted RenderedTaskInstanceFields because the ti need
     # to be expanded but here we are mimicking and made it map_index -1
+    session.add(tr)
     session.add(TaskFail(ti))
     XCom.set(key="test", value="value", task_id=ti.task_id, dag_id=dag.dag_id, run_id=ti.run_id)
     session.commit()
-    for table in [TaskFail, XCom]:
+    for table in [TaskFail, TaskInstanceNote, XCom]:
         assert session.query(table).count() == 1
     dr1.task_instance_scheduling_decisions(session)
-    for table in [TaskFail, XCom]:
+    for table in [TaskFail, TaskInstanceNote, XCom]:
         assert session.query(table).count() == 0
 
 

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -2258,9 +2258,9 @@ def test_mapped_task_depends_on_past(dag_maker, session):
 def test_clearing_task_and_moving_from_non_mapped_to_mapped(dag_maker, session):
     """
     Test that clearing a task and moving from non-mapped to mapped clears existing
-    references in XCom, TaskFail, and RenderedTaskInstanceFields
-    To be able to test this, RenderedTaskInstanceFields was not used in the test
-    since it would require that the task is expanded first.
+    references in XCom, TaskFail, TaskInstanceNote, TaskReschedule and
+    RenderedTaskInstanceFields. To be able to test this, RenderedTaskInstanceFields
+    was not used in the test since it would require that the task is expanded first.
     """
 
     from airflow.models.taskfail import TaskFail
@@ -2281,7 +2281,7 @@ def test_clearing_task_and_moving_from_non_mapped_to_mapped(dag_maker, session):
     tr = TaskReschedule(
         task=ti,
         run_id=ti.run_id,
-        try_number=ti.run_id,
+        try_number=ti.try_number,
         start_date=timezone.datetime(2017, 1, 1),
         end_date=timezone.datetime(2017, 1, 2),
         reschedule_date=timezone.datetime(2017, 1, 1),
@@ -2299,10 +2299,10 @@ def test_clearing_task_and_moving_from_non_mapped_to_mapped(dag_maker, session):
     session.add(TaskFail(ti))
     XCom.set(key="test", value="value", task_id=ti.task_id, dag_id=dag.dag_id, run_id=ti.run_id)
     session.commit()
-    for table in [TaskFail, TaskInstanceNote, XCom]:
+    for table in [TaskFail, TaskInstanceNote, TaskReschedule, XCom]:
         assert session.query(table).count() == 1
     dr1.task_instance_scheduling_decisions(session)
-    for table in [TaskFail, TaskInstanceNote, XCom]:
+    for table in [TaskFail, TaskInstanceNote, TaskReschedule, XCom]:
         assert session.query(table).count() == 0
 
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -3105,6 +3105,8 @@ class TestTaskInstance:
     def test_clear_db_references(self, session, create_task_instance):
         tables = [TaskFail, RenderedTaskInstanceFields, XCom]
         ti = create_task_instance()
+        ti.note = "sample note"
+
         session.merge(ti)
         session.commit()
         for table in [TaskFail, RenderedTaskInstanceFields]:
@@ -3113,9 +3115,16 @@ class TestTaskInstance:
         session.commit()
         for table in tables:
             assert session.query(table).count() == 1
+
+        filter_kwargs = dict(dag_id=ti.dag_id, task_id=ti.task_id, run_id=ti.run_id, map_index=ti.map_index)
+        ti_note = session.query(TaskInstanceNote).filter_by(**filter_kwargs).one()
+        assert ti_note.content == "sample note"
+
         ti.clear_db_references(session)
         for table in tables:
             assert session.query(table).count() == 0
+
+        assert session.query(TaskInstanceNote).filter_by(**filter_kwargs).one_or_none() is None
 
 
 @pytest.mark.parametrize("pool_override", [None, "test_pool2"])


### PR DESCRIPTION
The fix is to clear TaskInstanceNote and TaskReschedule objects of corresponding TaskInstance. Similar to commit a770edfac493f3972c10a43e45bcd0e7cfaea65f


closes: #31351
related: #31351