### PR TITLE
Add note about dropping Python 3.7 for kafka and impala

### DIFF
--- a/airflow/providers/apache/impala/CHANGELOG.rst
+++ b/airflow/providers/apache/impala/CHANGELOG.rst
@@ -15,9 +15,16 @@
     specific language governing permissions and limitations
     under the License.
 
+.. NOTE TO CONTRIBUTORS:
+   Please, only add notes to the Changelog just below the "Changelog" header when there are some breaking changes
+   and you want to add an explanation to the users on how they are supposed to deal with them.
+   The changelog is updated and maintained semi-automatically by release manager.
 
 Changelog
 ---------
+
+.. note::
+  This release dropped support for Python 3.7
 
 1.1.0
 .....

--- a/airflow/providers/apache/kafka/CHANGELOG.rst
+++ b/airflow/providers/apache/kafka/CHANGELOG.rst
@@ -15,9 +15,16 @@
     specific language governing permissions and limitations
     under the License.
 
+.. NOTE TO CONTRIBUTORS:
+   Please, only add notes to the Changelog just below the "Changelog" header when there are some breaking changes
+   and you want to add an explanation to the users on how they are supposed to deal with them.
+   The changelog is updated and maintained semi-automatically by release manager.
 
 Changelog
 ---------
+
+.. note::
+  This release dropped support for Python 3.7
 
 1.1.0
 .....


### PR DESCRIPTION
I missed these 2 providers in https://github.com/apache/airflow/pull/32015 because they did not have contributors note so they were not found in the script