### PR TITLE
Align `apiVersion` and `kind` order in chart templates

### DIFF
--- a/chart/templates/cleanup/cleanup-serviceaccount.yaml
+++ b/chart/templates/cleanup/cleanup-serviceaccount.yaml
@@ -21,8 +21,8 @@
 ## Airflow Cleanup ServiceAccount
 #################################
 {{- if and .Values.cleanup.serviceAccount.create .Values.cleanup.enabled }}
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: {{ include "cleanup.serviceAccountName" . }}
   labels:

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -29,8 +29,8 @@
 {{- $revisionHistoryLimit := or .Values.dagProcessor.revisionHistoryLimit .Values.revisionHistoryLimit }}
 {{- $securityContext := include "airflowPodSecurityContext" (list . .Values.dagProcessor) }}
 {{- $containerSecurityContext := include "containerSecurityContext" (list . .Values.dagProcessor) }}
-kind: Deployment
 apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: {{ .Release.Name }}-dag-processor
   labels:

--- a/chart/templates/dag-processor/dag-processor-serviceaccount.yaml
+++ b/chart/templates/dag-processor/dag-processor-serviceaccount.yaml
@@ -22,8 +22,8 @@
 #################################
 {{- if semverCompare ">=2.3.0" .Values.airflowVersion }}
 {{- if and .Values.dagProcessor.serviceAccount.create .Values.dagProcessor.enabled }}
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: {{ include "dagProcessor.serviceAccountName" . }}
   labels:

--- a/chart/templates/dags-persistent-volume-claim.yaml
+++ b/chart/templates/dags-persistent-volume-claim.yaml
@@ -21,8 +21,8 @@
 ## Airflow DAGs PersistentVolumeClaim
 ######################################
 {{- if and (not .Values.dags.persistence.existingClaim ) .Values.dags.persistence.enabled }}
-kind: PersistentVolumeClaim
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: {{ template "airflow_dags_volume_claim" . }}
   labels:

--- a/chart/templates/flower/flower-deployment.yaml
+++ b/chart/templates/flower/flower-deployment.yaml
@@ -29,8 +29,8 @@
 {{- $revisionHistoryLimit := or .Values.flower.revisionHistoryLimit .Values.revisionHistoryLimit }}
 {{- $securityContext := include "airflowPodSecurityContext" (list . .Values.flower) }}
 {{- $containerSecurityContext := include "containerSecurityContext" (list . .Values.flower) }}
-kind: Deployment
 apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: {{ .Release.Name }}-flower
   labels:

