### PR TITLE
Can end task instance from trigger

### DIFF
--- a/airflow/callbacks/callback_requests.py
+++ b/airflow/callbacks/callback_requests.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+from airflow.utils.state import TaskInstanceState
+
 if TYPE_CHECKING:
     from airflow.models.taskinstance import SimpleTaskInstance
 
@@ -71,6 +73,7 @@ class TaskCallbackRequest(CallbackRequest):
     :param is_failure_callback: Flag to determine whether it is a Failure Callback or Success Callback
     :param msg: Additional Message that can be used for logging to determine failure/zombie
     :param processor_subdir: Directory used by Dag Processor when parsed the dag.
+    :param task_callback_type: e.g. whether on success, on failure, on retry.
     """
 
     def __init__(
@@ -80,10 +83,12 @@ class TaskCallbackRequest(CallbackRequest):
         is_failure_callback: bool | None = True,
         processor_subdir: str | None = None,
         msg: str | None = None,
+        task_callback_type: TaskInstanceState | None = None,
     ):
         super().__init__(full_filepath=full_filepath, processor_subdir=processor_subdir, msg=msg)
         self.simple_task_instance = simple_task_instance
         self.is_failure_callback = is_failure_callback
+        self.task_callback_type = task_callback_type
 
     def to_json(self) -> str:
         from airflow.serialization.serialized_objects import BaseSerialization

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -348,11 +348,14 @@ class TaskDeferred(BaseException):
     resuming execution in the task.
     """
 
+    TRIGGER_EXIT = "__trigger_exit__"
+    """Sentinel value to signal the expectation that the trigger will exit the task."""
+
     def __init__(
         self,
         *,
         trigger,
-        method_name: str | None = None,
+        method_name: str = TRIGGER_EXIT,
         kwargs: dict[str, Any] | None = None,
         timeout: datetime.timedelta | None = None,
     ):

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -347,7 +347,7 @@ class TaskDeferred(BaseException):
         self,
         *,
         trigger,
-        method_name: str,
+        method_name: str | None = None,
         kwargs: dict[str, Any] | None = None,
         timeout: datetime.timedelta | None = None,
     ):

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -343,19 +343,22 @@ class TaskDeferred(BaseException):
     wishes to defer until a trigger fires.
 
     Triggers can send execution back to task or end the task instance directly.
-    If the trigger will end the task instance itself, ``method_name`` should be
-    None; otherwise, provide the name of the method that should be used when
-    resuming execution in the task.
+
+    If the trigger will end the task instance itself (i.e. not schedule the task to resume
+    its execution) then you should omit the ``method_name`` param; the default value,
+    ``'__not_set__'`` will be used.
+
+    Otherwise, provide the name of the method that should be used when resuming execution in the task.
     """
 
-    TRIGGER_EXIT = "__trigger_exit__"
-    """Sentinel value to signal the expectation that the trigger will exit the task."""
+    NOT_SET = "__not_set__"
+    """If task is deferred with method_name = NOT_SET, it's expected that the trigger will exit the task."""
 
     def __init__(
         self,
         *,
         trigger,
-        method_name: str = TRIGGER_EXIT,
+        method_name: str = NOT_SET,
         kwargs: dict[str, Any] | None = None,
         timeout: datetime.timedelta | None = None,
     ):

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -341,6 +341,11 @@ class TaskDeferred(BaseException):
 
     Special exception raised to signal that the operator it was raised from
     wishes to defer until a trigger fires.
+
+    Triggers can send execution back to task or end the task instance directly.
+    If the trigger will end the task instance itself, ``method_name`` should be
+    None; otherwise, provide the name of the method that should be used when
+    resuming execution in the task.
     """
 
     def __init__(

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -343,22 +343,19 @@ class TaskDeferred(BaseException):
     wishes to defer until a trigger fires.
 
     Triggers can send execution back to task or end the task instance directly.
-
-    If the trigger will end the task instance itself (i.e. not schedule the task to resume
-    its execution) then you should omit the ``method_name`` param; the default value,
-    ``'__not_set__'`` will be used.
-
-    Otherwise, provide the name of the method that should be used when resuming execution in the task.
+    If the trigger will end the task instance itself, ``method_name`` should be
+    None; otherwise, provide the name of the method that should be used when
+    resuming execution in the task.
     """
 
