### PR TITLE
Update documentation for constraints installation

### DIFF
--- a/docs/apache-airflow/installation/installing-from-pypi.rst
+++ b/docs/apache-airflow/installation/installing-from-pypi.rst
@@ -164,8 +164,8 @@ those dependencies that are stored in the original constraints file:
     requirements of Airflow or other dependencies installed in your system. However, by skipping constraints
     when you install or upgrade dependencies, you give ``pip`` a chance to resolve the conflicts for you,
     while keeping dependencies within the limits that Apache Airflow, providers and other dependencies require.
-    The resulting combination of those dependencies might not be tested together before as well as the set
-    of dependencies that come with constraints, but it should work in most cases as we usually add
+    The resulting combination of those dependencies and the set of dependencies that come with the 
+    constraints might not be tested before, but it should work in most cases as we usually add
     requirements, when Airflow depends on particular versions of some dependencies. In cases you cannot
     install some dependencies in the same environment as Airflow - you can attempt to use other approaches.
     See :ref:`best practices for handling conflicting/complex Python dependencies <best_practices/handling_conflicting_complex_python_dependencies>`

--- a/docs/apache-airflow/installation/installing-from-pypi.rst
+++ b/docs/apache-airflow/installation/installing-from-pypi.rst
@@ -65,7 +65,7 @@ Those are just examples, see further for more explanation why those are the best
    Generally speaking, Python community established practice is to perform application installation in a
    virtualenv created with ``virtualenv`` or ``venv`` tools. You can also use ``pipx`` to install Airflow in a
    application dedicated virtual environment created for you. There are also other tools that can be used
-   to manage your virtualenv installation and you are free to choose how you are managing the environments,
+   to manage your virtualenv installation and you are free to choose how you are managing the environments.
    Airflow has no limitation regarding to the tool of your choice when it comes to virtual environment.
 
    The only exception where you might consider not using virtualenv is when you are building a container

--- a/docs/apache-airflow/installation/installing-from-pypi.rst
+++ b/docs/apache-airflow/installation/installing-from-pypi.rst
@@ -102,7 +102,7 @@ performing dependency resolution.
 .. code-block:: bash
 
     pip install "apache-airflow[celery]==|version|" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-|version|/constraints-3.8.txt"
-    pip install "apache-airflow[celery]==|version|" apache-airflow-providers-google==10.1.1
+    pip install "apache-airflow==|version|" apache-airflow-providers-google==10.1.1
 
 You can also downgrade or upgrade other dependencies this way - even if they are not compatible with
 those dependencies that are stored in the original constraints file:

--- a/docs/apache-airflow/installation/installing-from-pypi.rst
+++ b/docs/apache-airflow/installation/installing-from-pypi.rst
@@ -124,7 +124,7 @@ but you can pick your own set of extras and providers to install.
     The reproducible installation guarantees that this initial installation steps will always work for you -
     providing that you use the right Python version and that you have appropriate Operating System dependencies
     installed for the providers to be installed. Some of the providers require additional OS dependencies to
-    be installed such us ``build-essential`` in order to compile libraries, or for example database client
+    be installed such as ``build-essential`` in order to compile libraries, or for example database client
     libraries in case you install a database provider, etc.. You need to figure out which system dependencies
     you need when your installation fails and install them before retrying the installation.
 

--- a/docs/apache-airflow/installation/installing-from-pypi.rst
+++ b/docs/apache-airflow/installation/installing-from-pypi.rst
@@ -192,8 +192,9 @@ Using your own constraints
 ==========================
 
 When you decide to install your own dependencies, or want to upgrade or downgrade providers, you might want
-to continue being able to keep reproducible installation of Airflow and those dependencies via a single command. In order to do that, you can produce your own constraints file and use it
-to install Airflow instead of the one provided by the community.
+to continue being able to keep reproducible installation of Airflow and those dependencies via a single command.
+In order to do that, you can produce your own constraints file and use it to install Airflow instead of the 
+one provided by the community.
 
 .. code-block:: bash
 

--- a/docs/apache-airflow/installation/installing-from-pypi.rst
+++ b/docs/apache-airflow/installation/installing-from-pypi.rst
@@ -164,7 +164,7 @@ those dependencies that are stored in the original constraints file:
     requirements of Airflow or other dependencies installed in your system. However, by skipping constraints
     when you install or upgrade dependencies, you give ``pip`` a chance to resolve the conflicts for you,
     while keeping dependencies within the limits that Apache Airflow, providers and other dependencies require.
