### PR TITLE
Add get_namespace to GKEPodHook

### DIFF
--- a/airflow/providers/google/cloud/hooks/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/hooks/kubernetes_engine.py
@@ -373,6 +373,9 @@ class GKEPodHook(GoogleBaseHook, PodOperatorHookProtocol):
     def is_in_cluster(self) -> bool:
         return False
 
+    def get_namespace(self):
+        """Get the namespace configured by the Airflow connection."""
+
     def _get_namespace(self):
         """Implemented for compatibility with KubernetesHook.  Deprecated; do not use."""
 


### PR DESCRIPTION
In next major release of CNCF this method will be used by KPO instead of _get_namespace so best to add it to GKE as soon as possible.
