### PR TITLE
Change `as_setup` and `as_teardown` to instance methods

### DIFF
--- a/airflow/example_dags/example_setup_teardown.py
+++ b/airflow/example_dags/example_setup_teardown.py
@@ -30,21 +30,19 @@ with DAG(
     catchup=False,
     tags=["example"],
 ) as dag:
-    root_setup = BashOperator.as_setup(task_id="root_setup", bash_command="echo 'Hello from root_setup'")
+    root_setup = BashOperator(task_id="root_setup", bash_command="echo 'Hello from root_setup'").as_setup()
     root_normal = BashOperator(task_id="normal", bash_command="echo 'I am just a normal task'")
-    root_teardown = BashOperator.as_teardown(
+    root_teardown = BashOperator(
         task_id="root_teardown", bash_command="echo 'Goodbye from root_teardown'"
-    )
+    ).as_teardown(root_setup)
     root_setup >> root_normal >> root_teardown
-    root_setup >> root_teardown
     with TaskGroup("section_1") as section_1:
-        inner_setup = BashOperator.as_setup(
+        inner_setup = BashOperator(
             task_id="taskgroup_setup", bash_command="echo 'Hello from taskgroup_setup'"
-        )
+        ).as_setup()
         inner_normal = BashOperator(task_id="normal", bash_command="echo 'I am just a normal task'")
-        inner_teardown = BashOperator.as_teardown(
+        inner_teardown = BashOperator(
             task_id="taskgroup_teardown", bash_command="echo 'Hello from taskgroup_teardown'"
-        )
+        ).as_teardown(inner_setup)
         inner_setup >> inner_normal >> inner_teardown
-        inner_setup >> inner_teardown
     root_normal >> section_1

