### PR TITLE
Add namespace to all namespace-scoped resources

### DIFF
--- a/chart/templates/cleanup/cleanup-cronjob.yaml
+++ b/chart/templates/cleanup/cleanup-cronjob.yaml
@@ -34,6 +34,7 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-cleanup
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: airflow-cleanup-pods

--- a/chart/templates/cleanup/cleanup-serviceaccount.yaml
+++ b/chart/templates/cleanup/cleanup-serviceaccount.yaml
@@ -25,6 +25,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ include "cleanup.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     release: {{ .Release.Name }}

--- a/chart/templates/configmaps/configmap.yaml
+++ b/chart/templates/configmaps/configmap.yaml
@@ -24,6 +24,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "airflow_config" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: config

--- a/chart/templates/configmaps/extra-configmaps.yaml
+++ b/chart/templates/configmaps/extra-configmaps.yaml
@@ -27,6 +27,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ tpl $configMapName $Global | quote }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     release: {{ $Global.Release.Name }}
     chart: "{{ $Global.Chart.Name }}-{{ $Global.Chart.Version }}"

--- a/chart/templates/configmaps/statsd-configmap.yaml
+++ b/chart/templates/configmaps/statsd-configmap.yaml
@@ -25,6 +25,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-statsd
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: config

--- a/chart/templates/configmaps/webserver-configmap.yaml
+++ b/chart/templates/configmaps/webserver-configmap.yaml
@@ -25,6 +25,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "airflow_webserver_config_configmap_name" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: config

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -32,6 +32,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: {{ .Release.Name }}-dag-processor
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: dag-processor

--- a/chart/templates/dag-processor/dag-processor-serviceaccount.yaml
+++ b/chart/templates/dag-processor/dag-processor-serviceaccount.yaml
@@ -26,6 +26,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ include "dagProcessor.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: dag-processor

--- a/chart/templates/dags-persistent-volume-claim.yaml
+++ b/chart/templates/dags-persistent-volume-claim.yaml
@@ -25,6 +25,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "airflow_dags_volume_claim" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: dags-pvc

--- a/chart/templates/flower/flower-deployment.yaml
+++ b/chart/templates/flower/flower-deployment.yaml
@@ -32,6 +32,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: {{ .Release.Name }}-flower
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: flower

--- a/chart/templates/flower/flower-ingress.yaml
+++ b/chart/templates/flower/flower-ingress.yaml
@@ -26,6 +26,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-flower-ingress
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: flower-ingress

--- a/chart/templates/flower/flower-networkpolicy.yaml
+++ b/chart/templates/flower/flower-networkpolicy.yaml
@@ -28,6 +28,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-flower-policy
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: airflow-flower-policy

--- a/chart/templates/flower/flower-service.yaml
+++ b/chart/templates/flower/flower-service.yaml
@@ -26,6 +26,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-flower
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: flower

--- a/chart/templates/flower/flower-serviceaccount.yaml
+++ b/chart/templates/flower/flower-serviceaccount.yaml
@@ -25,6 +25,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ include "flower.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: flower

--- a/chart/templates/jobs/create-user-job-serviceaccount.yaml
+++ b/chart/templates/jobs/create-user-job-serviceaccount.yaml
@@ -25,6 +25,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ include "createUserJob.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: create-user-job

--- a/chart/templates/jobs/create-user-job.yaml
+++ b/chart/templates/jobs/create-user-job.yaml
@@ -30,6 +30,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Release.Name }}-create-user
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: create-user-job

--- a/chart/templates/jobs/migrate-database-job-serviceaccount.yaml
+++ b/chart/templates/jobs/migrate-database-job-serviceaccount.yaml
@@ -25,6 +25,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ include "migrateDatabaseJob.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: run-airflow-migrations

--- a/chart/templates/jobs/migrate-database-job.yaml
+++ b/chart/templates/jobs/migrate-database-job.yaml
@@ -30,6 +30,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Release.Name }}-run-airflow-migrations
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: run-airflow-migrations

--- a/chart/templates/limitrange.yaml
+++ b/chart/templates/limitrange.yaml
@@ -25,6 +25,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: resources
     component: limitrange

--- a/chart/templates/logs-persistent-volume-claim.yaml
+++ b/chart/templates/logs-persistent-volume-claim.yaml
@@ -25,6 +25,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "airflow_logs_volume_claim" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: logs-pvc

--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -30,6 +30,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: {{ .Release.Name }}-pgbouncer
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: pgbouncer

--- a/chart/templates/pgbouncer/pgbouncer-networkpolicy.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-networkpolicy.yaml
@@ -25,6 +25,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-pgbouncer-policy
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: airflow-pgbouncer-policy

--- a/chart/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
@@ -29,6 +29,7 @@ apiVersion: policy/v1beta1
 {{- end }}
 metadata:
   name: {{ .Release.Name }}-pgbouncer-pdb
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: pgbouncer

--- a/chart/templates/pgbouncer/pgbouncer-service.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-service.yaml
@@ -25,6 +25,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-pgbouncer
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: pgbouncer

