### PR TITLE
Add smtp notification guide to index.rst

### DIFF
--- a/docs/apache-airflow-providers-smtp/index.rst
+++ b/docs/apache-airflow-providers-smtp/index.rst
@@ -27,6 +27,7 @@ Content
     :caption: References
 
     Connection types <connections/smtp>
+    SMTP Notifications <notifications/smtp_notifier_howto_guide>
     Python API <_api/airflow/providers/smtp/index>
 
 .. toctree::


### PR DESCRIPTION
In provider release wave https://github.com/apache/airflow/pull/32001 we have warning
```
  [39;49;00m[91m/opt/airflow/docs/apache-airflow-providers-smtp/notifications/smtp_notifier_howto_guide.rst: WARNING: document isn't included in any toctree[39;49;00m
  apache-airflow-providers-smtp                                done
```


https://github.com/apache/airflow/actions/runs/5312135603/jobs/9616607143?pr=32001#step:6:1074