-    NOT_SET = "__not_set__"
-    """If task is deferred with method_name = NOT_SET, it's expected that the trigger will exit the task."""
+    TRIGGER_EXIT = "__trigger_exit__"
+    """Sentinel value to signal the expectation that the trigger will exit the task."""
 
     def __init__(
         self,
         *,
         trigger,
-        method_name: str = NOT_SET,
+        method_name: str = TRIGGER_EXIT,
         kwargs: dict[str, Any] | None = None,
         timeout: datetime.timedelta | None = None,
     ):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1574,7 +1574,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self,
         *,
         trigger: BaseTrigger,
-        method_name: str = TaskDeferred.NOT_SET,
+        method_name: str = TaskDeferred.TRIGGER_EXIT,
         kwargs: dict[str, Any] | None = None,
         timeout: timedelta | None = None,
     ):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1574,7 +1574,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self,
         *,
         trigger: BaseTrigger,
-        method_name: str | None = None,
+        method_name: str = TaskDeferred.TRIGGER_EXIT,
         kwargs: dict[str, Any] | None = None,
         timeout: timedelta | None = None,
     ):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1584,6 +1584,11 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
 
         This is achieved by raising a special exception (TaskDeferred)
         which is caught in the main _execute_task wrapper.
+
+        Triggers can send execution back to task or end the task instance directly.
+        If the trigger will end the task instance itself, ``method_name`` should be
+        None; otherwise, provide the name of the method that should be used when
+        resuming execution in the task.
         """
         raise TaskDeferred(trigger=trigger, method_name=method_name, kwargs=kwargs, timeout=timeout)
 

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1574,7 +1574,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self,
         *,
         trigger: BaseTrigger,
-        method_name: str,
+        method_name: str | None = None,
         kwargs: dict[str, Any] | None = None,
         timeout: timedelta | None = None,
     ):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1574,7 +1574,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self,
         *,
         trigger: BaseTrigger,
-        method_name: str = TaskDeferred.TRIGGER_EXIT,
+        method_name: str = TaskDeferred.NOT_SET,
         kwargs: dict[str, Any] | None = None,
         timeout: timedelta | None = None,
     ):

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1689,7 +1689,7 @@ class TaskInstance(Base, LoggingMixin):
                 if traceback is not None:
                     self.log.error("Trigger failed:\n%s", "\n".join(traceback))
                 raise TaskDeferralError(next_kwargs.get("error", "Unknown"))
-            elif self.next_method == TaskDeferred.TRIGGER_EXIT:
+            elif self.next_method == TaskDeferred.NOT_SET:
                 raise TaskDeferralError(
                     "Task is resuming from deferral without next_method specified. "
                     "You must either set `method_name` when deferring, or use a trigger "

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1693,6 +1693,8 @@ class TaskInstance(Base, LoggingMixin):
             execute_callable = getattr(task_to_execute, self.next_method)
             if self.next_kwargs:
                 execute_callable = partial(execute_callable, **self.next_kwargs)
+        elif self.next_kwargs is not None:
+            raise AirflowException("Task is coming out of deferral without next_method specified.")
         else:
             execute_callable = task_to_execute.execute
         # If a timeout is specified for the task, make it fail

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1689,7 +1689,7 @@ class TaskInstance(Base, LoggingMixin):
                 if traceback is not None:
                     self.log.error("Trigger failed:\n%s", "\n".join(traceback))
                 raise TaskDeferralError(next_kwargs.get("error", "Unknown"))
-            elif self.next_method == TaskDeferred.NOT_SET:
+            elif self.next_method == TaskDeferred.TRIGGER_EXIT:
                 raise TaskDeferralError(
                     "Task is resuming from deferral without next_method specified. "
                     "You must either set `method_name` when deferring, or use a trigger "

--- a/airflow/models/trigger.py
+++ b/airflow/models/trigger.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import datetime
-import logging
 from traceback import format_exception
 from typing import Any, Iterable
 
@@ -27,15 +26,12 @@ from sqlalchemy.orm import Session, joinedload, relationship
 from airflow.api_internal.internal_api_call import internal_api_call
 from airflow.models.base import Base
 from airflow.models.taskinstance import TaskInstance
-from airflow.triggers.base import BaseTaskEndEvent, BaseTrigger
+from airflow.triggers.base import BaseTrigger
 from airflow.utils import timezone
 from airflow.utils.retries import run_with_db_retries
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import ExtendedJSON, UtcDateTime, with_row_locks
 from airflow.utils.state import TaskInstanceState
-from airflow.utils.xcom import XCOM_RETURN_KEY
-
-log = logging.getLogger(__name__)
 
 
 class Trigger(Base):
@@ -154,32 +150,7 @@ class Trigger(Base):
         for task_instance in session.query(TaskInstance).filter(
             TaskInstance.trigger_id == trigger_id, TaskInstance.state == TaskInstanceState.DEFERRED
         ):
-            if isinstance(event, BaseTaskEndEvent):
-                # task will be marked with terminal state and will not resume on worker
-                task_instance.trigger_id = None
-                task_instance.state = event.task_instance_state
-                if event.xcom_return:
-                    task_instance.xcom_push(key=XCOM_RETURN_KEY, value=event.xcom_return)
-                if event.other_xcom:
-                    for key, value in event.other_xcom.items():
-                        if key == XCOM_RETURN_KEY:
-                            log.warning(
-                                "Trigger yielded `other_xcom` with reserved key %s; ignoring. ti=%s",
-                                XCOM_RETURN_KEY,
-                                task_instance,
-                            )
-                            continue
-                        task_instance.xcom_push(key=key, value=value)
-            else:
-                # task will be resumed on worker; set up next kwargs and schedule
-                # Add the event's payload into the kwargs for the task
-                next_kwargs = task_instance.next_kwargs or {}
-                next_kwargs["event"] = event.payload
-                task_instance.next_kwargs = next_kwargs
-                # Remove ourselves as its trigger
-                task_instance.trigger_id = None
-                # Finally, mark it as scheduled so it gets re-queued
-                task_instance.state = TaskInstanceState.SCHEDULED
+            event.handle_submit(task_instance=task_instance)
 
     @classmethod
     @internal_api_call

--- a/airflow/models/trigger.py
+++ b/airflow/models/trigger.py
@@ -150,7 +150,7 @@ class Trigger(Base):
         for task_instance in session.query(TaskInstance).filter(
             TaskInstance.trigger_id == trigger_id, TaskInstance.state == TaskInstanceState.DEFERRED
         ):
-            event.handle_submit(task_instance=task_instance)
+            event.handle_submit(task_instance=task_instance, session=session)
 
     @classmethod
     @internal_api_call

--- a/airflow/sensors/date_time.py
+++ b/airflow/sensors/date_time.py
@@ -86,4 +86,4 @@ class DateTimeSensorAsync(DateTimeSensor):
     """
 
     def execute(self, context: Context):
