### PR TITLE
Catch the exception that triggerer initialization failed

### DIFF
--- a/airflow/jobs/triggerer_job_runner.py
+++ b/airflow/jobs/triggerer_job_runner.py
@@ -680,7 +680,13 @@ class TriggerRunner(threading.Thread, LoggingMixin):
                 # Either the trigger code or the path to it is bad. Fail the trigger.
                 self.failed_triggers.append((new_id, e))
                 continue
-            new_trigger_instance = trigger_class(**new_trigger_orm.kwargs)
+            try:
+                new_trigger_instance = trigger_class(**new_trigger_orm.kwargs)
+            except TypeError as err:
+                self.log.error("Trigger failed; message=%s", err)
+                self.failed_triggers.append((new_id, err))
+                continue
+
             self.set_trigger_logging_metadata(new_trigger_orm.task_instance, new_id, new_trigger_instance)
             self.to_create.append((new_id, new_trigger_instance))
         # Enqueue orphaned triggers for cancellation

--- a/airflow/jobs/triggerer_job_runner.py
+++ b/airflow/jobs/triggerer_job_runner.py
@@ -680,6 +680,7 @@ class TriggerRunner(threading.Thread, LoggingMixin):
                 # Either the trigger code or the path to it is bad. Fail the trigger.
                 self.failed_triggers.append((new_id, e))
                 continue
+
             try:
                 new_trigger_instance = trigger_class(**new_trigger_orm.kwargs)
             except TypeError as err:

--- a/airflow/jobs/triggerer_job_runner.py
+++ b/airflow/jobs/triggerer_job_runner.py
@@ -677,7 +677,7 @@ class TriggerRunner(threading.Thread, LoggingMixin):
                 new_trigger_orm = new_triggers[new_id]
                 trigger_class = self.get_trigger_by_classpath(new_trigger_orm.classpath)
                 new_trigger_instance = trigger_class(**new_trigger_orm.kwargs)
-            except (BaseException, TypeError) as err:
+            except BaseException as err:
                 # BaseException: Either the trigger code or the path to it is bad. Fail the trigger.
                 # TypeError: The argument of the __init__ method in the trigger might have been changed.
                 self.log.error("Trigger failed; message=%s", err)

--- a/airflow/jobs/triggerer_job_runner.py
+++ b/airflow/jobs/triggerer_job_runner.py
@@ -677,7 +677,7 @@ class TriggerRunner(threading.Thread, LoggingMixin):
                 new_trigger_orm = new_triggers[new_id]
                 trigger_class = self.get_trigger_by_classpath(new_trigger_orm.classpath)
                 new_trigger_instance = trigger_class(**new_trigger_orm.kwargs)
-            except BaseException as err:
+            except (BaseException, TypeError) as err:
                 # BaseException: Either the trigger code or the path to it is bad. Fail the trigger.
                 # TypeError: The argument of the __init__ method in the trigger might have been changed.
                 self.log.error("Trigger failed; message=%s", err)

--- a/airflow/jobs/triggerer_job_runner.py
+++ b/airflow/jobs/triggerer_job_runner.py
@@ -676,14 +676,10 @@ class TriggerRunner(threading.Thread, LoggingMixin):
             try:
                 new_trigger_orm = new_triggers[new_id]
                 trigger_class = self.get_trigger_by_classpath(new_trigger_orm.classpath)
-            except BaseException as e:
-                # Either the trigger code or the path to it is bad. Fail the trigger.
-                self.failed_triggers.append((new_id, e))
-                continue
-
-            try:
                 new_trigger_instance = trigger_class(**new_trigger_orm.kwargs)
-            except TypeError as err:
+            except (BaseException, TypeError) as err:
+                # BaseException: Either the trigger code or the path to it is bad. Fail the trigger.
+                # TypeError: The argument of the __init__ method in the trigger might have been changed.
                 self.log.error("Trigger failed; message=%s", err)
                 self.failed_triggers.append((new_id, err))
                 continue

