### PR TITLE
Check that chain_linear elements has len greater than 1

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1861,7 +1861,7 @@ def chain_linear(*elements: DependencyMixin | Sequence[DependencyMixin]):
     :param elements: a list of operators / lists of operators
     """
     if len(elements) == 1:
-        raise ValueError("elements has length 1; did you forget to add a `*`?")
+        raise ValueError("elements has length 1; did you forget to expand your list with `*`?")
     prev_elem = None
     for curr_elem in elements:
         if isinstance(curr_elem, EdgeModifier):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1860,6 +1860,8 @@ def chain_linear(*elements: DependencyMixin | Sequence[DependencyMixin]):
 
     :param elements: a list of operators / lists of operators
     """
+    if len(elements) == 1:
+        raise ValueError("elements has length 1; did you forget to add a `*`?")
     prev_elem = None
     for curr_elem in elements:
         if isinstance(curr_elem, EdgeModifier):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -37,7 +37,6 @@ from typing import (
     Callable,
     ClassVar,
     Collection,
-    Generator,
     Iterable,
     List,
     Sequence,
@@ -1861,19 +1860,21 @@ def chain_linear(*elements: DependencyMixin | Sequence[DependencyMixin]):
 
     :param elements: a list of operators / lists of operators
     """
-    if isinstance(elements, Generator) or len(elements) == 1:
-        raise ValueError(
-            "Either only one task or one collection of tasks was passed; "
-            "did you forget to expand it with `*`?"
-        )
+    if not elements:
+        raise ValueError("No tasks provided; nothing to do.")
     prev_elem = None
+    deps_set = False
     for curr_elem in elements:
         if isinstance(curr_elem, EdgeModifier):
             raise ValueError("Labels are not supported by chain_linear")
         if prev_elem is not None:
             for task in prev_elem:
                 task >> curr_elem
+                if not deps_set:
+                    deps_set = True
         prev_elem = [curr_elem] if isinstance(curr_elem, DependencyMixin) else curr_elem
+    if not deps_set:
+        raise ValueError("No dependencies were set. Did you forget to expand with `*`?")
 
 
 # pyupgrade assumes all type annotations can be lazily evaluated, but this is

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -37,6 +37,7 @@ from typing import (
     Callable,
     ClassVar,
     Collection,
+    Generator,
     Iterable,
     List,
     Sequence,
@@ -1860,8 +1861,11 @@ def chain_linear(*elements: DependencyMixin | Sequence[DependencyMixin]):
 
     :param elements: a list of operators / lists of operators
     """
-    if len(elements) == 1:
-        raise ValueError("elements has length 1; did you forget to expand your list with `*`?")
+    if isinstance(elements, Generator) or len(elements) == 1:
+        raise ValueError(
+            "Either only one task or one collection of tasks was passed; "
+            "did you forget to expand it with `*`?"
+        )
     prev_elem = None
     for curr_elem in elements:
         if isinstance(curr_elem, EdgeModifier):

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -564,7 +564,10 @@ class TestBaseOperator:
         with pytest.raises(ValueError, match="Labels are not supported"):
             chain_linear(t1, Label("hi"), t2)
 
-        with pytest.raises(ValueError, match="length 1"):
+        with pytest.raises(ValueError, match="nothing to do"):
+            chain_linear()
+
+        with pytest.raises(ValueError, match="Did you forget to expand"):
             chain_linear(t1)
 
     def test_chain_not_support_type(self):
@@ -916,6 +919,7 @@ def test_render_template_fields_logging(
     caplog, monkeypatch, task, context, expected_exception, expected_rendering, expected_log, not_expected_log
 ):
     """Verify if operator attributes are correctly templated."""
+
     # Trigger templating and verify results
     def _do_render():
         task.render_template_fields(context=context)

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -564,6 +564,9 @@ class TestBaseOperator:
         with pytest.raises(ValueError, match="Labels are not supported"):
             chain_linear(t1, Label("hi"), t2)
 
+        with pytest.raises(ValueError, match="length 1"):
+            chain_linear(t1)
+
     def test_chain_not_support_type(self):
         dag = DAG(dag_id="test_chain", start_date=datetime.now())
         [op1, op2] = [BaseOperator(task_id=f"t{i}", dag=dag) for i in range(1, 3)]


### PR DESCRIPTION
This is to help users when accidentally not expanding list e.g. `chain_linear(tasks)` instead of `chain_linear(*tasks)`.  cc @ReadytoRocc 