### PR TITLE
[AIP-49] Allow OTel export interval to use default values

### DIFF
--- a/airflow/metrics/otel_logger.py
+++ b/airflow/metrics/otel_logger.py
@@ -363,7 +363,8 @@ def get_otel_logger(cls) -> SafeOtelLogger:
     host = conf.get("metrics", "otel_host")  # ex: "breeze-otel-collector"
     port = conf.getint("metrics", "otel_port")  # ex: 4318
     prefix = conf.get("metrics", "otel_prefix")  # ex: "airflow"
-    interval = conf.getint("metrics", "otel_interval_milliseconds")  # ex: 30000
+    # PeriodicExportingMetricReader will default to an interval of 60000 millis.
+    interval = conf.getint("metrics", "otel_interval_milliseconds", fallback=None)  # ex: 30000
     debug = conf.getboolean("metrics", "otel_debugging_on")
 
     allow_list = conf.get("metrics", "metrics_allow_list", fallback=None)


### PR DESCRIPTION
PeriodicExportingMetricReader falls back to a 60000ms interval if no value is provided ([here](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py#L444)), but our code was making that a required value.

Corroborated by the related docs [here](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#periodic-exporting-metricreader)