### PR TITLE
Add append_job_name parameter in DataflowStartFlexTemplateOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/dataflow.py
+++ b/airflow/providers/google/cloud/operators/dataflow.py
@@ -782,6 +782,7 @@ class DataflowStartFlexTemplateOperator(GoogleCloudBaseOperator):
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
     :param deferrable: Run operator in the deferrable mode.
+    :param append_job_name: True if unique suffix has to be appended to job name.
     """
 
     template_fields: Sequence[str] = ("body", "location", "project_id", "gcp_conn_id")
@@ -798,6 +799,7 @@ class DataflowStartFlexTemplateOperator(GoogleCloudBaseOperator):
         wait_until_finished: bool | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         deferrable: bool = False,
+        append_job_name: bool = True,
         *args,
         **kwargs,
     ) -> None:
@@ -812,6 +814,7 @@ class DataflowStartFlexTemplateOperator(GoogleCloudBaseOperator):
         self.job: dict | None = None
         self.impersonation_chain = impersonation_chain
         self.deferrable = deferrable
+        self.append_job_name = append_job_name
 
         self._validate_deferrable_params()
 
@@ -838,7 +841,8 @@ class DataflowStartFlexTemplateOperator(GoogleCloudBaseOperator):
         return hook
 
     def execute(self, context: Context):
-        self._append_uuid_to_job_name()
+        if self.append_job_name:
+            self._append_uuid_to_job_name()
 
         def set_current_job(current_job):
             self.job = current_job

--- a/docs/apache-airflow-providers-google/operators/cloud/dataflow.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/dataflow.rst
@@ -212,8 +212,8 @@ Here is an example of running Flex template with
 .. exampleinclude:: /../../tests/system/providers/google/cloud/dataflow/example_dataflow_template.py
     :language: python
     :dedent: 4
-    :start-after: [START howto_operator_start_template_job]
-    :end-before: [END howto_operator_start_template_job]
+    :start-after: [START howto_operator_start_flex_template_job]
+    :end-before: [END howto_operator_start_flex_template_job]
 
 .. _howto/operator:DataflowStartSqlJobOperator:
 

--- a/tests/system/providers/google/cloud/dataflow/resources/schema.json
+++ b/tests/system/providers/google/cloud/dataflow/resources/schema.json
@@ -1,0 +1,14 @@
+{
+    "type": "record",
+    "name": "Person",
+    "fields": [
+        {
+            "name": "name",
+            "type": "string"
+        },
+        {
+            "name": "surname",
+            "type": "string"
+        }
+    ]
+}

--- a/tests/system/providers/google/cloud/dataflow/resources/text.csv
+++ b/tests/system/providers/google/cloud/dataflow/resources/text.csv
@@ -1,0 +1,3 @@
+name,surname
+John,Doe
+Jane,Smith


### PR DESCRIPTION
This PR closes [issue](https://b.corp.google.com/issues/283404156)
Adding the ability to pass append_job_name parameter in DataflowStartFlexTemplateOperator to specify the desired name for the job in Dataflow.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
