### PR TITLE
Restrict direct usage of driver params via extras for JDBC connection

### DIFF
--- a/airflow/providers/jdbc/CHANGELOG.rst
+++ b/airflow/providers/jdbc/CHANGELOG.rst
@@ -24,6 +24,20 @@
 Changelog
 ---------
 
+4.0.0
+.....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+To configure driver parameters (driver path and driver class), you can use the following methods:
+
+1. Supply them as constructor arguments when instantiating the hook.
+2. Set the "driver_path" and/or "driver_class" parameters in the "hook_params" dictionary when creating the hook using SQL operators.
+3. Set the "driver_path" and/or "driver_class" extra in the connection and correspondingly enable the "allow_driver_path_in_extra" and/or "allow_driver_class_in_extra" options in the "providers.jdbc" section of the Airflow configuration.
+4. Patch the "JdbcHook.default_driver_path" and/or "JdbcHook.default_driver_class" values in the "local_settings.py" file.
+
+
 3.4.0
 .....
 

--- a/airflow/providers/jdbc/hooks/jdbc.py
+++ b/airflow/providers/jdbc/hooks/jdbc.py
@@ -41,7 +41,7 @@ class JdbcHook(DbApiHook):
            "providers.jdbc" section of the Airflow configuration. If you're enabling these options in Airflow
            configuration, you should make sure that you trust the users who can edit connections in the UI
            to not use it maliciously.
-        4. Patch the "JdbcHook.default_driver_path" and/or "JdbcHook.default_driver_class" values in the
+        4. Patch the ``JdbcHook.default_driver_path`` and/or ``JdbcHook.default_driver_class`` values in the
            "local_settings.py" file.
 
     See :doc:`/connections/jdbc` for full documentation.

--- a/airflow/providers/jdbc/hooks/jdbc.py
+++ b/airflow/providers/jdbc/hooks/jdbc.py
@@ -38,7 +38,9 @@ class JdbcHook(DbApiHook):
            creating the hook using SQL operators.
         3. Set the "driver_path" and/or "driver_class" extra in the connection and correspondingly enable
            the "allow_driver_path_in_extra" and/or "allow_driver_class_in_extra" options in the
-           "providers.jdbc" section of the Airflow configuration.
+           "providers.jdbc" section of the Airflow configuration. If you're enabling these options in Airflow
+           configuration, you should make sure that you trust the users who can edit connections in the UI
+           to not use it maliciously.
         4. Patch the "JdbcHook.default_driver_path" and/or "JdbcHook.default_driver_class" values in the
            "local_settings.py" file.
 

--- a/airflow/providers/jdbc/hooks/jdbc.py
+++ b/airflow/providers/jdbc/hooks/jdbc.py
@@ -35,12 +35,19 @@ class JdbcHook(DbApiHook):
     To configure driver parameters, you can use the following methods:
         1. Supply them as constructor arguments when instantiating the hook.
         2. Set the "driver_path" and/or "driver_class" parameters in the "hook_params" dictionary when
-        creating the hook using SQL operators.
+           creating the hook using SQL operators.
         3. Set the "driver_path" and/or "driver_class" extra in the connection and correspondingly enable
-        the "allow_driver_path_in_extra" and/or "allow_driver_class_in_extra" options in the "providers.jdbc"
-        section of the Airflow configuration.
+           the "allow_driver_path_in_extra" and/or "allow_driver_class_in_extra" options in the
+           "providers.jdbc" section of the Airflow configuration.
         4. Patch the "JdbcHook.default_driver_path" and/or "JdbcHook.default_driver_class" values in the
-        "local_settings.py" file.
+           "local_settings.py" file.
+
+    See :doc:`/connections/jdbc` for full documentation.
+
+    :param args: passed to DbApiHook
+    :param driver_path: path to the JDBC driver jar file. See above for more info
+    :param driver_class: name of the JDBC driver class. See above for more info
+    :param kwargs: passed to DbApiHook
     """
 
     conn_name_attr = "jdbc_conn_id"

--- a/airflow/providers/jdbc/hooks/jdbc.py
+++ b/airflow/providers/jdbc/hooks/jdbc.py
@@ -31,6 +31,16 @@ class JdbcHook(DbApiHook):
     JDBC URL, username and password will be taken from the predefined connection.
     Note that the whole JDBC URL must be specified in the "host" field in the DB.
     Raises an airflow error if the given connection id doesn't exist.
+
+    To configure driver parameters, you can use the following methods:
+        1. Supply them as constructor arguments when instantiating the hook.
+        2. Set the "driver_path" and/or "driver_class" parameters in the "hook_params" dictionary when
+        creating the hook using SQL operators.
+        3. Set the "driver_path" and/or "driver_class" extra in the connection and correspondingly enable
+        the "allow_driver_path_in_extra" and/or "allow_driver_class_in_extra" options in the "providers.jdbc"
+        section of the Airflow configuration.
+        4. Patch the "JdbcHook.default_driver_path" and/or "JdbcHook.default_driver_class" values in the
+        "local_settings.py" file.
     """
 
     conn_name_attr = "jdbc_conn_id"
