### PR TITLE
Refactor Eks Create Cluster Operator code

### DIFF
--- a/airflow/providers/amazon/aws/operators/eks.py
+++ b/airflow/providers/amazon/aws/operators/eks.py
@@ -237,12 +237,6 @@ class EksCreateClusterOperator(BaseEksCreateOperator):
                         compute=FARGATE_FULL_NAME, requirement="fargate_pod_execution_role_arn"
                     )
                 )
-
-        self.eks_hook = EksHook(
-            aws_conn_id=self.aws_conn_id,
-            region_name=self.region,
-        )
-
         self.eks_hook.create_cluster(
             name=self.cluster_name,
             roleArn=self.cluster_role_arn,

--- a/tests/always/test_project_structure.py
+++ b/tests/always/test_project_structure.py
@@ -405,8 +405,6 @@ class TestAmazonProviderProjectStructure(ExampleCoverageTest):
         "airflow.providers.amazon.aws.transfers.exasol_to_s3.ExasolToS3Operator",
         # Glue Catalog sensor difficult to test
         "airflow.providers.amazon.aws.sensors.glue_catalog_partition.GlueCatalogPartitionSensor",
-        # This is a base class for some of the Eks Operators that create Eks resources
-        "airflow.providers.amazon.aws.operators.eks.BaseEksCreateOperator",
     }
 
     DEPRECATED_CLASSES = {

--- a/tests/always/test_project_structure.py
+++ b/tests/always/test_project_structure.py
@@ -405,6 +405,8 @@ class TestAmazonProviderProjectStructure(ExampleCoverageTest):
         "airflow.providers.amazon.aws.transfers.exasol_to_s3.ExasolToS3Operator",
         # Glue Catalog sensor difficult to test
         "airflow.providers.amazon.aws.sensors.glue_catalog_partition.GlueCatalogPartitionSensor",
+        # This is a base class for some of the Eks Operators that create Eks resources
+        "airflow.providers.amazon.aws.operators.eks.BaseEksCreateOperator",
     }
 
     DEPRECATED_CLASSES = {

--- a/tests/providers/amazon/aws/operators/test_eks.py
+++ b/tests/providers/amazon/aws/operators/test_eks.py
@@ -200,7 +200,11 @@ class TestEksCreateClusterOperator:
         operator.execute({})
         mock_create_cluster.assert_called_with(**convert_keys(parameters))
         mock_create_nodegroup.assert_not_called()
-        mock_waiter.assert_called_once_with(mock.ANY, name=CLUSTER_NAME)
+        mock_waiter.assert_called_once_with(
+            mock.ANY,
+            name=CLUSTER_NAME,
+            WaiterConfig={"Delay": mock.ANY, "MaxAttempts": mock.ANY},
+        )
         assert_expected_waiter_type(mock_waiter, "ClusterActive")
 
     @mock.patch.object(Waiter, "wait")
@@ -216,7 +220,11 @@ class TestEksCreateClusterOperator:
 
         mock_create_cluster.assert_called_once_with(**convert_keys(self.create_cluster_params))
         mock_create_nodegroup.assert_called_once_with(**convert_keys(self.create_nodegroup_params))
-        mock_waiter.assert_called_once_with(mock.ANY, name=CLUSTER_NAME)
+        mock_waiter.assert_called_once_with(
+            mock.ANY,
+            name=CLUSTER_NAME,
+            WaiterConfig={"Delay": mock.ANY, "MaxAttempts": mock.ANY},
+        )
         assert_expected_waiter_type(mock_waiter, "ClusterActive")
 
     @mock.patch.object(Waiter, "wait")
@@ -235,7 +243,12 @@ class TestEksCreateClusterOperator:
         mock_create_nodegroup.assert_called_once_with(**convert_keys(self.create_nodegroup_params))
         # Calls waiter once for the cluster and once for the nodegroup.
         assert mock_waiter.call_count == 2
-        mock_waiter.assert_called_with(mock.ANY, clusterName=CLUSTER_NAME, nodegroupName=NODEGROUP_NAME)
+        mock_waiter.assert_called_with(
+            mock.ANY,
+            clusterName=CLUSTER_NAME,
+            nodegroupName=NODEGROUP_NAME,
+            WaiterConfig={"Delay": mock.ANY, "MaxAttempts": mock.ANY},
+        )
         assert_expected_waiter_type(mock_waiter, "NodegroupActive")
 
     @mock.patch.object(Waiter, "wait")
@@ -253,7 +266,11 @@ class TestEksCreateClusterOperator:
         mock_create_fargate_profile.assert_called_once_with(
             **convert_keys(self.create_fargate_profile_params)
         )
-        mock_waiter.assert_called_once_with(mock.ANY, name=CLUSTER_NAME)
+        mock_waiter.assert_called_once_with(
+            mock.ANY,
+            name=CLUSTER_NAME,
+            WaiterConfig={"Delay": mock.ANY, "MaxAttempts": mock.ANY},
+        )
         assert_expected_waiter_type(mock_waiter, "ClusterActive")
 
     @mock.patch.object(Waiter, "wait")
@@ -275,7 +292,10 @@ class TestEksCreateClusterOperator:
         # Calls waiter once for the cluster and once for the nodegroup.
         assert mock_waiter.call_count == 2
         mock_waiter.assert_called_with(
-            mock.ANY, clusterName=CLUSTER_NAME, fargateProfileName=FARGATE_PROFILE_NAME
+            mock.ANY,
+            clusterName=CLUSTER_NAME,
+            fargateProfileName=FARGATE_PROFILE_NAME,
+            WaiterConfig={"Delay": mock.ANY, "MaxAttempts": mock.ANY},
         )
         assert_expected_waiter_type(mock_waiter, "FargateProfileActive")
 
@@ -377,7 +397,7 @@ class TestEksCreateFargateProfileOperator:
             mock.ANY,
             clusterName=CLUSTER_NAME,
             fargateProfileName=FARGATE_PROFILE_NAME,
-            WaiterConfig={"Delay": 10, "MaxAttempts": 60},
+            WaiterConfig={"Delay": mock.ANY, "MaxAttempts": mock.ANY},
         )
         assert_expected_waiter_type(mock_waiter, "FargateProfileActive")
 

