### PR TITLE
add async wait method to the "with logging" aws utils

### DIFF
--- a/airflow/providers/amazon/aws/utils/waiter_with_logging.py
+++ b/airflow/providers/amazon/aws/utils/waiter_with_logging.py
@@ -17,8 +17,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
+from typing import Any
 
 import jmespath
 from botocore.exceptions import WaiterError
@@ -31,10 +33,10 @@ def wait(
     waiter: Waiter,
     waiter_delay: int,
     max_attempts: int,
-    args: dict,
+    args: dict[str, Any],
     failure_message: str,
     status_message: str,
-    status_args: list,
+    status_args: list[str],
 ) -> None:
     """
     Use a boto waiter to poll an AWS service for the specified state. Although this function
@@ -47,7 +49,7 @@ def wait(
     :param args: The arguments to pass to the waiter.
     :param failure_message: The message to log if a failure state is reached.
     :param status_message: The message logged when printing the status of the service.
-    :param status_args: A list containing the arguments to retrieve status information from
+    :param status_args: A list containing the JMESPath queries to retrieve status information from
         the waiter response.
         e.g.
         response = {"Cluster": {"state": "CREATING"}}
@@ -68,23 +70,81 @@ def wait(
         except WaiterError as error:
             if "terminal failure" in str(error):
                 raise AirflowException(f"{failure_message}: {error}")
-            status_string = _format_status_string(status_args, error.last_response)
-            log.info("%s: %s", status_message, status_string)
+            log.info("%s: %s", status_message, _LazyStatusFormatter(status_args, error.last_response))
             time.sleep(waiter_delay)
 
             if attempt >= max_attempts:
                 raise AirflowException("Waiter error: max attempts reached")
 
 
-def _format_status_string(args, response):
+async def async_wait(
+    waiter: Waiter,
+    waiter_delay: int,
+    max_attempts: int,
+    args: dict[str, Any],
+    failure_message: str,
+    status_message: str,
+    status_args: list[str],
+):
     """
-    Loops through the supplied args list and generates a string
-    which contains values from the waiter response.
-    """
-    values = []
-    for arg in args:
-        value = jmespath.search(arg, response)
-        if value is not None and value != "":
-            values.append(str(value))
+    Use an async boto waiter to poll an AWS service for the specified state. Although this function
+    uses boto waiters to poll the state of the service, it logs the response of the service
+    after every attempt, which is not currently supported by boto waiters.
 
-    return " - ".join(values)
+    :param waiter: The boto waiter to use.
+    :param waiter_delay: The amount of time in seconds to wait between attempts.
+    :param max_attempts: The maximum number of attempts to be made.
+    :param args: The arguments to pass to the waiter.
+    :param failure_message: The message to log if a failure state is reached.
+    :param status_message: The message logged when printing the status of the service.
+    :param status_args: A list containing the JMESPath queries to retrieve status information from
+        the waiter response.
+        e.g.
+        response = {"Cluster": {"state": "CREATING"}}
+        status_args = ["Cluster.state"]
+
+        response = {
+        "Clusters": [{"state": "CREATING", "details": "User initiated."},]
+        }
+        status_args = ["Clusters[0].state", "Clusters[0].details"]
+    """
+    log = logging.getLogger(__name__)
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            await waiter.wait(**args, WaiterConfig={"MaxAttempts": 1})
+            break
+        except WaiterError as error:
+            if "terminal failure" in str(error):
+                raise AirflowException(f"{failure_message}: {error}")
+            log.info("%s: %s", status_message, _LazyStatusFormatter(status_args, error.last_response))
+            await asyncio.sleep(waiter_delay)
+
+            if attempt >= max_attempts:
+                raise AirflowException("Waiter error: max attempts reached")
+
+
+class _LazyStatusFormatter:
+    """
+    a wrapper containing the info necessary to extract the status from a response,
+    that'll only compute the value when necessary.
+    Used to avoid computations if the logs are disabled at the given level.
+    """
+
+    def __init__(self, jmespath_queries: list[str], response: dict[str, Any]):
+        self.jmespath_queries = jmespath_queries
+        self.response = response
+
+    def __str__(self):
+        """
+        Loops through the supplied args list and generates a string
+        which contains values from the waiter response.
+        """
+        values = []
+        for query in self.jmespath_queries:
+            value = jmespath.search(query, self.response)
+            if value is not None and value != "":
+                values.append(str(value))
+
+        return " - ".join(values)

--- a/airflow/providers/amazon/aws/utils/waiter_with_logging.py
+++ b/airflow/providers/amazon/aws/utils/waiter_with_logging.py
@@ -70,11 +70,12 @@ def wait(
         except WaiterError as error:
             if "terminal failure" in str(error):
                 raise AirflowException(f"{failure_message}: {error}")
-            log.info("%s: %s", status_message, _LazyStatusFormatter(status_args, error.last_response))
-            time.sleep(waiter_delay)
 
+            log.info("%s: %s", status_message, _LazyStatusFormatter(status_args, error.last_response))
             if attempt >= max_attempts:
                 raise AirflowException("Waiter error: max attempts reached")
+
+            time.sleep(waiter_delay)
 
 
 async def async_wait(
@@ -118,11 +119,12 @@ async def async_wait(
         except WaiterError as error:
             if "terminal failure" in str(error):
                 raise AirflowException(f"{failure_message}: {error}")
-            log.info("%s: %s", status_message, _LazyStatusFormatter(status_args, error.last_response))
-            await asyncio.sleep(waiter_delay)
 
+            log.info("%s: %s", status_message, _LazyStatusFormatter(status_args, error.last_response))
             if attempt >= max_attempts:
                 raise AirflowException("Waiter error: max attempts reached")
+
+            await asyncio.sleep(waiter_delay)
 
 
 class _LazyStatusFormatter:


### PR DESCRIPTION
also changed the status formatting in the logs so that it'd not be done if log level is not including INFO

cc @syedahsn 