### PR TITLE
openlineage: add support for system tests, add support for example_bigquery_queries system test

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1074,6 +1074,24 @@ class BigQueryGetDataOperator(GoogleCloudBaseOperator):
         self.log.info("Total extracted rows: %s", len(event["records"]))
         return event["records"]
 
+    def get_openlineage_facets_on_start(self):
+        from openlineage.client.run import Dataset
+
+        from airflow.providers.openlineage.extractors import OperatorLineage
+
+        if self.project_id is None:
+            self.project_id = BigQueryHook(
+                gcp_conn_id=self.gcp_conn_id,
+                impersonation_chain=self.impersonation_chain,
+                use_legacy_sql=self.use_legacy_sql,
+            ).project_id
+
+        return OperatorLineage(
+            inputs=[
+                Dataset(namespace="bigquery", name=f"{self.project_id}.{self.dataset_id}.{self.table_id}")
+            ]
+        )
+
 
 class BigQueryExecuteQueryOperator(GoogleCloudBaseOperator):
     """Executes BigQuery SQL queries in a specific BigQuery database.

--- a/airflow/providers/openlineage/provider.yaml
+++ b/airflow/providers/openlineage/provider.yaml
@@ -31,8 +31,8 @@ dependencies:
   - apache-airflow>=2.7.0
   - apache-airflow-providers-common-sql>=1.6.0
   - attrs>=22.2
-  - openlineage-integration-common>=0.28.0
-  - openlineage-python>=0.28.0
+  - openlineage-integration-common>=0.29.2
+  - openlineage-python>=0.29.2
 
 integrations:
   - integration-name: OpenLineage

--- a/airflow/providers/openlineage/transport/__init__.py
+++ b/airflow/providers/openlineage/transport/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/openlineage/transport/variable.py
+++ b/airflow/providers/openlineage/transport/variable.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.models import Variable
+from airflow.plugins_manager import AirflowPlugin, plugins
+from airflow.utils.log.logging_mixin import LoggingMixin
+from openlineage.client.run import DatasetEvent, JobEvent, RunEvent
+from openlineage.client.serde import Serde
+from openlineage.client.transport import Transport
+
+
+class VariableTransport(Transport, LoggingMixin):
+    """This transport sends OpenLineage events to Variables.
+    Key schema is <DAG_ID>.<TASK_ID>.event.<EVENT_TYPE>.
+    It's made to be used in system tests, stored data read by OpenLineageTestOperator.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        ...
+
+    def emit(self, event: RunEvent | DatasetEvent | JobEvent):
+        from airflow.providers.openlineage.plugins.openlineage import OpenLineageProviderPlugin
+
+        plugin: AirflowPlugin | None = next(  # type: ignore[assignment]
+            filter(lambda x: isinstance(x, OpenLineageProviderPlugin), plugins)  # type: ignore[arg-type]
+        )
+        if not plugin:
+            raise RuntimeError("OpenLineage listener should be set up here")
+
+        listener = plugin.listeners[0]  # type: ignore
+        ti = listener.current_ti  # type: ignore
+
+        key = f"{ti.dag_id}.{ti.task_id}.event.{event.eventType.value.lower()}"  # type: ignore[union-attr]
+        str_event = Serde.to_json(event)
+        Variable.set(key=key, value=str_event)

--- a/docs/apache-airflow-providers-openlineage/index.rst
+++ b/docs/apache-airflow-providers-openlineage/index.rst
@@ -116,8 +116,8 @@ PIP package                              Version required
 ``apache-airflow``                       ``>=2.7.0``
 ``apache-airflow-providers-common-sql``  ``>=1.6.0``
 ``attrs``                                ``>=22.2``
-``openlineage-integration-common``       ``>=0.28.0``
-``openlineage-python``                   ``>=0.28.0``
+``openlineage-integration-common``       ``>=0.29.2``
+``openlineage-python``                   ``>=0.29.2``
 =======================================  ==================
 
 Cross provider package dependencies

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -662,8 +662,8 @@
       "apache-airflow-providers-common-sql>=1.6.0",
       "apache-airflow>=2.7.0",
       "attrs>=22.2",
