### PR TITLE
Replace spelling directive with spelling:word-list

### DIFF
--- a/airflow/providers/amazon/aws/hooks/athena.py
+++ b/airflow/providers/amazon/aws/hooks/athena.py
@@ -18,7 +18,7 @@
 """
 This module contains AWS Athena hook.
 
-.. spelling::
+.. spelling:word-list::
 
     PageIterator
 """

--- a/airflow/providers/google/cloud/hooks/automl.py
+++ b/airflow/providers/google/cloud/hooks/automl.py
@@ -18,7 +18,7 @@
 """
 This module contains a Google AutoML hook.
 
-.. spelling::
+.. spelling:word-list::
 
     PredictResponse
 """

--- a/airflow/providers/google/cloud/hooks/cloud_memorystore.py
+++ b/airflow/providers/google/cloud/hooks/cloud_memorystore.py
@@ -18,7 +18,7 @@
 """
 Hooks for Cloud Memorystore service.
 
-.. spelling::
+.. spelling:word-list::
 
     DataProtectionMode
     FieldMask

--- a/airflow/providers/google/cloud/hooks/dlp.py
+++ b/airflow/providers/google/cloud/hooks/dlp.py
@@ -19,7 +19,7 @@
 This module contains a CloudDLPHook
 which allows you to connect to Google Cloud DLP service.
 
-.. spelling::
+.. spelling:word-list::
 
     ImageRedactionConfig
     RedactImageRequest

--- a/airflow/providers/google/cloud/hooks/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/hooks/kubernetes_engine.py
@@ -18,7 +18,7 @@
 """
 This module contains a Google Kubernetes Engine Hook.
 
-.. spelling::
+.. spelling:word-list::
 
     gapic
     enums

--- a/airflow/providers/google/cloud/hooks/os_login.py
+++ b/airflow/providers/google/cloud/hooks/os_login.py
@@ -16,7 +16,7 @@
 # under the License.
 """OS Login hooks.
 
-.. spelling::
+.. spelling:word-list::
     ImportSshPublicKeyResponse
     oslogin
 """

--- a/airflow/providers/google/cloud/hooks/pubsub.py
+++ b/airflow/providers/google/cloud/hooks/pubsub.py
@@ -18,7 +18,7 @@
 """
 This module contains a Google Pub/Sub Hook.
 
-.. spelling::
+.. spelling:word-list::
 
     MessageStoragePolicy
     ReceivedMessage

--- a/airflow/providers/google/cloud/hooks/vertex_ai/auto_ml.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/auto_ml.py
@@ -18,7 +18,7 @@
 """
 This module contains a Google Cloud Vertex AI hook.
 
-.. spelling::
+.. spelling:word-list::
 
     aiplatform
     au

--- a/airflow/providers/google/cloud/hooks/vertex_ai/batch_prediction_job.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/batch_prediction_job.py
@@ -17,7 +17,7 @@
 # under the License.
 """This module contains a Google Cloud Vertex AI hook.
 
-.. spelling::
+.. spelling:word-list::
 
     jsonl
     codepoints

--- a/airflow/providers/google/cloud/hooks/vertex_ai/endpoint_service.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/endpoint_service.py
@@ -17,7 +17,7 @@
 # under the License.
 """This module contains a Google Cloud Vertex AI hook.
 
-.. spelling::
+.. spelling:word-list::
 
     undeployed
     undeploy

--- a/airflow/providers/google/cloud/hooks/vertex_ai/hyperparameter_tuning_job.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/hyperparameter_tuning_job.py
@@ -17,7 +17,7 @@
 # under the License.
 """This module contains a Google Cloud Vertex AI hook.
 
-.. spelling::
+.. spelling:word-list::
 
     irreproducible
     codepoints

--- a/airflow/providers/google/cloud/hooks/vertex_ai/model_service.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/model_service.py
@@ -17,7 +17,7 @@
 # under the License.
 """This module contains a Google Cloud Vertex AI hook.
 
