### PR TITLE
Add missing BashOperator import to documentation example

### DIFF
--- a/docs/apache-airflow/howto/notifications.rst
+++ b/docs/apache-airflow/howto/notifications.rst
@@ -59,6 +59,7 @@ Here's an example of using the above notifier:
     from airflow import DAG
     from myprovider.notifier import MyNotifier
     from datetime import datetime
+    from airflow.operators.bash_operator import BashOperator
 
     with DAG(
         dag_id="example_notifier",

--- a/docs/apache-airflow/howto/notifications.rst
+++ b/docs/apache-airflow/howto/notifications.rst
@@ -56,10 +56,12 @@ Here's an example of using the above notifier:
 
 .. code-block:: python
 
-    from airflow import DAG
-    from myprovider.notifier import MyNotifier
     from datetime import datetime
+
+    from airflow.models.dag import DAG
     from airflow.operators.bash_operator import BashOperator
+
+    from myprovider.notifier import MyNotifier
 
     with DAG(
         dag_id="example_notifier",

--- a/docs/apache-airflow/howto/notifications.rst
+++ b/docs/apache-airflow/howto/notifications.rst
@@ -59,7 +59,7 @@ Here's an example of using the above notifier:
     from datetime import datetime
 
     from airflow.models.dag import DAG
-    from airflow.operators.bash_operator import BashOperator
+    from airflow.operators.bash import BashOperator
 
     from myprovider.notifier import MyNotifier
 


### PR DESCRIPTION
---
This pull request addresses an issue in the Airflow documentation where the BashOperator was used in a code example but not imported. To provide a more accurate and complete example for users, the necessary import statement has been added.

This change ensures that users who reference this example will have a fully functional code snippet that includes the necessary import for the BashOperator. This will help prevent confusion and potential errors when users attempt to implement the example in their projects.