### PR TITLE
Fix ExternalTaskSensor when there is not task group TIs for the current execution date

### DIFF
--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -366,16 +366,14 @@ class ExternalTaskSensor(BaseSensorOperator):
             ) / len(self.external_task_ids)
         elif self.external_task_group_id:
             external_task_group_task_ids = self.get_external_task_group_task_ids(session, dttm_filter)
-            count = (
-                0
-                if not external_task_group_task_ids
-                else (
+            if not external_task_group_task_ids:
+                count = 0
+            else:
+                count = (
                     self._count_query(TI, session, states, dttm_filter)
                     .filter(tuple_in_condition((TI.task_id, TI.map_index), external_task_group_task_ids))
                     .scalar()
-                )
-                / len(external_task_group_task_ids)
-            )
+                ) / len(external_task_group_task_ids)
         else:
             count = self._count_query(DR, session, states, dttm_filter).scalar()
         return count

--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -367,10 +367,15 @@ class ExternalTaskSensor(BaseSensorOperator):
         elif self.external_task_group_id:
             external_task_group_task_ids = self.get_external_task_group_task_ids(session, dttm_filter)
             count = (
-                self._count_query(TI, session, states, dttm_filter)
-                .filter(tuple_in_condition((TI.task_id, TI.map_index), external_task_group_task_ids))
-                .scalar()
-            ) / len(external_task_group_task_ids)
+                0
+                if not external_task_group_task_ids
+                else (
+                    self._count_query(TI, session, states, dttm_filter)
+                    .filter(tuple_in_condition((TI.task_id, TI.map_index), external_task_group_task_ids))
+                    .scalar()
+                )
+                / len(external_task_group_task_ids)
+            )
         else:
             count = self._count_query(DR, session, states, dttm_filter).scalar()
         return count

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -808,6 +808,26 @@ exit 0
         ):
             op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
+    def test_external_task_group_when_there_is_no_TIs(self):
+        """Test that the sensor does not fail when there are no TIs to check."""
+        self.add_time_sensor()
+        self.add_dummy_task_group_with_dynamic_tasks(State.FAILED)
+        op = ExternalTaskSensor(
+            task_id="test_external_task_sensor_check",
+            external_dag_id=TEST_DAG_ID,
+            external_task_group_id=TEST_TASK_GROUP_ID,
+            failed_states=[State.FAILED],
+            dag=self.dag,
+            poke_interval=1,
+            timeout=3,
+        )
+        with pytest.raises(AirflowSensorTimeout):
+            op.run(
+                start_date=DEFAULT_DATE + timedelta(hours=1),
+                end_date=DEFAULT_DATE + timedelta(hours=1),
+                ignore_ti_state=True,
+            )
+
 
 def test_external_task_sensor_check_zipped_dag_existence(dag_zip_maker):
     with dag_zip_maker("test_external_task_sensor_check_existense.py") as dagbag:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #32007
related: #30742

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
