### PR TITLE
AWS system test example_redshift: increase timeout

### DIFF
--- a/tests/system/providers/amazon/aws/example_redshift.py
+++ b/tests/system/providers/amazon/aws/example_redshift.py
@@ -132,7 +132,7 @@ with DAG(
         cluster_identifier=redshift_cluster_identifier,
         target_status="available",
         poke_interval=15,
-        timeout=60 * 15,
+        timeout=60 * 30,
     )
     # [END howto_sensor_redshift_cluster]
 
@@ -153,7 +153,7 @@ with DAG(
         cluster_identifier=redshift_cluster_identifier,
         target_status="available",
         poke_interval=15,
-        timeout=60 * 15,
+        timeout=60 * 30,
     )
 
     # [START howto_operator_redshift_pause_cluster]
@@ -168,7 +168,7 @@ with DAG(
         cluster_identifier=redshift_cluster_identifier,
         target_status="paused",
         poke_interval=15,
-        timeout=60 * 15,
+        timeout=60 * 30,
     )
 
     # [START howto_operator_redshift_resume_cluster]
@@ -183,7 +183,7 @@ with DAG(
         cluster_identifier=redshift_cluster_identifier,
         target_status="available",
         poke_interval=15,
-        timeout=60 * 15,
+        timeout=60 * 30,
     )
 
     set_up_connection = create_connection(conn_id_name, cluster_id=redshift_cluster_identifier)


### PR DESCRIPTION
Some of our recent system test execution failed because a sensor timed out waiting the cluster to be available. See errors below:

```
INFO     airflow.task:taskinstance.py:1358 Executing <Task(RedshiftClusterSensor): wait_cluster_available_after_resume> on 2021-01-01T00:00:00+00:00
INFO     airflow.task.operators:redshift_cluster.py:64 Poked cluster env123917c5-redshift-cluster for status 'available', found status 'resuming'
ERROR    airflow.task:taskinstance.py:1903 Task failed with exception
--
Traceback (most recent call last):
File "/opt/airflow/airflow/sensors/base.py", line 242, in execute
raise AirflowSensorTimeout(message)
airflow.exceptions.AirflowSensorTimeout: Sensor has timed out; run duration of 905.869984 seconds exceeds the specified timeout of 900.
```

Let's increase the timeouts avoid this kind of timeouts

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