-        self.defer(trigger=DateTimeTrigger(moment=timezone.parse(self.target_time)))
+        self.defer(trigger=DateTimeTrigger(moment=timezone.parse(self.target_time), exit_task=True))

--- a/airflow/sensors/date_time.py
+++ b/airflow/sensors/date_time.py
@@ -86,4 +86,4 @@ class DateTimeSensorAsync(DateTimeSensor):
     """
 
     def execute(self, context: Context):
-        self.defer(trigger=DateTimeTrigger(moment=timezone.parse(self.target_time), exit_task=True))
+        self.defer(trigger=DateTimeTrigger(moment=timezone.parse(self.target_time), end_task=True))

--- a/airflow/sensors/date_time.py
+++ b/airflow/sensors/date_time.py
@@ -86,11 +86,4 @@ class DateTimeSensorAsync(DateTimeSensor):
     """
 
     def execute(self, context: Context):
-        self.defer(
-            trigger=DateTimeTrigger(moment=timezone.parse(self.target_time)),
-            method_name="execute_complete",
-        )
-
-    def execute_complete(self, context, event=None):
-        """Callback for when the trigger fires - returns immediately."""
-        return None
+        self.defer(trigger=DateTimeTrigger(moment=timezone.parse(self.target_time)))

--- a/airflow/sensors/time_delta.py
+++ b/airflow/sensors/time_delta.py
@@ -64,4 +64,4 @@ class TimeDeltaSensorAsync(TimeDeltaSensor):
     def execute(self, context: Context):
         target_dttm = context["data_interval_end"]
         target_dttm += self.delta
