### PR TITLE
Update SparkSubmitOperator doc: rename spark_conn_id to conn_id

### DIFF
--- a/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/airflow/providers/apache/spark/operators/spark_submit.py
@@ -38,7 +38,7 @@ class SparkSubmitOperator(BaseOperator):
 
     :param application: The application that submitted as a job, either jar or py file. (templated)
     :param conf: Arbitrary Spark configuration properties (templated)
-    :param spark_conn_id: The :ref:`spark connection id <howto/connection:spark>` as configured
+    :param conn_id: The :ref:`spark connection id <howto/connection:spark>` as configured
         in Airflow administration. When an invalid connection_id is supplied, it will default to yarn.
     :param files: Upload additional files to the executor running the job, separated by a
                   comma. Files will be placed in the working directory of each executor.


### PR DESCRIPTION
There is no `spark_conn_id` in the **SparkSubmitOperator**, there is a `conn_id` for the Spark connection.

Screenshot:
![image](https://github.com/apache/airflow/assets/36465150/e57fd6e2-0860-4032-92c4-6ca236a78589)