### PR TITLE
Deprecate `wait_for_completion` from `EcsRegisterTaskDefinitionOperator` and `EcsDeregisterTaskDefinitionOperator`

### DIFF
--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -19,13 +19,14 @@ from __future__ import annotations
 
 import re
 import sys
+import warnings
 from datetime import timedelta
 from functools import cached_property
 from typing import TYPE_CHECKING, Sequence
 
 import boto3
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator, XCom
 from airflow.providers.amazon.aws.exceptions import EcsOperatorError, EcsTaskFailToStart
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
@@ -201,22 +202,28 @@ class EcsDeregisterTaskDefinitionOperator(EcsBaseOperator):
 
     :param task_definition: The family and revision (family:revision) or full Amazon Resource Name (ARN)
         of the task definition to deregister. If you use a family name, you must specify a revision.
-    :param wait_for_completion: obsolete, the operation completes instantly
-    :param waiter_delay: obsolete
-    :param waiter_max_attempts: obsolete
     """
 
-    template_fields: Sequence[str] = ("task_definition", "wait_for_completion")
+    template_fields: Sequence[str] = "task_definition"
 
     def __init__(
         self,
         *,
         task_definition: str,
-        wait_for_completion: bool = True,  # obsolete
-        waiter_delay: int | None = None,  # obsolete
-        waiter_max_attempts: int | None = None,  # obsolete
         **kwargs,
     ):
+        if "wait_for_completion" in kwargs or "waiter_delay" in kwargs or "waiter_max_attempts" in kwargs:
+            warnings.warn(
+                "'wait_for_completion' and waiter related params have no effect and are deprecated, "
+                "please remove them.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
+            # remove args to not trigger Invalid arguments exception
+            kwargs.pop("wait_for_completion", None)
+            kwargs.pop("waiter_delay", None)
+            kwargs.pop("waiter_max_attempts", None)
+
         super().__init__(**kwargs)
         self.task_definition = task_definition
 
@@ -243,16 +250,12 @@ class EcsRegisterTaskDefinitionOperator(EcsBaseOperator):
     :param container_definitions: A list of container definitions in JSON format that describe
         the different containers that make up your task.
     :param register_task_kwargs: Extra arguments for Register Task Definition.
-    :param wait_for_completion: obsolete, the operation completes instantly
-    :param waiter_delay: obsolete
-    :param waiter_max_attempts: obsolete
     """
 
     template_fields: Sequence[str] = (
         "family",
         "container_definitions",
         "register_task_kwargs",
-        "wait_for_completion",
     )
 
     def __init__(
@@ -266,6 +269,18 @@ class EcsRegisterTaskDefinitionOperator(EcsBaseOperator):
         waiter_max_attempts: int | None = None,  # obsolete
         **kwargs,
     ):
+        if "wait_for_completion" in kwargs or "waiter_delay" in kwargs or "waiter_max_attempts" in kwargs:
+            warnings.warn(
+                "'wait_for_completion' and waiter related params have no effect and are deprecated, "
+                "please remove them.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
+            # remove args to not trigger Invalid arguments exception
+            kwargs.pop("wait_for_completion", None)
+            kwargs.pop("waiter_delay", None)
+            kwargs.pop("waiter_max_attempts", None)
+
         super().__init__(**kwargs)
         self.family = family
         self.container_definitions = container_definitions

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -264,9 +264,6 @@ class EcsRegisterTaskDefinitionOperator(EcsBaseOperator):
         family: str,
         container_definitions: list[dict],
         register_task_kwargs: dict | None = None,
-        wait_for_completion: bool = True,  # obsolete
-        waiter_delay: int | None = None,  # obsolete
-        waiter_max_attempts: int | None = None,  # obsolete
         **kwargs,
     ):
         if "wait_for_completion" in kwargs or "waiter_delay" in kwargs or "waiter_max_attempts" in kwargs:

--- a/airflow/providers/amazon/aws/waiters/ecs.json
+++ b/airflow/providers/amazon/aws/waiters/ecs.json
@@ -50,38 +50,6 @@
                   "argument": "failures[].reason"
                 }
             ]
