### PR TITLE
breeze: sqlite volume should not contain whole /root/airflow directory

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -170,7 +170,7 @@ MSSQL_HOST_PORT = "21433"
 FLOWER_HOST_PORT = "25555"
 REDIS_HOST_PORT = "26379"
 
-SQLITE_URL = "sqlite:////root/airflow/airflow.db"
+SQLITE_URL = "sqlite:////root/airflow/sqlite/airflow.db"
 PYTHONDONTWRITEBYTECODE = True
 
 PRODUCTION_IMAGE = False

--- a/dev/breeze/src/airflow_breeze/params/shell_params.py
+++ b/dev/breeze/src/airflow_breeze/params/shell_params.py
@@ -182,7 +182,7 @@ class ShellParams:
 
     @property
     def sqlite_url(self) -> str:
-        sqlite_url = "sqlite:////root/airflow/airflow.db"
+        sqlite_url = "sqlite:////root/airflow/sqlite/airflow.db"
         return sqlite_url
 
     def print_badge_info(self):

--- a/scripts/ci/docker-compose/backend-sqlite.yml
+++ b/scripts/ci/docker-compose/backend-sqlite.yml
@@ -24,6 +24,6 @@ services:
       - AIRFLOW__CORE__EXECUTOR=SequentialExecutor
     volumes:
       - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
-      - sqlite-db-volume:/root/airflow
+      - sqlite-db-volume:/root/airflow/sqlite
 volumes:
   sqlite-db-volume:


### PR DESCRIPTION
By having volume contaning whole `/root/airflow` directory, it contains unintended files - like `airflow.cfg` configuration. 

https://apache-airflow.slack.com/archives/CCPRP7943/p1685029128180869