### PR TITLE
Fix wrong override for nested group default args

### DIFF
--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -179,7 +179,7 @@ class TaskGroup(DAGNode):
 
     def _update_default_args(self, parent_group: TaskGroup):
         if parent_group.default_args:
-            self.default_args = {**self.default_args, **parent_group.default_args}
+            self.default_args = {**parent_group.default_args, **self.default_args}
 
     @classmethod
     def create_root(cls, dag: DAG) -> TaskGroup:

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -1368,11 +1368,16 @@ def test_override_dag_default_args_in_multi_level_nested_tg():
                 "execution_timeout": timedelta(seconds=10),
             },
         ):
-            with TaskGroup(group_id="first_nested_task_group"):
+            with TaskGroup(
+                group_id="first_nested_task_group",
+                default_args={
+                    "owner": "z",
+                },
+            ):
                 with TaskGroup(group_id="second_nested_task_group"):
                     with TaskGroup(group_id="third_nested_task_group"):
                         task = EmptyOperator(task_id="task")
 
     assert task.retries == 1
-    assert task.owner == "y"
+    assert task.owner == "z"
     assert task.execution_timeout == timedelta(seconds=10)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: #31608

For more context, check this [comment](https://github.com/apache/airflow/pull/31608/files#r1221330010)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
