### PR TITLE
Fix MappedOperator-BaseOperator attr sync check

### DIFF
--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -289,6 +289,10 @@ class MappedOperator(AbstractOperator):
     """
 
     subdag: None = None  # Since we don't support SubDagOperator, this is always None.
+    supports_lineage: bool = False
+    is_setup: bool = False
+    is_teardown: bool = False
+    on_failure_fail_dagrun: bool = False
 
     HIDE_ATTRS_FROM_UI: ClassVar[frozenset[str]] = AbstractOperator.HIDE_ATTRS_FROM_UI | frozenset(
         (
@@ -334,6 +338,10 @@ class MappedOperator(AbstractOperator):
             "subdag",
             "task_group",
             "upstream_task_ids",
+            "supports_lineage",
+            "is_setup",
+            "is_teardown",
+            "on_failure_fail_dagrun",
         }
 
     @staticmethod

--- a/scripts/ci/pre_commit/pre_commit_base_operator_partial_arguments.py
+++ b/scripts/ci/pre_commit/pre_commit_base_operator_partial_arguments.py
@@ -137,6 +137,9 @@ def _iter_member_names(klass: ast.ClassDef) -> typing.Iterator[str]:
             yield node.target.id
         elif isinstance(node, ast.FunctionDef) and _is_property(node):
             yield node.name
+        elif isinstance(node, ast.Assign):
+            if len(node.targets) == 1 and isinstance(target := node.targets[0], ast.Name):
+                yield target.id
 
 
 def check_operator_member_parity() -> bool:

--- a/scripts/ci/pre_commit/pre_commit_base_operator_partial_arguments.py
+++ b/scripts/ci/pre_commit/pre_commit_base_operator_partial_arguments.py
@@ -138,8 +138,8 @@ def _iter_member_names(klass: ast.ClassDef) -> typing.Iterator[str]:
         elif isinstance(node, ast.FunctionDef) and _is_property(node):
             yield node.name
         elif isinstance(node, ast.Assign):
-            if len(node.targets) == 1 and isinstance(target := node.targets[0], ast.Name):
-                yield target.id
+            if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+                yield node.targets[0].id
 
 
 def check_operator_member_parity() -> bool:


### PR DESCRIPTION
We were missing some class attributes it seems.
