### PR TITLE
Use `__version__` in providers not `version`

### DIFF
--- a/airflow/providers/airbyte/__init__.py
+++ b/airflow/providers/airbyte/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.3.0"
+__version__ = "3.3.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-airbyte:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-airbyte:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/alibaba/__init__.py
+++ b/airflow/providers/alibaba/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "2.4.0"
+__version__ = "2.4.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-alibaba:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-alibaba:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/amazon/__init__.py
+++ b/airflow/providers/amazon/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "8.1.0"
+__version__ = "8.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-amazon:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-amazon:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/apache/beam/__init__.py
+++ b/airflow/providers/apache/beam/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "5.1.0"
+__version__ = "5.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-beam:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-apache-beam:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/apache/cassandra/__init__.py
+++ b/airflow/providers/apache/cassandra/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-cassandra:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-apache-cassandra:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/apache/drill/__init__.py
+++ b/airflow/providers/apache/drill/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "2.4.0"
+__version__ = "2.4.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-drill:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-apache-drill:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/apache/druid/__init__.py
+++ b/airflow/providers/apache/druid/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.4.0"
+__version__ = "3.4.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-druid:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-apache-druid:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/apache/flink/__init__.py
+++ b/airflow/providers/apache/flink/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "1.1.0"
+__version__ = "1.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-flink:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-apache-flink:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/apache/hdfs/__init__.py
+++ b/airflow/providers/apache/hdfs/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "4.0.0"
+__version__ = "4.0.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-hdfs:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-apache-hdfs:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/apache/hive/__init__.py
+++ b/airflow/providers/apache/hive/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "6.1.0"
+__version__ = "6.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-hive:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-apache-hive:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/apache/impala/__init__.py
+++ b/airflow/providers/apache/impala/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "1.1.0"
+__version__ = "1.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-impala:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-apache-impala:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/apache/kafka/__init__.py
+++ b/airflow/providers/apache/kafka/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "1.1.0"
+__version__ = "1.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-kafka:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-apache-kafka:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/apache/kylin/__init__.py
+++ b/airflow/providers/apache/kylin/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-kylin:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-apache-kylin:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/apache/livy/__init__.py
+++ b/airflow/providers/apache/livy/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.5.0"
+__version__ = "3.5.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-livy:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-apache-livy:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/apache/pig/__init__.py
+++ b/airflow/providers/apache/pig/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "4.1.0"
+__version__ = "4.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-pig:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-apache-pig:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/apache/pinot/__init__.py
+++ b/airflow/providers/apache/pinot/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "4.1.0"
+__version__ = "4.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-pinot:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-apache-pinot:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/apache/spark/__init__.py
+++ b/airflow/providers/apache/spark/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "4.1.0"
+__version__ = "4.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-spark:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-apache-spark:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/apache/sqoop/__init__.py
+++ b/airflow/providers/apache/sqoop/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-sqoop:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-apache-sqoop:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/arangodb/__init__.py
+++ b/airflow/providers/arangodb/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "2.2.0"
+__version__ = "2.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-arangodb:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-arangodb:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/asana/__init__.py
+++ b/airflow/providers/asana/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "2.2.0"
+__version__ = "2.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-asana:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-asana:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/atlassian/jira/__init__.py
+++ b/airflow/providers/atlassian/jira/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "2.1.0"
+__version__ = "2.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-atlassian-jira:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-atlassian-jira:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/celery/__init__.py
+++ b/airflow/providers/celery/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-celery:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-celery:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/cloudant/__init__.py
+++ b/airflow/providers/cloudant/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-cloudant:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-cloudant:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/cncf/kubernetes/__init__.py
+++ b/airflow/providers/cncf/kubernetes/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "6.2.0"
+__version__ = "6.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-cncf-kubernetes:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-cncf-kubernetes:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/common/sql/__init__.py
+++ b/airflow/providers/common/sql/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "1.5.0"
+__version__ = "1.5.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-common-sql:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-common-sql:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/databricks/__init__.py
+++ b/airflow/providers/databricks/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "4.2.0"
+__version__ = "4.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-databricks:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-databricks:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/datadog/__init__.py
+++ b/airflow/providers/datadog/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.3.0"
+__version__ = "3.3.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-datadog:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-datadog:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/dbt/cloud/__init__.py
+++ b/airflow/providers/dbt/cloud/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-dbt-cloud:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-dbt-cloud:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/dingding/__init__.py
+++ b/airflow/providers/dingding/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-dingding:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-dingding:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/discord/__init__.py
+++ b/airflow/providers/discord/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-discord:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-discord:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/docker/__init__.py
+++ b/airflow/providers/docker/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.7.0"
+__version__ = "3.7.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-docker:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-docker:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/elasticsearch/__init__.py
+++ b/airflow/providers/elasticsearch/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "4.5.0"
+__version__ = "4.5.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-elasticsearch:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-elasticsearch:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/exasol/__init__.py
+++ b/airflow/providers/exasol/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "4.2.0"
+__version__ = "4.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-exasol:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-exasol:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/facebook/__init__.py
+++ b/airflow/providers/facebook/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-facebook:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-facebook:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/ftp/__init__.py
+++ b/airflow/providers/ftp/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.4.0"
+__version__ = "3.4.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -36,4 +36,6 @@ except ImportError:
     from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
