### PR TITLE
 Allow variables to be printed to STDOUT with airflow variables export.

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -544,8 +544,10 @@ ARG_DEFAULT = Arg(
 ARG_DESERIALIZE_JSON = Arg(("-j", "--json"), help="Deserialize JSON variable", action="store_true")
 ARG_SERIALIZE_JSON = Arg(("-j", "--json"), help="Serialize JSON variable", action="store_true")
 ARG_VAR_IMPORT = Arg(("file",), help="Import variables from JSON file")
-ARG_VAR_EXPORT = Arg(("file",), help="Export all variables to JSON file")
-
+ARG_VAR_EXPORT = Arg(("file",),
+                     help="Export all variables to JSON file",
+                     type=argparse.FileType("w", encoding="UTF-8")
+                     )
 # kerberos
 ARG_PRINCIPAL = Arg(("principal",), help="kerberos principal", nargs="?")
 ARG_KEYTAB = Arg(("-k", "--keytab"), help="keytab", nargs="?", default=conf.get("kerberos", "keytab"))
@@ -1555,6 +1557,10 @@ VARIABLES_COMMANDS = (
     ActionCommand(
         name="export",
         help="Export all variables",
+        description=(
+            "All variables can be exported in STDOUT using the following command:\n"
+            "airflow variables export -\n"
+        ),
         func=lazy_load_command("airflow.cli.commands.variable_command.variables_export"),
         args=(ARG_VAR_EXPORT, ARG_VERBOSE),
     ),

--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -544,10 +544,9 @@ ARG_DEFAULT = Arg(
 ARG_DESERIALIZE_JSON = Arg(("-j", "--json"), help="Deserialize JSON variable", action="store_true")
 ARG_SERIALIZE_JSON = Arg(("-j", "--json"), help="Serialize JSON variable", action="store_true")
 ARG_VAR_IMPORT = Arg(("file",), help="Import variables from JSON file")
-ARG_VAR_EXPORT = Arg(("file",),
-                     help="Export all variables to JSON file",
-                     type=argparse.FileType("w", encoding="UTF-8")
-                     )
+ARG_VAR_EXPORT = Arg(
+    ("file",), help="Export all variables to JSON file", type=argparse.FileType("w", encoding="UTF-8")
+)
 # kerberos
 ARG_PRINCIPAL = Arg(("principal",), help="kerberos principal", nargs="?")
 ARG_KEYTAB = Arg(("-k", "--keytab"), help="keytab", nargs="?", default=conf.get("kerberos", "keytab"))

--- a/airflow/cli/commands/variable_command.py
+++ b/airflow/cli/commands/variable_command.py
@@ -89,18 +89,13 @@ def variables_export(args):
             except json.decoder.JSONDecodeError:
                 value = variable.val
             var_dict[variable.key] = value
-    file_is_stdout = _is_stdout(args.file)
 
     with args.file as f:
         f.write(json.dumps(var_dict, sort_keys=True, indent=4))
-    if file_is_stdout:
+    if args.file.name == "<stdout>":
         print("\nVariables successfully exported.", file=sys.stderr)
     else:
         print(f"Variables successfully exported to {args.file.name}.")
-
-
-def _is_stdout(fileio: io.TextIOWrapper) -> bool:
-    return fileio.name == "<stdout>"
 
 
 def _import_helper(filepath):

--- a/airflow/cli/commands/variable_command.py
+++ b/airflow/cli/commands/variable_command.py
@@ -79,15 +79,15 @@ def variables_export(args):
     """Exports all the variables to the file."""
     var_dict = {}
     with create_session() as session:
-        query = session.query(Variable).all()
+        rows = session.query(Variable)
 
-        data = json.JSONDecoder()
-        for variable in query:
+        decoder = json.JSONDecoder()
+        for row in rows:
             try:
-                value = data.decode(variable.val)
+                value = decoder.decode(row.val)
             except json.decoder.JSONDecodeError:
-                value = variable.val
-            var_dict[variable.key] = value
+                value = row.val
+            var_dict[row.key] = value
 
     with args.file as f:
         f.write(json.dumps(var_dict, sort_keys=True, indent=4))

--- a/airflow/cli/commands/variable_command.py
+++ b/airflow/cli/commands/variable_command.py
@@ -18,7 +18,6 @@
 """Variable subcommands."""
 from __future__ import annotations
 
-import io
 import json
 import os
 import sys

--- a/airflow/cli/commands/variable_command.py
+++ b/airflow/cli/commands/variable_command.py
@@ -85,7 +85,7 @@ def variables_export(args):
         for row in rows:
             try:
                 value = decoder.decode(row.val)
-            except json.decoder.JSONDecodeError:
+            except JSONDecodeError:
                 value = row.val
             var_dict[row.key] = value
 

--- a/airflow/cli/commands/variable_command.py
+++ b/airflow/cli/commands/variable_command.py
@@ -80,15 +80,15 @@ def variables_export(args):
     """Exports all the variables to the file."""
     var_dict = {}
     with create_session() as session:
-        qry = session.query(Variable).all()
+        query = session.query(Variable).all()
 
         data = json.JSONDecoder()
-        for var in qry:
+        for variable in query:
             try:
-                val = data.decode(var.val)
-            except Exception:
-                val = var.val
-            var_dict[var.key] = val
+                value = data.decode(variable.val)
+            except json.decoder.JSONDecodeError:
+                value = variable.val
+            var_dict[variable.key] = value
     file_is_stdout = _is_stdout(args.file)
 
     with args.file as f:


### PR DESCRIPTION


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #31851
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---

This change allows airflow cli to export variables to stdout similar to connections using `airflow variables export -`.


Fixes #31851
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
