### PR TITLE
Add note about dropping Python 3.7 for providers

### DIFF
--- a/airflow/providers/airbyte/CHANGELOG.rst
+++ b/airflow/providers/airbyte/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.3.0
 .....
 

--- a/airflow/providers/alibaba/CHANGELOG.rst
+++ b/airflow/providers/alibaba/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 2.4.0
 .....
 

--- a/airflow/providers/amazon/CHANGELOG.rst
+++ b/airflow/providers/amazon/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 8.1.0
 .....
 

--- a/airflow/providers/apache/beam/CHANGELOG.rst
+++ b/airflow/providers/apache/beam/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 5.1.0
 .....
 

--- a/airflow/providers/apache/cassandra/CHANGELOG.rst
+++ b/airflow/providers/apache/cassandra/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/apache/drill/CHANGELOG.rst
+++ b/airflow/providers/apache/drill/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 2.4.0
 .....
 

--- a/airflow/providers/apache/druid/CHANGELOG.rst
+++ b/airflow/providers/apache/druid/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.4.0
 .....
 

--- a/airflow/providers/apache/flink/CHANGELOG.rst
+++ b/airflow/providers/apache/flink/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 1.1.0
 .....
 

--- a/airflow/providers/apache/hdfs/CHANGELOG.rst
+++ b/airflow/providers/apache/hdfs/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 4.1.0
 -----
 

--- a/airflow/providers/apache/hive/CHANGELOG.rst
+++ b/airflow/providers/apache/hive/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 6.1.0
 .....
 

--- a/airflow/providers/apache/kylin/CHANGELOG.rst
+++ b/airflow/providers/apache/kylin/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/apache/livy/CHANGELOG.rst
+++ b/airflow/providers/apache/livy/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.5.0
 .....
 

--- a/airflow/providers/apache/pig/CHANGELOG.rst
+++ b/airflow/providers/apache/pig/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 4.1.0
 .....
 

--- a/airflow/providers/apache/pinot/CHANGELOG.rst
+++ b/airflow/providers/apache/pinot/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 4.1.0
 .....
 

--- a/airflow/providers/apache/spark/CHANGELOG.rst
+++ b/airflow/providers/apache/spark/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 4.1.0
 .....
 

--- a/airflow/providers/apache/sqoop/CHANGELOG.rst
+++ b/airflow/providers/apache/sqoop/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/arangodb/CHANGELOG.rst
+++ b/airflow/providers/arangodb/CHANGELOG.rst
@@ -25,6 +25,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 2.2.0
 .....
 

--- a/airflow/providers/asana/CHANGELOG.rst
+++ b/airflow/providers/asana/CHANGELOG.rst
@@ -23,6 +23,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 2.2.0
 .....
 

--- a/airflow/providers/atlassian/jira/CHANGELOG.rst
+++ b/airflow/providers/atlassian/jira/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 2.1.0
 .....
 

--- a/airflow/providers/celery/CHANGELOG.rst
+++ b/airflow/providers/celery/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/cloudant/CHANGELOG.rst
+++ b/airflow/providers/cloudant/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 
 
 7.0.0

--- a/airflow/providers/databricks/CHANGELOG.rst
+++ b/airflow/providers/databricks/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 4.2.0
 .....
 

--- a/airflow/providers/datadog/CHANGELOG.rst
+++ b/airflow/providers/datadog/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.3.0
 .....
 

--- a/airflow/providers/dbt/cloud/CHANGELOG.rst
+++ b/airflow/providers/dbt/cloud/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/dingding/CHANGELOG.rst
+++ b/airflow/providers/dingding/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/discord/CHANGELOG.rst
+++ b/airflow/providers/discord/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/docker/CHANGELOG.rst
+++ b/airflow/providers/docker/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.7.0
 .....
 

--- a/airflow/providers/elasticsearch/CHANGELOG.rst
+++ b/airflow/providers/elasticsearch/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 4.5.0
 .....
 

--- a/airflow/providers/exasol/CHANGELOG.rst
+++ b/airflow/providers/exasol/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 4.2.0
 .....
 

--- a/airflow/providers/facebook/CHANGELOG.rst
+++ b/airflow/providers/facebook/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/ftp/CHANGELOG.rst
+++ b/airflow/providers/ftp/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.4.1
 .....
 

--- a/airflow/providers/github/CHANGELOG.rst
+++ b/airflow/providers/github/CHANGELOG.rst
@@ -17,8 +17,16 @@
     specific language governing permissions and limitations
     under the License.
 
+.. NOTE TO CONTRIBUTORS:
+   Please, only add notes to the Changelog just below the "Changelog" header when there are some breaking changes
+   and you want to add an explanation to the users on how they are supposed to deal with them.
+   The changelog is updated and maintained semi-automatically by release manager.
+
 Changelog
 ---------
+
+.. note::
+  This release dropped support for Python 3.7
 
 2.3.0
 .....

--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -23,6 +23,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 10.1.1
 ......
 

--- a/airflow/providers/grpc/CHANGELOG.rst
+++ b/airflow/providers/grpc/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/hashicorp/CHANGELOG.rst
+++ b/airflow/providers/hashicorp/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.4.0
 .....
 

--- a/airflow/providers/http/CHANGELOG.rst
+++ b/airflow/providers/http/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 4.4.1
 .....
 

--- a/airflow/providers/imap/CHANGELOG.rst
+++ b/airflow/providers/imap/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.1
 .....
 

--- a/airflow/providers/influxdb/CHANGELOG.rst
+++ b/airflow/providers/influxdb/CHANGELOG.rst
@@ -25,6 +25,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 2.2.0
 .....
 

--- a/airflow/providers/jdbc/CHANGELOG.rst
+++ b/airflow/providers/jdbc/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 4.0.0
 .....
 

