### PR TITLE
Give more time for trigger logs to propagate in tests

### DIFF
--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -143,7 +143,11 @@ def test_trigger_logging_sensitive_info(session, capsys):
     finally:
         # We always have to stop the runner
         triggerer_job_runner.trigger_runner.stop = True
+    # Since we have now an in-memory process of forwarding the logs to stdout,
+    # give it more time for the trigger event to write the log.
+    time.sleep(0.5)
     stdout = capsys.readouterr().out
+
     assert "test_dag/test_run/sensitive_arg_task/-1/1 (ID 1) starting" in stdout
     assert "some_password" not in stdout
 


### PR DESCRIPTION
After #29482 triggerer logs are not printed directly to the stdout, but they are queued in memory and written by a separate thread. This causes a slight flakiness in case of CI tests for test_trigger_job - especially on MSSQL.

This simple workaround should give more time to the logs to propgate during the test

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
