### PR TITLE
Fix: JiraOperator support any return response from Jira client

### DIFF
--- a/airflow/providers/atlassian/jira/operators/jira.py
+++ b/airflow/providers/atlassian/jira/operators/jira.py
@@ -75,9 +75,9 @@ class JiraOperator(BaseOperator):
             hook = JiraHook(jira_conn_id=self.jira_conn_id)
             resource = hook.client
 
-        jira_result = getattr(resource, self.method_name)(**self.jira_method_args)
+        jira_result: Any = getattr(resource, self.method_name)(**self.jira_method_args)
 
-        output = jira_result.get("id", None) if jira_result is not None else None
+        output = jira_result.get("id", None) if isinstance(jira_result, dict) else None
         self.xcom_push(context, key="id", value=output)
 
         if self.result_processor:

--- a/tests/providers/atlassian/jira/operators/test_jira.py
+++ b/tests/providers/atlassian/jira/operators/test_jira.py
@@ -74,7 +74,7 @@ class TestJiraOperator:
         jira_ticket_search_operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         assert jira_mock.called
-        assert jira_mock.return_value.jql_get_list_of_tickets.called
+        assert jira_mock.return_value.get_project_issues_count.called
 
     @patch("airflow.providers.atlassian.jira.hooks.jira.Jira", autospec=True, return_value=jira_client_mock)
     def test_issue_search(self, jira_mock):

--- a/tests/providers/atlassian/jira/operators/test_jira.py
+++ b/tests/providers/atlassian/jira/operators/test_jira.py
@@ -61,6 +61,22 @@ class TestJiraOperator:
         assert jira_operator.get_jira_resource_method is None
 
     @patch("airflow.providers.atlassian.jira.hooks.jira.Jira", autospec=True, return_value=jira_client_mock)
+    def test_project_issue_count(self, jira_mock):
+        jira_mock.return_value.get_project_issues_count.return_value = 10
+
+        jira_ticket_search_operator = JiraOperator(
+            task_id="get-issue-count",
+            jira_method="get_project_issues_count",
+            jira_method_args={"project": "ABC"},
+            dag=self.dag,
+        )
+
+        jira_ticket_search_operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
+        assert jira_mock.called
+        assert jira_mock.return_value.jql_get_list_of_tickets.called
+
+    @patch("airflow.providers.atlassian.jira.hooks.jira.Jira", autospec=True, return_value=jira_client_mock)
     def test_issue_search(self, jira_mock):
         jql_str = "issuekey=TEST-1226"
         jira_mock.return_value.jql_get_list_of_tickets.return_value = minimal_test_ticket


### PR DESCRIPTION
Hello,

The JiraOperator fails when using methods that returns any other thing than a dict. This PR fix it by checking whenever a dict is returned.

### Example issue
The [`get_project_issues_count` method](https://github.com/atlassian-api/atlassian-python-api/blob/master/atlassian/jira.py#L2650) returns the number of issues in a project, as `int`.
```python
JiraOperator(
    task_id="example",
	jira_method="get_project_issues_count",
	jira_conn_id="jira",
	jira_method_args={"project": "ABC"},
    dag=dag,
)
```
However, the [current implementation of the JiraOperator](https://github.com/apache/airflow/blob/main/airflow/providers/atlassian/jira/operators/jira.py#L79) expect a dict as response, to perform a `get` on it.
Thus, the above code will fail, throwing the following:
```logs
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.9/site-packages/airflow/providers/atlassian/jira/operators/jira.py", line 79, in execute
    output = jira_result.get("id", None) if jira_result is not None else None
AttributeError: 'int' object has no attribute 'get'
```

### Solution
Check if it's a dict prior to performing a `get` on the returned value.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
