### PR TITLE
Testing connection - clearing old alert box when testing connection

### DIFF
--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -228,6 +228,11 @@ $(document).ready(() => {
     }
   }
 
+  function hideAlert() {
+    const alertBox = $(".container .row .alert");
+    alertBox.hide();
+  }
+
   /**
    * Produces JSON stringified data from a html form data
    *
@@ -299,6 +304,7 @@ $(document).ready(() => {
   // Bind click event to Test Connection button & perform an AJAX call via REST API
   $("#test-connection").on("click", (e) => {
     e.preventDefault();
+    hideAlert();
     $.ajax({
       url: connectionTestUrl,
       type: "post",


### PR DESCRIPTION
When testing the connection for the second time the alert box with the old value is confusing, it can mean two things
1. If the error is still the same
2. The connection call is not returned yet

Better to clear it before making a testing call.