### PR TITLE
openlineage: fix typing errors produced by bumping version, bump minimum version to 0.28, remove outdated warnings

### DIFF
--- a/airflow/providers/openlineage/provider.yaml
+++ b/airflow/providers/openlineage/provider.yaml
@@ -26,17 +26,11 @@ versions:
   - 1.0.0
 
 dependencies:
-  # This provider depends on Airflow features available in later versions, like
-  # lifecycle notifications https://github.com/apache/airflow/pull/27855
-  # or direct calls to Listener API https://github.com/apache/airflow/pull/29289
   - apache-airflow>=2.6.0
   - apache-airflow-providers-common-sql>=1.3.1
   - attrs>=22.2
-  # The openlineage-integration-common 0.27.1 introduced a breaking change in the configuration retrieval that
-  # Broke Airflow integration. Fix to deprecate it in https://github.com/OpenLineage/OpenLineage/pull/1908
-  # Is going to be merged in a follow-up release
-  - openlineage-integration-common>=0.22.0,!=0.27.1
-  - openlineage-python>=0.22.0
+  - openlineage-integration-common>=0.28.0
+  - openlineage-python>=0.28.0
 
 integrations:
   - integration-name: OpenLineage

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -624,8 +624,8 @@
       "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.6.0",
       "attrs>=22.2",
-      "openlineage-integration-common>=0.22.0,!=0.27.1",
-      "openlineage-python>=0.22.0"
+      "openlineage-integration-common>=0.28.0",
+      "openlineage-python>=0.28.0"
     ],
     "cross-providers-deps": [],
     "excluded-python-versions": []


### PR DESCRIPTION
OpenLineage 0.28.0 added some stricter type checks. This PR adjusts to that.

Also, it bumps minimum version to 0.28.0 - it's a "free action" as OL provider is not yet released. It also removes temporary comments in dependencies, that aren't relevant now.