### PR TITLE
SnowflakeSqlApiOperator - Change the base class

### DIFF
--- a/airflow/providers/snowflake/operators/snowflake.py
+++ b/airflow/providers/snowflake/operators/snowflake.py
@@ -459,25 +459,18 @@ class SnowflakeSqlApiOperator(SQLExecuteQueryOperator):
         self.token_renewal_delta = token_renewal_delta
         self.bindings = bindings
         self.execute_async = False
-        if self.__class__.__base__.__name__ != "SnowflakeOperator":
-            # It's better to do str check of the parent class name because currently SnowflakeOperator
-            # is deprecated and in future OSS SnowflakeOperator may be removed
-            if any(
-                [warehouse, database, role, schema, authenticator, session_parameters]
-            ):  # pragma: no cover
-                hook_params = kwargs.pop("hook_params", {})  # pragma: no cover
-                kwargs["hook_params"] = {
-                    "warehouse": warehouse,
-                    "database": database,
-                    "role": role,
-                    "schema": schema,
-                    "authenticator": authenticator,
-                    "session_parameters": session_parameters,
-                    **hook_params,
-                }
-            super().__init__(conn_id=snowflake_conn_id, **kwargs)  # pragma: no cover
-        else:
-            super().__init__(**kwargs)
+        if any([warehouse, database, role, schema, authenticator, session_parameters]):  # pragma: no cover
+            hook_params = kwargs.pop("hook_params", {})  # pragma: no cover
+            kwargs["hook_params"] = {
+                "warehouse": warehouse,
+                "database": database,
+                "role": role,
+                "schema": schema,
+                "authenticator": authenticator,
+                "session_parameters": session_parameters,
+                **hook_params,
+            }
+        super().__init__(conn_id=snowflake_conn_id, **kwargs)  # pragma: no cover
 
     def execute(self, context: Context) -> None:
         """

--- a/airflow/providers/snowflake/operators/snowflake.py
+++ b/airflow/providers/snowflake/operators/snowflake.py
@@ -370,7 +370,7 @@ class SnowflakeIntervalCheckOperator(SQLIntervalCheckOperator):
         self.query_ids: list[str] = []
 
 
-class SnowflakeSqlApiOperator(SnowflakeOperator):
+class SnowflakeSqlApiOperator(SQLExecuteQueryOperator):
     """
     Implemented Snowflake SQL API Operator to support multiple SQL statements sequentially,
     which is the behavior of the SnowflakeOperator, the Snowflake SQL API allows submitting


### PR DESCRIPTION
Since `SnowflakeOperator` will be deprecated, changed the `SnowflakeSqlApiOperator` base class to `SQLExecuteQueryOperator`.

cc: @eladkal 