### PR TITLE
Remove provide_session from Mypy plugin usage

### DIFF
--- a/dev/mypy/plugin/decorators.py
+++ b/dev/mypy/plugin/decorators.py
@@ -25,7 +25,6 @@ from mypy.plugin import FunctionContext, Plugin
 from mypy.types import CallableType, NoneType, UnionType
 
 TYPED_DECORATORS = {
-    "airflow.utils.session.provide_session": [],
     "airflow.providers.google.cloud.hooks.dataflow._fallback_to_project_id_from_variables": ["project_id"],
     "fallback_to_default_project_id of GoogleBaseHook": ["project_id"],
     "provide_gcp_credential_file of GoogleBaseHook": [],


### PR DESCRIPTION
I believe this is no longer needed now with ParamSpec. The plugin used to be there so a decorated function does not show up as untyped, but ParamSpec solves the issue.