-    raise RuntimeError(f"The package `apache-airflow-providers-ftp:{version}` requires Apache Airflow 2.4.0+")
+    raise RuntimeError(
+        f"The package `apache-airflow-providers-ftp:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
+    )

--- a/airflow/providers/github/__init__.py
+++ b/airflow/providers/github/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "2.3.0"
+__version__ = "2.3.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-github:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-github:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/google/__init__.py
+++ b/airflow/providers/google/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "10.1.0"
+__version__ = "10.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-google:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-google:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/grpc/__init__.py
+++ b/airflow/providers/grpc/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-grpc:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-grpc:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/hashicorp/__init__.py
+++ b/airflow/providers/hashicorp/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.4.0"
+__version__ = "3.4.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-hashicorp:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-hashicorp:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/http/__init__.py
+++ b/airflow/providers/http/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "4.4.0"
+__version__ = "4.4.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-http:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-http:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/imap/__init__.py
+++ b/airflow/providers/imap/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-imap:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-imap:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/influxdb/__init__.py
+++ b/airflow/providers/influxdb/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "2.2.0"
+__version__ = "2.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-influxdb:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-influxdb:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/jdbc/__init__.py
+++ b/airflow/providers/jdbc/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.4.0"
+__version__ = "3.4.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-jdbc:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-jdbc:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/jenkins/__init__.py
+++ b/airflow/providers/jenkins/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.3.0"
+__version__ = "3.3.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-jenkins:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-jenkins:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/microsoft/azure/__init__.py
+++ b/airflow/providers/microsoft/azure/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "6.1.0"
+__version__ = "6.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-microsoft-azure:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-microsoft-azure:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/microsoft/mssql/__init__.py
+++ b/airflow/providers/microsoft/mssql/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.4.0"
+__version__ = "3.4.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-microsoft-mssql:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-microsoft-mssql:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/microsoft/psrp/__init__.py
+++ b/airflow/providers/microsoft/psrp/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "2.3.0"
+__version__ = "2.3.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-microsoft-psrp:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-microsoft-psrp:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/microsoft/winrm/__init__.py
+++ b/airflow/providers/microsoft/winrm/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-microsoft-winrm:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-microsoft-winrm:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/mongo/__init__.py
+++ b/airflow/providers/mongo/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-mongo:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-mongo:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/mysql/__init__.py
+++ b/airflow/providers/mysql/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "5.1.0"
+__version__ = "5.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-mysql:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-mysql:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/neo4j/__init__.py
+++ b/airflow/providers/neo4j/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.3.0"
+__version__ = "3.3.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-neo4j:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-neo4j:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/odbc/__init__.py
+++ b/airflow/providers/odbc/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.3.0"
+__version__ = "3.3.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-odbc:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-odbc:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/openfaas/__init__.py
+++ b/airflow/providers/openfaas/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-openfaas:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-openfaas:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/openlineage/__init__.py
+++ b/airflow/providers/openlineage/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "1.0.0"
+__version__ = "1.0.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.6.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-openlineage:{version}` requires Apache Airflow 2.6.0+"
+        f"The package `apache-airflow-providers-openlineage:{__version__}` requires Apache Airflow 2.6.0+"
     )

