### PR TITLE
Fixed cron notation for daily DAG run

### DIFF
--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -190,9 +190,9 @@ DAGs do not *require* a schedule, but it's very common to define one. You define
     with DAG("my_daily_dag", schedule="@daily"):
         ...
 
-The ``schedule`` argument takes any value that is a valid `Crontab <https://en.wikipedia.org/wiki/Cron>`_ schedule value, so you could also do::
+The ``schedule`` argument takes any value that is a valid `Crontab <https://en.wikipedia.org/wiki/Cron>`_ schedule value, so for a daily run at 00:00, you could also do::
 
-    with DAG("my_daily_dag", schedule="0 * * * *"):
+    with DAG("my_daily_dag", schedule="0 0 * * *"):
         ...
 
 .. tip::


### PR DESCRIPTION
related: [#31668](https://github.com/apache/airflow/issues/31668)

### What do you see as an issue?

I found a small bug in the DAG Core Concepts documentation regarding the `@daily`schedule:
https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/dags.html#running-dags

DAGs do not require a schedule, but it’s very common to define one. You define it via the `schedule` argument, like this:

```python
with DAG("my_daily_dag", schedule="@daily"):
    ...
```

The `schedule` argument takes any value that is a valid [Crontab](https://en.wikipedia.org/wiki/Cron) schedule value, so you could also do:

```python
with DAG("my_daily_dag", schedule="0 * * * *"):
    ...
```

If I'm not mistaken, the daily crontab notation should be `0 0 * * *` instead of `0 * * * *`, otherwise the DAG would run every hour.

The second `0`of course needs to be replaced with the hour, at which the DAG should run daily.

### Solving the problem

I would change the documentation at the marked location:

The `schedule` argument takes any value that is a valid [Crontab](https://en.wikipedia.org/wiki/Cron) schedule value, so for a daily run at 00:00, you could also do:

```python
with DAG("my_daily_dag", schedule="0 0 * * *"):
    ...
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
