### PR TITLE
fix(providers/amazon): handle missing LogUri in emr describe_cluster API response

### DIFF
--- a/airflow/providers/amazon/aws/links/emr.py
+++ b/airflow/providers/amazon/aws/links/emr.py
@@ -44,7 +44,7 @@ class EmrLogsLink(BaseAwsLink):
 
 def get_log_uri(
     *, cluster: dict[str, Any] | None = None, emr_client: boto3.client = None, job_flow_id: str | None = None
-) -> str:
+) -> str | None:
     """
     Retrieves the S3 URI to the EMR Job logs.  Requires either the output of a
     describe_cluster call or both an EMR Client and a job_flow_id to look it up.
@@ -54,9 +54,8 @@ def get_log_uri(
             "Requires either the output of a describe_cluster call or both an EMR Client and a job_flow_id."
         )
 
-    if cluster:
-        log_uri = S3Hook.parse_s3_url(cluster["Cluster"]["LogUri"])
-    else:
-        response = emr_client.describe_cluster(ClusterId=job_flow_id)
-        log_uri = S3Hook.parse_s3_url(response["Cluster"]["LogUri"])
+    cluster_info = (cluster or emr_client.describe_cluster(ClusterId=job_flow_id))["Cluster"]
+    if "LogUri" not in cluster_info:
+        return None
+    log_uri = S3Hook.parse_s3_url(cluster_info["LogUri"])
     return "/".join(log_uri)

--- a/airflow/providers/amazon/aws/links/emr.py
+++ b/airflow/providers/amazon/aws/links/emr.py
@@ -41,6 +41,11 @@ class EmrLogsLink(BaseAwsLink):
     key = "emr_logs"
     format_str = BASE_AWS_CONSOLE_LINK + "/s3/buckets/{log_uri}?region={region_name}&prefix={job_flow_id}/"
 
+    def format_link(self, **kwargs) -> str:
+        if not kwargs["log_uri"]:
+            return ""
+        return super().format_link(**kwargs)
+
 
 def get_log_uri(
     *, cluster: dict[str, Any] | None = None, emr_client: boto3.client = None, job_flow_id: str | None = None

--- a/tests/providers/amazon/aws/links/test_links.py
+++ b/tests/providers/amazon/aws/links/test_links.py
@@ -26,7 +26,7 @@ from airflow.providers.amazon.aws.links.batch import (
     BatchJobDetailsLink,
     BatchJobQueueLink,
 )
-from airflow.providers.amazon.aws.links.emr import EmrClusterLink
+from airflow.providers.amazon.aws.links.emr import EmrClusterLink, get_log_uri
 from airflow.providers.amazon.aws.links.glue import GlueJobRunDetailsLink
 from airflow.providers.amazon.aws.links.logs import CloudWatchEventsLink
 from airflow.serialization.serialized_objects import SerializedDAG
@@ -154,3 +154,13 @@ class TestAwsLinks:
         assert (
             deserialized_task.get_extra_links(ti, extra_link_class.name) == extra_link_expected_url
         ), f"{_full_qualname(extra_link_class)} should be preserved in deserialized tasks after execution"
+
+
+@pytest.mark.parametrize(
+    "cluster_info, expected_uri",
+    (({"Cluster": {}}, None), ({"Cluster": {"LogUri": "s3://myLogUri/"}}, "myLogUri/")),
+)
+def test_get_log_uri(cluster_info, expected_uri):
+    emr_client = MagicMock()
+    emr_client.describe_cluster.return_value = cluster_info
+    assert get_log_uri(cluster=None, emr_client=emr_client, job_flow_id="test_job_flow_id") == expected_uri


### PR DESCRIPTION
According to the [this document](https://docs.aws.amazon.com/cli/latest/reference/emr/describe-cluster.html), it seems we might not always be able to get ["Cluster"]["LogUri"], and we encounter errors after the release in https://github.com/apache/airflow/issues/31322. In this PR, I set the return value of `get_log_uri` to `None` if we cannot get `LogUri`

Closes: #31480

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