--- a/airflow/providers/openlineage/plugins/adapter.py
+++ b/airflow/providers/openlineage/plugins/adapter.py
@@ -24,7 +24,7 @@ import requests.exceptions
 import yaml
 
 from airflow.configuration import conf
-from airflow.providers.openlineage import version as OPENLINEAGE_PROVIDER_VERSION
+from airflow.providers.openlineage import __version__ as OPENLINEAGE_PROVIDER_VERSION
 from airflow.providers.openlineage.extractors import OperatorLineage
 from airflow.providers.openlineage.utils.utils import OpenLineageRedactor
 from airflow.utils.log.logging_mixin import LoggingMixin

--- a/airflow/providers/opsgenie/__init__.py
+++ b/airflow/providers/opsgenie/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "5.1.0"
+__version__ = "5.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-opsgenie:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-opsgenie:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/oracle/__init__.py
+++ b/airflow/providers/oracle/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.7.0"
+__version__ = "3.7.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-oracle:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-oracle:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/pagerduty/__init__.py
+++ b/airflow/providers/pagerduty/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-pagerduty:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-pagerduty:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/papermill/__init__.py
+++ b/airflow/providers/papermill/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-papermill:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-papermill:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/plexus/__init__.py
+++ b/airflow/providers/plexus/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-plexus:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-plexus:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/postgres/__init__.py
+++ b/airflow/providers/postgres/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "5.5.0"
+__version__ = "5.5.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-postgres:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-postgres:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/presto/__init__.py
+++ b/airflow/providers/presto/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "5.1.0"
+__version__ = "5.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-presto:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-presto:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/qubole/__init__.py
+++ b/airflow/providers/qubole/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.4.0"
+__version__ = "3.4.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-qubole:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-qubole:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/redis/__init__.py
+++ b/airflow/providers/redis/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-redis:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-redis:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/salesforce/__init__.py
+++ b/airflow/providers/salesforce/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "5.4.0"
+__version__ = "5.4.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-salesforce:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-salesforce:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/samba/__init__.py
+++ b/airflow/providers/samba/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "4.2.0"
+__version__ = "4.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-samba:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-samba:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/segment/__init__.py
+++ b/airflow/providers/segment/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-segment:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-segment:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/sendgrid/__init__.py
+++ b/airflow/providers/sendgrid/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-sendgrid:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-sendgrid:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/sftp/__init__.py
+++ b/airflow/providers/sftp/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "4.3.0"
+__version__ = "4.3.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-sftp:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-sftp:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/singularity/__init__.py
+++ b/airflow/providers/singularity/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.2.0"
+__version__ = "3.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-singularity:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-singularity:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/slack/__init__.py
+++ b/airflow/providers/slack/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "7.3.0"
+__version__ = "7.3.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-slack:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-slack:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/smtp/__init__.py
+++ b/airflow/providers/smtp/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "1.1.0"
+__version__ = "1.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-smtp:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-smtp:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/snowflake/__init__.py
+++ b/airflow/providers/snowflake/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "4.1.0"
+__version__ = "4.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-snowflake:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-snowflake:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/sqlite/__init__.py
+++ b/airflow/providers/sqlite/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.4.0"
+__version__ = "3.4.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-sqlite:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-sqlite:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/ssh/__init__.py
+++ b/airflow/providers/ssh/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.7.0"
+__version__ = "3.7.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -36,4 +36,6 @@ except ImportError:
     from airflow.version import version as airflow_version
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
-    raise RuntimeError(f"The package `apache-airflow-providers-ssh:{version}` requires Apache Airflow 2.4.0+")
+    raise RuntimeError(
+        f"The package `apache-airflow-providers-ssh:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
+    )

