### PR TITLE
Remove outdated comment from `forward-credentials.yml`

### DIFF
--- a/scripts/ci/docker-compose/forward-credentials.yml
+++ b/scripts/ci/docker-compose/forward-credentials.yml
@@ -21,9 +21,7 @@ services:
     # Forwards local credentials to docker image
     # Useful for gcloud/aws/kubernetes etc. authorisation to be passed
     # To inside docker. Use with care - your credentials will be available to
-    # Everything you install in Docker
-    # If you add it here - also add it to "in_container_fix_ownership" method in
-    # the _in_container_utils.sh file to make it friendly for Linux users
+    # everything you install in Docker.
     environment:
       - GITHUB_TOKEN
     volumes:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
`in_container_fix_ownership` method  of `_in_container_utils.sh` does not handle `gcloud/aws/kubernetes` credentials anymore, so I removed an outdated comment about it.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
