### PR TITLE
Fix error handling when pre-importing modules in DAGs

### DIFF
--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -388,7 +388,7 @@ def iter_airflow_imports(file_path: str) -> Generator[str, None, None]:
     """Find Airflow modules imported in the given file."""
     try:
         parsed = ast.parse(Path(file_path).read_bytes())
-    except (OSError, SyntaxError, UnicodeDecodeError, ValueError):
+    except Exception:
         return
     for m in _find_imported_modules(parsed):
         if m.startswith("airflow."):

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -388,7 +388,7 @@ def iter_airflow_imports(file_path: str) -> Generator[str, None, None]:
     """Find Airflow modules imported in the given file."""
     try:
         parsed = ast.parse(Path(file_path).read_bytes())
-    except (OSError, SyntaxError, UnicodeDecodeError):
+    except (OSError, SyntaxError, UnicodeDecodeError, ValueError):
         return
     for m in _find_imported_modules(parsed):
         if m.startswith("airflow."):

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -934,6 +934,23 @@ class TestDagFileProcessor:
         )
         processor.start()
 
+    @mock.patch("airflow.dag_processing.processor.settings.dispose_orm", MagicMock)
+    @mock.patch.object(DagFileProcessorProcess, "_get_multiprocessing_context")
+    def test_nullbyte_exception_handling_when_preimporting_airflow(self, mock_context, tmpdir):
+        mock_context.return_value.Pipe.return_value = (MagicMock(), MagicMock())
+        dag_filename = os.path.join(tmpdir, "test_dag.py")
+        with open(dag_filename, "wb") as file:
+            file.write(b"hello\x00world")
+
+        processor = DagFileProcessorProcess(
+            file_path=dag_filename,
+            pickle_dags=False,
+            dag_ids=[],
+            dag_directory=[],
+            callback_requests=[],
+        )
+        processor.start()
+
 
 class TestProcessorAgent:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
We shouldn't raise an exception if the file we are trying to pre-import
modules from has a nullbyte. It's likely not even a python DAG.

Related: #30495, #31061