### PR TITLE
Improve support for lists in setup/teardown context manager

### DIFF
--- a/airflow/decorators/setup_teardown.py
+++ b/airflow/decorators/setup_teardown.py
@@ -22,6 +22,9 @@ from typing import Callable
 from airflow import AirflowException
 from airflow.decorators import python_task
 from airflow.decorators.task_group import _TaskGroupFactory
+from airflow.models import BaseOperator
+from airflow.models.taskmixin import DAGNode
+from airflow.utils.setup_teardown import SetupTeardownContext
 
 
 def setup_task(func: Callable) -> Callable:
@@ -48,3 +51,31 @@ def teardown_task(_func=None, *, on_failure_fail_dagrun: bool = False) -> Callab
     if _func is None:
         return teardown
     return teardown(_func)
+
+
+class ContextWrapper(list):
+    """A list subclass that has a context manager that pushes setup/teardown tasks to the context."""
+
+    def __init__(self, tasks: list[DAGNode]):
+        self.tasks = tasks
+        super().__init__(tasks)
+
+    def __enter__(self):
+        operators = []
+        for task in self.tasks:
+            if isinstance(task, BaseOperator):
+                operators.append(task)
+                if not task.is_setup and not task.is_teardown:
+                    raise AirflowException("Only setup/teardown tasks can be used as context managers.")
+            elif not task.operator.is_setup and not task.operator.is_teardown:
+                raise AirflowException("Only setup/teardown tasks can be used as context managers.")
+        if not operators:
+            operators = [task.operator for task in self.tasks]
+        SetupTeardownContext.push_setup_teardown_task(operators)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        SetupTeardownContext.set_work_task_roots_and_leaves()
+
+
+context_wrapper = ContextWrapper

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -26,33 +26,33 @@ if TYPE_CHECKING:
 class SetupTeardownContext:
     """Context manager for setup/teardown tasks."""
 
-    _context_managed_setup_task: Operator | tuple[Operator] | None = None
-    _previous_context_managed_setup_task: list[Operator | tuple[Operator]] = []
-    _context_managed_teardown_task: Operator | tuple[Operator] | None = None
-    _previous_context_managed_teardown_task: list[Operator | tuple[Operator]] = []
+    _context_managed_setup_task: Operator | list[Operator] | None = None
+    _previous_context_managed_setup_task: list[Operator | list[Operator]] = []
+    _context_managed_teardown_task: Operator | list[Operator] | None = None
+    _previous_context_managed_teardown_task: list[Operator | list[Operator]] = []
     active: bool = False
-    context_map: dict[Operator, list[Operator]] = {}
+    context_map: dict[Operator | tuple[Operator], list[Operator]] = {}
 
     @classmethod
-    def push_context_managed_setup_task(cls, task: Operator | tuple[Operator] | None):
+    def push_context_managed_setup_task(cls, task: Operator | list[Operator]):
         if cls._context_managed_setup_task:
             cls._previous_context_managed_setup_task.append(cls._context_managed_setup_task)
         cls._context_managed_setup_task = task
 
     @classmethod
-    def push_context_managed_teardown_task(cls, task: Operator | tuple[Operator]):
+    def push_context_managed_teardown_task(cls, task: Operator | list[Operator]):
         if cls._context_managed_teardown_task:
             cls._previous_context_managed_teardown_task.append(cls._context_managed_teardown_task)
         cls._context_managed_teardown_task = task
 
     @classmethod
-    def pop_context_managed_setup_task(cls) -> Operator | tuple[Operator] | None:
+    def pop_context_managed_setup_task(cls) -> Operator | list[Operator] | None:
         old_setup_task = cls._context_managed_setup_task
         if cls._previous_context_managed_setup_task:
             cls._context_managed_setup_task = cls._previous_context_managed_setup_task.pop()
             setup_task = cls._context_managed_setup_task
             if setup_task and old_setup_task:
-                if isinstance(setup_task, tuple):
+                if isinstance(setup_task, list):
                     for task in setup_task:
                         task.set_downstream(old_setup_task)
                 else:
@@ -63,28 +63,30 @@ class SetupTeardownContext:
 
     @classmethod
     def update_context_map(cls, operator):
-        setup_task = SetupTeardownContext.get_context_managed_setup_task()
-        teardown_task = SetupTeardownContext.get_context_managed_teardown_task()
         ctx = SetupTeardownContext.context_map
-        if setup_task:
+        if setup_task := SetupTeardownContext.get_context_managed_setup_task():
+            if isinstance(setup_task, list):
+                setup_task = tuple(setup_task)
             if ctx.get(setup_task) is None:
                 ctx[setup_task] = [operator]
             else:
                 ctx[setup_task].append(operator)
-        if teardown_task:
+        if teardown_task := SetupTeardownContext.get_context_managed_teardown_task():
+            if isinstance(teardown_task, list):
+                teardown_task = tuple(teardown_task)
             if ctx.get(teardown_task) is None:
                 ctx[teardown_task] = [operator]
             else:
                 ctx[teardown_task].append(operator)
 
     @classmethod
