### PR TITLE
allow anonymous AWS access

### DIFF
--- a/airflow/providers/amazon/aws/utils/connection_wrapper.py
+++ b/airflow/providers/amazon/aws/utils/connection_wrapper.py
@@ -23,6 +23,7 @@ from dataclasses import MISSING, InitVar, dataclass, field, fields
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
+from botocore import UNSIGNED
 from botocore.config import Config
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
@@ -236,6 +237,8 @@ class AwsConnectionWrapper(LoggingMixin):
         if not self.botocore_config and config_kwargs:
             # https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
             self.log.debug("Retrieving botocore config=%s from %s extra.", config_kwargs, self.conn_repr)
+            if config_kwargs.get("signature_version") == "unsigned":
+                config_kwargs["signature_version"] = UNSIGNED
             self.botocore_config = Config(**config_kwargs)
 
         if conn.host:

--- a/docs/apache-airflow-providers-amazon/connections/aws.rst
+++ b/docs/apache-airflow-providers-amazon/connections/aws.rst
@@ -121,6 +121,7 @@ Extra (optional)
 
     * ``config_kwargs``: Additional **kwargs** used to construct a
       `botocore.config.Config <https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html>`__.
+      To anonymously access public AWS resources (equivalent of `signature_version=botocore.UNSGINED`), set `"signature_version"="unsigned"` within `config_kwargs`.
     * ``endpoint_url``: Endpoint URL for the connection.
     * ``verify``: Whether or not to verify SSL certificates.
 

--- a/tests/providers/amazon/aws/utils/test_connection_wrapper.py
+++ b/tests/providers/amazon/aws/utils/test_connection_wrapper.py
@@ -20,6 +20,7 @@ from dataclasses import fields
 from unittest import mock
 
 import pytest
+from botocore import UNSIGNED
 from botocore.config import Config
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
@@ -309,6 +310,7 @@ class TestAwsConnectionWrapper:
             (Config(s3={"us_east_1_regional_endpoint": "regional"}), None),
             (Config(region_name="ap-southeast-1"), {"user_agent": "Airflow Amazon Provider"}),
             (None, {"user_agent": "Airflow Amazon Provider"}),
+            (None, {"signature_version": "unsigned"}),
             (None, None),
         ],
     )
@@ -326,6 +328,8 @@ class TestAwsConnectionWrapper:
             assert mock_botocore_config.assert_not_called
         else:
             assert mock_botocore_config.assert_called_once
+            if botocore_config_kwargs.get("signature_version") == "unsigned":
+                botocore_config_kwargs["signature_version"] = UNSIGNED
             assert mock.call(**botocore_config_kwargs) in mock_botocore_config.mock_calls
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
allow anonymous AWS access. this allows the consumer of any AWS operator to use the equivalent of `aws s3 cp <s3 path> . --no-sign-request`, to write a DAG that eg reads from a public S3 bucket without providing any credentials. to leverage this, an AWS connection can be created as such:
```
conn = Connection(
    conn_id="aws_demo",
    conn_type="aws",
    extra={
        "config_kwargs": {
            "signature_version": "unsigned",
        },
    },
)
```

this is necessary because botocore's `UNSIGNED` is not JSON-serializable, so using `botocore.UNSIGNED` when instantiating the connection will cause the connection processing to fail. instead we can use a string in the connection instantiation and convert it to botocore's expected value later. more history about this issue here: https://github.com/boto/botocore/issues/2442


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