--- a/chart/templates/pgbouncer/pgbouncer-serviceaccount.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-serviceaccount.yaml
@@ -25,6 +25,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ include "pgbouncer.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: pgbouncer

--- a/chart/templates/rbac/pod-cleanup-role.yaml
+++ b/chart/templates/rbac/pod-cleanup-role.yaml
@@ -25,6 +25,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-cleanup-role
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     release: {{ .Release.Name }}

--- a/chart/templates/rbac/pod-cleanup-rolebinding.yaml
+++ b/chart/templates/rbac/pod-cleanup-rolebinding.yaml
@@ -25,6 +25,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-cleanup-rolebinding
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     release: {{ .Release.Name }}

--- a/chart/templates/redis/redis-networkpolicy.yaml
+++ b/chart/templates/redis/redis-networkpolicy.yaml
@@ -25,6 +25,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-redis-policy
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: redis-policy

--- a/chart/templates/redis/redis-service.yaml
+++ b/chart/templates/redis/redis-service.yaml
@@ -25,6 +25,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-redis
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: redis

--- a/chart/templates/redis/redis-serviceaccount.yaml
+++ b/chart/templates/redis/redis-serviceaccount.yaml
@@ -25,6 +25,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ include "redis.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: redis

--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -30,6 +30,7 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: {{ .Release.Name }}-redis
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: redis

--- a/chart/templates/resourcequota.yaml
+++ b/chart/templates/resourcequota.yaml
@@ -25,6 +25,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: {{ .Release.Name }}-resource-quota
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: resources
     component: resourcequota

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -42,6 +42,7 @@ kind: {{ if $stateful }}StatefulSet{{ else }}Deployment{{ end }}
 apiVersion: apps/v1
 metadata:
   name: {{ .Release.Name }}-scheduler
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: scheduler

--- a/chart/templates/scheduler/scheduler-networkpolicy.yaml
+++ b/chart/templates/scheduler/scheduler-networkpolicy.yaml
@@ -25,6 +25,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-scheduler-policy
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: airflow-scheduler-policy

--- a/chart/templates/scheduler/scheduler-poddisruptionbudget.yaml
+++ b/chart/templates/scheduler/scheduler-poddisruptionbudget.yaml
@@ -29,6 +29,7 @@ apiVersion: policy/v1beta1
 {{- end }}
 metadata:
   name: {{ .Release.Name }}-scheduler-pdb
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: scheduler

--- a/chart/templates/scheduler/scheduler-service.yaml
+++ b/chart/templates/scheduler/scheduler-service.yaml
@@ -25,6 +25,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-scheduler
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: scheduler

--- a/chart/templates/scheduler/scheduler-serviceaccount.yaml
+++ b/chart/templates/scheduler/scheduler-serviceaccount.yaml
@@ -25,6 +25,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ include "scheduler.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: scheduler

--- a/chart/templates/secrets/elasticsearch-secret.yaml
+++ b/chart/templates/secrets/elasticsearch-secret.yaml
@@ -25,6 +25,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-elasticsearch
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}

--- a/chart/templates/secrets/extra-secrets.yaml
+++ b/chart/templates/secrets/extra-secrets.yaml
@@ -27,6 +27,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ tpl $secretName $Global | quote }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     release: {{ $Global.Release.Name }}
     chart: "{{ $Global.Chart.Name }}-{{ $Global.Chart.Version }}"

--- a/chart/templates/secrets/fernetkey-secret.yaml
+++ b/chart/templates/secrets/fernetkey-secret.yaml
@@ -26,6 +26,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-fernet-key
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     release: {{ .Release.Name }}

--- a/chart/templates/secrets/flower-secret.yaml
+++ b/chart/templates/secrets/flower-secret.yaml
@@ -25,6 +25,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-flower
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}

--- a/chart/templates/secrets/kerberos-keytab-secret.yaml
+++ b/chart/templates/secrets/kerberos-keytab-secret.yaml
@@ -24,6 +24,7 @@
 apiVersion: v1
 metadata:
   name: {{ include "kerberos_keytab_secret" . | quote }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: webserver

--- a/chart/templates/secrets/metadata-connection-secret.yaml
+++ b/chart/templates/secrets/metadata-connection-secret.yaml
@@ -32,6 +32,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-airflow-metadata
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     release: {{ .Release.Name }}

--- a/chart/templates/secrets/pgbouncer-certificates-secret.yaml
+++ b/chart/templates/secrets/pgbouncer-certificates-secret.yaml
@@ -25,6 +25,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ template "pgbouncer_certificates_secret" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}

--- a/chart/templates/secrets/pgbouncer-config-secret.yaml
+++ b/chart/templates/secrets/pgbouncer-config-secret.yaml
@@ -25,6 +25,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ template "pgbouncer_config_secret" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: pgbouncer

--- a/chart/templates/secrets/pgbouncer-stats-secret.yaml
+++ b/chart/templates/secrets/pgbouncer-stats-secret.yaml
@@ -25,6 +25,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ template "pgbouncer_stats_secret" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: pgbouncer

