### PR TITLE
Remove asynctest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -365,7 +365,6 @@ mypy_dependencies = [
 
 # Dependencies needed for development only
 devel_only = [
-    "asynctest~=0.13",
     "aws_xray_sdk",
     "beautifulsoup4>=4.7.1",
     "black",

--- a/tests/providers/amazon/aws/hooks/test_glue.py
+++ b/tests/providers/amazon/aws/hooks/test_glue.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import json
-import sys
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -30,11 +29,6 @@ from moto import mock_glue, mock_iam
 from airflow import AirflowException
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.hooks.glue import GlueJobHook
-
-if sys.version_info < (3, 8):
-    from asynctest import mock as async_mock
-else:
-    from unittest import mock as async_mock
 
 
 class TestGlueJobHook:
@@ -388,7 +382,7 @@ class TestGlueJobHook:
         assert get_state_mock.call_count == 3
 
     @pytest.mark.asyncio
-    @async_mock.patch.object(GlueJobHook, "async_get_job_state")
+    @mock.patch.object(GlueJobHook, "async_get_job_state")
     async def test_async_job_completion_success(self, get_state_mock: MagicMock):
         hook = GlueJobHook()
         hook.JOB_POLL_INTERVAL = 0
@@ -404,7 +398,7 @@ class TestGlueJobHook:
         get_state_mock.assert_called_with("job_name", "run_id")
 
     @pytest.mark.asyncio
-    @async_mock.patch.object(GlueJobHook, "async_get_job_state")
+    @mock.patch.object(GlueJobHook, "async_get_job_state")
     async def test_async_job_completion_failure(self, get_state_mock: MagicMock):
         hook = GlueJobHook()
         hook.JOB_POLL_INTERVAL = 0

--- a/tests/providers/amazon/aws/triggers/test_glue.py
+++ b/tests/providers/amazon/aws/triggers/test_glue.py
@@ -17,8 +17,9 @@
 
 from __future__ import annotations
 
+from unittest import mock
+
 import pytest
-from asynctest import MagicMock, mock
 
 from airflow import AirflowException
 from airflow.providers.amazon.aws.hooks.glue import GlueJobHook
@@ -28,7 +29,7 @@ from airflow.providers.amazon.aws.triggers.glue import GlueJobCompleteTrigger
 class TestGlueJobTrigger:
     @pytest.mark.asyncio
     @mock.patch.object(GlueJobHook, "async_get_job_state")
-    async def test_wait_job(self, get_state_mock: MagicMock):
+    async def test_wait_job(self, get_state_mock: mock.MagicMock):
         GlueJobHook.JOB_POLL_INTERVAL = 0.1
         trigger = GlueJobCompleteTrigger(
             job_name="job_name",
@@ -50,7 +51,7 @@ class TestGlueJobTrigger:
 
     @pytest.mark.asyncio
     @mock.patch.object(GlueJobHook, "async_get_job_state")
-    async def test_wait_job_failed(self, get_state_mock: MagicMock):
+    async def test_wait_job_failed(self, get_state_mock: mock.MagicMock):
         GlueJobHook.JOB_POLL_INTERVAL = 0.1
         trigger = GlueJobCompleteTrigger(
             job_name="job_name",

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 import tempfile
 from asyncio import Future
+from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import kubernetes
@@ -38,11 +38,6 @@ from airflow.utils import db
 from airflow.utils.db import merge_conn
 from tests.test_utils.db import clear_db_connections
 from tests.test_utils.providers import get_provider_min_airflow_version
-
-if sys.version_info < (3, 8):
-    from asynctest import mock
-else:
-    from unittest import mock
 
 KUBE_CONFIG_PATH = os.getenv("KUBECONFIG", "~/.kube/config")
 HOOK_MODULE = "airflow.providers.cncf.kubernetes.hooks.kubernetes"

--- a/tests/providers/cncf/kubernetes/triggers/test_pod.py
+++ b/tests/providers/cncf/kubernetes/triggers/test_pod.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import sys
 from asyncio import CancelledError, Future
 from datetime import datetime
+from unittest import mock
 
 import pytest
 import pytz
@@ -29,11 +29,6 @@ from kubernetes.client import models as k8s
 
 from airflow.providers.cncf.kubernetes.triggers.pod import ContainerState, KubernetesPodTrigger
 from airflow.triggers.base import TriggerEvent
-
-if sys.version_info < (3, 8):
-    from asynctest import mock
-else:
-    from unittest import mock
 
 TRIGGER_PATH = "airflow.providers.cncf.kubernetes.triggers.pod.KubernetesPodTrigger"
 HOOK_PATH = "airflow.providers.cncf.kubernetes.hooks.kubernetes.AsyncKubernetesHook"

--- a/tests/providers/databricks/triggers/test_databricks.py
+++ b/tests/providers/databricks/triggers/test_databricks.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-import sys
+from unittest import mock
 
 import pytest
 
@@ -26,11 +26,6 @@ from airflow.providers.databricks.hooks.databricks import RunState
 from airflow.providers.databricks.triggers.databricks import DatabricksExecutionTrigger
 from airflow.triggers.base import TriggerEvent
 from airflow.utils.session import provide_session
-
-if sys.version_info < (3, 8):
-    from asynctest import mock
-else:
-    from unittest import mock
 
 DEFAULT_CONN_ID = "databricks_default"
 HOST = "xx.cloud.databricks.com"

--- a/tests/providers/google/cloud/hooks/test_dataflow.py
+++ b/tests/providers/google/cloud/hooks/test_dataflow.py
@@ -20,9 +20,9 @@ from __future__ import annotations
 import copy
 import re
 import shlex
-import sys
 from asyncio import Future
 from typing import Any
+from unittest import mock
 from unittest.mock import MagicMock
 from uuid import UUID
 
@@ -41,12 +41,6 @@ from airflow.providers.google.cloud.hooks.dataflow import (
     _fallback_to_project_id_from_variables,
     process_line_and_extract_dataflow_job_id_callback,
 )
-
-if sys.version_info < (3, 8):
-    from asynctest import mock
-else:
-    from unittest import mock
-
 
 DEFAULT_RUNNER = "DirectRunner"
 BEAM_STRING = "airflow.providers.apache.beam.hooks.beam.{}"

--- a/tests/providers/google/cloud/hooks/test_datafusion.py
+++ b/tests/providers/google/cloud/hooks/test_datafusion.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import json
-import sys
+from unittest import mock
 
 import aiohttp
 import pytest
@@ -27,11 +27,6 @@ from yarl import URL
 from airflow import AirflowException
 from airflow.providers.google.cloud.hooks.datafusion import DataFusionAsyncHook, DataFusionHook
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
-
-if sys.version_info < (3, 8):
-    from asynctest import mock
-else:
-    from unittest import mock
 
 API_VERSION = "v1beta1"
 GCP_CONN_ID = "google_cloud_default"

--- a/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import sys
 from asyncio import Future
+from unittest import mock
 
 import kubernetes.client
 import pytest
@@ -33,11 +34,6 @@ from airflow.providers.google.cloud.hooks.kubernetes_engine import (
 )
 from airflow.providers.google.common.consts import CLIENT_INFO
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
-
-if sys.version_info < (3, 8):
-    from asynctest import mock
-else:
-    from unittest import mock
 
 TASK_ID = "test-gke-cluster-operator"
 CLUSTER_NAME = "test-cluster"

--- a/tests/providers/google/cloud/hooks/test_mlengine.py
+++ b/tests/providers/google/cloud/hooks/test_mlengine.py
@@ -17,8 +17,8 @@
 from __future__ import annotations
 
 import json
-import sys
 from copy import deepcopy
+from unittest import mock
 from unittest.mock import PropertyMock
 
 import httplib2
@@ -35,11 +35,6 @@ from tests.providers.google.cloud.utils.base_gcp_mock import (
     GCP_PROJECT_ID_HOOK_UNIT_TEST,
     mock_base_gcp_hook_default_project_id,
 )
-
-if sys.version_info < (3, 8):
-    from asynctest import mock
-else:
-    from unittest import mock
 
 pytest.mlengine_hook = MLEngineAsyncHook()
 pytest.PROJECT_ID = "test-project"

--- a/tests/providers/google/cloud/triggers/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/triggers/test_kubernetes_engine.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import sys
 from asyncio import CancelledError, Future
 from datetime import datetime
+from unittest import mock
 
 import pytest
 import pytz
@@ -31,11 +31,6 @@ from kubernetes.client import models as k8s
 from airflow.providers.cncf.kubernetes.triggers.kubernetes_pod import ContainerState
 from airflow.providers.google.cloud.triggers.kubernetes_engine import GKEOperationTrigger, GKEStartPodTrigger
 from airflow.triggers.base import TriggerEvent
-
-if sys.version_info < (3, 8):
-    from asynctest import mock
-else:
-    from unittest import mock
 
 TRIGGER_GKE_PATH = "airflow.providers.google.cloud.triggers.kubernetes_engine.GKEStartPodTrigger"
 TRIGGER_KUB_PATH = "airflow.providers.cncf.kubernetes.triggers.kubernetes_pod.KubernetesPodTrigger"


### PR DESCRIPTION
The asynctest package has gone largely unmaintained and does not work on Python 3.11. But we don't need it at all now since we've dropped 3.7; the stdlib unittest.mock covers its use cases perfectly.