### PR TITLE
Improve mypy warning on problem

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_mypy.py
+++ b/scripts/ci/pre_commit/pre_commit_mypy.py
@@ -86,8 +86,8 @@ if __name__ == "__main__":
             "[warning]If you see strange stacktraces above, "
             f"run `breeze ci-image build --python 3.8{flag}` and try again. "
             "You can also run `breeze down --cleanup-mypy-cache` to clean up the cache used. "
-            "Still sometimes diff heuristic in mypy is behaving abnormal, to double check you can double "
-            "check by calling `breeze static-checks --type mypy-[dev|core|providers|docs] --all-files` "
+            "Still sometimes diff heuristic in mypy is behaving abnormal, to double check you can "
+            "call `breeze static-checks --type mypy-[dev|core|providers|docs] --all-files` "
             'and then commit via `git commit --no-verify -m "commit message"`. CI will do a full check.'
         )
     sys.exit(cmd_result.returncode)

--- a/scripts/ci/pre_commit/pre_commit_mypy.py
+++ b/scripts/ci/pre_commit/pre_commit_mypy.py
@@ -87,6 +87,7 @@ if __name__ == "__main__":
             f"run `breeze ci-image build --python 3.8{flag}` and try again. "
             "You can also run `breeze down --cleanup-mypy-cache` to clean up the cache used. "
             "Still sometimes diff heuristic in mypy is behaving abnormal, to double check you can double "
-            "check by calling `breeze static-checks --type mypy-[dev|core|providers|docs] --all-files`."
+            "check by calling `breeze static-checks --type mypy-[dev|core|providers|docs] --all-files` "
+            'and then commit via `git commit --no-verify -m "commit message"`. CI will do a full check.'
         )
     sys.exit(cmd_result.returncode)

--- a/scripts/ci/pre_commit/pre_commit_mypy.py
+++ b/scripts/ci/pre_commit/pre_commit_mypy.py
@@ -85,6 +85,8 @@ if __name__ == "__main__":
         get_console().print(
             "[warning]If you see strange stacktraces above, "
             f"run `breeze ci-image build --python 3.8{flag}` and try again. "
-            "You can also run `breeze down --cleanup-mypy-cache` to clean up the cache used."
+            "You can also run `breeze down --cleanup-mypy-cache` to clean up the cache used. "
+            "Still sometimes diff heuristic in mypy is behaving abnormal, to double check you can double "
+            "check by calling `breeze static-checks --type mypy-[dev|core|providers|docs] --all-files`."
         )
     sys.exit(cmd_result.returncode)


### PR DESCRIPTION
As discussed in slack devchannel (https://apache-airflow.slack.com/archives/CCPRP7943/p1686518518985859) mypy pre-commit check sometimes behaves "strange" when calculating the diff and produces warnings even if breeze image is updated and mypy cache is cleaned. This PR improves the warning message.