--- a/chart/templates/flower/flower-service.yaml
+++ b/chart/templates/flower/flower-service.yaml
@@ -22,8 +22,8 @@
 #################################
 {{- if .Values.flower.enabled }}
 {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: {{ .Release.Name }}-flower
   labels:

--- a/chart/templates/flower/flower-serviceaccount.yaml
+++ b/chart/templates/flower/flower-serviceaccount.yaml
@@ -21,8 +21,8 @@
 ## Airflow Flower ServiceAccount
 ######################################
 {{- if and .Values.flower.enabled (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")) .Values.flower.serviceAccount.create }}
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: {{ include "flower.serviceAccountName" . }}
   labels:

--- a/chart/templates/jobs/create-user-job-serviceaccount.yaml
+++ b/chart/templates/jobs/create-user-job-serviceaccount.yaml
@@ -21,8 +21,8 @@
 ## Airflow Create User Job ServiceAccount
 ###########################################
 {{- if and .Values.createUserJob.serviceAccount.create .Values.webserver.defaultUser.enabled }}
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: {{ include "createUserJob.serviceAccountName" . }}
   labels:

--- a/chart/templates/jobs/migrate-database-job-serviceaccount.yaml
+++ b/chart/templates/jobs/migrate-database-job-serviceaccount.yaml
@@ -21,8 +21,8 @@
 ## Airflow Migrate Database Job ServiceAccount
 ##############################################
 {{- if .Values.migrateDatabaseJob.serviceAccount.create }}
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: {{ include "migrateDatabaseJob.serviceAccountName" . }}
   labels:

--- a/chart/templates/logs-persistent-volume-claim.yaml
+++ b/chart/templates/logs-persistent-volume-claim.yaml
@@ -21,8 +21,8 @@
 ## Airflow LOGs PersistentVolumeClaim
 ######################################
 {{- if and (not .Values.logs.persistence.existingClaim ) .Values.logs.persistence.enabled }}
-kind: PersistentVolumeClaim
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: {{ template "airflow_logs_volume_claim" . }}
   labels:

--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -28,8 +28,8 @@
 {{- $revisionHistoryLimit := or .Values.pgbouncer.revisionHistoryLimit .Values.revisionHistoryLimit }}
 {{- $containerSecurityContext := include "containerSecurityContext" (list . .Values.pgbouncer) }}
 {{- $containerSecurityContextMetricsExporter := include "containerSecurityContext" (list . .Values.pgbouncer.metricsExporterSidecar) }}
-kind: Deployment
 apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: {{ .Release.Name }}-pgbouncer
   labels:

--- a/chart/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
@@ -21,8 +21,8 @@
 ## Pgbouncer PodDisruptionBudget
 #################################
 {{- if and .Values.pgbouncer.enabled .Values.pgbouncer.podDisruptionBudget.enabled }}
-kind: PodDisruptionBudget
 apiVersion: policy/v1
+kind: PodDisruptionBudget
 metadata:
   name: {{ .Release.Name }}-pgbouncer-pdb
   labels:

--- a/chart/templates/pgbouncer/pgbouncer-serviceaccount.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-serviceaccount.yaml
@@ -21,8 +21,8 @@
 ## Airflow Pgbouncer ServiceAccount
 ######################################
 {{- if and .Values.pgbouncer.serviceAccount.create .Values.pgbouncer.enabled }}
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: {{ include "pgbouncer.serviceAccountName" . }}
   labels:

--- a/chart/templates/rbac/pod-cleanup-role.yaml
+++ b/chart/templates/rbac/pod-cleanup-role.yaml
@@ -21,8 +21,8 @@
 ## Airflow Cleanup Role
 #################################
 {{- if and .Values.rbac.create .Values.cleanup.enabled }}
-kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
 metadata:
   name: {{ .Release.Name }}-cleanup-role
   labels:

--- a/chart/templates/rbac/pod-cleanup-rolebinding.yaml
+++ b/chart/templates/rbac/pod-cleanup-rolebinding.yaml
@@ -21,8 +21,8 @@
 ## Airflow Cleanup Role Binding
 #################################
 {{- if and .Values.rbac.create .Values.cleanup.enabled }}
-kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-cleanup-rolebinding
   labels:

--- a/chart/templates/rbac/pod-launcher-role.yaml
+++ b/chart/templates/rbac/pod-launcher-role.yaml
@@ -21,12 +21,12 @@
 ## Airflow Pod Launcher Role
 #################################
 {{- if and .Values.rbac.create .Values.allowPodLaunching }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.multiNamespaceMode }}
 kind: ClusterRole
 {{- else }}
 kind: Role
 {{- end }}
-apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-pod-launcher-role
   {{- if not .Values.multiNamespaceMode }}

--- a/chart/templates/rbac/pod-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/pod-launcher-rolebinding.yaml
@@ -23,12 +23,12 @@
 {{- if and .Values.rbac.create .Values.allowPodLaunching }}
 {{- $schedulerLaunchExecutors := list "LocalExecutor" "LocalKubernetesExecutor" "KubernetesExecutor" "CeleryKubernetesExecutor" }}
 {{- $workerLaunchExecutors := list "CeleryExecutor" "LocalKubernetesExecutor" "KubernetesExecutor" "CeleryKubernetesExecutor" }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.multiNamespaceMode }}
 kind: ClusterRoleBinding
 {{- else }}
 kind: RoleBinding
 {{- end }}
-apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   {{- if not .Values.multiNamespaceMode }}
   namespace: "{{ .Release.Namespace }}"

--- a/chart/templates/rbac/pod-log-reader-role.yaml
+++ b/chart/templates/rbac/pod-log-reader-role.yaml
@@ -21,12 +21,12 @@
 ## Airflow Pod Reader Role
 #################################
 {{- if and .Values.rbac.create (or .Values.webserver.allowPodLogReading .Values.triggerer.enabled) }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.multiNamespaceMode }}
 kind: ClusterRole
 {{- else }}
 kind: Role
 {{- end }}
-apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-pod-log-reader-role
   {{- if not .Values.multiNamespaceMode }}

--- a/chart/templates/rbac/pod-log-reader-rolebinding.yaml
+++ b/chart/templates/rbac/pod-log-reader-rolebinding.yaml
@@ -21,12 +21,12 @@
 ## Airflow Pod Reader Role Binding
 #################################
 {{- if and .Values.rbac.create (or .Values.webserver.allowPodLogReading .Values.triggerer.enabled) }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.multiNamespaceMode }}
 kind: ClusterRoleBinding
 {{- else }}
 kind: RoleBinding
 {{- end }}
-apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   {{- if not .Values.multiNamespaceMode }}
   namespace: "{{ .Release.Namespace }}"

--- a/chart/templates/rbac/security-context-constraint-rolebinding.yaml
+++ b/chart/templates/rbac/security-context-constraint-rolebinding.yaml
@@ -22,12 +22,12 @@
 #################################
 {{- if and .Values.rbac.create .Values.rbac.createSCCRoleBinding }}
 {{- $hasWorkers := has .Values.executor (list "CeleryExecutor" "LocalKubernetesExecutor" "KubernetesExecutor" "CeleryKubernetesExecutor") }}
+apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.multiNamespaceMode }}
 kind: ClusterRoleBinding
 {{- else }}
 kind: RoleBinding
 {{- end }}
-apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   {{- if not .Values.multiNamespaceMode }}
   namespace: "{{ .Release.Namespace }}"

--- a/chart/templates/redis/redis-service.yaml
+++ b/chart/templates/redis/redis-service.yaml
@@ -21,8 +21,8 @@
 ## Airflow Redis Service
 #################################
 {{- if and .Values.redis.enabled (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")) }}
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: {{ .Release.Name }}-redis
   labels:

--- a/chart/templates/redis/redis-serviceaccount.yaml
+++ b/chart/templates/redis/redis-serviceaccount.yaml
@@ -21,8 +21,8 @@
 ## Airflow Redis ServiceAccount
 ######################################
 {{- if and .Values.redis.enabled .Values.redis.serviceAccount.create (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")) }}
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: {{ include "redis.serviceAccountName" . }}
   labels:

--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -27,8 +27,8 @@
 {{- $topologySpreadConstraints := or .Values.redis.topologySpreadConstraints .Values.topologySpreadConstraints }}
 {{- $securityContext := include "localPodSecurityContext" .Values.redis }}
 {{- $containerSecurityContext := include "containerSecurityContext" (list . .Values.redis) }}
-kind: StatefulSet
 apiVersion: apps/v1
+kind: StatefulSet
 metadata:
   name: {{ .Release.Name }}-redis
   labels:

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -41,8 +41,8 @@
 {{- $containerSecurityContext := include "containerSecurityContext" (list . .Values.scheduler) }}
 {{- $containerSecurityContextWaitForMigrations := include "containerSecurityContext" (list . .Values.scheduler.waitForMigrations) }}
 {{- $containerSecurityContextLogGroomerSidecar := include "containerSecurityContext" (list . .Values.scheduler.logGroomerSidecar) }}
-kind: {{ if $stateful }}StatefulSet{{ else }}Deployment{{ end }}
 apiVersion: apps/v1
+kind: {{ if $stateful }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
   name: {{ .Release.Name }}-scheduler
   labels:

--- a/chart/templates/scheduler/scheduler-poddisruptionbudget.yaml
+++ b/chart/templates/scheduler/scheduler-poddisruptionbudget.yaml
@@ -21,8 +21,8 @@
 ## Airflow Scheduler PodDisruptionBudget
 #################################
 {{- if .Values.scheduler.podDisruptionBudget.enabled }}
-kind: PodDisruptionBudget
 apiVersion: policy/v1
+kind: PodDisruptionBudget
 metadata:
   name: {{ .Release.Name }}-scheduler-pdb
   labels:

--- a/chart/templates/scheduler/scheduler-service.yaml
+++ b/chart/templates/scheduler/scheduler-service.yaml
@@ -21,8 +21,8 @@
 ## Airflow Scheduler Service
 #################################
 {{- if or (eq .Values.executor "LocalExecutor") (eq .Values.executor "LocalKubernetesExecutor") }}
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: {{ .Release.Name }}-scheduler
   labels:

--- a/chart/templates/scheduler/scheduler-serviceaccount.yaml
+++ b/chart/templates/scheduler/scheduler-serviceaccount.yaml
@@ -21,8 +21,8 @@
 ## Airflow Scheduler ServiceAccount
 #################################
 {{- if .Values.scheduler.serviceAccount.create }}
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: {{ include "scheduler.serviceAccountName" . }}
   labels:

--- a/chart/templates/secrets/elasticsearch-secret.yaml
+++ b/chart/templates/secrets/elasticsearch-secret.yaml
@@ -21,8 +21,8 @@
 ## Elasticsearch Secret
 #################################
 {{- if (and .Values.elasticsearch.enabled (not .Values.elasticsearch.secretName)) }}
-kind: Secret
 apiVersion: v1
+kind: Secret
 metadata:
   name: {{ .Release.Name }}-elasticsearch
   labels:

--- a/chart/templates/secrets/fernetkey-secret.yaml
+++ b/chart/templates/secrets/fernetkey-secret.yaml
@@ -22,8 +22,8 @@
 #################################
 {{- if not .Values.fernetKeySecretName }}
 {{- $generated_fernet_key := (randAlphaNum 32 | b64enc) }}
-kind: Secret
 apiVersion: v1
+kind: Secret
 metadata:
   name: {{ .Release.Name }}-fernet-key
   labels:

--- a/chart/templates/secrets/flower-secret.yaml
+++ b/chart/templates/secrets/flower-secret.yaml
@@ -21,8 +21,8 @@
 ## Flower Secret
 #################################
 {{- if (and (not .Values.flower.secretName) .Values.flower.username .Values.flower.password) }}
-kind: Secret
 apiVersion: v1
+kind: Secret
 metadata:
   name: {{ .Release.Name }}-flower
   labels:

--- a/chart/templates/secrets/kerberos-keytab-secret.yaml
+++ b/chart/templates/secrets/kerberos-keytab-secret.yaml
@@ -22,6 +22,7 @@
 #################################
 {{- if .Values.kerberos.keytabBase64Content }}
 apiVersion: v1
+kind: Secret
 metadata:
   name: {{ include "kerberos_keytab_secret" . | quote }}
   labels:
@@ -33,8 +34,7 @@ metadata:
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
+type: Opaque
 data:
   kerberos.keytab: {{ .Values.kerberos.keytabBase64Content }}
-kind: Secret
-type: Opaque
 {{- end }}

--- a/chart/templates/secrets/metadata-connection-secret.yaml
+++ b/chart/templates/secrets/metadata-connection-secret.yaml
@@ -28,8 +28,8 @@
 {{- $port := ((ternary .Values.ports.pgbouncer .Values.data.metadataConnection.port .Values.pgbouncer.enabled) | toString) }}
 {{- $database := (ternary (printf "%s-%s" .Release.Name "metadata") .Values.data.metadataConnection.db .Values.pgbouncer.enabled) }}
 {{- $query := ternary (printf "sslmode=%s" .Values.data.metadataConnection.sslmode) "" (eq .Values.data.metadataConnection.protocol "postgresql") }}
-kind: Secret
 apiVersion: v1
+kind: Secret
 metadata:
   name: {{ .Release.Name }}-airflow-metadata
   labels:

--- a/chart/templates/secrets/pgbouncer-certificates-secret.yaml
+++ b/chart/templates/secrets/pgbouncer-certificates-secret.yaml
@@ -21,8 +21,8 @@
 ## Pgbouncer Certificate Secret
 #################################
 {{- if or .Values.pgbouncer.ssl.ca .Values.pgbouncer.ssl.cert .Values.pgbouncer.ssl.key }}
-kind: Secret
 apiVersion: v1
+kind: Secret
 metadata:
   name: {{ template "pgbouncer_certificates_secret" . }}
   labels:

--- a/chart/templates/secrets/pgbouncer-config-secret.yaml
+++ b/chart/templates/secrets/pgbouncer-config-secret.yaml
@@ -21,8 +21,8 @@
 ## Pgbouncer Config Secret
 #################################
 {{- if (and .Values.pgbouncer.enabled (not .Values.pgbouncer.configSecretName)) }}
-kind: Secret
 apiVersion: v1
+kind: Secret
 metadata:
   name: {{ template "pgbouncer_config_secret" . }}
   labels:

--- a/chart/templates/secrets/pgbouncer-stats-secret.yaml
+++ b/chart/templates/secrets/pgbouncer-stats-secret.yaml
@@ -21,8 +21,8 @@
 ## Pgbouncer Stats Secret
 #################################
 {{- if .Values.pgbouncer.enabled }}
-kind: Secret
 apiVersion: v1
+kind: Secret
 metadata:
   name: {{ template "pgbouncer_stats_secret" . }}
   labels:

--- a/chart/templates/secrets/redis-secrets.yaml
+++ b/chart/templates/secrets/redis-secrets.yaml
@@ -30,8 +30,8 @@
 {{- $random_redis_password := randAlphaNum 10 }}
 {{- if and .Values.redis.enabled (not .Values.redis.passwordSecretName) }}
 # If passwordSecretName is not set, we will either use the set password, or use the generated one
-kind: Secret
 apiVersion: v1
+kind: Secret
 metadata:
   name: {{ .Release.Name }}-redis-password
   labels:
@@ -56,8 +56,8 @@ data:
 ##################################
 ## Airflow Redis Connection Secret
 ##################################
-kind: Secret
 apiVersion: v1
+kind: Secret
 metadata:
   name: {{ .Release.Name }}-broker-url
   labels:

--- a/chart/templates/secrets/registry-secret.yaml
+++ b/chart/templates/secrets/registry-secret.yaml
@@ -21,8 +21,8 @@
 ## Registry Secret
 #################################
 {{- if (and .Values.registry.connection (not .Values.registry.secretName)) }}
-kind: Secret
 apiVersion: v1
+kind: Secret
 metadata:
   name: {{ .Release.Name }}-registry
   labels:

--- a/chart/templates/secrets/result-backend-connection-secret.yaml
+++ b/chart/templates/secrets/result-backend-connection-secret.yaml
@@ -30,8 +30,8 @@
 {{- $port := (ternary .Values.ports.pgbouncer $connection.port .Values.pgbouncer.enabled) | toString }}
 {{- $database := ternary (printf "%s-%s" .Release.Name "result-backend") $connection.db .Values.pgbouncer.enabled }}
 {{- $query := ternary (printf "sslmode=%s" $connection.sslmode) "" (eq $connection.protocol "postgresql") }}
-kind: Secret
 apiVersion: v1
+kind: Secret
 metadata:
   name: {{ .Release.Name }}-airflow-result-backend
   labels:

--- a/chart/templates/secrets/webserver-secret-key-secret.yaml
+++ b/chart/templates/secrets/webserver-secret-key-secret.yaml
@@ -22,8 +22,8 @@
 ############################################
 {{- if not .Values.webserverSecretKeySecretName }}
 {{ $generated_secret_key := (randAlphaNum 32 | b64enc) }}
-kind: Secret
 apiVersion: v1
+kind: Secret
 metadata:
   name: {{ .Release.Name }}-webserver-secret-key
   labels:

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -28,8 +28,8 @@
 {{- $revisionHistoryLimit := or .Values.statsd.revisionHistoryLimit .Values.revisionHistoryLimit }}
 {{- $securityContext := include "localPodSecurityContext" .Values.statsd }}
 {{- $containerSecurityContext := include "containerSecurityContext" (list . .Values.statsd) }}
-kind: Deployment
 apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: {{ .Release.Name }}-statsd
   labels:

--- a/chart/templates/statsd/statsd-service.yaml
+++ b/chart/templates/statsd/statsd-service.yaml
@@ -21,8 +21,8 @@
 ## Airflow StatsD Service
 #################################
 {{- if .Values.statsd.enabled }}
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: {{ .Release.Name }}-statsd
   labels:

--- a/chart/templates/statsd/statsd-serviceaccount.yaml
+++ b/chart/templates/statsd/statsd-serviceaccount.yaml
@@ -21,8 +21,8 @@
 ## Airflow StatsD ServiceAccount
 ######################################
 {{- if and .Values.statsd.enabled .Values.statsd.serviceAccount.create }}
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: {{ include "statsd.serviceAccountName" . }}
   labels:

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -33,8 +33,8 @@
 {{- $containerSecurityContext := include "containerSecurityContext" (list . .Values.triggerer) }}
 {{- $containerSecurityContextWaitForMigrations := include "containerSecurityContext" (list . .Values.triggerer.waitForMigrations) }}
 {{- $containerSecurityContextLogGroomer := include "containerSecurityContext" (list . .Values.triggerer.logGroomerSidecar) }}
-kind: {{ if $persistence }}StatefulSet{{ else }}Deployment{{ end }}
 apiVersion: apps/v1
+kind: {{ if $persistence }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
   name: {{ .Release.Name }}-triggerer
   labels:

--- a/chart/templates/triggerer/triggerer-service.yaml
+++ b/chart/templates/triggerer/triggerer-service.yaml
@@ -23,8 +23,8 @@
 {{- /* Airflow version 2.6.0 is when triggerer logs serve introduced */ -}}
 {{- if semverCompare ">=2.6.0" .Values.airflowVersion }}
 {{- if .Values.triggerer.enabled }}
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: {{ .Release.Name }}-triggerer
   labels:

--- a/chart/templates/triggerer/triggerer-serviceaccount.yaml
+++ b/chart/templates/triggerer/triggerer-serviceaccount.yaml
@@ -22,8 +22,8 @@
 #################################
 {{- if semverCompare ">=2.2.0" .Values.airflowVersion }}
 {{- if and .Values.triggerer.serviceAccount.create .Values.triggerer.enabled }}
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: {{ include "triggerer.serviceAccountName" . }}
   labels:

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -28,8 +28,8 @@
 {{- $securityContext := include "airflowPodSecurityContext" (list . .Values.webserver) }}
 {{- $containerSecurityContext := include "containerSecurityContext" (list . .Values.webserver) }}
 {{- $containerSecurityContextWaitForMigrations := include "containerSecurityContext" (list . .Values.webserver.waitForMigrations) }}
-kind: Deployment
 apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: {{ .Release.Name }}-webserver
   labels:

--- a/chart/templates/webserver/webserver-poddisruptionbudget.yaml
+++ b/chart/templates/webserver/webserver-poddisruptionbudget.yaml
@@ -21,8 +21,8 @@
 ## Airflow Webserver PodDisruptionBudget
 #################################
 {{- if .Values.webserver.podDisruptionBudget.enabled }}
-kind: PodDisruptionBudget
 apiVersion: policy/v1
+kind: PodDisruptionBudget
 metadata:
   name: {{ .Release.Name }}-webserver-pdb
   labels:

--- a/chart/templates/webserver/webserver-service.yaml
+++ b/chart/templates/webserver/webserver-service.yaml
@@ -20,8 +20,8 @@
 ################################
 ## Airflow Webserver Service
 #################################
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: {{ .Release.Name }}-webserver
   labels:

--- a/chart/templates/webserver/webserver-serviceaccount.yaml
+++ b/chart/templates/webserver/webserver-serviceaccount.yaml
@@ -21,8 +21,8 @@
 ## Airflow Webserver ServiceAccount
 ######################################
 {{- if .Values.webserver.serviceAccount.create }}
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: {{ include "webserver.serviceAccountName" . }}
   labels:

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -34,8 +34,8 @@
 {{- $containerSecurityContextWaitForMigrations := include "containerSecurityContext" (list . .Values.workers.waitForMigrations) }}
 {{- $containerSecurityContextLogGroomerSidecar := include "containerSecurityContext" (list . .Values.workers.logGroomerSidecar) }}
 {{- $containerSecurityContextKerberosSidecar := include "containerSecurityContext" (list . .Values.workers.kerberosSidecar) }}
-kind: {{ if $persistence }}StatefulSet{{ else }}Deployment{{ end }}
 apiVersion: apps/v1
+kind: {{ if $persistence }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
   name: {{ .Release.Name }}-worker
   labels:

--- a/chart/templates/workers/worker-service.yaml
+++ b/chart/templates/workers/worker-service.yaml
@@ -21,8 +21,8 @@
 ## Airflow Worker Service
 #################################
 {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: {{ .Release.Name }}-worker
   labels:

--- a/chart/templates/workers/worker-serviceaccount.yaml
+++ b/chart/templates/workers/worker-serviceaccount.yaml
@@ -21,8 +21,8 @@
 ## Airflow Worker ServiceAccount
 #################################
 {{- if and .Values.workers.serviceAccount.create (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") (eq .Values.executor "KubernetesExecutor") (eq .Values.executor "LocalKubernetesExecutor")) }}
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: {{ include "worker.serviceAccountName" . }}
   labels:


### PR DESCRIPTION
Minor formatting changes to align chart templates with common style. 

The actual order does not affect functionality, however it is a common practice to place `apiVersion` first and than `kind`.