### PR TITLE
Refacto accessing mock call args in unit tests

### DIFF
--- a/tests/core/test_sentry.py
+++ b/tests/core/test_sentry.py
@@ -167,7 +167,7 @@ class TestSentryHook:
         Test before send callable gets passed to the sentry SDK.
         """
         assert sentry
-        called = sentry_sdk.call_args[1]["before_send"]
+        called = sentry_sdk.call_args.kwargs["before_send"]
         expected = import_string("tests.core.test_sentry.before_send")
         assert called == expected
 
@@ -176,7 +176,7 @@ class TestSentryHook:
         Test transport gets passed to the sentry SDK
         """
         assert sentry_custom_transport
-        called = sentry_sdk.call_args[1]["transport"]
+        called = sentry_sdk.call_args.kwargs["transport"]
         expected = import_string("tests.core.test_sentry.CustomTransport")
         assert called == expected
 

--- a/tests/integration/providers/apache/cassandra/hooks/test_cassandra.py
+++ b/tests/integration/providers/apache/cassandra/hooks/test_cassandra.py
@@ -82,7 +82,7 @@ class TestCassandraHook:
                 load_balancing_policy=mock.ANY,
             )
 
-            assert isinstance(mock_cluster_ctor.call_args[1]["load_balancing_policy"], TokenAwarePolicy)
+            assert isinstance(mock_cluster_ctor.call_args.kwargs["load_balancing_policy"], TokenAwarePolicy)
 
     def test_get_lb_policy_with_no_args(self):
         # test LB policies with no args

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2122,7 +2122,7 @@ class TestSchedulerJob:
 
         # Verify Callback is not set (i.e is None) when no callbacks are set on DAG
         self.job_runner._send_dag_callbacks_to_processor.assert_called_once()
-        call_args = self.job_runner._send_dag_callbacks_to_processor.call_args[0]
+        call_args = self.job_runner._send_dag_callbacks_to_processor.call_args.args
         assert call_args[0].dag_id == dr.dag_id
         assert call_args[1] is None
 
@@ -2157,7 +2157,7 @@ class TestSchedulerJob:
 
         # Verify Callback is set (i.e is None) when no callbacks are set on DAG
         self.job_runner._send_dag_callbacks_to_processor.assert_called_once()
-        call_args = self.job_runner._send_dag_callbacks_to_processor.call_args[0]
+        call_args = self.job_runner._send_dag_callbacks_to_processor.call_args.args
         assert call_args[0].dag_id == dr.dag_id
         assert call_args[1] is not None
         assert call_args[1].msg == msg
@@ -4545,7 +4545,7 @@ class TestSchedulerJob:
             self.job_runner._find_zombies()
 
         scheduler_job.executor.callback_sink.send.assert_called_once()
-        requests = scheduler_job.executor.callback_sink.send.call_args[0]
+        requests = scheduler_job.executor.callback_sink.send.call_args.args
         assert 1 == len(requests)
         assert requests[0].full_filepath == dag.fileloc
         assert requests[0].msg == str(self.job_runner._generate_zombie_message_details(ti))
@@ -4680,7 +4680,7 @@ class TestSchedulerJob:
                 msg=str(self.job_runner._generate_zombie_message_details(ti)),
             )
         ]
