### PR TITLE
Bring back unicodecsv as depenendency of Airflow

### DIFF
--- a/licenses/LICENSE-unicodecsv.txt
+++ b/licenses/LICENSE-unicodecsv.txt
@@ -1,0 +1,25 @@
+Copyright 2010 Jeremy Dunck. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this list of
+      conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, this list
+      of conditions and the following disclaimer in the documentation and/or other materials
+      provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY JEREMY DUNCK ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JEREMY DUNCK OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those of the
+authors and should not be interpreted as representing official policies, either expressed
+or implied, of Jeremy Dunck.

--- a/setup.cfg
+++ b/setup.cfg
@@ -146,6 +146,11 @@ install_requires =
     tenacity>=6.2.0,!=8.2.0
     termcolor>=1.1.0
     typing-extensions>=4.0.0
+    # We should remove this dependency when Providers are limited to Airflow 2.7+
+    # as we replaced the usage of unicodecsv with csv in Airflow 2.7
+    # See https://github.com/apache/airflow/pull/31693
+    # We should also remove "licenses/LICENSE-unicodecsv.txt" file when we remove this dependency
+    unicodecsv>=0.14.1
     werkzeug>=2.0
 
 [options.packages.find]


### PR DESCRIPTION
Removing unicodescv as dependency invites problems when users will use older hive, google, microsoft providers, because they were using unicodecsv, but they did not declare it as dependency (it was a transitive dependency of the "apache-airflow" package).

It has been removed in #31693

Unicodecsv has very low footprint so this is not a problem to keep it.

The dependency misses license in it's package, therefore we add the licence in our "licences" folder.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
