### PR TITLE
Mark `[secrets] backend_kwargs` as a sensitive config

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -155,6 +155,7 @@ SENSITIVE_CONFIG_VALUES = {
     ("atlas", "password"),
     ("smtp", "smtp_password"),
     ("webserver", "secret_key"),
+    ("secrets", "backend_kwargs"),
     # The following options are deprecated
     ("core", "sql_alchemy_conn"),
 }


### PR DESCRIPTION
That config option can have sensitive values in it, so let's mark it as being sensitive.