### PR TITLE
Cleanup Kubernetes < 1.23 support

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -720,16 +720,6 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{ $config | toJson | print }}
 {{- end }}
 
-{{/* Allow Kubernetes Version to be overridden. Credit to https://github.com/prometheus-community/helm-charts for Regex. */}}
-{{- define "kubeVersion" }}
-  {{- $kubeVersion := default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
-  {{/* Special use case for Amazon EKS, Google GKE */}}
-  {{- if and (regexMatch "\\d+\\.\\d+\\.\\d+-(?:eks|gke).+" $kubeVersion) (not .Values.kubeVersionOverride) -}}
-    {{- $kubeVersion = regexFind "\\d+\\.\\d+\\.\\d+" $kubeVersion -}}
-  {{- end -}}
-  {{- $kubeVersion -}}
-{{- end }}
-
 {{/*
 Set the default value for pod securityContext
 If no value is passed for securityContexts.pod or <node>.securityContexts.pod or legacy securityContext and <node>.securityContext, defaults to global uid and gid.

--- a/chart/templates/cleanup/cleanup-cronjob.yaml
+++ b/chart/templates/cleanup/cleanup-cronjob.yaml
@@ -26,11 +26,7 @@
 {{- $tolerations := or .Values.cleanup.tolerations .Values.tolerations }}
 {{- $topologySpreadConstraints := or .Values.cleanup.topologySpreadConstraints .Values.topologySpreadConstraints }}
 {{- $securityContext := include "airflowPodSecurityContext" (list . .Values.cleanup) }}
-{{- if semverCompare ">= 1.21.x" (include "kubeVersion" .) }}
 apiVersion: batch/v1
-{{- else }}
-apiVersion: batch/v1beta1
-{{- end }}
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-cleanup

--- a/chart/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
@@ -22,11 +22,7 @@
 #################################
 {{- if and .Values.pgbouncer.enabled .Values.pgbouncer.podDisruptionBudget.enabled }}
 kind: PodDisruptionBudget
-{{- if semverCompare ">= 1.21.x" (include "kubeVersion" .) }}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 metadata:
   name: {{ .Release.Name }}-pgbouncer-pdb
   labels:

--- a/chart/templates/scheduler/scheduler-poddisruptionbudget.yaml
+++ b/chart/templates/scheduler/scheduler-poddisruptionbudget.yaml
@@ -22,11 +22,7 @@
 #################################
 {{- if .Values.scheduler.podDisruptionBudget.enabled }}
 kind: PodDisruptionBudget
-{{- if semverCompare ">= 1.21.x" (include "kubeVersion" .) }}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 metadata:
   name: {{ .Release.Name }}-scheduler-pdb
   labels:

--- a/chart/templates/webserver/webserver-poddisruptionbudget.yaml
+++ b/chart/templates/webserver/webserver-poddisruptionbudget.yaml
@@ -22,11 +22,7 @@
 #################################
 {{- if .Values.webserver.podDisruptionBudget.enabled }}
 kind: PodDisruptionBudget
-{{- if semverCompare ">= 1.21.x" (include "kubeVersion" .) }}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 metadata:
   name: {{ .Release.Name }}-webserver-pdb
   labels:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -44,12 +44,6 @@
             "default": "",
             "x-docsSection": null
         },
-        "kubeVersionOverride": {
-            "description": "Provide a Kubernetes version (used for API Version selection) to override the auto-detected version",
-            "type": "string",
-            "default": "",
-            "x-docsSection": null
-        },
         "uid": {
             "description": "User of airflow user.",
             "type": "integer",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,9 +25,6 @@ fullnameOverride: ""
 # Provide a name to substitute for the name of the chart
 nameOverride: ""
 
-# Provide a Kubernetes version (used for API Version selection) to override the auto-detected version
-kubeVersionOverride: ""
-
 # Max number of old replicasets to retain. Can be overridden by each deployment's revisionHistoryLimit
 revisionHistoryLimit: ~
 


### PR DESCRIPTION
The PR cleans up support for Kubernetes 1.22 and older versions that was dropped in PR https://github.com/apache/airflow/pull/29884.

The property `kubeVersionOverride` and the named template `kubeVersion` are also deleted, because they are not used after the cleanup.