### PR TITLE
Fix `BigQueryInsertJobOperator` not exiting deferred state

### DIFF
--- a/tests/providers/google/cloud/triggers/test_bigquery.py
+++ b/tests/providers/google/cloud/triggers/test_bigquery.py
@@ -180,7 +180,7 @@ class TestBigQueryInsertJobTrigger:
 
         mock_job_client = AsyncMock(Job)
         mock_job_instance.return_value = mock_job_client
-        mock_job_instance.return_value.result.side_effect = OSError
+        mock_job_instance.return_value.get_job.return_value = {"status": {"state": "running"}}
         caplog.set_level(logging.INFO)
 
         task = asyncio.create_task(insert_job_trigger.run().__anext__())
@@ -189,8 +189,7 @@ class TestBigQueryInsertJobTrigger:
         # TriggerEvent was not returned
         assert task.done() is False
 
-        assert "Query is still running..." in caplog.text
-        assert f"Sleeping for {POLLING_PERIOD_SECONDS} seconds." in caplog.text
+        assert "Bigquery job status is running. Sleeping for 4.0 seconds." in caplog.text
 
         # Prevents error when task is destroyed while in "pending" state
         asyncio.get_event_loop().stop()
@@ -205,7 +204,7 @@ class TestBigQueryInsertJobTrigger:
 
         generator = insert_job_trigger.run()
         actual = await generator.asend(None)
-        assert TriggerEvent({"status": "error", "message": "error"}) == actual
+        assert TriggerEvent({"status": "error"}) == actual
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
@@ -241,7 +240,7 @@ class TestBigQueryGetDataTrigger:
 
         mock_job_client = AsyncMock(Job)
         mock_job_instance.return_value = mock_job_client
-        mock_job_instance.return_value.result.side_effect = OSError
+        mock_job_instance.return_value.get_job.return_value = {"status": {"state": "RUNNING"}}
         caplog.set_level(logging.INFO)
 
         task = asyncio.create_task(get_data_trigger.run().__anext__())
@@ -250,8 +249,7 @@ class TestBigQueryGetDataTrigger:
         # TriggerEvent was not returned
         assert task.done() is False
 
-        assert "Query is still running..." in caplog.text
-        assert f"Sleeping for {POLLING_PERIOD_SECONDS} seconds." in caplog.text
+        assert "Bigquery job status is running. Sleeping for 4.0 seconds." in caplog.text
 
         # Prevents error when task is destroyed while in "pending" state
         asyncio.get_event_loop().stop()
@@ -266,7 +264,7 @@ class TestBigQueryGetDataTrigger:
 
         generator = get_data_trigger.run()
         actual = await generator.asend(None)
-        assert TriggerEvent({"status": "error", "message": "error"}) == actual
+        assert TriggerEvent({"status": "error"}) == actual
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
@@ -336,8 +334,7 @@ class TestBigQueryCheckTrigger:
 
         mock_job_client = AsyncMock(Job)
         mock_job_instance.return_value = mock_job_client
-        mock_job_instance.return_value.result.side_effect = OSError
-        caplog.set_level(logging.INFO)
+        mock_job_instance.return_value.get_job.return_value = {"status": {"state": "running"}}
 
         task = asyncio.create_task(check_trigger.run().__anext__())
         await asyncio.sleep(0.5)
@@ -345,8 +342,7 @@ class TestBigQueryCheckTrigger:
         # TriggerEvent was not returned
         assert task.done() is False
 
-        assert "Query is still running..." in caplog.text
-        assert f"Sleeping for {POLLING_PERIOD_SECONDS} seconds." in caplog.text
+        assert "Bigquery job status is running. Sleeping for 4.0 seconds." in caplog.text
 
         # Prevents error when task is destroyed while in "pending" state
         asyncio.get_event_loop().stop()


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/31584
`get_job_status` method of bigquery hook should directly call `get_job` of google sdk method to to return the job status return by API and not predict based on exception type.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
