### PR TITLE
[AWS hook] use provided client to get the official waiter on fallback

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -870,7 +870,7 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
             )
         # If there is no custom waiter found for the provided name,
         # then try checking the service's official waiters.
-        return self.conn.get_waiter(waiter_name)
+        return client.get_waiter(waiter_name)
 
     @staticmethod
     def _apply_parameters_value(config: dict, waiter_name: str, parameters: dict[str, str] | None) -> dict:


### PR DESCRIPTION
we use the provided client to create custom waiters, but we need to use it for "official" ones too 

Otherwise, passing an async client here still returns a synchronous waiter.

cc @ferruzzi @syedahsn 