### PR TITLE
Add ™ to Airflow in prominent places

### DIFF
--- a/docs/apache-airflow/core-concepts/index.rst
+++ b/docs/apache-airflow/core-concepts/index.rst
@@ -18,7 +18,7 @@
 Core Concepts
 =============================
 
-Here you can find detailed documentation about each one of Airflow's core concepts and how to use them, as well as a high-level :doc:`architectural overview <overview>`.
+Here you can find detailed documentation about each one of the core concepts of Apache Airflow™ and how to use them, as well as a high-level :doc:`architectural overview <overview>`.
 
 **Architecture**
 

--- a/docs/apache-airflow/index.rst
+++ b/docs/apache-airflow/index.rst
@@ -15,10 +15,10 @@
     specific language governing permissions and limitations
     under the License.
 
-What is Airflow?
+What is Airflow ™?
 =========================================
 
-`Apache Airflow <https://github.com/apache/airflow>`_ is an open-source platform for developing, scheduling,
+`Apache Airflow™ <https://github.com/apache/airflow>`_ is an open-source platform for developing, scheduling,
 and monitoring batch-oriented workflows. Airflow's extensible Python framework enables you to build workflows
 connecting with virtually any technology. A web interface helps manage the state of your workflows. Airflow is
 deployable in many ways, varying from a single process on your laptop to a distributed setup to support even
@@ -30,7 +30,7 @@ The main characteristic of Airflow workflows is that all workflows are defined i
 code" serves several purposes:
 
 - **Dynamic**: Airflow pipelines are configured as Python code, allowing for dynamic pipeline generation.
-- **Extensible**: The Airflow framework contains operators to connect with numerous technologies. All Airflow components are extensible to easily adjust to your environment.
+- **Extensible**: The Airflow™ framework contains operators to connect with numerous technologies. All Airflow components are extensible to easily adjust to your environment.
 - **Flexible**: Workflow parameterization is built-in leveraging the `Jinja <https://jinja.palletsprojects.com>`_ templating engine.
 
 Take a look at the following snippet of code:
@@ -80,9 +80,9 @@ Each column represents one DAG run. These are two of the most used views in Airf
 other views which allow you to deep dive into the state of your workflows.
 
 
-Why Airflow?
+Why Airflow™?
 =========================================
-Airflow is a batch workflow orchestration platform. The Airflow framework contains operators to connect with
+Airflow™ is a batch workflow orchestration platform. The Airflow framework contains operators to connect with
 many technologies and is easily extensible to connect with a new technology. If your workflows have a clear
 start and end, and run at regular intervals, they can be programmed as an Airflow DAG.
 
@@ -111,10 +111,10 @@ such as `Slack <https://s.apache.org/airflow-slack>`_ and mailing lists.
 Airflow as a Platform is highly customizable. By utilizing :doc:`public-airflow-interface` you can extend
 and customize almost every aspect of Airflow.
 
-Why not Airflow?
-================
+Why not Airflow™?
+=================
 
-Airflow was built for finite batch workflows. While the CLI and REST API do allow triggering workflows,
+Airflow™ was built for finite batch workflows. While the CLI and REST API do allow triggering workflows,
 Airflow was not built for infinitely-running event-based workflows. Airflow is not a streaming solution.
 However, a streaming system such as Apache Kafka is often seen working together with Apache Airflow. Kafka can
 be used for ingestion and processing in real-time, event data is written to a storage location, and Airflow

--- a/docs/apache-airflow/index.rst
+++ b/docs/apache-airflow/index.rst
@@ -15,7 +15,7 @@
     specific language governing permissions and limitations
     under the License.
 
-What is Airflow ™?
+What is Airflow™?
 =========================================
 
 `Apache Airflow™ <https://github.com/apache/airflow>`_ is an open-source platform for developing, scheduling,

--- a/docs/apache-airflow/installation/index.rst
+++ b/docs/apache-airflow/installation/index.rst
@@ -16,8 +16,8 @@
     under the License.
 
 
-Installation
-------------
+Installation of Airflow™
+------------------------
 
 .. contents:: :local:
 
@@ -34,7 +34,7 @@ Installation
     Setting up the database <setting-up-the-database>
     Upgrading <upgrading>
 
-This page describes installations options that you might use when considering how to install Airflow.
+This page describes installations options that you might use when considering how to install Airflow™.
 Airflow consists of many components, often distributed among many physical or virtual machines, therefore
 installation of Airflow might be quite complex, depending on the options you choose.
 

--- a/docs/apache-airflow/installation/installing-from-pypi.rst
+++ b/docs/apache-airflow/installation/installing-from-pypi.rst
@@ -63,7 +63,7 @@ Those are just examples, see further for more explanation why those are the best
 .. note::
 
    Generally speaking, Python community established practice is to perform application installation in a
-   virtualenv created with ``virtualenv`` or ``venv`` tools. You can also use ``pipx`` to install Airflow in a
+   virtualenv created with ``virtualenv`` or ``venv`` tools. You can also use ``pipx`` to install Airflow™ in a
    application dedicated virtual environment created for you. There are also other tools that can be used
    to manage your virtualenv installation and you are free to choose how you are managing the environments.
    Airflow has no limitation regarding to the tool of your choice when it comes to virtual environment.
