### PR TITLE
Fix masking nested variable fields

### DIFF
--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -142,7 +142,7 @@ class Variable(Base, LoggingMixin):
         else:
             if deserialize_json:
                 obj = json.loads(var_val)
-                mask_secret(var_val, key)
+                mask_secret(obj, key)
                 return obj
             else:
                 mask_secret(var_val, key)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #31873

Currently we mask the value of the dumped json, which we will try to filter form the log, but if a part of this value appears in the log, we will keep it:
```python
>>> from airflow.utils.log.secrets_masker import SecretsMasker
>>> filt = SecretsMasker()
>>> filt.add_mask('{"api_key": "key_value"}',"var_name.api_key")
>>> filt.patterns
{'\\{"api_key":\\ "key_value"\\}'}
>>> filt.add_mask({"api_key": "key_value"},"var_name.api_key")
>>> filt.patterns
{'key_value', '\\{"api_key":\\ "key_value"\\}'}
```
By masking the loaded dict, we will filter only the nested values considered as secrets.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