-    def pop_context_managed_teardown_task(cls) -> Operator | tuple[Operator] | None:
+    def pop_context_managed_teardown_task(cls) -> Operator | list[Operator] | None:
         old_teardown_task = cls._context_managed_teardown_task
         if cls._previous_context_managed_teardown_task:
             cls._context_managed_teardown_task = cls._previous_context_managed_teardown_task.pop()
             teardown_task = cls._context_managed_teardown_task
             if teardown_task and old_teardown_task:
-                if isinstance(teardown_task, tuple):
+                if isinstance(teardown_task, list):
                     for task in teardown_task:
                         task.set_upstream(old_teardown_task)
                 else:
@@ -94,11 +96,11 @@ class SetupTeardownContext:
         return old_teardown_task
 
     @classmethod
-    def get_context_managed_setup_task(cls) -> Operator | tuple[Operator] | None:
+    def get_context_managed_setup_task(cls) -> Operator | list[Operator] | None:
         return cls._context_managed_setup_task
 
     @classmethod
-    def get_context_managed_teardown_task(cls) -> Operator | tuple[Operator] | None:
+    def get_context_managed_teardown_task(cls) -> Operator | list[Operator] | None:
         return cls._context_managed_teardown_task
 
     @classmethod
@@ -108,38 +110,36 @@ class SetupTeardownContext:
             if first_task.is_teardown:
                 if not all(task.is_teardown == first_task.is_teardown for task in operator):
                     raise ValueError("All tasks in the list must be either setup or teardown tasks")
-                SetupTeardownContext.push_context_managed_teardown_task(tuple(operator))
-                upstream_setup: tuple[Operator] = tuple(
-                    task for task in first_task.upstream_list if task.is_setup
-                )
+                SetupTeardownContext.push_context_managed_teardown_task(operator)
+                upstream_setup: list[Operator] = [task for task in first_task.upstream_list if task.is_setup]
                 if upstream_setup:
                     SetupTeardownContext.push_context_managed_setup_task(upstream_setup)
             elif first_task.is_setup:
                 if not all(task.is_setup == first_task.is_setup for task in operator):
                     raise ValueError("All tasks in the list must be either setup or teardown tasks")
-                SetupTeardownContext.push_context_managed_setup_task(tuple(operator))
-                downstream_teardown: tuple[Operator] = tuple(
+                SetupTeardownContext.push_context_managed_setup_task(operator)
+                downstream_teardown: list[Operator] = [
                     task for task in first_task.downstream_list if task.is_teardown
-                )
+                ]
                 if downstream_teardown:
                     SetupTeardownContext.push_context_managed_teardown_task(downstream_teardown)
         elif operator.is_teardown:
             SetupTeardownContext.push_context_managed_teardown_task(operator)
-            upstream_setup = tuple(task for task in operator.upstream_list if task.is_setup)
+            upstream_setup = [task for task in operator.upstream_list if task.is_setup]
             if upstream_setup:
                 SetupTeardownContext.push_context_managed_setup_task(upstream_setup)
         elif operator.is_setup:
             SetupTeardownContext.push_context_managed_setup_task(operator)
-            downstream_teardown = tuple(task for task in operator.downstream_list if task.is_teardown)
+            downstream_teardown = [task for task in operator.downstream_list if task.is_teardown]
             if downstream_teardown:
                 SetupTeardownContext.push_context_managed_teardown_task(downstream_teardown)
         SetupTeardownContext.active = True
 
     @classmethod
     def set_work_task_roots_and_leaves(cls):
-        setup_task = cls.get_context_managed_setup_task()
-        teardown_task = cls.get_context_managed_teardown_task()
-        if setup_task:
+        if setup_task := cls.get_context_managed_setup_task():
+            if isinstance(setup_task, list):
+                setup_task = tuple(setup_task)
             tasks_in_context = cls.context_map.get(setup_task, [])
             if tasks_in_context:
                 roots = [task for task in tasks_in_context if not task.upstream_list]
@@ -150,7 +150,9 @@ class SetupTeardownContext:
                         task >> roots
                 else:
                     setup_task >> roots
-        if teardown_task:
+        if teardown_task := cls.get_context_managed_teardown_task():
+            if isinstance(teardown_task, list):
+                teardown_task = tuple(teardown_task)
             tasks_in_context = cls.context_map.get(teardown_task, [])
             if tasks_in_context:
                 leaves = [task for task in tasks_in_context if not task.downstream_list]
@@ -163,6 +165,10 @@ class SetupTeardownContext:
                     teardown_task << leaves
         setup_task = SetupTeardownContext.pop_context_managed_setup_task()
         teardown_task = SetupTeardownContext.pop_context_managed_teardown_task()
+        if isinstance(setup_task, list):
+            setup_task = tuple(setup_task)
+        if isinstance(teardown_task, list):
+            teardown_task = tuple(teardown_task)
         SetupTeardownContext.active = False
         SetupTeardownContext.context_map.pop(setup_task, None)
         SetupTeardownContext.context_map.pop(teardown_task, None)


### PR DESCRIPTION
This commit addresses an issue related to utilizing lists within the setup/teardown context manager. To enable the usage of a list of tasks on the right-hand side of the context manager, a new function called context_wrapper has been introduced. This is a subclass of 'list' that has
 the functionality of a context manager. Users will need to utilize this wrapper whenever they intend
to use a list within the RHS of the context manager.