-        callback_requests = scheduler_job.executor.callback_sink.send.call_args[0]
+        callback_requests = scheduler_job.executor.callback_sink.send.call_args.args
         assert len(callback_requests) == 1
         assert {zombie.simple_task_instance.key for zombie in expected_failure_callback_requests} == {
             result.simple_task_instance.key for result in callback_requests

--- a/tests/kubernetes/test_client.py
+++ b/tests/kubernetes/test_client.py
@@ -89,6 +89,6 @@ class TestClient:
     @conf_vars({("kubernetes", "api_client_retry_configuration"): '{"total": 3, "backoff_factor": 0.5}'})
     def test_api_client_retry_configuration_correct_values(self, mock_in_cluster_loader):
         get_kube_client(in_cluster=True)
-        client_configuration = mock_in_cluster_loader().load_and_set.call_args[0][0]
+        client_configuration = mock_in_cluster_loader().load_and_set.call_args.args[0]
         assert client_configuration.retries.total == 3
         assert client_configuration.retries.backoff_factor == 0.5

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2597,7 +2597,7 @@ class TestTaskInstance:
         ti1.state = State.FAILED
         ti1.handle_failure("test failure handling")
 
-        context_arg_1 = mock_on_failure_1.call_args[0][0]
+        context_arg_1 = mock_on_failure_1.call_args.args[0]
         assert context_arg_1 and "task_instance" in context_arg_1
         mock_on_retry_1.assert_not_called()
 
@@ -2618,7 +2618,7 @@ class TestTaskInstance:
 
         mock_on_failure_2.assert_not_called()
 
-        context_arg_2 = mock_on_retry_2.call_args[0][0]
+        context_arg_2 = mock_on_retry_2.call_args.args[0]
         assert context_arg_2 and "task_instance" in context_arg_2
 
         # test the scenario where normally we would retry but have been asked to fail
@@ -2637,7 +2637,7 @@ class TestTaskInstance:
         ti3.state = State.FAILED
         ti3.handle_failure("test force_fail handling", force_fail=True)
 
-        context_arg_3 = mock_on_failure_3.call_args[0][0]
+        context_arg_3 = mock_on_failure_3.call_args.args[0]
         assert context_arg_3 and "task_instance" in context_arg_3
         mock_on_retry_3.assert_not_called()
 
@@ -2807,8 +2807,8 @@ class TestTaskInstance:
         with patch.object(TI, "log") as log, pytest.raises(AirflowException):
             ti.run()
         log.error.assert_called_once()
-        assert log.error.call_args[0] == ("Task failed with exception",)
-        exc_info = log.error.call_args[1]["exc_info"]
+        assert log.error.call_args.args == ("Task failed with exception",)
+        exc_info = log.error.call_args.kwargs["exc_info"]
         filename = exc_info[2].tb_frame.f_code.co_filename
         formatted_exc = format_exception(*exc_info)
         assert sys.modules[PythonOperator.__module__].__file__ == filename, "".join(formatted_exc)

--- a/tests/operators/test_email.py
+++ b/tests/operators/test_email.py
@@ -59,6 +59,6 @@ class TestEmailOperator:
         with conf_vars({("email", "email_backend"): "tests.operators.test_email.send_email_test"}):
             self._run_as_operator()
         assert send_email_test.call_count == 1
-        call_args = send_email_test.call_args[1]
+        call_args = send_email_test.call_args.kwargs
         assert call_args["files"] == ["/tmp/Report-A-2016-01-01.csv"]
         assert call_args["custom_headers"] == {"Reply-To": "reply_to@example.com"}

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -603,7 +603,7 @@ class TestAwsBaseHook:
         _, mock_creds_fetcher_kwargs = mock_credentials_fetcher.call_args
         assert isinstance(mock_creds_fetcher_kwargs["web_identity_token_loader"], FileWebIdentityTokenLoader)
         assert mock_creds_fetcher_kwargs["web_identity_token_loader"]() == "TOKEN"
-        assert mock_open_.call_args[0][0] == "/my-token-path"
+        assert mock_open_.call_args.args[0] == "/my-token-path"
 
     @mock.patch.object(AwsBaseHook, "get_connection")
     @mock_sts
@@ -1092,4 +1092,4 @@ def test_custom_waiter_with_resource_type(waiter_path_mock: MagicMock):
     with mock.patch("airflow.providers.amazon.aws.waiters.base_waiter.BaseBotoWaiter") as BaseBotoWaiter:
         hook.get_waiter("other_wait")
 
-    assert isinstance(BaseBotoWaiter.call_args[1]["client"], botocore.client.BaseClient)
+    assert isinstance(BaseBotoWaiter.call_args.kwargs["client"], botocore.client.BaseClient)

--- a/tests/providers/amazon/aws/hooks/test_sagemaker.py
+++ b/tests/providers/amazon/aws/hooks/test_sagemaker.py
@@ -715,7 +715,7 @@ class TestSageMakerHook:
 
         assert arn == "hellotest"
 
-        args_passed = mock_conn().start_pipeline_execution.call_args[1]
+        args_passed = mock_conn().start_pipeline_execution.call_args.kwargs
         assert args_passed["PipelineName"] == "test_name"
 
         # check conversion to the weird format for passing parameters (list of tuples)
@@ -878,7 +878,7 @@ class TestSageMakerHook:
             wait_for_completion=False,
         )
 
