### PR TITLE
Remove note about triggerer being 3.7+ only

### DIFF
--- a/docs/apache-airflow/authoring-and-scheduling/deferring.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/deferring.rst
@@ -31,11 +31,6 @@ This is where *Deferrable Operators* come in. A deferrable operator is one that 
 
 Using deferrable operators as a DAG author is almost transparent; writing them, however, takes a bit more work.
 
-.. note::
-
-    Deferrable Operators & Triggers rely on more recent ``asyncio`` features, and as a result only work
-    on Python 3.7 or higher.
-
 
 Using Deferrable Operators
 --------------------------


### PR DESCRIPTION
3.7 is now the lowest Python version Airflow supports, so no need to explicitly call out that the triggerer requires 3.7+.