### PR TITLE
Remove found_descendents param from get_flat_relative_ids

### DIFF
--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -154,18 +154,13 @@ class AbstractOperator(Templater, DAGNode):
             return self.upstream_task_ids
         return self.downstream_task_ids
 
-    def get_flat_relative_ids(
-        self,
-        upstream: bool = False,
-        found_descendants: set[str] | None = None,
-    ) -> set[str]:
+    def get_flat_relative_ids(self, upstream: bool = False) -> set[str]:
         """Get a flat set of relative IDs, upstream or downstream."""
         dag = self.get_dag()
         if not dag:
             return set()
 
-        if found_descendants is None:
-            found_descendants = set()
+        found_descendants = set()
 
         task_ids_to_trace = self.get_direct_relative_ids(upstream)
         while task_ids_to_trace:

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -160,7 +160,7 @@ class AbstractOperator(Templater, DAGNode):
         if not dag:
             return set()
 
-        relatives = set()
+        relatives: set[str] = set()
 
         task_ids_to_trace = self.get_direct_relative_ids(upstream)
         while task_ids_to_trace:

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -154,7 +154,7 @@ class AbstractOperator(Templater, DAGNode):
             return self.upstream_task_ids
         return self.downstream_task_ids
 
-    def get_flat_relative_ids(self, upstream: bool = False) -> set[str]:
+    def get_flat_relative_ids(self, *, upstream: bool = False) -> set[str]:
         """
         Get a flat set of relative IDs, upstream or downstream.
 
@@ -185,7 +185,7 @@ class AbstractOperator(Templater, DAGNode):
         dag = self.get_dag()
         if not dag:
             return set()
-        return [dag.task_dict[task_id] for task_id in self.get_flat_relative_ids(upstream)]
+        return [dag.task_dict[task_id] for task_id in self.get_flat_relative_ids(upstream=upstream)]
 
     def _iter_all_mapped_downstreams(self) -> Iterator[MappedOperator | MappedTaskGroup]:
         """Return mapped nodes that are direct dependencies of the current task.

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -155,7 +155,13 @@ class AbstractOperator(Templater, DAGNode):
         return self.downstream_task_ids
 
     def get_flat_relative_ids(self, upstream: bool = False) -> set[str]:
-        """Get a flat set of relative IDs, upstream or downstream."""
+        """
+        Get a flat set of relative IDs, upstream or downstream.
+
+        Will recurse each relative found in the direction specified.
+
+        :param upstream: Whether to look for upstream or downstream relatives.
+        """
         dag = self.get_dag()
         if not dag:
             return set()

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -160,19 +160,19 @@ class AbstractOperator(Templater, DAGNode):
         if not dag:
             return set()
 
-        found_descendants = set()
+        relatives = set()
 
         task_ids_to_trace = self.get_direct_relative_ids(upstream)
         while task_ids_to_trace:
             task_ids_to_trace_next: set[str] = set()
             for task_id in task_ids_to_trace:
-                if task_id in found_descendants:
+                if task_id in relatives:
                     continue
                 task_ids_to_trace_next.update(dag.task_dict[task_id].get_direct_relative_ids(upstream))
-                found_descendants.add(task_id)
+                relatives.add(task_id)
             task_ids_to_trace = task_ids_to_trace_next
 
-        return found_descendants
+        return relatives
 
     def get_flat_relatives(self, upstream: bool = False) -> Collection[Operator]:
         """Get a flat list of relatives, either upstream or downstream."""


### PR DESCRIPTION
By the looks of it, this param is unused.  Since the class is designated private, it is permissable to remove it.