### PR TITLE
Add descriptions for celery and dask cert configs

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2108,19 +2108,22 @@ celery:
       example: ~
       default: "False"
     ssl_key:
-      description: ~
+      description: |
+        Path to the client key.
       version_added: ~
       type: string
       example: ~
       default: ""
     ssl_cert:
-      description: ~
+      description: |
+        Path to the client certificate.
       version_added: ~
       type: string
       example: ~
       default: ""
     ssl_cacert:
-      description: ~
+      description: |
+        Path to the CA certificate.
       version_added: ~
       type: string
       example: ~
@@ -2213,19 +2216,21 @@ dask:
       default: "127.0.0.1:8786"
     tls_ca:
       description: |
-        TLS/ SSL settings to access a secured Dask scheduler.
+        Path to a CA certificate file encoded in PEM format to access a secured Dask scheduler.
       version_added: ~
       type: string
       example: ~
       default: ""
     tls_cert:
-      description: ~
+      description: |
+        Path to a certificate file for the client, encoded in PEM format.
       version_added: ~
       type: string
       example: ~
       default: ""
     tls_key:
-      description: ~
+      description: |
+        Path to a key file for the client, encoded in PEM format.
       version_added: ~
       type: string
       example: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1086,8 +1086,14 @@ sync_parallelism = 0
 # Import path for celery configuration options
 celery_config_options = airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG
 ssl_active = False
+
+# Path to the client key.
 ssl_key =
+
+# Path to the client certificate.
 ssl_cert =
+
+# Path to the CA certificate.
 ssl_cacert =
 
 # Celery Pool implementation.
@@ -1144,9 +1150,13 @@ worker_precheck = False
 # The IP address and port of the Dask cluster's scheduler.
 cluster_address = 127.0.0.1:8786
 
-# TLS/ SSL settings to access a secured Dask scheduler.
+# Path to a CA certificate file encoded in PEM format to access a secured Dask scheduler.
 tls_ca =
+
+# Path to a certificate file for the client, encoded in PEM format.
 tls_cert =
+
+# Path to a key file for the client, encoded in PEM format.
 tls_key =
 
 [scheduler]


### PR DESCRIPTION
We should clarify these are all paths, not actually the contents as strings.