### PR TITLE
Add a return statement to enforce a single yield in certain triggers

### DIFF
--- a/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -141,6 +141,7 @@ class KubernetesPodTrigger(BaseTrigger):
                             "message": "All containers inside pod have started successfully.",
                         }
                     )
+                    return
                 elif self.should_wait(pod_phase=pod_status, container_state=container_state):
                     self.log.info("Container is not completed and still working.")
 
@@ -159,6 +160,7 @@ class KubernetesPodTrigger(BaseTrigger):
                                     "message": message,
                                 }
                             )
+                            return
 
                     self.log.info("Sleeping for %s seconds.", self.poll_interval)
                     await asyncio.sleep(self.poll_interval)
@@ -171,6 +173,7 @@ class KubernetesPodTrigger(BaseTrigger):
                             "message": pod.status.message,
                         }
                     )
+                    return
             except CancelledError:
                 # That means that task was marked as failed
                 if self.get_logs:
@@ -193,6 +196,7 @@ class KubernetesPodTrigger(BaseTrigger):
                         "message": "Pod execution was cancelled",
                     }
                 )
+                return
             except Exception as e:
                 self.log.exception("Exception occurred while checking pod phase:")
                 yield TriggerEvent(
@@ -203,6 +207,7 @@ class KubernetesPodTrigger(BaseTrigger):
                         "message": str(e),
                     }
                 )
+                return
 
     def _get_async_hook(self) -> AsyncKubernetesHook:
         if self._hook is None:

--- a/airflow/providers/databricks/triggers/databricks.py
+++ b/airflow/providers/databricks/triggers/databricks.py
@@ -89,6 +89,7 @@ class DatabricksExecutionTrigger(BaseTrigger):
                             "run_state": run_state.to_json(),
                         }
                     )
+                    return
                 else:
                     self.log.info(
                         "run-id %s in run state %s. sleeping for %s seconds",

--- a/airflow/providers/google/cloud/triggers/bigquery.py
+++ b/airflow/providers/google/cloud/triggers/bigquery.py
@@ -88,16 +88,19 @@ class BigQueryInsertJobTrigger(BaseTrigger):
                             "message": "Job completed",
                         }
                     )
+                    return
                 elif response_from_hook == "pending":
                     self.log.info("Query is still running...")
                     self.log.info("Sleeping for %s seconds.", self.poll_interval)
                     await asyncio.sleep(self.poll_interval)
                 else:
                     yield TriggerEvent({"status": "error", "message": response_from_hook})
+                    return
 
             except Exception as e:
                 self.log.exception("Exception occurred while checking for query completion")
                 yield TriggerEvent({"status": "error", "message": str(e)})
+                return
 
     def _get_async_hook(self) -> BigQueryAsyncHook:
         return BigQueryAsyncHook(gcp_conn_id=self.conn_id)
@@ -140,6 +143,7 @@ class BigQueryCheckTrigger(BigQueryInsertJobTrigger):
                                 "records": None,
                             }
                         )
+                        return
                     else:
                         # Extract only first record from the query results
                         first_record = records.pop(0)
@@ -149,6 +153,7 @@ class BigQueryCheckTrigger(BigQueryInsertJobTrigger):
                                 "records": first_record,
                             }
                         )
+                        return
 
                 elif response_from_hook == "pending":
                     self.log.info("Query is still running...")
@@ -156,9 +161,11 @@ class BigQueryCheckTrigger(BigQueryInsertJobTrigger):
                     await asyncio.sleep(self.poll_interval)
                 else:
                     yield TriggerEvent({"status": "error", "message": response_from_hook})
+                    return
             except Exception as e:
                 self.log.exception("Exception occurred while checking for query completion")
                 yield TriggerEvent({"status": "error", "message": str(e)})
+                return
 
 
 class BigQueryGetDataTrigger(BigQueryInsertJobTrigger):
@@ -206,15 +213,18 @@ class BigQueryGetDataTrigger(BigQueryInsertJobTrigger):
                             "records": records,
                         }
                     )