--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -37,7 +37,7 @@ from airflow.models.baseoperator import BaseOperator
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 from airflow.triggers.base import TriggerEvent
-from airflow.triggers.temporal import TimeDeltaTrigger
+from airflow.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
 from airflow.triggers.testing import FailureTrigger, SuccessTrigger
 from airflow.utils import timezone
 from airflow.utils.log.logging_mixin import RedirectStdHandler
@@ -284,6 +284,26 @@ class TestTriggerRunner:
         with pytest.raises(asyncio.CancelledError):
             await trigger_runner.run_trigger(1, mock_trigger)
         assert "Trigger cancelled due to timeout" in caplog.text
+
+    @patch("airflow.models.trigger.Trigger.bulk_fetch")
+    @patch(
+        "airflow.jobs.triggerer_job_runner.TriggerRunner.get_trigger_by_classpath",
+        return_value=DateTimeTrigger,
+    )
+    def test_update_trigger_with_triggerer_argument_change(
+        self, mock_bulk_fetch, mock_get_trigger_by_classpath, session, caplog
+    ) -> None:
+        trigger_runner = TriggerRunner()
+        mock_trigger_orm = MagicMock()
+        mock_trigger_orm.kwargs = {"moment": ..., "not_exists_arg": ...}
+        mock_get_trigger_by_classpath.return_value = {1: mock_trigger_orm}
+
+        trigger_runner.update_triggers({1})
+
+        assert (
+            "Trigger failed; message=__init__() got an unexpected keyword argument 'not_exists_arg'"
+            in caplog.text
+        )
 
 
 def test_trigger_create_race_condition_18392(session, tmp_path):


### PR DESCRIPTION
Catch the exception that triggerer initialization failed

## What's the issue
When we migrate from an older provider to a newer version with an argument removed from the trigger, it results in the following exception that causes the triggerer to fail.

```text
TypeError: __init__() got an unexpected keyword argument '.....'
```

from [airflow/jobs/triggerer_job_runner.py#L683](https://github.com/apache/airflow/blob/0560881f0eaef9c583b11e937bf1f79d13e5ac7c/airflow/jobs/triggerer_job_runner.py#L683)

## What's changed
Catch the exception and set the old task to failed

## How to reproduce

### Step 1

```sh
git clone https://github.com/apache/airflow.git

cd airflow

# The latest main branch when I reproduced this issue
git checkout d2c038e0437a23ce1f41960ce6e27216d9f9e579

cp airflow/example_dags/example_time_delta_sensor_async.py files/dags
```

### Step 2

Add a new argument to `airflow/triggers/temporal.py` like the following

<details>
<summary>airflow/triggers/temporal.py</summary>

```python
......
class DateTimeTrigger(BaseTrigger):
    def __init__(self, moment: datetime.datetime, old_arg: int = 123):
        ......
        self.old_arg = old_arg
        
    def serialize(self) -> tuple[str, dict[str, Any]]:
        return ("airflow.triggers.temporal.DateTimeTrigger", {"moment": self.moment, "old_arg": self.old_arg})
```
</details>


### Step 3

```sh
breeze --python 3.9 --backend sqlite start-airflow --db-reset
```

Go to the web UI and run DAG "example_time_delta_sensor_async"

Ensure the task goes into the `DEFERRED` state without finishing

Go back to the terminal and run command `stop_airflow`

### Step 4

```sh
# make sure the changes on airflow/triggers/temporal.py are reverted
git checkout .
git checkout d2c038e0437a23ce1f41960ce6e27216d9f9e579

breeze --python 3.9 --backend sqlite start-airflow --db-reset
```

### Step 5

Check the log in the triggerer. We will see the error message that caused the trigger to stop.

```text
TypeError: __init__() got an unexpected keyword argument '.....'
```


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
