### PR TITLE
Change working directory for breeze unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,7 +384,8 @@ jobs:
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - run: breeze setup version
-      - run: python -m pytest ./dev/breeze/ -n auto --color=yes
+      - run: python -m pytest -n auto --color=yes
+        working-directory: ./dev/breeze/
       - run: breeze setup check-all-params-in-groups
 
   tests-www:


### PR DESCRIPTION
The recent version of pytest released on June 10th introduced change that it will read conftest tests starting in the directory which is current working directory, this causes breeze tests run with working directory being top airflow directory to fail because it's requirements do not contain a few libraries that are used in airflow's conftest.py

This change rather than specifying directory at pytest command line, changes working directory for the tests.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