@@ -80,7 +80,7 @@ Constraints files
 Why we need constraints
 =======================
 
-Airflow installation can be tricky because Airflow is both a library and an application.
+Airflow™ installation can be tricky because Airflow is both a library and an application.
 
 Libraries usually keep their dependencies open and applications usually pin them, but we should do neither
 and both at the same time. We decided to keep our dependencies as open as possible
@@ -239,10 +239,10 @@ Installation and upgrade scenarios
 
 In order to simplify the installation, we have prepared examples of how to upgrade Airflow and providers.
 
-Installing Airflow with extras and providers
-============================================
+Installing Airflow™ with extras and providers
+=============================================
 
-If you need to install extra dependencies of Airflow, you can use the script below to make an installation
+If you need to install extra dependencies of Airflow™, you can use the script below to make an installation
 a one-liner (the example below installs Postgres and Google providers, as well as ``async`` extra).
 
 .. code-block:: bash
@@ -335,8 +335,8 @@ Troubleshooting
 
 This section describes how to troubleshoot installation issues with PyPI installation.
 
-Airflow command is not recognized
-=================================
+The 'airflow' command is not recognized
+=======================================
 
 If the ``airflow`` command is not getting recognized (can happen on Windows when using WSL), then
 ensure that ``~/.local/bin`` is in your ``PATH`` environment variable, and add it in if necessary:
@@ -350,7 +350,7 @@ You can also start airflow with ``python -m airflow``
 Symbol not found: ``_Py_GetArgcArgv``
 =====================================
 
-If you see ``Symbol not found: _Py_GetArgcArgv`` while starting or importing Airflow, this may mean that you are using an incompatible version of Python.
+If you see ``Symbol not found: _Py_GetArgcArgv`` while starting or importing ``airflow``, this may mean that you are using an incompatible version of Python.
 For a homebrew installed version of Python, this is generally caused by using Python in ``/usr/local/opt/bin`` rather than the Frameworks installation (e.g. for ``python 3.8``: ``/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8``).
 
 The crux of the issue is that a library Airflow depends on, ``setproctitle``, uses a non-public Python API

--- a/docs/apache-airflow/installation/installing-from-sources.rst
+++ b/docs/apache-airflow/installation/installing-from-sources.rst
@@ -23,7 +23,7 @@ Released packages
 
 .. jinja:: official_download_page
 
-    This page describes downloading and verifying ``Apache Airflow`` version
+    This page describes downloading and verifying Airflow™ version
     ``{{ airflow_version }}`` using officially released packages.
     You can also install ``Apache Airflow`` - as most Python packages - via :doc:`PyPI <installing-from-pypi>`.
     You can choose different version of Airflow by selecting different version from the drop-down at
@@ -35,7 +35,7 @@ the packages. The packages are available via the
 `Official Apache Software Foundations Downloads <http://ws.apache.org/mirrors.cgi>`_
 
 
-The |version| downloads are available at:
+The |version| downloads of Airflow™ are available at:
 
 .. jinja:: official_download_page
 

--- a/docs/apache-airflow/installation/prerequisites.rst
+++ b/docs/apache-airflow/installation/prerequisites.rst
@@ -18,7 +18,7 @@
 Prerequisites
 -------------
 
-Airflow is tested with:
+Airflow™ is tested with:
 
 * Python: 3.8, 3.9, 3.10, 3.11
 
@@ -55,7 +55,7 @@ wildly on the deployment options you have
 
 .. warning::
 
-  Airflow currently can be run on POSIX-compliant Operating Systems. For development it is regularly
+  Airflow™ currently can be run on POSIX-compliant Operating Systems. For development it is regularly
   tested on fairly modern Linux Distros and recent versions of MacOS.
   On Windows you can run it via WSL2 (Windows Subsystem for Linux 2) or via Linux Containers.
   The work to add Windows support is tracked via `#10388 <https://github.com/apache/airflow/issues/10388>`__

--- a/docs/apache-airflow/installation/setting-up-the-database.rst
+++ b/docs/apache-airflow/installation/setting-up-the-database.rst
@@ -18,7 +18,7 @@
 Setting up the database
 -----------------------
 
-Airflow requires a database. If you're just experimenting and learning Airflow, you can stick with the
+Apache Airflow™ requires a database. If you're just experimenting and learning Airflow, you can stick with the
 default SQLite option. If you don't want to use SQLite, then take a look at
 :doc:`/howto/set-up-database` to setup a different database.
 

--- a/docs/apache-airflow/installation/supported-versions.rst
+++ b/docs/apache-airflow/installation/supported-versions.rst
@@ -21,7 +21,7 @@ Supported versions
 Version Life Cycle
 ``````````````````
 
-Apache Airflow version life cycle:
+Apache Airflow™ version life cycle:
 
  .. This table is automatically updated by pre-commit scripts/ci/pre_commit/pre_commit_supported_versions.py
  .. Beginning of auto-generated table

--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -15,8 +15,8 @@
     specific language governing permissions and limitations
     under the License.
 
-Upgrading Airflow to a newer version
-------------------------------------
+Upgrading Airflow™ to a newer version
+-------------------------------------
 
 Why you need to upgrade
 =======================


### PR DESCRIPTION
We've started the process of registering the trademark of Airflow and we need to add ™ marks in prominent places of our website.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
