### PR TITLE
Use kube_client over default CoreV1Api for deleting pods

### DIFF
--- a/airflow/cli/commands/kubernetes_command.py
+++ b/airflow/cli/commands/kubernetes_command.py
@@ -148,8 +148,8 @@ def cleanup_pods(args):
 
 def _delete_pod(name, namespace):
     """Helper Function for cleanup_pods."""
-    core_v1 = client.CoreV1Api()
+    kube_client = get_kube_client()
     delete_options = client.V1DeleteOptions()
     print(f'Deleting POD "{name}" from "{namespace}" namespace')
-    api_response = core_v1.delete_namespaced_pod(name=name, namespace=namespace, body=delete_options)
+    api_response = kube_client.delete_namespaced_pod(name=name, namespace=namespace, body=delete_options)
     print(api_response)

--- a/tests/cli/commands/test_kubernetes_command.py
+++ b/tests/cli/commands/test_kubernetes_command.py
@@ -64,9 +64,11 @@ class TestCleanUpPodsCommand:
         cls.parser = cli_parser.get_parser()
 
     @mock.patch("kubernetes.client.CoreV1Api.delete_namespaced_pod")
-    def test_delete_pod(self, delete_namespaced_pod):
+    @mock.patch("airflow.kubernetes.kube_client.config.load_incluster_config")
+    def test_delete_pod(self, load_incluster_config, delete_namespaced_pod):
         kubernetes_command._delete_pod("dummy", "awesome-namespace")
         delete_namespaced_pod.assert_called_with(body=mock.ANY, name="dummy", namespace="awesome-namespace")
+        load_incluster_config.assert_called_once()
 
     @mock.patch("airflow.cli.commands.kubernetes_command._delete_pod")
     @mock.patch("kubernetes.client.CoreV1Api.list_namespaced_pod")


### PR DESCRIPTION
This PR uses the helper util Kubernetes client over the default CoreV1Api client when deleting pods through the CLI. In the original implementation PR this change was agreed upon but never made: https://github.com/apache/airflow/pull/11802/files#r607034452

Closes #31476 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
