### PR TITLE
Use a continuation token to get logs in ecs

### DIFF
--- a/airflow/providers/amazon/aws/hooks/ecs.py
+++ b/airflow/providers/amazon/aws/hooks/ecs.py
@@ -178,9 +178,9 @@ class EcsTaskLogFetcher(Thread):
             for log_event in log_events:
                 self.logger.info(self._event_to_str(log_event))
 
-    def _get_log_events(
-        self, skip_token: AwsLogsHook.ContinuationToken = AwsLogsHook.ContinuationToken()
-    ) -> Generator:
+    def _get_log_events(self, skip_token: AwsLogsHook.ContinuationToken | None = None) -> Generator:
+        if skip_token is None:
+            skip_token = AwsLogsHook.ContinuationToken()
         try:
             yield from self.hook.get_log_events(
                 self.log_group, self.log_stream_name, continuation_token=skip_token

--- a/airflow/providers/amazon/aws/hooks/ecs.py
+++ b/airflow/providers/amazon/aws/hooks/ecs.py
@@ -171,17 +171,20 @@ class EcsTaskLogFetcher(Thread):
         self.hook = AwsLogsHook(aws_conn_id=aws_conn_id, region_name=region_name)
 
     def run(self) -> None:
-        logs_to_skip = 0
+        continuation_token = AwsLogsHook.ContinuationToken()
         while not self.is_stopped():
             time.sleep(self.fetch_interval.total_seconds())
-            log_events = self._get_log_events(logs_to_skip)
+            log_events = self._get_log_events(continuation_token)
             for log_event in log_events:
                 self.logger.info(self._event_to_str(log_event))
-                logs_to_skip += 1
 
-    def _get_log_events(self, skip: int = 0) -> Generator:
+    def _get_log_events(
+        self, skip_token: AwsLogsHook.ContinuationToken = AwsLogsHook.ContinuationToken()
+    ) -> Generator:
         try:
-            yield from self.hook.get_log_events(self.log_group, self.log_stream_name, skip=skip)
+            yield from self.hook.get_log_events(
+                self.log_group, self.log_stream_name, continuation_token=skip_token
+            )
         except ClientError as error:
             if error.response["Error"]["Code"] != "ResourceNotFoundException":
                 self.logger.warning("Error on retrieving Cloudwatch log events", error)

--- a/airflow/providers/amazon/aws/hooks/logs.py
+++ b/airflow/providers/amazon/aws/hooks/logs.py
@@ -63,7 +63,7 @@ class AwsLogsHook(AwsBaseHook):
         start_time: int = 0,
         skip: int = 0,
         start_from_head: bool = True,
-        continuation_token: ContinuationToken = ContinuationToken(),
+        continuation_token: ContinuationToken | None = None,
     ) -> Generator:
         """
         A generator for log items in a single stream. This will yield all the
@@ -86,6 +86,9 @@ class AwsLogsHook(AwsBaseHook):
                  |   'message' (str): The log event data.
                  |   'ingestionTime' (int): The time in milliseconds the event was ingested.
         """
+        if continuation_token is None:
+            continuation_token = AwsLogsHook.ContinuationToken()
+
         num_consecutive_empty_response = 0
         while True:
             if continuation_token.value is not None:

--- a/airflow/providers/amazon/aws/hooks/logs.py
+++ b/airflow/providers/amazon/aws/hooks/logs.py
@@ -113,16 +113,16 @@ class AwsLogsHook(AwsBaseHook):
 
             yield from events
 
+            if continuation_token.value == response["nextForwardToken"]:
+                return
+
             if not event_count:
                 num_consecutive_empty_response += 1
                 if num_consecutive_empty_response >= NUM_CONSECUTIVE_EMPTY_RESPONSE_EXIT_THRESHOLD:
                     # Exit if there are more than NUM_CONSECUTIVE_EMPTY_RESPONSE_EXIT_THRESHOLD consecutive
                     # empty responses
                     return
-            elif continuation_token.value != response["nextForwardToken"]:
-                num_consecutive_empty_response = 0
             else:
-                # Exit if the value of nextForwardToken is same in subsequent calls
-                return
+                num_consecutive_empty_response = 0
 
             continuation_token.value = response["nextForwardToken"]

--- a/airflow/providers/amazon/aws/hooks/logs.py
+++ b/airflow/providers/amazon/aws/hooks/logs.py
@@ -50,6 +50,12 @@ class AwsLogsHook(AwsBaseHook):
         kwargs["client_type"] = "logs"
         super().__init__(*args, **kwargs)
 
+    class ContinuationToken:
+        """Just a wrapper around a str token to allow updating it from the caller."""
+
+        def __init__(self):
+            self.value: str | None = None
+
     def get_log_events(
         self,
         log_group: str,
@@ -57,6 +63,7 @@ class AwsLogsHook(AwsBaseHook):
         start_time: int = 0,
         skip: int = 0,
         start_from_head: bool = True,
+        continuation_token: ContinuationToken = ContinuationToken(),
     ) -> Generator:
         """
         A generator for log items in a single stream. This will yield all the
@@ -72,16 +79,17 @@ class AwsLogsHook(AwsBaseHook):
             This is for when there are multiple entries at the same timestamp.
         :param start_from_head: whether to start from the beginning (True) of the log or
             at the end of the log (False).
+        :param continuation_token: a wrapper around a token indicating where to read logs from.
+            Will be updated as this method reads new logs, to be reused in subsequent calls.
         :return: | A CloudWatch log event with the following key-value pairs:
                  |   'timestamp' (int): The time in milliseconds of the event.
                  |   'message' (str): The log event data.
                  |   'ingestionTime' (int): The time in milliseconds the event was ingested.
         """
         num_consecutive_empty_response = 0
-        next_token = None
         while True:
-            if next_token is not None:
-                token_arg: dict[str, str] = {"nextToken": next_token}
+            if continuation_token.value is not None:
+                token_arg: dict[str, str] = {"nextToken": continuation_token.value}
             else:
                 token_arg = {}
 
@@ -111,10 +119,10 @@ class AwsLogsHook(AwsBaseHook):
                     # Exit if there are more than NUM_CONSECUTIVE_EMPTY_RESPONSE_EXIT_THRESHOLD consecutive
                     # empty responses
                     return
-            elif next_token != response["nextForwardToken"]:
+            elif continuation_token.value != response["nextForwardToken"]:
                 num_consecutive_empty_response = 0
             else:
                 # Exit if the value of nextForwardToken is same in subsequent calls
                 return
 
-            next_token = response["nextForwardToken"]
+            continuation_token.value = response["nextForwardToken"]

--- a/airflow/providers/amazon/aws/hooks/logs.py
+++ b/airflow/providers/amazon/aws/hooks/logs.py
@@ -79,7 +79,7 @@ class AwsLogsHook(AwsBaseHook):
             This is for when there are multiple entries at the same timestamp.
         :param start_from_head: whether to start from the beginning (True) of the log or
             at the end of the log (False).
-        :param continuation_token: a wrapper around a token indicating where to read logs from.
+        :param continuation_token: a token indicating where to read logs from.
             Will be updated as this method reads new logs, to be reused in subsequent calls.
         :return: | A CloudWatch log event with the following key-value pairs:
                  |   'timestamp' (int): The time in milliseconds of the event.


### PR DESCRIPTION
The current implem browses logs from the start every time it tries to get new logs, which results in longer and longer fetching times, and also many calls that can potentially trigger rate limits.

There is a very simple way to avoid this, with the token returned by every request that allows to continue from where the last call left.