### PR TITLE
Replace daemon Thread in dev-mode of breeze start-airflow with forking

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -17,17 +17,18 @@
 """Useful tools for running commands."""
 from __future__ import annotations
 
+import atexit
 import contextlib
 import os
 import re
 import shlex
+import signal
 import stat
 import subprocess
 import sys
 from distutils.version import StrictVersion
 from functools import lru_cache
 from pathlib import Path
-from threading import Thread
 from typing import Mapping, Union
 
 from rich.markup import escape
@@ -470,7 +471,15 @@ def run_compile_www_assets(
         f"{WWW_ASSET_OUT_DEV_MODE_FILE if dev else WWW_ASSET_OUT_FILE}\n"
     )
     if run_in_background:
-        thread = Thread(daemon=True, target=_run_compile_internally, args=(command_to_execute, dev))
-        thread.start()
+        pid = os.fork()
+        if pid:
+            # Parent process - send signal to process group of the child process
+            atexit.register(os.killpg, pid, signal.SIGTERM)
+        else:
+            # Check if we are not a group leader already (We should not be)
+            if os.getpid() != os.getsid(0):
+                # and create a new process group where we aer the leader
+                os.setpgid(0, 0)
+            _run_compile_internally(command_to_execute, dev)
     else:
         return _run_compile_internally(command_to_execute, dev)

--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -478,7 +478,7 @@ def run_compile_www_assets(
         else:
             # Check if we are not a group leader already (We should not be)
             if os.getpid() != os.getsid(0):
-                # and create a new process group where we aer the leader
+                # and create a new process group where we are the leader
                 os.setpgid(0, 0)
             _run_compile_internally(command_to_execute, dev)
     else:


### PR DESCRIPTION
When you run the dev mode for Breeze start-airlfow the webpack to compile the assets is run in the background and should be stopped as soon as the main process leaves. This has been done via daemon Thread, however it turns out that when daemon thread gets stopped at exit, it is stopped pretty abruptly. Quoting

https://docs.python.org/3/library/threading.html ::

> Note Daemon threads are abruptly stopped at shutdown. Their resources
(such as open files, database transactions, etc.) may not be released properly. If you want your threads to stop gracefully, make them non-daemonic and use a suitable signalling mechanism such as an Event.

This also means that if the daemon threds starts a subprocess, the thread is killed but the subprocess is not - the subprocess gets orphaned and gets adopted by init process and continues running.

Tis PR replaces the mechanism with forking. Instead of running thread, it will fork a new process that will run the compilation (including starting the subprocess that runs it). It will also change group for the started forked process to be the same as the new pid, which creates a new process group and register an atexit method to send TERM to all the processes belonging to that grop, so even if the node process that runs compilation does not propagate the TERM signal (it does not) to the webpack processes, all the webpack processes share the same process group and get the SIGTERM signal.

Fixes: #31384

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
