### PR TITLE
Add semi-automated deprecation removal process

### DIFF
--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -167,6 +167,11 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
 
         self.client = elasticsearch.Elasticsearch(host, **es_kwargs)
         # in airflow.cfg, host of elasticsearch has to be http://dockerhostXxxx:9200
+
+        if log_id_template is not None:
+            # todo: remove-on-provider-version=5.0 author=dstandish
+            #   remove log_id_template param in next major release
+            pass
         if USE_PER_RUN_LOG_ID and log_id_template is not None:
             warnings.warn(
                 "Passing log_id_template to ElasticsearchTaskHandler is deprecated and has no effect",

--- a/tests/test_utils/providers.py
+++ b/tests/test_utils/providers.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
+
 import semver
 
 
@@ -48,11 +50,14 @@ def get_provider_version(provider_name):
     return semver.VersionInfo.parse(info.version)
 
 
-def get_provider_min_airflow_version(provider_name):
-    from airflow.providers_manager import ProvidersManager
+def get_provider_min_airflow_version(provider_name, deps=None):
+    if not deps:  # this is a performance speedup when we have the provider data already
+        from airflow.providers_manager import ProvidersManager
 
-    p = ProvidersManager()
-    deps = p.providers[provider_name].data["dependencies"]
-    airflow_dep = next(x for x in deps if x.startswith("apache-airflow"))
-    min_airflow_version = tuple(map(int, airflow_dep.split(">=")[1].split(".")))
-    return min_airflow_version
+        data = ProvidersManager().providers[provider_name].data
+        deps = data["dependencies"]
+    with suppress(Exception):
+        airflow_dep = next(x for x in deps if x.startswith("apache-airflow"))
+        min_airflow_version = tuple(map(int, airflow_dep.split(">=")[1].split(".")))
+        return min_airflow_version
+    return 0, 0, 0


### PR DESCRIPTION
Ok I resurrected this PR from the dustbin @eladkal & @potiuk.

What this does is add two standardized "todo" directives that will allow us to essentially set a reminder to make certain code changes at provider release time.

It adds a new section to the github issue template:

```
Found providers with todos which should be addressed now. There are two classes of such todos. One is when the provider version is nowgreater than that specified in comment. The other is when the
current min airflow version for the provider is greaterthan specified in the comment.

## apache-airflow-providers-elasticsearch
### remove-on-provider-version
  - [ ] airflow/providers/elasticsearch/log/es_task_handler.py:169 (@dstandish)
```

This is achieved with two different todo directives:

One of them is about min airflow version:

```
# todo: remove-on-min-airflow-version=2.6 author=dstandish
```

When you add this, you'll get tagged when the new release bumps the min airflow version to 2.6 in that provider.

The other one is about provider version:

```
# todo: remove-on-provider-version=7.0 author=dstandish
```

With this one, I'll get notified at release time when provider version is bumped to 7.0.

This feels like a relatively simple enhancement that could help us remember to remove things.  And it is responsive to the concern that provider manager should not be blocked if the person who added the tag doesn't respond.

The "author" element is optional.

Let me know what you think