### PR TITLE
Limit openlineage-integration-common until breaking change is fixed

### DIFF
--- a/airflow/providers/openlineage/provider.yaml
+++ b/airflow/providers/openlineage/provider.yaml
@@ -32,7 +32,10 @@ dependencies:
   - apache-airflow>=2.6.0
   - apache-airflow-providers-common-sql>=1.3.1
   - attrs>=22.2
-  - openlineage-integration-common>=0.22.0
+  # The openlineage-integration-common 0.27.1 introduced a breaking change in the configuration retrieval that
+  # Broke Airflow integration. Fix to deprecate it in https://github.com/OpenLineage/OpenLineage/pull/1908
+  # Is going to be merged in a follow-up release
+  - openlineage-integration-common>=0.22.0,!=0.27.1
   - openlineage-python>=0.22.0
 
 integrations:

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -623,7 +623,7 @@
       "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.6.0",
       "attrs>=22.2",
-      "openlineage-integration-common>=0.22.0",
+      "openlineage-integration-common>=0.22.0,!=0.27.1",
       "openlineage-python>=0.22.0"
     ],
     "cross-providers-deps": [],


### PR DESCRIPTION
There was a breaking change in the openlineage-integration-common that broke the way configuration was read. There is a PR in https://github.com/OpenLineage/OpenLineage/pull/1908 to address it that will be merged and released soon. We should exclude the version that contains the breaking change.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
