### PR TITLE
Fix where account url is build if not provided using login (account name)

### DIFF
--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -185,6 +185,8 @@ def test_connection() -> APIResponse:
     conn_env_var = f"{CONN_ENV_PREFIX}{transient_conn_id.upper()}"
     try:
         data = connection_schema.load(body)
+        print(data)
+        print("i was here")
         data["conn_id"] = transient_conn_id
         conn = Connection(**data)
         os.environ[conn_env_var] = conn.get_uri()

--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -185,8 +185,6 @@ def test_connection() -> APIResponse:
     conn_env_var = f"{CONN_ENV_PREFIX}{transient_conn_id.upper()}"
     try:
         data = connection_schema.load(body)
-        print(data)
-        print("i was here")
         data["conn_id"] = transient_conn_id
         conn = Connection(**data)
         os.environ[conn_env_var] = conn.get_uri()

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -546,26 +546,11 @@ class WasbAsyncHook(WasbHook):
         extra = conn.extra_dejson or {}
         client_secret_auth_config = extra.pop("client_secret_auth_config", {})
 
-        if self.public_read:
-            # Here we use anonymous public read
-            # more info
-            # https://docs.microsoft.com/en-us/azure/storage/blobs/storage-manage-access-to-resources
-            self.blob_service_client = AsyncBlobServiceClient(account_url=conn.host, **extra)
-            return self.blob_service_client
-
         connection_string = self._get_field(extra, "connection_string")
         if connection_string:
             # connection_string auth takes priority
             self.blob_service_client = AsyncBlobServiceClient.from_connection_string(
                 connection_string, **extra
-            )
-            return self.blob_service_client
-
-        shared_access_key = self._get_field(extra, "shared_access_key")
-        if shared_access_key:
-            # using shared access key
-            self.blob_service_client = AsyncBlobServiceClient(
-                account_url=conn.host, credential=shared_access_key, **extra
             )
             return self.blob_service_client
 
@@ -582,13 +567,30 @@ class WasbAsyncHook(WasbHook):
             )
             return self.blob_service_client
 
+        account_url = conn.host if conn.host else f"https://{conn.login}.blob.core.windows.net/"
+
+        if self.public_read:
+            # Here we use anonymous public read
+            # more info
+            # https://docs.microsoft.com/en-us/azure/storage/blobs/storage-manage-access-to-resources
+            self.blob_service_client = AsyncBlobServiceClient(account_url=account_url, **extra)
+            return self.blob_service_client
+
+        shared_access_key = self._get_field(extra, "shared_access_key")
+        if shared_access_key:
+            # using shared access key
+            self.blob_service_client = AsyncBlobServiceClient(
+                account_url=account_url, credential=shared_access_key, **extra
+            )
+            return self.blob_service_client
+
         sas_token = self._get_field(extra, "sas_token")
         if sas_token:
             if sas_token.startswith("https"):
                 self.blob_service_client = AsyncBlobServiceClient(account_url=sas_token, **extra)
             else:
                 self.blob_service_client = AsyncBlobServiceClient(
-                    account_url=f"https://{conn.login}.blob.core.windows.net/{sas_token}", **extra
+                    account_url=f"{account_url}/{sas_token}", **extra
                 )
             return self.blob_service_client
 
@@ -598,7 +600,7 @@ class WasbAsyncHook(WasbHook):
             credential = AsyncDefaultAzureCredential()
             self.log.info("Using DefaultAzureCredential as credential")
         self.blob_service_client = AsyncBlobServiceClient(
-            account_url=f"https://{conn.login}.blob.core.windows.net/",
+            account_url=account_url,
             credential=credential,
             **extra,
         )

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -126,7 +126,7 @@ class WasbHook(BaseHook):
     def get_ui_field_behaviour() -> dict[str, Any]:
         """Returns custom field behaviour."""
         return {
-            "hidden_fields": ["schema", "port", "extra"],
+            "hidden_fields": ["schema", "port"],
             "relabeling": {
                 "login": "Blob Storage Login (optional)",
                 "password": "Blob Storage Key (optional)",
@@ -140,6 +140,7 @@ class WasbHook(BaseHook):
                 "tenant_id": "tenant",
                 "shared_access_key": "shared access key",
                 "sas_token": "account url or token",
+                "extra": "additional options for use with ClientSecretCredential or DefaultAzureCredential",
             },
         }
 
@@ -176,21 +177,10 @@ class WasbHook(BaseHook):
         extra = conn.extra_dejson or {}
         client_secret_auth_config = extra.pop("client_secret_auth_config", {})
 
-        if self.public_read:
-            # Here we use anonymous public read
-            # more info
-            # https://docs.microsoft.com/en-us/azure/storage/blobs/storage-manage-access-to-resources
-            return BlobServiceClient(account_url=conn.host, **extra)
-
         connection_string = self._get_field(extra, "connection_string")
         if connection_string:
             # connection_string auth takes priority
             return BlobServiceClient.from_connection_string(connection_string, **extra)
-
-        shared_access_key = self._get_field(extra, "shared_access_key")
-        if shared_access_key:
-            # using shared access key
-            return BlobServiceClient(account_url=conn.host, credential=shared_access_key, **extra)
 
         tenant = self._get_field(extra, "tenant_id")
         if tenant:
