### PR TITLE
Logging from all containers in KubernetesOperatorPod

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -26,7 +26,7 @@ import string
 from collections.abc import Container
 from contextlib import AbstractContextManager
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any, Iterable, Sequence
 
 from kubernetes.client import CoreV1Api, models as k8s
 from slugify import slugify
@@ -276,7 +276,7 @@ class KubernetesPodOperator(BaseOperator):
         reattach_on_restart: bool = True,
         startup_timeout_seconds: int = 120,
         get_logs: bool = True,
-        container_logs: list[str] | str | Literal[True] = BASE_CONTAINER_NAME,
+        container_logs: Iterable[str] | str | Literal[True] = BASE_CONTAINER_NAME,
         image_pull_policy: str | None = None,
         annotations: dict | None = None,
         container_resources: k8s.V1ResourceRequirements | None = None,

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -59,6 +59,7 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     get_container_termination_message,
 )
 from airflow.settings import pod_mutation_hook
+from airflow.typing_compat import Literal
 from airflow.utils import yaml
 from airflow.utils.helpers import prune_dict, validate_key
 from airflow.utils.timezone import utcnow
@@ -275,7 +276,7 @@ class KubernetesPodOperator(BaseOperator):
         reattach_on_restart: bool = True,
         startup_timeout_seconds: int = 120,
         get_logs: bool = True,
-        container_logs: list[str] | str | bool = BASE_CONTAINER_NAME,
+        container_logs: list[str] | str | Literal[True] = BASE_CONTAINER_NAME,
         image_pull_policy: str | None = None,
         annotations: dict | None = None,
         container_resources: k8s.V1ResourceRequirements | None = None,

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -349,8 +349,8 @@ class KubernetesPodOperator(BaseOperator):
         self.reattach_on_restart = reattach_on_restart
         self.get_logs = get_logs
         self.container_logs = container_logs
-        if base_container_name and self.container_logs == KubernetesPodOperator.BASE_CONTAINER_NAME:
-            self.container_logs = base_container_name
+        if self.container_logs == KubernetesPodOperator.BASE_CONTAINER_NAME:
+            self.container_logs = KubernetesPodOperator.BASE_CONTAINER_NAME
         self.image_pull_policy = image_pull_policy
         self.node_selector = node_selector or {}
         self.annotations = annotations or {}

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -177,9 +177,9 @@ class KubernetesPodOperator(BaseOperator):
     :param startup_timeout_seconds: timeout in seconds to startup the pod.
     :param get_logs: get the stdout of the base container as logs of the tasks.
     :param container_logs: list of containers whose logs will be published to stdout
-        Takes an array of containers, a single container name or ``True``. If True,
-        all the containers' logs are published. Works in conjunction
-        with get_logs param. (default: True)
+        Takes a sequence of containers, a single container name or True. If True,
+        all the containers logs are published. Works in conjunction with get_logs param.
+        The default value is the base container.
     :param image_pull_policy: Specify a policy to cache or always pull an image.
     :param annotations: non-identifying metadata you can attach to the Pod.
         Can be a large range of data, and can include characters

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -350,7 +350,9 @@ class KubernetesPodOperator(BaseOperator):
         self.get_logs = get_logs
         self.container_logs = container_logs
         if self.container_logs == KubernetesPodOperator.BASE_CONTAINER_NAME:
-            self.container_logs = KubernetesPodOperator.BASE_CONTAINER_NAME
+            self.container_logs = (
+                base_container_name if base_container_name else KubernetesPodOperator.BASE_CONTAINER_NAME
+            )
         self.image_pull_policy = image_pull_policy
         self.node_selector = node_selector or {}
         self.annotations = annotations or {}

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -349,6 +349,8 @@ class KubernetesPodOperator(BaseOperator):
         self.reattach_on_restart = reattach_on_restart
         self.get_logs = get_logs
         self.container_logs = container_logs
+        if base_container_name and self.container_logs == KubernetesPodOperator.BASE_CONTAINER_NAME:
+            self.container_logs = base_container_name
         self.image_pull_policy = image_pull_policy
         self.node_selector = node_selector or {}
         self.annotations = annotations or {}

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -598,13 +598,12 @@ class PodManager(LoggingMixin):
     @tenacity.retry(stop=tenacity.stop_after_attempt(3), wait=tenacity.wait_exponential(), reraise=True)
     def get_container_names(self, pod: V1Pod) -> list[str]:
         """Return container names from the POD except for the airflow-xcom-sidecar container."""
