### PR TITLE
Chart: Do not propagate global security context to statsd and redis

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -244,7 +244,7 @@ If release name contains chart name it will be used as a full name.
   {{- end }}
   {{- end }}
   {{- if .Values.dags.gitSync.extraVolumeMounts }}
-    {{- toYaml .Values.dags.gitSync.extraVolumeMounts | nindent 2 }}
+    {{- tpl (toYaml .Values.dags.gitSync.extraVolumeMounts) . | nindent 2 }}
   {{- end }}
 {{- end }}
 

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -875,8 +875,6 @@ capabilities:
 
     The template can be called like so:
       include "externalContainerSecurityContext" .Values.statsd
-
-     Where `.` is the global variables scope and `.Values.webserver` the local variables scope for the webserver template.
     */}}
 {{- define "externalContainerSecurityContext" -}}
   {{- if .securityContexts.container -}}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -244,7 +244,7 @@ If release name contains chart name it will be used as a full name.
   {{- end }}
   {{- end }}
   {{- if .Values.dags.gitSync.extraVolumeMounts }}
-    {{- tpl (toYaml .Values.dags.gitSync.extraVolumeMounts) . | nindent 2 }}
+    {{- toYaml .Values.dags.gitSync.extraVolumeMounts | nindent 2 }}
   {{- end }}
 {{- end }}
 

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -747,7 +747,7 @@ Where `.` is the global variables scope and `.Values.webserver` the local variab
       {{ toYaml $.Values.securityContexts.pod | print }}
     {{- else if $.Values.securityContext -}}
       {{ toYaml $.Values.securityContext | print }}
-    {{- else if .uid -}}
+    {{- else if not (kindIs "invalid"  .uid) -}}
 runAsUser: {{ .uid }}
     {{- else -}}
 runAsUser: {{ $.Values.uid }}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -864,6 +864,31 @@ capabilities:
   {{- end -}}
 {{- end -}}
 