-        self.defer(trigger=DateTimeTrigger(moment=target_dttm))
+        self.defer(trigger=DateTimeTrigger(moment=target_dttm, exit_task=True))

--- a/airflow/sensors/time_delta.py
+++ b/airflow/sensors/time_delta.py
@@ -64,4 +64,4 @@ class TimeDeltaSensorAsync(TimeDeltaSensor):
     def execute(self, context: Context):
         target_dttm = context["data_interval_end"]
         target_dttm += self.delta
-        self.defer(trigger=DateTimeTrigger(moment=target_dttm, exit_task=True))
+        self.defer(trigger=DateTimeTrigger(moment=target_dttm, end_task=True))

--- a/airflow/sensors/time_delta.py
+++ b/airflow/sensors/time_delta.py
@@ -64,8 +64,4 @@ class TimeDeltaSensorAsync(TimeDeltaSensor):
     def execute(self, context: Context):
         target_dttm = context["data_interval_end"]
         target_dttm += self.delta
-        self.defer(trigger=DateTimeTrigger(moment=target_dttm), method_name="execute_complete")
-
-    def execute_complete(self, context, event=None):
-        """Callback for when the trigger fires - returns immediately."""
-        return None
+        self.defer(trigger=DateTimeTrigger(moment=target_dttm))

--- a/airflow/sensors/time_sensor.py
+++ b/airflow/sensors/time_sensor.py
@@ -70,4 +70,4 @@ class TimeSensorAsync(BaseSensorOperator):
         self.target_datetime = timezone.convert_to_utc(aware_time)
 
     def execute(self, context: Context):
-        self.defer(trigger=DateTimeTrigger(moment=self.target_datetime, exit_task=True))
+        self.defer(trigger=DateTimeTrigger(moment=self.target_datetime, end_task=True))

--- a/airflow/sensors/time_sensor.py
+++ b/airflow/sensors/time_sensor.py
@@ -70,11 +70,4 @@ class TimeSensorAsync(BaseSensorOperator):
         self.target_datetime = timezone.convert_to_utc(aware_time)
 
     def execute(self, context: Context):
-        self.defer(
-            trigger=DateTimeTrigger(moment=self.target_datetime),
-            method_name="execute_complete",
-        )
-
-    def execute_complete(self, context, event=None):
-        """Callback for when the trigger fires - returns immediately."""
-        return None
+        self.defer(trigger=DateTimeTrigger(moment=self.target_datetime))

--- a/airflow/sensors/time_sensor.py
+++ b/airflow/sensors/time_sensor.py
@@ -70,4 +70,4 @@ class TimeSensorAsync(BaseSensorOperator):
         self.target_datetime = timezone.convert_to_utc(aware_time)
 
     def execute(self, context: Context):
-        self.defer(trigger=DateTimeTrigger(moment=self.target_datetime))
+        self.defer(trigger=DateTimeTrigger(moment=self.target_datetime, exit_task=True))

--- a/airflow/triggers/base.py
+++ b/airflow/triggers/base.py
@@ -115,7 +115,7 @@ class TriggerEvent:
     events.
     """
 
-    def __init__(self, payload: Any = None):
+    def __init__(self, payload):
         self.payload = payload
 
     def __repr__(self) -> str:

--- a/airflow/triggers/temporal.py
+++ b/airflow/triggers/temporal.py
@@ -20,7 +20,7 @@ import asyncio
 import datetime
 from typing import Any
 
-from airflow.triggers.base import BaseTrigger, TaskSuccessEvent
+from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.utils import timezone
 
 
@@ -69,7 +69,7 @@ class DateTimeTrigger(BaseTrigger):
             self.log.info("sleeping 1 second...")
             await asyncio.sleep(1)
         self.log.info("Sensor time condition reached; marking task successful and exiting")
-        yield TaskSuccessEvent()
+        yield TriggerEvent()
 
 
 class TimeDeltaTrigger(DateTimeTrigger):

--- a/airflow/triggers/temporal.py
+++ b/airflow/triggers/temporal.py
@@ -38,7 +38,7 @@ class DateTimeTrigger(BaseTrigger):
         reached or resume the task
     """
 