-        containers = []
         pod_info = self.read_pod(pod)
-        for container_spec in pod_info.spec.containers:
-            if container_spec.name != ContainerNames.XCOM_CONTAINER:
-                containers.append(container_spec.name)
-
-        return containers
+        return [
+            container_spec.name
+            for container_spec in pod_info.spec.containers
+            if container_spec.name != ContainerNames.XCOM_CONTAINER
+        ]
 
     @tenacity.retry(stop=tenacity.stop_after_attempt(3), wait=tenacity.wait_exponential(), reraise=True)
     def read_pod_events(self, pod: V1Pod) -> CoreV1EventList:

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -77,7 +77,7 @@ class PodPhase:
 
 
 class ContainerNames:
-    """Possible container names for airflow"""
+    """Possible container names for airflow."""
 
     XCOM_CONTAINER = "airflow-xcom-sidecar"
 
@@ -599,7 +599,7 @@ class PodManager(LoggingMixin):
 
     @tenacity.retry(stop=tenacity.stop_after_attempt(3), wait=tenacity.wait_exponential(), reraise=True)
     def get_container_names(self, pod: V1Pod) -> list[str]:
-        """Return container names from the POD except for the airflow-xcom-sidecar container"""
+        """Return container names from the POD except for the airflow-xcom-sidecar container."""
         containers = []
         pod_info = self.read_pod(pod)
         for container_spec in pod_info.spec.containers:

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -432,7 +432,7 @@ class PodManager(LoggingMixin):
                 time.sleep(1)
 
     def fetch_requested_container_logs(
-        self, pod: V1Pod, container_logs: list[str] | str | Literal[True], follow_logs=False
+        self, pod: V1Pod, container_logs: Iterable[str] | str | Literal[True], follow_logs=False
     ) -> list[PodLoggingStatus]:
         """
         Follow the logs of containers in the pod specified by input parameter and publish

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -499,7 +499,7 @@ class PodManager(LoggingMixin):
 
         :param pod: pod spec that will be monitored
         :param container_name: name of the container within the pod to monitor
-        :return if container has completed
+        :return: if container has completed
         """
         while True:
             remote_pod = self.read_pod(pod)

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -490,13 +490,12 @@ class PodManager(LoggingMixin):
 
         return pod_logging_statuses
 
-    def await_container_completion(self, pod: V1Pod, container_name: str) -> bool:
+    def await_container_completion(self, pod: V1Pod, container_name: str) -> None:
         """
         Waits for the given container in the given pod to be completed.
 
         :param pod: pod spec that will be monitored
         :param container_name: name of the container within the pod to monitor
-        :return: if container has completed
         """
         while True:
             remote_pod = self.read_pod(pod)
@@ -505,7 +504,6 @@ class PodManager(LoggingMixin):
                 break
             self.log.info("Waiting for container '%s' state to be completed", container_name)
             time.sleep(1)
-        return terminated
 
     def await_pod_completion(self, pod: V1Pod) -> V1Pod:
         """

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -131,13 +131,10 @@ def container_is_running(pod: V1Pod, container_name: str) -> bool:
 
 def container_is_completed(pod: V1Pod, container_name: str) -> bool:
     """
-    Examines V1Pod ``pod`` to determine whether ``container_name`` is running.
+    Examines V1Pod ``pod`` to determine whether ``container_name`` is completed.
     If that container is present and completed, returns True.  Returns False otherwise.
     """
-    container_statuses = pod.status.container_statuses if pod and pod.status else None
-    if not container_statuses:
-        return False
-    container_status = next((status for status in container_statuses if status.name == container_name), None)
+    container_status = get_container_status(pod, container_name)
     if not container_status:
         return False
     return container_status.state.terminated is not None

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -76,12 +76,6 @@ class PodPhase:
     terminal_states = {FAILED, SUCCEEDED}
 
 
-class ContainerNames:
-    """Possible container names for airflow."""
-
-    XCOM_CONTAINER = "airflow-xcom-sidecar"
-
-
 class PodOperatorHookProtocol(Protocol):
     """
     Protocol to define methods relied upon by KubernetesPodOperator.
