### PR TITLE
Fix deletion of Airflow source dir in virtualenv installation script

### DIFF
--- a/scripts/tools/initialize_virtualenv.py
+++ b/scripts/tools/initialize_virtualenv.py
@@ -112,7 +112,7 @@ def main():
     Setup local virtual environment.
     """
     airflow_home_dir = Path(os.environ.get("AIRFLOW_HOME", Path.home() / "airflow"))
-    airflow_sources = Path(__file__).parents[2]
+    airflow_sources = Path(__file__).parents[2].absolute()
 
     if not check_if_in_virtualenv():
         print(

--- a/scripts/tools/initialize_virtualenv.py
+++ b/scripts/tools/initialize_virtualenv.py
@@ -112,7 +112,7 @@ def main():
     Setup local virtual environment.
     """
     airflow_home_dir = Path(os.environ.get("AIRFLOW_HOME", Path.home() / "airflow"))
-    airflow_sources = Path(__file__).parents[2].absolute()
+    airflow_sources = Path(__file__).resolve().parents[2]
 
     if not check_if_in_virtualenv():
         print(


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
---
I was following the contributors quick start guide and my source directory kept getting deleted when running this command:
`./scripts/tools/initialize_virtualenv.py`
My source directory happened to be `$HOME/airflow`. With this fix, at least the check if `airflow_home_dir == airflow_sources` works again.
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
