### PR TITLE
fix for sql sensor with presto

### DIFF
--- a/airflow/providers/common/sql/sensors/sql.py
+++ b/airflow/providers/common/sql/sensors/sql.py
@@ -90,6 +90,8 @@ class SqlSensor(BaseSensorOperator):
 
         self.log.info("Poking: %s (with parameters %s)", self.sql, self.parameters)
         records = hook.get_records(self.sql, self.parameters)
+        if 'presto' in hook: 
+            records = hook.run(sql=self.sql, paramaters=self.parameters, handler==lambda cursor: cursor.fetchall())
         if not records:
             if self.fail_on_empty:
                 raise AirflowException("No rows returned, raising as per fail_on_empty flag")


### PR DESCRIPTION
Presto queries with the get_records() function return none. in order to use the sensor with presto, the run() function with the provided hander could be used.
please see issue #31612

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
