### PR TITLE
📝 Update release documentation

### DIFF
--- a/docs/apache-airflow/release-process.rst
+++ b/docs/apache-airflow/release-process.rst
@@ -31,7 +31,7 @@ Since Airflow 2.0.0 and provider packages 1.0.0 we aim to follow SemVer, meaning
 In git, each minor version will have its own branch, called ``vX-Y-stable`` where bugfix/security releases will be issued from.
 Commits and PRs should not normally go direct to these branches, but instead should target the main branch and then be cherry-picked by the release managers to these release branches.
 As a general rule of thumb changes that will be included in a bugfix/security release will be associated with the corresponding github milestone in the PR but this is currently a manual process and deviations may occur.
-In all cases the maintainers reserve the right to punt a PR to a later release if they deem it prudent.
+In all cases, the release managers reserve the right to postpone a PR to a later release if they deem it prudent.
 Additionally, no new features will be added to a patch release and minor releases are currently targeted at a roughly 2-3 month cadence.
 
 Each Airflow release will also have a tag in git indicating its version number, signed with the release manager's key.

--- a/docs/apache-airflow/release-process.rst
+++ b/docs/apache-airflow/release-process.rst
@@ -30,6 +30,9 @@ Since Airflow 2.0.0 and provider packages 1.0.0 we aim to follow SemVer, meaning
 
 In git, each minor version will have its own branch, called ``vX-Y-stable`` where bugfix/security releases will be issued from.
 Commits and PRs should not normally go direct to these branches, but instead should target the main branch and then be cherry-picked by the release managers to these release branches.
+As a general rule of thumb changes that will be included in a bugfix/security release will be associated with the corresponding github milestone in the PR but this is currently a manual process and deviations may occur.
+In all cases the maintainers reserve the right to punt a PR to a later release if they deem it prudent.
+Additionally, no new features will be added to a patch release and minor releases are currently targeted at a roughly 2-3 month cadence.
 
 Each Airflow release will also have a tag in git indicating its version number, signed with the release manager's key.
 Tags for the main Airflow release have the form ``X.Y.Z`` (no leading ``v``) and provider packages are tagged with the form ``providers-<name>/X.Y.Z``.

--- a/docs/apache-airflow/release-process.rst
+++ b/docs/apache-airflow/release-process.rst
@@ -30,7 +30,7 @@ Since Airflow 2.0.0 and provider packages 1.0.0 we aim to follow SemVer, meaning
 
 In git, each minor version will have its own branch, called ``vX-Y-stable`` where bugfix/security releases will be issued from.
 Commits and PRs should not normally go direct to these branches, but instead should target the main branch and then be cherry-picked by the release managers to these release branches.
-As a general rule of thumb changes that will be included in a bugfix/security release will be associated with the corresponding github milestone in the PR but this is currently a manual process and deviations may occur.
+As a general rule of thumb, changes that will be included in a bugfix/security release will be associated with the corresponding github milestone in the PR but this is currently a manual process and deviations may occur.
 In all cases, the release managers reserve the right to postpone a PR to a later release if they deem it prudent.
 Additionally, no new features will be added to a patch release and minor releases are currently targeted at a roughly 2-3 month cadence.
 


### PR DESCRIPTION
Updates the release documentation based on the slack conversation [here](https://apache-airflow.slack.com/archives/C03G9H97MM2/p1685467707791689?thread_ts=1685466670.125099&cid=C03G9H97MM2) to note the following items
* PRs that are targeted for a patch version release are generally marked with the corresponding milestone reference (but deviations happen due to the manual process)
* Maintainers reserve the right to punt a PR to a subsequent release at any time
* New features are not allowed into patch releases and must wait for the next minor release (which is currently targeted at every 2-3 months).
