### PR TITLE
Respect `AUTOCOMMIT` in `session_parameters` of `SnowflakeHook`

### DIFF
--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -310,6 +310,16 @@ class SnowflakeHook(DbApiHook):
         return create_engine(self._conn_params_to_sqlalchemy_uri(conn_params), **engine_kwargs)
 
     def set_autocommit(self, conn, autocommit: Any) -> None:
+        """
+        Set autocommit. If AUTOCOMMIT is set in the session_parameters, do not override it.
+
+        :param conn: The connection
+        :param autocommit: The value of the autocommit parameter.
+        """
+        session_parameters = self._get_conn_params()["session_parameters"]
+        if isinstance(session_parameters, dict) and "AUTOCOMMIT" in session_parameters:
+            autocommit = session_parameters["AUTOCOMMIT"]
+
         conn.autocommit(autocommit)
         conn.autocommit_mode = autocommit
 


### PR DESCRIPTION
For Snowflake, do not override the autocommit session parameter. First it is checked if AUTOCOMMIT is defined and override it in set_autocommit.
closes: #30236

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