-        assert conn_mock().create_auto_ml_job.call_args[1] == {
+        assert conn_mock().create_auto_ml_job.call_args.kwargs == {
             "AutoMLJobConfig": {"CompletionCriteria": {"MaxAutoMLJobRuntimeInSeconds": 30}},
             "AutoMLJobName": "a",
             "InputDataConfig": [

--- a/tests/providers/amazon/aws/operators/test_s3_file_transform.py
+++ b/tests/providers/amazon/aws/operators/test_s3_file_transform.py
@@ -109,7 +109,7 @@ class TestS3FileTransformOperator:
         )
         op.execute(None)
 
-        assert script_args == mock_popen.call_args[0][0][3:]
+        assert script_args == mock_popen.call_args.args[0][3:]
 
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.select_key", return_value="input")
     @mock_s3

--- a/tests/providers/amazon/aws/operators/test_sagemaker_model.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_model.py
@@ -94,7 +94,7 @@ class TestSageMakerRegisterModelVersionOperator:
 
         create_group_mock.assert_called_once_with("group-name", "")
         conn_mock().create_model_package.assert_called_once()
-        args_dict = conn_mock().create_model_package.call_args[1]
+        args_dict = conn_mock().create_model_package.call_args.kwargs
         assert args_dict["InferenceSpecification"]["Containers"][0]["Image"] == image
         assert args_dict["InferenceSpecification"]["Containers"][0]["ModelDataUrl"] == model
         assert args_dict["ModelPackageGroupName"] == group
@@ -142,5 +142,5 @@ class TestSageMakerRegisterModelVersionOperator:
         op.execute(None)
 
         conn_mock().create_model_package.assert_called_once()
-        args_dict = conn_mock().create_model_package.call_args[1]
+        args_dict = conn_mock().create_model_package.call_args.kwargs
         assert args_dict["InferenceSpecification"]["SupportedResponseMIMETypes"] == response_type

--- a/tests/providers/amazon/aws/secrets/test_secrets_manager.py
+++ b/tests/providers/amazon/aws/secrets/test_secrets_manager.py
@@ -378,7 +378,7 @@ class TestSecretsManagerBackend:
 
         secrets_manager_backend.client
         assert mock_session_factory.call_count == 1
-        mock_session_factory_call_kwargs = mock_session_factory.call_args[1]
+        mock_session_factory_call_kwargs = mock_session_factory.call_args.kwargs
         assert "conn" in mock_session_factory_call_kwargs
         conn_wrapper = mock_session_factory_call_kwargs["conn"]
 

--- a/tests/providers/amazon/aws/secrets/test_systems_manager.py
+++ b/tests/providers/amazon/aws/secrets/test_systems_manager.py
@@ -173,7 +173,7 @@ class TestSsmSecrets:
 
         systems_manager.client
         assert mock_session_factory.call_count == 1
-        mock_session_factory_call_kwargs = mock_session_factory.call_args[1]
+        mock_session_factory_call_kwargs = mock_session_factory.call_args.kwargs
         assert "conn" in mock_session_factory_call_kwargs
         conn_wrapper = mock_session_factory_call_kwargs["conn"]
 

--- a/tests/providers/amazon/aws/transfers/test_redshift_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_redshift_to_s3.py
@@ -88,7 +88,7 @@ class TestRedshiftToS3Transfer:
         assert mock_run.call_count == 1
         assert access_key in unload_query
         assert secret_key in unload_query
-        assert_equal_ignore_multiple_spaces(mock_run.call_args[0][0], unload_query)
+        assert_equal_ignore_multiple_spaces(mock_run.call_args.args[0], unload_query)
 
     @pytest.mark.parametrize("table_as_file_name, expected_s3_key", [[True, "key/table_"], [False, "key"]])
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
@@ -149,7 +149,7 @@ class TestRedshiftToS3Transfer:
         assert access_key in unload_query
         assert secret_key in unload_query
         assert token in unload_query
-        assert_equal_ignore_multiple_spaces(mock_run.call_args[0][0], unload_query)
+        assert_equal_ignore_multiple_spaces(mock_run.call_args.args[0], unload_query)
 
     @pytest.mark.parametrize(
         "table, table_as_file_name, expected_s3_key",
@@ -215,7 +215,7 @@ class TestRedshiftToS3Transfer:
         assert mock_run.call_count == 1
         assert access_key in unload_query
         assert secret_key in unload_query
-        assert_equal_ignore_multiple_spaces(mock_run.call_args[0][0], unload_query)
+        assert_equal_ignore_multiple_spaces(mock_run.call_args.args[0], unload_query)
 
     @pytest.mark.parametrize("table_as_file_name, expected_s3_key", [[True, "key/table_"], [False, "key"]])
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
@@ -274,7 +274,7 @@ class TestRedshiftToS3Transfer:
 
         assert mock_run.call_count == 1
         assert extra["role_arn"] in unload_query
-        assert_equal_ignore_multiple_spaces(mock_run.call_args[0][0], unload_query)
+        assert_equal_ignore_multiple_spaces(mock_run.call_args.args[0], unload_query)
 
     def test_template_fields_overrides(self):
         assert RedshiftToS3Operator.template_fields == (
@@ -380,7 +380,7 @@ class TestRedshiftToS3Transfer:
 
         mock_rs.execute_statement.assert_called_once()
         # test with all args besides sql
-        _call = deepcopy(mock_rs.execute_statement.call_args[1])
+        _call = deepcopy(mock_rs.execute_statement.call_args.kwargs)
         _call.pop("Sql")
         assert _call == dict(
             Database=database,
@@ -394,4 +394,4 @@ class TestRedshiftToS3Transfer:
             Id="STATEMENT_ID",
         )
         # test sql arg
-        assert_equal_ignore_multiple_spaces(mock_rs.execute_statement.call_args[1]["Sql"], unload_query)
+        assert_equal_ignore_multiple_spaces(mock_rs.execute_statement.call_args.kwargs["Sql"], unload_query)

--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -73,7 +73,7 @@ class TestS3ToRedshiftTransfer:
         assert mock_run.call_count == 1
         assert access_key in copy_query
         assert secret_key in copy_query
-        assert_equal_ignore_multiple_spaces(mock_run.call_args[0][0], copy_query)
+        assert_equal_ignore_multiple_spaces(mock_run.call_args.args[0], copy_query)
 
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
@@ -120,7 +120,7 @@ class TestS3ToRedshiftTransfer:
         assert mock_run.call_count == 1
         assert access_key in copy_query
         assert secret_key in copy_query
-        assert_equal_ignore_multiple_spaces(mock_run.call_args[0][0], copy_query)
+        assert_equal_ignore_multiple_spaces(mock_run.call_args.args[0], copy_query)
 
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
@@ -170,7 +170,7 @@ class TestS3ToRedshiftTransfer:
                     {copy_statement}
                     COMMIT
                     """
-        assert_equal_ignore_multiple_spaces("\n".join(mock_run.call_args[0][0]), transaction)
+        assert_equal_ignore_multiple_spaces("\n".join(mock_run.call_args.args[0]), transaction)
 
         assert mock_run.call_count == 1
 
@@ -225,7 +225,7 @@ class TestS3ToRedshiftTransfer:
                     INSERT INTO {schema}.{table} SELECT * FROM #{table};
                     COMMIT
                     """
-        assert_equal_ignore_multiple_spaces("\n".join(mock_run.call_args[0][0]), transaction)
+        assert_equal_ignore_multiple_spaces("\n".join(mock_run.call_args.args[0]), transaction)
 
         assert mock_run.call_count == 1
 
@@ -274,7 +274,7 @@ class TestS3ToRedshiftTransfer:
         assert secret_key in copy_statement
         assert token in copy_statement
         assert mock_run.call_count == 1
-        assert_equal_ignore_multiple_spaces(mock_run.call_args[0][0], copy_statement)
+        assert_equal_ignore_multiple_spaces(mock_run.call_args.args[0], copy_statement)
 
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
@@ -322,7 +322,7 @@ class TestS3ToRedshiftTransfer:
 
         assert extra["role_arn"] in copy_statement
         assert mock_run.call_count == 1
-        assert_equal_ignore_multiple_spaces(mock_run.call_args[0][0], copy_statement)
+        assert_equal_ignore_multiple_spaces(mock_run.call_args.args[0], copy_statement)
 
     def test_template_fields_overrides(self):
         assert S3ToRedshiftOperator.template_fields == (
@@ -433,7 +433,7 @@ class TestS3ToRedshiftTransfer:
 
         mock_rs.execute_statement.assert_called_once()
         # test with all args besides sql
-        _call = deepcopy(mock_rs.execute_statement.call_args[1])
+        _call = deepcopy(mock_rs.execute_statement.call_args.kwargs)
         _call.pop("Sql")
         assert _call == dict(
             Database=database,
@@ -447,4 +447,4 @@ class TestS3ToRedshiftTransfer:
             Id="STATEMENT_ID",
         )
         # test sql arg
-        assert_equal_ignore_multiple_spaces(mock_rs.execute_statement.call_args[1]["Sql"], copy_query)
+        assert_equal_ignore_multiple_spaces(mock_rs.execute_statement.call_args.kwargs["Sql"], copy_query)

--- a/tests/providers/amazon/aws/utils/test_waiter.py
+++ b/tests/providers/amazon/aws/utils/test_waiter.py
@@ -46,7 +46,7 @@ def assert_expected_waiter_type(waiter: mock.MagicMock, expected: str):
     :param waiter: A mocked Boto3 Waiter object.
     :param expected: The expected class name of the Waiter object, for example "ClusterActive".
     """
-    assert expected in str(type(waiter.call_args[0][0]))
+    assert expected in str(type(waiter.call_args.args[0]))
 
 
 class TestWaiter:

--- a/tests/providers/apache/beam/operators/test_beam.py
+++ b/tests/providers/apache/beam/operators/test_beam.py
@@ -426,7 +426,7 @@ class TestBeamRunGoPipelineOperator:
         """
 
         def tmp_dir_side_effect(prefix: str) -> str:
-            sub_dir = tmp_path / mock_tmp_dir.call_args[1]["prefix"]
+            sub_dir = tmp_path / mock_tmp_dir.call_args.kwargs["prefix"]
             sub_dir.mkdir()
             return str(sub_dir)
 
@@ -591,7 +591,7 @@ class TestBeamRunGoPipelineOperator:
         """
 
         def tmp_dir_side_effect(prefix: str) -> str:
-            sub_dir = tmp_path / mock_tmp_dir.call_args[1]["prefix"]
+            sub_dir = tmp_path / mock_tmp_dir.call_args.kwargs["prefix"]
             sub_dir.mkdir()
             return str(sub_dir)
 

--- a/tests/providers/apache/hdfs/hooks/test_webhdfs.py
+++ b/tests/providers/apache/hdfs/hooks/test_webhdfs.py
@@ -207,8 +207,8 @@ class TestWebHDFSHook:
         self.webhdfs_hook.get_conn()
         connection = mock_get_connection.return_value
 
-        assert f"https://{connection.host}:{connection.port}" == mock_kerberos_client.call_args[0][0]
-        assert "/ssl/cert/path" == mock_kerberos_client.call_args[1]["session"].verify
+        assert f"https://{connection.host}:{connection.port}" == mock_kerberos_client.call_args.args[0]
+        assert "/ssl/cert/path" == mock_kerberos_client.call_args.kwargs["session"].verify
 
     @patch("airflow.providers.apache.hdfs.hooks.webhdfs.InsecureClient")
     @patch(
@@ -225,9 +225,9 @@ class TestWebHDFSHook:
 
         assert (
             f"https://{connection.host}:{connection.port}/{connection.schema}"
-            == mock_insecure_client.call_args[0][0]
+            == mock_insecure_client.call_args.args[0]
         )
-        assert not mock_insecure_client.call_args[1]["session"].verify
+        assert not mock_insecure_client.call_args.kwargs["session"].verify
 
     @patch("airflow.providers.apache.hdfs.hooks.webhdfs.InsecureClient")
     @patch(
@@ -240,8 +240,8 @@ class TestWebHDFSHook:
         self.webhdfs_hook.get_conn()
         connection = mock_get_connection.return_value
 
-        assert f"https://{connection.host}/{connection.schema}" == mock_insecure_client.call_args[0][0]
-        assert not mock_insecure_client.call_args[1]["session"].verify
+        assert f"https://{connection.host}/{connection.schema}" == mock_insecure_client.call_args.args[0]
+        assert not mock_insecure_client.call_args.kwargs["session"].verify
 
     @patch("airflow.providers.apache.hdfs.hooks.webhdfs.InsecureClient")
     @patch(
@@ -254,5 +254,5 @@ class TestWebHDFSHook:
         self.webhdfs_hook.get_conn()
         connection = mock_get_connection.return_value
 
-        assert f"https://{connection.host}:{connection.port}" == mock_insecure_client.call_args[0][0]
-        assert not mock_insecure_client.call_args[1]["session"].verify
+        assert f"https://{connection.host}:{connection.port}" == mock_insecure_client.call_args.args[0]
+        assert not mock_insecure_client.call_args.kwargs["session"].verify

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -272,13 +272,13 @@ class TestHiveCliHook:
         hook.load_df(df=df, table=table, delimiter=delimiter, encoding=encoding)
 
         assert mock_to_csv.call_count == 1
-        kwargs = mock_to_csv.call_args[1]
+        kwargs = mock_to_csv.call_args.kwargs
         assert kwargs["header"] is False
         assert kwargs["index"] is False
         assert kwargs["sep"] == delimiter
 
         assert mock_load_file.call_count == 1
-        kwargs = mock_load_file.call_args[1]
+        kwargs = mock_load_file.call_args.kwargs
         assert kwargs["delimiter"] == delimiter
         assert kwargs["field_dict"] == {"c": "STRING"}
         assert isinstance(kwargs["field_dict"], OrderedDict)
@@ -294,7 +294,7 @@ class TestHiveCliHook:
             hook.load_df(df=pd.DataFrame({"c": range(0, 10)}), table="t", create=create, recreate=recreate)
 
             assert mock_load_file.call_count == 1
-            kwargs = mock_load_file.call_args[1]
+            kwargs = mock_load_file.call_args.kwargs
             assert kwargs["create"] == create
             assert kwargs["recreate"] == recreate
 

--- a/tests/providers/apache/hive/transfers/test_mysql_to_hive.py
+++ b/tests/providers/apache/hive/transfers/test_mysql_to_hive.py
@@ -240,7 +240,7 @@ class TestTransfer:
             ordered_dict["c3"] = "BIGINT"
             ordered_dict["c4"] = "DECIMAL(38,0)"
             ordered_dict["c5"] = "TIMESTAMP"
-            assert spy_on_hive.load_file.call_args[1]["field_dict"] == ordered_dict
+            assert spy_on_hive.load_file.call_args.kwargs["field_dict"] == ordered_dict
         finally:
             with closing(hook.get_conn()) as conn:
                 with closing(conn.cursor()) as cursor:

--- a/tests/providers/apache/livy/hooks/test_livy.py
+++ b/tests/providers/apache/livy/hooks/test_livy.py
@@ -243,7 +243,7 @@ class TestLivyHook:
             method="POST", endpoint="/batches", data=json.dumps({"file": "sparkapp"}), headers={}
         )
 
-        request_args = mock_request.call_args[1]
+        request_args = mock_request.call_args.kwargs
         assert "data" in request_args
         assert isinstance(request_args["data"], str)
 

--- a/tests/providers/apache/livy/operators/test_livy.py
+++ b/tests/providers/apache/livy/operators/test_livy.py
@@ -116,7 +116,7 @@ class TestLivyOperator:
         )
         task.execute(context=self.mock_context)
 
-        call_args = {k: v for k, v in mock_post.call_args[1].items() if v}
+        call_args = {k: v for k, v in mock_post.call_args.kwargs.items() if v}
         assert call_args == {"file": "sparkapp"}
         mock_get.assert_called_once_with(BATCH_ID, retry_args=None)
         mock_dump_logs.assert_called_once_with(BATCH_ID)
@@ -257,7 +257,7 @@ class TestLivyOperator:
         with pytest.raises(TaskDeferred):
             task.execute(context=self.mock_context)
 
-            call_args = {k: v for k, v in mock_post.call_args[1].items() if v}
+            call_args = {k: v for k, v in mock_post.call_args.kwargs.items() if v}
             assert call_args == {"file": "sparkapp"}
             mock_get.assert_called_once_with(BATCH_ID, retry_args=None)
             mock_dump_logs.assert_called_once_with(BATCH_ID)

--- a/tests/providers/apache/pig/hooks/test_pig.py
+++ b/tests/providers/apache/pig/hooks/test_pig.py
@@ -81,7 +81,7 @@ class TestPigCliHook:
         stdout = hook.run_cli("")
         assert stdout == ""
 
-        popen_first_arg = popen_mock.call_args[0][0]
+        popen_first_arg = popen_mock.call_args.args[0]
         for pig_prop in test_properties.split():
             assert pig_prop in popen_first_arg
 

--- a/tests/providers/cncf/kubernetes/decorators/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/decorators/test_kubernetes.py
@@ -93,7 +93,7 @@ def test_basic_kubernetes(dag_maker, session, mock_create_pod: mock.Mock, mock_h
     )
     assert mock_create_pod.call_count == 1
 
-    containers = mock_create_pod.call_args[1]["pod"].spec.containers
+    containers = mock_create_pod.call_args.kwargs["pod"].spec.containers
     assert len(containers) == 1
     assert containers[0].command[0] == "bash"
     assert len(containers[0].args) == 0
@@ -135,7 +135,7 @@ def test_kubernetes_with_input_output(
     )
     assert mock_create_pod.call_count == 1
 
-    containers = mock_create_pod.call_args[1]["pod"].spec.containers
+    containers = mock_create_pod.call_args.kwargs["pod"].spec.containers
 
     # First container is Python script
     assert len(containers) == 2

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -171,7 +171,7 @@ class TestKubernetesPodOperator:
         remote_pod_mock.status.phase = "Succeeded"
         self.await_pod_mock.return_value = remote_pod_mock
         operator.execute(context=context)
-        return self.await_start_mock.call_args[1]["pod"]
+        return self.await_start_mock.call_args.kwargs["pod"]
 
     def sanitize_for_serialization(self, obj):
         return ApiClient().sanitize_for_serialization(obj)

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -687,24 +687,24 @@ class TestDockerOperator:
         operator = DockerOperator(task_id="test", image="test", extra_hosts=hosts_obj)
         operator.execute(None)
         self.client_mock.create_container.assert_called_once()
-        assert "host_config" in self.client_mock.create_container.call_args[1]
-        assert "extra_hosts" in self.client_mock.create_host_config.call_args[1]
-        assert hosts_obj is self.client_mock.create_host_config.call_args[1]["extra_hosts"]
+        assert "host_config" in self.client_mock.create_container.call_args.kwargs
+        assert "extra_hosts" in self.client_mock.create_host_config.call_args.kwargs
+        assert hosts_obj is self.client_mock.create_host_config.call_args.kwargs["extra_hosts"]
 
     def test_privileged(self):
         privileged = mock.Mock()
         operator = DockerOperator(task_id="test", image="test", privileged=privileged)
         operator.execute(None)
         self.client_mock.create_container.assert_called_once()
-        assert "host_config" in self.client_mock.create_container.call_args[1]
-        assert "privileged" in self.client_mock.create_host_config.call_args[1]
-        assert privileged is self.client_mock.create_host_config.call_args[1]["privileged"]
+        assert "host_config" in self.client_mock.create_container.call_args.kwargs
+        assert "privileged" in self.client_mock.create_host_config.call_args.kwargs
+        assert privileged is self.client_mock.create_host_config.call_args.kwargs["privileged"]
 
     def test_port_bindings(self):
         port_bindings = {8000: 8080}
         operator = DockerOperator(task_id="test", image="test", port_bindings=port_bindings)
         operator.execute(None)
         self.client_mock.create_container.assert_called_once()
-        assert "host_config" in self.client_mock.create_container.call_args[1]
-        assert "port_bindings" in self.client_mock.create_host_config.call_args[1]
-        assert port_bindings == self.client_mock.create_host_config.call_args[1]["port_bindings"]
+        assert "host_config" in self.client_mock.create_container.call_args.kwargs
+        assert "port_bindings" in self.client_mock.create_host_config.call_args.kwargs
+        assert port_bindings == self.client_mock.create_host_config.call_args.kwargs["port_bindings"]

--- a/tests/providers/http/sensors/test_http.py
+++ b/tests/providers/http/sensors/test_http.py
@@ -113,7 +113,7 @@ class TestHttpSensor:
 
         task.execute(context={})
 
-        received_request = mock_session_send.call_args[0][0]
+        received_request = mock_session_send.call_args.args[0]
 
         prep_request = requests.Request("HEAD", "https://www.httpbin.org", {}).prepare()
 

--- a/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
@@ -188,8 +188,8 @@ def test_get_connection_by_credential_client_secret(connection_id: str, credenti
         connection = hook.get_conn()
         assert connection is not None
         mock_create_client.assert_called_once()
-        assert isinstance(mock_create_client.call_args[0][0], credential_type)
-        assert mock_create_client.call_args[0][1] == "subscriptionId"
+        assert isinstance(mock_create_client.call_args.args[0], credential_type)
+        assert mock_create_client.call_args.args[1] == "subscriptionId"
 
 
 @parametrize(

--- a/tests/providers/microsoft/azure/hooks/test_azure_synapse.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_synapse.py
@@ -120,8 +120,8 @@ def test_get_connection_by_credential_client_secret(connection_id: str, credenti
         connection = hook.get_conn()
         assert connection is not None
         mock_create_client.assert_called_once()
-        assert isinstance(mock_create_client.call_args[0][0], credential_type)
-        assert mock_create_client.call_args[0][-1] == "subscriptionId"
+        assert isinstance(mock_create_client.call_args.args[0], credential_type)
+        assert mock_create_client.call_args.args[-1] == "subscriptionId"
 
 
 def test_run_spark_job(hook: AzureSynapseHook):

--- a/tests/providers/microsoft/azure/log/test_wasb_task_handler.py
+++ b/tests/providers/microsoft/azure/log/test_wasb_task_handler.py
@@ -80,7 +80,7 @@ class TestWasbTaskHandler:
                 # Initialize the hook
                 handler.hook
 
-        assert "Could not create a WasbHook with connection id '%s'" in mock_exc.call_args[0][0]
+        assert "Could not create a WasbHook with connection id '%s'" in mock_exc.call_args.args[0]
 
     def test_set_context_raw(self, ti):
         ti.raw = True

--- a/tests/providers/microsoft/psrp/operators/test_psrp.py
+++ b/tests/providers/microsoft/psrp/operators/test_psrp.py
@@ -100,7 +100,7 @@ class TestPsrpOperator:
         else:
             output = op.execute(None)
             assert output == [json.loads(output) for output in ps.output] if do_xcom_push else ps.output
-            is_logged = hook_impl.call_args[1]["on_output_callback"] == op.log.info
+            is_logged = hook_impl.call_args.kwargs["on_output_callback"] == op.log.info
             assert do_xcom_push ^ is_logged
         expected_ps_calls = [
             call.add_command(psrp_session_init),

--- a/tests/providers/mysql/hooks/test_mysql.py
+++ b/tests/providers/mysql/hooks/test_mysql.py
@@ -412,4 +412,4 @@ class TestMySql:
                 SELECT * INTO OUTFILE '{tmp_file}'
                 FROM {table}
             """
-            assert_equal_ignore_multiple_spaces(mock_execute.call_args[0][0], query)
+            assert_equal_ignore_multiple_spaces(mock_execute.call_args.args[0], query)

--- a/tests/providers/neo4j/hooks/test_neo4j.py
+++ b/tests/providers/neo4j/hooks/test_neo4j.py
@@ -135,7 +135,7 @@ class TestNeo4jHookConn:
             neo4j_hook = Neo4jHook()
             with neo4j_hook.get_conn():
                 if should_provide_encrypted:
-                    assert "encrypted" in mock_graph_database.call_args[1]
-                    assert mock_graph_database.call_args[1]["encrypted"] == expected_encrypted
+                    assert "encrypted" in mock_graph_database.call_args.kwargs
+                    assert mock_graph_database.call_args.kwargs["encrypted"] == expected_encrypted
                 else:
-                    assert "encrypted" not in mock_graph_database.call_args[1]
+                    assert "encrypted" not in mock_graph_database.call_args.kwargs

--- a/tests/providers/openlineage/plugins/test_listener.py
+++ b/tests/providers/openlineage/plugins/test_listener.py
@@ -61,7 +61,7 @@ def test_listener_does_not_change_task_instance(render_mock, xcom_push_mock):
     ti._run_raw_task()
 
     # check if task returns the same DataFrame
-    pd.testing.assert_frame_equal(xcom_push_mock.call_args[1]["value"], render_df())
+    pd.testing.assert_frame_equal(xcom_push_mock.call_args.kwargs["value"], render_df())
 
     # check if render_template method always get the same unrendered field
-    assert not isinstance(render_mock.call_args[0][0], pd.DataFrame)
+    assert not isinstance(render_mock.call_args.args[0], pd.DataFrame)

--- a/tests/providers/postgres/hooks/test_postgres.py
+++ b/tests/providers/postgres/hooks/test_postgres.py
@@ -292,7 +292,7 @@ class TestPostgresHook:
             assert self.cur.close.call_count == 1
             assert self.conn.commit.call_count == 1
             self.cur.copy_expert.assert_called_once_with(statement, open_mock.return_value)
-            assert open_mock.call_args[0] == (filename, "r+")
+            assert open_mock.call_args.args == (filename, "r+")
 
     def test_bulk_load(self):
         hook = PostgresHook()

--- a/tests/providers/slack/hooks/test_slack.py
+++ b/tests/providers/slack/hooks/test_slack.py
@@ -392,7 +392,7 @@ class TestSlackHook:
         )
 
         # Validate file properties
-        mock_file = mock_files_upload.call_args[1]["file"]
+        mock_file = mock_files_upload.call_args.kwargs["file"]
         assert mock_file.mode == "rb"
         assert mock_file.name == str(file)
 
@@ -411,7 +411,7 @@ class TestSlackHook:
         hook.send_file(file=file)
 
         assert mock_files_upload.call_count == 1
-        call_args = mock_files_upload.call_args[1]
+        call_args = mock_files_upload.call_args.kwargs
         assert "filename" in call_args
         assert call_args["filename"] == filename
 

--- a/tests/providers/smtp/operators/test_smtp.py
+++ b/tests/providers/smtp/operators/test_smtp.py
@@ -48,5 +48,5 @@ class TestEmailOperator:
         smtp_client_mock = mock_smtplib.SMTP_SSL()
         op = EmailOperator(task_id="test_email", to="to", subject="subject", html_content="content")
         op.execute({})
-        call_args = smtp_client_mock.sendmail.call_args[1]
+        call_args = smtp_client_mock.sendmail.call_args.kwargs
         assert call_args["from_addr"] == sender_email

--- a/tests/providers/snowflake/hooks/test_snowflake.py
+++ b/tests/providers/snowflake/hooks/test_snowflake.py
@@ -467,7 +467,7 @@ class TestPytestSnowflakeHook:
         ), mock.patch("airflow.providers.snowflake.hooks.snowflake.create_engine") as mock_create_engine:
             hook = SnowflakeHook(snowflake_conn_id="test_conn")
             conn = hook.get_sqlalchemy_engine()
-            assert "private_key" in mock_create_engine.call_args[1]["connect_args"]
+            assert "private_key" in mock_create_engine.call_args.kwargs["connect_args"]
             assert mock_create_engine.return_value == conn
 
     def test_hook_parameters_should_take_precedence(self):

--- a/tests/providers/snowflake/transfers/test_s3_to_snowflake.py
+++ b/tests/providers/snowflake/transfers/test_s3_to_snowflake.py
@@ -69,7 +69,7 @@ class TestS3ToSnowflakeTransfer:
             copy_query += f"\npattern='{pattern}'"
 
         mock_run.assert_called_once()
-        assert mock_run.call_args[0][0] == copy_query
+        assert mock_run.call_args.args[0] == copy_query
 
     @pytest.mark.parametrize("pattern", [None, ".*[.]csv"])
     @pytest.mark.parametrize("files", [None, ["foo.csv", "bar.json", "spam.parquet", "egg.xml"]])

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -1034,7 +1034,7 @@ class TestSSHHook:
         with hook.get_conn():
             assert ssh_mock.return_value.set_missing_host_key_policy.called is True
             assert isinstance(
-                ssh_mock.return_value.set_missing_host_key_policy.call_args[0][0], paramiko.AutoAddPolicy
+                ssh_mock.return_value.set_missing_host_key_policy.call_args.args[0], paramiko.AutoAddPolicy
             )
             assert ssh_mock.return_value.load_host_keys.called is False
 
@@ -1046,7 +1046,8 @@ class TestSSHHook:
             with hook.get_conn():
                 assert ssh_mock.return_value.set_missing_host_key_policy.called is True
                 assert isinstance(
-                    ssh_mock.return_value.set_missing_host_key_policy.call_args[0][0], paramiko.AutoAddPolicy
+                    ssh_mock.return_value.set_missing_host_key_policy.call_args.args[0],
+                    paramiko.AutoAddPolicy,
                 )
                 assert ssh_mock.return_value.load_host_keys.called is True
 
@@ -1055,7 +1056,8 @@ class TestSSHHook:
             with hook.get_conn():
                 assert ssh_mock.return_value.set_missing_host_key_policy.called is True
                 assert isinstance(
-                    ssh_mock.return_value.set_missing_host_key_policy.call_args[0][0], paramiko.AutoAddPolicy
+                    ssh_mock.return_value.set_missing_host_key_policy.call_args.args[0],
+                    paramiko.AutoAddPolicy,
                 )
                 assert ssh_mock.return_value.load_host_keys.called is False
 

--- a/tests/security/test_kerberos.py
+++ b/tests/security/test_kerberos.py
@@ -100,7 +100,7 @@ class TestKerberos:
             "Renewing kerberos ticket to work around kerberos 1.8.1: kinit -c /tmp/airflow_krb5_ccache -R",
         ]
 
-        assert mock_subprocess.Popen.call_args[0][0] == expected_cmd
+        assert mock_subprocess.Popen.call_args.args[0] == expected_cmd
         assert mock_subprocess.mock_calls == [
             mock.call.Popen(
                 expected_cmd,

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -169,7 +169,7 @@ class TestDb:
             dialect.name = "postgresql"  # offline migration not supported with postgres
             mock_gcr.return_value = "90d1635d7b86"
             upgradedb(from_revision=None, to_revision=None, show_sql_only=True)
-            actual = mock_om.call_args[0][2]
+            actual = mock_om.call_args.args[2]
             assert re.match(r"90d1635d7b86:[a-z0-9]+", actual) is not None
 
     def test_offline_upgrade_fails_for_migration_less_than_2_0_0_head(self):
@@ -192,13 +192,13 @@ class TestDb:
     @mock.patch("airflow.utils.db._offline_migration")
     def test_downgrade_sql_no_from(self, mock_om):
         downgrade(to_revision="abc", show_sql_only=True, from_revision=None)
-        actual = mock_om.call_args[1]["revision"]
+        actual = mock_om.call_args.kwargs["revision"]
         assert re.match(r"[a-z0-9]+:abc", actual) is not None
 
     @mock.patch("airflow.utils.db._offline_migration")
     def test_downgrade_sql_with_from(self, mock_om):
         downgrade(to_revision="abc", show_sql_only=True, from_revision="123")
-        actual = mock_om.call_args[1]["revision"]
+        actual = mock_om.call_args.kwargs["revision"]
         assert actual == "123:abc"
 
     @mock.patch("alembic.command.downgrade")
@@ -210,7 +210,7 @@ class TestDb:
     @mock.patch("alembic.command.downgrade")
     def test_downgrade_with_from(self, mock_om):
         downgrade(to_revision="abc")
-        actual = mock_om.call_args[1]["revision"]
+        actual = mock_om.call_args.kwargs["revision"]
         assert actual == "abc"
 
     @pytest.mark.parametrize("skip_init", [False, True])

--- a/tests/utils/test_db_cleanup.py
+++ b/tests/utils/test_db_cleanup.py
@@ -110,7 +110,7 @@ class TestDBCleanup:
             confirm=False,
             **kwargs,
         )
-        assert cleanup_table_mock.call_args[1]["skip_archive"] is should_skip
+        assert cleanup_table_mock.call_args.kwargs["skip_archive"] is should_skip
 
     @pytest.mark.parametrize(
         "table_names",

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -407,7 +407,7 @@ class TestFileTaskLogHandler:
 
         # first we find pod name
         mock_list_pod.assert_called_once()
-        actual_kwargs = mock_list_pod.call_args[1]
+        actual_kwargs = mock_list_pod.call_args.kwargs
         assert actual_kwargs["namespace"] == namespace_to_call
         actual_selector = actual_kwargs["label_selector"]
         assert re.match(


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Replace mock.call_args[index] by mock.call_args.{args|kwargs} to make the tests more readable.
This two attributes were added in python 3.8 by python/cpython#11807

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
