### PR TITLE
kafka provider: fix KafkaBaseHook name in the docs

### DIFF
--- a/docs/apache-airflow-providers-apache-kafka/hooks.rst
+++ b/docs/apache-airflow-providers-apache-kafka/hooks.rst
@@ -19,13 +19,13 @@
 Apache Kafka Hooks
 ==================
 
-.. _howto/hook:KafkaHook:
+.. _howto/hook:KafkaBaseHook:
 
 KafkaHook
 ------------------------
 
 A base hook for interacting with Apache Kafka. Use this hook as a base class when creating your own Kafka hooks.
-For parameter definitions take a look at :class:`~airflow.providers.apache.kafka.hooks.base.KafkaHook`.
+For parameter definitions take a look at :class:`~airflow.providers.apache.kafka.hooks.base.KafkaBaseHook`.
 
 
 .. _howto/hook:KafkaAdminClientHook:


### PR DESCRIPTION
Minor issue I noticed in kafka provider docs, kafka base hook class name is actually `KafkaBaseHook`: https://github.com/apache/airflow/blob/main/airflow/providers/apache/kafka/hooks/base.py#L27

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
