### PR TITLE
Raise error in dag trigger for paused dag

### DIFF
--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -318,6 +318,11 @@ def post_dag_run(*, dag_id: str, session: Session = NEW_SESSION) -> APIResponse:
             title="DAG cannot be triggered",
             detail=f"DAG with dag_id: '{dag_id}' has import errors",
         )
+    if dm.is_paused:
+        raise BadRequest(
+            title="DAG cannot be triggered",
+            detail=f"DAG with dag_id: '{dag_id}' is paused.",
+        )
     try:
         post_body = dagrun_schema.load(get_json_request_dict(), session=session)
     except ValidationError as err:

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -149,7 +149,7 @@ def dag_trigger(args) -> None:
     if not dag:
         raise SystemExit(f"DAG: {args.dag_id} does not exist in 'dag' table")
     if dag.is_paused:
-        raise AirflowException(f"DAG with dag_id: {args.dag_id} is paused.")
+        raise SystemExit(f"DAG with dag_id: {args.dag_id} is paused.")
     api_client = get_current_api_client()
     try:
         message = api_client.trigger_dag(

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -145,6 +145,11 @@ def dag_backfill(args, dag: list[DAG] | DAG | None = None) -> None:
 @cli_utils.action_cli
 def dag_trigger(args) -> None:
     """Creates a dag run for the specified dag."""
+    dag = DagModel.get_dagmodel(args.dag_id)
+    if not dag:
+        raise SystemExit(f"DAG: {args.dag_id} does not exist in 'dag' table")
+    if dag.is_paused:
+        raise AirflowException(f"DAG with dag_id: {args.dag_id} is paused.")
     api_client = get_current_api_client()
     try:
         message = api_client.trigger_dag(

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -1119,6 +1119,24 @@ class TestPostDagRun(TestDagRunEndpoint):
             "type": EXCEPTIONS_LINK_MAP[400],
         } == response.json
 
+    def test_should_respond_400_if_a_dag_is_paused(self, session):
+        """Test that if a dagmodel is paused, dags won't be triggered"""
+        dm = self._create_dag("TEST_DAG_ID")
+        dm.has_import_errors = True
+        session.add(dm)
+        session.flush()
+        response = self.client.post(
+            "api/v1/dags/TEST_DAG_ID/dagRuns",
+            json={},
+            environ_overrides={"REMOTE_USER": "test"},
+        )
+        assert {
+            "detail": "DAG with dag_id: 'TEST_DAG_ID' is paused.",
+            "status": 400,
+            "title": "DAG cannot be triggered",
+            "type": EXCEPTIONS_LINK_MAP[400],
+        } == response.json
+
     def test_should_response_200_for_matching_execution_date_logical_date(self):
         execution_date = "2020-11-10T08:25:56.939143+00:00"
         logical_date = "2020-11-10T08:25:56.939143+00:00"

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -1122,7 +1122,7 @@ class TestPostDagRun(TestDagRunEndpoint):
     def test_should_respond_400_if_a_dag_is_paused(self, session):
         """Test that if a dagmodel is paused, dags won't be triggered"""
         dm = self._create_dag("TEST_DAG_ID")
-        dm.has_import_errors = True
+        dm.is_paused = True
         session.add(dm)
         session.flush()
         response = self.client.post(

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -668,7 +668,7 @@ class TestCliDags:
         dag_command.dag_pause(args)
 
         args = self.parser.parse_args(["dags", "trigger", "example_bash_operator"])
-        with pytest.raises(AirflowException) as e:
+        with pytest.raises(SystemExit) as e:
             dag_command.dag_trigger(args)
         assert str(e.value) == f"DAG with dag_id: {args.dag_id} is paused."
 

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -663,6 +663,15 @@ class TestCliDags:
         assert "trigger_dag_xxx" == parsed_out[0]["dag_run_id"]
         assert {"conf1": "val1", "conf2": "val2"} == parsed_out[0]["conf"]
 
+    def test_trigger_paused_dag(self):
+        args = self.parser.parse_args(["dags", "pause", "example_bash_operator"])
+        dag_command.dag_pause(args)
+
+        args = self.parser.parse_args(["dags", "trigger", "example_bash_operator"])
+        with pytest.raises(AirflowException) as e:
+            dag_command.dag_trigger(args)
+        assert str(e.value) == f"DAG with dag_id: {args.dag_id} is paused."
+
     def test_delete_dag(self):
         DM = DagModel
         key = "my_dag_id"


### PR DESCRIPTION
If dag is paused and a user trigger dag externally either with CLI or REST API.
It creates a dagrun with queued state and then stuck in the queued state which is confusing for the user. 
Raising an error if dag is paused and if a user is trying to create a dagrun.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
