### PR TITLE
Add `preserveAsciiControlCharacters` to `src_fmt_configs` for GCStoBQ

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -528,6 +528,7 @@ class GCSToBigQueryOperator(BaseOperator):
                 "skipLeadingRows",
                 "quote",
                 "encoding",
+                "preserveAsciiControlCharacters",
             ],
             "googleSheetsOptions": ["skipLeadingRows"],
         }


### PR DESCRIPTION
PR #27679 added the ability to specify `preserveAsciiControlCharacters` to `src_fmt_configs` for the BigQuery hook, but the GCSToBigQueryOperator seems to have it's own `src_fmt_configs` mappings.

So, this PR also adds this capability when wanting to transfer data from GCS to a BigQuery table.