### PR TITLE
Add default Trigger.serialize implementation

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -32,6 +32,7 @@ __version__ = "2.7.0.dev0"
 
 import os
 import sys
+from pathlib import Path
 from typing import Callable
 
 if os.environ.get("_AIRFLOW_PATCH_GEVENT"):
@@ -130,3 +131,5 @@ if STATICA_HACK:  # pragma: no cover
     from airflow.models.xcom_arg import XComArg
     from airflow.exceptions import AirflowException
     from airflow.models.dataset import Dataset
+
+AIRFLOW_ROOT = Path(__file__).parent

--- a/airflow/triggers/base.py
+++ b/airflow/triggers/base.py
@@ -51,6 +51,45 @@ class BaseTrigger(abc.ABC, LoggingMixin):
         """
         raise NotImplementedError
 
+    def _serialize_classpath(self):
+        class_name = self.__class__.__name__
+        mod = inspect.getmodule(self)
+
+        # easy case
+        if mod and mod.__name__ != "__main__":
+            return f"{mod.__name__}.{class_name}"
+
+        # tougher: the file being run defines the method, or we're in repl
+        mod_file = inspect.getfile(self.__class__)
+
+        # in repl: impossible
+        if mod_file == "<input>":
+            raise ValueError(
+                "Logic for automated serialization of trigger does not work "
+                "when defining the class in a repl; please define the class "
+                "in another module and import it; alternatively, implement "
+                "the `serialize` method and hardcode the import path."
+            )
+
+        from airflow import AIRFLOW_ROOT
+
+        # entrypoint file defines the class
+        try:
+            rel_path = Path(mod_file).relative_to(AIRFLOW_ROOT)
+        except ValueError:
+            # entrypoint file not relative to airflow dir; can't guess classpath
+            raise ValueError(
+                f"Class {class_name} is not located in a submodule of "
+                f"Airflow. You must implement its `serialize` method and hardcode "
+                f"the fully qualified class name."
+            )
+        mod_full_name = ".".join([*rel_path.parts[:-1], rel_path.stem])
+        return f"airflow.{mod_full_name}.{class_name}"
+
+    def _serialize_kwargs(self):
+        params = inspect.signature(self.__init__).parameters.keys()  # type: ignore[misc]
+        return {k: getattr(self, k) for k in params}
+
     def serialize(self) -> tuple[str, dict[str, Any]]:
         """
         Returns the information needed to reconstruct this Trigger.
@@ -60,36 +99,7 @@ class BaseTrigger(abc.ABC, LoggingMixin):
 
         :return: Tuple of (class path, keyword arguments needed to re-instantiate).
         """
-        params = inspect.signature(self.__init__).parameters.keys()  # type: ignore[misc]
-        kwargs = {k: getattr(self, k) for k in params}
-        class_name = self.__class__.__name__
-        mod = inspect.getmodule(self)
-        # easy case
-        if mod and mod.__name__ != "__main__":
-            return f"{mod.__name__}.{class_name}", kwargs
-
-        print("tougher case")
-        # the file being run defines the method
-        from airflow import AIRFLOW_ROOT
-
-        mod_file = inspect.getfile(self.__class__)
-        if mod_file == "<input>":
-            raise ValueError(
-                "Logic for automated serialization of trigger does not work "
-                "when defining the class in a repl; please define the class "
-                "in another module and import it; alternatively, implement "
-                "the `serialize` method and hardcode the import path."
-            )
-        try:
-            rel_path = Path(mod_file).relative_to(AIRFLOW_ROOT)
-        except ValueError:
-            raise ValueError(
-                f"Class {class_name} is not located in a submodule of "
-                f"Airflow. You must implement its `serialize` method and hardcode "
-                f"the fully qualified class name."
-            )
-        mod_full_name = ".".join([*rel_path.parts[:-1], rel_path.stem])
-        return f"airflow.{mod_full_name}.{class_name}", kwargs
+        return self._serialize_classpath(), self._serialize_kwargs()
 
     @abc.abstractmethod
     async def run(self) -> AsyncIterator[TriggerEvent]:

--- a/airflow/triggers/base.py
+++ b/airflow/triggers/base.py
@@ -95,7 +95,7 @@ class BaseTrigger(abc.ABC, LoggingMixin):
         Returns the information needed to reconstruct this Trigger.
 
         In most cases the default implementation should work but there may be some cases where
-        you will need to implement.
+        you will need to override this method.
 
         :return: Tuple of (class path, keyword arguments needed to re-instantiate).
         """

--- a/airflow/triggers/temporal.py
+++ b/airflow/triggers/temporal.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import asyncio
 import datetime
-from typing import Any
 
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.utils import timezone
@@ -43,9 +42,6 @@ class DateTimeTrigger(BaseTrigger):
             raise ValueError("You cannot pass naive datetimes")
         else:
             self.moment = timezone.convert_to_utc(moment)
-
-    def serialize(self) -> tuple[str, dict[str, Any]]:
-        return ("airflow.triggers.temporal.DateTimeTrigger", {"moment": self.moment})
 
     async def run(self):
         """

--- a/airflow/triggers/temporal.py
+++ b/airflow/triggers/temporal.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+from typing import Any
 
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.utils import timezone
@@ -82,3 +83,6 @@ class TimeDeltaTrigger(DateTimeTrigger):
 
     def __init__(self, delta: datetime.timedelta):
         super().__init__(moment=timezone.utcnow() + delta)
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        return "airflow.triggers.temporal.DateTimeTrigger", {"moment": self.moment}


### PR DESCRIPTION
This should cover most cases. If it fails, user will need to implement, which is no worse than today, where user must always implement.

Is this worth doing?  I'm not sure.  But more than once I've been bitten by this.

Problem with this approach: can't handle kwargs, or when init param differs from instance attr

Should we add two optional attrs, `attrs_to_serialize` and `class_path`?

