### PR TITLE
Add notice about supporting older Python/Kubernetes versions as best efforts

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,9 @@ They are based on the official release schedule of Python and Kubernetes, nicely
    make them work in our CI pipeline (which might not be immediate due to dependencies catching up with
    new versions of Python mostly) we release new images/support in Airflow based on the working CI setup.
 
+4. This policy is best-effort which means there may be situations where we might terminate support earlier
+   if circumstances require it.
+
 ## Base OS support for reference Airflow images
 
 The Airflow Community provides conveniently packaged container images that are published whenever


### PR DESCRIPTION
Waiting for [[LAZY CONSENSUS] define supporting older Python/Kubernetes versions as best efforts](https://lists.apache.org/thread/b53jvo1cqzp7gnkfpfksv3pswmsk35g0) to be accepted

Slack thread: https://apache-airflow.slack.com/archives/C03G9H97MM2/p1684950831139999