--- a/chart/templates/secrets/redis-secrets.yaml
+++ b/chart/templates/secrets/redis-secrets.yaml
@@ -34,6 +34,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-redis-password
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: redis
@@ -60,6 +61,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-broker-url
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: redis

--- a/chart/templates/secrets/registry-secret.yaml
+++ b/chart/templates/secrets/registry-secret.yaml
@@ -25,6 +25,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-registry
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}

--- a/chart/templates/secrets/result-backend-connection-secret.yaml
+++ b/chart/templates/secrets/result-backend-connection-secret.yaml
@@ -34,6 +34,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-airflow-result-backend
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     release: {{ .Release.Name }}

--- a/chart/templates/secrets/webserver-secret-key-secret.yaml
+++ b/chart/templates/secrets/webserver-secret-key-secret.yaml
@@ -26,6 +26,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-webserver-secret-key
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: webserver

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -31,6 +31,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: {{ .Release.Name }}-statsd
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: statsd

--- a/chart/templates/statsd/statsd-networkpolicy.yaml
+++ b/chart/templates/statsd/statsd-networkpolicy.yaml
@@ -25,6 +25,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-statsd-policy
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: statsd-policy

--- a/chart/templates/statsd/statsd-service.yaml
+++ b/chart/templates/statsd/statsd-service.yaml
@@ -25,6 +25,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-statsd
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: statsd

--- a/chart/templates/statsd/statsd-serviceaccount.yaml
+++ b/chart/templates/statsd/statsd-serviceaccount.yaml
@@ -25,6 +25,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ include "statsd.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: statsd

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -34,6 +34,7 @@ kind: {{ if $persistence }}StatefulSet{{ else }}Deployment{{ end }}
 apiVersion: apps/v1
 metadata:
   name: {{ .Release.Name }}-triggerer
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: triggerer

--- a/chart/templates/triggerer/triggerer-networkpolicy.yaml
+++ b/chart/templates/triggerer/triggerer-networkpolicy.yaml
@@ -28,6 +28,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-triggerer-policy
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: airflow-triggerer-policy

--- a/chart/templates/triggerer/triggerer-service.yaml
+++ b/chart/templates/triggerer/triggerer-service.yaml
@@ -27,6 +27,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-triggerer
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: triggerer

--- a/chart/templates/triggerer/triggerer-serviceaccount.yaml
+++ b/chart/templates/triggerer/triggerer-serviceaccount.yaml
@@ -26,6 +26,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ include "triggerer.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: triggerer

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -30,6 +30,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: {{ .Release.Name }}-webserver
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: webserver

--- a/chart/templates/webserver/webserver-ingress.yaml
+++ b/chart/templates/webserver/webserver-ingress.yaml
@@ -25,6 +25,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-airflow-ingress
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: airflow-ingress

--- a/chart/templates/webserver/webserver-networkpolicy.yaml
+++ b/chart/templates/webserver/webserver-networkpolicy.yaml
@@ -26,6 +26,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-webserver-policy
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: airflow-webserver-policy

--- a/chart/templates/webserver/webserver-poddisruptionbudget.yaml
+++ b/chart/templates/webserver/webserver-poddisruptionbudget.yaml
@@ -29,6 +29,7 @@ apiVersion: policy/v1beta1
 {{- end }}
 metadata:
   name: {{ .Release.Name }}-webserver-pdb
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: webserver

--- a/chart/templates/webserver/webserver-service.yaml
+++ b/chart/templates/webserver/webserver-service.yaml
@@ -24,6 +24,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-webserver
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: webserver

--- a/chart/templates/webserver/webserver-serviceaccount.yaml
+++ b/chart/templates/webserver/webserver-serviceaccount.yaml
@@ -25,6 +25,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ include "webserver.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: webserver

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -33,6 +33,7 @@ kind: {{ if $persistence }}StatefulSet{{ else }}Deployment{{ end }}
 apiVersion: apps/v1
 metadata:
   name: {{ .Release.Name }}-worker
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: worker

--- a/chart/templates/workers/worker-networkpolicy.yaml
+++ b/chart/templates/workers/worker-networkpolicy.yaml
@@ -25,6 +25,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-worker-policy
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: airflow-worker-policy

--- a/chart/templates/workers/worker-service.yaml
+++ b/chart/templates/workers/worker-service.yaml
@@ -25,6 +25,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-worker
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: worker

--- a/chart/templates/workers/worker-serviceaccount.yaml
+++ b/chart/templates/workers/worker-serviceaccount.yaml
@@ -25,6 +25,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ include "worker.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     tier: airflow
     component: worker


### PR DESCRIPTION
This PR explicitly adds the `namespace` metadata to all namespace-scoped resources in the Helm templates, because the existing version breaks when using it with `helm template` because Helm does not inject the namespace everywhere then. This is also was ArgoCD did in https://github.com/argoproj/argo-helm/pull/1937 to mitigate this issue for its users.

closes: #31356

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
