### PR TITLE
Chart: Fix cluster-wide RBAC naming clash when using multiple multiNamespace releases with the same name

### DIFF
--- a/chart/templates/rbac/pod-launcher-role.yaml
+++ b/chart/templates/rbac/pod-launcher-role.yaml
@@ -28,15 +28,20 @@ kind: Role
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-pod-launcher-role
   {{- if not .Values.multiNamespaceMode }}
+  name: {{ .Release.Name }}-pod-launcher-role
   namespace: "{{ .Release.Namespace }}"
+  {{- else }}
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-pod-launcher-role
   {{- end }}
   labels:
     tier: airflow
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+    {{- if .Values.multiNamespaceMode }}
+    namespace: "{{ .Release.Namespace }}"
+    {{- end }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/chart/templates/rbac/pod-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/pod-launcher-rolebinding.yaml
@@ -32,13 +32,18 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   {{- if not .Values.multiNamespaceMode }}
   namespace: "{{ .Release.Namespace }}"
-  {{- end }}
   name: {{ .Release.Name }}-pod-launcher-rolebinding
+  {{- else }}
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-pod-launcher-rolebinding
+  {{- end }}
   labels:
     tier: airflow
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+    {{- if .Values.multiNamespaceMode }}
+    namespace: "{{ .Release.Namespace }}"
+    {{- end }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -46,10 +51,11 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   {{- if .Values.multiNamespaceMode }}
   kind: ClusterRole
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-pod-launcher-role
   {{- else }}
   kind: Role
-  {{- end }}
   name: {{ .Release.Name }}-pod-launcher-role
+  {{- end }}
 subjects:
   {{- if has .Values.executor $schedulerLaunchExecutors }}
   - kind: ServiceAccount

--- a/chart/templates/rbac/pod-log-reader-role.yaml
+++ b/chart/templates/rbac/pod-log-reader-role.yaml
@@ -28,15 +28,20 @@ kind: Role
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-pod-log-reader-role
   {{- if not .Values.multiNamespaceMode }}
+  name: {{ .Release.Name }}-pod-log-reader-role
   namespace: "{{ .Release.Namespace }}"
+  {{- else }}
+  name: {{ .Release.Name }}-{{ .Release.Namespace}}-pod-log-reader-role
   {{- end }}
   labels:
     tier: airflow
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+    {{- if .Values.multiNamespaceMode }}
+    namespace: "{{ .Release.Namespace }}"
+    {{- end }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/chart/templates/rbac/pod-log-reader-rolebinding.yaml
+++ b/chart/templates/rbac/pod-log-reader-rolebinding.yaml
@@ -30,13 +30,18 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   {{- if not .Values.multiNamespaceMode }}
   namespace: "{{ .Release.Namespace }}"
-  {{- end }}
   name: {{ .Release.Name }}-pod-log-reader-rolebinding
+  {{- else }}
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-pod-log-reader-rolebinding
+  {{- end }}
   labels:
     tier: airflow
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+    {{- if .Values.multiNamespaceMode }}
+    namespace: "{{ .Release.Namespace }}"
+    {{- end }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -44,10 +49,11 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   {{- if .Values.multiNamespaceMode }}
   kind: ClusterRole
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-pod-log-reader-role
   {{- else }}
   kind: Role
-  {{- end }}
   name: {{ .Release.Name }}-pod-log-reader-role
+  {{- end }}
 subjects:
   {{- if .Values.webserver.allowPodLogReading }}
   - kind: ServiceAccount

--- a/chart/templates/rbac/security-context-constraint-rolebinding.yaml
+++ b/chart/templates/rbac/security-context-constraint-rolebinding.yaml
@@ -30,14 +30,19 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   {{- if not .Values.multiNamespaceMode }}
-  namespace: "{{ .Release.Namespace }}"
-  {{- end }}
   name: {{ .Release.Name }}-scc-rolebinding
+  namespace: "{{ .Release.Namespace }}"
+  {{- else }}
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-scc-rolebinding
+  {{- end }}
   labels:
     tier: airflow
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+    {{- if .Values.multiNamespaceMode }}
+    namespace: "{{ .Release.Namespace }}"
+    {{- end }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/newsfragments/31613.fix.rst
+++ b/newsfragments/31613.fix.rst
@@ -1,0 +1,6 @@
+Helm chart only fix: `ClusterRole`s and `ClusterRoleBinding`s created when `multiNamespaceMode` is enabled now have unique names.
+* `{{ .Release.Name }}-pod-launcher-role` has been renamed to `{{ .Release.Name }}-{{ .Release.Namespace }}-pod-launcher-role`
+* `{{ .Release.Name }}-pod-launcher-rolebinding` has been renamed to `{{ .Release.Name }}-{{ .Release.Namespace }}-pod-launcher-rolebinding`
+* `{{ .Release.Name }}-pod-log-reader-role` has been renamed to `{{ .Release.Name }}-{{ .Release.Namespace }}-pod-log-reader-role`
+* `{{ .Release.Name }}-pod-log-reader-rolebinding` has been renamed to `{{ .Release.Name }}-{{ .Release.Namespace }}-pod-log-reader-rolebinding`
+* `{{ .Release.Name }}-scc-rolebinding` has been renamed to `{{ .Release.Name }}-{{ .Release.Namespace }}-scc-rolebinding`


### PR DESCRIPTION
Currently, when deploying multiple releases that share the same release name in **different** namespaces deployment is failing due to a naming clash of the cluster-scoped RBAC resources.

This PR introduces changes that make sure that `ClusterRole`s and `ClusterRoleBinding`s are uniquely named according to both the release name, as well as the release namespace, thus solving the naming clash.

---

Steps to reproduce current behavior:
1. Create namespace `airflow-a`
2. Install helm chart release named `airflow` into namespace `airflow-a` with `multiNamespaceMode: true`
3. Create namespace `airflow-b`
4. Install helm chart release named `airflow` into namespace `airflow-b` with `multiNamespaceMode: true`
5. Installing the helm chart will fail due to a naming clash of the cluster-wide RBAC resources

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
