### PR TITLE
Optimize deferrable mode execution for `LivyOperator`

### DIFF
--- a/airflow/providers/apache/livy/operators/livy.py
+++ b/airflow/providers/apache/livy/operators/livy.py
@@ -151,18 +151,30 @@ class LivyOperator(BaseOperator):
             context["ti"].xcom_push(key="app_id", value=self.get_hook().get_batch(self._batch_id)["appId"])
             return self._batch_id
 
-        self.defer(
-            timeout=self.execution_timeout,
-            trigger=LivyTrigger(
-                batch_id=self._batch_id,
-                spark_params=self.spark_params,
-                livy_conn_id=self._livy_conn_id,
-                polling_interval=self._polling_interval,
-                extra_options=self._extra_options,
-                extra_headers=self._extra_headers,
-            ),
-            method_name="execute_complete",
-        )
+        hook = self.get_hook()
+        state = hook.get_batch_state(self._batch_id, retry_args=self.retry_args)
+        self.log.debug("Batch with id %s is in state: %s", self._batch_id, state.value)
+        if state not in hook.TERMINAL_STATES:
+            self.defer(
+                timeout=self.execution_timeout,
+                trigger=LivyTrigger(
+                    batch_id=self._batch_id,
+                    spark_params=self.spark_params,
+                    livy_conn_id=self._livy_conn_id,
+                    polling_interval=self._polling_interval,
+                    extra_options=self._extra_options,
+                    extra_headers=self._extra_headers,
+                ),
+                method_name="execute_complete",
+            )
+        else:
+            self.log.info("Batch with id %s terminated with state: %s", self._batch_id, state.value)
+            hook.dump_batch_logs(self._batch_id)
+            if state != BatchState.SUCCESS:
+                raise AirflowException(f"Batch {self._batch_id} did not succeed")
+
+            context["ti"].xcom_push(key="app_id", value=self.get_hook().get_batch(self._batch_id)["appId"])
+            return self._batch_id
 
     def poll_for_termination(self, batch_id: int | str) -> None:
         """

--- a/tests/providers/apache/livy/operators/test_livy.py
+++ b/tests/providers/apache/livy/operators/test_livy.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from airflow.exceptions import AirflowException, TaskDeferred
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.models.dag import DAG
 from airflow.providers.apache.livy.hooks.livy import BatchState, LivyHook
@@ -235,6 +235,7 @@ class TestLivyOperator:
         mock_dump_logs.assert_called_with(BATCH_ID)
         assert mock_livy.call_count == 3
 
+    @patch("airflow.providers.apache.livy.operators.livy.LivyOperator.defer")
     @patch(
         "airflow.providers.apache.livy.operators.livy.LivyHook.dump_batch_logs",
         return_value=None,
@@ -245,7 +246,7 @@ class TestLivyOperator:
     )
     @patch("airflow.providers.apache.livy.operators.livy.LivyHook.post_batch", return_value=BATCH_ID)
     @patch("airflow.providers.apache.livy.operators.livy.LivyHook.get_batch", return_value=GET_BATCH)
-    def test_execution_deferrable(self, mock_get_batch, mock_post, mock_get, mock_dump_logs):
+    def test_execution_deferrable(self, mock_get_batch, mock_post, mock_get, mock_dump_logs, mock_defer):
         task = LivyOperator(
             livy_conn_id="livyunittest",
             file="sparkapp",
@@ -254,19 +255,28 @@ class TestLivyOperator:
             task_id="livy_example",
             deferrable=True,
         )
-        with pytest.raises(TaskDeferred):
-            task.execute(context=self.mock_context)
+        task.execute(context=self.mock_context)
+        assert not mock_defer.called
+        call_args = {k: v for k, v in mock_post.call_args[1].items() if v}
+        assert call_args == {"file": "sparkapp"}
+        mock_get.assert_called_once_with(BATCH_ID, retry_args=None)
+        mock_dump_logs.assert_called_once_with(BATCH_ID)
+        mock_get_batch.assert_called_once_with(BATCH_ID)
+        self.mock_context["ti"].xcom_push.assert_called_once_with(key="app_id", value=APP_ID)
 
-            call_args = {k: v for k, v in mock_post.call_args.kwargs.items() if v}
-            assert call_args == {"file": "sparkapp"}
-            mock_get.assert_called_once_with(BATCH_ID, retry_args=None)
-            mock_dump_logs.assert_called_once_with(BATCH_ID)
-            mock_get_batch.assert_called_once_with(BATCH_ID)
-            self.mock_context["ti"].xcom_push.assert_called_once_with(key="app_id", value=APP_ID)
-
-    @patch("airflow.providers.apache.livy.operators.livy.LivyHook.post_batch")
+    @patch(
+        "airflow.providers.apache.livy.operators.livy.LivyHook.dump_batch_logs",
+        return_value=None,
+    )
+    @patch(
+        "airflow.providers.apache.livy.operators.livy.LivyHook.get_batch_state",
+        return_value=BatchState.SUCCESS,
+    )
+    @patch("airflow.providers.apache.livy.operators.livy.LivyHook.post_batch", return_value=BATCH_ID)
     @patch("airflow.providers.apache.livy.operators.livy.LivyHook.get_batch", return_value=GET_BATCH)
-    def test_execution_with_extra_options_deferrable(self, mock_get_batch, mock_post):
+    def test_execution_with_extra_options_deferrable(
+        self, mock_get_batch, mock_post, mock_get_batch_state, mock_dump_logs
+    ):
         extra_options = {"check_response": True}
         task = LivyOperator(
             file="sparkapp",
@@ -276,15 +286,23 @@ class TestLivyOperator:
             deferrable=True,
         )
 
-        with pytest.raises(TaskDeferred):
-            task.execute(context=self.mock_context)
-
-            assert task.get_hook().extra_options == extra_options
+        task.execute(context=self.mock_context)
+        assert task.get_hook().extra_options == extra_options
 
     @patch("airflow.providers.apache.livy.operators.livy.LivyHook.delete_batch")
     @patch("airflow.providers.apache.livy.operators.livy.LivyHook.post_batch", return_value=BATCH_ID)
     @patch("airflow.providers.apache.livy.operators.livy.LivyHook.get_batch", return_value=GET_BATCH)
-    def test_deletion_deferrable(self, mock_get_batch, mock_post, mock_delete):
+    @patch(
+        "airflow.providers.apache.livy.operators.livy.LivyHook.get_batch_state",
+        return_value=BatchState.SUCCESS,
+    )
+    @patch(
+        "airflow.providers.apache.livy.operators.livy.LivyHook.dump_batch_logs",
+        return_value=None,
+    )
+    def test_deletion_deferrable(
+        self, mock_dump_logs, mock_get_batch_state, mock_get_batch, mock_post, mock_delete
+    ):
         task = LivyOperator(
             livy_conn_id="livyunittest",
             file="sparkapp",
@@ -292,11 +310,10 @@ class TestLivyOperator:
             task_id="livy_example",
             deferrable=True,
         )
-        with pytest.raises(TaskDeferred):
-            task.execute(context=self.mock_context)
-            task.kill()
+        task.execute(context=self.mock_context)
+        task.kill()
 
-            mock_delete.assert_called_once_with(BATCH_ID)
+        mock_delete.assert_called_once_with(BATCH_ID)
 
     def test_injected_hook_deferrable(self):
         def_hook = LivyHook(livy_conn_id="livyunittest")
@@ -324,16 +341,15 @@ class TestLivyOperator:
         )
         caplog.clear()
 
-        with pytest.raises(TaskDeferred):
-            with caplog.at_level(level=logging.INFO, logger=task.get_hook().log.name):
-                task.execute(context=self.mock_context)
+        with caplog.at_level(level=logging.INFO, logger=task.get_hook().log.name):
+            task.execute(context=self.mock_context)
 
-                assert "first_line" in caplog.messages
-                assert "second_line" in caplog.messages
-                assert "third_line" in caplog.messages
+            assert "first_line" in caplog.messages
+            assert "second_line" in caplog.messages
+            assert "third_line" in caplog.messages
 
-            mock_get.assert_called_once_with(BATCH_ID, retry_args=None)
-            mock_get_logs.assert_called_once_with(BATCH_ID, 0, 100)
+        mock_get.assert_called_once_with(BATCH_ID, retry_args=None)
+        mock_get_logs.assert_called_once_with(BATCH_ID, 0, 100)
 
     @patch("airflow.providers.apache.livy.operators.livy.LivyHook.get_batch", return_value={"appId": APP_ID})
     @patch("airflow.providers.apache.livy.operators.livy.LivyHook.post_batch", return_value=BATCH_ID)


### PR DESCRIPTION
This PR verifies if a LivyOperator task has already reached a terminal state to prevent unnecessary deferring. This way, we can skip deferring the task if it has already reached a terminal state.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
