### PR TITLE
Fix Databricks SQL operator serialization

### DIFF
--- a/tests/providers/databricks/operators/test_databricks_sql.py
+++ b/tests/providers/databricks/operators/test_databricks_sql.py
@@ -22,10 +22,10 @@ import tempfile
 from unittest.mock import patch
 
 import pytest
-from databricks.sql.types import Row
 
 from airflow.providers.common.sql.hooks.sql import fetch_all_handler
-from airflow.providers.databricks.operators.databricks_sql import DatabricksSqlOperator
+from airflow.providers.databricks.operators.databricks_sql import DatabricksSqlOperator, Row
+from airflow.serialization.serde import serialize
 
 DATE = "2017-04-20"
 TASK_ID = "databricks-sql-operator"
@@ -149,6 +149,25 @@ def test_exec_success(sql, return_last, split_statement, hook_results, hook_desc
             return_last=return_last,
             split_statements=split_statement,
         )
+
+
+def test_return_value_serialization():
+    hook_descriptions = [[("id",), ("value",)]]
+    hook_results = [Row(id=1, value="value1"), Row(id=2, value="value2")]
+
+    with patch("airflow.providers.databricks.operators.databricks_sql.DatabricksSqlHook") as db_mock_class:
+        op = DatabricksSqlOperator(
+            task_id=TASK_ID,
+            sql="select * from dummy2",
+            do_xcom_push=True,
+            return_last=True,
+        )
+        db_mock = db_mock_class.return_value
+        db_mock.run.return_value = hook_results
+        db_mock.descriptions = hook_descriptions
+        result = op.execute({})
+        serialized_result = serialize(result)
+        assert serialized_result == serialize(([("id",), ("value",)], [(1, "value1"), (2, "value2")]))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The Databricks SQL operator returned Databricks Row which were not serializatble, because they were special extension of tuples that also acted as dict. In case of SQLOperator, we return a different format of output - separately descriptions of the rows and separately rows of values which are regular tuples.

This PR converts the Databrick Rows into regular tuples on the flight while processing the output

Fixes: #31753
Fixes: #31499

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
