### PR TITLE
Add pydantic support to serde

### DIFF
--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -156,7 +156,7 @@ def serialize(o: object, depth: int = 0) -> U | None:
 
     # pydantic models are recursive
     if _is_pydantic(cls):
-        data = o.dict()
+        data = o.dict()  # type: ignore[call-overload]
         dct[DATA] = serialize(data, depth + 1)
         return dct
 
@@ -309,8 +309,12 @@ def _stringify(classname: str, version: int, value: T | None) -> str:
 
 
 def _is_pydantic(cls: Any) -> bool:
-    """Return True if the class is a pydantic model."""
-    return hasattr(cls, "validate") and hasattr(cls, "json") and hasattr(cls, "dict")
+    """Return True if the class is a pydantic model.
+
+    Checking is done by attributes as it is significantly faster than
+    using isinstance.
+    """
+    return hasattr(cls, "__validators__") and hasattr(cls, "__fields__") and hasattr(cls, "dict")
 
 
 def _register():

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -156,7 +156,7 @@ def serialize(o: object, depth: int = 0) -> U | None:
 
     # pydantic models are recursive
     if _is_pydantic(cls):
-        data = o.dict()  # type: ignore[call-overload]
+        data = o.dict()  # type: ignore[attr-defined]
         dct[DATA] = serialize(data, depth + 1)
         return dct
 

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -154,6 +154,12 @@ def serialize(o: object, depth: int = 0) -> U | None:
         dct[DATA] = data
         return dct
 
+    # pydantic models are recursive
+    if _is_pydantic(cls):
+        data = o.dict()
+        dct[DATA] = serialize(data, depth + 1)
+        return dct
+
     # dataclasses
     if dataclasses.is_dataclass(cls):
         # fixme: unfortunately using asdict with nested dataclasses it looses information
@@ -250,8 +256,8 @@ def deserialize(o: T | None, full=True, type_hint: Any = None) -> object:
     if hasattr(cls, "deserialize"):
         return getattr(cls, "deserialize")(deserialize(value), version)
 
-    # attr or dataclass
-    if attr.has(cls) or dataclasses.is_dataclass(cls):
+    # attr or dataclass or pydantic
+    if attr.has(cls) or dataclasses.is_dataclass(cls) or _is_pydantic(cls):
         class_version = getattr(cls, "__version__", 0)
         if int(version) > class_version:
             raise TypeError(
@@ -300,6 +306,11 @@ def _stringify(classname: str, version: int, value: T | None) -> str:
         s = s[:-1] + ")"
 
     return s
+
+
+def _is_pydantic(cls: Any) -> bool:
+    """Return True if the class is a pydantic model."""
+    return hasattr(cls, "validate") and hasattr(cls, "json") and hasattr(cls, "dict")
 
 
 def _register():

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -20,6 +20,7 @@ import datetime
 import enum
 from dataclasses import dataclass
 from importlib import import_module
+from pydantic import BaseModel
 from typing import ClassVar
 
 import attr
@@ -90,6 +91,13 @@ class V:
     s: list
     t: tuple
     c: int
+
+
+class U(BaseModel):
+    __version__: ClassVar[int] = 1
+    x: int
+    v: V
+    u: tuple
 
 
 @pytest.mark.usefixtures("recalculate_patterns")
@@ -317,3 +325,9 @@ class TestSerDe:
         i = Z(10)
         e = deserialize(i)
         assert i == e
+
+    def test_pydantic(self):
+        i = U(x=10, v=V(W(10), ["l1", "l2"], (1, 2), 10), u=(1, 2))
+        e = serialize(i)
+        s = deserialize(e)
+        assert i == s

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -20,11 +20,11 @@ import datetime
 import enum
 from dataclasses import dataclass
 from importlib import import_module
-from pydantic import BaseModel
 from typing import ClassVar
 
 import attr
 import pytest
+from pydantic import BaseModel
 
 from airflow.datasets import Dataset
 from airflow.serialization.serde import (


### PR DESCRIPTION
This adds support of serialization and deserialization of pydantic models. Pydantic takes precedence over dataclasses.

cc: @potiuk @mhenc @uranusjr 