### PR TITLE
Support providing creds lifetime for GCP connection token

### DIFF
--- a/airflow/providers/google/cloud/utils/credentials_provider.py
+++ b/airflow/providers/google/cloud/utils/credentials_provider.py
@@ -205,6 +205,7 @@ class _CredentialProvider(LoggingMixin):
         disable_logging: bool = False,
         target_principal: str | None = None,
         delegates: Sequence[str] | None = None,
+        lifetime: int | None = None,
     ) -> None:
         super().__init__()
         key_options = [key_path, key_secret_name, keyfile_dict]
@@ -223,6 +224,7 @@ class _CredentialProvider(LoggingMixin):
         self.disable_logging = disable_logging
         self.target_principal = target_principal
         self.delegates = delegates
+        self.lifetime = lifetime
 
     def get_credentials_and_project(self) -> tuple[google.auth.credentials.Credentials, str]:
         """
@@ -260,6 +262,16 @@ class _CredentialProvider(LoggingMixin):
             )
 
             project_id = _get_project_id_from_service_account_email(self.target_principal)
+
+        if self.lifetime:
+            # Create new impersonated credentials with an extended expiration time
+            credentials = impersonated_credentials.Credentials(
+                source_credentials=credentials.source_credentials,
+                target_principal=credentials.target_principal,
+                delegates=credentials.delegates,
+                target_scopes=credentials.target_scopes,
+                lifetime=self.lifetime,
+            )
 
         return credentials, project_id
 

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -44,6 +44,7 @@ from google.auth.transport import _http_client
 from googleapiclient import discovery
 from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseDownload, build_http, set_user_agent
+from wtforms.validators import Optional
 
 from airflow import version
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
@@ -214,6 +215,11 @@ class GoogleBaseHook(BaseHook):
                 widget=BS3TextFieldWidget(),
                 default=5,
             ),
+            "lifetime": IntegerField(
+                lazy_gettext("Lifetime of a token in seconds"),
+                validators=[Optional(), NumberRange(min=0)],
+                widget=BS3TextFieldWidget(),
+            ),
         }
 
     @staticmethod
@@ -262,6 +268,8 @@ class GoogleBaseHook(BaseHook):
 
         target_principal, delegates = _get_target_principal_and_delegates(self.impersonation_chain)
 
+        lifetime = self._get_field("lifetime", None)
+
         credentials, project_id = get_credentials_and_project_id(
             key_path=key_path,
             keyfile_dict=keyfile_dict_json,
@@ -272,6 +280,7 @@ class GoogleBaseHook(BaseHook):
             delegate_to=self.delegate_to,
             target_principal=target_principal,
             delegates=delegates,
+            lifetime=lifetime,
         )
 
         overridden_project_id = self._get_field("project")

--- a/docs/apache-airflow-providers-google/connections/gcp.rst
+++ b/docs/apache-airflow-providers-google/connections/gcp.rst
@@ -125,6 +125,9 @@ Number of Retries
     represents the last request. If zero (default), we attempt the
     request only once.
 
+Lifetime (optional)
+    Integer, number of seconds token should be valid for.
+
     When specifying the connection in environment variable you should specify
     it using URI syntax, with the following requirements:
 

--- a/tests/providers/google/cloud/utils/test_credentials_provider.py
+++ b/tests/providers/google/cloud/utils/test_credentials_provider.py
@@ -390,6 +390,29 @@ class TestGetGcpCredentialsAndProjectId:
             )
             assert not caplog.record_tuples
 
+    @mock.patch(
+        "airflow.providers.google.cloud.utils.credentials_provider.impersonated_credentials.Credentials"
+    )
+    @mock.patch("google.auth.default")
+    def test_get_credentials_and_project_id_with_default_auth_and_lifetime(
+        self, mock_auth_default, mock_impersonated_credentials
+    ):
+        mock_credentials = mock.MagicMock()
+        mock_auth_default.return_value = (mock_credentials, self.test_project_id)
+
+        result = get_credentials_and_project_id(
+            lifetime=7200,
+        )
+        mock_auth_default.assert_called_once_with(scopes=None)
+        mock_impersonated_credentials.assert_called_once_with(
+            source_credentials=mock_credentials.source_credentials,
+            target_principal=mock_credentials.target_principal,
+            delegates=mock_credentials.delegates,
+            target_scopes=mock_credentials.target_scopes,
+            lifetime=7200,
+        )
+        assert mock_impersonated_credentials.return_value == result[0]
+
 
 class TestGetScopes:
     def test_get_scopes_with_default(self):

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -370,6 +370,7 @@ class TestGoogleBaseHook:
             delegate_to=None,
             target_principal=None,
             delegates=None,
+            lifetime=None,
         )
         assert ("CREDENTIALS", "PROJECT_ID") == result
 
@@ -407,6 +408,7 @@ class TestGoogleBaseHook:
             delegate_to=None,
             target_principal=None,
             delegates=None,
+            lifetime=None,
         )
         assert (mock_credentials, "PROJECT_ID") == result
 
@@ -437,6 +439,7 @@ class TestGoogleBaseHook:
             delegate_to=None,
             target_principal=None,
             delegates=None,
+            lifetime=None,
         )
         assert (mock_credentials, "PROJECT_ID") == result
 
@@ -457,6 +460,7 @@ class TestGoogleBaseHook:
             delegate_to="USER",
             target_principal=None,
             delegates=None,
+            lifetime=None,
         )
         assert (mock_credentials, "PROJECT_ID") == result
 
@@ -493,6 +497,7 @@ class TestGoogleBaseHook:
             delegate_to=None,
             target_principal=None,
             delegates=None,
+            lifetime=None,
         )
         assert ("CREDENTIALS", "SECOND_PROJECT_ID") == result
 
@@ -695,6 +700,7 @@ class TestGoogleBaseHook:
             delegate_to=None,
             target_principal=target_principal,
             delegates=delegates,
+            lifetime=None,
         )
         assert (mock_credentials, PROJECT_ID) == result
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: #31648

Add a new field for GCP connection extra to override the token default lifetime. 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