--- a/tests/providers/amazon/aws/operators/test_eks.py
+++ b/tests/providers/amazon/aws/operators/test_eks.py
@@ -247,7 +247,7 @@ class TestEksCreateClusterOperator:
             mock.ANY,
             clusterName=CLUSTER_NAME,
             nodegroupName=NODEGROUP_NAME,
-            WaiterConfig={"Delay": mock.ANY, "MaxAttempts": mock.ANY},
+            WaiterConfig={"MaxAttempts": mock.ANY},
         )
         assert_expected_waiter_type(mock_waiter, "NodegroupActive")
 
@@ -295,7 +295,7 @@ class TestEksCreateClusterOperator:
             mock.ANY,
             clusterName=CLUSTER_NAME,
             fargateProfileName=FARGATE_PROFILE_NAME,
-            WaiterConfig={"Delay": mock.ANY, "MaxAttempts": mock.ANY},
+            WaiterConfig={"MaxAttempts": mock.ANY},
         )
         assert_expected_waiter_type(mock_waiter, "FargateProfileActive")
 
@@ -397,7 +397,7 @@ class TestEksCreateFargateProfileOperator:
             mock.ANY,
             clusterName=CLUSTER_NAME,
             fargateProfileName=FARGATE_PROFILE_NAME,
-            WaiterConfig={"Delay": mock.ANY, "MaxAttempts": mock.ANY},
+            WaiterConfig={"MaxAttempts": mock.ANY},
         )
         assert_expected_waiter_type(mock_waiter, "FargateProfileActive")
 

--- a/tests/providers/amazon/aws/triggers/test_eks.py
+++ b/tests/providers/amazon/aws/triggers/test_eks.py
@@ -32,8 +32,8 @@ from airflow.triggers.base import TriggerEvent
 
 TEST_CLUSTER_IDENTIFIER = "test-cluster"
 TEST_FARGATE_PROFILE_NAME = "test-fargate-profile"
-TEST_POLL_INTERVAL = 10
-TEST_MAX_ATTEMPTS = 10
+TEST_WAITER_DELAY = 10
+TEST_WAITER_MAX_ATTEMPTS = 10
 TEST_AWS_CONN_ID = "test-aws-id"
 
 
