### PR TITLE
Add credential configuration file support to Google Cloud Hook

### DIFF
--- a/airflow/providers/google/cloud/utils/credentials_provider.py
+++ b/airflow/providers/google/cloud/utils/credentials_provider.py
@@ -325,13 +325,13 @@ class _CredentialProvider(LoggingMixin):
                 self.credential_config_file, scopes=self.scopes
             )
         else:
-            with tempfile.NamedTemporaryFile() as temp_credentials_fd:
+            with tempfile.NamedTemporaryFile(mode="w+t") as temp_credentials_fd:
                 if isinstance(self.credential_config_file, dict):
                     self._log_info("Getting connection using credential configuration dict.")
-                    temp_credentials_fd.write(json.dumps(self.credential_config_file).encode())
+                    temp_credentials_fd.write(json.dumps(self.credential_config_file))
                 elif isinstance(self.credential_config_file, str):
                     self._log_info("Getting connection using credential configuration string.")
-                    temp_credentials_fd.write(self.credential_config_file.encode())
+                    temp_credentials_fd.write(self.credential_config_file)
 
                 temp_credentials_fd.flush()
                 credentials, project_id = google.auth.load_credentials_from_file(

--- a/airflow/providers/google/cloud/utils/credentials_provider.py
+++ b/airflow/providers/google/cloud/utils/credentials_provider.py
@@ -26,7 +26,6 @@ import logging
 import os.path
 import tempfile
 from contextlib import ExitStack, contextmanager
-from json import JSONDecodeError
 from typing import Collection, Generator, Sequence
 from urllib.parse import urlencode
 
@@ -318,7 +317,7 @@ class _CredentialProvider(LoggingMixin):
         return credentials, project_id
 
     def _get_credentials_using_credential_config_file(self):
-        if os.path.exists(self.credential_config_file):
+        if isinstance(self.credential_config_file, str) and os.path.exists(self.credential_config_file):
             self._log_info(
                 f"Getting connection using credential configuration file: `{self.credential_config_file}`"
             )
@@ -329,8 +328,8 @@ class _CredentialProvider(LoggingMixin):
             with tempfile.NamedTemporaryFile() as temp_credentials_fd:
                 if isinstance(self.credential_config_file, dict):
                     self._log_info("Getting connection using credential configuration dict.")
-                    json.dump(self.credential_config_file, temp_credentials_fd)
-                else:
+                    temp_credentials_fd.write(json.dumps(self.credential_config_file).encode())
+                elif isinstance(self.credential_config_file, str):
                     self._log_info("Getting connection using credential configuration string.")
                     temp_credentials_fd.write(self.credential_config_file.encode())
 

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -198,6 +198,9 @@ class GoogleBaseHook(BaseHook):
             "project": StringField(lazy_gettext("Project Id"), widget=BS3TextFieldWidget()),
             "key_path": StringField(lazy_gettext("Keyfile Path"), widget=BS3TextFieldWidget()),
             "keyfile_dict": PasswordField(lazy_gettext("Keyfile JSON"), widget=BS3PasswordFieldWidget()),
+            "credential_config_file": StringField(
+                lazy_gettext("Credential Configuration File"), widget=BS3TextFieldWidget()
+            ),
             "scope": StringField(lazy_gettext("Scopes (comma separated)"), widget=BS3TextFieldWidget()),
             "key_secret_name": StringField(
                 lazy_gettext("Keyfile Secret Name (in GCP Secret Manager)"), widget=BS3TextFieldWidget()
@@ -251,14 +254,18 @@ class GoogleBaseHook(BaseHook):
                     keyfile_dict_json = json.loads(keyfile_dict)
         except json.decoder.JSONDecodeError:
             raise AirflowException("Invalid key JSON.")
+
         key_secret_name: str | None = self._get_field("key_secret_name", None)
         key_secret_project_id: str | None = self._get_field("key_secret_project_id", None)
+
+        credential_config_file: str | None = self._get_field("credential_config_file", None)
 
         target_principal, delegates = _get_target_principal_and_delegates(self.impersonation_chain)
 
         credentials, project_id = get_credentials_and_project_id(
             key_path=key_path,
             keyfile_dict=keyfile_dict_json,
+            credential_config_file=credential_config_file,
             key_secret_name=key_secret_name,
             key_secret_project_id=key_secret_project_id,
             scopes=self.scopes,

--- a/docs/apache-airflow-providers-google/connections/gcp.rst
+++ b/docs/apache-airflow-providers-google/connections/gcp.rst
@@ -36,6 +36,11 @@ There are two ways to connect to Google Cloud using Airflow.
    Key can be specified as a path to the key file (``Keyfile Path``), as a key payload (``Keyfile JSON``)
    or as secret in Secret Manager (``Keyfile secret name``). Only one way of defining the key can be used at a time.
    If you need to manage multiple keys then you should configure multiple connections.
+3. Using a `credential configuration file <https://googleapis.dev/python/google-auth/2.9.0/user-guide.html#external-credentials-workload-identity-federation>`_,
+   by specifying the path to a valid credential configuration.
+   A credential configuration file is a configutation file that typically contains non-sensitive metadata to instruct
+   the `google-auth` library on how to retrieve external subject tokens and exchange them for service account access
+   tokens.
 
    .. warning:: Additional permissions might be needed
 
@@ -95,6 +100,11 @@ Keyfile JSON
     Contents of a `service account
     <https://cloud.google.com/docs/authentication/#service_accounts>`_ key
     file (JSON format) on disk.
+
+    Not required if using application default credentials.
+
+Credential Configuration File
+    Path to a `credential configuration file <https://google.aip.dev/auth/4117>`_ (JSON format) on disk.
 
     Not required if using application default credentials.
 

--- a/docs/apache-airflow-providers-google/connections/gcp.rst
+++ b/docs/apache-airflow-providers-google/connections/gcp.rst
@@ -38,8 +38,8 @@ There are two ways to connect to Google Cloud using Airflow.
    If you need to manage multiple keys then you should configure multiple connections.
 3. Using a `credential configuration file <https://googleapis.dev/python/google-auth/2.9.0/user-guide.html#external-credentials-workload-identity-federation>`_,
    by specifying the path to a valid credential configuration.
-   A credential configuration file is a configutation file that typically contains non-sensitive metadata to instruct
-   the `google-auth` library on how to retrieve external subject tokens and exchange them for service account access
+   A credential configuration file is a configuration file that typically contains non-sensitive metadata to instruct
+   the ``google-auth`` library on how to retrieve external subject tokens and exchange them for service account access
    tokens.
 
    .. warning:: Additional permissions might be needed
@@ -104,7 +104,7 @@ Keyfile JSON
     Not required if using application default credentials.
 
 Credential Configuration File
-    Path to a `credential configuration file <https://google.aip.dev/auth/4117>`_ (JSON format) on disk.
+    Credential configuration file JSON or path to a credential configuration file on the filesystem.
 
     Not required if using application default credentials.
 

--- a/docs/apache-airflow-providers-google/connections/gcp.rst
+++ b/docs/apache-airflow-providers-google/connections/gcp.rst
@@ -37,7 +37,7 @@ There are two ways to connect to Google Cloud using Airflow.
    or as secret in Secret Manager (``Keyfile secret name``). Only one way of defining the key can be used at a time.
    If you need to manage multiple keys then you should configure multiple connections.
 3. Using a `credential configuration file <https://googleapis.dev/python/google-auth/2.9.0/user-guide.html#external-credentials-workload-identity-federation>`_,
-   by specifying the path to a valid credential configuration.
+   by specifying the path to or the content of a valid credential configuration file.
    A credential configuration file is a configuration file that typically contains non-sensitive metadata to instruct
    the ``google-auth`` library on how to retrieve external subject tokens and exchange them for service account access
    tokens.

--- a/tests/providers/google/cloud/utils/test_credentials_provider.py
+++ b/tests/providers/google/cloud/utils/test_credentials_provider.py
@@ -133,7 +133,6 @@ class TestProvideGcpConnAndCredentials:
 class TestGetGcpCredentialsAndProjectId:
     test_scopes = _DEFAULT_SCOPES
     test_key_file = "KEY_PATH.json"
-    test_credential_config_file = "CREDS_CONFIG_FILE.json"
     test_project_id = "project_id"
 
     @mock.patch("google.auth.default", return_value=("CREDENTIALS", "PROJECT_ID"))

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -363,6 +363,7 @@ class TestGoogleBaseHook:
         mock_get_creds_and_proj_id.assert_called_once_with(
             key_path=None,
             keyfile_dict=None,
+            credential_config_file=None,
             key_secret_name=None,
             key_secret_project_id=None,
             scopes=self.instance.scopes,
@@ -399,6 +400,7 @@ class TestGoogleBaseHook:
         mock_get_creds_and_proj_id.assert_called_once_with(
             key_path="KEY_PATH.json",
             keyfile_dict=None,
+            credential_config_file=None,
             key_secret_name=None,
             key_secret_project_id=None,
             scopes=self.instance.scopes,
@@ -428,6 +430,7 @@ class TestGoogleBaseHook:
         mock_get_creds_and_proj_id.assert_called_once_with(
             key_path=None,
             keyfile_dict=service_account,
+            credential_config_file=None,
             key_secret_name=None,
             key_secret_project_id=None,
             scopes=self.instance.scopes,
@@ -447,6 +450,7 @@ class TestGoogleBaseHook:
         mock_get_creds_and_proj_id.assert_called_once_with(
             key_path=None,
             keyfile_dict=None,
+            credential_config_file=None,
             key_secret_name=None,
             key_secret_project_id=None,
             scopes=self.instance.scopes,
@@ -482,6 +486,7 @@ class TestGoogleBaseHook:
         mock_get_creds_and_proj_id.assert_called_once_with(
             key_path=None,
             keyfile_dict=None,
+            credential_config_file=None,
             key_secret_name=None,
             key_secret_project_id=None,
             scopes=self.instance.scopes,
@@ -683,6 +688,7 @@ class TestGoogleBaseHook:
         mock_get_creds_and_proj_id.assert_called_once_with(
             key_path=None,
             keyfile_dict=None,
+            credential_config_file=None,
             key_secret_name=None,
             key_secret_project_id=None,
             scopes=self.instance.scopes,


### PR DESCRIPTION
Add support to authenticate to GCP using a credential configuration file explicitly defined in a connection.

This allows Airflow users to authenticate to GCP using external accounts without relying on the ADC mechanism, allowing the configuration of multiple connections utilizing this mechanism, which offers more flexibility than service account keys.