### PR TITLE
fix spark-kubernetes-operator compatibility

### DIFF
--- a/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -16,8 +16,13 @@
 # under the License.
 from __future__ import annotations
 
-from unittest.mock import patch
+from datetime import datetime
+from unittest.mock import MagicMock, patch
 
+import pytest
+from dateutil import tz
+
+from airflow import AirflowException
 from airflow.providers.cncf.kubernetes.operators.spark_kubernetes import SparkKubernetesOperator
 
 
@@ -43,13 +48,22 @@ def test_spark_kubernetes_operator(mock_kubernetes_hook):
 @patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes.Watch.stream")
 @patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes._load_body_to_dict")
 @patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes.KubernetesHook")
-def test_execute(mock_kubernetes_hook, mock_load_body_to_dict, mock_stream):
+def test_execute_with_watch(mock_kubernetes_hook, mock_load_body_to_dict, mock_stream):
     mock_load_body_to_dict.return_value = {"metadata": {"name": "spark-app"}}
-    mock_kubernetes_hook.return_value.get_namespace.return_value = "default"
-    mock_stream.side_effect = [[{"type": "ADDED"}], []]
 
-    op = SparkKubernetesOperator(task_id="task_id", application_file="application_file")
-    op.execute({})
+    mock_kubernetes_hook.return_value.create_custom_object.return_value = {
+        "metadata": {"name": "spark-app", "creationTimestamp": "2022-01-01T00:00:00Z"}
+    }
+    mock_kubernetes_hook.return_value.get_namespace.return_value = "default"
+
+    object_mock = MagicMock()
+    object_mock.reason = "SparkDriverRunning"
+    object_mock.last_timestamp = datetime(2022, 1, 1, 23, 59, 59, tzinfo=tz.tzutc())
+    mock_stream.side_effect = [[{"object": object_mock}], []]
+
+    op = SparkKubernetesOperator(task_id="task_id", application_file="application_file", watch=True)
+    operator_output = op.execute({})
+
     mock_kubernetes_hook.return_value.create_custom_object.assert_called_once_with(
         group="sparkoperator.k8s.io",
         version="v1beta2",
@@ -60,21 +74,69 @@ def test_execute(mock_kubernetes_hook, mock_load_body_to_dict, mock_stream):
 
     assert mock_stream.call_count == 2
     mock_stream.assert_any_call(
-        mock_kubernetes_hook.return_value.core_v1_client.list_namespaced_pod,
+        mock_kubernetes_hook.return_value.core_v1_client.list_namespaced_event,
         namespace="default",
-        _preload_content=False,
         watch=True,
-        label_selector="sparkoperator.k8s.io/app-name=spark-app,spark-role=driver",
-        field_selector="status.phase=Running",
+        field_selector="involvedObject.kind=SparkApplication,involvedObject.name=spark-app",
     )
-
     mock_stream.assert_any_call(
         mock_kubernetes_hook.return_value.core_v1_client.read_namespaced_pod_log,
         name="spark-app-driver",
         namespace="default",
-        _preload_content=False,
         timestamps=True,
     )
+
+    assert operator_output == {"metadata": {"name": "spark-app", "creationTimestamp": "2022-01-01T00:00:00Z"}}
+
+
+@patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes.SparkKubernetesOperator.on_kill")
+@patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes.Watch.stream")
+@patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes._load_body_to_dict")
+@patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes.KubernetesHook")
+def test_raise_exception_when_job_fails(
+    mock_kubernetes_hook, mock_load_body_to_dict, mock_stream, mock_on_kill
+):
+    mock_load_body_to_dict.return_value = {"metadata": {"name": "spark-app"}}
+
+    mock_kubernetes_hook.return_value.create_custom_object.return_value = {
+        "metadata": {"name": "spark-app", "creationTimestamp": "2022-01-01T00:00:00Z"}
+    }
+    mock_kubernetes_hook.return_value.get_namespace.return_value = "default"
+
+    object_mock = MagicMock()
+    object_mock.reason = "SparkApplicationFailed"
+    object_mock.message = "spark-app submission failed"
+    object_mock.last_timestamp = datetime(2022, 1, 1, 23, 59, 59, tzinfo=tz.tzutc())
+
+    mock_stream.side_effect = [[{"object": object_mock}], []]
+    op = SparkKubernetesOperator(task_id="task_id", application_file="application_file", watch=True)
+    with pytest.raises(AirflowException, match="spark-app submission failed"):
+        op.execute({})
+
+    assert mock_on_kill.has_called_once()
+
+
+@patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes._load_body_to_dict")
+@patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes.KubernetesHook")
+def test_execute_without_watch(mock_kubernetes_hook, mock_load_body_to_dict):
+    mock_load_body_to_dict.return_value = {"metadata": {"name": "spark-app"}}
+
+    mock_kubernetes_hook.return_value.create_custom_object.return_value = {
+        "metadata": {"name": "spark-app", "creationTimestamp": "2022-01-01T00:00:00Z"}
+    }
+    mock_kubernetes_hook.return_value.get_namespace.return_value = "default"
+
+    op = SparkKubernetesOperator(task_id="task_id", application_file="application_file")
+    operator_output = op.execute({})
+
+    mock_kubernetes_hook.return_value.create_custom_object.assert_called_once_with(
+        group="sparkoperator.k8s.io",
+        version="v1beta2",
+        plural="sparkapplications",
+        body={"metadata": {"name": "spark-app"}},
+        namespace="default",
+    )
+    assert operator_output == {"metadata": {"name": "spark-app", "creationTimestamp": "2022-01-01T00:00:00Z"}}
 
 
 @patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes._load_body_to_dict")


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:


related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR would fix the problems mentioned in the issue.

- with new args `watch: bool = False` this operator executes as same as the old version and the compatibility issue would solves
- The job status covers by the k8s events in case of success or fail
- tests for these situation

closes: #31183

---
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
