### PR TITLE
Add credential configuration file support to Google Secrets Manager secrets backend

### DIFF
--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -72,6 +72,7 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
     :param gcp_key_path: Path to Google Cloud Service Account key file (JSON). Mutually exclusive with
         gcp_keyfile_dict. use default credentials in the current environment if not provided.
     :param gcp_keyfile_dict: Dictionary of keyfile parameters. Mutually exclusive with gcp_key_path.
+    :param gcp_credential_config_file: File path to or content of a GCP credential configuration file.
     :param gcp_scopes: Comma-separated string containing OAuth2 scopes
     :param project_id: Project ID to read the secrets from. If not passed, the project ID from credentials
         will be used.
@@ -85,6 +86,7 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
         config_prefix: str = "airflow-config",
         gcp_keyfile_dict: dict | None = None,
         gcp_key_path: str | None = None,
+        gcp_credential_config_file: dict[str, str] | str | None = None,
         gcp_scopes: str | None = None,
         project_id: str | None = None,
         sep: str = "-",
@@ -103,13 +105,16 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
                 )
         try:
             self.credentials, self.project_id = get_credentials_and_project_id(
-                keyfile_dict=gcp_keyfile_dict, key_path=gcp_key_path, scopes=gcp_scopes
+                keyfile_dict=gcp_keyfile_dict,
+                key_path=gcp_key_path,
+                credential_config_file=gcp_credential_config_file,
+                scopes=gcp_scopes,
             )
         except (DefaultCredentialsError, FileNotFoundError):
             log.exception(
                 "Unable to load credentials for GCP Secret Manager. "
-                "Make sure that the keyfile path, dictionary, or GOOGLE_APPLICATION_CREDENTIALS "
-                "environment variable is correct and properly configured."
+                "Make sure that the keyfile path or dictionary, credential configuration file, "
+                "or GOOGLE_APPLICATION_CREDENTIALS environment variable is correct and properly configured."
             )
 
         # In case project id provided

--- a/docs/apache-airflow-providers-google/secrets-backends/google-cloud-secret-manager-backend.rst
+++ b/docs/apache-airflow-providers-google/secrets-backends/google-cloud-secret-manager-backend.rst
@@ -73,6 +73,7 @@ the following parameters:
 * ``variables_prefix``: Specifies the prefix of the secret to read to get Variables. Default: ``"airflow-variables"``
 * ``gcp_key_path``: Path to Google Cloud Service Account Key file (JSON).
 * ``gcp_keyfile_dict``: Dictionary of keyfile parameters.
+* ``gcp_credential_config_file``: File path to or content of a GCP credential configuration file.
 * ``gcp_scopes``: Comma-separated string containing OAuth2 scopes.
 * ``sep``: Separator used to concatenate connections_prefix and conn_id. Default: ``"-"``
 * ``project_id``: Project ID to read the secrets from. If not passed, the project ID from credentials will be used.
@@ -95,6 +96,8 @@ You can configure the credentials in three ways:
 * By default, Application Default Credentials (ADC) is used obtain credentials.
 * ``gcp_key_path`` option in ``backend_kwargs`` option - allows you to configure authorizations with a service account stored in local file.
 * ``gcp_keyfile_dict`` option in ``backend_kwargs`` option - allows you to configure authorizations with a service account stored in Airflow configuration.
+* ``gcp_credential_config_file`` option in ``backend_kwargs`` option - allows you to configure authentication with a credential configuration file.
+  A credential configuration file is a configuration file that typically contains non-sensitive metadata to instruct the ``google-auth`` library on how to retrieve external subject tokens and exchange them for service account access tokens.
 
 .. note::
 


### PR DESCRIPTION
This PR adds a `gcp_credential_config_file` `backend_kwargs` option to Google Secrets Manager's secret backend implementation that allows the secrets backend to authenticate to the secrets manager service using a [credential configuration file](https://google.aip.dev/auth/4117). This is usually used to support workload identity federation use cases by providing external credentials, but it also supports a wide range of credential types:
- `authorized_user`
- `service_account`
- `external_account`
- `external_account_authorized_user`
- `impersonated_service_account`
- `gdch_service_account`

This is a follow-up PR to #31548.