### PR TITLE
Fix Hashicorp client authentication for `userpass` and `aws_iam` methods

### DIFF
--- a/airflow/providers/hashicorp/_internal_client/vault_client.py
+++ b/airflow/providers/hashicorp/_internal_client/vault_client.py
@@ -222,11 +222,11 @@ class _VaultClient(LoggingMixin):
 
     def _auth_userpass(self, _client: hvac.Client) -> None:
         if self.auth_mount_point:
-            _client.auth_userpass(
+            _client.auth.userpass.login(
                 username=self.username, password=self.password, mount_point=self.auth_mount_point
             )
         else:
-            _client.auth_userpass(username=self.username, password=self.password)
+            _client.auth.userpass.login(username=self.username, password=self.password)
 
     def _auth_radius(self, _client: hvac.Client) -> None:
         if self.auth_mount_point:
@@ -301,14 +301,14 @@ class _VaultClient(LoggingMixin):
 
     def _auth_aws_iam(self, _client: hvac.Client) -> None:
         if self.auth_mount_point:
-            _client.auth_aws_iam(
+            _client.auth.aws.iam_login(
                 access_key=self.key_id,
                 secret_key=self.secret_id,
                 role=self.role_id,
                 mount_point=self.auth_mount_point,
             )
         else:
-            _client.auth_aws_iam(access_key=self.key_id, secret_key=self.secret_id, role=self.role_id)
+            _client.auth.aws.iam_login(access_key=self.key_id, secret_key=self.secret_id, role=self.role_id)
 
     def _auth_approle(self, _client: hvac.Client) -> None:
         if self.auth_mount_point:

--- a/tests/providers/hashicorp/_internal_client/test_vault_client.py
+++ b/tests/providers/hashicorp/_internal_client/test_vault_client.py
@@ -94,7 +94,7 @@ class TestVaultClient:
         )
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180")
-        client.auth_aws_iam.assert_called_with(
+        client.auth.aws.iam_login.assert_called_with(
             access_key="user",
             secret_key="pass",
             role="role",
@@ -116,7 +116,7 @@ class TestVaultClient:
         )
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180")
-        client.auth_aws_iam.assert_called_with(
+        client.auth.aws.iam_login.assert_called_with(
             access_key="user", secret_key="pass", role="role", mount_point="other"
         )
         client.is_authenticated.assert_called_with()
@@ -556,7 +556,7 @@ class TestVaultClient:
         )
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180")
-        client.auth_userpass.assert_called_with(username="user", password="pass")
+        client.auth.userpass.login.assert_called_with(username="user", password="pass")
         client.is_authenticated.assert_called_with()
         assert 2 == vault_client.kv_engine_version
 
@@ -573,7 +573,7 @@ class TestVaultClient:
         )
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180")
-        client.auth_userpass.assert_called_with(username="user", password="pass", mount_point="other")
+        client.auth.userpass.login.assert_called_with(username="user", password="pass", mount_point="other")
         client.is_authenticated.assert_called_with()
         assert 2 == vault_client.kv_engine_version
 

--- a/tests/providers/hashicorp/hooks/test_vault.py
+++ b/tests/providers/hashicorp/hooks/test_vault.py
@@ -298,7 +298,7 @@ class TestVaultHook:
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180")
-        test_client.auth_aws_iam.assert_called_with(
+        test_client.auth.aws.iam_login.assert_called_with(
             access_key="user",
             secret_key="pass",
             role="role",
@@ -325,7 +325,7 @@ class TestVaultHook:
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180")
-        test_client.auth_aws_iam.assert_called_with(
+        test_client.auth.aws.iam_login.assert_called_with(
             access_key="user",
             secret_key="pass",
             role="role",
@@ -340,7 +340,7 @@ class TestVaultHook:
         test_hook = VaultHook(vault_conn_id="vault_conn_id")
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="https://vault.example.com")
-        test_client.auth_aws_iam.assert_called_with(
+        test_client.auth.aws.iam_login.assert_called_with(
             access_key="login",
             secret_key="pass",
             role="role",
@@ -896,7 +896,7 @@ class TestVaultHook:
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180")
-        test_client.auth_userpass.assert_called_with(username="user", password="pass")
+        test_client.auth.userpass.login.assert_called_with(username="user", password="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
 
@@ -921,7 +921,7 @@ class TestVaultHook:
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180")
-        test_client.auth_userpass.assert_called_with(username="user", password="pass")
+        test_client.auth.userpass.login.assert_called_with(username="user", password="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #31573

In [hvac 0.7.0](https://hvac.readthedocs.io/en/stable/changelog.html#november-1st-2018), all auth method classes were moved under the `auth` property on the `hvac.Client` class, and the old methods were deprecated and removed in the version 1.0.0.
In this PR I switch to the new methods for the last two authentication methods which are on the old ones: `userpass` and `aws_iam`.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
