### PR TITLE
Flash an error msg instead of failure in `rendered-templates` when map index is not found

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1408,6 +1408,9 @@ class Airflow(AirflowBaseView):
         dag_run = dag.get_dagrun(execution_date=dttm, session=session)
         raw_task = dag.get_task(task_id).prepare_for_execution()
 
+        title = "Rendered Template"
+        html_dict = {}
+
         ti: TaskInstance
         if dag_run is None:
             # No DAG run matching given logical date. This usually means this
@@ -1422,8 +1425,18 @@ class Airflow(AirflowBaseView):
             if ti:
                 ti.refresh_from_task(raw_task)
             else:
-                # When there is no task instance with the given map_index
-                ti = TaskInstance(raw_task, map_index=map_index)
+                flash(f"there is no task instance with the provided map_index {map_index}", "error")
+                return self.render_template(
+                    "airflow/ti_code.html",
+                    html_dict=html_dict,
+                    dag=dag,
+                    task_id=task_id,
+                    execution_date=execution_date,
+                    map_index=map_index,
+                    form=form,
+                    root=root,
+                    title=title,
+                )
 
         try:
             ti.get_rendered_template_fields(session=session)
@@ -1443,8 +1456,6 @@ class Airflow(AirflowBaseView):
         # but we'll display some quasi-meaingful field names.
         task = ti.task.unmap(None)
 
-        title = "Rendered Template"
-        html_dict = {}
         renderers = wwwutils.get_attr_renderer()
 
         for template_field in task.template_fields:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1419,7 +1419,11 @@ class Airflow(AirflowBaseView):
             ti.dag_run = DagRun(dag_id=dag_id, execution_date=dttm)
         else:
             ti = dag_run.get_task_instance(task_id=task_id, map_index=map_index, session=session)
-            ti.refresh_from_task(raw_task)
+            if ti:
+                ti.refresh_from_task(raw_task)
+            else:
+                # When there is no task instance with the given map_index
+                ti = TaskInstance(raw_task, map_index=map_index)
 
         try:
             ti.get_rendered_template_fields(session=session)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #32005

Before this PR:
![image](https://github.com/apache/airflow/assets/21311487/9df5c1c1-74dc-45b9-8b95-0c3d193dc453)

After this PR:
![image](https://github.com/apache/airflow/assets/21311487/19381b07-2e72-495d-b063-c8e28e565eee)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