-    The resulting combination of those dependencies and the set of dependencies that come with the 
+    The resulting combination of those dependencies and the set of dependencies that come with the
     constraints might not be tested before, but it should work in most cases as we usually add
     requirements, when Airflow depends on particular versions of some dependencies. In cases you cannot
     install some dependencies in the same environment as Airflow - you can attempt to use other approaches.
@@ -193,7 +193,7 @@ Using your own constraints
 
 When you decide to install your own dependencies, or want to upgrade or downgrade providers, you might want
 to continue being able to keep reproducible installation of Airflow and those dependencies via a single command.
-In order to do that, you can produce your own constraints file and use it to install Airflow instead of the 
+In order to do that, you can produce your own constraints file and use it to install Airflow instead of the
 one provided by the community.
 
 .. code-block:: bash
@@ -301,9 +301,11 @@ that conflicts with the version of apache-airflow that you are using:
 
     Installing, upgrading, downgrading providers separately is not guaranteed to work with all
     Airflow versions or other providers. Some providers have minimum-required version of Airflow and some
-    versions of providers might have conflicting requirements with Airflow or other dependencies you
-    might have installed. In cases you cannot install dependencies in the same environment as Airflow -
-    you can attempt to use other approaches.
+    versions of providers might have limits on dependencies that are conflicting with limits of other
+    providers or other dependencies installed. For example google provider before 10.1.0 version had limit
+    of protobuf library ``<=3.20.0`` while for example ``google-ads`` library that is supported by google
+    has requirement for protobuf library ``>=4``. In such cases installing those two dependencies alongside
+    in a single environment will not work. In such cases you can attempt to use other approaches.
     See :ref:`best practices for handling conflicting/complex Python dependencies <best_practices/handling_conflicting_complex_python_dependencies>`
 
 

--- a/docs/apache-airflow/installation/installing-from-pypi.rst
+++ b/docs/apache-airflow/installation/installing-from-pypi.rst
@@ -130,7 +130,7 @@ to install Airflow instead of the one provided by the community.
 .. code-block:: bash
 
     pip install "apache-airflow[celery]==|version|" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-|version|/constraints-3.8.txt"
-    pip install "apache-airflow[celery]==|version|" dbt-core==0.20.0
+    pip install "apache-airflow==|version|" dbt-core==0.20.0
     pip freeze > my-constraints.txt
 
 

--- a/docs/apache-airflow/installation/installing-from-pypi.rst
+++ b/docs/apache-airflow/installation/installing-from-pypi.rst
@@ -55,7 +55,7 @@ upgraded or downgraded by ``pip``.
 
 .. code-block:: bash
 
-    pip install "apache-airflow==|version|" apache-airflow-providers-google=10.1.0
+    pip install "apache-airflow==|version|" apache-airflow-providers-google==10.1.0
 
 
 Those are just examples, see further for more explanation why those are the best practices.

--- a/docs/apache-airflow/installation/installing-from-pypi.rst
+++ b/docs/apache-airflow/installation/installing-from-pypi.rst
@@ -141,7 +141,7 @@ reasons. Installing such dependencies should be done without constraints as a se
 
 When you do such an upgrade, you should make sure to also add the ``apache-airflow`` package to the list of
 packages to install and pin it to the version that you have, otherwise you might end up with a
-different version of Airflow than you expect as ``pip`` can upgrade/downgrade it automatically when
+different version of Airflow than you expect because ``pip`` can upgrade/downgrade it automatically when
 performing dependency resolution.
 
 

--- a/docs/apache-airflow/installation/installing-from-pypi.rst
+++ b/docs/apache-airflow/installation/installing-from-pypi.rst
@@ -124,8 +124,7 @@ Using your own constraints
 ==========================
 
 When you decide to install your own dependencies, or want to upgrade or downgrade providers, you might want
-to continue being able to keep reproducible installation of Airflow and those dependencies via single command
-line . In order to do that, you can produce your own constraints file and use it
+to continue being able to keep reproducible installation of Airflow and those dependencies via a single command. In order to do that, you can produce your own constraints file and use it
 to install Airflow instead of the one provided by the community.
 
 .. code-block:: bash


### PR DESCRIPTION
Airlow constraints and custom depenencies are a mystery for our users. The reason why we are using constraints is not clear and user are confused when they should and when they shoudl not use constraints. Recent discussions with users and "Mastering Custom Dependencies" presentation in London has proven that we need to do better and simplify the documentation while giving more, better examples. That includes trimming down of boilerplate description in the constraint information, explaining a little more on what reproducibke (not repeatable!) build is, adding expectation that users will not use constraints for all pip commands and explaining how to produce your own constraints if you need a reproducible, custom build.

This PR aims to fulfill those goals.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