-.. spelling::
+.. spelling:word-list::
 
     aiplatform
     camelCase

--- a/airflow/providers/google/cloud/operators/cloud_memorystore.py
+++ b/airflow/providers/google/cloud/operators/cloud_memorystore.py
@@ -18,7 +18,7 @@
 """
 Operators for Google Cloud Memorystore service.
 
-.. spelling::
+.. spelling:word-list::
 
     FieldMask
     memcache

--- a/airflow/providers/google/cloud/operators/pubsub.py
+++ b/airflow/providers/google/cloud/operators/pubsub.py
@@ -18,7 +18,7 @@
 """
 This module contains Google PubSub operators.
 
-.. spelling::
+.. spelling:word-list::
 
     MessageStoragePolicy
 """

--- a/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
@@ -17,7 +17,7 @@
 # under the License.
 """This module contains Google Vertex AI operators.
 
-.. spelling::
+.. spelling:word-list::
 
     jsonl
     codepoints

--- a/airflow/providers/google/cloud/operators/vertex_ai/endpoint_service.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/endpoint_service.py
@@ -17,7 +17,7 @@
 # under the License.
 """This module contains Google Vertex AI operators.
 
-.. spelling::
+.. spelling:word-list::
 
     undeployed
     undeploy

--- a/airflow/providers/google/cloud/operators/vertex_ai/hyperparameter_tuning_job.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/hyperparameter_tuning_job.py
@@ -17,7 +17,7 @@
 # under the License.
 """This module contains Google Vertex AI operators.
 
-.. spelling::
+.. spelling:word-list::
 
     irreproducible
     codepoints

--- a/airflow/providers/google/cloud/operators/vertex_ai/model_service.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/model_service.py
@@ -17,7 +17,7 @@
 # under the License.
 """This module contains Google Vertex AI operators.
 
-.. spelling::
+.. spelling:word-list::
 
     aiplatform
     camelCase

--- a/airflow/providers/google/cloud/utils/mlengine_prediction_summary.py
+++ b/airflow/providers/google/cloud/utils/mlengine_prediction_summary.py
@@ -102,7 +102,7 @@ To test outside of the dag:
         ]
     )
 
-.. spelling::
+.. spelling:word-list::
 
     pcoll
 """

--- a/airflow/providers/google/common/utils/id_token_credentials.py
+++ b/airflow/providers/google/common/utils/id_token_credentials.py
@@ -24,7 +24,7 @@ To obtain info about this token, run the following commands:
     ID_TOKEN="$(python -m airflow.providers.google.common.utils.id_token_credentials)"
     curl "https://www.googleapis.com/oauth2/v3/tokeninfo?id_token=${ID_TOKEN}" -v
 
-.. spelling::
+.. spelling:word-list::
 
     RefreshError
 """

--- a/airflow/providers/influxdb/hooks/influxdb.py
+++ b/airflow/providers/influxdb/hooks/influxdb.py
@@ -18,7 +18,7 @@
 """
 This module allows to connect to a InfluxDB database.
 
-.. spelling::
+.. spelling:word-list::
 
     FluxTable
 """

--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -18,7 +18,7 @@
 """
 This module contains Azure Data Explorer hook.
 
-.. spelling::
+.. spelling:word-list::
 
     KustoResponseDataSetV
     kusto

--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -16,7 +16,7 @@
 # under the License.
 """Spelling exceptions.
 
-.. spelling::
+.. spelling:word-list::
     CreateRunResponse
     DatasetResource
     LinkedServiceResource

--- a/docs/apache-airflow-providers-dbt-cloud/connections.rst
+++ b/docs/apache-airflow-providers-dbt-cloud/connections.rst
@@ -15,7 +15,7 @@
     specific language governing permissions and limitations
     under the License.
 
-.. spelling::
+.. spelling:word-list::
 
     getdbt
 


### PR DESCRIPTION
Apparently `.. spelling::` is deprecated.