+                    return
                 elif response_from_hook == "pending":
                     self.log.info("Query is still running...")
                     self.log.info("Sleeping for %s seconds.", self.poll_interval)
                     await asyncio.sleep(self.poll_interval)
                 else:
                     yield TriggerEvent({"status": "error", "message": response_from_hook})
+                    return
             except Exception as e:
                 self.log.exception("Exception occurred while checking for query completion")
                 yield TriggerEvent({"status": "error", "message": str(e)})
+                return
 
 
 class BigQueryIntervalCheckTrigger(BigQueryInsertJobTrigger):
@@ -345,6 +355,7 @@ class BigQueryIntervalCheckTrigger(BigQueryInsertJobTrigger):
                             "second_row_data": second_job_row,
                         }
                     )
+                    return
                 elif first_job_response_from_hook == "pending" or second_job_response_from_hook == "pending":
                     self.log.info("Query is still running...")
                     self.log.info("Sleeping for %s seconds.", self.poll_interval)
@@ -353,10 +364,12 @@ class BigQueryIntervalCheckTrigger(BigQueryInsertJobTrigger):
                     yield TriggerEvent(
                         {"status": "error", "message": second_job_response_from_hook, "data": None}
                     )
+                    return
 
             except Exception as e:
                 self.log.exception("Exception occurred while checking for query completion")
                 yield TriggerEvent({"status": "error", "message": str(e)})
+                return
 
 
 class BigQueryValueCheckTrigger(BigQueryInsertJobTrigger):
@@ -428,16 +441,18 @@ class BigQueryValueCheckTrigger(BigQueryInsertJobTrigger):
                     records = records.pop(0) if records else None
                     hook.value_check(self.sql, self.pass_value, records, self.tolerance)
                     yield TriggerEvent({"status": "success", "message": "Job completed", "records": records})
+                    return
                 elif response_from_hook == "pending":
                     self.log.info("Query is still running...")
                     self.log.info("Sleeping for %s seconds.", self.poll_interval)
                     await asyncio.sleep(self.poll_interval)
                 else:
                     yield TriggerEvent({"status": "error", "message": response_from_hook, "records": None})
-
+                    return
             except Exception as e:
                 self.log.exception("Exception occurred while checking for query completion")
                 yield TriggerEvent({"status": "error", "message": str(e)})
+                return
 
 
 class BigQueryTableExistenceTrigger(BaseTrigger):
@@ -495,10 +510,12 @@ class BigQueryTableExistenceTrigger(BaseTrigger):
                 )
                 if response:
                     yield TriggerEvent({"status": "success", "message": "success"})
+                    return
                 await asyncio.sleep(self.poll_interval)
             except Exception as e:
                 self.log.exception("Exception occurred while checking for Table existence")
                 yield TriggerEvent({"status": "error", "message": str(e)})
+                return
 
     async def _table_exists(
         self, hook: BigQueryTableAsyncHook, dataset: str, table_id: str, project_id: str
@@ -577,9 +594,11 @@ class BigQueryTablePartitionExistenceTrigger(BigQueryTableExistenceTrigger):
                                 "message": f"Partition: {self.partition_id} in table: {self.table_id}",
                             }
                         )
+                        return
                     job_id = None
                 elif status == "error":
                     yield TriggerEvent({"status": "error", "message": status})
+                    return
                 self.log.info("Sleeping for %s seconds.", self.poll_interval)
                 await asyncio.sleep(self.poll_interval)
 

--- a/airflow/providers/google/cloud/triggers/bigquery_dts.py
+++ b/airflow/providers/google/cloud/triggers/bigquery_dts.py
@@ -105,7 +105,7 @@ class BigQueryDataTransferRunTrigger(BaseTrigger):
                             "config_id": self.config_id,
                         }
                     )
-
+                    return
                 elif state == TransferState.FAILED:
                     self.log.info("Job has failed")
                     yield TriggerEvent(
@@ -115,7 +115,7 @@ class BigQueryDataTransferRunTrigger(BaseTrigger):
                             "message": "Job has failed",
                         }
                     )
-
+                    return
                 if state == TransferState.CANCELLED:
                     self.log.info("Job has been cancelled.")
                     yield TriggerEvent(
@@ -125,12 +125,11 @@ class BigQueryDataTransferRunTrigger(BaseTrigger):
                             "message": "Job was cancelled",
                         }
                     )
