### PR TITLE
Use null and not default value if array in trigger form is empty

### DIFF
--- a/airflow/www/static/js/trigger.js
+++ b/airflow/www/static/js/trigger.js
@@ -46,7 +46,7 @@ function updateJSONconf() {
             values[values.length] = lines[j].trim();
           }
         }
-        params[keyName] = values.length === 0 ? params[keyName] : values;
+        params[keyName] = values.length === 0 ? null : values;
       } else if (elements[i].value.length === 0) {
         params[keyName] = null;
       } else if (


### PR DESCRIPTION
This PR is for branch 2.6 releases only. It is already fixed on main/2.7.0++

Not more details on this PR, it is a one-liner, details in the bug ticket

closes: #31869
