### PR TITLE
Enable search in note column in DagRun and TaskInstance

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -774,8 +774,8 @@ class CustomSQLAInterface(SQLAInterface):
                 continue
             proxy_instance = getattr(self.obj, obj_attr)
             if hasattr(proxy_instance.remote_attr.prop, "columns"):
-                self.list_columns[desc.value_attr] = proxy_instance.remote_attr.prop.columns[0]
-                self.list_properties[desc.value_attr] = proxy_instance.remote_attr.prop
+                self.list_columns[obj_attr] = proxy_instance.remote_attr.prop.columns[0]
+                self.list_properties[obj_attr] = proxy_instance.remote_attr.prop
 
     def is_utcdatetime(self, col_name):
         """Check if the datetime is a UTC one."""

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -5177,7 +5177,6 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         "queued_at",
         "start_date",
         "end_date",
-        # Ordering is not supported on association proxies
         # "note", # todo: maybe figure out how to re-enable this
         "external_trigger",
         "conf",
@@ -5532,10 +5531,14 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
     ]
 
     order_columns = [
-        item for item in list_columns if item not in [
-            "try_number", "log_url", "external_executor_id", 
-            # Ordering is not supported on association proxies
-            "note", # todo: maybe figure out how to re-enable this
+        item
+        for item in list_columns
+        if item
+        not in [
+            "try_number",
+            "log_url",
+            "external_executor_id",
+            "note",  # todo: maybe figure out how to re-enable this
         ]
     ]
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -5150,7 +5150,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         "run_type",
         "start_date",
         "end_date",
-        # "note",  # todo: maybe figure out how to re-enable this
+        "note",
         "external_trigger",
     ]
     label_columns = {
@@ -5177,6 +5177,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         "queued_at",
         "start_date",
         "end_date",
+        # Ordering is not supported on association proxies
         # "note", # todo: maybe figure out how to re-enable this
         "external_trigger",
         "conf",
@@ -5531,7 +5532,11 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
     ]
 
     order_columns = [
-        item for item in list_columns if item not in ["try_number", "log_url", "external_executor_id"]
+        item for item in list_columns if item not in [
+            "try_number", "log_url", "external_executor_id", 
+            # Ordering is not supported on association proxies
+            "note", # todo: maybe figure out how to re-enable this
+        ]
     ]
 
     label_columns = {
@@ -5548,7 +5553,7 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
         "operator",
         "start_date",
         "end_date",
-        # "note",  # todo: maybe make note work with TI search?
+        "note",
         "hostname",
         "priority_weight",
         "queue",


### PR DESCRIPTION
This change re-enables search in notes for the DagRun and TaskInstance views (under the Browse dropdown menu). 

Turns out *desc.value_attr* is the column name in the remote table. This means that this only worked if the attribute with the association proxy had the same name as the associated column, otherwise the wrong column name was used as the key (e.g. content instead of note). The only instance this caused an issue was for the notes, the names were matching in all other cases that are shown in the UI. 

I took the liberty to fix the note search for the TaskInstance view as well, at the expense of disabling ordering by note. Unfortunately sorting by an association proxy isn't supported, and mixing it with the actual field reference (table_name.column_name format) didn't solve the issue either.


closes: #30042 