-      "openlineage-integration-common>=0.28.0",
-      "openlineage-python>=0.28.0"
+      "openlineage-integration-common>=0.29.2",
+      "openlineage-python>=0.29.2"
     ],
     "cross-providers-deps": [
       "common.sql"

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -24,7 +24,21 @@ from unittest import mock
 
 import pytest
 
+from airflow import plugins_manager
+from airflow.providers.openlineage.plugins.openlineage import OpenLineageProviderPlugin
+
 REQUIRED_ENV_VARS = ("SYSTEM_TESTS_ENV_ID",)
+
+
+@pytest.fixture(scope="package", autouse=True)
+def setup_openlineage():
+    with mock.patch.dict(
+        "os.environ",
+        AIRFLOW__OPENLINEAGE__TRANSPORT='{"type": "airflow.providers.openlineage.transport.variable'
+        '.VariableTransport"}',
+    ):
+        plugins_manager.register_plugin(OpenLineageProviderPlugin())
+        yield
 
 
 @pytest.fixture(scope="package", autouse=True)

--- a/tests/test_utils/openlineage.py
+++ b/tests/test_utils/openlineage.py
@@ -1,0 +1,173 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from urllib.parse import urlparse
+
+from jinja2 import Environment
+
+from airflow.models.baseoperator import BaseOperator
+from airflow.models.variable import Variable
+from airflow.utils.context import Context
+
+log = logging.getLogger(__name__)
+
+
+def any(result):
+    return result
+
+
+def is_datetime(result):
+    try:
+        x = parse(result)  # noqa
+        return "true"
+    except:  # noqa
+        pass
+    return "false"
+
+
+def is_uuid(result):
+    try:
+        uuid.UUID(result)  # noqa
+        return "true"
+    except:  # noqa
+        pass
+    return "false"
+
+
+def env_var(var: str, default: str | None = None) -> str:
+    """The env_var() function. Return the environment variable named 'var'.
+    If there is no such environment variable set, return the default.
+    If the default is None, raise an exception for an undefined variable.
+    """
+    if var in os.environ:
+        return os.environ[var]
+    elif default is not None:
+        return default
+    else:
+        msg = f"Env var required but not provided: '{var}'"
+        raise Exception(msg)
+
+
+def not_match(result, pattern) -> str:
+    if pattern in result:
+        raise Exception(f"Found {pattern} in {result}")
+    return "true"
+
+
+def url_scheme_authority(url) -> str:
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def url_path(url) -> str:
+    return urlparse(url).path
+
+
+def setup_jinja() -> Environment:
+    env = Environment()
+    env.globals["any"] = any
+    env.globals["is_datetime"] = is_datetime
+    env.globals["is_uuid"] = is_uuid
+    env.globals["env_var"] = env_var
+    env.globals["not_match"] = not_match
+    env.filters["url_scheme_authority"] = url_scheme_authority
+    env.filters["url_path"] = url_path
+    return env
+
+
+env = setup_jinja()
+
+
+def match(expected, result) -> bool:
+    """
+    Check if result is "equal" to expected value. Omits keys not specified in expected value
+    and resolves any jinja templates found.
+    """
+    if isinstance(expected, dict):
+        # Take a look only at keys present at expected dictionary
+        for k, v in expected.items():
+            if k not in result:
+                log.error("Key %s not in received event %s\nExpected %s", k, result, expected)
+                return False
+            if not match(v, result[k]):
+                log.error(
+                    "For key %s, expected value %s not equals received %s\nExpected: %s, request: %s",
+                    k,
+                    v,
+                    result[k],
+                    expected,
+                    result,
+                )
+                return False
+    elif isinstance(expected, list):
+        if len(expected) != len(result):
+            log.error("Length does not match: expected %d, result: %d", len(expected), len(result))
+            return False
+        for i, x in enumerate(expected):
+            if not match(x, result[i]):
+                log.error(
+                    "List not matched at %d\nexpected:\n%s\nresult: \n%s",
+                    i,
+                    json.dumps(x),
+                    json.dumps(result[i]),
+                )
+                return False
+    elif isinstance(expected, str):
+        if "{{" in expected:
+            # Evaluate jinja: in some cases, we want to check only if key exists, or if
+            # value has the right type
+            rendered = env.from_string(expected).render(result=result)
+            if rendered == "true" or rendered == result:
+                return True
+            log.error("Rendered value %s does not equal 'true' or %s", rendered, result)
+            return False
+        elif expected != result:
+            log.error("Expected value %s does not equal result %s", expected, result)
+            return False
+    elif expected != result:
+        log.error("Object of type %s: %s does not match %s", type(expected), expected, result)
+        return False
+    return True
+
+
+class OpenlineageTestOperator(BaseOperator):
+    """Operator for testing purposes.
+    It compares expected event templates set on initialization with ones emitted by OpenLineage integration
+    and stored in Variables by VariableTransport.
+    :param event_templates: dictionary where key is the key used by VariableTransport in format of
+        <DAG_ID>.<TASK_ID>.event.<EVENT_TYPE>, and value is event template (fragment)
+         that need to be in received events.
+    :raises: ValueError if the received events do not match with expected ones.
+    """
+
+    def __init__(self, event_templates: dict[str, dict], **kwargs):
+        super().__init__(**kwargs)
+        self.event_templates = event_templates
+
+    def execute(self, context: Context):
+        for key, template in self.event_templates.items():
+            send_event = Variable.get(key=key)
+            self.log.error("Events: %s", send_event)
+            if send_event:
+                self.log.error("Events: %s, %s, %s", send_event, len(send_event), type(send_event))
+            if not match(template, json.loads(send_event)):
+                raise ValueError("Event received does not match one specified in test")


### PR DESCRIPTION
The idea for system tests is as follows:

- add `VariableTransport` that will push OpenLineage events to `Variable` with key `<DAG_ID>.<TASK_ID>.event.<EVENT_TYPE>`.
- System tests DAGs will be configured to use this transport
- then, newly added `OpenLineageTestOperator` will compare the `expected` events with the ones that are stored in Variables.

This PR adds those components, as well as OL support for `BigQueryGetDataOperator` and OL support for system test utilizing it. 

PR is based on previous PR: https://github.com/apache/airflow/pull/31293 - only second commit is relevant to this PR.

Closes: #29676
