### PR TITLE
Make `on_failure_fail_dagrun` overridable with task.override

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -342,6 +342,7 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
             if "trigger_rule" in self.kwargs:
                 raise ValueError("Trigger rule not configurable for teardown tasks.")
             self.kwargs.update(trigger_rule=TriggerRule.ALL_DONE_SETUP_SUCCESS)
+        on_failure_fail_dagrun = self.kwargs.pop("on_failure_fail_dagrun", self.on_failure_fail_dagrun)
         op = self.operator_class(
             python_callable=self.function,
             op_args=args,
@@ -351,7 +352,7 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
         )
         op.is_setup = self.is_setup
         op.is_teardown = self.is_teardown
-        op.on_failure_fail_dagrun = self.on_failure_fail_dagrun
+        op.on_failure_fail_dagrun = on_failure_fail_dagrun
         op_doc_attrs = [op.doc, op.doc_json, op.doc_md, op.doc_rst, op.doc_yaml]
         # Set the task's doc_md to the function's docstring if it exists and no other doc* args are set.
         if self.function.__doc__ and not any(op_doc_attrs):
@@ -487,7 +488,6 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
         result = attr.evolve(self, kwargs={**self.kwargs, **kwargs})
         setattr(result, "is_setup", self.is_setup)
         setattr(result, "is_teardown", self.is_teardown)
-        setattr(result, "on_failure_fail_dagrun", self.on_failure_fail_dagrun)
         return result
 
 

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -168,6 +168,18 @@ class TestSetupTearDownTask:
         setup_task = dag.task_group.children["mytask2"]
         assert setup_task.is_setup
 
+    def test_teardown_on_failure_fail_dagrun_can_be_overriden(self, dag_maker):
+        @teardown
+        def mytask():
+            print("I am a teardown task")
+
+        with dag_maker() as dag:
+            mytask.override(on_failure_fail_dagrun=True)()
+        assert len(dag.task_group.children) == 1
+        teardown_task = dag.task_group.children["mytask"]
+        assert teardown_task.is_teardown
+        assert teardown_task.on_failure_fail_dagrun
+
     def test_setup_teardown_mixed_up_in_a_dag(self, dag_maker):
         @setup
         def setuptask():


### PR DESCRIPTION
Unlike is_setup and is_teardown, on_failure_fail_dagrun can be supplied to a task as an argument. This commit is to make it overridable

closes: https://github.com/apache/airflow/issues/31656