+  {{/*
+     Set the default value for external container securityContext(redis and statsd).
+     If no value is passed for <node>.securityContexts.container, defaults to deny privileges escallation and dropping all POSIX capabilities.
+
+     +-----------------------------------+      +-----------------------------------------------------------+
+     | <node>.securityContexts.container |  ->  | allowPrivilegesEscalation: false, capabilities.drop: [ALL]|
+     +-----------------------------------+      +-----------------------------------------------------------+
+
+
+    The template can be called like so:
+      include "externalContainerSecurityContext" .Values.statsd
+
+     Where `.` is the global variables scope and `.Values.webserver` the local variables scope for the webserver template.
+    */}}
+{{- define "externalContainerSecurityContext" -}}
+  {{- if .securityContexts.container -}}
+    {{ toYaml .securityContexts.container | print }}
+  {{- else -}}
+allowPrivilegeEscalation: false
+capabilities:
+  drop:
+    - ALL
+  {{- end -}}
+{{- end -}}
+
 {{- define "container_extra_envs" -}}
   {{- $ := index . 0 -}}
   {{- $env := index . 1 -}}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -722,11 +722,11 @@ server_tls_key_file = /etc/pgbouncer/server.key
 
 {{/*
 Set the default value for pod securityContext
-If no value is passed for securityContexts.pod or <node>.securityContexts.pod or legacy securityContext and <node>.securityContext, defaults to <node>.uid if set and to global uid and gid otherwise.
+If no value is passed for securityContexts.pod or <node>.securityContexts.pod or legacy securityContext and <node>.securityContext, defaults to global uid and gid.
 
-    +-----------------------------+      +------------------------+      +----------------------+      +-----------------+      +------------+      +-------------------------+
-    | <node>.securityContexts.pod |  ->  | <node>.securityContext |  ->  | securityContexts.pod |  ->  | securityContext |  ->  | <node>.uid |  ->  | Values.uid + Values.gid |
-    +-----------------------------+      +------------------------+      +----------------------+      +-----------------+      +------------+      +-------------------------+
+    +-----------------------------+      +------------------------+      +----------------------+      +-----------------+      +-------------------------+
+    | <node>.securityContexts.pod |  ->  | <node>.securityContext |  ->  | securityContexts.pod |  ->  | securityContext |  ->  | Values.uid + Values.gid |
+    +-----------------------------+      +------------------------+      +----------------------+      +-----------------+      +-------------------------+
 
 Values are not accumulated meaning that if runAsUser is set to 10 in <node>.securityContexts.pod,
 any extra values set to securityContext or uid+gid will be ignored.
@@ -747,8 +747,6 @@ Where `.` is the global variables scope and `.Values.webserver` the local variab
       {{ toYaml $.Values.securityContexts.pod | print }}
     {{- else if $.Values.securityContext -}}
       {{ toYaml $.Values.securityContext | print }}
-    {{- else if not (kindIs "invalid"  .uid) -}}
-runAsUser: {{ .uid }}
     {{- else -}}
 runAsUser: {{ $.Values.uid }}
 fsGroup: {{ $.Values.gid }}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -722,11 +722,11 @@ server_tls_key_file = /etc/pgbouncer/server.key
 
 {{/*
 Set the default value for pod securityContext
-If no value is passed for securityContexts.pod or <node>.securityContexts.pod or legacy securityContext and <node>.securityContext, defaults to global uid and gid.
+If no value is passed for securityContexts.pod or <node>.securityContexts.pod or legacy securityContext and <node>.securityContext, defaults to <node>.uid if set and to global uid and gid otherwise.
 
-    +-----------------------------+      +------------------------+      +----------------------+      +-----------------+      +-------------------------+
-    | <node>.securityContexts.pod |  ->  | <node>.securityContext |  ->  | securityContexts.pod |  ->  | securityContext |  ->  | Values.uid + Values.gid |
-    +-----------------------------+      +------------------------+      +----------------------+      +-----------------+      +-------------------------+
+    +-----------------------------+      +------------------------+      +----------------------+      +-----------------+      +------------+      +-------------------------+
+    | <node>.securityContexts.pod |  ->  | <node>.securityContext |  ->  | securityContexts.pod |  ->  | securityContext |  ->  | <node>.uid |  ->  | Values.uid + Values.gid |
+    +-----------------------------+      +------------------------+      +----------------------+      +-----------------+      +------------+      +-------------------------+
 
 Values are not accumulated meaning that if runAsUser is set to 10 in <node>.securityContexts.pod,
 any extra values set to securityContext or uid+gid will be ignored.
@@ -747,6 +747,8 @@ Where `.` is the global variables scope and `.Values.webserver` the local variab
       {{ toYaml $.Values.securityContexts.pod | print }}
     {{- else if $.Values.securityContext -}}
       {{ toYaml $.Values.securityContext | print }}
+    {{- else if .uid -}}
+runAsUser: {{ .uid }}
     {{- else -}}
 runAsUser: {{ $.Values.uid }}
 fsGroup: {{ $.Values.gid }}

--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -25,7 +25,7 @@
 {{- $affinity := or .Values.redis.affinity .Values.affinity }}
 {{- $tolerations := or .Values.redis.tolerations .Values.tolerations }}
 {{- $topologySpreadConstraints := or .Values.redis.topologySpreadConstraints .Values.topologySpreadConstraints }}
-{{- $securityContext := include "localPodSecurityContext" .Values.redis }}
+{{- $securityContext := include "airflowPodSecurityContext" (list . .Values.redis) }}
 {{- $containerSecurityContext := include "containerSecurityContext" (list . .Values.redis) }}
 apiVersion: apps/v1
 kind: StatefulSet

--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -25,8 +25,7 @@
 {{- $affinity := or .Values.redis.affinity .Values.affinity }}
 {{- $tolerations := or .Values.redis.tolerations .Values.tolerations }}
 {{- $topologySpreadConstraints := or .Values.redis.topologySpreadConstraints .Values.topologySpreadConstraints }}
-{{- $securityContext := include "airflowPodSecurityContext" (list . .Values.redis) }}
-{{- $containerSecurityContext := include "containerSecurityContext" (list . .Values.redis) }}
+{{- $securityContext := include "localPodSecurityContext" .Values.redis }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -80,7 +79,7 @@ spec:
         - name: redis
           image: {{ template "redis_image" . }}
           imagePullPolicy: {{ .Values.images.redis.pullPolicy }}
-          securityContext: {{ $containerSecurityContext | nindent 12 }}
+          securityContext: {{- toYaml .Values.redis.securityContexts.container | nindent 12 }}
           command: ["/bin/sh"]
           resources: {{- toYaml .Values.redis.resources | nindent 12 }}
           args: ["-c", "redis-server --requirepass ${REDIS_PASSWORD}"]

--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -26,6 +26,7 @@
 {{- $tolerations := or .Values.redis.tolerations .Values.tolerations }}
 {{- $topologySpreadConstraints := or .Values.redis.topologySpreadConstraints .Values.topologySpreadConstraints }}
 {{- $securityContext := include "localPodSecurityContext" .Values.redis }}
+{{- $containerSecurityContext := include "externalContainerSecurityContext" .Values.redis }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -79,7 +80,7 @@ spec:
         - name: redis
           image: {{ template "redis_image" . }}
           imagePullPolicy: {{ .Values.images.redis.pullPolicy }}
-          securityContext: {{- toYaml .Values.redis.securityContexts.container | nindent 12 }}
+          securityContext: {{ $containerSecurityContext | nindent 12 }}
           command: ["/bin/sh"]
           resources: {{- toYaml .Values.redis.resources | nindent 12 }}
           args: ["-c", "redis-server --requirepass ${REDIS_PASSWORD}"]

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -27,6 +27,7 @@
 {{- $topologySpreadConstraints := or .Values.statsd.topologySpreadConstraints .Values.topologySpreadConstraints }}
 {{- $revisionHistoryLimit := or .Values.statsd.revisionHistoryLimit .Values.revisionHistoryLimit }}
 {{- $securityContext := include "localPodSecurityContext" .Values.statsd }}
+{{- $containerSecurityContext := include "externalContainerSecurityContext" .Values.statsd }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -88,7 +89,7 @@ spec:
         - name: statsd
           image: {{ template "statsd_image" . }}
           imagePullPolicy: {{ .Values.images.statsd.pullPolicy }}
-          securityContext: {{- toYaml .Values.statsd.securityContexts.container | nindent 12 }}
+          securityContext: {{ $containerSecurityContext | nindent 12 }}
           {{- if .Values.statsd.args }}
           args: {{ tpl (toYaml .Values.statsd.args) . | nindent 12 }}
           {{- else}}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -26,8 +26,7 @@
 {{- $tolerations := or .Values.statsd.tolerations .Values.tolerations }}
 {{- $topologySpreadConstraints := or .Values.statsd.topologySpreadConstraints .Values.topologySpreadConstraints }}
 {{- $revisionHistoryLimit := or .Values.statsd.revisionHistoryLimit .Values.revisionHistoryLimit }}
-{{- $securityContext := include "airflowPodSecurityContext" (list . .Values.statsd) }}
-{{- $containerSecurityContext := include "containerSecurityContext" (list . .Values.statsd) }}
+{{- $securityContext := include "localPodSecurityContext" .Values.statsd }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -89,7 +88,7 @@ spec:
         - name: statsd
           image: {{ template "statsd_image" . }}
           imagePullPolicy: {{ .Values.images.statsd.pullPolicy }}
-          securityContext: {{ $containerSecurityContext | nindent 12 }}
+          securityContext: {{- toYaml .Values.statsd.securityContexts.container | nindent 12 }}
           {{- if .Values.statsd.args }}
           args: {{ tpl (toYaml .Values.statsd.args) . | nindent 12 }}
           {{- else}}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -26,7 +26,7 @@
 {{- $tolerations := or .Values.statsd.tolerations .Values.tolerations }}
 {{- $topologySpreadConstraints := or .Values.statsd.topologySpreadConstraints .Values.topologySpreadConstraints }}
 {{- $revisionHistoryLimit := or .Values.statsd.revisionHistoryLimit .Values.revisionHistoryLimit }}
-{{- $securityContext := include "localPodSecurityContext" .Values.statsd }}
+{{- $securityContext := include "airflowPodSecurityContext" (list . .Values.statsd) }}
 {{- $containerSecurityContext := include "containerSecurityContext" (list . .Values.statsd) }}
 apiVersion: apps/v1
 kind: Deployment

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4790,7 +4790,7 @@
                     "default": []
                 },
                 "securityContext": {
-                    "description": "Security context for the StatsD pod (deprecated, use `securityContexts` instead). If not set, the values from `securityContext` will be used.",
+                    "description": "Security context for the StatsD pod (deprecated, use `securityContexts` instead).",
                     "type": "object",
                     "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
                     "default": {},

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4803,7 +4803,7 @@
                     ]
                 },
                 "securityContexts": {
-                    "description": "Security context definition for the statsd. If not set, the values from global `securityContexts` will be used.",
+                    "description": "Security context definition for the statsd.",
                     "type": "object",
                     "x-docsSection": "Kubernetes",
                     "properties": {
@@ -5517,7 +5517,7 @@
                     ]
                 },
                 "securityContexts": {
-                    "description": "Security context definition for the redis. If not set, the values from global `securityContexts` will be used.",
+                    "description": "Security context definition for the redis.",
                     "type": "object",
                     "x-docsSection": "Kubernetes",
                     "properties": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1629,7 +1629,6 @@ statsd:
   uid: 65534
   # When not set, `statsd.uid` will be used
 
-  # When not set, the values defined in the global securityContext will be used
   # (deprecated, use `securityContexts` instead)
   securityContext: {}
   #  runAsUser: 65534

--- a/tests/charts/security/test_security_context.py
+++ b/tests/charts/security/test_security_context.py
@@ -211,6 +211,30 @@ class TestSecurityContext:
             )
 
     # Test securityContexts for main containers
+    def test_global_security_context(self):
+        ctx_value_pod = {"runAsUser": 7000}
+        ctx_value_container = {"allowPrivilegeEscalation": False}
+        docs = render_chart(
+            values={"securityContexts": {"containers": ctx_value_container, "pod": ctx_value_pod}},
+            show_only=[
+                "templates/flower/flower-deployment.yaml",
+                "templates/scheduler/scheduler-deployment.yaml",
+                "templates/webserver/webserver-deployment.yaml",
+                "templates/workers/worker-deployment.yaml",
+                "templates/statsd/statsd-deployment.yaml",
+                "templates/jobs/create-user-job.yaml",
+                "templates/jobs/migrate-database-job.yaml",
+                "templates/triggerer/triggerer-deployment.yaml",
+            ],
+        )
+
+        for index in range(len(docs)):
+            assert ctx_value_container == jmespath.search(
+                "spec.template.spec.containers[0].securityContext", docs[index]
+            )
+            assert ctx_value_pod == jmespath.search("spec.template.spec.securityContext", docs[index])
+
+    # Test securityContexts for main containers
     def test_main_container_setting(self):
         ctx_value = {"allowPrivilegeEscalation": False}
         security_context = {"securityContexts": {"container": ctx_value}}

--- a/tests/charts/security/test_security_context.py
+++ b/tests/charts/security/test_security_context.py
@@ -234,6 +234,7 @@ class TestSecurityContext:
                 "spec.template.spec.containers[0].securityContext", docs[index]
             )
             assert ctx_value_pod == jmespath.search("spec.template.spec.securityContext", docs[index])
+
         # Global security context is not propagated to redis and statsd, so we test default value
         default_ctx_value_container = {"allowPrivilegeEscalation": False, "capabilities": {"drop": ["ALL"]}}
         default_ctx_value_pod_statsd = {"runAsUser": 65534}

--- a/tests/charts/security/test_security_context.py
+++ b/tests/charts/security/test_security_context.py
@@ -221,19 +221,24 @@ class TestSecurityContext:
                 "templates/scheduler/scheduler-deployment.yaml",
                 "templates/webserver/webserver-deployment.yaml",
                 "templates/workers/worker-deployment.yaml",
-                "templates/statsd/statsd-deployment.yaml",
                 "templates/jobs/create-user-job.yaml",
                 "templates/jobs/migrate-database-job.yaml",
                 "templates/triggerer/triggerer-deployment.yaml",
+                "templates/statsd/statsd-deployment.yaml",
                 "templates/redis/redis-statefulset.yaml",
             ],
         )
 
-        for index in range(len(docs)):
+        for index in range(len(docs)-2):
             assert ctx_value_container == jmespath.search(
                 "spec.template.spec.containers[0].securityContext", docs[index]
             )
             assert ctx_value_pod == jmespath.search("spec.template.spec.securityContext", docs[index])
+        for index in range(len(docs)-2, len(docs)):
+            assert ctx_value_container != jmespath.search(
+                "spec.template.spec.containers[0].securityContext", docs[index]
+            )
+            assert ctx_value_pod != jmespath.search("spec.template.spec.securityContext", docs[index])
 
     # Test securityContexts for main containers
     def test_main_container_setting(self):

--- a/tests/charts/security/test_security_context.py
+++ b/tests/charts/security/test_security_context.py
@@ -225,6 +225,7 @@ class TestSecurityContext:
                 "templates/jobs/create-user-job.yaml",
                 "templates/jobs/migrate-database-job.yaml",
                 "templates/triggerer/triggerer-deployment.yaml",
+                "templates/redis/redis-statefulset.yaml",
             ],
         )
 

--- a/tests/charts/security/test_security_context.py
+++ b/tests/charts/security/test_security_context.py
@@ -234,11 +234,20 @@ class TestSecurityContext:
                 "spec.template.spec.containers[0].securityContext", docs[index]
             )
             assert ctx_value_pod == jmespath.search("spec.template.spec.securityContext", docs[index])
+        # Global security context is not propagated to redis and statsd, so we test default value
+        default_ctx_value_container = {"allowPrivilegeEscalation": False, "capabilities": {"drop": ["ALL"]}}
+        default_ctx_value_pod_statsd = {"runAsUser": 65534}
+        default_ctx_value_pod_redis = {"runAsUser": 0}
         for index in range(len(docs) - 2, len(docs)):
-            assert ctx_value_container != jmespath.search(
+            assert default_ctx_value_container == jmespath.search(
                 "spec.template.spec.containers[0].securityContext", docs[index]
             )
-            assert ctx_value_pod != jmespath.search("spec.template.spec.securityContext", docs[index])
+        assert default_ctx_value_pod_statsd == jmespath.search(
+            "spec.template.spec.securityContext", docs[len(docs) - 2]
+        )
+        assert default_ctx_value_pod_redis == jmespath.search(
+            "spec.template.spec.securityContext", docs[len(docs) - 1]
+        )
 
     # Test securityContexts for main containers
     def test_main_container_setting(self):

--- a/tests/charts/security/test_security_context.py
+++ b/tests/charts/security/test_security_context.py
@@ -229,12 +229,12 @@ class TestSecurityContext:
             ],
         )
 
-        for index in range(len(docs)-2):
+        for index in range(len(docs) - 2):
             assert ctx_value_container == jmespath.search(
                 "spec.template.spec.containers[0].securityContext", docs[index]
             )
             assert ctx_value_pod == jmespath.search("spec.template.spec.securityContext", docs[index])
-        for index in range(len(docs)-2, len(docs)):
+        for index in range(len(docs) - 2, len(docs)):
             assert ctx_value_container != jmespath.search(
                 "spec.template.spec.containers[0].securityContext", docs[index]
             )


### PR DESCRIPTION
Global pod security context (`.Values.securityContexts.pod` parameter) is not propagated to statsd deployment when statsd security context is not specified. However at the same time container security context is propagated(`.Values.securityContexts.containers` parameter). According to documentation looks like it should be propagated, see https://github.com/apache/airflow/blob/main/chart/values.schema.json#L4806 and https://github.com/apache/airflow/blob/main/chart/values.yaml#L1588 . I think it would be convinient to be able to propagate global security context to statsd deployment, so instead of changing documentation I added the propagation of global pod security context to statsd deployment.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
