### PR TITLE
Less precise check for error message in trigger initialization

### DIFF
--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -300,10 +300,8 @@ class TestTriggerRunner:
 
         trigger_runner.update_triggers({1})
 
-        assert (
-            "Trigger failed; message=__init__() got an unexpected keyword argument 'not_exists_arg'"
-            in caplog.text
-        )
+        assert "Trigger failed" in caplog.text
+        assert "got an unexpected keyword argument 'not_exists_arg'" in caplog.text
 
 
 def test_trigger_create_race_condition_18392(session, tmp_path):


### PR DESCRIPTION
The test for error message (introduced in #31999) in trigger initialization expected precise error message, however Python 3.10 changed the details printed when TypeError was converted to string (including the information about class being created not only method). This caused the tests to fail on Python 3.10 and 3.11.

Making two asserts with two parts of the message expected solves the problem for all python versions.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
