### PR TITLE
Switch Google Ads API version from v13 to v14

### DIFF
--- a/airflow/providers/google/ads/hooks/ads.py
+++ b/airflow/providers/google/ads/hooks/ads.py
@@ -24,9 +24,9 @@ from typing import IO, Any
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
-from google.ads.googleads.v13.services.services.customer_service import CustomerServiceClient
-from google.ads.googleads.v13.services.services.google_ads_service import GoogleAdsServiceClient
-from google.ads.googleads.v13.services.types.google_ads_service import GoogleAdsRow
+from google.ads.googleads.v14.services.services.customer_service import CustomerServiceClient
+from google.ads.googleads.v14.services.services.google_ads_service import GoogleAdsServiceClient
+from google.ads.googleads.v14.services.types.google_ads_service import GoogleAdsRow
 from google.api_core.page_iterator import GRPCIterator
 from google.auth.exceptions import GoogleAuthError
 
@@ -73,7 +73,7 @@ class GoogleAdsHook(BaseHook):
     :return: list of Google Ads Row object(s)
     """
 
-    default_api_version = "v13"
+    default_api_version = "v14"
 
     def __init__(
         self,

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -74,7 +74,7 @@ dependencies:
   - gcloud-aio-auth>=4.0.0,<5.0.0
   - gcloud-aio-bigquery>=6.1.2
   - gcloud-aio-storage
-  - google-ads>=20.0.0
+  - google-ads>=21.2.0
   - google-api-core>=2.11.0
   - google-api-python-client>=1.6.0
   - google-auth>=1.0.0

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -381,7 +381,7 @@
       "gcloud-aio-auth>=4.0.0,<5.0.0",
       "gcloud-aio-bigquery>=6.1.2",
       "gcloud-aio-storage",
-      "google-ads>=20.0.0",
+      "google-ads>=21.2.0",
       "google-api-core>=2.11.0",
       "google-api-python-client>=1.6.0",
       "google-auth-httplib2>=0.0.1",


### PR DESCRIPTION
New API version v14 was released on 2023-06-07.

https://developers.google.com/google-ads/api/docs/release-notes#v14