### PR TITLE
Fix docstring errors resulted from cross-merged commits

### DIFF
--- a/airflow/providers/smtp/notifications/smtp.py
+++ b/airflow/providers/smtp/notifications/smtp.py
@@ -34,7 +34,7 @@ from airflow.providers.smtp.hooks.smtp import SmtpHook
 
 class SmtpNotifier(BaseNotifier):
     """
-    SMTP Notifier
+    SMTP Notifier.
 
     :param smtp_conn_id: The :ref:`smtp connection id <howto/connection:smtp>`
         that contains the information used to authenticate the client.
@@ -82,11 +82,11 @@ class SmtpNotifier(BaseNotifier):
 
     @cached_property
     def hook(self) -> SmtpHook:
-        """Smtp Events Hook"""
+        """Smtp Events Hook."""
         return SmtpHook(smtp_conn_id=self.smtp_conn_id)
 
     def notify(self, context):
-        """Send a email via smtp server"""
+        """Send a email via smtp server."""
         with self.hook as smtp:
             smtp.send_email_smtp(
                 smtp_conn_id=self.smtp_conn_id,


### PR DESCRIPTION
The #31359 and #31742 were merged independently and the first one did not have the fixes enabled by the second. This PR fixes it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
