### PR TITLE
Reverse check for docker-compose version, prioritizing v2

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -301,7 +301,7 @@ def check_remote_ghcr_io_commands():
             sys.exit(1)
 
 
-DOCKER_COMPOSE_COMMAND = ["docker-compose"]
+DOCKER_COMPOSE_COMMAND = ["docker", "compose"]
 
 
 def check_docker_compose_version():
@@ -313,7 +313,7 @@ def check_docker_compose_version():
     warning for the user.
     """
     version_pattern = re.compile(r"(\d+)\.(\d+)\.(\d+)")
-    docker_compose_version_command = ["docker-compose", "--version"]
+    docker_compose_version_command = ["docker", "compose", "version"]
     try:
         docker_compose_version_result = run_command(
             docker_compose_version_command,
@@ -322,8 +322,8 @@ def check_docker_compose_version():
             text=True,
             dry_run_override=False,
         )
-    except FileNotFoundError:
-        docker_compose_version_command = ["docker", "compose", "version"]
+    except Exception:
+        docker_compose_version_command = ["docker-compose", "--version"]
         docker_compose_version_result = run_command(
             docker_compose_version_command,
             no_output_dump_on_exception=True,
@@ -332,7 +332,7 @@ def check_docker_compose_version():
             dry_run_override=False,
         )
         DOCKER_COMPOSE_COMMAND.clear()
-        DOCKER_COMPOSE_COMMAND.extend(["docker", "compose"])
+        DOCKER_COMPOSE_COMMAND.append("docker-compose")
     if docker_compose_version_result.returncode == 0:
         docker_compose_version = docker_compose_version_result.stdout
         version_extracted = version_pattern.search(docker_compose_version)

--- a/dev/breeze/tests/test_docker_command_utils.py
+++ b/dev/breeze/tests/test_docker_command_utils.py
@@ -127,7 +127,7 @@ def test_check_docker_compose_version_unknown(mock_get_console, mock_run_command
     check_docker_compose_version()
     expected_run_command_calls = [
         call(
-            ["docker-compose", "--version"],
+            ["docker", "compose", "version"],
             no_output_dump_on_exception=True,
             capture_output=True,
             text=True,
@@ -150,7 +150,7 @@ def test_check_docker_compose_version_low(mock_get_console, mock_run_command):
     mock_run_command.return_value.stdout = "1.28.5"
     check_docker_compose_version()
     mock_run_command.assert_called_with(
-        ["docker-compose", "--version"],
+        ["docker", "compose", "version"],
         no_output_dump_on_exception=True,
         capture_output=True,
         text=True,
@@ -179,7 +179,7 @@ def test_check_docker_compose_version_ok(mock_get_console, mock_run_command):
     mock_run_command.return_value.stdout = "1.29.0"
     check_docker_compose_version()
     mock_run_command.assert_called_with(
-        ["docker-compose", "--version"],
+        ["docker", "compose", "version"],
         no_output_dump_on_exception=True,
         capture_output=True,
         text=True,
@@ -197,7 +197,7 @@ def test_check_docker_compose_version_higher(mock_get_console, mock_run_command)
     mock_run_command.return_value.stdout = "1.29.2"
     check_docker_compose_version()
     mock_run_command.assert_called_with(
-        ["docker-compose", "--version"],
+        ["docker", "compose", "version"],
         no_output_dump_on_exception=True,
         capture_output=True,
         text=True,

--- a/docker_tests/command_utils.py
+++ b/docker_tests/command_utils.py
@@ -29,8 +29,8 @@ def run_command(
             return subprocess.check_output(cmd, **kwargs).decode()
         else:
             try:
-                subprocess.run(cmd, check=check, **kwargs)
-                return True
+                result = subprocess.run(cmd, check=check, **kwargs)
+                return result.returncode == 0
             except FileNotFoundError:
                 if check:
                     raise


### PR DESCRIPTION
The docker-compose version v2 is now the "primary" version used when you install docker, so it is more likely that it will be available. We should check if v2 is available and use it. Also checking the list of containers via json is only available when v2 is used so we should only do it then.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
