### PR TITLE
Fix number param html type in trigger template

### DIFF
--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -72,7 +72,7 @@
     {% elif "enum" in form_details.schema and form_details.schema.enum %}
       <select class="my_select2 form-control" name="element_{{ form_key }}" id="element_{{ form_key }}" data-placeholder="Select Value"
         onchange="updateJSONconf();"
-        {%- if "integer" in form_details.schema.type %} valuetype="number" {% elif "number" in form_details.schema.type %} valuetype="decimal" {%- endif %}
+        {%- if "integer" in form_details.schema.type or "number" in form_details.schema.type %} valuetype="number"{% endif %}
         {%- if not "null" in form_details.schema.type %} required=""{% endif %}>
         {% for option in form_details.schema.enum -%}
           <option value="{{ option }}"
@@ -117,7 +117,7 @@
       </textarea>
     {% elif form_details.schema and ("integer" in form_details.schema.type or "number" in form_details.schema.type) %}
       <input class="form-control" name="element_{{ form_key }}" id="element_{{ form_key }}"
-             {% if "integer" in form_details.schema.type %} valuetype="number" type="number" {%else%} valuetype="decimal" type="decimal" {% endif %}
+             valuetype="number" {% if "integer" in form_details.schema.type %} type="number" {%else%} type="decimal" {% endif %}
         value="{% if form_details.value %}{{ form_details.value }}{% endif %}"
         {%- if form_details.schema.minimum %} min="{{ form_details.schema.minimum }}"{% endif %}
         {%- if form_details.schema.maximum %} max="{{ form_details.schema.maximum }}"{% endif %}

--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -117,7 +117,7 @@
       </textarea>
     {% elif form_details.schema and ("integer" in form_details.schema.type or "number" in form_details.schema.type) %}
       <input class="form-control" name="element_{{ form_key }}" id="element_{{ form_key }}"
-             valuetype="number" {% if "integer" in form_details.schema.type %} type="number" {%else%} type="decimal" {% endif %}
+             valuetype="number" {% if "integer" in form_details.schema.type %} type="number" {% else %} type="decimal" {% endif %}
         value="{% if form_details.value %}{{ form_details.value }}{% endif %}"
         {%- if form_details.schema.minimum %} min="{{ form_details.schema.minimum }}"{% endif %}
         {%- if form_details.schema.maximum %} max="{{ form_details.schema.maximum }}"{% endif %}


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: #31930
related: #31946

It seems that when I changed the `valuetype` to `decimal`, the value was passed to the API a string which raise a validation exception in the dag run. Changing just the type to decimal is sufficient to fix the initial issue, for ex:
```python
DAG(
    dag_id="params",
    schedule_interval=None,
    start_date=days_ago(2),
    params={
        "param_1": Param(default=None, type=["number", "null"]),
        "param_2": Param(default='x', type='string')
    },
)
```
![image](https://github.com/apache/airflow/assets/21311487/1441ed5c-850d-48e9-a3ec-fd929e783649)

![image](https://github.com/apache/airflow/assets/21311487/abbf8f2a-52c7-4710-baeb-6653a3e824cb)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
