### PR TITLE
Allow direct invocations without a dag to wrapped functions

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -349,6 +349,11 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
             multiple_outputs=self.multiple_outputs,
             **self.kwargs,
         )
+        # If the operator is not in a DAG context, we assume it is being called from a test directly
+        # e.g. not from dag.test(). In this case, we just execute the wrapped function itself.
+        if op.get_dag() is None:
+            return self.function(*args, **kwargs)
+
         op.is_setup = self.is_setup
         op.is_teardown = self.is_teardown
         op.on_failure_fail_dagrun = self.on_failure_fail_dagrun


### PR DESCRIPTION
This allows @task decorated functions to be called directly, so that e.g. unit tests keep on working for defined functions. Context from a task or a dag is unavailable when a function is called like this.

Why is this relevant?

For example: data scientists typically define their models in a kind of notebook interface. Currently, if they start decorating their functions with `@task` any tests or function calls will seize to work as XComArg are returned and the function is not executed. This requires to run the full workflow through `dag.test()` which cannot be executed incrementally and interferes with the notebook style of working.

With this change decorated tasks behave the same as undecorated tasks when being called without a DAG context. This allows mixing non-dag code and dag code together simplifying collaboration between data engineering and data science a.o.

Note: I'm aware that tests fail, this is to gather feedback on the approach and the change

@dimberman @potiuk @ashb 