### PR TITLE
fixing circular import error in providers caused by airflow version check

### DIFF
--- a/airflow/providers/airbyte/__init__.py
+++ b/airflow/providers/airbyte/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.3.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/airbyte/__init__.py
+++ b/airflow/providers/airbyte/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.3.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-airbyte:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/airbyte/__init__.py
+++ b/airflow/providers/airbyte/__init__.py
@@ -35,7 +35,9 @@ version = "3.3.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/airbyte/__init__.py
+++ b/airflow/providers/airbyte/__init__.py
@@ -34,7 +34,7 @@ version = "3.3.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/airbyte/__init__.py
+++ b/airflow/providers/airbyte/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.3.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/airbyte/__init__.py
+++ b/airflow/providers/airbyte/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.3.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-airbyte:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/alibaba/__init__.py
+++ b/airflow/providers/alibaba/__init__.py
@@ -35,7 +35,9 @@ version = "2.4.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/alibaba/__init__.py
+++ b/airflow/providers/alibaba/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "2.4.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/alibaba/__init__.py
+++ b/airflow/providers/alibaba/__init__.py
@@ -34,7 +34,7 @@ version = "2.4.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/alibaba/__init__.py
+++ b/airflow/providers/alibaba/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "2.4.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/alibaba/__init__.py
+++ b/airflow/providers/alibaba/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "2.4.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-alibaba:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/alibaba/__init__.py
+++ b/airflow/providers/alibaba/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "2.4.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-alibaba:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/amazon/__init__.py
+++ b/airflow/providers/amazon/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "8.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-amazon:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/amazon/__init__.py
+++ b/airflow/providers/amazon/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "8.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/amazon/__init__.py
+++ b/airflow/providers/amazon/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "8.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/amazon/__init__.py
+++ b/airflow/providers/amazon/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "8.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-amazon:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/amazon/__init__.py
+++ b/airflow/providers/amazon/__init__.py
@@ -35,7 +35,9 @@ version = "8.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/amazon/__init__.py
+++ b/airflow/providers/amazon/__init__.py
@@ -34,7 +34,7 @@ version = "8.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/beam/__init__.py
+++ b/airflow/providers/apache/beam/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "5.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-beam:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/beam/__init__.py
+++ b/airflow/providers/apache/beam/__init__.py
@@ -34,7 +34,7 @@ version = "5.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/beam/__init__.py
+++ b/airflow/providers/apache/beam/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "5.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-beam:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/beam/__init__.py
+++ b/airflow/providers/apache/beam/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "5.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/beam/__init__.py
+++ b/airflow/providers/apache/beam/__init__.py
@@ -35,7 +35,9 @@ version = "5.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/beam/__init__.py
+++ b/airflow/providers/apache/beam/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "5.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/cassandra/__init__.py
+++ b/airflow/providers/apache/cassandra/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-cassandra:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/cassandra/__init__.py
+++ b/airflow/providers/apache/cassandra/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/cassandra/__init__.py
+++ b/airflow/providers/apache/cassandra/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/cassandra/__init__.py
+++ b/airflow/providers/apache/cassandra/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-cassandra:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/cassandra/__init__.py
+++ b/airflow/providers/apache/cassandra/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/cassandra/__init__.py
+++ b/airflow/providers/apache/cassandra/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/drill/__init__.py
+++ b/airflow/providers/apache/drill/__init__.py
@@ -35,7 +35,9 @@ version = "2.4.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/drill/__init__.py
+++ b/airflow/providers/apache/drill/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "2.4.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/drill/__init__.py
+++ b/airflow/providers/apache/drill/__init__.py
@@ -34,7 +34,7 @@ version = "2.4.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/drill/__init__.py
+++ b/airflow/providers/apache/drill/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "2.4.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/drill/__init__.py
+++ b/airflow/providers/apache/drill/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "2.4.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-drill:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/drill/__init__.py
+++ b/airflow/providers/apache/drill/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "2.4.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-drill:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/druid/__init__.py
+++ b/airflow/providers/apache/druid/__init__.py
@@ -35,7 +35,9 @@ version = "3.4.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/druid/__init__.py
+++ b/airflow/providers/apache/druid/__init__.py
@@ -34,7 +34,7 @@ version = "3.4.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/druid/__init__.py
+++ b/airflow/providers/apache/druid/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.4.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/druid/__init__.py
+++ b/airflow/providers/apache/druid/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.4.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/druid/__init__.py
+++ b/airflow/providers/apache/druid/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.4.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-druid:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/druid/__init__.py
+++ b/airflow/providers/apache/druid/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.4.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-druid:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/flink/__init__.py
+++ b/airflow/providers/apache/flink/__init__.py
@@ -34,7 +34,7 @@ version = "1.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/flink/__init__.py
+++ b/airflow/providers/apache/flink/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "1.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-flink:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/flink/__init__.py
+++ b/airflow/providers/apache/flink/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "1.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/flink/__init__.py
+++ b/airflow/providers/apache/flink/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "1.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/flink/__init__.py
+++ b/airflow/providers/apache/flink/__init__.py
@@ -35,7 +35,9 @@ version = "1.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/flink/__init__.py
+++ b/airflow/providers/apache/flink/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "1.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-flink:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/hdfs/__init__.py
+++ b/airflow/providers/apache/hdfs/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "4.0.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/hdfs/__init__.py
+++ b/airflow/providers/apache/hdfs/__init__.py
@@ -35,7 +35,9 @@ version = "4.0.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/hdfs/__init__.py
+++ b/airflow/providers/apache/hdfs/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "4.0.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-hdfs:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/hdfs/__init__.py
+++ b/airflow/providers/apache/hdfs/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "4.0.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-hdfs:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/hdfs/__init__.py
+++ b/airflow/providers/apache/hdfs/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "4.0.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/hdfs/__init__.py
+++ b/airflow/providers/apache/hdfs/__init__.py
@@ -34,7 +34,7 @@ version = "4.0.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/hive/__init__.py
+++ b/airflow/providers/apache/hive/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "6.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/hive/__init__.py
+++ b/airflow/providers/apache/hive/__init__.py
@@ -34,7 +34,7 @@ version = "6.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/hive/__init__.py
+++ b/airflow/providers/apache/hive/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "6.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-hive:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/hive/__init__.py
+++ b/airflow/providers/apache/hive/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "6.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/hive/__init__.py
+++ b/airflow/providers/apache/hive/__init__.py
@@ -35,7 +35,9 @@ version = "6.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/hive/__init__.py
+++ b/airflow/providers/apache/hive/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "6.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-hive:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/impala/__init__.py
+++ b/airflow/providers/apache/impala/__init__.py
@@ -34,7 +34,7 @@ version = "1.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/impala/__init__.py
+++ b/airflow/providers/apache/impala/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "1.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/impala/__init__.py
+++ b/airflow/providers/apache/impala/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "1.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-impala:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/impala/__init__.py
+++ b/airflow/providers/apache/impala/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "1.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/impala/__init__.py
+++ b/airflow/providers/apache/impala/__init__.py
@@ -35,7 +35,9 @@ version = "1.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/impala/__init__.py
+++ b/airflow/providers/apache/impala/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "1.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-impala:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/kafka/__init__.py
+++ b/airflow/providers/apache/kafka/__init__.py
@@ -34,7 +34,7 @@ version = "1.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/kafka/__init__.py
+++ b/airflow/providers/apache/kafka/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "1.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/kafka/__init__.py
+++ b/airflow/providers/apache/kafka/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "1.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/kafka/__init__.py
+++ b/airflow/providers/apache/kafka/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "1.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-kafka:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/kafka/__init__.py
+++ b/airflow/providers/apache/kafka/__init__.py
@@ -35,7 +35,9 @@ version = "1.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/kafka/__init__.py
+++ b/airflow/providers/apache/kafka/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "1.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-kafka:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/kylin/__init__.py
+++ b/airflow/providers/apache/kylin/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/kylin/__init__.py
+++ b/airflow/providers/apache/kylin/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/kylin/__init__.py
+++ b/airflow/providers/apache/kylin/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-kylin:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/kylin/__init__.py
+++ b/airflow/providers/apache/kylin/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-kylin:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/kylin/__init__.py
+++ b/airflow/providers/apache/kylin/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/kylin/__init__.py
+++ b/airflow/providers/apache/kylin/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/livy/__init__.py
+++ b/airflow/providers/apache/livy/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.5.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/livy/__init__.py
+++ b/airflow/providers/apache/livy/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.5.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-livy:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/livy/__init__.py
+++ b/airflow/providers/apache/livy/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.5.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-livy:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/livy/__init__.py
+++ b/airflow/providers/apache/livy/__init__.py
@@ -35,7 +35,9 @@ version = "3.5.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/livy/__init__.py
+++ b/airflow/providers/apache/livy/__init__.py
@@ -34,7 +34,7 @@ version = "3.5.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/livy/__init__.py
+++ b/airflow/providers/apache/livy/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.5.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/pig/__init__.py
+++ b/airflow/providers/apache/pig/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "4.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/pig/__init__.py
+++ b/airflow/providers/apache/pig/__init__.py
@@ -34,7 +34,7 @@ version = "4.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/pig/__init__.py
+++ b/airflow/providers/apache/pig/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "4.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/pig/__init__.py
+++ b/airflow/providers/apache/pig/__init__.py
@@ -35,7 +35,9 @@ version = "4.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/pig/__init__.py
+++ b/airflow/providers/apache/pig/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "4.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-pig:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/pig/__init__.py
+++ b/airflow/providers/apache/pig/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "4.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-pig:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/pinot/__init__.py
+++ b/airflow/providers/apache/pinot/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "4.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-pinot:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/pinot/__init__.py
+++ b/airflow/providers/apache/pinot/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "4.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/pinot/__init__.py
+++ b/airflow/providers/apache/pinot/__init__.py
@@ -34,7 +34,7 @@ version = "4.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/pinot/__init__.py
+++ b/airflow/providers/apache/pinot/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "4.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/pinot/__init__.py
+++ b/airflow/providers/apache/pinot/__init__.py
@@ -35,7 +35,9 @@ version = "4.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/pinot/__init__.py
+++ b/airflow/providers/apache/pinot/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "4.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-pinot:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/spark/__init__.py
+++ b/airflow/providers/apache/spark/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "4.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/spark/__init__.py
+++ b/airflow/providers/apache/spark/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "4.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-spark:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/spark/__init__.py
+++ b/airflow/providers/apache/spark/__init__.py
@@ -34,7 +34,7 @@ version = "4.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/spark/__init__.py
+++ b/airflow/providers/apache/spark/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "4.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/spark/__init__.py
+++ b/airflow/providers/apache/spark/__init__.py
@@ -35,7 +35,9 @@ version = "4.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/spark/__init__.py
+++ b/airflow/providers/apache/spark/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "4.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-spark:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/sqoop/__init__.py
+++ b/airflow/providers/apache/sqoop/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-sqoop:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/sqoop/__init__.py
+++ b/airflow/providers/apache/sqoop/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/sqoop/__init__.py
+++ b/airflow/providers/apache/sqoop/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/apache/sqoop/__init__.py
+++ b/airflow/providers/apache/sqoop/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-apache-sqoop:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/apache/sqoop/__init__.py
+++ b/airflow/providers/apache/sqoop/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/apache/sqoop/__init__.py
+++ b/airflow/providers/apache/sqoop/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/arangodb/__init__.py
+++ b/airflow/providers/arangodb/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "2.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-arangodb:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/arangodb/__init__.py
+++ b/airflow/providers/arangodb/__init__.py
@@ -35,7 +35,9 @@ version = "2.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/arangodb/__init__.py
+++ b/airflow/providers/arangodb/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "2.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-arangodb:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/arangodb/__init__.py
+++ b/airflow/providers/arangodb/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "2.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/arangodb/__init__.py
+++ b/airflow/providers/arangodb/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "2.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/arangodb/__init__.py
+++ b/airflow/providers/arangodb/__init__.py
@@ -34,7 +34,7 @@ version = "2.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/asana/__init__.py
+++ b/airflow/providers/asana/__init__.py
@@ -35,7 +35,9 @@ version = "2.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/asana/__init__.py
+++ b/airflow/providers/asana/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "2.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/asana/__init__.py
+++ b/airflow/providers/asana/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "2.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-asana:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/asana/__init__.py
+++ b/airflow/providers/asana/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "2.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/asana/__init__.py
+++ b/airflow/providers/asana/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "2.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-asana:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/asana/__init__.py
+++ b/airflow/providers/asana/__init__.py
@@ -34,7 +34,7 @@ version = "2.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/atlassian/jira/__init__.py
+++ b/airflow/providers/atlassian/jira/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "2.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-atlassian-jira:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/atlassian/jira/__init__.py
+++ b/airflow/providers/atlassian/jira/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "2.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/atlassian/jira/__init__.py
+++ b/airflow/providers/atlassian/jira/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "2.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/atlassian/jira/__init__.py
+++ b/airflow/providers/atlassian/jira/__init__.py
@@ -34,7 +34,7 @@ version = "2.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/atlassian/jira/__init__.py
+++ b/airflow/providers/atlassian/jira/__init__.py
@@ -35,7 +35,9 @@ version = "2.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/atlassian/jira/__init__.py
+++ b/airflow/providers/atlassian/jira/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "2.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-atlassian-jira:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/celery/__init__.py
+++ b/airflow/providers/celery/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/celery/__init__.py
+++ b/airflow/providers/celery/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/celery/__init__.py
+++ b/airflow/providers/celery/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/celery/__init__.py
+++ b/airflow/providers/celery/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/celery/__init__.py
+++ b/airflow/providers/celery/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-celery:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/celery/__init__.py
+++ b/airflow/providers/celery/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-celery:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/cloudant/__init__.py
+++ b/airflow/providers/cloudant/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/cloudant/__init__.py
+++ b/airflow/providers/cloudant/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-cloudant:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/cloudant/__init__.py
+++ b/airflow/providers/cloudant/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/cloudant/__init__.py
+++ b/airflow/providers/cloudant/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-cloudant:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/cloudant/__init__.py
+++ b/airflow/providers/cloudant/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/cloudant/__init__.py
+++ b/airflow/providers/cloudant/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/cncf/kubernetes/__init__.py
+++ b/airflow/providers/cncf/kubernetes/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "6.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/cncf/kubernetes/__init__.py
+++ b/airflow/providers/cncf/kubernetes/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "6.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-cncf-kubernetes:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/cncf/kubernetes/__init__.py
+++ b/airflow/providers/cncf/kubernetes/__init__.py
@@ -35,7 +35,9 @@ version = "6.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/cncf/kubernetes/__init__.py
+++ b/airflow/providers/cncf/kubernetes/__init__.py
@@ -34,7 +34,7 @@ version = "6.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/cncf/kubernetes/__init__.py
+++ b/airflow/providers/cncf/kubernetes/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "6.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/cncf/kubernetes/__init__.py
+++ b/airflow/providers/cncf/kubernetes/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "6.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-cncf-kubernetes:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/common/sql/__init__.py
+++ b/airflow/providers/common/sql/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "1.5.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-common-sql:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/common/sql/__init__.py
+++ b/airflow/providers/common/sql/__init__.py
@@ -35,7 +35,9 @@ version = "1.5.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/common/sql/__init__.py
+++ b/airflow/providers/common/sql/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "1.5.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-common-sql:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/common/sql/__init__.py
+++ b/airflow/providers/common/sql/__init__.py
@@ -34,7 +34,7 @@ version = "1.5.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/common/sql/__init__.py
+++ b/airflow/providers/common/sql/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "1.5.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/common/sql/__init__.py
+++ b/airflow/providers/common/sql/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "1.5.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/databricks/__init__.py
+++ b/airflow/providers/databricks/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "4.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/databricks/__init__.py
+++ b/airflow/providers/databricks/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "4.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-databricks:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/databricks/__init__.py
+++ b/airflow/providers/databricks/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "4.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/databricks/__init__.py
+++ b/airflow/providers/databricks/__init__.py
@@ -35,7 +35,9 @@ version = "4.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/databricks/__init__.py
+++ b/airflow/providers/databricks/__init__.py
@@ -34,7 +34,7 @@ version = "4.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/databricks/__init__.py
+++ b/airflow/providers/databricks/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "4.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-databricks:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/datadog/__init__.py
+++ b/airflow/providers/datadog/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.3.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/datadog/__init__.py
+++ b/airflow/providers/datadog/__init__.py
@@ -35,7 +35,9 @@ version = "3.3.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/datadog/__init__.py
+++ b/airflow/providers/datadog/__init__.py
@@ -34,7 +34,7 @@ version = "3.3.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/datadog/__init__.py
+++ b/airflow/providers/datadog/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.3.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-datadog:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/datadog/__init__.py
+++ b/airflow/providers/datadog/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.3.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/datadog/__init__.py
+++ b/airflow/providers/datadog/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.3.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-datadog:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/dbt/cloud/__init__.py
+++ b/airflow/providers/dbt/cloud/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-dbt-cloud:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/dbt/cloud/__init__.py
+++ b/airflow/providers/dbt/cloud/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-dbt-cloud:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/dbt/cloud/__init__.py
+++ b/airflow/providers/dbt/cloud/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/dbt/cloud/__init__.py
+++ b/airflow/providers/dbt/cloud/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/dbt/cloud/__init__.py
+++ b/airflow/providers/dbt/cloud/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/dbt/cloud/__init__.py
+++ b/airflow/providers/dbt/cloud/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/dingding/__init__.py
+++ b/airflow/providers/dingding/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-dingding:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/dingding/__init__.py
+++ b/airflow/providers/dingding/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/dingding/__init__.py
+++ b/airflow/providers/dingding/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/dingding/__init__.py
+++ b/airflow/providers/dingding/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-dingding:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/dingding/__init__.py
+++ b/airflow/providers/dingding/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/dingding/__init__.py
+++ b/airflow/providers/dingding/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/discord/__init__.py
+++ b/airflow/providers/discord/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/discord/__init__.py
+++ b/airflow/providers/discord/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/discord/__init__.py
+++ b/airflow/providers/discord/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-discord:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/discord/__init__.py
+++ b/airflow/providers/discord/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-discord:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/discord/__init__.py
+++ b/airflow/providers/discord/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/discord/__init__.py
+++ b/airflow/providers/discord/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/docker/__init__.py
+++ b/airflow/providers/docker/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.7.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/docker/__init__.py
+++ b/airflow/providers/docker/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.7.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/docker/__init__.py
+++ b/airflow/providers/docker/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.7.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-docker:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/docker/__init__.py
+++ b/airflow/providers/docker/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.7.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-docker:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/docker/__init__.py
+++ b/airflow/providers/docker/__init__.py
@@ -34,7 +34,7 @@ version = "3.7.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/docker/__init__.py
+++ b/airflow/providers/docker/__init__.py
@@ -35,7 +35,9 @@ version = "3.7.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/elasticsearch/__init__.py
+++ b/airflow/providers/elasticsearch/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "4.5.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-elasticsearch:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/elasticsearch/__init__.py
+++ b/airflow/providers/elasticsearch/__init__.py
@@ -35,7 +35,9 @@ version = "4.5.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/elasticsearch/__init__.py
+++ b/airflow/providers/elasticsearch/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "4.5.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/elasticsearch/__init__.py
+++ b/airflow/providers/elasticsearch/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "4.5.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-elasticsearch:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/elasticsearch/__init__.py
+++ b/airflow/providers/elasticsearch/__init__.py
@@ -34,7 +34,7 @@ version = "4.5.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/elasticsearch/__init__.py
+++ b/airflow/providers/elasticsearch/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "4.5.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/exasol/__init__.py
+++ b/airflow/providers/exasol/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "4.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/exasol/__init__.py
+++ b/airflow/providers/exasol/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "4.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/exasol/__init__.py
+++ b/airflow/providers/exasol/__init__.py
@@ -35,7 +35,9 @@ version = "4.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/exasol/__init__.py
+++ b/airflow/providers/exasol/__init__.py
@@ -34,7 +34,7 @@ version = "4.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/exasol/__init__.py
+++ b/airflow/providers/exasol/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "4.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-exasol:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/exasol/__init__.py
+++ b/airflow/providers/exasol/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "4.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-exasol:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/facebook/__init__.py
+++ b/airflow/providers/facebook/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/facebook/__init__.py
+++ b/airflow/providers/facebook/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-facebook:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/facebook/__init__.py
+++ b/airflow/providers/facebook/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/facebook/__init__.py
+++ b/airflow/providers/facebook/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-facebook:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/facebook/__init__.py
+++ b/airflow/providers/facebook/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/facebook/__init__.py
+++ b/airflow/providers/facebook/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/ftp/__init__.py
+++ b/airflow/providers/ftp/__init__.py
@@ -34,7 +34,7 @@ version = "3.4.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/ftp/__init__.py
+++ b/airflow/providers/ftp/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.4.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/ftp/__init__.py
+++ b/airflow/providers/ftp/__init__.py
@@ -32,5 +32,5 @@ __all__ = ["version"]
 
 version = "3.4.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(f"The package `apache-airflow-providers-ftp:{version}` requires Apache Airflow 2.4.0+")

