### PR TITLE
Add more prominent message explaining what to do when static checks fail

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -533,7 +533,21 @@ def static_checks(
     )
     if static_checks_result.returncode != 0:
         if os.environ.get("CI"):
-            get_console().print("[error]There were errors during pre-commit check. They should be fixed[/]")
+            get_console().print("\n[error]This error means that you have to fix the issues listed above:[/]")
+            get_console().print("\n[info]Some of the problems might be fixed automatically via pre-commit[/]")
+            get_console().print(
+                "\n[info]You can run it locally with: `pre-commit run --all-files` "
+                "but it might take quite some time.[/]"
+            )
+            get_console().print(
+                "\n[info]If you use breeze you can also run it faster via: "
+                "`breeze static-checks --only-my-changes` but it might produce slightly "
+                "different results.[/]"
+            )
+            get_console().print(
+                "\n[info]To run `pre-commit` as part of git workflow, use "
+                "`pre-commit install`. This will make pre-commit run as you commit changes[/]\n"
+            )
     sys.exit(static_checks_result.returncode)
 
 


### PR DESCRIPTION
Pre-commit prints a useful message when static check changes

```
Update ER diagram..................................................................Passed
pre-commit hook(s) made changes.
If you are seeing this message in CI, reproduce locally with: `pre-commit run --all-files`.
To run `pre-commit` as part of git workflow, use `pre-commit install`.
All changes made by hooks:
```

But it is not highglighted in any way in the CI output and it might be missed when users are not familiar with pre-commit.

We  repeat the message and add more detailed instructions what to do (Including helpful `breeze static-checks --only-my-changes` commamnd that helps to run static checks faster. We do it also in the way that will be more prominently displayed at the end of the output and highlighted. We can point the user to follow those instructions if they ask rather than explain them to look at CONTRIBUTING guide.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
