### PR TITLE
Add missing waitForMigrations for workers

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -141,6 +141,7 @@ spec:
             - name: logs
               mountPath: {{ template "airflow_logs" . }}
         {{- end }}
+        {{- if .Values.workers.waitForMigrations.enabled }}
         - name: wait-for-airflow-migrations
           resources: {{- toYaml .Values.workers.resources | nindent 12 }}
           image: {{ template "airflow_image_for_migrations" . }}
@@ -164,6 +165,7 @@ spec:
             {{- if .Values.workers.waitForMigrations.env }}
               {{- tpl (toYaml .Values.workers.waitForMigrations.env) $ | nindent 12 }}
             {{- end }}
+        {{- end }}
         {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
           {{- include "git_sync_container" (dict "Values" .Values "is_init" "true") | nindent 8 }}
         {{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1645,6 +1645,11 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
+                        "enabled": {
+                            "description": "Enable wait-for-airflow-migrations init container.",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "env": {
                             "description": "Add additional env vars to wait-for-airflow-migrations init container.",
                             "type": "array",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -646,6 +646,8 @@ workers:
     #   memory: 128Mi
 
   waitForMigrations:
+    # Whether to create init container to wait for db migrations
+    enabled: true
     env: []
 
   env: []

--- a/tests/charts/airflow_core/test_worker.py
+++ b/tests/charts/airflow_core/test_worker.py
@@ -82,6 +82,18 @@ class TestWorker:
             "image": "test-registry/test-repo:test-tag",
         } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
 
+    def test_disable_wait_for_migration(self):
+        docs = render_chart(
+            values={
+                "workers": {
+                    "waitForMigrations": {"enabled": False},
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+        actual = jmespath.search("spec.template.spec.initContainers", docs[0])
+        assert actual is None
+
     def test_should_add_extra_init_containers(self):
         docs = render_chart(
             values={

--- a/tests/charts/airflow_core/test_worker.py
+++ b/tests/charts/airflow_core/test_worker.py
@@ -91,7 +91,9 @@ class TestWorker:
             },
             show_only=["templates/workers/worker-deployment.yaml"],
         )
-        actual = jmespath.search("spec.template.spec.initContainers[?name=='wait-for-airflow-migrations']", docs[0])
+        actual = jmespath.search(
+            "spec.template.spec.initContainers[?name=='wait-for-airflow-migrations']", docs[0]
+        )
         assert actual is None
 
     def test_should_add_extra_init_containers(self):

--- a/tests/charts/airflow_core/test_worker.py
+++ b/tests/charts/airflow_core/test_worker.py
@@ -91,7 +91,7 @@ class TestWorker:
             },
             show_only=["templates/workers/worker-deployment.yaml"],
         )
-        actual = jmespath.search("spec.template.spec.initContainers", docs[0])
+        actual = jmespath.search("spec.template.spec.initContainers[?name=='wait-for-airflow-migrations']", docs[0])
         assert actual is None
 
     def test_should_add_extra_init_containers(self):


### PR DESCRIPTION
Add missing `waitForMigrations.enabled` flag and associated logic for `workers` section in helm chart. All other components have this flag. 

closes: #31624