### PR TITLE
Fix wrong cron example in documentation

### DIFF
--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -192,7 +192,7 @@ DAGs do not *require* a schedule, but it's very common to define one. You define
 
 The ``schedule`` argument takes any value that is a valid `Crontab <https://en.wikipedia.org/wiki/Cron>`_ schedule value, so you could also do::
 
-    with DAG("my_daily_dag", schedule="0 * * * *"):
+    with DAG("my_daily_dag", schedule="0 0 * * *"):
         ...
 
 .. tip::


### PR DESCRIPTION
The cron meaning in the demonstrated example is incorrect. The example above shows @daily, but the cron syntax (0 * * * *) would mean that this DAG runs every hour instead of every day. Correct cron syntax for @daily should be: (0 0 * * *)

closes: #31668