### PR TITLE
Fix deferrable mode execution in `WasbPrefixSensor`

### DIFF
--- a/airflow/providers/microsoft/azure/triggers/wasb.py
+++ b/airflow/providers/microsoft/azure/triggers/wasb.py
@@ -143,7 +143,7 @@ class WasbPrefixSensorTrigger(BaseTrigger):
         prefix_exists = False
         hook = WasbAsyncHook(wasb_conn_id=self.wasb_conn_id, public_read=self.public_read)
         try:
-            async with hook.blob_service_client:
+            async with await hook.get_async_conn():
                 while not prefix_exists:
                     prefix_exists = await hook.check_for_prefix_async(
                         container_name=self.container_name,


### PR DESCRIPTION
`WasbPrefixSensor` current fails with below error when deferrable flag is set to True. This PR fixes this issue.

```
Traceback (most recent call last):
  File "/opt/airflow/airflow/providers/microsoft/azure/sensors/wasb.py", line 194, in execute_complete
    raise AirflowException(event["message"])
airflow.exceptions.AirflowException: __aexit__
```

Post this fix, the sensor executes as expected

```
[2023-05-19, 11:08:06 UTC] {triggerer_job_runner.py:608} INFO - Trigger example_wasb_sensors/manual__2023-05-19T11:07:51.929984+00:00/wasb_prefix_sensor/-1/1 (ID 1) fired: TriggerEvent<{'status': 'success', 'message': 'Prefix example_az found in container test-container-providers'}>
[2023-05-19, 11:08:09 UTC] {standard_task_runner.py:85} INFO - Job 28: Subtask wasb_prefix_sensor
[2023-05-19, 11:08:09 UTC] {task_command.py:410} INFO - Running <TaskInstance: example_wasb_sensors.wasb_prefix_sensor manual__2023-05-19T11:07:51.929984+00:00 [running]> on host 47367d127faa
[2023-05-19, 11:08:10 UTC] {wasb.py:195} INFO - Prefix example_az found in container test-container-providers
```


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
