### PR TITLE
Workaround mypy confusing default with necessary arguments

### DIFF
--- a/airflow/triggers/external_task.py
+++ b/airflow/triggers/external_task.py
@@ -77,7 +77,8 @@ class TaskStateTrigger(BaseTrigger):
         hit one of the states yet, or not.
         """
         while True:
-            num_tasks = await self.count_tasks()
+            # mypy confuses typing here
+            num_tasks = await self.count_tasks()  # type: ignore[call-arg]
             if num_tasks == len(self.execution_dates):
                 yield TriggerEvent(True)
             await asyncio.sleep(self.poll_interval)
@@ -141,7 +142,8 @@ class DagStateTrigger(BaseTrigger):
         hit one of the states yet, or not.
         """
         while True:
-            num_dags = await self.count_dags()
+            # mypy confuses typing here
+            num_dags = await self.count_dags()  # type: ignore[call-arg]
             if num_dags == len(self.execution_dates):
                 yield TriggerEvent(self.serialize())
             await asyncio.sleep(self.poll_interval)


### PR DESCRIPTION
Mypy heuristics gets the typing wrong in those cases, so we need to ignore them for now

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