-
+                    return
                 else:
                     self.log.info("Job is still working...")
                     self.log.info("Waiting for %s seconds", self.poll_interval)
                     await asyncio.sleep(self.poll_interval)
-
             except Exception as e:
                 yield TriggerEvent(
                     {
@@ -138,6 +137,7 @@ class BigQueryDataTransferRunTrigger(BaseTrigger):
                         "message": f"Trigger failed with exception: {str(e)}",
                     }
                 )
+                return
 
     def _get_async_hook(self) -> AsyncBiqQueryDataTransferServiceHook:
         return AsyncBiqQueryDataTransferServiceHook(

--- a/airflow/providers/google/cloud/triggers/dataflow.py
+++ b/airflow/providers/google/cloud/triggers/dataflow.py
@@ -107,6 +107,7 @@ class TemplateJobStartTrigger(BaseTrigger):
                             "message": "Job completed",
                         }
                     )
+                    return
                 elif status == JobState.JOB_STATE_FAILED:
                     yield TriggerEvent(
                         {
@@ -114,6 +115,7 @@ class TemplateJobStartTrigger(BaseTrigger):
                             "message": f"Dataflow job with id {self.job_id} has failed its execution",
                         }
                     )
+                    return
                 elif status == JobState.JOB_STATE_STOPPED:
                     yield TriggerEvent(
                         {
@@ -121,6 +123,7 @@ class TemplateJobStartTrigger(BaseTrigger):
                             "message": f"Dataflow job with id {self.job_id} was stopped",
                         }
                     )
+                    return
                 else:
                     self.log.info("Job is still running...")
                     self.log.info("Current job status is: %s", status)
@@ -129,6 +132,7 @@ class TemplateJobStartTrigger(BaseTrigger):
             except Exception as e:
                 self.log.exception("Exception occurred while checking for job completion.")
                 yield TriggerEvent({"status": "error", "message": str(e)})
+                return
 
     def _get_async_hook(self) -> AsyncDataflowHook:
         return AsyncDataflowHook(

--- a/airflow/providers/google/cloud/triggers/datafusion.py
+++ b/airflow/providers/google/cloud/triggers/datafusion.py
@@ -101,16 +101,18 @@ class DataFusionStartPipelineTrigger(BaseTrigger):
                             "message": "Pipeline is running",
                         }
                     )
+                    return
                 elif response_from_hook == "pending":
                     self.log.info("Pipeline is not still in running state...")
                     self.log.info("Sleeping for %s seconds.", self.poll_interval)
                     await asyncio.sleep(self.poll_interval)
                 else:
                     yield TriggerEvent({"status": "error", "message": response_from_hook})
-
+                    return
             except Exception as e:
                 self.log.exception("Exception occurred while checking for pipeline state")
                 yield TriggerEvent({"status": "error", "message": str(e)})
+                return
 
     def _get_async_hook(self) -> DataFusionAsyncHook:
         return DataFusionAsyncHook(

--- a/airflow/providers/google/cloud/triggers/dataproc.py
+++ b/airflow/providers/google/cloud/triggers/dataproc.py
@@ -279,8 +279,10 @@ class DataprocDeleteClusterTrigger(DataprocBaseTrigger):
                 await asyncio.sleep(self.polling_interval_seconds)
             except NotFound:
                 yield TriggerEvent({"status": "success", "message": ""})
+                return
             except Exception as e:
                 yield TriggerEvent({"status": "error", "message": str(e)})
+                return
         yield TriggerEvent({"status": "error", "message": "Timeout"})
 
 
@@ -322,6 +324,7 @@ class DataprocWorkflowTrigger(DataprocBaseTrigger):
                                 "message": operation.error.message,
                             }
                         )
+                        return
                     yield TriggerEvent(
                         {
                             "operation_name": operation.name,
@@ -330,6 +333,7 @@ class DataprocWorkflowTrigger(DataprocBaseTrigger):
                             "message": "Operation is successfully ended.",
                         }
                     )
+                    return
                 else:
                     self.log.info("Sleeping for %s seconds.", self.polling_interval_seconds)
                     await asyncio.sleep(self.polling_interval_seconds)
