### PR TITLE
Call setup / teardown validation in dagbag load

### DIFF
--- a/airflow/example_dags/example_setup_teardown_taskflow.py
+++ b/airflow/example_dags/example_setup_teardown_taskflow.py
@@ -61,10 +61,13 @@ with DAG(
         def hello():
             print("I say hello")
 
-        my_setup()
-        hello()
-        my_teardown()
+        s = my_setup()
+        w = hello()
+        t = my_teardown()
+        s >> w >> t
+        s >> t
 
-    root_setup()
+    rs = root_setup()
     normal() >> section_1()
-    root_teardown()
+    rt = root_teardown()
+    rs >> rt

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -685,6 +685,7 @@ class DAG(LoggingMixin):
             )
         self.params.validate()
         self.timetable.validate()
+        self.validate_setup_teardown()
 
     def validate_setup_teardown(self):
         """


### PR DESCRIPTION
The missing call was just an oversight -- added the method and tests but not the call.

Also added a few tests as a drive by.