-        },
-        "task_definition_active": {
-            "operation": "DescribeTaskDefinition",
-            "delay": 15,
-            "maxAttempts": 60,
-            "acceptors": [
-                {
-                    "expected": "ACTIVE",
-                    "matcher": "path",
-                    "state": "success",
-                    "argument": "taskDefinition.status"
-                },
-                {
-                    "expected": "DELETE_IN_PROGRESS",
-                    "matcher": "path",
-                    "state": "failure",
-                    "argument": "taskDefinition.status"
-                }
-            ]
-        },
-        "task_definition_inactive": {
-            "operation": "DescribeTaskDefinition",
-            "delay": 15,
-            "maxAttempts": 60,
-            "acceptors": [
-                {
-                    "expected": "INACTIVE",
-                    "matcher": "path",
-                    "state": "success",
-                    "argument": "taskDefinition.status"
-                }
-            ]
         }
     }
 }

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -795,4 +795,6 @@ class TestEcsRegisterTaskDefinitionOperator(EcsBaseTestCase):
 
     def test_deprecation(self):
         with pytest.warns(AirflowProviderDeprecationWarning):
-            EcsRegisterTaskDefinitionOperator(task_id="id", task_definition="def", wait_for_completion=True)
+            EcsRegisterTaskDefinitionOperator(
+                task_id="id", wait_for_completion=True, **TASK_DEFINITION_CONFIG
+            )

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -744,33 +744,7 @@ class TestEcsDeleteClusterOperator(EcsBaseTestCase):
 
 
 class TestEcsDeregisterTaskDefinitionOperator(EcsBaseTestCase):
-    @pytest.mark.parametrize("waiter_delay, waiter_max_attempts", WAITERS_TEST_CASES)
-    def test_execute_with_waiter(self, patch_hook_waiters, waiter_delay, waiter_max_attempts):
-        mocked_waiters = mock.MagicMock(name="MockedHookWaitersMethod")
-        patch_hook_waiters.return_value = mocked_waiters
-        op = EcsDeregisterTaskDefinitionOperator(
-            task_id="task",
-            task_definition=TASK_DEFINITION_NAME,
-            wait_for_completion=True,
-            waiter_delay=waiter_delay,
-            waiter_max_attempts=waiter_max_attempts,
-        )
-        with mock.patch.object(self.client, "deregister_task_definition") as mock_client_method:
-            result = op.execute({})
-            mock_client_method.assert_called_once_with(taskDefinition=TASK_DEFINITION_NAME)
-        patch_hook_waiters.assert_called_once_with("task_definition_inactive")
-
-        expected_waiter_config = {}
-        if waiter_delay:
-            expected_waiter_config["Delay"] = waiter_delay
-        if waiter_max_attempts:
-            expected_waiter_config["MaxAttempts"] = waiter_max_attempts
-        mocked_waiters.wait.assert_called_once_with(
-            taskDefinition=mock.ANY, WaiterConfig=expected_waiter_config
-        )
-        assert result is not None
-
-    def test_execute_immediate_delete(self, patch_hook_waiters):
+    def test_execute_immediate_delete(self):
         """Test if task definition deleted during initial request."""
         op = EcsDeregisterTaskDefinitionOperator(
             task_id="task", task_definition=TASK_DEFINITION_NAME, wait_for_completion=True
@@ -781,69 +755,11 @@ class TestEcsDeregisterTaskDefinitionOperator(EcsBaseTestCase):
             }
             result = op.execute({})
             mock_client_method.assert_called_once_with(taskDefinition=TASK_DEFINITION_NAME)
-        patch_hook_waiters.assert_not_called()
         assert result == "foo-bar"
-
-    def test_execute_without_waiter(self, patch_hook_waiters):
-        op = EcsDeregisterTaskDefinitionOperator(
-            task_id="task", task_definition=TASK_DEFINITION_NAME, wait_for_completion=False
-        )
-        with mock.patch.object(self.client, "deregister_task_definition") as mock_client_method:
-            result = op.execute({})
-            mock_client_method.assert_called_once_with(taskDefinition=TASK_DEFINITION_NAME)
-        patch_hook_waiters.assert_not_called()
-        assert result is not None
 
 
 class TestEcsRegisterTaskDefinitionOperator(EcsBaseTestCase):
