### PR TITLE
GCSHook support for cacheControl typo

### DIFF
--- a/airflow/providers/google/cloud/hooks/gcs.py
+++ b/airflow/providers/google/cloud/hooks/gcs.py
@@ -516,7 +516,7 @@ class GCSHook(GoogleBaseHook):
             blob.metadata = metadata
 
         if cache_control:
-            blob.cacheControl = cache_control
+            blob.cache_control = cache_control
 
         if filename and data:
             raise ValueError(


### PR DESCRIPTION
My previous PR https://github.com/apache/airflow/issues/31337 had a typo, this fixes it.

I found this while testing https://github.com/apache/airflow/issues/32030