-    def __init__(self, moment: datetime.datetime, end_task=False):
+    def __init__(self, moment: datetime.datetime, *, end_task=False):
         super().__init__()
         if not isinstance(moment, datetime.datetime):
             raise TypeError(f"Expected datetime.datetime type for moment. Got {type(moment)}")
@@ -95,5 +95,5 @@ class TimeDeltaTrigger(DateTimeTrigger):
     DateTimeTrigger class, since they're operationally the same.
     """
 
-    def __init__(self, delta: datetime.timedelta, end_task=False):
+    def __init__(self, delta: datetime.timedelta, *, end_task=False):
         super().__init__(moment=timezone.utcnow() + delta, end_task=end_task)

--- a/airflow/triggers/temporal.py
+++ b/airflow/triggers/temporal.py
@@ -20,7 +20,7 @@ import asyncio
 import datetime
 from typing import Any
 
-from airflow.triggers.base import BaseTrigger, TriggerEvent
+from airflow.triggers.base import BaseTrigger, TaskSuccessEvent
 from airflow.utils import timezone
 
 
@@ -45,7 +45,7 @@ class DateTimeTrigger(BaseTrigger):
             self.moment = timezone.convert_to_utc(moment)
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
-        return ("airflow.triggers.temporal.DateTimeTrigger", {"moment": self.moment})
+        return "airflow.triggers.temporal.DateTimeTrigger", {"moment": self.moment}
 
     async def run(self):
         """
@@ -68,9 +68,8 @@ class DateTimeTrigger(BaseTrigger):
         while self.moment > timezone.utcnow():
             self.log.info("sleeping 1 second...")
             await asyncio.sleep(1)
-        # Send our single event and then we're done
-        self.log.info("yielding event with payload %r", self.moment)
-        yield TriggerEvent(self.moment)
+        self.log.info("Sensor time condition reached; marking task successful and exiting")
+        yield TaskSuccessEvent()
 
 
 class TimeDeltaTrigger(DateTimeTrigger):

--- a/airflow/triggers/temporal.py
+++ b/airflow/triggers/temporal.py
@@ -20,7 +20,7 @@ import asyncio
 import datetime
 from typing import Any
 
-from airflow.triggers.base import BaseTrigger, TriggerEvent
+from airflow.triggers.base import BaseTrigger, TaskSuccessEvent
 from airflow.utils import timezone
 
 
@@ -69,7 +69,7 @@ class DateTimeTrigger(BaseTrigger):
             self.log.info("sleeping 1 second...")
             await asyncio.sleep(1)
         self.log.info("Sensor time condition reached; marking task successful and exiting")
-        yield TriggerEvent()
+        yield TaskSuccessEvent()
 
 
 class TimeDeltaTrigger(DateTimeTrigger):

--- a/airflow/triggers/temporal.py
+++ b/airflow/triggers/temporal.py
@@ -34,11 +34,11 @@ class DateTimeTrigger(BaseTrigger):
     The provided datetime MUST be in UTC.
 
     :param moment: when to yield event
-    :param exit_task: whether the trigger should mark the task successful after time condition
+    :param end_task: whether the trigger should mark the task successful after time condition
         reached or resume the task
     """
 
-    def __init__(self, moment: datetime.datetime, exit_task=False):
+    def __init__(self, moment: datetime.datetime, end_task=False):
         super().__init__()
         if not isinstance(moment, datetime.datetime):
             raise TypeError(f"Expected datetime.datetime type for moment. Got {type(moment)}")
@@ -47,12 +47,12 @@ class DateTimeTrigger(BaseTrigger):
             raise ValueError("You cannot pass naive datetimes")
         else:
             self.moment = timezone.convert_to_utc(moment)
-        self.exit_task = exit_task
+        self.end_task = end_task
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         return "airflow.triggers.temporal.DateTimeTrigger", {
             "moment": self.moment,
-            "exit_task": self.exit_task,
+            "end_task": self.end_task,
         }
 
     async def run(self):
@@ -76,7 +76,7 @@ class DateTimeTrigger(BaseTrigger):
         while self.moment > timezone.utcnow():
             self.log.info("sleeping 1 second...")
             await asyncio.sleep(1)
-        if self.exit_task:
+        if self.end_task:
             self.log.info("Sensor time condition reached; marking task successful and exiting")
             yield TaskSuccessEvent()
         else:

--- a/airflow/triggers/temporal.py
+++ b/airflow/triggers/temporal.py
@@ -95,5 +95,5 @@ class TimeDeltaTrigger(DateTimeTrigger):
     DateTimeTrigger class, since they're operationally the same.
     """
 
