### PR TITLE
Add libgeos-dev to dev dependencies in CI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ fi
 function get_dev_apt_deps() {
     if [[ "${DEV_APT_DEPS=}" == "" ]]; then
         DEV_APT_DEPS="apt-transport-https apt-utils build-essential ca-certificates dirmngr \
-freetds-bin freetds-dev git gosu graphviz graphviz-dev krb5-user ldap-utils libffi-dev \
+freetds-bin freetds-dev git gosu graphviz graphviz-dev krb5-user ldap-utils libffi-dev libgeos-dev \
 libkrb5-dev libldap2-dev libleveldb1d libleveldb-dev libsasl2-2 libsasl2-dev libsasl2-modules \
 libssl-dev locales lsb-release openssh-client sasl2-bin \
 software-properties-common sqlite3 sudo unixodbc unixodbc-dev"

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -54,7 +54,7 @@ fi
 function get_dev_apt_deps() {
     if [[ "${DEV_APT_DEPS=}" == "" ]]; then
         DEV_APT_DEPS="apt-transport-https apt-utils build-essential ca-certificates dirmngr \
-freetds-bin freetds-dev git gosu graphviz graphviz-dev krb5-user ldap-utils libffi-dev \
+freetds-bin freetds-dev git gosu graphviz graphviz-dev krb5-user ldap-utils libffi-dev libgeos-dev \
 libkrb5-dev libldap2-dev libleveldb1d libleveldb-dev libsasl2-2 libsasl2-dev libsasl2-modules \
 libssl-dev locales lsb-release openssh-client sasl2-bin \
 software-properties-common sqlite3 sudo unixodbc unixodbc-dev"
@@ -1233,12 +1233,11 @@ ENV PYTHON_BASE_IMAGE=${PYTHON_BASE_IMAGE} \
 
 RUN echo "Base image version: ${PYTHON_BASE_IMAGE}"
 
-ARG ADDITIONAL_DEV_APT_DEPS="git graphviz gosu libpq-dev netcat rsync"
 ARG DEV_APT_COMMAND=""
 ARG ADDITIONAL_DEV_APT_COMMAND=""
 ARG ADDITIONAL_DEV_ENV_VARS=""
 ARG ADDITIONAL_DEV_APT_DEPS="bash-completion dumb-init git graphviz gosu krb5-user \
-less libenchant-2-2 libgcc-10-dev libpq-dev net-tools netcat \
+less libenchant-2-2 libgcc-10-dev libgeos-dev libpq-dev net-tools netcat \
 openssh-server postgresql-client software-properties-common rsync tmux unzip vim xxd"
 
 ARG ADDITIONAL_DEV_APT_ENV=""

--- a/scripts/docker/install_os_dependencies.sh
+++ b/scripts/docker/install_os_dependencies.sh
@@ -36,7 +36,7 @@ fi
 function get_dev_apt_deps() {
     if [[ "${DEV_APT_DEPS=}" == "" ]]; then
         DEV_APT_DEPS="apt-transport-https apt-utils build-essential ca-certificates dirmngr \
-freetds-bin freetds-dev git gosu graphviz graphviz-dev krb5-user ldap-utils libffi-dev \
+freetds-bin freetds-dev git gosu graphviz graphviz-dev krb5-user ldap-utils libffi-dev libgeos-dev \
 libkrb5-dev libldap2-dev libleveldb1d libleveldb-dev libsasl2-2 libsasl2-dev libsasl2-modules \
 libssl-dev locales lsb-release openssh-client sasl2-bin \
 software-properties-common sqlite3 sudo unixodbc unixodbc-dev"

--- a/scripts/in_container/verify_providers.py
+++ b/scripts/in_container/verify_providers.py
@@ -21,7 +21,6 @@ import importlib
 import logging
 import os
 import pkgutil
-import platform
 import re
 import subprocess
 import sys
@@ -280,23 +279,17 @@ def import_all_classes(
             try:
                 with warnings.catch_warnings(record=True) as w:
                     warnings.filterwarnings("always", category=DeprecationWarning)
-                    try:
-                        _module = importlib.import_module(modinfo.name)
-                        for attribute_name in dir(_module):
-                            class_name = modinfo.name + "." + attribute_name
-                            attribute = getattr(_module, attribute_name)
-                            if isclass(attribute):
-                                imported_classes.append(class_name)
-                            if isclass(attribute) and (
-                                issubclass(attribute, logging.Handler)
-                                or issubclass(attribute, BaseSecretsBackend)
-                            ):
-                                classes_with_potential_circular_import.append(class_name)
-                    except OSError as e:
-                        if "geos_c" in str(e) and platform.machine() in ("aarch64", "arm64"):
-                            # we ignore the missing geos_c library on Apple Silicon
-                            continue
-                        raise
+                    _module = importlib.import_module(modinfo.name)
+                    for attribute_name in dir(_module):
+                        class_name = modinfo.name + "." + attribute_name
+                        attribute = getattr(_module, attribute_name)
+                        if isclass(attribute):
+                            imported_classes.append(class_name)
+                        if isclass(attribute) and (
+                            issubclass(attribute, logging.Handler)
+                            or issubclass(attribute, BaseSecretsBackend)
+                        ):
+                            classes_with_potential_circular_import.append(class_name)
                 if w:
                     all_warnings.extend(w)
             except AirflowOptionalProviderFeatureException:


### PR DESCRIPTION
When running some Mlengine tests, pytest (when running assert rewrite) attempts to load libgeos-dev library, which breaks collection of some Google Provider tests on ARM image (it is used by Shapely library imported by recent BigQuery library)

This PR Adds the library as preinstalled in the CI image.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