--- a/airflow/example_dags/example_setup_teardown.py
+++ b/airflow/example_dags/example_setup_teardown.py
@@ -34,7 +34,7 @@ with DAG(
     root_normal = BashOperator(task_id="normal", bash_command="echo 'I am just a normal task'")
     root_teardown = BashOperator(
         task_id="root_teardown", bash_command="echo 'Goodbye from root_teardown'"
-    ).as_teardown(root_setup)
+    ).as_teardown(setups=root_setup)
     root_setup >> root_normal >> root_teardown
     with TaskGroup("section_1") as section_1:
         inner_setup = BashOperator(
@@ -43,6 +43,6 @@ with DAG(
         inner_normal = BashOperator(task_id="normal", bash_command="echo 'I am just a normal task'")
         inner_teardown = BashOperator(
             task_id="taskgroup_teardown", bash_command="echo 'Hello from taskgroup_teardown'"
-        ).as_teardown(inner_setup)
+        ).as_teardown(setups=inner_setup)
         inner_setup >> inner_normal >> inner_teardown
     root_normal >> section_1

--- a/airflow/example_dags/example_setup_teardown_taskflow.py
+++ b/airflow/example_dags/example_setup_teardown_taskflow.py
@@ -48,9 +48,11 @@ with DAG(
     t3 = task_3()
     t1 >> t2 >> t3.as_teardown(t1)
 
+    # the method `as_teadrown` will mark t3 as teardown, t1 as setup, and arrow t1 >> t3
     # now if you clear t2 (downstream), then t1 will be cleared in addition to t3
 
-    # it's also possible to mark a task as setup or teardown when you define it
+    # it's also possible to use a decorator to mark a task as setup or
+    # teardown when you define it. see below.
 
     @setup
     def dag_setup():
@@ -64,14 +66,19 @@ with DAG(
     def dag_normal_task():
         print("I am just a normal task")
 
-    # since we already marked these as setup / teardown, we just need to make sure they are linked
-    # here we make sure setup and teardown are connected.
-    # if not using `as_teardown` we must arrow them explicitly
     s = dag_setup()
     t = dag_teardown()
-    s >> t
-    # and here we add our "work" task a.k.a. normal task.
-    s >> dag_normal_task() >> t
+
+    # by using the decorators, dag_setup and dag_teardown are already marked as setup / teardown
+    # now we just need to make sure they are linked directly
+
+    # now we can use context manager to wire these up properly
+    with s >> t:
+        dag_normal_task()
+
+    # the context manager is equivalent to this:
+    # s >> t
+    # s >> dag_normal_task() >> t
 
     @task_group
     def section_1():

--- a/airflow/example_dags/example_setup_teardown_taskflow.py
+++ b/airflow/example_dags/example_setup_teardown_taskflow.py
@@ -46,7 +46,7 @@ with DAG(
     t1 = task_1()
     t2 = task_2()
     t3 = task_3()
-    t1 >> t2 >> t3.as_teardown(t1)
+    t1 >> t2 >> t3.as_teardown(setups=t1)
 
     # the method `as_teadrown` will mark t3 as teardown, t1 as setup, and arrow t1 >> t3
     # now if you clear t2 (downstream), then t1 will be cleared in addition to t3
@@ -92,7 +92,7 @@ with DAG(
         def hello():
             print("I say hello")
 
-        (s := my_setup()) >> hello() >> my_teardown().as_teardown(s)
+        (s := my_setup()) >> hello() >> my_teardown().as_teardown(setups=s)
 
     # and let's put section 1 inside the "dag setup" and "dag teardown"
     s >> section_1() >> t

--- a/airflow/example_dags/example_setup_teardown_taskflow.py
+++ b/airflow/example_dags/example_setup_teardown_taskflow.py
@@ -71,14 +71,12 @@ with DAG(
 
     # by using the decorators, dag_setup and dag_teardown are already marked as setup / teardown
     # now we just need to make sure they are linked directly
-
-    # now we can use context manager to wire these up properly
+    # what we need to do is this::
+    #     s >> t
+    #     s >> dag_normal_task() >> t
+    # but we can use a context manager to make it cleaner
     with s >> t:
         dag_normal_task()
-
-    # the context manager is equivalent to this:
-    # s >> t
-    # s >> dag_normal_task() >> t
 
     @task_group
     def section_1():

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -224,8 +224,8 @@ class AbstractOperator(Templater, DAGNode):
 
     def as_teardown(
         self,
-        setups: BaseOperator | Iterable[BaseOperator] | ArgNotSet = NOTSET,
         *,
+        setups: BaseOperator | Iterable[BaseOperator] | ArgNotSet = NOTSET,
         on_failure_fail_dagrun=NOTSET,
     ):
         self.is_teardown = True

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -171,7 +171,7 @@ class AbstractOperator(Templater, DAGNode):
 
         :meta private:
         """
-        if self.is_teardown is True:
+        if self.is_teardown is True and value is True:
             raise ValueError(f"Cannot mark task '{self.task_id}' as setup; task is already a teardown.")
         self._is_setup = value
 

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -171,7 +171,7 @@ class AbstractOperator(Templater, DAGNode):
 
         :meta private:
         """
-        if self.is_teardown is True and value is True:
+        if self.is_teardown is True:
             raise ValueError(f"Cannot mark task '{self.task_id}' as setup; task is already a teardown.")
         self._is_setup = value
 

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -26,7 +26,7 @@ from airflow.compat.functools import cache
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.models.expandinput import NotFullyPopulated
-from airflow.models.taskmixin import DAGNode
+from airflow.models.taskmixin import DAGNode, DependencyMixin
 from airflow.template.templater import Templater
 from airflow.utils.context import Context
 from airflow.utils.log.secrets_masker import redact
@@ -35,6 +35,7 @@ from airflow.utils.sqlalchemy import skip_locked, with_row_locks
 from airflow.utils.state import State, TaskInstanceState
 from airflow.utils.task_group import MappedTaskGroup
 from airflow.utils.trigger_rule import TriggerRule
+from airflow.utils.types import NOTSET, ArgNotSet
 from airflow.utils.weight_rule import WeightRule
 
 TaskStateChangeCallback = Callable[[Context], None]
@@ -102,6 +103,11 @@ class AbstractOperator(Templater, DAGNode):
 
     outlets: list
     inlets: list
+    trigger_rule: TriggerRule
+
+    _is_setup = False
+    _is_teardown = False
+    _on_failure_fail_dagrun = False
 
     HIDE_ATTRS_FROM_UI: ClassVar[frozenset[str]] = frozenset(
         (
@@ -148,6 +154,92 @@ class AbstractOperator(Templater, DAGNode):
     @property
     def node_id(self) -> str:
         return self.task_id
+
+    @property
+    def is_setup(self):
+        """
+        Whether the operator is a setup task.
+
+        :meta private:
+        """
+        return self._is_setup
+
+    @is_setup.setter
+    def is_setup(self, value):
+        """
+        Setter for is_setup property.
+
+        :meta private:
+        """
+        if self.is_teardown is True:
+            raise ValueError(f"Cannot mark task '{self.task_id}' as setup; task is already a teardown.")
+        self._is_setup = value
+
+    @property
+    def is_teardown(self):
+        """
+        Whether the operator is a teardown task.
+
+        :meta private:
+        """
+        return self._is_teardown
+
+    @is_teardown.setter
+    def is_teardown(self, value):
+        """
+        Setter for is_teardown property.
+
+        :meta private:
+        """
+        if self.is_setup is True:
+            raise ValueError(f"Cannot mark task '{self.task_id}' as teardown; task is already a setup.")
+        self._is_teardown = value
+
+    @property
+    def on_failure_fail_dagrun(self):
+        """
+        Whether the operator should fail the dagrun on failure.
+
+        :meta private:
+        """
+        return self._on_failure_fail_dagrun
+
+    @on_failure_fail_dagrun.setter
+    def on_failure_fail_dagrun(self, value):
+        """
+        Setter for on_failure_fail_dagrun property.
+
+        :meta private:
+        """
+        if value is True and self.is_teardown is not True:
+            raise ValueError(
+                f"Cannot set task on_failure_fail_dagrun for "
+                f"'{self.task_id}' because it is not a teardown task."
+            )
+        self._on_failure_fail_dagrun = value
+
+    def as_setup(self):
+        self.is_setup = True
+        return self
+
+    def as_teardown(
+        self,
+        setups: BaseOperator | Iterable[BaseOperator] | ArgNotSet = NOTSET,
+        *,
+        on_failure_fail_dagrun=NOTSET,
+    ):
+        self.is_teardown = True
+        if TYPE_CHECKING:
+            assert isinstance(self, BaseOperator)  # is_teardown not supported for MappedOperator
+        self.trigger_rule = TriggerRule.ALL_DONE_SETUP_SUCCESS
+        if on_failure_fail_dagrun is not NOTSET:
+            self.on_failure_fail_dagrun = on_failure_fail_dagrun
+        if not isinstance(setups, ArgNotSet):
+            setups = [setups] if isinstance(setups, DependencyMixin) else setups
+            for s in setups:
+                s.is_setup = True
+                s >> self
+        return self
 
     def get_direct_relative_ids(self, upstream: bool = False) -> set[str]:
         """Get direct relative IDs to the current task, upstream or downstream."""

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -171,7 +171,7 @@ class AbstractOperator(Templater, DAGNode):
 
         :meta private:
         """
-        if self.is_teardown is True:
+        if self.is_teardown is True and value is True:
             raise ValueError(f"Cannot mark task '{self.task_id}' as setup; task is already a teardown.")
         self._is_setup = value
 
@@ -191,7 +191,7 @@ class AbstractOperator(Templater, DAGNode):
 
         :meta private:
         """
-        if self.is_setup is True:
+        if self.is_setup is True and value is True:
             raise ValueError(f"Cannot mark task '{self.task_id}' as teardown; task is already a setup.")
         self._is_teardown = value
 
@@ -211,7 +211,7 @@ class AbstractOperator(Templater, DAGNode):
 
         :meta private:
         """
-        if not self.is_teardown:
+        if value is True and self.is_teardown is not True:
             raise ValueError(
                 f"Cannot set task on_failure_fail_dagrun for "
                 f"'{self.task_id}' because it is not a teardown task."

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -191,7 +191,7 @@ class AbstractOperator(Templater, DAGNode):
 
         :meta private:
         """
-        if self.is_setup is True:
+        if self.is_setup is True and value is True:
             raise ValueError(f"Cannot mark task '{self.task_id}' as teardown; task is already a setup.")
         self._is_teardown = value
 

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -191,7 +191,7 @@ class AbstractOperator(Templater, DAGNode):
 
         :meta private:
         """
-        if self.is_setup is True and value is True:
+        if self.is_setup is True:
             raise ValueError(f"Cannot mark task '{self.task_id}' as teardown; task is already a setup.")
         self._is_teardown = value
 

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -211,7 +211,7 @@ class AbstractOperator(Templater, DAGNode):
 
         :meta private:
         """
-        if value is True and self.is_teardown is not True:
+        if not self.is_teardown:
             raise ValueError(
                 f"Cannot set task on_failure_fail_dagrun for "
                 f"'{self.task_id}' because it is not a teardown task."

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -987,6 +987,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         if setups is not NOTSET:
             setups = [setups] if isinstance(setups, DependencyMixin) else setups
             for s in setups:
+                s.is_setup = True
                 s >> self
         return self
 

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -721,25 +721,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     # Set to True for an operator instantiated by a mapped operator.
     __from_mapped = False
 
-    is_setup = False
-    """
-    Whether the operator is a setup task
-
-    :meta private:
-    """
-    is_teardown = False
-    """
-    Whether the operator is a teardown task
-
-    :meta private:
-    """
-    on_failure_fail_dagrun = False
-    """
-    Whether the operator should fail the dagrun on failure
-
-    :meta private:
-    """
-
     def __init__(
         self,
         task_id: str,
@@ -975,21 +956,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
 
         if SetupTeardownContext.active:
             SetupTeardownContext.update_context_map(self)
-
-    def as_setup(self):
-        self.is_setup = True
-        return self
-
-    def as_teardown(self, setups=NOTSET, *, on_failure_fail_dagrun=False):
-        self.trigger_rule = TriggerRule.ALL_DONE_SETUP_SUCCESS
-        self.on_failure_fail_dagrun = on_failure_fail_dagrun
-        self.is_teardown = True
-        if setups is not NOTSET:
-            setups = [setups] if isinstance(setups, DependencyMixin) else setups
-            for s in setups:
-                s.is_setup = True
-                s >> self
-        return self
 
     def __enter__(self):
         if not self.is_setup and not self.is_teardown:

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -290,9 +290,6 @@ class MappedOperator(AbstractOperator):
 
     subdag: None = None  # Since we don't support SubDagOperator, this is always None.
     supports_lineage: bool = False
-    is_setup: bool = False
-    is_teardown: bool = False
-    on_failure_fail_dagrun: bool = False
 
     HIDE_ATTRS_FROM_UI: ClassVar[frozenset[str]] = AbstractOperator.HIDE_ATTRS_FROM_UI | frozenset(
         (
@@ -326,6 +323,24 @@ class MappedOperator(AbstractOperator):
                 f"SLAs are unsupported with mapped tasks. Please set `sla=None` for task "
                 f"{self.task_id!r}."
             )
+
+    @AbstractOperator.is_setup.setter  # type: ignore[attr-defined]
+    def is_setup(self, value):
+        """
+        Setter for is_setup property. Disabled for MappedOperator.
+
+        :meta private:
+        """
+        raise ValueError("Cannot set is_setup for mapped operator.")
+
+    @AbstractOperator.is_teardown.setter  # type: ignore[attr-defined]
+    def is_teardown(self, value):
+        """
+        Setter for is_teardown property. Disabled for MappedOperator.
+
+        :meta private:
+        """
+        raise ValueError("Cannot set is_teardown for mapped operator.")
 
     @classmethod
     @cache
@@ -390,6 +405,11 @@ class MappedOperator(AbstractOperator):
     @property
     def trigger_rule(self) -> TriggerRule:
         return self.partial_kwargs.get("trigger_rule", DEFAULT_TRIGGER_RULE)
+
+    @trigger_rule.setter
+    def trigger_rule(self, value):
+        # required for mypy which complains about overriding writeable attr with read-only property
+        raise ValueError("Cannot set trigger_rule for mapped operator.")
 
     @property
     def depends_on_past(self) -> bool:

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -24,11 +24,12 @@ import pendulum
 
 from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
 from airflow.serialization.enums import DagAttributeTypes
-from airflow.utils.types import NOTSET
+from airflow.utils.types import NOTSET, ArgNotSet
 
 if TYPE_CHECKING:
     from logging import Logger
 
+    from airflow.models.baseoperator import BaseOperator
     from airflow.models.dag import DAG
     from airflow.models.operator import Operator
     from airflow.utils.edgemodifier import EdgeModifier
@@ -70,11 +71,16 @@ class DependencyMixin:
         """Set a task or a task list to be directly downstream from the current task."""
         raise NotImplementedError()
 
-    def as_setup(self):
+    def as_setup(self) -> DependencyMixin:
         """Mark a task as setup task."""
         raise NotImplementedError()
 
-    def as_teardown(self, setups=NOTSET, *, on_failure_fail_dagrun=False):
+    def as_teardown(
+        self,
+        setups: BaseOperator | Iterable[BaseOperator] | ArgNotSet = NOTSET,
+        *,
+        on_failure_fail_dagrun=NOTSET,
+    ) -> DependencyMixin:
         """Mark a task as teardown and set its setups as direct relatives."""
         raise NotImplementedError()
 

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -77,8 +77,8 @@ class DependencyMixin:
 
     def as_teardown(
         self,
-        setups: BaseOperator | Iterable[BaseOperator] | ArgNotSet = NOTSET,
         *,
+        setups: BaseOperator | Iterable[BaseOperator] | ArgNotSet = NOTSET,
         on_failure_fail_dagrun=NOTSET,
     ) -> DependencyMixin:
         """Mark a task as teardown and set its setups as direct relatives."""

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -24,6 +24,7 @@ import pendulum
 
 from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
 from airflow.serialization.enums import DagAttributeTypes
+from airflow.utils.types import NOTSET
 
 if TYPE_CHECKING:
     from logging import Logger
@@ -67,6 +68,14 @@ class DependencyMixin:
         self, other: DependencyMixin | Sequence[DependencyMixin], edge_modifier: EdgeModifier | None = None
     ):
         """Set a task or a task list to be directly downstream from the current task."""
+        raise NotImplementedError()
+
+    def as_setup(self):
+        """Mark a task as setup task."""
+        raise NotImplementedError()
+
+    def as_teardown(self, setups=NOTSET, *, on_failure_fail_dagrun=False):
+        """Mark a task as teardown and set its setups as direct relatives."""
         raise NotImplementedError()
 
     def update_relative(

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -329,8 +329,8 @@ class PlainXComArg(XComArg):
 
     def as_teardown(
         self,
-        setups: BaseOperator | Iterable[BaseOperator] | ArgNotSet = NOTSET,
         *,
+        setups: BaseOperator | Iterable[BaseOperator] | ArgNotSet = NOTSET,
         on_failure_fail_dagrun=NOTSET,
     ):
         for operator, _ in self.iter_references():

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -960,7 +960,8 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 v = cls.deserialize(v)
             elif k in ("outlets", "inlets"):
                 v = cls.deserialize(v)
-
+            elif k == "on_failure_fail_dagrun":
+                k = "_on_failure_fail_dagrun"
             # else use v as it is
 
             setattr(op, k, v)

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -65,7 +65,7 @@ class TestSetupTearDownTask:
 
     def test_marking_operator_as_setup_task(self, dag_maker):
         with dag_maker() as dag:
-            BashOperator.as_setup(task_id="mytask", bash_command='echo "I am a setup task"')
+            BashOperator(task_id="mytask", bash_command='echo "I am a setup task"').as_setup()
 
         assert len(dag.task_group.children) == 1
         setup_task = dag.task_group.children["mytask"]
@@ -86,7 +86,7 @@ class TestSetupTearDownTask:
 
     def test_marking_operator_as_teardown_task(self, dag_maker):
         with dag_maker() as dag:
-            BashOperator.as_teardown(task_id="mytask", bash_command='echo "I am a setup task"')
+            BashOperator(task_id="mytask", bash_command='echo "I am a setup task"').as_teardown()
 
         assert len(dag.task_group.children) == 1
         teardown_task = dag.task_group.children["mytask"]
@@ -146,11 +146,10 @@ class TestSetupTearDownTask:
     @pytest.mark.parametrize("on_failure_fail_dagrun", [True, False])
     def test_classic_teardown_task_works_with_on_failure_fail_dagrun(self, on_failure_fail_dagrun, dag_maker):
         with dag_maker() as dag:
-            BashOperator.as_teardown(
+            BashOperator(
                 task_id="mytask",
                 bash_command='echo "I am a teardown task"',
-                on_failure_fail_dagrun=on_failure_fail_dagrun,
-            )
+            ).as_teardown(on_failure_fail_dagrun=on_failure_fail_dagrun)
 
         teardown_task = dag.task_group.children["mytask"]
         assert teardown_task.is_teardown
@@ -605,11 +604,11 @@ class TestSetupTearDownTask:
             print("mytask")
 
         with dag_maker() as dag:
-            setuptask = BashOperator.as_setup(task_id="setuptask", bash_command="echo 1")
-            setuptask2 = BashOperator.as_setup(task_id="setuptask2", bash_command="echo 1")
+            setuptask = BashOperator(task_id="setuptask", bash_command="echo 1").as_setup()
+            setuptask2 = BashOperator(task_id="setuptask2", bash_command="echo 1").as_setup()
 
-            teardowntask = BashOperator.as_teardown(task_id="teardowntask", bash_command="echo 1")
-            teardowntask2 = BashOperator.as_teardown(task_id="teardowntask2", bash_command="echo 1")
+            teardowntask = BashOperator(task_id="teardowntask", bash_command="echo 1").as_teardown()
+            teardowntask2 = BashOperator(task_id="teardowntask2", bash_command="echo 1").as_teardown()
             with setuptask >> teardowntask:
                 with setuptask2 >> teardowntask2:
                     mytask() >> mytask2()
@@ -643,11 +642,11 @@ class TestSetupTearDownTask:
             print("mytask")
 
         with dag_maker() as dag:
-            setuptask = BashOperator.as_setup(task_id="setuptask", bash_command="echo 1")
-            setuptask2 = BashOperator.as_setup(task_id="setuptask2", bash_command="echo 1")
+            setuptask = BashOperator(task_id="setuptask", bash_command="echo 1").as_setup()
+            setuptask2 = BashOperator(task_id="setuptask2", bash_command="echo 1").as_setup()
 
-            teardowntask = BashOperator.as_teardown(task_id="teardowntask", bash_command="echo 1")
-            teardowntask2 = BashOperator.as_teardown(task_id="teardowntask2", bash_command="echo 1")
+            teardowntask = BashOperator(task_id="teardowntask", bash_command="echo 1").as_teardown()
+            teardowntask2 = BashOperator(task_id="teardowntask2", bash_command="echo 1").as_teardown()
             with setuptask >> teardowntask:
                 with setuptask2 >> teardowntask2:
                     mytask() << mytask2()
@@ -676,7 +675,7 @@ class TestSetupTearDownTask:
             print("mytask")
 
         with dag_maker() as dag:
-            setuptask = BashOperator.as_setup(task_id="setuptask", bash_command="echo 1")
+            setuptask = BashOperator(task_id="setuptask", bash_command="echo 1").as_setup()
             with setuptask:
                 mytask() >> mytask2()
 
@@ -698,7 +697,7 @@ class TestSetupTearDownTask:
             print("mytask")
 
         with dag_maker("foo") as dag:
-            teardowntask = BashOperator.as_teardown(task_id="teardowntask", bash_command="echo 1")
+            teardowntask = BashOperator(task_id="teardowntask", bash_command="echo 1").as_teardown()
             with teardowntask:
                 mytask() >> mytask2()
 
@@ -720,10 +719,10 @@ class TestSetupTearDownTask:
             print("mytask")
 
         with dag_maker() as dag:
-            setuptask = BashOperator.as_setup(task_id="setuptask", bash_command="echo 1")
-            setuptask2 = BashOperator.as_setup(task_id="setuptask2", bash_command="echo 1")
+            setuptask = BashOperator(task_id="setuptask", bash_command="echo 1").as_setup()
+            setuptask2 = BashOperator(task_id="setuptask2", bash_command="echo 1").as_setup()
 
-            teardowntask = BashOperator.as_teardown(task_id="teardowntask", bash_command="echo 1")
+            teardowntask = BashOperator(task_id="teardowntask", bash_command="echo 1").as_teardown()
             with setuptask >> teardowntask:
                 with setuptask2:
                     mytask() << mytask2()
@@ -758,8 +757,8 @@ class TestSetupTearDownTask:
             print("mytask")
 
         with dag_maker() as dag:
-            setuptask = BashOperator.as_setup(task_id="setuptask", bash_command="echo 1")
-            setuptask2 = BashOperator.as_setup(task_id="setuptask2", bash_command="echo 1")
+            setuptask = BashOperator(task_id="setuptask", bash_command="echo 1").as_setup()
+            setuptask2 = BashOperator(task_id="setuptask2", bash_command="echo 1").as_setup()
             with setuptask:
                 t1 = mytask()
                 t2 = mytask2()
@@ -801,8 +800,8 @@ class TestSetupTearDownTask:
             print("mytask")
 
         with dag_maker() as dag:
-            setuptask = BashOperator.as_setup(task_id="setuptask", bash_command="echo 1")
-            setuptask2 = BashOperator.as_setup(task_id="setuptask2", bash_command="echo 1")
+            setuptask = BashOperator(task_id="setuptask", bash_command="echo 1").as_setup()
+            setuptask2 = BashOperator(task_id="setuptask2", bash_command="echo 1").as_setup()
             with setuptask:
                 t1 = mytask()
                 t2 = mytask2()
@@ -841,11 +840,11 @@ class TestSetupTearDownTask:
             print("mytask")
 
         with dag_maker() as dag:
-            setuptask = BashOperator.as_setup(task_id="setuptask", bash_command="echo 1")
-            setuptask2 = BashOperator.as_setup(task_id="setuptask2", bash_command="echo 1")
+            setuptask = BashOperator(task_id="setuptask", bash_command="echo 1").as_setup()
+            setuptask2 = BashOperator(task_id="setuptask2", bash_command="echo 1").as_setup()
 
-            teardowntask = BashOperator.as_teardown(task_id="teardowntask", bash_command="echo 1")
-            teardowntask2 = BashOperator.as_teardown(task_id="teardowntask2", bash_command="echo 1")
+            teardowntask = BashOperator(task_id="teardowntask", bash_command="echo 1").as_teardown()
+            teardowntask2 = BashOperator(task_id="teardowntask2", bash_command="echo 1").as_teardown()
             with setuptask >> teardowntask:
                 with setuptask2 >> teardowntask2:
                     mytask()
@@ -1047,9 +1046,9 @@ class TestSetupTearDownTask:
             print("mytask")
 
         with dag_maker() as dag:
-            teardowntask = BashOperator.as_teardown(task_id="teardowntask", bash_command="echo 1")
-            teardowntask2 = BashOperator.as_teardown(task_id="teardowntask2", bash_command="echo 1")
-            setuptask = BashOperator.as_setup(task_id="setuptask", bash_command="echo 1")
+            teardowntask = BashOperator(task_id="teardowntask", bash_command="echo 1").as_teardown()
+            teardowntask2 = BashOperator(task_id="teardowntask2", bash_command="echo 1").as_teardown()
+            setuptask = BashOperator(task_id="setuptask", bash_command="echo 1").as_setup()
             with [teardowntask, teardowntask2] << setuptask:
                 mytask()
 
@@ -1077,9 +1076,9 @@ class TestSetupTearDownTask:
             print("mytask")
 
         with dag_maker() as dag:
-            teardowntask = BashOperator.as_teardown(task_id="teardowntask", bash_command="echo 1")
-            teardowntask2 = BashOperator.as_teardown(task_id="teardowntask2", bash_command="echo 1")
-            setuptask = BashOperator.as_setup(task_id="setuptask", bash_command="echo 1")
+            teardowntask = BashOperator(task_id="teardowntask", bash_command="echo 1").as_teardown()
+            teardowntask2 = BashOperator(task_id="teardowntask2", bash_command="echo 1").as_teardown()
+            setuptask = BashOperator(task_id="setuptask", bash_command="echo 1").as_setup()
             with setuptask >> context_wrapper([teardowntask, teardowntask2]):
                 mytask()
 

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -3541,16 +3541,16 @@ class TestTaskClearingSetupTeardownBehavior:
         """
 
         def teardown_task(task_id):
-            return BaseOperator.as_teardown(task_id=task_id)
+            return BaseOperator(task_id=task_id).as_teardown()
 
         def teardown_task_f(task_id):
-            return BaseOperator.as_teardown(task_id=task_id, on_failure_fail_dagrun=True)
+            return BaseOperator(task_id=task_id).as_teardown(on_failure_fail_dagrun=True)
 
         def work_task(task_id):
             return BaseOperator(task_id=task_id)
 
         def setup_task(task_id):
-            return BaseOperator.as_setup(task_id=task_id)
+            return BaseOperator(task_id=task_id).as_setup()
 
         def make_task(task_id):
             """
@@ -3709,7 +3709,7 @@ class TestTaskClearingSetupTeardownBehavior:
         assert self.cleared_downstream(w1) == {s1, w1, w2, t1}
         assert self.cleared_downstream(w2) == {w2}
         # and if there's a downstream setup, it will be included as well
-        s2 = BaseOperator.as_setup(task_id="s2", dag=dag)
+        s2 = BaseOperator(task_id="s2", dag=dag).as_setup()
         t1 >> s2
         assert w1.get_flat_relative_ids(upstream=False) == {"t1", "w2", "s2"}
         assert self.cleared_downstream(w1) == {s1, w1, w2, t1, s2}
@@ -3755,16 +3755,16 @@ class TestTaskClearingSetupTeardownBehavior:
         """
         dag = DAG(dag_id="test_dag", start_date=pendulum.now())
         with dag:
-            dag_setup = BaseOperator.as_setup(task_id="dag_setup")
-            dag_teardown = BaseOperator.as_teardown(task_id="dag_teardown")
+            dag_setup = BaseOperator(task_id="dag_setup").as_setup()
+            dag_teardown = BaseOperator(task_id="dag_teardown").as_teardown()
             dag_setup >> dag_teardown
             for group_name in ("g1", "g2"):
                 with TaskGroup(group_name) as tg:
-                    group_setup = BaseOperator.as_setup(task_id="group_setup")
+                    group_setup = BaseOperator(task_id="group_setup").as_setup()
                     w1 = BaseOperator(task_id="w1")
                     w2 = BaseOperator(task_id="w2")
                     w3 = BaseOperator(task_id="w3")
-                    group_teardown = BaseOperator.as_teardown(task_id="group_teardown")
+                    group_teardown = BaseOperator(task_id="group_teardown").as_teardown()
                     group_setup >> w1 >> w2 >> w3 >> group_teardown
                     group_setup >> group_teardown
                 dag_setup >> tg >> dag_teardown

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1304,7 +1304,7 @@ class TestTaskInstance:
                 task = EmptyOperator(task_id=f"work_{i}", dag=dag)
                 task.set_downstream(downstream)
             for i in range(upstream_setups):
-                task = EmptyOperator.as_setup(task_id=f"setup_{i}", dag=dag)
+                task = EmptyOperator(task_id=f"setup_{i}", dag=dag).as_setup()
                 task.set_downstream(downstream)
             assert task.start_date is not None
             run_date = task.start_date + datetime.timedelta(days=5)

--- a/tests/models/test_taskmixin.py
+++ b/tests/models/test_taskmixin.py
@@ -1,0 +1,130 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from itertools import product
+
+import pytest
+
+from airflow.decorators import task
+from airflow.models.baseoperator import BaseOperator
+
+
+def cleared_tasks(dag, task_id):
+    dag_ = dag.partial_subset(task_id, include_downstream=True, include_upstream=False)
+    return {x.task_id for x in dag_.tasks}
+
+
+def get_task_attr(task_like, attr):
+    try:
+        return getattr(task_like, attr)
+    except AttributeError:
+        return getattr(task_like.operator, attr)
+
+
+def make_task(name, type_):
+    if type_ == "classic":
+        return BaseOperator(task_id=name)
+    else:
+
+        @task
+        def my_task():
+            pass
+
+        return my_task.override(task_id=name)()
+
+
+@pytest.mark.parametrize("setup_type, work_type, teardown_type", product(*3 * [["classic", "taskflow"]]))
+def test_as_teardown(dag_maker, setup_type, work_type, teardown_type):
+    """
+    Check that as_teardown works properly as implemented in PlainXComArg
+
+    It should mark the teardown as teardown, and if a task is provided, it should mark that as setup
+    and set it as a direct upstream.
+    """
+    with dag_maker() as dag:
+        s1 = make_task(name="s1", type_=setup_type)
+        w1 = make_task(name="w1", type_=work_type)
+        t1 = make_task(name="t1", type_=teardown_type)
+    # initial conditions
+    assert cleared_tasks(dag, "w1") == {"w1"}
+
+    # after setting deps, still none are setup / teardown
+    # verify relationships
+    s1 >> w1 >> t1
+    assert cleared_tasks(dag, "w1") == {"w1", "t1"}
+    assert get_task_attr(t1, "is_teardown") is False
+    assert get_task_attr(s1, "is_setup") is False
+    assert get_task_attr(t1, "upstream_task_ids") == {"w1"}
+
+    # now when we use as_teardown, s1 should be setup, t1 should be teardown, and we should have s1 >> t1
+    t1.as_teardown(s1)
+    assert cleared_tasks(dag, "w1") == {"s1", "w1", "t1"}
+    assert get_task_attr(t1, "is_teardown") is True
+    assert get_task_attr(s1, "is_setup") is True
+    assert get_task_attr(t1, "upstream_task_ids") == {"w1", "s1"}
+
+
+@pytest.mark.parametrize("setup_type, work_type, teardown_type", product(*3 * [["classic", "taskflow"]]))
+def test_as_teardown_oneline(dag_maker, setup_type, work_type, teardown_type):
+    """
+    Check that as_teardown implementations work properly. Tests all combinations of taskflow and classic.
+
+    It should mark the teardown as teardown, and if a task is provided, it should mark that as setup
+    and set it as a direct upstream.
+    """
+
+    with dag_maker() as dag:
+        s1 = make_task(name="s1", type_=setup_type)
+        w1 = make_task(name="w1", type_=work_type)
+        t1 = make_task(name="t1", type_=teardown_type)
+
+    # verify initial conditions
+    for task_ in (s1, w1, t1):
+        assert get_task_attr(task_, "upstream_list") == []
+        assert get_task_attr(task_, "downstream_list") == []
+        assert get_task_attr(task_, "is_setup") is False
+        assert get_task_attr(task_, "is_teardown") is False
+        assert cleared_tasks(dag, get_task_attr(task_, "task_id")) == {get_task_attr(task_, "task_id")}
+
+    # now set the deps in one line
+    s1 >> w1 >> t1.as_teardown(s1)
+
+    # verify resulting configuration
+    # should be equiv to the following:
+    #   * s1.is_setup = True
+    #   * t1.is_teardown = True
+    #   * s1 >> t1
+    #   * s1 >> w1 >> t1
+    for task_, exp_up, exp_down in [
+        (s1, set(), {"w1", "t1"}),
+        (w1, {"s1"}, {"t1"}),
+        (t1, {"s1", "w1"}, set()),
+    ]:
+        assert get_task_attr(task_, "upstream_task_ids") == exp_up
+        assert get_task_attr(task_, "downstream_task_ids") == exp_down
+    assert cleared_tasks(dag, "s1") == {"s1", "w1", "t1"}
+    assert cleared_tasks(dag, "w1") == {"s1", "w1", "t1"}
+    assert cleared_tasks(dag, "t1") == {"t1"}
+    for task_, exp_is_setup, exp_is_teardown in [
+        (s1, True, False),
+        (w1, False, False),
+        (t1, False, True),
+    ]:
+        assert get_task_attr(task_, "is_setup") is exp_is_setup
+        assert get_task_attr(task_, "is_teardown") is exp_is_teardown

--- a/tests/models/test_taskmixin.py
+++ b/tests/models/test_taskmixin.py
@@ -73,7 +73,7 @@ def test_as_teardown(dag_maker, setup_type, work_type, teardown_type):
     assert get_task_attr(t1, "upstream_task_ids") == {"w1"}
 
     # now when we use as_teardown, s1 should be setup, t1 should be teardown, and we should have s1 >> t1
-    t1.as_teardown(s1)
+    t1.as_teardown(setups=s1)
     assert cleared_tasks(dag, "w1") == {"s1", "w1", "t1"}
     assert get_task_attr(t1, "is_teardown") is True
     assert get_task_attr(s1, "is_setup") is True
@@ -103,7 +103,7 @@ def test_as_teardown_oneline(dag_maker, setup_type, work_type, teardown_type):
         assert cleared_tasks(dag, get_task_attr(task_, "task_id")) == {get_task_attr(task_, "task_id")}
 
     # now set the deps in one line
-    s1 >> w1 >> t1.as_teardown(s1)
+    s1 >> w1 >> t1.as_teardown(setups=s1)
 
     # verify resulting configuration
     # should be equiv to the following:
@@ -210,7 +210,7 @@ def test_no_setup_or_teardown_for_mapped_operator(dag_maker):
     # combining setup and teardown with vanilla mapped task is fine
     with dag_maker():
         s1 = BaseOperator(task_id="s1").as_setup()
-        t1 = BaseOperator(task_id="t1").as_teardown(s1)
+        t1 = BaseOperator(task_id="t1").as_teardown(setups=s1)
         added_vals = add_one.expand(x=[1, 2, 3])
         print_task_task = print_task(added_vals)
         s1 >> added_vals

--- a/tests/models/test_xcom_arg.py
+++ b/tests/models/test_xcom_arg.py
@@ -20,7 +20,7 @@ import pytest
 
 from airflow.models.xcom_arg import XComArg
 from airflow.operators.bash import BashOperator
-from airflow.operators.python import PythonOperator
+from airflow.operators.python import PythonOperator, task
 from airflow.utils.types import NOTSET
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_dags, clear_db_runs
@@ -223,3 +223,99 @@ def test_xcom_zip(dag_maker, session, fillvalue, expected_results):
         ti.run(session=session)
 
     assert results == expected_results
+
+
+def test_as_teardown(dag_maker):
+    """
+    Check that as_teardown works properly as implemented in PlainXComArg
+
+    It should mark the teardown as teardown, and if a task is provided, it should mark that as setup
+    and set it as a direct upstream.
+    """
+
+    @task
+    def my_task():
+        pass
+
+    def cleared_tasks(task_id):
+        dag_ = dag.partial_subset(task_id, include_downstream=True, include_upstream=False)
+        return {x.task_id for x in dag_.tasks}
+
+    with dag_maker() as dag:
+        s1 = my_task.override(task_id="s1")()
+        w1 = my_task.override(task_id="w1")()
+        t1 = my_task.override(task_id="t1")()
+    # initial conditions
+    assert cleared_tasks("w1") == {"w1"}
+
+    # after setting deps, still none are setup / teardown
+    # verify relationships
+    s1 >> w1 >> t1
+    assert cleared_tasks("w1") == {"w1", "t1"}
+    assert t1.operator.is_teardown is False
+    assert s1.operator.is_setup is False
+    assert t1.operator.upstream_task_ids == {"w1"}
+
+    # now when we use as_teardown, s1 should be setup, t1 should be teardown, and we should have s1 >> t1
+    t1.as_teardown(s1)
+    assert cleared_tasks("w1") == {"s1", "w1", "t1"}
+    assert t1.operator.is_teardown is True
+    assert s1.operator.is_setup is True
+    assert t1.operator.upstream_task_ids == {"w1", "s1"}
+
+
+def test_as_teardown_oneline(dag_maker):
+    """
+    Check that as_teardown works properly as implemented in PlainXComArg
+
+    It should mark the teardown as teardown, and if a task is provided, it should mark that as setup
+    and set it as a direct upstream.
+    """
+
+    @task
+    def my_task():
+        pass
+
+    def cleared_tasks(task_id):
+        dag_ = dag.partial_subset(task_id, include_downstream=True, include_upstream=False)
+        return {x.task_id for x in dag_.tasks}
+
+    with dag_maker() as dag:
+        s1 = my_task.override(task_id="s1")()
+        w1 = my_task.override(task_id="w1")()
+        t1 = my_task.override(task_id="t1")()
+
+    # verify initial conditions
+    for task_ in (s1, w1, t1):
+        assert task_.operator.upstream_list == []
+        assert task_.operator.downstream_list == []
+        assert task_.operator.is_setup is False
+        assert task_.operator.is_teardown is False
+        assert cleared_tasks(task_.operator.task_id) == {task_.operator.task_id}
+
+    # now set the deps in one line
+    s1 >> w1 >> t1.as_teardown(s1)
+
+    # verify resulting configuration
+    # should be equiv to the following:
+    #   * s1.is_setup = True
+    #   * t1.is_teardown = True
+    #   * s1 >> t1
+    #   * s1 >> w1 >> t1
+    for task_, exp_up, exp_down in [
+        (s1, set(), {"w1", "t1"}),
+        (w1, {"s1"}, {"t1"}),
+        (t1, {"s1", "w1"}, set()),
+    ]:
+        assert task_.operator.upstream_task_ids == exp_up
+        assert task_.operator.downstream_task_ids == exp_down
+    assert cleared_tasks("s1") == {"s1", "w1", "t1"}
+    assert cleared_tasks("w1") == {"s1", "w1", "t1"}
+    assert cleared_tasks("t1") == {"t1"}
+    for task_, exp_is_setup, exp_is_teardown in [
+        (s1, True, False),
+        (w1, False, False),
+        (t1, False, True),
+    ]:
+        assert task_.operator.is_setup is exp_is_setup
+        assert task_.operator.is_teardown is exp_is_teardown

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1394,8 +1394,8 @@ class TestStringifiedDAGs:
 
         serialized_dag = SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(dag))
         task = serialized_dag.task_group.children["mytask"]
-        assert task.is_teardown
-        assert task.on_failure_fail_dagrun
+        assert task.is_teardown is True
+        assert task.on_failure_fail_dagrun is True
 
     def test_deps_sorted(self):
         """

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1328,18 +1328,18 @@ class TestStringifiedDAGs:
 
         execution_date = datetime(2020, 1, 1)
         with DAG("test_task_group_setup_teardown_tasks", start_date=execution_date) as dag:
-            EmptyOperator.as_setup(task_id="setup")
-            EmptyOperator.as_teardown(task_id="teardown")
+            EmptyOperator(task_id="setup").as_setup()
+            EmptyOperator(task_id="teardown").as_teardown()
 
             with TaskGroup("group1"):
-                EmptyOperator.as_setup(task_id="setup1")
+                EmptyOperator(task_id="setup1").as_setup()
                 EmptyOperator(task_id="task1")
-                EmptyOperator.as_teardown(task_id="teardown1")
+                EmptyOperator(task_id="teardown1").as_teardown()
 
                 with TaskGroup("group2"):
-                    EmptyOperator.as_setup(task_id="setup2")
+                    EmptyOperator(task_id="setup2").as_setup()
                     EmptyOperator(task_id="task2")
-                    EmptyOperator.as_teardown(task_id="teardown2")
+                    EmptyOperator(task_id="teardown2").as_teardown()
 
         dag_dict = SerializedDAG.to_dict(dag)
         SerializedDAG.validate_schema(dag_dict)

--- a/tests/ti_deps/deps/test_trigger_rule_dep.py
+++ b/tests/ti_deps/deps/test_trigger_rule_dep.py
@@ -64,7 +64,7 @@ def get_task_instance(monkeypatch, session, dag_maker):
             for task_id in normal_tasks or []:
                 EmptyOperator(task_id=task_id) >> task
             for task_id in setup_tasks or []:
-                EmptyOperator.as_setup(task_id=task_id) >> task
+                EmptyOperator(task_id=task_id).as_setup() >> task
         dr = dag_maker.create_dagrun()
         ti = dr.task_instances[0]
         ti.task = task


### PR DESCRIPTION
TLDR: 
* provides a oneline syntax for setting setup / teardown deps
* makes it easy to convert dags to use feature
* provides a mechanism to combine "reusable" taskflow tasks with setup / teardown
* set setup and teardown in the same place you set deps

This provides a number of benefits.

One is now we can do MyTeardown(...).as_teardown(the_setup) instead of having to arrow directly these two.

The other is that I think it can be cognitively easier to set these properties while setting relationships rather than when instantiating.

This can also make it easier to "convert" an existing dag to use setup / teardown.  For example, take a look at [this system test dag](https://github.com/apache/airflow/blob/main/tests/system/providers/amazon/aws/example_dms.py#L407-L429).  Imagine converting that to use setup / teardown.  If you need to set setup / teardown at instantiation, you are doing it far away from where you are actually setting the relationships between the tasks.  But I think sometimes it makes a lot of sense to set those properties at the same time as you set those relationships.  The present PR doesn't force user to do this, but it makes it possible.

Finally, this *also* makes it possible to define reusable, parameterized tasks in taskflow, and use them as setups / teardowns / work tasks depending on context.  If we force you to set it at decorator level, then you must pick and we don't provide an official mechanism to override.

Example of how this can make authoring a bit cleaner. I give two ways supported with the new approach, and for comparison i include the old way you had to do it.

New way 1:
```python
with DAG(
    dag_id="example_setup_teardown",
    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
) as dag:
    s1 = BashOperator(task_id="setup", bash_command="echo 'Hello from setup'")
    w1 = BashOperator(task_id="normal", bash_command="echo 'I am just a normal task'")
    t1 = BashOperator(
        task_id="teardown", bash_command="echo 'Goodbye from teardown'"
    )
    s1.as_setup() >> w1 >> t1.as_teardown(s1)
```

new way 2:
```python
with DAG(
    dag_id="example_setup_teardown",
    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
) as dag:
    s1 = BashOperator(task_id="setup", bash_command="echo 'Hello from setup'").as_setup()
    w1 = BashOperator(task_id="normal", bash_command="echo 'I am just a normal task'")
    t1 = BashOperator(
        task_id="teardown", bash_command="echo 'Goodbye from teardown'"
    ).as_teardown(s1)
    s1 >> w1 >> t1
```


Old way:
```python
with DAG(
    dag_id="example_setup_teardown",
    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
) as dag:
    s1 = BashOperator.as_setup(task_id="setup", bash_command="echo 'Hello from setup'")
    w1 = BashOperator(task_id="normal", bash_command="echo 'I am just a normal task'")
    t1 = BashOperator.as_teardown(
        task_id="teardown", bash_command="echo 'Goodbye from teardown'"
    )
    s1 >> w1 >> t1
    s1 >> t1
```

