### PR TITLE
Include a progress callback on K8sPodOperators

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -556,6 +556,7 @@ class KubernetesPodOperator(BaseOperator):
                     container_name=self.base_container_name,
                     follow=True,
                     post_termination_timeout=self.POST_TERMINATION_TIMEOUT,
+                    progress_callback=self.progress_callback
                 )
             else:
                 self.pod_manager.await_container_completion(
@@ -873,6 +874,11 @@ class KubernetesPodOperator(BaseOperator):
         pod = self.build_pod_request_obj()
         print(yaml.dump(prune_dict(pod.to_dict(), mode="strict")))
 
+    def progress_callback(self) -> None:
+        """
+        Expose a callback hook on status lines
+        """
+        pass
 
 class _optionally_suppress(AbstractContextManager):
     """

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -25,7 +25,7 @@ import warnings
 from contextlib import closing, suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Generator, cast
+from typing import TYPE_CHECKING, Generator, cast, Callable
 
 import pendulum
 import tenacity
@@ -336,6 +336,7 @@ class PodManager(LoggingMixin):
         follow=False,
         since_time: DateTime | None = None,
         post_termination_timeout: int = 120,
+        progress_callback: Callable[str, None] = lambda r: None,
     ) -> PodLoggingStatus:
         """
         Follows the logs of container and streams to airflow logging.
@@ -379,6 +380,7 @@ class PodManager(LoggingMixin):
                     line = raw_line.decode("utf-8", errors="backslashreplace")
                     timestamp, message = self.parse_log_line(line)
                     self.log.info(message)
+                    progress_callback(message)
             except BaseHTTPError as e:
                 self.log.warning(
                     "Reading of logs interrupted with error %r; will retry. "


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/31745

Include a progress_callback function would allow users to make stateful tasks based on Docker run logs like what dataflow Docker operator is being doing