### PR TITLE
Add option to pass extra configs to ClientSecretCredential 

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -174,6 +174,7 @@ class WasbHook(BaseHook):
         """Return the BlobServiceClient object."""
         conn = self.get_connection(self.conn_id)
         extra = conn.extra_dejson or {}
+        client_secret_auth_config = extra.pop("client_secret_auth_config", {})
 
         if self.public_read:
             # Here we use anonymous public read
@@ -196,7 +197,7 @@ class WasbHook(BaseHook):
             # use Active Directory auth
             app_id = conn.login
             app_secret = conn.password
-            token_credential = ClientSecretCredential(tenant, app_id, app_secret)
+            token_credential = ClientSecretCredential(tenant, app_id, app_secret, **client_secret_auth_config)
             return BlobServiceClient(account_url=conn.host, credential=token_credential, **extra)
 
         sas_token = self._get_field(extra, "sas_token")
@@ -542,6 +543,7 @@ class WasbAsyncHook(WasbHook):
 
         conn = await sync_to_async(self.get_connection)(self.conn_id)
         extra = conn.extra_dejson or {}
+        client_secret_auth_config = extra.pop("client_secret_auth_config", {})
 
         if self.public_read:
             # Here we use anonymous public read
@@ -571,7 +573,9 @@ class WasbAsyncHook(WasbHook):
             # use Active Directory auth
             app_id = conn.login
             app_secret = conn.password
-            token_credential = AsyncClientSecretCredential(tenant, app_id, app_secret)
+            token_credential = AsyncClientSecretCredential(
+                tenant, app_id, app_secret, **client_secret_auth_config
+            )
             self.blob_service_client = AsyncBlobServiceClient(
                 account_url=conn.host, credential=token_credential, **extra  # type:ignore[arg-type]
             )

--- a/docs/apache-airflow-providers-microsoft-azure/connections/wasb.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/wasb.rst
@@ -71,6 +71,7 @@ Extra (optional)
     * ``shared_access_key``: Specify the shared access key. Needed for shared access key authentication.
     * ``connection_string``: Connection string for use with connection string authentication.
     * ``sas_token``: SAS Token for use with SAS Token authentication.
+    * ``client_secret_auth_config``: Extra config to pass while authenticating as a service principal using `ClientSecretCredential <https://learn.microsoft.com/en-in/python/api/azure-identity/azure.identity.clientsecretcredential?view=azure-python>`_
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.

--- a/tests/providers/microsoft/azure/hooks/test_wasb.py
+++ b/tests/providers/microsoft/azure/hooks/test_wasb.py
@@ -166,7 +166,7 @@ class TestWasbHook:
         assert isinstance(hook.get_conn(), BlobServiceClient)
         assert isinstance(hook.get_conn().credential, DefaultAzureCredential)
 
-    def test_ad_connection(self):
+    def test_azure_directory_connection(self):
         hook = WasbHook(wasb_conn_id=self.ad_conn_id)
         assert isinstance(hook.get_conn(), BlobServiceClient)
         assert isinstance(hook.get_conn().credential, ClientSecretCredential)

--- a/tests/providers/microsoft/azure/hooks/test_wasb.py
+++ b/tests/providers/microsoft/azure/hooks/test_wasb.py
@@ -21,7 +21,7 @@ import json
 from unittest import mock
 
 import pytest
-from azure.identity import DefaultAzureCredential
+from azure.identity import ClientSecretCredential, DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient
 
 from airflow.exceptions import AirflowException
@@ -51,8 +51,14 @@ class TestWasbHook:
         self.extra__wasb__http_sas_conn_id = "extra__http_sas_token_id"
         self.public_read_conn_id = "pub_read_id"
         self.managed_identity_conn_id = "managed_identity"
+        self.authority = "https://test_authority.com"
 
         self.proxies = {"http": "http_proxy_uri", "https": "https_proxy_uri"}
+        self.client_secret_auth_config = {
+            "proxies": self.proxies,
+            "connection_verify": False,
+            "authority": self.authority,
+        }
 
         db.merge_conn(
             Connection(
@@ -85,7 +91,13 @@ class TestWasbHook:
                 host="conn_host",
                 login="appID",
                 password="appsecret",
-                extra=json.dumps({"tenant_id": "token", "proxies": self.proxies}),
+                extra=json.dumps(
+                    {
+                        "tenant_id": "token",
+                        "proxies": self.proxies,
+                        "client_secret_auth_config": self.client_secret_auth_config,
+                    }
+                ),
             )
         )
         db.merge_conn(
@@ -154,6 +166,11 @@ class TestWasbHook:
         assert isinstance(hook.get_conn(), BlobServiceClient)
         assert isinstance(hook.get_conn().credential, DefaultAzureCredential)
 
+    def test_ad_connection(self):
+        hook = WasbHook(wasb_conn_id=self.ad_conn_id)
+        assert isinstance(hook.get_conn(), BlobServiceClient)
+        assert isinstance(hook.get_conn().credential, ClientSecretCredential)
+
     @pytest.mark.parametrize(
         argnames="conn_id_str, extra_key",
         argvalues=[
@@ -196,6 +213,12 @@ class TestWasbHook:
         hook = WasbHook(wasb_conn_id=conn_id, public_read=True)
         conn = hook.get_conn()
         assert conn._config.proxy_policy.proxies == self.proxies
+
+    def test_extra_client_secret_auth_config_ad_connection(self):
+        conn_id = self.ad_conn_id
+        hook = WasbHook(wasb_conn_id=conn_id)
+        conn = hook.get_conn()
+        assert conn.credential._authority == self.authority
 
     @mock.patch("airflow.providers.microsoft.azure.hooks.wasb.BlobServiceClient")
     def test_check_for_blob(self, mock_service):


### PR DESCRIPTION
The option to pass extra configs is essential, for example - when working with a proxy (ex socks) to authenticate as a service principal using `ClientSecretCredential`. Currently, it isn't possible to do so. Hence added the option to pass extra options to `ClientSecretCredential`. Have added a few tests to validate it.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