@@ -341,3 +345,4 @@ class DataprocWorkflowTrigger(DataprocBaseTrigger):
                         "message": str(e),
                     }
                 )
+                return

--- a/airflow/providers/google/cloud/triggers/gcs.py
+++ b/airflow/providers/google/cloud/triggers/gcs.py
@@ -79,6 +79,7 @@ class GCSBlobTrigger(BaseTrigger):
                 )
                 if res == "success":
                     yield TriggerEvent({"status": "success", "message": res})
+                    return
                 await asyncio.sleep(self.poke_interval)
         except Exception as e:
             yield TriggerEvent({"status": "error", "message": str(e)})
@@ -159,6 +160,7 @@ class GCSCheckBlobUpdateTimeTrigger(BaseTrigger):
                 )
                 if status:
                     yield TriggerEvent(res)
+                    return
                 await asyncio.sleep(self.poke_interval)
         except Exception as e:
             yield TriggerEvent({"status": "error", "message": str(e)})
@@ -262,6 +264,7 @@ class GCSPrefixBlobTrigger(GCSBlobTrigger):
                     yield TriggerEvent(
                         {"status": "success", "message": "Successfully completed", "matches": res}
                     )
+                    return
                 await asyncio.sleep(self.poke_interval)
         except Exception as e:
             yield TriggerEvent({"status": "error", "message": str(e)})
@@ -364,6 +367,7 @@ class GCSUploadSessionTrigger(GCSPrefixBlobTrigger):
                 res = self._is_bucket_updated(set(list_blobs))
                 if res["status"] in ("success", "error"):
                     yield TriggerEvent(res)
+                    return
                 await asyncio.sleep(self.poke_interval)
         except Exception as e:
             yield TriggerEvent({"status": "error", "message": str(e)})

--- a/airflow/providers/google/cloud/triggers/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/triggers/kubernetes_engine.py
@@ -176,7 +176,7 @@ class GKEOperationTrigger(BaseTrigger):
                             "operation_name": operation.name,
                         }
                     )
-
+                    return
                 elif status == Operation.Status.RUNNING or status == Operation.Status.PENDING:
                     self.log.info("Operation is still running.")
                     self.log.info("Sleeping for %ss...", self.poll_interval)
@@ -189,6 +189,7 @@ class GKEOperationTrigger(BaseTrigger):
                             "message": f"Operation has failed with status: {operation.status}",
                         }
                     )
+                    return
             except Exception as e:
                 self.log.exception("Exception occurred while checking operation status")
                 yield TriggerEvent(
@@ -197,6 +198,7 @@ class GKEOperationTrigger(BaseTrigger):
                         "message": str(e),
                     }
                 )
+                return
 
     def _get_hook(self) -> GKEAsyncHook:
         if self._hook is None:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: #31703

In #31703, we decided to remove certain return statements under the assumption that they were unnecessary after yielding an event. However, upon testing this strategy, it appears that in certain cases (specifically when the triggerer service is overloaded), we end up generating a significant number of events. As a result, we continue with unnecessary processing, which further burdens the triggerer.

To test that, I have created a new module `airflow/tests.py`:
```python
from __future__ import annotations

from airflow.models import BaseOperator
from airflow.triggers.base import BaseTrigger, TriggerEvent


class TestTrigger(BaseTrigger):
    def serialize(self) -> tuple[str, dict]:
        return ("airflow.tests.TestTrigger", {} )

    async def run(self):
        ind = 0
        while True:
            yield TriggerEvent(
                {
                    "message": f"Hello, world! {ind}",
                }
            )
            ind += 1
            # retrun


class TestOperator(BaseOperator):
    def execute(self, context):
        self.defer(
            trigger=TestTrigger(),
            method_name="execute_complete",
        )

    def execute_complete(self, context: dict | None, event: dict):
        print(event)
```
And this small dag:
```python
from datetime import datetime

from airflow.models import DAG
from airflow.tests import TestOperator

with DAG(
    dag_id="test_trigger",
    start_date=datetime(2021, 1, 1),
    schedule_interval=None,

) as dag:
    TestOperator(task_id="test_trigger")
```
which I tested in breeze.