--- a/airflow/providers/jenkins/CHANGELOG.rst
+++ b/airflow/providers/jenkins/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.3.0
 .....
 

--- a/airflow/providers/microsoft/azure/CHANGELOG.rst
+++ b/airflow/providers/microsoft/azure/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 6.1.1
 .....
 

--- a/airflow/providers/microsoft/mssql/CHANGELOG.rst
+++ b/airflow/providers/microsoft/mssql/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.4.0
 .....
 

--- a/airflow/providers/microsoft/psrp/CHANGELOG.rst
+++ b/airflow/providers/microsoft/psrp/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 2.3.0
 .....
 

--- a/airflow/providers/microsoft/winrm/CHANGELOG.rst
+++ b/airflow/providers/microsoft/winrm/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/mongo/CHANGELOG.rst
+++ b/airflow/providers/mongo/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/mysql/CHANGELOG.rst
+++ b/airflow/providers/mysql/CHANGELOG.rst
@@ -23,6 +23,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 5.1.0
 .....
 

--- a/airflow/providers/neo4j/CHANGELOG.rst
+++ b/airflow/providers/neo4j/CHANGELOG.rst
@@ -25,6 +25,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.3.0
 .....
 

--- a/airflow/providers/odbc/CHANGELOG.rst
+++ b/airflow/providers/odbc/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 4.0.0
 .....
 

--- a/airflow/providers/openfaas/CHANGELOG.rst
+++ b/airflow/providers/openfaas/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/opsgenie/CHANGELOG.rst
+++ b/airflow/providers/opsgenie/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 5.1.0
 .....
 

--- a/airflow/providers/oracle/CHANGELOG.rst
+++ b/airflow/providers/oracle/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.7.0
 .....
 

--- a/airflow/providers/pagerduty/CHANGELOG.rst
+++ b/airflow/providers/pagerduty/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/papermill/CHANGELOG.rst
+++ b/airflow/providers/papermill/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/plexus/CHANGELOG.rst
+++ b/airflow/providers/plexus/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/postgres/CHANGELOG.rst
+++ b/airflow/providers/postgres/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 5.5.0
 .....
 

--- a/airflow/providers/presto/CHANGELOG.rst
+++ b/airflow/providers/presto/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 5.1.0
 .....
 

--- a/airflow/providers/qubole/CHANGELOG.rst
+++ b/airflow/providers/qubole/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.4.0
 .....
 

--- a/airflow/providers/redis/CHANGELOG.rst
+++ b/airflow/providers/redis/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/salesforce/CHANGELOG.rst
+++ b/airflow/providers/salesforce/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 5.4.0
 .....
 

--- a/airflow/providers/samba/CHANGELOG.rst
+++ b/airflow/providers/samba/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 4.2.0
 .....
 

--- a/airflow/providers/segment/CHANGELOG.rst
+++ b/airflow/providers/segment/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/sendgrid/CHANGELOG.rst
+++ b/airflow/providers/sendgrid/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/sftp/CHANGELOG.rst
+++ b/airflow/providers/sftp/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 4.3.0
 .....
 

--- a/airflow/providers/singularity/CHANGELOG.rst
+++ b/airflow/providers/singularity/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.2.0
 .....
 

--- a/airflow/providers/slack/CHANGELOG.rst
+++ b/airflow/providers/slack/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 7.3.0
 .....
 

--- a/airflow/providers/smtp/CHANGELOG.rst
+++ b/airflow/providers/smtp/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 1.1.0
 .....
 

--- a/airflow/providers/snowflake/CHANGELOG.rst
+++ b/airflow/providers/snowflake/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 4.1.0
 .....
 

--- a/airflow/providers/sqlite/CHANGELOG.rst
+++ b/airflow/providers/sqlite/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.4.1
 .....
 

--- a/airflow/providers/ssh/CHANGELOG.rst
+++ b/airflow/providers/ssh/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.7.0
 .....
 

--- a/airflow/providers/tableau/CHANGELOG.rst
+++ b/airflow/providers/tableau/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 4.2.0
 .....
 

--- a/airflow/providers/tabular/CHANGELOG.rst
+++ b/airflow/providers/tabular/CHANGELOG.rst
@@ -15,8 +15,16 @@
     specific language governing permissions and limitations
     under the License.
 
+.. NOTE TO CONTRIBUTORS:
+   Please, only add notes to the Changelog just below the "Changelog" header when there are some breaking changes
+   and you want to add an explanation to the users on how they are supposed to deal with them.
+   The changelog is updated and maintained semi-automatically by release manager.
+
 Changelog
 ---------
+
+.. note::
+  This release dropped support for Python 3.7
 
 1.2.0
 .....

--- a/airflow/providers/telegram/CHANGELOG.rst
+++ b/airflow/providers/telegram/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 4.1.0
 .....
 

--- a/airflow/providers/trino/CHANGELOG.rst
+++ b/airflow/providers/trino/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 5.1.0
 .....
 

--- a/airflow/providers/vertica/CHANGELOG.rst
+++ b/airflow/providers/vertica/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.4.0
 .....
 

--- a/airflow/providers/yandex/CHANGELOG.rst
+++ b/airflow/providers/yandex/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 3.3.0
 .....
 

--- a/airflow/providers/zendesk/CHANGELOG.rst
+++ b/airflow/providers/zendesk/CHANGELOG.rst
@@ -24,6 +24,9 @@
 Changelog
 ---------
 
+.. note::
+  This release dropped support for Python 3.7
+
 4.3.0
 .....
 


### PR DESCRIPTION
followup on https://github.com/apache/airflow/pull/32001#discussion_r1234159435

I will adjust the entry to the upcoming release version of each provider in the release PR