### PR TITLE
Only show code tab when a task is not selected

### DIFF
--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback } from "react";
 import {
   Flex,
   Divider,
@@ -65,10 +65,9 @@ const tabToIndex = (tab?: string) => {
     case "graph":
       return 1;
     case "code":
-      return 2;
     case "logs":
     case "mapped_tasks":
-      return 3;
+      return 2;
     case "details":
     default:
       return 0;
@@ -77,6 +76,7 @@ const tabToIndex = (tab?: string) => {
 
 const indexToTab = (
   index: number,
+  taskId: string | null,
   showLogs: boolean,
   showMappedTasks: boolean
 ) => {
@@ -84,8 +84,7 @@ const indexToTab = (
     case 1:
       return "graph";
     case 2:
-      return "code";
-    case 3:
+      if (!taskId) return "code";
       if (showMappedTasks) return "mapped_tasks";
       if (showLogs) return "logs";
       return undefined;
@@ -127,19 +126,13 @@ const Details = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
   const onChangeTab = useCallback(
     (index: number) => {
       const params = new URLSearchParamsWrapper(searchParams);
-      const newTab = indexToTab(index, showLogs, showMappedTasks);
+      const newTab = indexToTab(index, taskId, showLogs, showMappedTasks);
       if (newTab) params.set(TAB_PARAM, newTab);
       else params.delete(TAB_PARAM);
       setSearchParams(params);
     },
-    [setSearchParams, searchParams, showLogs, showMappedTasks]
+    [setSearchParams, searchParams, showLogs, showMappedTasks, taskId]
   );
-
-  useEffect(() => {
-    if ((!taskId || isGroup) && tabIndex > 2) {
-      onChangeTab(1);
-    }
-  }, [runId, taskId, tabIndex, isGroup, onChangeTab]);
 
   const run = dagRuns.find((r) => r.runId === runId);
   const { data: mappedTaskInstance } = useTaskInstance({

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -117,7 +117,7 @@ const Details = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
   const isGroup = !!children;
   const isGroupOrMappedTaskSummary = isGroup || isMappedTaskSummary;
   const showLogs = !!(isTaskInstance && !isGroupOrMappedTaskSummary);
-  const showDagCode = !(isTaskInstance && !isGroupOrMappedTaskSummary);
+  const showDagCode = !taskId;
   const showMappedTasks = !!(isTaskInstance && isMappedTaskSummary && !isGroup);
 
   const [searchParams, setSearchParams] = useSearchParams();


### PR DESCRIPTION
We were showing the code tab for task groups or mapped tasks. Instead we should only show it when nothing or only a dag run is selected.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
