### PR TITLE
Retain on_failure_fail_dagrun attr when other task attrs are overriden

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -488,6 +488,7 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
         result = attr.evolve(self, kwargs={**self.kwargs, **kwargs})
         setattr(result, "is_setup", self.is_setup)
         setattr(result, "is_teardown", self.is_teardown)
+        setattr(result, "on_failure_fail_dagrun", self.on_failure_fail_dagrun)
         return result
 
 

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -180,6 +180,18 @@ class TestSetupTearDownTask:
         assert teardown_task.is_teardown
         assert teardown_task.on_failure_fail_dagrun
 
+    def test_retain_on_failure_fail_dagrun_when_other_attrs_are_overriden(self, dag_maker):
+        @teardown(on_failure_fail_dagrun=True)
+        def mytask():
+            print("I am a teardown task")
+
+        with dag_maker() as dag:
+            mytask.override(task_id="mytask2")()
+        assert len(dag.task_group.children) == 1
+        teardown_task = dag.task_group.children["mytask2"]
+        assert teardown_task.is_teardown
+        assert teardown_task.on_failure_fail_dagrun
+
     def test_setup_teardown_mixed_up_in_a_dag(self, dag_maker):
         @setup
         def setuptask():


### PR DESCRIPTION
When on_failure_fail_dagrun is True on a task and we override other attributes of a task using task.override, we should still retain the value of on_failure_fail_dagrun. This needs special treatment since it's not original task param.