--- a/airflow/providers/ftp/__init__.py
+++ b/airflow/providers/ftp/__init__.py
@@ -35,7 +35,9 @@ version = "3.4.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(f"The package `apache-airflow-providers-ftp:{version}` requires Apache Airflow 2.4.0+")

--- a/airflow/providers/ftp/__init__.py
+++ b/airflow/providers/ftp/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.4.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(f"The package `apache-airflow-providers-ftp:{version}` requires Apache Airflow 2.4.0+")

--- a/airflow/providers/ftp/__init__.py
+++ b/airflow/providers/ftp/__init__.py
@@ -32,5 +32,10 @@ __all__ = ["version"]
 
 version = "3.4.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(f"The package `apache-airflow-providers-ftp:{version}` requires Apache Airflow 2.4.0+")

--- a/airflow/providers/github/__init__.py
+++ b/airflow/providers/github/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "2.3.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-github:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/github/__init__.py
+++ b/airflow/providers/github/__init__.py
@@ -34,7 +34,7 @@ version = "2.3.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/github/__init__.py
+++ b/airflow/providers/github/__init__.py
@@ -35,7 +35,9 @@ version = "2.3.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/github/__init__.py
+++ b/airflow/providers/github/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "2.3.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-github:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/github/__init__.py
+++ b/airflow/providers/github/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "2.3.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/github/__init__.py
+++ b/airflow/providers/github/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "2.3.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/google/__init__.py
+++ b/airflow/providers/google/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "10.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/google/__init__.py
+++ b/airflow/providers/google/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "10.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-google:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/google/__init__.py
+++ b/airflow/providers/google/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "10.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/google/__init__.py
+++ b/airflow/providers/google/__init__.py
@@ -35,7 +35,9 @@ version = "10.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/google/__init__.py
+++ b/airflow/providers/google/__init__.py
@@ -34,7 +34,7 @@ version = "10.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/google/__init__.py
+++ b/airflow/providers/google/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "10.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-google:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/google/ads/_vendor/__init__.py
+++ b/airflow/providers/google/ads/_vendor/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/interceptors/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/interceptors/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/v12/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/v12/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/v12/common/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/v12/common/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/v12/common/types/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/v12/common/types/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/v12/enums/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/v12/enums/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/v12/enums/types/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/v12/enums/types/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/v12/errors/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/v12/errors/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/v12/errors/types/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/v12/errors/types/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/v12/resources/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/v12/resources/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/v12/resources/types/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/v12/resources/types/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/v12/services/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/v12/services/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/v12/services/services/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/v12/services/services/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/v12/services/services/customer_service/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/v12/services/services/customer_service/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/v12/services/services/customer_service/transports/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/v12/services/services/customer_service/transports/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/v12/services/services/google_ads_service/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/v12/services/services/google_ads_service/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/v12/services/services/google_ads_service/transports/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/v12/services/services/google_ads_service/transports/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/google/ads/_vendor/googleads/v12/services/types/__init__.py
+++ b/airflow/providers/google/ads/_vendor/googleads/v12/services/types/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/grpc/__init__.py
+++ b/airflow/providers/grpc/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-grpc:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/grpc/__init__.py
+++ b/airflow/providers/grpc/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-grpc:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/grpc/__init__.py
+++ b/airflow/providers/grpc/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/grpc/__init__.py
+++ b/airflow/providers/grpc/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/grpc/__init__.py
+++ b/airflow/providers/grpc/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/grpc/__init__.py
+++ b/airflow/providers/grpc/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/hashicorp/__init__.py
+++ b/airflow/providers/hashicorp/__init__.py
@@ -35,7 +35,9 @@ version = "3.4.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/hashicorp/__init__.py
+++ b/airflow/providers/hashicorp/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.4.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-hashicorp:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/hashicorp/__init__.py
+++ b/airflow/providers/hashicorp/__init__.py
@@ -34,7 +34,7 @@ version = "3.4.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/hashicorp/__init__.py
+++ b/airflow/providers/hashicorp/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.4.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/hashicorp/__init__.py
+++ b/airflow/providers/hashicorp/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.4.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/hashicorp/__init__.py
+++ b/airflow/providers/hashicorp/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.4.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-hashicorp:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/http/__init__.py
+++ b/airflow/providers/http/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "4.4.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-http:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/http/__init__.py
+++ b/airflow/providers/http/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "4.4.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/http/__init__.py
+++ b/airflow/providers/http/__init__.py
@@ -35,7 +35,9 @@ version = "4.4.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/http/__init__.py
+++ b/airflow/providers/http/__init__.py
@@ -34,7 +34,7 @@ version = "4.4.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/http/__init__.py
+++ b/airflow/providers/http/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "4.4.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-http:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/http/__init__.py
+++ b/airflow/providers/http/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "4.4.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/imap/__init__.py
+++ b/airflow/providers/imap/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/imap/__init__.py
+++ b/airflow/providers/imap/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/imap/__init__.py
+++ b/airflow/providers/imap/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-imap:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/imap/__init__.py
+++ b/airflow/providers/imap/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/imap/__init__.py
+++ b/airflow/providers/imap/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/imap/__init__.py
+++ b/airflow/providers/imap/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-imap:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/influxdb/__init__.py
+++ b/airflow/providers/influxdb/__init__.py
@@ -35,7 +35,9 @@ version = "2.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/influxdb/__init__.py
+++ b/airflow/providers/influxdb/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "2.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-influxdb:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/influxdb/__init__.py
+++ b/airflow/providers/influxdb/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "2.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/influxdb/__init__.py
+++ b/airflow/providers/influxdb/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "2.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-influxdb:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/influxdb/__init__.py
+++ b/airflow/providers/influxdb/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "2.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/influxdb/__init__.py
+++ b/airflow/providers/influxdb/__init__.py
@@ -34,7 +34,7 @@ version = "2.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/jdbc/__init__.py
+++ b/airflow/providers/jdbc/__init__.py
@@ -35,7 +35,9 @@ version = "3.4.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/jdbc/__init__.py
+++ b/airflow/providers/jdbc/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.4.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-jdbc:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/jdbc/__init__.py
+++ b/airflow/providers/jdbc/__init__.py
@@ -34,7 +34,7 @@ version = "3.4.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/jdbc/__init__.py
+++ b/airflow/providers/jdbc/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.4.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/jdbc/__init__.py
+++ b/airflow/providers/jdbc/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.4.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/jdbc/__init__.py
+++ b/airflow/providers/jdbc/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.4.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-jdbc:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/jenkins/__init__.py
+++ b/airflow/providers/jenkins/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.3.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/jenkins/__init__.py
+++ b/airflow/providers/jenkins/__init__.py
@@ -35,7 +35,9 @@ version = "3.3.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/jenkins/__init__.py
+++ b/airflow/providers/jenkins/__init__.py
@@ -34,7 +34,7 @@ version = "3.3.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/jenkins/__init__.py
+++ b/airflow/providers/jenkins/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.3.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-jenkins:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/jenkins/__init__.py
+++ b/airflow/providers/jenkins/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.3.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/jenkins/__init__.py
+++ b/airflow/providers/jenkins/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.3.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-jenkins:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/microsoft/azure/__init__.py
+++ b/airflow/providers/microsoft/azure/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "6.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/microsoft/azure/__init__.py
+++ b/airflow/providers/microsoft/azure/__init__.py
@@ -34,7 +34,7 @@ version = "6.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/microsoft/azure/__init__.py
+++ b/airflow/providers/microsoft/azure/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "6.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-microsoft-azure:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/microsoft/azure/__init__.py
+++ b/airflow/providers/microsoft/azure/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "6.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-microsoft-azure:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/microsoft/azure/__init__.py
+++ b/airflow/providers/microsoft/azure/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "6.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/microsoft/azure/__init__.py
+++ b/airflow/providers/microsoft/azure/__init__.py
@@ -35,7 +35,9 @@ version = "6.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/microsoft/mssql/__init__.py
+++ b/airflow/providers/microsoft/mssql/__init__.py
@@ -35,7 +35,9 @@ version = "3.4.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/microsoft/mssql/__init__.py
+++ b/airflow/providers/microsoft/mssql/__init__.py
@@ -34,7 +34,7 @@ version = "3.4.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/microsoft/mssql/__init__.py
+++ b/airflow/providers/microsoft/mssql/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.4.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/microsoft/mssql/__init__.py
+++ b/airflow/providers/microsoft/mssql/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.4.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/microsoft/mssql/__init__.py
+++ b/airflow/providers/microsoft/mssql/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.4.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-microsoft-mssql:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/microsoft/mssql/__init__.py
+++ b/airflow/providers/microsoft/mssql/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.4.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-microsoft-mssql:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/microsoft/psrp/__init__.py
+++ b/airflow/providers/microsoft/psrp/__init__.py
@@ -34,7 +34,7 @@ version = "2.3.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/microsoft/psrp/__init__.py
+++ b/airflow/providers/microsoft/psrp/__init__.py
@@ -35,7 +35,9 @@ version = "2.3.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/microsoft/psrp/__init__.py
+++ b/airflow/providers/microsoft/psrp/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "2.3.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-microsoft-psrp:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/microsoft/psrp/__init__.py
+++ b/airflow/providers/microsoft/psrp/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "2.3.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/microsoft/psrp/__init__.py
+++ b/airflow/providers/microsoft/psrp/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "2.3.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-microsoft-psrp:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/microsoft/psrp/__init__.py
+++ b/airflow/providers/microsoft/psrp/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "2.3.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/microsoft/winrm/__init__.py
+++ b/airflow/providers/microsoft/winrm/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-microsoft-winrm:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/microsoft/winrm/__init__.py
+++ b/airflow/providers/microsoft/winrm/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/microsoft/winrm/__init__.py
+++ b/airflow/providers/microsoft/winrm/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/microsoft/winrm/__init__.py
+++ b/airflow/providers/microsoft/winrm/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/microsoft/winrm/__init__.py
+++ b/airflow/providers/microsoft/winrm/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-microsoft-winrm:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/microsoft/winrm/__init__.py
+++ b/airflow/providers/microsoft/winrm/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/mongo/__init__.py
+++ b/airflow/providers/mongo/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/mongo/__init__.py
+++ b/airflow/providers/mongo/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/mongo/__init__.py
+++ b/airflow/providers/mongo/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-mongo:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/mongo/__init__.py
+++ b/airflow/providers/mongo/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-mongo:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/mongo/__init__.py
+++ b/airflow/providers/mongo/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/mongo/__init__.py
+++ b/airflow/providers/mongo/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/mysql/__init__.py
+++ b/airflow/providers/mysql/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "5.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-mysql:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/mysql/__init__.py
+++ b/airflow/providers/mysql/__init__.py
@@ -34,7 +34,7 @@ version = "5.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/mysql/__init__.py
+++ b/airflow/providers/mysql/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "5.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-mysql:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/mysql/__init__.py
+++ b/airflow/providers/mysql/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "5.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/mysql/__init__.py
+++ b/airflow/providers/mysql/__init__.py
@@ -35,7 +35,9 @@ version = "5.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/mysql/__init__.py
+++ b/airflow/providers/mysql/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "5.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/neo4j/__init__.py
+++ b/airflow/providers/neo4j/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.3.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/neo4j/__init__.py
+++ b/airflow/providers/neo4j/__init__.py
@@ -35,7 +35,9 @@ version = "3.3.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/neo4j/__init__.py
+++ b/airflow/providers/neo4j/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.3.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-neo4j:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/neo4j/__init__.py
+++ b/airflow/providers/neo4j/__init__.py
@@ -34,7 +34,7 @@ version = "3.3.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/neo4j/__init__.py
+++ b/airflow/providers/neo4j/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.3.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/neo4j/__init__.py
+++ b/airflow/providers/neo4j/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.3.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-neo4j:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/odbc/__init__.py
+++ b/airflow/providers/odbc/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.3.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/odbc/__init__.py
+++ b/airflow/providers/odbc/__init__.py
@@ -35,7 +35,9 @@ version = "3.3.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/odbc/__init__.py
+++ b/airflow/providers/odbc/__init__.py
@@ -34,7 +34,7 @@ version = "3.3.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/odbc/__init__.py
+++ b/airflow/providers/odbc/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.3.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/odbc/__init__.py
+++ b/airflow/providers/odbc/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.3.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-odbc:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/odbc/__init__.py
+++ b/airflow/providers/odbc/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.3.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-odbc:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/openfaas/__init__.py
+++ b/airflow/providers/openfaas/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/openfaas/__init__.py
+++ b/airflow/providers/openfaas/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/openfaas/__init__.py
+++ b/airflow/providers/openfaas/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-openfaas:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/openfaas/__init__.py
+++ b/airflow/providers/openfaas/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-openfaas:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/openfaas/__init__.py
+++ b/airflow/providers/openfaas/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/openfaas/__init__.py
+++ b/airflow/providers/openfaas/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/openlineage/__init__.py
+++ b/airflow/providers/openlineage/__init__.py
@@ -26,13 +26,16 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "1.0.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.6.0"):
+try:
+    from airflow import __version__ as airflow_version
+except ImportError:
+    from airflow.version import version as airflow_version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.6.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-openlineage:{version}` requires Apache Airflow 2.6.0+"
     )

--- a/airflow/providers/opsgenie/__init__.py
+++ b/airflow/providers/opsgenie/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "5.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-opsgenie:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/opsgenie/__init__.py
+++ b/airflow/providers/opsgenie/__init__.py
@@ -34,7 +34,7 @@ version = "5.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/opsgenie/__init__.py
+++ b/airflow/providers/opsgenie/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "5.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-opsgenie:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/opsgenie/__init__.py
+++ b/airflow/providers/opsgenie/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "5.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/opsgenie/__init__.py
+++ b/airflow/providers/opsgenie/__init__.py
@@ -35,7 +35,9 @@ version = "5.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/opsgenie/__init__.py
+++ b/airflow/providers/opsgenie/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "5.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/oracle/__init__.py
+++ b/airflow/providers/oracle/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.7.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/oracle/__init__.py
+++ b/airflow/providers/oracle/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.7.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/oracle/__init__.py
+++ b/airflow/providers/oracle/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.7.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-oracle:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/oracle/__init__.py
+++ b/airflow/providers/oracle/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.7.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-oracle:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/oracle/__init__.py
+++ b/airflow/providers/oracle/__init__.py
@@ -34,7 +34,7 @@ version = "3.7.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/oracle/__init__.py
+++ b/airflow/providers/oracle/__init__.py
@@ -35,7 +35,9 @@ version = "3.7.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/pagerduty/__init__.py
+++ b/airflow/providers/pagerduty/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/pagerduty/__init__.py
+++ b/airflow/providers/pagerduty/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-pagerduty:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/pagerduty/__init__.py
+++ b/airflow/providers/pagerduty/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/pagerduty/__init__.py
+++ b/airflow/providers/pagerduty/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-pagerduty:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/pagerduty/__init__.py
+++ b/airflow/providers/pagerduty/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/pagerduty/__init__.py
+++ b/airflow/providers/pagerduty/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/papermill/__init__.py
+++ b/airflow/providers/papermill/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-papermill:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/papermill/__init__.py
+++ b/airflow/providers/papermill/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/papermill/__init__.py
+++ b/airflow/providers/papermill/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/papermill/__init__.py
+++ b/airflow/providers/papermill/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-papermill:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/papermill/__init__.py
+++ b/airflow/providers/papermill/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/papermill/__init__.py
+++ b/airflow/providers/papermill/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/plexus/__init__.py
+++ b/airflow/providers/plexus/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/plexus/__init__.py
+++ b/airflow/providers/plexus/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/plexus/__init__.py
+++ b/airflow/providers/plexus/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/plexus/__init__.py
+++ b/airflow/providers/plexus/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-plexus:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/plexus/__init__.py
+++ b/airflow/providers/plexus/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/plexus/__init__.py
+++ b/airflow/providers/plexus/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-plexus:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/postgres/__init__.py
+++ b/airflow/providers/postgres/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "5.5.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/postgres/__init__.py
+++ b/airflow/providers/postgres/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "5.5.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/postgres/__init__.py
+++ b/airflow/providers/postgres/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "5.5.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-postgres:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/postgres/__init__.py
+++ b/airflow/providers/postgres/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "5.5.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-postgres:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/postgres/__init__.py
+++ b/airflow/providers/postgres/__init__.py
@@ -34,7 +34,7 @@ version = "5.5.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/postgres/__init__.py
+++ b/airflow/providers/postgres/__init__.py
@@ -35,7 +35,9 @@ version = "5.5.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/presto/__init__.py
+++ b/airflow/providers/presto/__init__.py
@@ -34,7 +34,7 @@ version = "5.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/presto/__init__.py
+++ b/airflow/providers/presto/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "5.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-presto:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/presto/__init__.py
+++ b/airflow/providers/presto/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "5.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-presto:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/presto/__init__.py
+++ b/airflow/providers/presto/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "5.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/presto/__init__.py
+++ b/airflow/providers/presto/__init__.py
@@ -35,7 +35,9 @@ version = "5.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/presto/__init__.py
+++ b/airflow/providers/presto/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "5.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/qubole/__init__.py
+++ b/airflow/providers/qubole/__init__.py
@@ -35,7 +35,9 @@ version = "3.4.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/qubole/__init__.py
+++ b/airflow/providers/qubole/__init__.py
@@ -34,7 +34,7 @@ version = "3.4.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/qubole/__init__.py
+++ b/airflow/providers/qubole/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.4.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/qubole/__init__.py
+++ b/airflow/providers/qubole/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.4.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/qubole/__init__.py
+++ b/airflow/providers/qubole/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.4.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-qubole:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/qubole/__init__.py
+++ b/airflow/providers/qubole/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.4.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-qubole:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/redis/__init__.py
+++ b/airflow/providers/redis/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-redis:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/redis/__init__.py
+++ b/airflow/providers/redis/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/redis/__init__.py
+++ b/airflow/providers/redis/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-redis:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/redis/__init__.py
+++ b/airflow/providers/redis/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/redis/__init__.py
+++ b/airflow/providers/redis/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/redis/__init__.py
+++ b/airflow/providers/redis/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/salesforce/__init__.py
+++ b/airflow/providers/salesforce/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "5.4.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-salesforce:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/salesforce/__init__.py
+++ b/airflow/providers/salesforce/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "5.4.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/salesforce/__init__.py
+++ b/airflow/providers/salesforce/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "5.4.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/salesforce/__init__.py
+++ b/airflow/providers/salesforce/__init__.py
@@ -34,7 +34,7 @@ version = "5.4.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/salesforce/__init__.py
+++ b/airflow/providers/salesforce/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "5.4.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-salesforce:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/salesforce/__init__.py
+++ b/airflow/providers/salesforce/__init__.py
@@ -35,7 +35,9 @@ version = "5.4.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/samba/__init__.py
+++ b/airflow/providers/samba/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "4.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-samba:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/samba/__init__.py
+++ b/airflow/providers/samba/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "4.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/samba/__init__.py
+++ b/airflow/providers/samba/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "4.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/samba/__init__.py
+++ b/airflow/providers/samba/__init__.py
@@ -35,7 +35,9 @@ version = "4.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/samba/__init__.py
+++ b/airflow/providers/samba/__init__.py
@@ -34,7 +34,7 @@ version = "4.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/samba/__init__.py
+++ b/airflow/providers/samba/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "4.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-samba:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/segment/__init__.py
+++ b/airflow/providers/segment/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-segment:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/segment/__init__.py
+++ b/airflow/providers/segment/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-segment:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/segment/__init__.py
+++ b/airflow/providers/segment/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/segment/__init__.py
+++ b/airflow/providers/segment/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/segment/__init__.py
+++ b/airflow/providers/segment/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/segment/__init__.py
+++ b/airflow/providers/segment/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/sendgrid/__init__.py
+++ b/airflow/providers/sendgrid/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-sendgrid:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/sendgrid/__init__.py
+++ b/airflow/providers/sendgrid/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/sendgrid/__init__.py
+++ b/airflow/providers/sendgrid/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/sendgrid/__init__.py
+++ b/airflow/providers/sendgrid/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-sendgrid:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/sendgrid/__init__.py
+++ b/airflow/providers/sendgrid/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/sendgrid/__init__.py
+++ b/airflow/providers/sendgrid/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/sftp/__init__.py
+++ b/airflow/providers/sftp/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "4.3.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/sftp/__init__.py
+++ b/airflow/providers/sftp/__init__.py
@@ -34,7 +34,7 @@ version = "4.3.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/sftp/__init__.py
+++ b/airflow/providers/sftp/__init__.py
@@ -35,7 +35,9 @@ version = "4.3.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/sftp/__init__.py
+++ b/airflow/providers/sftp/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "4.3.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-sftp:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/sftp/__init__.py
+++ b/airflow/providers/sftp/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "4.3.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-sftp:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/sftp/__init__.py
+++ b/airflow/providers/sftp/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "4.3.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/singularity/__init__.py
+++ b/airflow/providers/singularity/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-singularity:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/singularity/__init__.py
+++ b/airflow/providers/singularity/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/singularity/__init__.py
+++ b/airflow/providers/singularity/__init__.py
@@ -34,7 +34,7 @@ version = "3.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/singularity/__init__.py
+++ b/airflow/providers/singularity/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/singularity/__init__.py
+++ b/airflow/providers/singularity/__init__.py
@@ -35,7 +35,9 @@ version = "3.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/singularity/__init__.py
+++ b/airflow/providers/singularity/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-singularity:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/slack/__init__.py
+++ b/airflow/providers/slack/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "7.3.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-slack:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/slack/__init__.py
+++ b/airflow/providers/slack/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "7.3.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/slack/__init__.py
+++ b/airflow/providers/slack/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "7.3.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/slack/__init__.py
+++ b/airflow/providers/slack/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "7.3.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-slack:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/slack/__init__.py
+++ b/airflow/providers/slack/__init__.py
@@ -34,7 +34,7 @@ version = "7.3.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/slack/__init__.py
+++ b/airflow/providers/slack/__init__.py
@@ -35,7 +35,9 @@ version = "7.3.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/smtp/__init__.py
+++ b/airflow/providers/smtp/__init__.py
@@ -34,7 +34,7 @@ version = "1.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/smtp/__init__.py
+++ b/airflow/providers/smtp/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "1.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/smtp/__init__.py
+++ b/airflow/providers/smtp/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "1.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-smtp:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/smtp/__init__.py
+++ b/airflow/providers/smtp/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "1.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-smtp:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/smtp/__init__.py
+++ b/airflow/providers/smtp/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "1.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/smtp/__init__.py
+++ b/airflow/providers/smtp/__init__.py
@@ -35,7 +35,9 @@ version = "1.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/snowflake/__init__.py
+++ b/airflow/providers/snowflake/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "4.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/snowflake/__init__.py
+++ b/airflow/providers/snowflake/__init__.py
@@ -34,7 +34,7 @@ version = "4.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/snowflake/__init__.py
+++ b/airflow/providers/snowflake/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "4.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/snowflake/__init__.py
+++ b/airflow/providers/snowflake/__init__.py
@@ -35,7 +35,9 @@ version = "4.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/snowflake/__init__.py
+++ b/airflow/providers/snowflake/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "4.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-snowflake:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/snowflake/__init__.py
+++ b/airflow/providers/snowflake/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "4.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-snowflake:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/sqlite/__init__.py
+++ b/airflow/providers/sqlite/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.4.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-sqlite:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/sqlite/__init__.py
+++ b/airflow/providers/sqlite/__init__.py
@@ -35,7 +35,9 @@ version = "3.4.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/sqlite/__init__.py
+++ b/airflow/providers/sqlite/__init__.py
@@ -34,7 +34,7 @@ version = "3.4.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/sqlite/__init__.py
+++ b/airflow/providers/sqlite/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.4.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-sqlite:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/sqlite/__init__.py
+++ b/airflow/providers/sqlite/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.4.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/sqlite/__init__.py
+++ b/airflow/providers/sqlite/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.4.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/ssh/__init__.py
+++ b/airflow/providers/ssh/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.7.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(f"The package `apache-airflow-providers-ssh:{version}` requires Apache Airflow 2.4.0+")

--- a/airflow/providers/ssh/__init__.py
+++ b/airflow/providers/ssh/__init__.py
@@ -35,7 +35,9 @@ version = "3.7.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(f"The package `apache-airflow-providers-ssh:{version}` requires Apache Airflow 2.4.0+")

--- a/airflow/providers/ssh/__init__.py
+++ b/airflow/providers/ssh/__init__.py
@@ -32,5 +32,5 @@ __all__ = ["version"]
 
 version = "3.7.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(f"The package `apache-airflow-providers-ssh:{version}` requires Apache Airflow 2.4.0+")

--- a/airflow/providers/ssh/__init__.py
+++ b/airflow/providers/ssh/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.7.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/ssh/__init__.py
+++ b/airflow/providers/ssh/__init__.py
@@ -32,5 +32,10 @@ __all__ = ["version"]
 
 version = "3.7.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(f"The package `apache-airflow-providers-ssh:{version}` requires Apache Airflow 2.4.0+")

--- a/airflow/providers/ssh/__init__.py
+++ b/airflow/providers/ssh/__init__.py
@@ -34,7 +34,7 @@ version = "3.7.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/tableau/__init__.py
+++ b/airflow/providers/tableau/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "4.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-tableau:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/tableau/__init__.py
+++ b/airflow/providers/tableau/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "4.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/tableau/__init__.py
+++ b/airflow/providers/tableau/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "4.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/tableau/__init__.py
+++ b/airflow/providers/tableau/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "4.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-tableau:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/tableau/__init__.py
+++ b/airflow/providers/tableau/__init__.py
@@ -35,7 +35,9 @@ version = "4.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/tableau/__init__.py
+++ b/airflow/providers/tableau/__init__.py
@@ -34,7 +34,7 @@ version = "4.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/tabular/__init__.py
+++ b/airflow/providers/tabular/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "1.2.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/tabular/__init__.py
+++ b/airflow/providers/tabular/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "1.2.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-tabular:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/tabular/__init__.py
+++ b/airflow/providers/tabular/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "1.2.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/tabular/__init__.py
+++ b/airflow/providers/tabular/__init__.py
@@ -34,7 +34,7 @@ version = "1.2.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/tabular/__init__.py
+++ b/airflow/providers/tabular/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "1.2.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-tabular:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/tabular/__init__.py
+++ b/airflow/providers/tabular/__init__.py
@@ -35,7 +35,9 @@ version = "1.2.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/telegram/__init__.py
+++ b/airflow/providers/telegram/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "4.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-telegram:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/telegram/__init__.py
+++ b/airflow/providers/telegram/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "4.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/telegram/__init__.py
+++ b/airflow/providers/telegram/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "4.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-telegram:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/telegram/__init__.py
+++ b/airflow/providers/telegram/__init__.py
@@ -34,7 +34,7 @@ version = "4.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/telegram/__init__.py
+++ b/airflow/providers/telegram/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "4.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/telegram/__init__.py
+++ b/airflow/providers/telegram/__init__.py
@@ -35,7 +35,9 @@ version = "4.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/trino/__init__.py
+++ b/airflow/providers/trino/__init__.py
@@ -34,7 +34,7 @@ version = "5.1.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/trino/__init__.py
+++ b/airflow/providers/trino/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "5.1.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-trino:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/trino/__init__.py
+++ b/airflow/providers/trino/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "5.1.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/trino/__init__.py
+++ b/airflow/providers/trino/__init__.py
@@ -35,7 +35,9 @@ version = "5.1.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/trino/__init__.py
+++ b/airflow/providers/trino/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "5.1.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-trino:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/trino/__init__.py
+++ b/airflow/providers/trino/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "5.1.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/vertica/__init__.py
+++ b/airflow/providers/vertica/__init__.py
@@ -35,7 +35,9 @@ version = "3.4.0"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/vertica/__init__.py
+++ b/airflow/providers/vertica/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.4.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-vertica:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/vertica/__init__.py
+++ b/airflow/providers/vertica/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.4.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-vertica:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/vertica/__init__.py
+++ b/airflow/providers/vertica/__init__.py
@@ -34,7 +34,7 @@ version = "3.4.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/vertica/__init__.py
+++ b/airflow/providers/vertica/__init__.py
@@ -33,10 +33,13 @@ __all__ = ["version"]
 version = "3.4.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/vertica/__init__.py
+++ b/airflow/providers/vertica/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "3.4.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/yandex/__init__.py
+++ b/airflow/providers/yandex/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "3.3.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-yandex:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/yandex/__init__.py
+++ b/airflow/providers/yandex/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "3.3.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-yandex:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/yandex/__init__.py
+++ b/airflow/providers/yandex/__init__.py
@@ -32,12 +32,7 @@ __all__ = ["version"]
 
 version = "3.3.0"
 
-try:
-    airflow_version = airflow.__version__
-except ImportError:
-    airflow_version = airflow.version.version
-
-if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-yandex:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/zendesk/__init__.py
+++ b/airflow/providers/zendesk/__init__.py
@@ -26,21 +26,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "4.3.0"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/airflow/providers/zendesk/__init__.py
+++ b/airflow/providers/zendesk/__init__.py
@@ -34,7 +34,7 @@ version = "4.3.0"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):

--- a/airflow/providers/zendesk/__init__.py
+++ b/airflow/providers/zendesk/__init__.py
@@ -32,7 +32,12 @@ __all__ = ["version"]
 
 version = "4.3.0"
 
-if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-zendesk:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/zendesk/__init__.py
+++ b/airflow/providers/zendesk/__init__.py
@@ -32,7 +32,7 @@ __all__ = ["version"]
 
 version = "4.3.0"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
+if packaging.version.parse(airflow.__version__) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
         f"The package `apache-airflow-providers-zendesk:{version}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/zendesk/__init__.py
