### PR TITLE
Add back accidentally removed `create_session` in utils/db.py

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -40,7 +40,7 @@ from airflow.models import import_all_models
 from airflow.utils import helpers
 
 # TODO: remove create_session once we decide to break backward compatibility
-from airflow.utils.session import NEW_SESSION, provide_session
+from airflow.utils.session import NEW_SESSION, create_session, provide_session  # noqa: F401
 
 if TYPE_CHECKING:
     from alembic.runtime.environment import EnvironmentContext

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -42,6 +42,9 @@ from airflow.utils.db import (
     compare_server_default,
     compare_type,
     create_default_connections,
+    # The create_session is not used. It is imported here to
+    # guard against removing it from utils.db accidentally
+    create_session,  # noqa: F401
     downgrade,
     resetdb,
     upgradedb,


### PR DESCRIPTION
The create_session function was accidentally removed in commit https://github.com/apache/airflow/commit/522661b6ad4479e3c8243b2d2c8a793d1af82c17 and it's a breaking change.

