### PR TITLE
Add valid spark on k8s airflow connection urls to tests

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -21,7 +21,7 @@ import json
 import logging
 import warnings
 from json import JSONDecodeError
-from urllib.parse import SplitResult, parse_qsl, quote, unquote, urlencode, urlsplit
+from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit
 
 from sqlalchemy import Boolean, Column, Integer, String, Text
 from sqlalchemy.orm import declared_attr, reconstructor, synonym
@@ -197,10 +197,7 @@ class Connection(Base, LoggingMixin):
         uri_list[idx : idx + 3] = ":__"
         uri = "".join(uri_list)
         uri = urlsplit(uri)
-        uri = [e for e in uri]
-        # replace back :__ with ://
-        uri[1] = uri[1].replace(":__", "://")
-        uri = SplitResult(uri[0], uri[1], uri[2], uri[3], uri[4])
+        uri = uri._replace(netloc=uri.netloc.replace(":__", "://"))
         return uri, True
 
     def _parse_from_uri(self, uri: str):

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -21,7 +21,7 @@ import json
 import logging
 import warnings
 from json import JSONDecodeError
-from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit
+from urllib.parse import SplitResult, parse_qsl, quote, unquote, urlencode, urlsplit
 
 from sqlalchemy import Boolean, Column, Integer, String, Text
 from sqlalchemy.orm import declared_attr, reconstructor, synonym
@@ -186,16 +186,46 @@ class Connection(Base, LoggingMixin):
             conn_type = conn_type.replace("-", "_")
         return conn_type
 
+    @staticmethod
+    def split_uri_to_parts(uri):
+        c = uri.count("://")
+        if c < 2:
+            return urlsplit(uri), False
+        idx = uri.rfind("://")
+        # replace :// with :__
+        uri_list = list(uri)
+        uri_list[idx : idx + 3] = ":__"
+        uri = "".join(uri_list)
+        uri = urlsplit(uri)
+        uri = [e for e in uri]
+        # replace back :__ with ://
+        uri[1] = uri[1].replace(":__", "://")
+        uri = SplitResult(uri[0], uri[1], uri[2], uri[3], uri[4])
+        return uri, True
+
     def _parse_from_uri(self, uri: str):
-        uri_parts = urlsplit(uri)
+        uri_parts, specially_parsed = self.split_uri_to_parts(uri)
         conn_type = uri_parts.scheme
         self.conn_type = self._normalize_conn_type(conn_type)
-        self.host = _parse_netloc_to_hostname(uri_parts)
         quoted_schema = uri_parts.path[1:]
         self.schema = unquote(quoted_schema) if quoted_schema else quoted_schema
         self.login = unquote(uri_parts.username) if uri_parts.username else uri_parts.username
         self.password = unquote(uri_parts.password) if uri_parts.password else uri_parts.password
-        self.port = uri_parts.port
+        if specially_parsed:
+            uri_parts_str = str(uri_parts.netloc)
+            idx = uri_parts_str.find("://")
+            idx2 = uri_parts_str.find("@")
+            if idx2 != -1:
+                self.host = uri_parts_str[idx2 + 1 :]
+            else:
+                self.host = uri_parts_str
+            if len(str(uri_parts.netloc)[idx + 3 :].split(":")) < 2:
+                self.port = None
+            else:
+                self.port = int(str(uri_parts.netloc)[idx + 3 :].split(":")[1])
+        else:
+            self.port = uri_parts.port
+            self.host = _parse_netloc_to_hostname(uri_parts)
         if uri_parts.query:
             query = dict(parse_qsl(uri_parts.query, keep_blank_values=True))
             if self.EXTRA_KEY in query:

--- a/tests/always/test_connection.py
+++ b/tests/always/test_connection.py
@@ -485,40 +485,40 @@ class TestConnection:
                 ),
             ),
             (
-                "spark://k8s://100.68.0.1:443?deploy-mode=cluster",
+                "spark://k8s%3a%2F%2F100.68.0.1:443?deploy-mode=cluster",
                 ConnectionParts(
                     conn_type="spark",
                     login=None,
                     password=None,
-                    host="k8s://100.68.0.1:443",
+                    host="k8s://100.68.0.1",
                     port=443,
                     schema="",
                 ),
             ),
             (
-                "spark://user:password@k8s://100.68.0.1:443?deploy-mode=cluster",
+                "spark://user:password@k8s%3a%2F%2F100.68.0.1:443?deploy-mode=cluster",
                 ConnectionParts(
                     conn_type="spark",
                     login="user",
                     password="password",
-                    host="k8s://100.68.0.1:443",
+                    host="k8s://100.68.0.1",
                     port=443,
                     schema="",
                 ),
             ),
             (
-                "spark://user@k8s://100.68.0.1:443?deploy-mode=cluster",
+                "spark://user@k8s%3a%2F%2F100.68.0.1:443?deploy-mode=cluster",
                 ConnectionParts(
                     conn_type="spark",
                     login="user",
                     password=None,
-                    host="k8s://100.68.0.1:443",
+                    host="k8s://100.68.0.1",
                     port=443,
                     schema="",
                 ),
             ),
             (
-                "spark://k8s://no.port.com?deploy-mode=cluster",
+                "spark://k8s%3a%2F%2Fno.port.com?deploy-mode=cluster",
                 ConnectionParts(
                     conn_type="spark",
                     login=None,

--- a/tests/always/test_connection.py
+++ b/tests/always/test_connection.py
@@ -484,6 +484,50 @@ class TestConnection:
                     schema="",
                 ),
             ),
+            (
+                "spark://k8s://100.68.0.1:443?deploy-mode=cluster",
+                ConnectionParts(
+                    conn_type="spark",
+                    login=None,
+                    password=None,
+                    host="k8s://100.68.0.1:443",
+                    port=443,
+                    schema="",
+                ),
+            ),
+            (
+                "spark://user:password@k8s://100.68.0.1:443?deploy-mode=cluster",
+                ConnectionParts(
+                    conn_type="spark",
+                    login="user",
+                    password="password",
+                    host="k8s://100.68.0.1:443",
+                    port=443,
+                    schema="",
+                ),
+            ),
+            (
+                "spark://user@k8s://100.68.0.1:443?deploy-mode=cluster",
+                ConnectionParts(
+                    conn_type="spark",
+                    login="user",
+                    password=None,
+                    host="k8s://100.68.0.1:443",
+                    port=443,
+                    schema="",
+                ),
+            ),
+            (
+                "spark://k8s://no.port.com?deploy-mode=cluster",
+                ConnectionParts(
+                    conn_type="spark",
+                    login=None,
+                    password=None,
+                    host="k8s://no.port.com",
+                    port=None,
+                    schema="",
+                ),
+            ),
         ],
     )
     def test_connection_from_with_auth_info(self, uri, uri_parts):


### PR DESCRIPTION
<!--
Thank you for cparseuting! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Airflow connections parses valid urls fine. The issue described in #21638 provided a wrong url as input to the connections with double `://` leading to parsing issues. This PR simply adds a few valid spark on k8s connection urls to the existing test suite. 

Testing by adding various different unit test cases to cover the breadth

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
