### PR TITLE
Remove endoflife update from release process

### DIFF
--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -53,7 +53,6 @@
   - [Update `main` with the latest release details](#update-main-with-the-latest-release-details)
   - [Update default Airflow version in the helm chart](#update-default-airflow-version-in-the-helm-chart)
   - [Update airflow/config_templates/config.yml file](#update-airflowconfig_templatesconfigyml-file)
-  - [Update EndOfLife data](#update-endoflife-data)
   - [API clients](#api-clients)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -881,10 +880,6 @@ File `airflow/config_templates/config.yml` contains documentation on all configu
 
 - Update `airflow/config_templates/config.yml` with the details, and commit it.
 
-## Update EndOfLife data
-
-- Make a PR [EndOfLife](https://github.com/endoflife-date/endoflife.date) with release date, latest version and updated
-changelog link.
 
 ## API clients
 


### PR DESCRIPTION
They now use a script that automatically parse PyPI and update the latest released version and also the release date. Last couple of time I did the release, there was no need to do that, it was already done, and can't be overridden manually, more details here:
https://github.com/endoflife-date/endoflife.date/pull/2781#issuecomment-1494944004

cc: @ephraimbuddy 