@@ -602,7 +596,7 @@ class PodManager(LoggingMixin):
         return [
             container_spec.name
             for container_spec in pod_info.spec.containers
-            if container_spec.name != ContainerNames.XCOM_CONTAINER
+            if container_spec.name != PodDefaults.SIDECAR_CONTAINER_NAME
         ]
 
     @tenacity.retry(stop=tenacity.stop_after_attempt(3), wait=tenacity.wait_exponential(), reraise=True)

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -500,7 +500,7 @@ class TestKubernetesPodOperatorSystem:
             )
             context = create_context(k)
             k.execute(context=context)
-            mock_logger.info.assert_any_call("retrieved from mount")
+            mock_logger.info.assert_any_call("[%s] %s", "base", "retrieved from mount")
             actual_pod = self.api_client.sanitize_for_serialization(k.pod)
             self.expected_pod["spec"]["containers"][0]["args"] = args
             self.expected_pod["spec"]["containers"][0]["volumeMounts"] = [

--- a/tests/providers/cncf/kubernetes/utils/test_pod_manager.py
+++ b/tests/providers/cncf/kubernetes/utils/test_pod_manager.py
@@ -336,7 +336,7 @@ class TestPodManager:
             assert ret.running is False
 
     # adds all valid types for container_logs
-    @pytest.mark.parametrize("container_logs", [1, None, dict()])
+    @pytest.mark.parametrize("container_logs", [1, None, 6.8])
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.container_is_running")
     def test_fetch_requested_container_logs_invalid(self, container_running, container_logs):
         mock_pod = MagicMock()

--- a/tests/providers/cncf/kubernetes/utils/test_pod_manager.py
+++ b/tests/providers/cncf/kubernetes/utils/test_pod_manager.py
@@ -316,6 +316,7 @@ class TestPodManager:
         assert ret.last_log_time is None
         assert ret.running is False
 
+    # adds all valid types for container_logs
     @pytest.mark.parametrize("follow", [True, False])
     @pytest.mark.parametrize("container_logs", ["base", "alpine", True, ["base", "alpine"]])
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.container_is_running")
@@ -335,8 +336,8 @@ class TestPodManager:
         for ret in ret_values:
             assert ret.running is False
 
-    # adds all valid types for container_logs
-    @pytest.mark.parametrize("container_logs", [1, None, 6.8])
+    # adds all invalid types for container_logs
+    @pytest.mark.parametrize("container_logs", [1, None, 6.8, False])
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.container_is_running")
     def test_fetch_requested_container_logs_invalid(self, container_running, container_logs):
         mock_pod = MagicMock()

--- a/tests/providers/cncf/kubernetes/utils/test_pod_manager.py
+++ b/tests/providers/cncf/kubernetes/utils/test_pod_manager.py
@@ -356,13 +356,6 @@ class TestPodManager:
 
         assert len(ret_values) == 0
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.container_is_completed")
-    def test_await_container_completion(self, container_completed):
-        mock_pod = MagicMock()
-        container_completed.return_value = None
-        status_completed = self.pod_manager.await_container_completion(pod=mock_pod, container_name="base")
-        assert status_completed is None
-
     @mock.patch("pendulum.now")
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.container_is_running")
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodLogsConsumer.logs_available")

--- a/tests/providers/cncf/kubernetes/utils/test_pod_manager.py
+++ b/tests/providers/cncf/kubernetes/utils/test_pod_manager.py
@@ -359,9 +359,9 @@ class TestPodManager:
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.container_is_completed")
     def test_await_container_completion(self, container_completed):
         mock_pod = MagicMock()
-        container_completed.return_value = True
+        container_completed.return_value = None
         status_completed = self.pod_manager.await_container_completion(pod=mock_pod, container_name="base")
-        assert status_completed is True
+        assert status_completed is None
 
     @mock.patch("pendulum.now")
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.container_is_running")


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #27282 

This PR adds support to get logs from all the containers in a pod and publish them in the airflow logging instead of always getting the base container logs. 
A new option `container_logging` has been added which works in conjunction with `get_logs` option. ie. if `get_logs` isn't set, `container_logging` will not be checked.

The flag takes the following values:
```
list[str]: A list of container names
str: One single container name
Literal[True]: Log everything
and make the argument default to BASE_CONTAINER_NAME.
```
This was a community suggestion here: https://github.com/apache/airflow/pull/28981/files#r1071928325

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