-    @pytest.mark.parametrize("waiter_delay, waiter_max_attempts", WAITERS_TEST_CASES)
-    def test_execute_with_waiter(self, patch_hook_waiters, waiter_delay, waiter_max_attempts):
-        mock_ti = mock.MagicMock(name="MockedTaskInstance")
-        mocked_waiters = mock.MagicMock(name="MockedHookWaitersMethod")
-        patch_hook_waiters.return_value = mocked_waiters
-        expected_task_definition_config = {
-            "family": "family_name",
-            "containerDefinitions": [
-                {
-                    "name": CONTAINER_NAME,
-                    "image": "ubuntu",
-                    "workingDirectory": "/usr/bin",
-                    "entryPoint": ["sh", "-c"],
-                    "command": ["ls"],
-                }
-            ],
-            "cpu": "256",
-            "memory": "512",
-            "networkMode": "awsvpc",
-        }
-        op = EcsRegisterTaskDefinitionOperator(
-            task_id="task",
-            **TASK_DEFINITION_CONFIG,
-            wait_for_completion=True,
-            waiter_delay=waiter_delay,
-            waiter_max_attempts=waiter_max_attempts,
-        )
-        with mock.patch.object(self.client, "register_task_definition") as mock_client_method:
-            result = op.execute({"ti": mock_ti})
-            mock_client_method.assert_called_once_with(**expected_task_definition_config)
-        patch_hook_waiters.assert_called_once_with("task_definition_active")
-        mock_ti.xcom_push.assert_called_once_with(key="task_definition_arn", value=mock.ANY)
-
-        expected_waiter_config = {}
-        if waiter_delay:
-            expected_waiter_config["Delay"] = waiter_delay
-        if waiter_max_attempts:
-            expected_waiter_config["MaxAttempts"] = waiter_max_attempts
-        mocked_waiters.wait.assert_called_once_with(
-            taskDefinition=mock.ANY, WaiterConfig=expected_waiter_config
-        )
-        mocked_waiters.wait.assert_called_once_with(
-            taskDefinition=mock.ANY, WaiterConfig=expected_waiter_config
-        )
-
-        assert result is not None
-
-    def test_execute_immediate_create(self, patch_hook_waiters):
+    def test_execute_immediate_create(self):
         """Test if task definition created during initial request."""
         mock_ti = mock.MagicMock(name="MockedTaskInstance")
         expected_task_definition_config = {
@@ -862,39 +778,13 @@ class TestEcsRegisterTaskDefinitionOperator(EcsBaseTestCase):
             "networkMode": "awsvpc",
         }
         op = EcsRegisterTaskDefinitionOperator(task_id="task", **TASK_DEFINITION_CONFIG)
+
         with mock.patch.object(self.client, "register_task_definition") as mock_client_method:
             mock_client_method.return_value = {
                 "taskDefinition": {"status": "ACTIVE", "taskDefinitionArn": "foo-bar"}
             }
             result = op.execute({"ti": mock_ti})
             mock_client_method.assert_called_once_with(**expected_task_definition_config)
-        patch_hook_waiters.assert_not_called()
+
         mock_ti.xcom_push.assert_called_once_with(key="task_definition_arn", value="foo-bar")
         assert result == "foo-bar"
