### PR TITLE
Better error message when serializing callable without name

### DIFF
--- a/airflow/utils/module_loading.py
+++ b/airflow/utils/module_loading.py
@@ -43,7 +43,7 @@ def import_string(dotted_path: str):
 
 def qualname(o: object | Callable) -> str:
     """Convert an attribute/class/function to a string importable by ``import_string``."""
-    if callable(o):
+    if callable(o) and hasattr(o, "__module__") and hasattr(o, "__name__"):
         return f"{o.__module__}.{o.__name__}"
 
     cls = o

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -100,6 +100,11 @@ class U(BaseModel):
     u: tuple
 
 
+class C:
+    def __call__(self):
+        return None
+
+
 @pytest.mark.usefixtures("recalculate_patterns")
 class TestSerDe:
     def test_ser_primitives(self):
@@ -331,3 +336,10 @@ class TestSerDe:
         e = serialize(i)
         s = deserialize(e)
         assert i == s
+
+    def test_error_when_serializing_callable_without_name(self):
+        i = C()
+        with pytest.raises(
+            TypeError, match="cannot serialize object of type <class 'tests.serialization.test_serde.C'>"
+        ):
+            serialize(i)


### PR DESCRIPTION
When Callable without `__name__` got serialized, the error message was pretty cryptic: `AttributeError: __name__. Did you mean: '__ne__'?` without printing what the failing type is.

This PR adds a more meaningful message

Related to #31753, #31499

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
