### PR TITLE
set contributor note in prepare_provider_packages.py

### DIFF
--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -80,6 +80,10 @@ INITIAL_CHANGELOG_CONTENT = """
     specific language governing permissions and limitations
     under the License.
 
+.. NOTE TO CONTRIBUTORS:
+   Please, only add notes to the Changelog just below the "Changelog" header when there are some breaking changes
+   and you want to add an explanation to the users on how they are supposed to deal with them.
+   The changelog is updated and maintained semi-automatically by release manager.
 
 Changelog
 ---------


### PR DESCRIPTION
To prevent cases where new providers are distinct with the initial note