@@ -43,8 +43,8 @@ class TestEksCreateFargateProfileTrigger:
             cluster_name=TEST_CLUSTER_IDENTIFIER,
             fargate_profile_name=TEST_FARGATE_PROFILE_NAME,
             aws_conn_id=TEST_AWS_CONN_ID,
-            poll_interval=TEST_POLL_INTERVAL,
-            max_attempts=TEST_MAX_ATTEMPTS,
+            waiter_delay=TEST_WAITER_DELAY,
+            waiter_max_attempts=TEST_WAITER_MAX_ATTEMPTS,
         )
 
         class_path, args = eks_create_fargate_profile_trigger.serialize()
@@ -52,8 +52,8 @@ class TestEksCreateFargateProfileTrigger:
         assert args["cluster_name"] == TEST_CLUSTER_IDENTIFIER
         assert args["fargate_profile_name"] == TEST_FARGATE_PROFILE_NAME
         assert args["aws_conn_id"] == TEST_AWS_CONN_ID
-        assert args["poll_interval"] == str(TEST_POLL_INTERVAL)
-        assert args["max_attempts"] == str(TEST_MAX_ATTEMPTS)
+        assert args["waiter_delay"] == str(TEST_WAITER_DELAY)
+        assert args["waiter_max_attempts"] == str(TEST_WAITER_MAX_ATTEMPTS)
 
     @pytest.mark.asyncio
     @mock.patch.object(EksHook, "async_conn")
@@ -67,8 +67,8 @@ class TestEksCreateFargateProfileTrigger:
             cluster_name=TEST_CLUSTER_IDENTIFIER,
             fargate_profile_name=TEST_FARGATE_PROFILE_NAME,
             aws_conn_id=TEST_AWS_CONN_ID,
-            poll_interval=TEST_POLL_INTERVAL,
-            max_attempts=TEST_MAX_ATTEMPTS,
+            waiter_delay=TEST_WAITER_DELAY,
+            waiter_max_attempts=TEST_WAITER_MAX_ATTEMPTS,
         )
 
         generator = eks_create_fargate_profile_trigger.run()
@@ -96,8 +96,8 @@ class TestEksCreateFargateProfileTrigger:
             cluster_name=TEST_CLUSTER_IDENTIFIER,
             fargate_profile_name=TEST_FARGATE_PROFILE_NAME,
             aws_conn_id=TEST_AWS_CONN_ID,
-            poll_interval=TEST_POLL_INTERVAL,
-            max_attempts=TEST_MAX_ATTEMPTS,
+            waiter_delay=TEST_WAITER_DELAY,
+            waiter_max_attempts=TEST_WAITER_MAX_ATTEMPTS,
         )
 
         generator = eks_create_fargate_profile_trigger.run()
@@ -126,8 +126,8 @@ class TestEksCreateFargateProfileTrigger:
             cluster_name=TEST_CLUSTER_IDENTIFIER,
             fargate_profile_name=TEST_FARGATE_PROFILE_NAME,
             aws_conn_id=TEST_AWS_CONN_ID,
-            poll_interval=TEST_POLL_INTERVAL,
-            max_attempts=2,
+            waiter_delay=TEST_WAITER_DELAY,
+            waiter_max_attempts=2,
         )
         with pytest.raises(AirflowException) as exc:
             generator = eks_create_fargate_profile_trigger.run()
@@ -158,8 +158,8 @@ class TestEksCreateFargateProfileTrigger:
             cluster_name=TEST_CLUSTER_IDENTIFIER,
             fargate_profile_name=TEST_FARGATE_PROFILE_NAME,
             aws_conn_id=TEST_AWS_CONN_ID,
-            poll_interval=TEST_POLL_INTERVAL,
-            max_attempts=TEST_MAX_ATTEMPTS,
+            waiter_delay=TEST_WAITER_DELAY,
+            waiter_max_attempts=TEST_WAITER_MAX_ATTEMPTS,
         )
 
         with pytest.raises(AirflowException) as exc:
@@ -175,8 +175,8 @@ class TestEksDeleteFargateProfileTrigger:
             cluster_name=TEST_CLUSTER_IDENTIFIER,
             fargate_profile_name=TEST_FARGATE_PROFILE_NAME,
             aws_conn_id=TEST_AWS_CONN_ID,
