### PR TITLE
allow 'breeze start-airflow --use-packages-from-dist' without specifying Airflow version

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -816,7 +816,7 @@ if [[ ${SKIP_ENVIRONMENT_INITIALIZATION=} != "true" ]]; then
                 fi
             fi
         done
-        if [[ ${USE_AIRFLOW_VERSION} != "wheel" && ${USE_AIRFLOW_VERSION} != "sdist" && ${USE_AIRFLOW_VERSION} != "none" ]]; then
+        if [[ ${USE_AIRFLOW_VERSION} != "wheel" && ${USE_AIRFLOW_VERSION} != "sdist" && ${USE_AIRFLOW_VERSION} != "none" && ${USE_AIRFLOW_VERSION} != "" ]]; then
             echo
             echo "${COLOR_BLUE}Also adding airflow in specified version ${USE_AIRFLOW_VERSION} to make sure it is not upgraded by >= limits${COLOR_RESET}"
             echo

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -241,7 +241,7 @@ if [[ ${SKIP_ENVIRONMENT_INITIALIZATION=} != "true" ]]; then
                 fi
             fi
         done
-        if [[ ${USE_AIRFLOW_VERSION} != "wheel" && ${USE_AIRFLOW_VERSION} != "sdist" && ${USE_AIRFLOW_VERSION} != "none" ]]; then
+        if [[ ${USE_AIRFLOW_VERSION} != "wheel" && ${USE_AIRFLOW_VERSION} != "sdist" && ${USE_AIRFLOW_VERSION} != "none" && ${USE_AIRFLOW_VERSION} != "" ]]; then
             echo
             echo "${COLOR_BLUE}Also adding airflow in specified version ${USE_AIRFLOW_VERSION} to make sure it is not upgraded by >= limits${COLOR_RESET}"
             echo


### PR DESCRIPTION
This allows to run `breeze start-airflow` with some specific provider packages with Airflow source on current branch.

Without it running fails:

```
Installing all found providers

Adding openlineage to install via /dist/apache_airflow_providers_openlineage-1.0.0-py3-none-any.whl

Also adding airflow in specified version  to make sure it is not upgraded by >= limits


Installing: /dist/apache_airflow_providers_openlineage-1.0.0-py3-none-any.whl apache-airflow==

Processing /dist/apache_airflow_providers_openlineage-1.0.0-py3-none-any.whl
ERROR: Could not find a version that satisfies the requirement apache-airflow== (from versions: 1.10.9-bin, 1.8.1, 1.8.2rc1, 1.8.2, 1.9.0, 1.10.0, 1.10.1b1, 1.10.1rc2, 1.10.1, 1.10.2b2, 1.10.2rc1, 1.10.2rc2, 1.10.2rc3, 1.10.2, 1.10.3b1, 1.10.3b2, 1.10.3rc1, 1.10.3rc2, 1.10.3, 1.10.4b2, 1.10.4rc1, 1.10.4rc2, 1.10.4rc3, 1.10.4rc4, 1.10.4rc5, 1.10.4, 1.10.5rc1, 1.10.5, 1.10.6rc1, 1.10.6rc2, 1.10.6, 1.10.7rc1, 1.10.7rc2, 1.10.7rc3, 1.10.7, 1.10.8rc1, 1.10.8, 1.10.9rc1, 1.10.9, 1.10.10rc1, 1.10.10rc2, 1.10.10rc3, 1.10.10rc4, 1.10.10rc5, 1.10.10, 1.10.11rc1, 1.10.11rc2, 1.10.11, 1.10.12rc1, 1.10.12rc2, 1.10.12rc3, 1.10.12rc4, 1.10.12, 1.10.13rc1, 1.10.13, 1.10.14rc1, 1.10.14rc2, 1.10.14rc3, 1.10.14rc4, 1.10.14, 1.10.15rc1, 1.10.15, 2.0.0b1, 2.0.0b2, 2.0.0b3, 2.0.0rc1, 2.0.0rc2, 2.0.0rc3, 2.0.0, 2.0.1rc1, 2.0.1rc2, 2.0.1, 2.0.2rc1, 2.0.2, 2.1.0rc1, 2.1.0rc2, 2.1.0, 2.1.1rc1, 2.1.1, 2.1.2rc1, 2.1.2, 2.1.3rc1, 2.1.3, 2.1.4rc1, 2.1.4rc2, 2.1.4, 2.2.0b1, 2.2.0b2, 2.2.0rc1, 2.2.0, 2.2.1rc1, 2.2.1rc2, 2.2.1, 2.2.2rc1, 2.2.2rc2, 2.2.2, 2.2.3rc1, 2.2.3rc2, 2.2.3, 2.2.4rc1, 2.2.4, 2.2.5rc1, 2.2.5rc2, 2.2.5rc3, 2.2.5, 2.3.0b1, 2.3.0rc1, 2.3.0rc2, 2.3.0, 2.3.1rc1, 2.3.1, 2.3.2rc1, 2.3.2rc2, 2.3.2, 2.3.3rc1, 2.3.3rc2, 2.3.3rc3, 2.3.3, 2.3.4rc1, 2.3.4, 2.4.0b1, 2.4.0rc1, 2.4.0, 2.4.1rc1, 2.4.1, 2.4.2rc1, 2.4.2, 2.4.3rc1, 2.4.3, 2.5.0rc1, 2.5.0rc2, 2.5.0rc3, 2.5.0, 2.5.1rc1, 2.5.1rc2, 2.5.1, 2.5.2rc1, 2.5.2rc2, 2.5.2, 2.5.3rc1, 2.5.3rc2, 2.5.3, 2.6.0b1, 2.6.0rc1, 2.6.0rc2, 2.6.0rc3, 2.6.0rc4, 2.6.0rc5, 2.6.0, 2.6.1rc1, 2.6.1rc2, 2.6.1rc3, 2.6.1)
ERROR: No matching distribution found for apache-airflow==
Error 1 returned
```