### PR TITLE
Fix name format in the batch requests

### DIFF
--- a/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/airflow/providers/google/cloud/hooks/dataproc.py
@@ -897,7 +897,7 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         """
         client = self.get_batch_client(region)
-        name = f"projects/{project_id}/regions/{region}/batches/{batch_id}"
+        name = f"projects/{project_id}/locations/{region}/batches/{batch_id}"
 
         client.delete_batch(
             request={
@@ -933,7 +933,7 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         """
         client = self.get_batch_client(region)
-        name = f"projects/{project_id}/regions/{region}/batches/{batch_id}"
+        name = f"projects/{project_id}/locations/{region}/batches/{batch_id}"
 
         result = client.get_batch(
             request={
@@ -1707,7 +1707,7 @@ class DataprocAsyncHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         """
         client = self.get_batch_client(region)
-        name = f"projects/{project_id}/regions/{region}/batches/{batch_id}"
+        name = f"projects/{project_id}/locations/{region}/batches/{batch_id}"
 
         await client.delete_batch(
             request={
@@ -1743,7 +1743,7 @@ class DataprocAsyncHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         """
         client = self.get_batch_client(region)
-        name = f"projects/{project_id}/regions/{region}/batches/{batch_id}"
+        name = f"projects/{project_id}/locations/{region}/batches/{batch_id}"
 
         result = await client.get_batch(
             request={

--- a/tests/providers/google/cloud/hooks/test_dataproc.py
+++ b/tests/providers/google/cloud/hooks/test_dataproc.py
@@ -54,7 +54,7 @@ CLUSTER = {
 }
 BATCH = {"batch": "test-batch"}
 BATCH_ID = "batch-id"
-BATCH_NAME = "projects/{}/regions/{}/batches/{}"
+BATCH_NAME = "projects/{}/locations/{}/batches/{}"
 PARENT = "projects/{}/regions/{}"
 
 BASE_STRING = "airflow.providers.google.common.hooks.base_google.{}"


### PR DESCRIPTION
closes: #32069

The name argument in the [hook code](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/hooks/dataproc.py#L1746) follows the format "projects/PROJECT_ID/regions/DATAPROC_REGION/batches/BATCH_ID". However, according to the [Google Cloud DataProc API Reference](https://cloud.google.com/dataproc-serverless/docs/reference/rpc/google.cloud.dataproc.v1#google.cloud.dataproc.v1.GetBatchRequest), it should be in the format "projects/PROJECT_ID/locations/DATAPROC_REGION/batches/BATCH_ID .
