### PR TITLE
Updates release notes for snakebite-py3 incompatibility with protobuf

### DIFF
--- a/airflow/providers/apache/hdfs/CHANGELOG.rst
+++ b/airflow/providers/apache/hdfs/CHANGELOG.rst
@@ -49,6 +49,25 @@ you can use 3.* version of the provider, but the recommendation is to switch to 
 
 * ``Remove snakebite-py3 based HDFS hooks and sensors (#31262)``
 
+
+.. note::
+
+   Protobuf 3 required by the snakebite-py3 library has ended its life in June 2023 and Airflow and it's
+   providers stopped supporting it. If you would like to continue using HDFS hooks and sensors
+   based on snakebite-py3 library when you have protobuf library 4.+ you can install the 3.* version
+   of the provider but due to Protobuf incompatibility, you need to do one of the the two things:
+
+   * set ``PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python`` variable in your environment.
+   * downgrade protobuf to latest 3.* version (3.20.3 at this time)
+
+   Setting ``PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python`` will make many libraries using protobuf
+   much slower - including multiple Google client libraries and Kubernetes. Downgrading protobuf to
+   (already End-Of-Life) 3.* version will make some of the latest versions of the new providers
+   incompatible (for example google and grpc) and you will have to downgrade those providers as well.
+   Both should be treated as a temporary workaround only, and you should migrate to WebHDFS
+   as soon as possible.
+
+
 Misc
 ~~~~
 


### PR DESCRIPTION
Users that would like to use previous version of hdfs provider with new Airlfow will have to configure their environment temporarily to use Python based protobuf serualization.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
