### PR TITLE
Small cleanups / optimizations in DagRun.update_state

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -602,12 +602,11 @@ class DagRun(Base, LoggingMixin):
             # will be computed as if the teardown task simply didn't exist.
             teardown_task_ids = {t.task_id for t in dag.teardowns}
             upstream_of_teardowns = {t.task_id for t in dag.tasks_upstream_of_teardowns}
-            teardown_tis = {ti for ti in tis if ti.task_id in teardown_task_ids}
-            on_failure_fail_tis = {ti for ti in teardown_tis if ti.task.on_failure_fail_dagrun}
-            tis_upstream_of_teardowns = {ti for ti in tis if ti.task_id in upstream_of_teardowns}
-            leaf_tis -= teardown_tis
-            leaf_tis |= on_failure_fail_tis
-            leaf_tis |= tis_upstream_of_teardowns
+            leaf_tis.difference_update(ti for ti in tis if ti.task_id in teardown_task_ids)
+            leaf_tis.update(
+                (ti for ti in teardown_tis if ti.task.on_failure_fail_dagrun),
+                (ti for ti in tis if ti.task_id in upstream_of_teardowns),
+            )
 
         # if all roots finished and at least one failed, the run failed
         if not unfinished.tis and any(leaf_ti.state in State.failed_states for leaf_ti in leaf_tis):

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -602,11 +602,12 @@ class DagRun(Base, LoggingMixin):
             # will be computed as if the teardown task simply didn't exist.
             teardown_task_ids = {t.task_id for t in dag.teardowns}
             upstream_of_teardowns = {t.task_id for t in dag.tasks_upstream_of_teardowns}
-            leaf_tis.difference_update(ti for ti in tis if ti.task_id in teardown_task_ids)
-            leaf_tis.update(
-                (ti for ti in teardown_tis if ti.task.on_failure_fail_dagrun),
-                (ti for ti in tis if ti.task_id in upstream_of_teardowns),
-            )
+            teardown_tis = {ti for ti in tis if ti.task_id in teardown_task_ids}
+            on_failure_fail_tis = {ti for ti in teardown_tis if ti.task.on_failure_fail_dagrun}
+            tis_upstream_of_teardowns = {ti for ti in tis if ti.task_id in upstream_of_teardowns}
+            leaf_tis -= teardown_tis
+            leaf_tis |= on_failure_fail_tis
+            leaf_tis |= tis_upstream_of_teardowns
 
         # if all roots finished and at least one failed, the run failed
         if not unfinished.tis and any(leaf_ti.state in State.failed_states for leaf_ti in leaf_tis):

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -596,19 +596,18 @@ class DagRun(Base, LoggingMixin):
                         unfinished = unfinished.recalculate()
 
         leaf_task_ids = {t.task_id for t in dag.leaves}
-        leaf_tis = [ti for ti in tis if ti.task_id in leaf_task_ids if ti.state != TaskInstanceState.REMOVED]
-        # TODO: Remove 'getattr' if setup/teardown is available for mapped task
+        leaf_tis = {ti for ti in tis if ti.task_id in leaf_task_ids if ti.state != TaskInstanceState.REMOVED}
         if dag.teardowns:
             # when on_failure_fail_dagrun is `False`, the final state of the DagRun
             # will be computed as if the teardown task simply didn't exist.
-            teardown_task_ids = [t.task_id for t in dag.teardowns]
-            upstream_of_teardowns = [t.task_id for t in dag.tasks_upstream_of_teardowns]
-            teardown_tis = [ti for ti in tis if ti.task_id in teardown_task_ids]
-            on_failure_fail_tis = [ti for ti in teardown_tis if getattr(ti.task, "on_failure_fail_dagrun")]
-            tis_upstream_of_teardowns = [ti for ti in tis if ti.task_id in upstream_of_teardowns]
-            leaf_tis = list(set(leaf_tis) - set(teardown_tis))
-            leaf_tis.extend(on_failure_fail_tis)
-            leaf_tis.extend(tis_upstream_of_teardowns)
+            teardown_task_ids = {t.task_id for t in dag.teardowns}
+            upstream_of_teardowns = {t.task_id for t in dag.tasks_upstream_of_teardowns}
+            teardown_tis = {ti for ti in tis if ti.task_id in teardown_task_ids}
+            on_failure_fail_tis = {ti for ti in teardown_tis if ti.task.on_failure_fail_dagrun}
+            tis_upstream_of_teardowns = {ti for ti in tis if ti.task_id in upstream_of_teardowns}
+            leaf_tis -= teardown_tis
+            leaf_tis |= on_failure_fail_tis
+            leaf_tis |= tis_upstream_of_teardowns
 
         # if all roots finished and at least one failed, the run failed
         if not unfinished.tis and any(leaf_ti.state in State.failed_states for leaf_ti in leaf_tis):

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -603,11 +603,10 @@ class DagRun(Base, LoggingMixin):
             teardown_task_ids = {t.task_id for t in dag.teardowns}
             upstream_of_teardowns = {t.task_id for t in dag.tasks_upstream_of_teardowns}
             teardown_tis = {ti for ti in tis if ti.task_id in teardown_task_ids}
-            on_failure_fail_tis = {ti for ti in teardown_tis if ti.task.on_failure_fail_dagrun}
-            tis_upstream_of_teardowns = {ti for ti in tis if ti.task_id in upstream_of_teardowns}
+            on_failure_fail_tis = (ti for ti in teardown_tis if ti.task.on_failure_fail_dagrun)
+            tis_upstream_of_teardowns = (ti for ti in tis if ti.task_id in upstream_of_teardowns)
             leaf_tis -= teardown_tis
-            leaf_tis |= on_failure_fail_tis
-            leaf_tis |= tis_upstream_of_teardowns
+            leaf_tis.update(on_failure_fail_tis, tis_upstream_of_teardowns)
 
         # if all roots finished and at least one failed, the run failed
         if not unfinished.tis and any(leaf_ti.state in State.failed_states for leaf_ti in leaf_tis):


### PR DESCRIPTION
1. no longer need getattr since mappedoperator has the attributes
2. the line `leaf_tis = list(set(leaf_tis) - set(teardown_tis))` drew my attention to the question, why weren't we using sets in the first place? So i switched to use sets. since there's a lot of `in` logic, good chance it's at least not worse, and it's a tiny bit cleaner this way.
