### PR TITLE
Disable setting ODBC driver via extra by default

### DIFF
--- a/airflow/providers/odbc/CHANGELOG.rst
+++ b/airflow/providers/odbc/CHANGELOG.rst
@@ -24,6 +24,17 @@
 Changelog
 ---------
 
+4.0.0
+.....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+The driver parameter has to be passed via keyword ``driver`` argument when initializing the Hook or via
+``hook_params`` dictionary (with ``driver`` key) when instantiating Hook from SQL Operators. It was possible
+to instantiate it via extras before, but in this version, only setting it via constructor is supported.
+
+
 3.3.0
 .....
 

--- a/tests/providers/odbc/hooks/test_odbc.py
+++ b/tests/providers/odbc/hooks/test_odbc.py
@@ -18,7 +18,9 @@
 from __future__ import annotations
 
 import json
+import logging
 from unittest import mock
+from unittest.mock import patch
 from urllib.parse import quote_plus, urlsplit
 
 import pyodbc
@@ -43,11 +45,12 @@ class TestOdbcHook:
         hook.get_connection.return_value = connection
         return hook
 
-    def test_driver_in_extra(self):
+    def test_driver_in_extra_not_used(self):
         conn_params = dict(extra=json.dumps(dict(Driver="Fake Driver", Fake_Param="Fake Param")))
-        hook = self.get_hook(conn_params=conn_params)
+        hook_params = {"driver": "ParamDriver"}
+        hook = self.get_hook(conn_params=conn_params, hook_params=hook_params)
         expected = (
-            "DRIVER={Fake Driver};"
+            "DRIVER={ParamDriver};"
             "SERVER=host;"
             "DATABASE=schema;"
             "UID=login;"
@@ -177,10 +180,39 @@ class TestOdbcHook:
         assert hook.driver == "Blah driver"
         hook = self.get_hook(hook_params=dict(driver="{Blah driver}"))
         assert hook.driver == "Blah driver"
-        hook = self.get_hook(conn_params=dict(extra='{"driver": "Blah driver"}'))
+
+    def test_driver_extra_raises_warning_by_default(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="airflow.providers.odbc.hooks.test_odbc"):
+            driver = self.get_hook(conn_params=dict(extra='{"driver": "Blah driver"}')).driver
+            assert "Please provide driver via 'driver' parameter of the Hook" in caplog.text
+            assert driver is None
+
+    def test_driver_extra_works_when_allow_driver_extra(self):
+        hook = self.get_hook(
+            conn_params=dict(extra='{"driver": "Blah driver"}'), hook_params=dict(allow_driver_extra=True)
+        )
         assert hook.driver == "Blah driver"
-        hook = self.get_hook(conn_params=dict(extra='{"driver": "{Blah driver}"}'))
-        assert hook.driver == "Blah driver"
+
+    def test_default_driver_set(self):
+        with patch.object(OdbcHook, "default_driver", "Blah driver"):
+            hook = self.get_hook()
+            assert hook.driver == "Blah driver"
+
+    def test_driver_extra_works_when_default_driver_set(self):
+        with patch.object(OdbcHook, "default_driver", "Blah driver"):
+            hook = self.get_hook()
+            assert hook.driver == "Blah driver"
+
+    def test_driver_none_by_default(self):
+        hook = self.get_hook()
+        assert hook.driver is None
+
+    def test_driver_extra_raises_warning_and_returns_default_driver_by_default(self, caplog):
+        with patch.object(OdbcHook, "default_driver", "Blah driver"):
+            with caplog.at_level(logging.WARNING, logger="airflow.providers.odbc.hooks.test_odbc"):
+                driver = self.get_hook(conn_params=dict(extra='{"driver": "Blah driver2"}')).driver
+                assert "Please provide driver via 'driver' parameter of the Hook" in caplog.text
+                assert driver == "Blah driver"
 
     def test_database(self):
         hook = self.get_hook(hook_params=dict(database="abc"))


### PR DESCRIPTION
By default setting driver via extra is disabled by default but we
have several more ways to set it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
