### PR TITLE
Fix accessing a GKE cluster through the private endpoint in `GKEStartPodOperator`

### DIFF
--- a/tests/providers/google/cloud/operators/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/operators/test_kubernetes_engine.py
@@ -66,6 +66,7 @@ KUB_OPERATOR_EXEC = "airflow.providers.cncf.kubernetes.operators.kubernetes_pod.
 TEMP_FILE = "tempfile.NamedTemporaryFile"
 GKE_OP_PATH = "airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator"
 CLUSTER_URL = "https://test-host"
+CLUSTER_PRIVATE_URL = "https://test-private-host"
 SSL_CA_CERT = "TEST_SSL_CA_CERT_CONTENT"
 
 
@@ -292,6 +293,31 @@ class TestGKEPodOperator:
         self.gke_op.execute(context=mock.MagicMock())
 
         fetch_cluster_info_mock.assert_called_once()
+
+    @pytest.mark.parametrize("use_internal_ip", [True, False])
+    @mock.patch(f"{GKE_HOOK_PATH}.get_cluster")
+    def test_cluster_info(self, get_cluster_mock, use_internal_ip):
+        get_cluster_mock.return_value = mock.MagicMock(
+            **{
+                "endpoint": "test-host",
+                "private_cluster_config.private_endpoint": "test-private-host",
+                "master_auth.cluster_ca_certificate": SSL_CA_CERT,
+            }
+        )
+        gke_op = GKEStartPodOperator(
+            project_id=TEST_GCP_PROJECT_ID,
+            location=PROJECT_LOCATION,
+            cluster_name=CLUSTER_NAME,
+            task_id=PROJECT_TASK_ID,
+            name=TASK_NAME,
+            namespace=NAMESPACE,
+            image=IMAGE,
+            use_internal_ip=use_internal_ip,
+        )
+        cluster_url, ssl_ca_cert = gke_op.fetch_cluster_info()
+
+        assert cluster_url == CLUSTER_PRIVATE_URL if use_internal_ip else CLUSTER_URL
+        assert ssl_ca_cert == SSL_CA_CERT
 
 
 class TestGKEPodOperatorAsync:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #31387

In this PR, I reuse the parameter `use_internal_ip` which was removed in #29266 to allow the users to use the private endpoint to access the GKE cluster in the operator `GKEStartPodOperator`.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
