### PR TITLE
Fix dropdown default and adjust tutorial to use 42 as default for proof

### DIFF
--- a/airflow/example_dags/example_params_ui_tutorial.py
+++ b/airflow/example_dags/example_params_ui_tutorial.py
@@ -65,11 +65,11 @@ with DAG(
         ),
         # If you want to have a selection list box then you can use the enum feature of JSON schema
         "pick_one": Param(
-            "value 1",
+            "value 42",
             type="string",
             title="Select one Value",
             description="You can use JSON schema enum's to generate drop down selection boxes.",
-            enum=[f"value {i}" for i in range(1, 42)],
+            enum=[f"value {i}" for i in range(16, 64)],
         ),
         # Boolean as proper parameter with description
         "bool": Param(

--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -71,10 +71,10 @@
       </div>
     {% elif "enum" in form_details.schema and form_details.schema.enum %}
       <select class="my_select2 form-control" name="element_{{ form_key }}" id="element_{{ form_key }}" data-placeholder="Select Value"
-        value="{% if form_details.value %}{{ form_details.value }}{% endif %}" onchange="updateJSONconf();"
+        onchange="updateJSONconf();"
         {%- if not "null" in form_details.schema.type %} required=""{% endif %}>
         {% for option in form_details.schema.enum -%}
-        <option>{{ option }}</option>
+        <option{% if form_details.value == option %} selected="true"{% endif %}>{{ option }}</option>
         {% endfor -%}
       </select>
     {% elif form_details.schema and "array" in form_details.schema.type %}


### PR DESCRIPTION
closes: #31399 

This PR fixes the bug that drop-downs in trigger Form are not correctly initialized with the defined default value. In Airflow 2.6.1 always the first value is picked on the UI.

Would have been better if I would have read the HTML specs before ( :-D ) but at least I found my own contributed bug.

To make this visible better I also changed the default in the tutorial DAG to be not the first item in the list. If this would have been before like this I would have seen the bug earlier.

How to test?
* Open the "example_params_ui_tutorial" DAG form and see that defait of the dropdown is "value 42".