### PR TITLE
[AIP-49] OTel Timers

### DIFF
--- a/airflow/metrics/otel_logger.py
+++ b/airflow/metrics/otel_logger.py
@@ -37,7 +37,6 @@ from airflow.metrics.validators import (
     OTEL_NAME_MAX_LENGTH,
     AllowListValidator,
     stat_name_otel_handler,
-    validate_stat,
 )
 
 log = logging.getLogger(__name__)
@@ -132,6 +131,29 @@ def _skip_due_to_rate(rate: float) -> bool:
     return rate < 1 and random.random() > rate
 
 
+class _OtelTimer(Timer):
+    """
+    An implementation of Stats.Timer() which records the result in the OTel Metrics Map.
+    OpenTelemetry does not have a native timer, we will store the values as a Gauge.
+
+    :param name: The name of the timer.
+    :param tags: Tags to append to the timer.
+    """
+
+    def __init__(self, otel_logger, name, tags):
+        super().__init__()
+        self.otel_logger = otel_logger
+        self.name = name
+        self.tags = tags
+
+    def stop(self, send: bool = True) -> None:
+        super().stop(send)
+        if self.name and send:
+            self.otel_logger.metrics_map.set_gauge_value(
+                full_name(prefix=self.otel_logger.prefix, name=self.name), self.duration, False, self.tags
+            )
+
+
 class SafeOtelLogger:
     """Otel Logger."""
 
@@ -199,7 +221,6 @@ class SafeOtelLogger:
             counter.add(-count, attributes=tags)
             return counter
 
-    @validate_stat
     def gauge(
         self,
         stat: str,
@@ -251,7 +272,6 @@ class SafeOtelLogger:
             self.metrics_map.set_gauge_value(full_name(prefix=self.prefix, name=stat), float(dt), False, tags)
         return None
 
-    @validate_stat
     def timer(
         self,
         stat: str | None = None,
@@ -259,8 +279,8 @@ class SafeOtelLogger:
         tags: Attributes = None,
         **kwargs,
     ) -> TimerProtocol:
-        warnings.warn(f"Create timer {stat}: OpenTelemetry Timers are not yet implemented.")
-        return Timer()
+        """Timer context manager returns the duration and can be cancelled."""
+        return _OtelTimer(self, stat, tags)
 
 
 class MetricsMap:

--- a/airflow/metrics/otel_logger.py
+++ b/airflow/metrics/otel_logger.py
@@ -140,7 +140,7 @@ class _OtelTimer(Timer):
     :param tags: Tags to append to the timer.
     """
 
-    def __init__(self, otel_logger, name, tags):
+    def __init__(self, otel_logger: SafeOtelLogger, name: str | None, tags: Attributes):
         super().__init__()
         self.otel_logger = otel_logger
         self.name = name
@@ -263,14 +263,13 @@ class SafeOtelLogger:
         tags: Attributes = None,
     ) -> None:
         """
-        OpenTelemetry does not have a native timer, we will store
-        them as a Gauge whose value represents the seconds elapsed.
+        OpenTelemetry does not have a native timer, they are stored
+        as a Gauge whose value represents the seconds elapsed.
         """
         if self.metrics_validator.test(stat) and name_is_otel_safe(self.prefix, stat):
             if isinstance(dt, datetime.timedelta):
                 dt = dt.total_seconds()
             self.metrics_map.set_gauge_value(full_name(prefix=self.prefix, name=stat), float(dt), False, tags)
-        return None
 
     def timer(
         self,
@@ -331,7 +330,7 @@ class MetricsMap:
         if key in self.map.keys():
             del self.map[key]
 
-    def set_gauge_value(self, name: str, value: float, delta: bool, tags: Attributes):
+    def set_gauge_value(self, name: str, value: float | None, delta: bool, tags: Attributes):
         """
         Overrides the last reading for a Gauge with a new value.
 
@@ -342,7 +341,7 @@ class MetricsMap:
         :returns: None
         """
         key: str = _generate_key_name(name, tags)
-        new_value = value
+        new_value = value or DEFAULT_GAUGE_VALUE
         old_value = self.poke_gauge(name, tags)
         if delta:
             new_value += old_value


### PR DESCRIPTION
Follow-up to https://github.com/apache/airflow/pull/31725

**Objective**
This PR adds OpenTelemetry support for timer metrics.  With this merged, OTel and StatsD support should be at feature parity.

** Testing**
Passes `breeze testing tests` and `breeze static-checks` locally.  I have added unit tests for both new methods and these can also be manually tested by launching Breeze with `breeze start-airflow --integration otel` if anyone wants to check it out.  Below is a screenshot of Grafana graphing the task run duration for a DAG which waited for a random period between 1 and 10 seconds and ran every minute: 
![image](https://github.com/apache/airflow/assets/1920178/7c619f93-de60-47b6-906b-441babd56e6e)

