### PR TITLE
Introducing AirflowClusterPolicySkipDag exception

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -169,8 +169,12 @@ class AirflowClusterPolicyViolation(AirflowException):
     """Raise when there is a violation of a Cluster Policy in DAG definition."""
 
 
+class AirflowClusterPolicySkipDag(AirflowException):
+    """Raise when dag skip is needed in Cluster Policy."""
+
+
 class AirflowClusterPolicyError(AirflowException):
-    """Raise when there is an error except AirflowClusterPolicyViolation in Cluster Policy."""
+    """Raise when there is an error except AirflowClusterPolicyViolation AirflowClusterPolicySkipDag and in Cluster Policy."""
 
 
 class AirflowTimetableInvalid(AirflowException):

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -174,7 +174,7 @@ class AirflowClusterPolicySkipDag(AirflowException):
 
 
 class AirflowClusterPolicyError(AirflowException):
-    """Raise when there is an error except AirflowClusterPolicyViolation AirflowClusterPolicySkipDag and in Cluster Policy."""
+    """Raise when there is an error except AirflowClusterPolicyViolation and AirflowClusterPolicySkipDag in Cluster Policy."""
 
 
 class AirflowTimetableInvalid(AirflowException):

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -170,11 +170,14 @@ class AirflowClusterPolicyViolation(AirflowException):
 
 
 class AirflowClusterPolicySkipDag(AirflowException):
-    """Raise when dag skip is needed in Cluster Policy."""
+    """Raise when skipping dag is needed in Cluster Policy."""
 
 
 class AirflowClusterPolicyError(AirflowException):
-    """Raise when there is an error except AirflowClusterPolicyViolation and AirflowClusterPolicySkipDag in Cluster Policy."""
+    """
+    Raise when there is an error in Cluster Policy,
+    except AirflowClusterPolicyViolation and AirflowClusterPolicySkipDag.
+    """
 
 
 class AirflowTimetableInvalid(AirflowException):

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -480,7 +480,7 @@ class DagBag(LoggingMixin):
 
             for task in dag.tasks:
                 settings.task_policy(task)
