### PR TITLE
Add the missing `map_index` to the xcom key when skipping downstream tasks

### DIFF
--- a/airflow/models/skipmixin.py
+++ b/airflow/models/skipmixin.py
@@ -86,6 +86,7 @@ class SkipMixin(LoggingMixin):
         execution_date: DateTime,
         tasks: Iterable[DAGNode],
         session: Session = NEW_SESSION,
+        map_index: int = -1,
     ):
         """
         Sets tasks instances to skipped from the same dag run.
@@ -98,6 +99,7 @@ class SkipMixin(LoggingMixin):
         :param execution_date: execution_date
         :param tasks: tasks to skip (not task_ids)
         :param session: db session to use
+        :param map_index: map_index of the current task instance
         """
         task_list = _ensure_tasks(tasks)
         if not task_list:
@@ -142,6 +144,7 @@ class SkipMixin(LoggingMixin):
                 task_id=task_id,
                 dag_id=dag_run.dag_id,
                 run_id=dag_run.run_id,
+                map_index=map_index,
                 session=session,
             )
 

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -260,12 +260,17 @@ class ShortCircuitOperator(PythonOperator, SkipMixin):
 
             if self.ignore_downstream_trigger_rules is True:
                 self.log.info("Skipping all downstream tasks...")
-                self.skip(dag_run, execution_date, downstream_tasks)
+                self.skip(dag_run, execution_date, downstream_tasks, map_index=context["ti"].map_index)
             else:
                 self.log.info("Skipping downstream tasks while respecting trigger rules...")
                 # Explicitly setting the state of the direct, downstream task(s) to "skipped" and letting the
                 # Scheduler handle the remaining downstream task(s) appropriately.
-                self.skip(dag_run, execution_date, context["task"].get_direct_relatives(upstream=False))
+                self.skip(
+                    dag_run,
+                    execution_date,
+                    context["task"].get_direct_relatives(upstream=False),
+                    map_index=context["ti"].map_index,
+                )
 
         self.log.info("Done.")
 

--- a/airflow/operators/subdag.py
+++ b/airflow/operators/subdag.py
@@ -226,6 +226,11 @@ class SubDagOperator(BaseSensorOperator):
         self.log.debug("Downstream task_ids %s", downstream_tasks)
 
         if downstream_tasks:
-            self.skip(context["dag_run"], context["execution_date"], downstream_tasks)
+            self.skip(
+                context["dag_run"],
+                context["execution_date"],
+                downstream_tasks,
+                map_index=context["ti"].map_index,
+            )
 
         self.log.info("Done.")

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -31,6 +31,7 @@ from unittest import mock
 import pytest
 from slugify import slugify
 
+from airflow.decorators import task_group
 from airflow.exceptions import AirflowException, DeserializingResultError, RemovedInAirflow3Warning
 from airflow.models import DAG, DagRun, TaskInstance as TI
 from airflow.models.baseoperator import BaseOperator
@@ -617,6 +618,53 @@ class TestShortCircuitOperator(BasePythonTest):
         tis = dr.get_task_instances()
         assert tis[0].xcom_pull(task_ids=short_op_push_xcom.task_id, key="return_value") == "signature"
         assert tis[0].xcom_pull(task_ids=short_op_no_push_xcom.task_id, key="return_value") is None
+
+    def test_xcom_push_skipped_tasks(self):
+        with self.dag:
+            short_op_push_xcom = ShortCircuitOperator(
+                task_id="push_xcom_from_shortcircuit", python_callable=lambda: False
+            )
+            empty_task = EmptyOperator(task_id="empty_task")
+            short_op_push_xcom >> empty_task
+        dr = self.create_dag_run()
+        short_op_push_xcom.run(start_date=self.default_date, end_date=self.default_date)
+        tis = dr.get_task_instances()
+        assert tis[0].xcom_pull(task_ids=short_op_push_xcom.task_id, key="skipmixin_key") == {
+            "skipped": ["empty_task"]
+        }
+
+    def test_mapped_xcom_push_skipped_tasks(self, session):
+        with self.dag:
+
+            @task_group
+            def group(x):
+                short_op_push_xcom = ShortCircuitOperator(
+                    task_id="push_xcom_from_shortcircuit",
+                    python_callable=lambda arg: arg % 2 == 0,
+                    op_kwargs={"arg": x},
+                )
+                empty_task = EmptyOperator(task_id="empty_task")
+                short_op_push_xcom >> empty_task
+
+            group.expand(x=[0, 1])
+        dr = self.create_dag_run()
+        decision = dr.task_instance_scheduling_decisions(session=session)
+        for ti in decision.schedulable_tis:
+            ti.run()
+        # dr.run(start_date=self.default_date, end_date=self.default_date)
+        tis = dr.get_task_instances()
+
+        assert (
+            tis[0].xcom_pull(task_ids="group.push_xcom_from_shortcircuit", key="return_value", map_indexes=0)
+            is True
+        )
+        assert (
+            tis[0].xcom_pull(task_ids="group.push_xcom_from_shortcircuit", key="skipmixin_key", map_indexes=0)
+            is None
+        )
+        assert tis[0].xcom_pull(
+            task_ids="group.push_xcom_from_shortcircuit", key="skipmixin_key", map_indexes=1
+        ) == {"skipped": ["group.empty_task"]}
 
 
 virtualenv_string_args: list[str] = []

--- a/tests/operators/test_subdag_operator.py
+++ b/tests/operators/test_subdag_operator.py
@@ -337,7 +337,7 @@ class TestSubDagOperator:
             "execution_date": DEFAULT_DATE,
             "dag_run": dag_run,
             "task": subdag_task,
-            "ti": mock.MagicMock(**{"map_index": -1}),
+            "ti": mock.MagicMock(map_index=-1),
         }
         subdag_task.post_execute(context)
 

--- a/tests/operators/test_subdag_operator.py
+++ b/tests/operators/test_subdag_operator.py
@@ -333,11 +333,18 @@ class TestSubDagOperator:
             for task, state in zip(dummy_subdag_tasks, states)
         ]
 
-        context = {"execution_date": DEFAULT_DATE, "dag_run": dag_run, "task": subdag_task}
+        context = {
+            "execution_date": DEFAULT_DATE,
+            "dag_run": dag_run,
+            "task": subdag_task,
+            "ti": mock.MagicMock(**{"map_index": -1}),
+        }
         subdag_task.post_execute(context)
 
         if skip_parent:
-            mock_skip.assert_called_once_with(context["dag_run"], context["execution_date"], [dummy_dag_task])
+            mock_skip.assert_called_once_with(
+                context["dag_run"], context["execution_date"], [dummy_dag_task], map_index=-1
+            )
         else:
             mock_skip.assert_not_called()
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #31526

Add the ti map_index to the xcom key, when push `skipmixin_key` xcom which contains the list of skipped tasks ids.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
