### PR TITLE
Switch default Google ads to v13

### DIFF
--- a/airflow/providers/google/ads/hooks/ads.py
+++ b/airflow/providers/google/ads/hooks/ads.py
@@ -73,7 +73,7 @@ class GoogleAdsHook(BaseHook):
     :return: list of Google Ads Row object(s)
     """
 
-    default_api_version = "v12"
+    default_api_version = "v13"
 
     def __init__(
         self,


### PR DESCRIPTION
Switch the default API used by Google ads to v13 (v12 will be sunset soon)

Follow up to #31369

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
