### PR TITLE
PythonVirtualenvOperator: termination error message in alert

### DIFF
--- a/airflow/utils/python_virtualenv_script.jinja2
+++ b/airflow/utils/python_virtualenv_script.jinja2
@@ -49,7 +49,12 @@ with open(sys.argv[3], "r") as file:
 
 # Script
 {{ python_callable_source }}
-res = {{ python_callable }}(*arg_dict["args"], **arg_dict["kwargs"])
+try:
+    res = {{ python_callable }}(*arg_dict["args"], **arg_dict["kwargs"])
+except Exception as e:
+    with open(sys.argv[4], "w") as file:
+        file.write(str(e))
+    raise
 
 # Write output
 with open(sys.argv[2], "wb") as file:

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -681,6 +681,14 @@ class BaseTestPythonVirtualenvOperator(BasePythonTest):
         with pytest.raises(CalledProcessError):
             self.run_as_task(f)
 
+    def test_fail_with_message(self):
+        def f():
+            raise Exception("Custom error message")
+
+        with pytest.raises(AirflowException) as e:
+            self.run_as_task(f)
+            assert "Custom error message" in str(e)
+
     def test_string_args(self):
         def f():
             global virtualenv_string_args


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The error alert email from PythonVirtualenvOperator and ExternalPythonOperator  only contain exit status code. It doesn't contain error messages similar to PythonOperator. This change adds the error message on these operators too.

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
