### PR TITLE
AlertPolicyServiceClient and NotificationChannelServiceClient using default credentials only

### DIFF
--- a/airflow/providers/google/cloud/hooks/stackdriver.py
+++ b/airflow/providers/google/cloud/hooks/stackdriver.py
@@ -56,12 +56,12 @@ class StackdriverHook(GoogleBaseHook):
 
     def _get_policy_client(self):
         if not self._policy_client:
-            self._policy_client = monitoring_v3.AlertPolicyServiceClient()
+            self._policy_client = monitoring_v3.AlertPolicyServiceClient(credentials=self.get_credentials())
         return self._policy_client
 
     def _get_channel_client(self):
         if not self._channel_client:
-            self._channel_client = monitoring_v3.NotificationChannelServiceClient()
+            self._channel_client = monitoring_v3.NotificationChannelServiceClient(credentials=self.get_credentials())
         return self._channel_client
 
     @GoogleBaseHook.fallback_to_default_project_id


### PR DESCRIPTION
AlertPolicyServiceClient and NotificationChannelServiceClient falling back to default credentials rather than using credentials provided through gcp_conn_id
