### PR TITLE
Fix for "Filter dags by tag" flickering on initial load of dags.html

### DIFF
--- a/airflow/www/static/css/dags.css
+++ b/airflow/www/static/css/dags.css
@@ -27,6 +27,7 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
+  align-items: center;
   margin: 0;
   padding-top: 16px;
 }

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -158,7 +158,7 @@
       <div style="min-width: 200px; padding: 0 10px;">
         <form id="tags_form">
           <div class="form-group search-input">
-            <select multiple name="tags" id="tags_filter" class="select2-drop-mask">
+            <select style="display: none;" multiple name="tags" id="tags_filter" class="select2-drop-mask">
               {% for tag in tags %}
                 <option value="{{ tag.name }}" {% if tag.selected %}selected{% endif %}>{{ tag.name }}</option>
               {% endfor %}


### PR DESCRIPTION
Isuue - 

https://github.com/apache/airflow/assets/35839624/851a446e-3afd-4731-b77a-2fd32485ab0d

The below the flicker snapshot - 
![image](https://github.com/apache/airflow/assets/35839624/ff798c1f-3b68-4ccf-81ff-532bdc603f78)

Its probably because HTML loads faster than JS.

Fix - 
Added `display: none;` to the div causing the issue. Hence it will be hidden unless JS loads, and after it, it becomes visible without any flicker.

https://github.com/apache/airflow/assets/35839624/4d774584-b6cb-4b42-8565-2eadf3e25571


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