+++ b/airflow/providers/zendesk/__init__.py
@@ -33,9 +33,14 @@ __all__ = ["version"]
 version = "4.3.0"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(

--- a/dev/provider_packages/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
+++ b/dev/provider_packages/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
@@ -51,10 +51,13 @@ __all__ = ["version"]
 version = "{{ RELEASE }}{{ VERSION_SUFFIX }}"
 
 try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+try:
     airflow_version = airflow.__version__
 except Exception:
-    from importlib.metadata import version
-
     version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("{{ MIN_AIRFLOW_VERSION }}"):

--- a/dev/provider_packages/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
+++ b/dev/provider_packages/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
@@ -52,7 +52,7 @@ version = "{{ RELEASE }}{{ VERSION_SUFFIX }}"
 
 try:
     airflow_version = airflow.__version__
-except ImportError:
+except Exception:
     airflow_version = airflow.version.version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("{{ MIN_AIRFLOW_VERSION }}"):

--- a/dev/provider_packages/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
+++ b/dev/provider_packages/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
@@ -50,7 +50,12 @@ __all__ = ["version"]
 
 version = "{{ RELEASE }}{{ VERSION_SUFFIX }}"
 
-if packaging.version.parse(airflow.version.version) < packaging.version.parse("{{ MIN_AIRFLOW_VERSION }}"):
+try:
+    airflow_version = airflow.__version__
+except ImportError:
+    airflow_version = airflow.version.version
+
+if packaging.version.parse(airflow_version) < packaging.version.parse("{{ MIN_AIRFLOW_VERSION }}"):
     raise RuntimeError(
         f"The package `{{ PACKAGE_PIP_NAME }}:{version}` requires Apache Airflow {{ MIN_AIRFLOW_VERSION }}+"
     )

--- a/dev/provider_packages/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
+++ b/dev/provider_packages/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
@@ -53,7 +53,9 @@ version = "{{ RELEASE }}{{ VERSION_SUFFIX }}"
 try:
     airflow_version = airflow.__version__
 except Exception:
-    airflow_version = airflow.version.version
+    from importlib.metadata import version
+
+    version("airflow")
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("{{ MIN_AIRFLOW_VERSION }}"):
     raise RuntimeError(

--- a/dev/provider_packages/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
+++ b/dev/provider_packages/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
@@ -44,21 +44,14 @@ from __future__ import annotations
 
 import packaging.version
 
-import airflow
-
 __all__ = ["version"]
 
 version = "{{ RELEASE }}{{ VERSION_SUFFIX }}"
 
 try:
-    from importlib.metadata import version
+    from airflow import __version__ as airflow_version
 except ImportError:
-    from importlib_metadata import version
-
-try:
-    airflow_version = airflow.__version__
-except Exception:
-    version("airflow")
+    from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("{{ MIN_AIRFLOW_VERSION }}"):
     raise RuntimeError(


### PR DESCRIPTION
We recently worked on testing our project with the latest providers' version, https://github.com/apache/airflow/issues/31322 but encountered a circular import error. Thanks, @ash, for suggesting to me how to solve this on https://github.com/apache/airflow/pull/30994/files#r1197635148

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