-
-    def test_execute_without_waiter(self, patch_hook_waiters):
-        mock_context = mock.MagicMock()
-        expected_task_definition_config = {
-            "family": "family_name",
-            "containerDefinitions": [
-                {
-                    "name": CONTAINER_NAME,
-                    "image": "ubuntu",
-                    "workingDirectory": "/usr/bin",
-                    "entryPoint": ["sh", "-c"],
-                    "command": ["ls"],
-                }
-            ],
-            "cpu": "256",
-            "memory": "512",
-            "networkMode": "awsvpc",
-        }
-
-        op = EcsRegisterTaskDefinitionOperator(
-            task_id="task", **TASK_DEFINITION_CONFIG, wait_for_completion=False
-        )
-        with mock.patch.object(self.client, "register_task_definition") as mock_client_method:
-            result = op.execute(mock_context)
-            mock_client_method.assert_called_once_with(**expected_task_definition_config)
-        patch_hook_waiters.assert_not_called()
-        assert result is not None

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -24,7 +24,7 @@ from unittest import mock
 import boto3
 import pytest
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.exceptions import EcsOperatorError, EcsTaskFailToStart
 from airflow.providers.amazon.aws.hooks.ecs import EcsHook
 from airflow.providers.amazon.aws.operators.ecs import (
@@ -757,6 +757,10 @@ class TestEcsDeregisterTaskDefinitionOperator(EcsBaseTestCase):
             mock_client_method.assert_called_once_with(taskDefinition=TASK_DEFINITION_NAME)
         assert result == "foo-bar"
 
+    def test_deprecation(self):
+        with pytest.warns(AirflowProviderDeprecationWarning):
+            EcsDeregisterTaskDefinitionOperator(task_id="id", task_definition="def", wait_for_completion=True)
+
 
 class TestEcsRegisterTaskDefinitionOperator(EcsBaseTestCase):
     def test_execute_immediate_create(self):
@@ -788,3 +792,7 @@ class TestEcsRegisterTaskDefinitionOperator(EcsBaseTestCase):
 
         mock_ti.xcom_push.assert_called_once_with(key="task_definition_arn", value="foo-bar")
         assert result == "foo-bar"
+
+    def test_deprecation(self):
+        with pytest.warns(AirflowProviderDeprecationWarning):
+            EcsRegisterTaskDefinitionOperator(task_id="id", task_definition="def", wait_for_completion=True)

--- a/tests/providers/amazon/aws/waiters/test_custom_waiters.py
+++ b/tests/providers/amazon/aws/waiters/test_custom_waiters.py
@@ -129,8 +129,6 @@ class TestCustomECSServiceWaiters:
         hook_waiters = EcsHook(aws_conn_id=None).list_waiters()
         assert "cluster_active" in hook_waiters
         assert "cluster_inactive" in hook_waiters
-        assert "task_definition_active" in hook_waiters
-        assert "task_definition_inactive" in hook_waiters
 
     @staticmethod
     def describe_clusters(
@@ -221,35 +219,6 @@ class TestCustomECSServiceWaiters:
                 "status": status,
             }
         }
-
-    def test_task_definition_active(self, mock_describe_task_definition):
-        """Test task definition reach active state during creation."""
-        mock_describe_task_definition.side_effect = [
-            self.describe_task_definition(EcsTaskDefinitionStates.INACTIVE),
-            self.describe_task_definition(EcsTaskDefinitionStates.INACTIVE),
-            self.describe_task_definition(EcsTaskDefinitionStates.ACTIVE),
-        ]
-        waiter = EcsHook(aws_conn_id=None).get_waiter("task_definition_active")
-        waiter.wait(taskDefinition="spam-egg", WaiterConfig={"Delay": 0.01, "MaxAttempts": 3})
-
-    def test_task_definition_failure(self, mock_describe_task_definition):
-        """Test task definition reach delete in progress state during creation."""
-        mock_describe_task_definition.side_effect = [
-            self.describe_task_definition(EcsTaskDefinitionStates.DELETE_IN_PROGRESS),
-        ]
-        waiter = EcsHook(aws_conn_id=None).get_waiter("task_definition_active")
-        with pytest.raises(WaiterError, match='matched expected path: "DELETE_IN_PROGRESS"'):
-            waiter.wait(taskDefinition="spam-egg", WaiterConfig={"Delay": 0.01, "MaxAttempts": 1})
-
-    def test_task_definition_inactive(self, mock_describe_task_definition):
-        """Test task definition reach inactive state during deletion."""
-        mock_describe_task_definition.side_effect = [
-            self.describe_task_definition(EcsTaskDefinitionStates.ACTIVE),
-            self.describe_task_definition(EcsTaskDefinitionStates.ACTIVE),
-            self.describe_task_definition(EcsTaskDefinitionStates.INACTIVE),
-        ]
-        waiter = EcsHook(aws_conn_id=None).get_waiter("task_definition_inactive")
-        waiter.wait(taskDefinition="spam-egg", WaiterConfig={"Delay": 0.01, "MaxAttempts": 3})
 
 
 class TestCustomDynamoDBServiceWaiters:


### PR DESCRIPTION
those operations are actually completed instantly.

the doc to deregister says it explicitely:
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deregister-task-definition.html
> When you deregister a task definition revision, it’s immediately marked as INACTIVE.

to register a task, it's less clear, but task definition states show no transition states https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-definition-state.html and expriments show that the task is always returned as active right after having been created.
