### PR TITLE
Fix task.sensor annotation in type stub

### DIFF
--- a/airflow/decorators/__init__.pyi
+++ b/airflow/decorators/__init__.pyi
@@ -453,7 +453,7 @@ class TaskDecoratorCollection:
         :param max_wait: maximum wait interval between pokes, can be ``timedelta`` or ``float`` seconds
         """
     @overload
-    def sensor(self, python_callable: FParams | FReturn | None = None) -> Task[FParams, FReturn]: ...
+    def sensor(self, python_callable: Callable[FParams, FReturn] | None = None) -> Task[FParams, FReturn]: ...
 
 task: TaskDecoratorCollection
 setup: Callable


### PR DESCRIPTION
Not sure how the annotation ended up like that, it’s wrong.