-    def __init__(self, delta: datetime.timedelta, **kwargs):
-        super().__init__(moment=timezone.utcnow() + delta, **kwargs)
+    def __init__(self, delta: datetime.timedelta, end_task=False):
+        super().__init__(moment=timezone.utcnow() + delta, end_task=end_task)

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -603,8 +603,8 @@ class TestTaskInstance:
         ti.refresh_from_db()
         assert ti.state == "deferred"
 
-        # ti should have next_method == "__not_set__" when deferred without specifying method_name
-        assert ti.next_method == "__not_set__"
+        # ti should have next_method == "__trigger_exit__" when deferred without specifying method_name
+        assert ti.next_method == "__trigger_exit__"
         assert ti.next_kwargs == {}
 
         # simulate being set back to "scheduled" from the triggerer

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -603,8 +603,8 @@ class TestTaskInstance:
         ti.refresh_from_db()
         assert ti.state == "deferred"
 
-        # ti should have next_method == "__trigger_exit__" when deferred without specifying method_name
-        assert ti.next_method == "__trigger_exit__"
+        # ti should have next_method == "__not_set__" when deferred without specifying method_name
+        assert ti.next_method == "__not_set__"
         assert ti.next_kwargs == {}
 
         # simulate being set back to "scheduled" from the triggerer

--- a/tests/models/test_trigger.py
+++ b/tests/models/test_trigger.py
@@ -29,6 +29,7 @@ from airflow.triggers.base import TaskFailedEvent, TaskSkippedEvent, TaskSuccess
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.state import State
+from airflow.utils.xcom import XCOM_RETURN_KEY
 
 
 @pytest.fixture