-            poll_interval=TEST_POLL_INTERVAL,
-            max_attempts=TEST_MAX_ATTEMPTS,
+            waiter_delay=TEST_WAITER_DELAY,
+            waiter_max_attempts=TEST_WAITER_MAX_ATTEMPTS,
         )
 
         class_path, args = eks_delete_fargate_profile_trigger.serialize()
@@ -184,8 +184,8 @@ class TestEksDeleteFargateProfileTrigger:
         assert args["cluster_name"] == TEST_CLUSTER_IDENTIFIER
         assert args["fargate_profile_name"] == TEST_FARGATE_PROFILE_NAME
         assert args["aws_conn_id"] == TEST_AWS_CONN_ID
-        assert args["poll_interval"] == str(TEST_POLL_INTERVAL)
-        assert args["max_attempts"] == str(TEST_MAX_ATTEMPTS)
+        assert args["waiter_delay"] == str(TEST_WAITER_DELAY)
+        assert args["waiter_max_attempts"] == str(TEST_WAITER_MAX_ATTEMPTS)
 
     @pytest.mark.asyncio
     @mock.patch.object(EksHook, "async_conn")
@@ -199,8 +199,8 @@ class TestEksDeleteFargateProfileTrigger:
             cluster_name=TEST_CLUSTER_IDENTIFIER,
             fargate_profile_name=TEST_FARGATE_PROFILE_NAME,
             aws_conn_id=TEST_AWS_CONN_ID,
-            poll_interval=TEST_POLL_INTERVAL,
-            max_attempts=TEST_MAX_ATTEMPTS,
+            waiter_delay=TEST_WAITER_DELAY,
+            waiter_max_attempts=TEST_WAITER_MAX_ATTEMPTS,
         )
 
         generator = eks_delete_fargate_profile_trigger.run()
@@ -228,8 +228,8 @@ class TestEksDeleteFargateProfileTrigger:
             cluster_name=TEST_CLUSTER_IDENTIFIER,
             fargate_profile_name=TEST_FARGATE_PROFILE_NAME,
             aws_conn_id=TEST_AWS_CONN_ID,
-            poll_interval=TEST_POLL_INTERVAL,
-            max_attempts=TEST_MAX_ATTEMPTS,
+            waiter_delay=TEST_WAITER_DELAY,
+            waiter_max_attempts=TEST_WAITER_MAX_ATTEMPTS,
         )
 
         generator = eks_delete_fargate_profile_trigger.run()
@@ -257,8 +257,8 @@ class TestEksDeleteFargateProfileTrigger:
             cluster_name=TEST_CLUSTER_IDENTIFIER,
             fargate_profile_name=TEST_FARGATE_PROFILE_NAME,
             aws_conn_id=TEST_AWS_CONN_ID,
-            poll_interval=TEST_POLL_INTERVAL,
-            max_attempts=2,
+            waiter_delay=TEST_WAITER_DELAY,
+            waiter_max_attempts=2,
         )
         with pytest.raises(AirflowException) as exc:
             generator = eks_delete_fargate_profile_trigger.run()
@@ -289,8 +289,8 @@ class TestEksDeleteFargateProfileTrigger:
             cluster_name=TEST_CLUSTER_IDENTIFIER,
             fargate_profile_name=TEST_FARGATE_PROFILE_NAME,
             aws_conn_id=TEST_AWS_CONN_ID,
-            poll_interval=TEST_POLL_INTERVAL,
-            max_attempts=TEST_MAX_ATTEMPTS,
+            waiter_delay=TEST_WAITER_DELAY,
+            waiter_max_attempts=TEST_WAITER_MAX_ATTEMPTS,
         )
         with pytest.raises(AirflowException) as exc:
             generator = eks_delete_fargate_profile_trigger.run()


### PR DESCRIPTION
The `EksCreateClusterOperator` is capable of creating a Fargate Profile or Nodegroup that is associated with the newly created cluster. The code for creating the Fargate Profile and Nodegroup is the same as the code in `EksCreateFargateProfileOperator` and `EksCreateNodegroupOperator` respectively. 
This PR refactors the code to reuse some of the code to decrease code duplication. This step also simplifies adding deferrable mode to these operators.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
