### PR TITLE
fix return values on glue operators deferrable mode

### DIFF
--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -200,4 +200,4 @@ class GlueJobOperator(BaseOperator):
     def execute_complete(self, context, event=None):
         if event["status"] != "success":
             raise AirflowException(f"Error in glue job: {event}")
-        return
+        return event["value"]

--- a/airflow/providers/amazon/aws/operators/glue_crawler.py
+++ b/airflow/providers/amazon/aws/operators/glue_crawler.py
@@ -107,4 +107,4 @@ class GlueCrawlerOperator(BaseOperator):
     def execute_complete(self, context, event=None):
         if event["status"] != "success":
             raise AirflowException(f"Error in glue crawl: {event}")
-        return
+        return self.config["Name"]

--- a/airflow/providers/amazon/aws/triggers/glue.py
+++ b/airflow/providers/amazon/aws/triggers/glue.py
@@ -59,5 +59,5 @@ class GlueJobCompleteTrigger(BaseTrigger):
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         hook = GlueJobHook(aws_conn_id=self.aws_conn_id)
-        await hook.async_job_completion(self.job_name, self.run_id, self.verbose)
-        yield TriggerEvent({"status": "success", "message": "Job done"})
+        glue_job_run = await hook.async_job_completion(self.job_name, self.run_id, self.verbose)
+        yield TriggerEvent({"status": "success", "message": "Job done", "value": glue_job_run["JobRunId"]})

--- a/airflow/providers/amazon/aws/triggers/glue.py
+++ b/airflow/providers/amazon/aws/triggers/glue.py
@@ -59,5 +59,5 @@ class GlueJobCompleteTrigger(BaseTrigger):
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         hook = GlueJobHook(aws_conn_id=self.aws_conn_id)
-        glue_job_run = await hook.async_job_completion(self.job_name, self.run_id, self.verbose)
-        yield TriggerEvent({"status": "success", "message": "Job done", "value": glue_job_run["JobRunId"]})
+        await hook.async_job_completion(self.job_name, self.run_id, self.verbose)
+        yield TriggerEvent({"status": "success", "message": "Job done", "value": self.run_id})

--- a/airflow/providers/amazon/aws/triggers/glue_crawler.py
+++ b/airflow/providers/amazon/aws/triggers/glue_crawler.py
@@ -68,10 +68,7 @@ class GlueCrawlerCompleteTrigger(BaseTrigger):
                     break  # we reach this point only if the waiter met a success criteria
                 except WaiterError as error:
                     if "terminal failure" in str(error):
-                        yield TriggerEvent(
-                            {"status": "failure", "message": f"Glue Crawler creation Failed: {error}"}
-                        )
-                        break
+                        raise
                     self.log.info("Status of glue crawl is %s", error.last_response["Crawler"]["State"])
                     await asyncio.sleep(int(self.poll_interval))
 


### PR DESCRIPTION
when implementing the glue deferrable operators in #30948 I forgot to match the return value of the `execute` function in the deferrable handler.
Fixing that here, so that the behavior stays the same when using the deferrable version.

Also changing error handling to throw right away instead of returning the error in an event, saving unnecessary scheduling work.