@@ -152,7 +153,7 @@ def test_submit_event_task_end(session, create_task_instance, event_cls, expecte
     # now, for each type, submit event
     # verify that (1) task ends in right state and (2) xcom is pushed
     Trigger.submit_event(
-        trigger.id, event_cls(xcom_return="xcomret", other_xcom={"a": "b", "c": "d"}), session=session
+        trigger.id, event_cls(xcoms={XCOM_RETURN_KEY: "xcomret", "a": "b", "c": "d"}), session=session
     )
     # commit changes made by submit event and expire all cache to read from db.
     session.flush()

--- a/tests/models/test_trigger.py
+++ b/tests/models/test_trigger.py
@@ -23,9 +23,9 @@ import pytz
 
 from airflow.jobs.job import Job
 from airflow.jobs.triggerer_job_runner import TriggererJobRunner
-from airflow.models import TaskInstance, Trigger
+from airflow.models import TaskInstance, Trigger, XCom
 from airflow.operators.empty import EmptyOperator
-from airflow.triggers.base import TriggerEvent
+from airflow.triggers.base import TaskFailedEvent, TaskSkippedEvent, TaskSuccessEvent, TriggerEvent
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.state import State
@@ -88,7 +88,7 @@ def test_clean_unused(session, create_task_instance):
 def test_submit_event(session, create_task_instance):
     """
     Tests that events submitted to a trigger re-wake their dependent
-    task instances.
+    task instances if not using a TaskEndEvent.
     """
     # Make a trigger
     trigger = Trigger(classpath="airflow.triggers.testing.SuccessTrigger", kwargs={})
@@ -111,6 +111,58 @@ def test_submit_event(session, create_task_instance):
     updated_task_instance = session.query(TaskInstance).one()
     assert updated_task_instance.state == State.SCHEDULED
     assert updated_task_instance.next_kwargs == {"event": 42, "cheesecake": True}
+
+
+@pytest.mark.parametrize(
+    "event_cls, expected",
+    [
+        (TaskSuccessEvent, "success"),
+        (TaskFailedEvent, "failed"),
+        (TaskSkippedEvent, "skipped"),
+    ],
+)
+def test_submit_event_task_end(session, create_task_instance, event_cls, expected):
+    """
+    Tests that events inheriting BaseTaskEndEvent *don't* re-wake their dependent
+    but mark them in the appropriate terminal state and send xcom
+    """
+    # Make a trigger
+    trigger = Trigger(classpath="does.not.matter", kwargs={})
+    trigger.id = 1
+    session.add(trigger)
+    session.commit()
+    # Make a TaskInstance that's deferred and waiting on it
+    task_instance = create_task_instance(
+        session=session, execution_date=timezone.utcnow(), state=State.DEFERRED
+    )
+    task_instance.trigger_id = trigger.id
+    session.commit()
+
+    def get_xcoms(ti):
+        return XCom.get_many(dag_ids=[ti.dag_id], task_ids=[ti.task_id], run_id=ti.run_id).all()
+
+    # now for the real test
+    # first check initial state
+    ti: TaskInstance = session.query(TaskInstance).one()
+    assert ti.state == "deferred"
+    assert get_xcoms(ti) == []
+
+    session.flush()
+    session.expunge_all()
+    # now, for each type, submit event
+    # verify that (1) task ends in right state and (2) xcom is pushed
+    Trigger.submit_event(
+        trigger.id, event_cls(xcom_return="xcomret", other_xcom={"a": "b", "c": "d"}), session=session
+    )
+    # commit changes made by submit event and expire all cache to read from db.
+    session.flush()
+    session.expunge_all()
+    # Check that the task instance is now correct
+    ti = session.query(TaskInstance).one()
+    assert ti.state == expected
+    assert ti.next_kwargs is None
+    actual_xcoms = {x.key: x.value for x in get_xcoms(ti)}
+    assert actual_xcoms == {"return_value": "xcomret", "a": "b", "c": "d"}
 
 
 def test_submit_failure(session, create_task_instance):

--- a/tests/sensors/test_time_sensor.py
+++ b/tests/sensors/test_time_sensor.py
@@ -64,7 +64,6 @@ class TestTimeSensorAsync:
 
         assert isinstance(exc_info.value.trigger, DateTimeTrigger)
         assert exc_info.value.trigger.moment == timezone.datetime(2020, 7, 7, 10)
-        assert exc_info.value.method_name == "execute_complete"
         assert exc_info.value.kwargs is None
 
     def test_target_time_aware(self):

--- a/tests/triggers/test_temporal.py
+++ b/tests/triggers/test_temporal.py
@@ -25,6 +25,7 @@ import pytest
 from airflow.triggers.base import TriggerEvent
 from airflow.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
 from airflow.utils import timezone
+from airflow.utils.state import TaskInstanceState
 
 
 def test_input_validation():
@@ -95,4 +96,4 @@ async def test_datetime_trigger_timing(tz):
     assert trigger_task.done() is True
     result = trigger_task.result()
     assert isinstance(result, TriggerEvent)
-    assert result.payload == past_moment
+    assert result.payload == TaskInstanceState.SUCCESS

--- a/tests/triggers/test_temporal.py
+++ b/tests/triggers/test_temporal.py
@@ -45,7 +45,7 @@ def test_datetime_trigger_serialization():
     trigger = DateTimeTrigger(moment)
     classpath, kwargs = trigger.serialize()
     assert classpath == "airflow.triggers.temporal.DateTimeTrigger"
-    assert kwargs == {"moment": moment}
+    assert kwargs == {"moment": moment, "exit_task": trigger.exit_task}
 
 
 def test_timedelta_trigger_serialization():


### PR DESCRIPTION
With this change, if desired, we can avoid having to resume the task on a worker.  We can end the task (in states success, failed, or skipped) from the trigger itself.

Closes: #31718

cc @Lee-W 