--- a/airflow/providers/tableau/__init__.py
+++ b/airflow/providers/tableau/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "4.2.0"
+__version__ = "4.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-tableau:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-tableau:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/tabular/__init__.py
+++ b/airflow/providers/tabular/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "1.2.0"
+__version__ = "1.2.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-tabular:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-tabular:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/telegram/__init__.py
+++ b/airflow/providers/telegram/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "4.1.0"
+__version__ = "4.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-telegram:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-telegram:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/trino/__init__.py
+++ b/airflow/providers/trino/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "5.1.0"
+__version__ = "5.1.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-trino:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-trino:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/vertica/__init__.py
+++ b/airflow/providers/vertica/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.4.0"
+__version__ = "3.4.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-vertica:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-vertica:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/airflow/providers/yandex/__init__.py
+++ b/airflow/providers/yandex/__init__.py
@@ -28,11 +28,11 @@ import packaging.version
 
 import airflow
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "3.3.0"
+__version__ = "3.3.0"
 
 if packaging.version.parse(airflow.version.version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-yandex:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-yandex:{__version__}` requires Apache Airflow 2.4.0+"
     )

--- a/airflow/providers/zendesk/__init__.py
+++ b/airflow/providers/zendesk/__init__.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "4.3.0"
+__version__ = "4.3.0"
 
 try:
     from airflow import __version__ as airflow_version
@@ -37,5 +37,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("2.4.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-zendesk:{version}` requires Apache Airflow 2.4.0+"
+        f"The package `apache-airflow-providers-zendesk:{__version__}` requires Apache Airflow 2.4.0+"  # NOQA: E501
     )

--- a/dev/provider_packages/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
+++ b/dev/provider_packages/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
@@ -44,9 +44,9 @@ from __future__ import annotations
 
 import packaging.version
 
-__all__ = ["version"]
+__all__ = ["__version__"]
 
-version = "{{ RELEASE }}{{ VERSION_SUFFIX }}"
+__version__ = "{{ RELEASE }}{{ VERSION_SUFFIX }}"
 
 try:
     from airflow import __version__ as airflow_version
@@ -55,5 +55,5 @@ except ImportError:
 
 if packaging.version.parse(airflow_version) < packaging.version.parse("{{ MIN_AIRFLOW_VERSION }}"):
     raise RuntimeError(
-        f"The package `{{ PACKAGE_PIP_NAME }}:{version}` requires Apache Airflow {{ MIN_AIRFLOW_VERSION }}+"
+        f"The package `{{ PACKAGE_PIP_NAME }}:{__version__}` requires Apache Airflow {{ MIN_AIRFLOW_VERSION }}+"  # NOQA: E501
     )


### PR DESCRIPTION
This is for consistency with what we do in `airflow` and is a common
pattern in Python modules.

As discussed breifly in https://github.com/apache/airflow/pull/30994#discussion_r1197642908

As per [PEP 396](https://peps.python.org/pep-0396/): 

> 3. When a module (or package) includes a version number, the version SHOULD be available in the `__version__` attribute
> 4. For modules which live inside a namespace package, the module SHOULD include the `__version__` attribute. The namespace package itself SHOULD NOT include its own `__version__` attribute.

(The namespace package is `airflow.providers` in our case, so all good.)

TIL there is a pep for this, even if it's now rejected the above bits are still a useful indicator of what is common

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
