### PR TITLE
Increase timeouts for hook related tests

### DIFF
--- a/tests/always/test_providers_manager.py
+++ b/tests/always/test_providers_manager.py
@@ -165,6 +165,7 @@ class TestProviderManager:
             raise AssertionError("There are warnings generated during hook imports. Please fix them")
         assert [] == [w.message for w in warning_records.list if "hook-class-names" in str(w.message)]
 
+    @pytest.mark.execution_timeout(150)
     def test_hook_values(self):
         with pytest.warns(expected_warning=None) as warning_records:
             with self._caplog.at_level(logging.WARNING):

--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -51,6 +51,7 @@ def clear_connections():
         session.query(Connection).delete()
 
 
+@pytest.mark.execution_timeout(150)
 def test_create_connection(admin_client, session):
     resp = admin_client.post("/connection/add", data=CONNECTION, follow_redirects=True)
     check_content_in_response("Added Row", resp)


### PR DESCRIPTION
After upgrading to newer google providers, it takes a little longer to import all google provider hooks to get all the information for provider's manager and adding connection. This should be optimised before we release the new google provider, but in order to stabilize the tests we can increase timeouts for the tests.

Issue to do so created: #31370

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
