### PR TITLE
fix vpc used in aws system tests

### DIFF
--- a/tests/system/providers/amazon/aws/example_redshift.py
+++ b/tests/system/providers/amazon/aws/example_redshift.py
@@ -77,9 +77,9 @@ def create_connection(conn_id_name: str, cluster_id: str):
 @task
 def setup_security_group(sec_group_name: str, ip_permissions: list[dict]):
     client = boto3.client("ec2")
-    vpc_id = client.describe_vpcs()["Vpcs"][0]["VpcId"]
+    default_vpc = client.describe_vpcs(Filters=[{"Name": "is-default", "Values": ["true"]}])["Vpcs"][0]
     security_group = client.create_security_group(
-        Description="Redshift-system-test", GroupName=sec_group_name, VpcId=vpc_id
+        Description="Redshift-system-test", GroupName=sec_group_name, VpcId=default_vpc["VpcId"]
     )
     client.get_waiter("security_group_exists").wait(
         GroupIds=[security_group["GroupId"]],

--- a/tests/system/providers/amazon/aws/example_redshift.py
+++ b/tests/system/providers/amazon/aws/example_redshift.py
@@ -40,6 +40,7 @@ from airflow.providers.amazon.aws.sensors.redshift_cluster import RedshiftCluste
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.utils.trigger_rule import TriggerRule
 from tests.system.providers.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder
+from tests.system.providers.amazon.aws.utils.ec2 import get_default_vpc_id
 
 DAG_ID = "example_redshift"
 DB_LOGIN = "adminuser"
@@ -75,11 +76,10 @@ def create_connection(conn_id_name: str, cluster_id: str):
 
 
 @task
-def setup_security_group(sec_group_name: str, ip_permissions: list[dict]):
+def setup_security_group(sec_group_name: str, ip_permissions: list[dict], vpc_id: str):
     client = boto3.client("ec2")
-    default_vpc = client.describe_vpcs(Filters=[{"Name": "is-default", "Values": ["true"]}])["Vpcs"][0]
     security_group = client.create_security_group(
-        Description="Redshift-system-test", GroupName=sec_group_name, VpcId=default_vpc["VpcId"]
+        Description="Redshift-system-test", GroupName=sec_group_name, VpcId=vpc_id
     )
     client.get_waiter("security_group_exists").wait(
         GroupIds=[security_group["GroupId"]],
@@ -111,7 +111,9 @@ with DAG(
     conn_id_name = f"{env_id}-conn-id"
     sg_name = f"{env_id}-sg"
 
-    set_up_sg = setup_security_group(sec_group_name=sg_name, ip_permissions=[IP_PERMISSION])
+    get_vpc_id = get_default_vpc_id()
+
+    set_up_sg = setup_security_group(sg_name, [IP_PERMISSION], get_vpc_id)
 
     # [START howto_operator_redshift_cluster]
     create_cluster = RedshiftCreateClusterOperator(

--- a/tests/system/providers/amazon/aws/example_redshift_s3_transfers.py
+++ b/tests/system/providers/amazon/aws/example_redshift_s3_transfers.py
@@ -98,9 +98,9 @@ def create_connection(conn_id_name: str, cluster_id: str):
 @task
 def setup_security_group(sec_group_name: str, ip_permissions: list[dict]):
     client = boto3.client("ec2")
-    vpc_id = client.describe_vpcs()["Vpcs"][0]["VpcId"]
+    default_vpc = client.describe_vpcs(Filters=[{"Name": "is-default", "Values": ["true"]}])["Vpcs"][0]
     security_group = client.create_security_group(
-        Description="Redshift-system-test", GroupName=sec_group_name, VpcId=vpc_id
+        Description="Redshift-system-test", GroupName=sec_group_name, VpcId=default_vpc["VpcId"]
     )
     client.get_waiter("security_group_exists").wait(
         GroupIds=[security_group["GroupId"]],

--- a/tests/system/providers/amazon/aws/example_redshift_s3_transfers.py
+++ b/tests/system/providers/amazon/aws/example_redshift_s3_transfers.py
@@ -41,6 +41,7 @@ from airflow.providers.amazon.aws.transfers.s3_to_redshift import S3ToRedshiftOp
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.utils.trigger_rule import TriggerRule
 from tests.system.providers.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder
+from tests.system.providers.amazon.aws.utils.ec2 import get_default_vpc_id
 
 DAG_ID = "example_redshift_to_s3"
 
@@ -96,11 +97,10 @@ def create_connection(conn_id_name: str, cluster_id: str):
 
 
 @task
-def setup_security_group(sec_group_name: str, ip_permissions: list[dict]):
+def setup_security_group(sec_group_name: str, ip_permissions: list[dict], vpc_id: str):
     client = boto3.client("ec2")
-    default_vpc = client.describe_vpcs(Filters=[{"Name": "is-default", "Values": ["true"]}])["Vpcs"][0]
     security_group = client.create_security_group(
-        Description="Redshift-system-test", GroupName=sec_group_name, VpcId=default_vpc["VpcId"]
+        Description="Redshift-system-test", GroupName=sec_group_name, VpcId=vpc_id
     )
     client.get_waiter("security_group_exists").wait(
         GroupIds=[security_group["GroupId"]],
@@ -132,7 +132,9 @@ with DAG(
     sg_name = f"{env_id}-sg"
     bucket_name = f"{env_id}-bucket"
 
-    set_up_sg = setup_security_group(sec_group_name=sg_name, ip_permissions=[IP_PERMISSION])
+    get_vpc_id = get_default_vpc_id()
+
+    set_up_sg = setup_security_group(sg_name, [IP_PERMISSION], get_vpc_id)
 
     create_bucket = S3CreateBucketOperator(
         task_id="s3_create_bucket",

--- a/tests/system/providers/amazon/aws/example_s3_to_sql.py
+++ b/tests/system/providers/amazon/aws/example_s3_to_sql.py
@@ -40,6 +40,7 @@ from airflow.providers.amazon.aws.transfers.s3_to_sql import S3ToSqlOperator
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator, SQLTableCheckOperator
 from airflow.utils.trigger_rule import TriggerRule
 from tests.system.providers.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder
+from tests.system.providers.amazon.aws.utils.ec2 import get_default_vpc_id
 from tests.system.utils.watcher import watcher
 
 sys_test_context_task = SystemTestContextBuilder().build()
@@ -82,12 +83,10 @@ def create_connection(conn_id_name: str, cluster_id: str):
 
 
 @task
-def setup_security_group(sec_group_name: str, ip_permissions: list[dict]):
+def setup_security_group(sec_group_name: str, ip_permissions: list[dict], vpc_id: str):
     client = boto3.client("ec2")
-    default_vpc = client.describe_vpcs(Filters=[{"Name": "is-default", "Values": ["true"]}])["Vpcs"][0]
-
     security_group = client.create_security_group(
-        Description="Redshift-system-test", GroupName=sec_group_name, VpcId=default_vpc["VpcId"]
+        Description="Redshift-system-test", GroupName=sec_group_name, VpcId=vpc_id
     )
     client.get_waiter("security_group_exists").wait(
         GroupIds=[security_group["GroupId"]], GroupNames=[sec_group_name]
@@ -119,7 +118,9 @@ with DAG(
     s3_bucket_name = f"{env_id}-bucket"
     s3_key = f"{env_id}/files/cocktail_list.csv"
 
-    set_up_sg = setup_security_group(sec_group_name=sg_name, ip_permissions=[IP_PERMISSION])
+    get_vpc_id = get_default_vpc_id()
+
+    set_up_sg = setup_security_group(sg_name, [IP_PERMISSION], get_vpc_id)
 
     create_cluster = RedshiftCreateClusterOperator(
         task_id="create_cluster",

--- a/tests/system/providers/amazon/aws/example_sql_to_s3.py
+++ b/tests/system/providers/amazon/aws/example_sql_to_s3.py
@@ -87,9 +87,9 @@ def create_connection(conn_id_name: str, cluster_id: str):
 @task
 def setup_security_group(sec_group_name: str, ip_permissions: list[dict]):
     client = boto3.client("ec2")
-    vpc_id = client.describe_vpcs()["Vpcs"][0]["VpcId"]
+    default_vpc = client.describe_vpcs(Filters=[{"Name": "is-default", "Values": ["true"]}])["Vpcs"][0]
     security_group = client.create_security_group(
-        Description="Redshift-system-test", GroupName=sec_group_name, VpcId=vpc_id
+        Description="Redshift-system-test", GroupName=sec_group_name, VpcId=default_vpc["VpcId"]
     )
     client.get_waiter("security_group_exists").wait(
         GroupIds=[security_group["GroupId"]],

--- a/tests/system/providers/amazon/aws/example_sql_to_s3.py
+++ b/tests/system/providers/amazon/aws/example_sql_to_s3.py
@@ -37,6 +37,7 @@ from airflow.providers.amazon.aws.transfers.sql_to_s3 import SqlToS3Operator
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.utils.trigger_rule import TriggerRule
 from tests.system.providers.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder
+from tests.system.providers.amazon.aws.utils.ec2 import get_default_vpc_id
 
 DAG_ID = "example_sql_to_s3"
 DB_LOGIN = "adminuser"
@@ -85,11 +86,10 @@ def create_connection(conn_id_name: str, cluster_id: str):
 
 
 @task
-def setup_security_group(sec_group_name: str, ip_permissions: list[dict]):
+def setup_security_group(sec_group_name: str, ip_permissions: list[dict], vpc_id: str):
     client = boto3.client("ec2")
-    default_vpc = client.describe_vpcs(Filters=[{"Name": "is-default", "Values": ["true"]}])["Vpcs"][0]
     security_group = client.create_security_group(
-        Description="Redshift-system-test", GroupName=sec_group_name, VpcId=default_vpc["VpcId"]
+        Description="Redshift-system-test", GroupName=sec_group_name, VpcId=vpc_id
     )
     client.get_waiter("security_group_exists").wait(
         GroupIds=[security_group["GroupId"]],
@@ -127,7 +127,9 @@ with DAG(
         bucket_name=bucket_name,
     )
 
-    set_up_sg = setup_security_group(sec_group_name=sg_name, ip_permissions=[IP_PERMISSION])
+    get_vpc_id = get_default_vpc_id()
+
+    set_up_sg = setup_security_group(sg_name, [IP_PERMISSION], get_vpc_id)
 
     create_cluster = RedshiftCreateClusterOperator(
         task_id="create_cluster",


### PR DESCRIPTION
when the user running those tests has several VPCs, just picking the first one is likely to fail. We should look for the default vpc.

This is already what was done in https://github.com/apache/airflow/blob/main/tests/system/providers/amazon/aws/example_s3_to_sql.py#L87-L91