@@ -39,57 +49,89 @@ class JdbcHook(DbApiHook):
     hook_name = "JDBC Connection"
     supports_autocommit = True
 
-    @staticmethod
-    def get_connection_form_widgets() -> dict[str, Any]:
-        """Get connection widgets to add to connection form."""
-        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
-        from flask_babel import lazy_gettext
-        from wtforms import StringField
+    default_driver_path: str | None = None
+    default_driver_class: str | None = None
 
-        return {
-            "drv_path": StringField(lazy_gettext("Driver Path"), widget=BS3TextFieldWidget()),
-            "drv_clsname": StringField(lazy_gettext("Driver Class"), widget=BS3TextFieldWidget()),
-        }
+    def __init__(
+        self,
+        *args,
+        driver_path: str | None = None,
+        driver_class: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._driver_path = driver_path
+        self._driver_class = driver_class
 
     @staticmethod
     def get_ui_field_behaviour() -> dict[str, Any]:
         """Get custom field behaviour."""
         return {
-            "hidden_fields": ["port", "schema", "extra"],
+            "hidden_fields": ["port", "schema"],
             "relabeling": {"host": "Connection URL"},
         }
 
-    def _get_field(self, extras: dict, field_name: str):
-        """Get field from extra.
-
-        This first checks the short name, then check for prefixed name for
-        backward compatibility.
+    @property
+    def connection_extra_lower(self) -> dict:
         """
-        backcompat_prefix = "extra__jdbc__"
-        if field_name.startswith("extra__"):
-            raise ValueError(
-                f"Got prefixed name {field_name}; please remove the '{backcompat_prefix}' prefix "
-                "when using this method."
-            )
-        if field_name in extras:
-            return extras[field_name] or None
-        prefixed_name = f"{backcompat_prefix}{field_name}"
-        return extras.get(prefixed_name) or None
+        ``connection.extra_dejson`` but where keys are converted to lower case.
+
+        This is used internally for case-insensitive access of jdbc params.
+        """
+        conn = self.get_connection(getattr(self, self.conn_name_attr))
+        return {k.lower(): v for k, v in conn.extra_dejson.items()}
+
+    @property
+    def driver_path(self) -> str | None:
+        from airflow.configuration import conf
+
+        extra_driver_path = self.connection_extra_lower.get("driver_path")
+        if extra_driver_path:
+            if conf.getboolean("providers.jdbc", "allow_driver_path_in_extra", fallback=False):
+                self._driver_path = extra_driver_path
+            else:
+                self.log.warning(
+                    "You have supplied 'driver_path' via connection extra but it will not be used. In order "
+                    "to use 'driver_path' from extra you must set airflow config setting "
+                    "`allow_driver_path_in_extra = True` in section `providers.jdbc`. Alternatively you may "
+                    "specify it via 'driver_path' parameter of the hook constructor or via 'hook_params' "
+                    "dictionary with key 'driver_path' if using SQL operators."
+                )
+        if not self._driver_path:
+            self._driver_path = self.default_driver_path
+        return self._driver_path
+
+    @property
+    def driver_class(self) -> str | None:
+        from airflow.configuration import conf
+
+        extra_driver_class = self.connection_extra_lower.get("driver_class")
+        if extra_driver_class:
+            if conf.getboolean("providers.jdbc", "allow_driver_class_in_extra", fallback=False):
+                self._driver_class = extra_driver_class
+            else:
+                self.log.warning(
+                    "You have supplied 'driver_class' via connection extra but it will not be used. In order "
+                    "to use 'driver_class' from extra you must set airflow config setting "
+                    "`allow_driver_class_in_extra = True` in section `providers.jdbc`. Alternatively you may "
+                    "specify it via 'driver_class' parameter of the hook constructor or via 'hook_params' "
+                    "dictionary with key 'driver_class' if using SQL operators."
+                )
+        if not self._driver_class:
+            self._driver_class = self.default_driver_class
+        return self._driver_class
 
     def get_conn(self) -> jaydebeapi.Connection:
         conn: Connection = self.get_connection(getattr(self, self.conn_name_attr))
-        extras = conn.extra_dejson
         host: str = conn.host
         login: str = conn.login
         psw: str = conn.password
-        jdbc_driver_loc: str | None = self._get_field(extras, "drv_path")
-        jdbc_driver_name: str | None = self._get_field(extras, "drv_clsname")
 
         conn = jaydebeapi.connect(
-            jclassname=jdbc_driver_name,
+            jclassname=self.driver_class,
             url=str(host),
             driver_args=[str(login), str(psw)],
-            jars=jdbc_driver_loc.split(",") if jdbc_driver_loc else None,
+            jars=self.driver_path.split(",") if self.driver_path else None,
         )
         return conn
 

--- a/airflow/providers/jdbc/provider.yaml
+++ b/airflow/providers/jdbc/provider.yaml
@@ -23,6 +23,7 @@ description: |
 
 suspended: false
 versions:
+  - 4.0.0
   - 3.4.0
   - 3.3.0
   - 3.2.1

--- a/docs/apache-airflow-providers-jdbc/connections/jdbc.rst
+++ b/docs/apache-airflow-providers-jdbc/connections/jdbc.rst
@@ -43,6 +43,14 @@ Port (optional)
 Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in JDBC connection. The following parameters out of the standard python parameters are supported:
 
-    * ``conn_prefix`` - Used to build the connection url in ``JdbcOperator``, added in front of host (``conn_prefix`` ``host`` [: ``port`` ] / ``schema``)
-    * ``drv_clsname`` - Full qualified Java class name of the JDBC driver. For ``JdbcOperator``.
-    * ``drv_path`` - Jar filename or sequence of filenames for the JDBC driver libs. For ``JdbcOperator``.
+    - ``driver_class``
+      * Full qualified Java class name of the JDBC driver. For ``JdbcOperator``.
+        Note that this is only considered if ``allow_driver_class_in_extra`` is set to True in airflow config section
+        ``providers.jdbc`` (by default it is not considered).  Note: if setting this config from env vars, use
+        ``AIRFLOW__PROVIDERS_JDBC__ALLOW_DRIVER_CLASS_IN_EXTRA=true``.
+
+    - ``driver_path``
+      * Jar filename or sequence of filenames for the JDBC driver libs. For ``JdbcOperator``.
+      Note that this is only considered if ``allow_driver_path_in_extra`` is set to True in airflow config section
+        ``providers.jdbc`` (by default it is not considered).  Note: if setting this config from env vars, use
+        ``AIRFLOW__PROVIDERS_JDBC__ALLOW_DRIVER_PATH_IN_EXTRA=true``.

--- a/docs/apache-airflow-providers-jdbc/connections/jdbc.rst
+++ b/docs/apache-airflow-providers-jdbc/connections/jdbc.rst
@@ -54,3 +54,8 @@ Extra (optional)
           Note that this is only considered if ``allow_driver_path_in_extra`` is set to True in airflow config section
           ``providers.jdbc`` (by default it is not considered).  Note: if setting this config from env vars, use
           ``AIRFLOW__PROVIDERS_JDBC__ALLOW_DRIVER_PATH_IN_EXTRA=true``.
+
+    .. note::
+        Setting ``allow_driver_path_in_extra`` or ``allow_driver_class_in_extra`` to True allows users to set the driver
+        via the Airflow Connection's ``extra`` field.  By default this is not allowed.  If enabling this functionality,
+        you should make sure that you trust the users who can edit connections in the UI to not use it maliciously.

--- a/docs/apache-airflow-providers-jdbc/connections/jdbc.rst
+++ b/docs/apache-airflow-providers-jdbc/connections/jdbc.rst
@@ -44,13 +44,13 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in JDBC connection. The following parameters out of the standard python parameters are supported:
 
     - ``driver_class``
-      * Full qualified Java class name of the JDBC driver. For ``JdbcOperator``.
-        Note that this is only considered if ``allow_driver_class_in_extra`` is set to True in airflow config section
-        ``providers.jdbc`` (by default it is not considered).  Note: if setting this config from env vars, use
-        ``AIRFLOW__PROVIDERS_JDBC__ALLOW_DRIVER_CLASS_IN_EXTRA=true``.
+        * Full qualified Java class name of the JDBC driver. For ``JdbcOperator``.
+          Note that this is only considered if ``allow_driver_class_in_extra`` is set to True in airflow config section
+          ``providers.jdbc`` (by default it is not considered).  Note: if setting this config from env vars, use
+          ``AIRFLOW__PROVIDERS_JDBC__ALLOW_DRIVER_CLASS_IN_EXTRA=true``.
 
     - ``driver_path``
-      * Jar filename or sequence of filenames for the JDBC driver libs. For ``JdbcOperator``.
-      Note that this is only considered if ``allow_driver_path_in_extra`` is set to True in airflow config section
-        ``providers.jdbc`` (by default it is not considered).  Note: if setting this config from env vars, use
-        ``AIRFLOW__PROVIDERS_JDBC__ALLOW_DRIVER_PATH_IN_EXTRA=true``.
+        * Jar filename or sequence of filenames for the JDBC driver libs. For ``JdbcOperator``.
+          Note that this is only considered if ``allow_driver_path_in_extra`` is set to True in airflow config section
+          ``providers.jdbc`` (by default it is not considered).  Note: if setting this config from env vars, use
+          ``AIRFLOW__PROVIDERS_JDBC__ALLOW_DRIVER_PATH_IN_EXTRA=true``.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -788,7 +788,6 @@ javascript
 jaydebeapi
 Jdbc
 jdbc
-JdbcHook
 jdk
 jenkins
 JenkinsRequest

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -788,6 +788,7 @@ javascript
 jaydebeapi
 Jdbc
 jdbc
+JdbcHook
 jdk
 jenkins
 JenkinsRequest


### PR DESCRIPTION
Restrict direct usage of driver params via extras and add 
configuration requirements to allow it. Additionally,
several other ways have been added to achieve setting
the driver parameters.



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