@@ -200,14 +190,25 @@ class WasbHook(BaseHook):
             token_credential = ClientSecretCredential(tenant, app_id, app_secret, **client_secret_auth_config)
             return BlobServiceClient(account_url=conn.host, credential=token_credential, **extra)
 
+        account_url = conn.host if conn.host else f"https://{conn.login}.blob.core.windows.net/"
+
+        if self.public_read:
+            # Here we use anonymous public read
+            # more info
+            # https://docs.microsoft.com/en-us/azure/storage/blobs/storage-manage-access-to-resources
+            return BlobServiceClient(account_url=account_url, **extra)
+
+        shared_access_key = self._get_field(extra, "shared_access_key")
+        if shared_access_key:
+            # using shared access key
+            return BlobServiceClient(account_url=account_url, credential=shared_access_key, **extra)
+
         sas_token = self._get_field(extra, "sas_token")
         if sas_token:
             if sas_token.startswith("https"):
                 return BlobServiceClient(account_url=sas_token, **extra)
             else:
-                return BlobServiceClient(
-                    account_url=f"https://{conn.login}.blob.core.windows.net/{sas_token}", **extra
-                )
+                return BlobServiceClient(account_url=f"{account_url}/{sas_token}", **extra)
 
         # Fall back to old auth (password) or use managed identity if not provided.
         credential = conn.password
@@ -215,7 +216,7 @@ class WasbHook(BaseHook):
             credential = DefaultAzureCredential()
             self.log.info("Using DefaultAzureCredential as credential")
         return BlobServiceClient(
-            account_url=f"https://{conn.login}.blob.core.windows.net/",
+            account_url=account_url,
             credential=credential,
             **extra,
         )

--- a/docs/apache-airflow-providers-microsoft-azure/connections/wasb.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/wasb.rst
@@ -54,23 +54,31 @@ Configuring the Connection
 --------------------------
 
 Login (optional)
-    Specify the login used for azure blob storage. For use with Shared Key Credential and SAS Token authentication.
+    Specify the login used for azure blob storage. Strictly needed for Active Directory (token) authentication as Service principle credential. Optional for rest if host (account url) is specified.
 
 Password (optional)
     Specify the password used for azure blob storage. For use with
     Active Directory (token credential) and shared key authentication.
 
 Host (optional)
-    Specify the account url for anonymous public read, Active Directory, shared access key authentication.
+    Specify the account url for azure blob storage. Strictly needed for Active Directory (token) authentication as Service principle credential. Optional for the rest if login (account name) is specified.
+
+Blob Storage Connection String (optional)
+    Connection string for use with connection string authentication.
+
+Blob Storage Shared Access Key (optional)
+    Specify the shared access key. Needed only for shared access key authentication.
+
+SAS Token (optional)
+    SAS Token for use with SAS Token authentication.
+
+Tenant Id (Active Directory Auth) (optional)
+    Specify the tenant to use. Required only for Active Directory (token) authentication.
 
 Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Azure connection.
     The following parameters are all optional:
 
-    * ``tenant_id``: Specify the tenant to use. Needed for Active Directory (token) authentication.
-    * ``shared_access_key``: Specify the shared access key. Needed for shared access key authentication.
-    * ``connection_string``: Connection string for use with connection string authentication.
-    * ``sas_token``: SAS Token for use with SAS Token authentication.
     * ``client_secret_auth_config``: Extra config to pass while authenticating as a service principal using `ClientSecretCredential <https://learn.microsoft.com/en-in/python/api/azure-identity/azure.identity.clientsecretcredential?view=azure-python>`_
 
 When specifying the connection in environment variable you should specify

--- a/docs/apache-airflow-providers-microsoft-azure/connections/wasb.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/wasb.rst
@@ -54,14 +54,14 @@ Configuring the Connection
 --------------------------
 
 Login (optional)
-    Specify the login used for azure blob storage. Strictly needed for Active Directory (token) authentication as Service principle credential. Optional for rest if host (account url) is specified.
+    Specify the login used for Azure Blob Storage. Strictly needed for Active Directory (token) authentication as Service principle credential. Optional for the rest if host (account url) is specified.
 
 Password (optional)
-    Specify the password used for azure blob storage. For use with
+    Specify the password used for Azure Blob Storage. For use with
     Active Directory (token credential) and shared key authentication.
 
 Host (optional)
-    Specify the account url for azure blob storage. Strictly needed for Active Directory (token) authentication as Service principle credential. Optional for the rest if login (account name) is specified.
+    Specify the account url for Azure Blob Storage. Strictly needed for Active Directory (token) authentication as Service principle credential. Optional for the rest if login (account name) is specified.
 
 Blob Storage Connection String (optional)
     Connection string for use with connection string authentication.


### PR DESCRIPTION
closes: #31811

Builds account URL for below-mentioned auth methods if account URL is not provided using account name (login)
- Public read
- Shared access key

It helps avoid avoidable error. Doesn't apply to connection string and Azure AD. 
Updated docs to reflect the same and implemented test to cover the changes made.
Exposed `extra` field (which was hidden) to incorporate the changes in #31783 which was missed.

A sample is provided below 
Before - 

![20230622_234834](https://github.com/apache/airflow/assets/35839624/c816d595-0340-4d09-a820-f288267c5e68)

After - 

![20230622_235820](https://github.com/apache/airflow/assets/35839624/2ed1d8af-79d8-4a6f-a86e-862b6761c01f)

<!--

Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