When I tested it without a `return`, I got:
```
[2023-06-17, 21:33:05 UTC] {taskinstance.py:1135} INFO - Dependencies all met for dep_context=non-requeueable deps ti=<TaskInstance: test_trigger.test_trigger manual__2023-06-17T21:33:05.186752+00:00 [queued]>
[2023-06-17, 21:33:05 UTC] {taskinstance.py:1135} INFO - Dependencies all met for dep_context=requeueable deps ti=<TaskInstance: test_trigger.test_trigger manual__2023-06-17T21:33:05.186752+00:00 [queued]>
[2023-06-17, 21:33:05 UTC] {taskinstance.py:1338} INFO - Starting attempt 1 of 1
[2023-06-17, 21:33:05 UTC] {taskinstance.py:1359} INFO - Executing <Task(TestOperator): test_trigger> on 2023-06-17 21:33:05.186752+00:00
[2023-06-17, 21:33:05 UTC] {standard_task_runner.py:57} INFO - Started process 4802 to run task
[2023-06-17, 21:33:05 UTC] {standard_task_runner.py:84} INFO - Running: ['***', 'tasks', 'run', 'test_trigger', 'test_trigger', 'manual__2023-06-17T21:33:05.186752+00:00', '--job-id', '137', '--raw', '--subdir', 'DAGS_FOLDER/trigger.py', '--cfg-path', '/tmp/tmppovv3qxe']
[2023-06-17, 21:33:05 UTC] {standard_task_runner.py:85} INFO - Job 137: Subtask test_trigger
[2023-06-17, 21:33:06 UTC] {task_command.py:410} INFO - Running <TaskInstance: test_trigger.test_trigger manual__2023-06-17T21:33:05.186752+00:00 [running]> on host d3e0d78cfce9
[2023-06-17, 21:33:06 UTC] {taskinstance.py:1637} INFO - Exporting env vars: AIRFLOW_CTX_DAG_OWNER='***' AIRFLOW_CTX_DAG_ID='test_trigger' AIRFLOW_CTX_TASK_ID='test_trigger' AIRFLOW_CTX_EXECUTION_DATE='2023-06-17T21:33:05.186752+00:00' AIRFLOW_CTX_TRY_NUMBER='1' AIRFLOW_CTX_DAG_RUN_ID='manual__2023-06-17T21:33:05.186752+00:00'
[2023-06-17, 21:33:06 UTC] {taskinstance.py:1505} INFO - Pausing task as DEFERRED. dag_id=test_trigger, task_id=test_trigger, execution_date=20230617T213305, start_date=20230617T213305
[2023-06-17, 21:33:06 UTC] {local_task_job_runner.py:222} INFO - Task exited with return code 100 (task deferral)
[2023-06-17, 21:33:08 UTC] {triggerer_job_runner.py:608} INFO - Trigger test_trigger/manual__2023-06-17T21:33:05.186752+00:00/test_trigger/-1/1 (ID 64) fired: TriggerEvent<{'message': 'Hello, world! 0'}>
[2023-06-17, 21:33:08 UTC] {triggerer_job_runner.py:608} INFO - Trigger test_trigger/manual__2023-06-17T21:33:05.186752+00:00/test_trigger/-1/1 (ID 64) fired: TriggerEvent<{'message': 'Hello, world! 1'}>
[2023-06-17, 21:33:08 UTC] {triggerer_job_runner.py:608} INFO - Trigger test_trigger/manual__2023-06-17T21:33:05.186752+00:00/test_trigger/-1/1 (ID 64) fired: TriggerEvent<{'message': 'Hello, world! 2'}>
[2023-06-17, 21:33:08 UTC] {triggerer_job_runner.py:608} INFO - Trigger test_trigger/manual__2023-06-17T21:33:05.186752+00:00/test_trigger/-1/1 (ID 64) fired: TriggerEvent<{'message': 'Hello, world! 3'}>
[2023-06-17, 21:33:08 UTC] {triggerer_job_runner.py:608} INFO - Trigger test_trigger/manual__2023-06-17T21:33:05.186752+00:00/test_trigger/-1/1 (ID 64) fired: TriggerEvent<{'message': 'Hello, world! 4'}>
[2023-06-17, 21:33:08 UTC] {triggerer_job_runner.py:608} INFO - Trigger test_trigger/manual__2023-06-17T21:33:05.186752+00:00/test_trigger/-1/1 (ID 64) fired: TriggerEvent<{'message': 'Hello, world! 5'}>
[2023-06-17, 21:33:08 UTC] {triggerer_job_runner.py:608} INFO - Trigger test_trigger/manual__2023-06-17T21:33:05.186752+00:00/test_trigger/-1/1 (ID 64) fired: TriggerEvent<{'message': 'Hello, world! 6'}>
...
[2023-06-17, 21:33:09 UTC] {triggerer_job_runner.py:608} INFO - Trigger test_trigger/manual__2023-06-17T21:33:05.186752+00:00/test_trigger/-1/1 (ID 64) fired: TriggerEvent<{'message': 'Hello, world! 26651'}>
[2023-06-17, 21:33:09 UTC] {triggerer_job_runner.py:608} INFO - Trigger test_trigger/manual__2023-06-17T21:33:05.186752+00:00/test_trigger/-1/1 (ID 64) fired: TriggerEvent<{'message': 'Hello, world! 26652'}>
[2023-06-17, 21:33:09 UTC] {triggerer_job_runner.py:608} INFO - Trigger test_trigger/manual__2023-06-17T21:33:05.186752+00:00/test_trigger/-1/1 (ID 64) fired: TriggerEvent<{'message': 'Hello, world! 26653'}>
[2023-06-17, 21:33:09 UTC] {triggerer_job_runner.py:608} INFO - Trigger test_trigger/manual__2023-06-17T21:33:05.186752+00:00/test_trigger/-1/1 (ID 64) fired: TriggerEvent<{'message': 'Hello, world! 26654'}>
[2023-06-17, 21:33:09 UTC] {triggerer_job_runner.py:608} INFO - Trigger test_trigger/manual__2023-06-17T21:33:05.186752+00:00/test_trigger/-1/1 (ID 64) fired: TriggerEvent<{'message': 'Hello, world! 26655'}>
[2023-06-17, 21:33:09 UTC] {logging_mixin.py:152} INFO - {'message': 'Hello, world! 0'}
[2023-06-17, 21:33:09 UTC] {taskinstance.py:1377} INFO - Marking task as SUCCESS. dag_id=test_trigger, task_id=test_trigger, execution_date=20230617T213305, start_date=20230617T213305, end_date=20230617T213309
[2023-06-17, 21:33:09 UTC] {local_task_job_runner.py:225} INFO - Task exited with return code 0
[2023-06-17, 21:33:09 UTC] {taskinstance.py:2752} INFO - 0 downstream tasks scheduled from follow-on schedule check
```
and even more than 26k in other runs when the triggerer was overloaded.

