### PR TITLE
Fix wrong deprecation waring for `kubernetes_executor` section

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -254,7 +254,7 @@ class AirflowConfigParser(ConfigParser):
     }
 
     # A mapping of new section -> (old section, since_version).
-    deprecated_sections: dict[str, tuple[str, str]] = {"kubernetes_executor": ("kubernetes", "2.5.0")}
+    deprecated_sections: dict[str, tuple[str, str]] = {"kubernetes": ("kubernetes_executor", "2.5.0")}
 
     # Now build the inverse so we can go from old_section/old_key to new_section/new_key
     # if someone tries to retrieve it based on old_section/old_key


### PR DESCRIPTION
We renamed `kubernetes` to `kubernetes_executor` in airflow.cfg. But we got it mixed up to show deprecation.

Example:

```
[2023-05-19, 21:40:47 UTC] {logging_mixin.py:149} WARNING - /usr/local/lib/python3.10/site-packages/airflow/kubernetes/kube_config.py:37 DeprecationWarning: The pod_template_file option in [kubernetes] has been moved to the pod_template_file option in [kubernetes_executor] - the old setting has been used, but please update your config.

```

In 2.5: https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-config-section-kubernetes-renamed-to-kubernetes-executor-26873 

PR https://github.com/apache/airflow/pull/26873

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