-        except AirflowClusterPolicyViolation:
+        except (AirflowClusterPolicyViolation, AirflowClusterPolicySkipDag):
             raise
         except Exception as e:
             self.log.exception(e)

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -38,6 +38,7 @@ from airflow import settings
 from airflow.configuration import conf
 from airflow.exceptions import (
     AirflowClusterPolicyError,
+    AirflowClusterPolicySkipDag,
     AirflowClusterPolicyViolation,
     AirflowDagCycleException,
     AirflowDagDuplicatedIdException,
@@ -442,6 +443,8 @@ class DagBag(LoggingMixin):
             try:
                 dag.validate()
                 self.bag_dag(dag=dag, root_dag=dag)
+            except AirflowClusterPolicySkipDag:
+                pass
             except Exception as e:
                 self.log.exception("Failed to bag_dag: %s", dag.fileloc)
                 self.import_errors[dag.fileloc] = f"{type(e).__name__}: {e}"

--- a/docs/apache-airflow/administration-and-deployment/cluster-policies.rst
+++ b/docs/apache-airflow/administration-and-deployment/cluster-policies.rst
@@ -45,7 +45,7 @@ exception to indicate that the dag/task they were passed is not compliant and sh
 
 They can also raise the :class:`~airflow.exceptions.AirflowClusterPolicySkipDag` exception
 when skipping that DAG is needed intentionally. Unlike :class:`~airflow.exceptions.AirflowClusterPolicyViolation`,
-this exception is not displayed on the Airflow web UI (Internally, it's not recorded on ``import_error`` table on metadb.)
+this exception is not displayed on the Airflow web UI (Internally, it's not recorded on ``import_error`` table on meta database.)
 
 Any extra attributes set by a cluster policy take priority over those defined in your DAG file; for example,
 if you set an ``sla`` on your Task in the DAG file, and then your cluster policy also sets an ``sla``, the

--- a/docs/apache-airflow/administration-and-deployment/cluster-policies.rst
+++ b/docs/apache-airflow/administration-and-deployment/cluster-policies.rst
@@ -45,7 +45,7 @@ exception to indicate that the dag/task they were passed is not compliant and sh
 
 They can also raise the :class:`~airflow.exceptions.AirflowClusterPolicySkipDag` exception
 when skipping that DAG is needed intentionally. Unlike :class:`~airflow.exceptions.AirflowClusterPolicyViolation`,
-this exception is not displayed on the Airflow web UI (Internally, it's not recorded on `import_error` table on metadb.)
+this exception is not displayed on the Airflow web UI (Internally, it's not recorded on ``import_error`` table on metadb.)
 
 Any extra attributes set by a cluster policy take priority over those defined in your DAG file; for example,
 if you set an ``sla`` on your Task in the DAG file, and then your cluster policy also sets an ``sla``, the

--- a/docs/apache-airflow/administration-and-deployment/cluster-policies.rst
+++ b/docs/apache-airflow/administration-and-deployment/cluster-policies.rst
@@ -43,6 +43,10 @@ There are three main types of cluster policy:
 The DAG and Task cluster policies can raise the  :class:`~airflow.exceptions.AirflowClusterPolicyViolation`
 exception to indicate that the dag/task they were passed is not compliant and should not be loaded.
 
+They can also raise the :class:`~airflow.exceptions.AirflowClusterPolicySkipDag` exception
+when skipping that DAG is needed intentionally. Unlike :class:`~airflow.exceptions.AirflowClusterPolicyViolation`,
+this exception is not displayed on the Airflow web UI (Internally, it's not recorded on `import_error` table on metadb.)
+
 Any extra attributes set by a cluster policy take priority over those defined in your DAG file; for example,
 if you set an ``sla`` on your Task in the DAG file, and then your cluster policy also sets an ``sla``, the
 cluster policy's value will take precedence.

--- a/docs/apache-airflow/best-practices.rst
+++ b/docs/apache-airflow/best-practices.rst
@@ -418,7 +418,7 @@ you can also raise :class:`~airflow.exceptions.AirflowClusterPolicySkipDag` exce
       if "only_for_beta" in dag.tags:
           raise AirflowClusterPolicySkipDag(f"DAG {dag.dag_id} is not loaded on `prod.` Airflow cluster, due to `only_for_beta` tag")
 
-The example above, shows the ``dag_policy`` code snippet to skip the DAG depending on the dag tags.
+The example above, shows the ``dag_policy`` code snippet to skip the DAG depending on the tags it has.
 
 .. _best_practices/reducing_dag_complexity:
 

--- a/docs/apache-airflow/best-practices.rst
+++ b/docs/apache-airflow/best-practices.rst
@@ -416,7 +416,9 @@ you can also raise :class:`~airflow.exceptions.AirflowClusterPolicySkipDag` exce
       """Skipping the DAG with `only_for_beta` tag."""
 
       if "only_for_beta" in dag.tags:
-          raise AirflowClusterPolicySkipDag(f"DAG {dag.dag_id} is not loaded on `prod.` Airflow cluster, due to `only_for_beta` tag")
+          raise AirflowClusterPolicySkipDag(
+              f"DAG {dag.dag_id} is not loaded on the production cluster, due to `only_for_beta` tag."
+          )
 
 The example above, shows the ``dag_policy`` code snippet to skip the DAG depending on the tags it has.
 

--- a/docs/apache-airflow/best-practices.rst
+++ b/docs/apache-airflow/best-practices.rst
@@ -394,6 +394,32 @@ It's important to note, that without ``watcher`` task, the whole DAG Run will ge
 If we want the ``watcher`` to monitor the state of all tasks, we need to make it dependent on all of them separately. Thanks to this, we can fail the DAG Run if any of the tasks fail. Note that the watcher task has a trigger rule set to ``"one_failed"``.
 On the other hand, without the ``teardown`` task, the ``watcher`` task will not be needed, because ``failing_task`` will propagate its ``failed`` state to downstream task ``passed_task`` and the whole DAG Run will also get the ``failed`` status.
 
+
+Using AirflowClusterPolicySkipDag exception in cluster policies to skip specific DAGs
+----------------------------
+
+.. versionadded:: 2.7
+
+Airflow DAGs can usually be deployed and updated with the specific branch of Git repository via ``git-sync``.
+But, when you have to run multiple Airflow clusters for some operational reasons, it's very cumbersome to maintain multiple Git branches.
+Especially, you have some difficulties when you need to synchronize two separate branches(like ``prod`` and ``beta``) periodically with proper branching strategy.
+
+- cherry-pick is too cumbersome to maintain Git repository.
+- hard-reset is not recommended way for GitOps
+
+So, you can consider connecting multiple Airflow clusters with same Git branch (like ``main``), and maintaining those with different environment variables and different connection configurations with same ``connection_id``.
+you can also raise :class:`~airflow.exceptions.AirflowClusterPolicySkipDag` exception on the cluster policy, to load specific DAGs to :class:`~airflow.models.dagbag.DagBag` on the specific Airflow deployment only, if needed.
+
+.. code-block:: python
+
+  def dag_policy(dag: DAG):
+      """Skipping the DAG with `only_for_beta` tag."""
+
+      if "only_for_beta" in dag.tags:
+          raise AirflowClusterPolicySkipDag(f"DAG {dag.dag_id} is not loaded on `prod.` Airflow cluster, due to `only_for_beta` tag")
+
+The example above, shows the ``dag_policy`` code snippet to skip the DAG depending on the dag tags.
+
 .. _best_practices/reducing_dag_complexity:
 
 Reducing DAG complexity

--- a/docs/apache-airflow/best-practices.rst
+++ b/docs/apache-airflow/best-practices.rst
@@ -396,7 +396,7 @@ On the other hand, without the ``teardown`` task, the ``watcher`` task will not 
 
 
 Using AirflowClusterPolicySkipDag exception in cluster policies to skip specific DAGs
-----------------------------
+-------------------------------------------------------------------------------------
 
 .. versionadded:: 2.7
 

--- a/tests/cluster_policies/__init__.py
+++ b/tests/cluster_policies/__init__.py
@@ -73,7 +73,7 @@ def example_task_policy(task: BaseOperator):
 
 # [START example_dag_cluster_policy]
 def dag_policy(dag: DAG):
-    """Ensure that DAG has at least one tag"""
+    """Ensure that DAG has at least one tag and skip the DAG with `only_for_beta` tag."""
     if not dag.tags:
         raise AirflowClusterPolicyViolation(
             f"DAG {dag.dag_id} has no tags. At least one tag required. File path: {dag.fileloc}"

--- a/tests/cluster_policies/__init__.py
+++ b/tests/cluster_policies/__init__.py
@@ -22,7 +22,7 @@ from datetime import timedelta
 from typing import Callable
 
 from airflow.configuration import conf
-from airflow.exceptions import AirflowClusterPolicyViolation
+from airflow.exceptions import AirflowClusterPolicyViolation, AirflowClusterPolicySkipDag
 from airflow.models import DAG, TaskInstance
 from airflow.models.baseoperator import BaseOperator
 
@@ -78,6 +78,9 @@ def dag_policy(dag: DAG):
         raise AirflowClusterPolicyViolation(
             f"DAG {dag.dag_id} has no tags. At least one tag required. File path: {dag.fileloc}"
         )
+    
+    if "only_for_beta" in dag.tags:
+        raise AirflowClusterPolicySkipDag(f"DAG {dag.dag_id} is not loaded on `prod.` Airflow cluster, due to `only_for_beta` tag")
 
 
 # [END example_dag_cluster_policy]

--- a/tests/cluster_policies/__init__.py
+++ b/tests/cluster_policies/__init__.py
@@ -22,7 +22,7 @@ from datetime import timedelta
 from typing import Callable
 
 from airflow.configuration import conf
-from airflow.exceptions import AirflowClusterPolicyViolation, AirflowClusterPolicySkipDag
+from airflow.exceptions import AirflowClusterPolicySkipDag, AirflowClusterPolicyViolation
 from airflow.models import DAG, TaskInstance
 from airflow.models.baseoperator import BaseOperator
 
@@ -78,9 +78,11 @@ def dag_policy(dag: DAG):
         raise AirflowClusterPolicyViolation(
             f"DAG {dag.dag_id} has no tags. At least one tag required. File path: {dag.fileloc}"
         )
-    
+
     if "only_for_beta" in dag.tags:
-        raise AirflowClusterPolicySkipDag(f"DAG {dag.dag_id} is not loaded on `prod.` Airflow cluster, due to `only_for_beta` tag")
+        raise AirflowClusterPolicySkipDag(
+            f"DAG {dag.dag_id} is not loaded on the production cluster, due to `only_for_beta` tag."
+        )
 
 
 # [END example_dag_cluster_policy]


### PR DESCRIPTION
We currently deploy and operate 2 Airflow cluster (prod & beta) connected with separate branch(like `prod`, and `beta`) via git-sync.

But, we had some difficulty when we needed to sync two separate branches(`prod` and `beta`) periodically with proper branching strategy
- cherry-pick is too cumbersome to maintain repo.
- hard-reset is not recommended solution for GitOps

So, we decided to connect two Airflow deployments to same branch(like `main`). But, if needed, we have to activate specific DAG on specific airflow deployment only, based on the DAG tag!

I found `is_active` prop on `DagModel` ORM object. but I think it's not efficient to set this prop on the `dag_policy`, due to metadb overhead per parsing DAG.

How about introducing `AirflowClusterPolicySkipDag` exception, and using it for skipping dag without showing import error message on Web UI (=without recording it on `import_error` table)?

example)
```
def dag_policy(dag: DAG):
    if "only_for_beta" in dag.tags:
        raise AirflowClusterPolicySkipDag("`only_for_beta` tag is detected")
``` 

It's just making a back-door for another MR (I previously committed) below.

related: https://github.com/apache/airflow/pull/29056

I found another workaround with `core.might_contain_dag_callable` config introduced on `v2.6.0` (https://github.com/apache/airflow/pull/30104)
But this option cannot cover the case of a `.py` file containing multiple `DAG`s with different activating tags