However, when using a return statement, I consistently observed a single sent event. Moreover, I noticed that this approach consumes less memory as there are fewer events being added to the deque `events`.

```
[2023-06-17, 21:32:45 UTC] {taskinstance.py:1135} INFO - Dependencies all met for dep_context=non-requeueable deps ti=<TaskInstance: test_trigger.test_trigger manual__2023-06-17T21:32:45.026487+00:00 [queued]>
[2023-06-17, 21:32:45 UTC] {taskinstance.py:1135} INFO - Dependencies all met for dep_context=requeueable deps ti=<TaskInstance: test_trigger.test_trigger manual__2023-06-17T21:32:45.026487+00:00 [queued]>
[2023-06-17, 21:32:45 UTC] {taskinstance.py:1338} INFO - Starting attempt 1 of 1
[2023-06-17, 21:32:45 UTC] {taskinstance.py:1359} INFO - Executing <Task(TestOperator): test_trigger> on 2023-06-17 21:32:45.026487+00:00
[2023-06-17, 21:32:45 UTC] {standard_task_runner.py:57} INFO - Started process 4788 to run task
[2023-06-17, 21:32:45 UTC] {standard_task_runner.py:84} INFO - Running: ['***', 'tasks', 'run', 'test_trigger', 'test_trigger', 'manual__2023-06-17T21:32:45.026487+00:00', '--job-id', '131', '--raw', '--subdir', 'DAGS_FOLDER/trigger.py', '--cfg-path', '/tmp/tmpikm55djk']
[2023-06-17, 21:32:45 UTC] {standard_task_runner.py:85} INFO - Job 131: Subtask test_trigger
[2023-06-17, 21:32:46 UTC] {task_command.py:410} INFO - Running <TaskInstance: test_trigger.test_trigger manual__2023-06-17T21:32:45.026487+00:00 [running]> on host d3e0d78cfce9
[2023-06-17, 21:32:46 UTC] {taskinstance.py:1637} INFO - Exporting env vars: AIRFLOW_CTX_DAG_OWNER='***' AIRFLOW_CTX_DAG_ID='test_trigger' AIRFLOW_CTX_TASK_ID='test_trigger' AIRFLOW_CTX_EXECUTION_DATE='2023-06-17T21:32:45.026487+00:00' AIRFLOW_CTX_TRY_NUMBER='1' AIRFLOW_CTX_DAG_RUN_ID='manual__2023-06-17T21:32:45.026487+00:00'
[2023-06-17, 21:32:46 UTC] {taskinstance.py:1505} INFO - Pausing task as DEFERRED. dag_id=test_trigger, task_id=test_trigger, execution_date=20230617T213245, start_date=20230617T213245
[2023-06-17, 21:32:46 UTC] {local_task_job_runner.py:222} INFO - Task exited with return code 100 (task deferral)
[2023-06-17, 21:32:47 UTC] {triggerer_job_runner.py:608} INFO - Trigger test_trigger/manual__2023-06-17T21:32:45.026487+00:00/test_trigger/-1/1 (ID 63) fired: TriggerEvent<{'message': 'Hello, world! 0'}>
[2023-06-17, 21:32:48 UTC] {taskinstance.py:1135} INFO - Dependencies all met for dep_context=non-requeueable deps ti=<TaskInstance: test_trigger.test_trigger manual__2023-06-17T21:32:45.026487+00:00 [queued]>
[2023-06-17, 21:32:48 UTC] {taskinstance.py:1135} INFO - Dependencies all met for dep_context=requeueable deps ti=<TaskInstance: test_trigger.test_trigger manual__2023-06-17T21:32:45.026487+00:00 [queued]>
[2023-06-17, 21:32:48 UTC] {taskinstance.py:1336} INFO - Resuming after deferral
[2023-06-17, 21:32:48 UTC] {taskinstance.py:1359} INFO - Executing <Task(TestOperator): test_trigger> on 2023-06-17 21:32:45.026487+00:00
[2023-06-17, 21:32:48 UTC] {standard_task_runner.py:57} INFO - Started process 4796 to run task
[2023-06-17, 21:32:48 UTC] {standard_task_runner.py:84} INFO - Running: ['***', 'tasks', 'run', 'test_trigger', 'test_trigger', 'manual__2023-06-17T21:32:45.026487+00:00', '--job-id', '134', '--raw', '--subdir', 'DAGS_FOLDER/trigger.py', '--cfg-path', '/tmp/tmpbtzk4o5s']
[2023-06-17, 21:32:48 UTC] {standard_task_runner.py:85} INFO - Job 134: Subtask test_trigger
[2023-06-17, 21:32:48 UTC] {task_command.py:410} INFO - Running <TaskInstance: test_trigger.test_trigger manual__2023-06-17T21:32:45.026487+00:00 [running]> on host d3e0d78cfce9
[2023-06-17, 21:32:48 UTC] {logging_mixin.py:152} INFO - {'message': 'Hello, world! 0'}
[2023-06-17, 21:32:48 UTC] {taskinstance.py:1377} INFO - Marking task as SUCCESS. dag_id=test_trigger, task_id=test_trigger, execution_date=20230617T213245, start_date=20230617T213245, end_date=20230617T213248
[2023-06-17, 21:32:48 UTC] {local_task_job_runner.py:225} INFO - Task exited with return code 0
[2023-06-17, 21:32:48 UTC] {taskinstance.py:2752} INFO - 0 downstream tasks scheduled from follow-on schedule check
```
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
