### PR TITLE
Fix AWS "Operators and hooks" page to display "Sensors" item

### DIFF
--- a/docs/exts/operators_and_hooks_ref.py
+++ b/docs/exts/operators_and_hooks_ref.py
@@ -100,7 +100,7 @@ def _prepare_operators_data(tags: set[str] | None):
 
     all_operators_by_integration = _prepare_resource_index(package_data, "operators")
     all_hooks_by_integration = _prepare_resource_index(package_data, "hooks")
-    all_sensors_by_integration = _prepare_resource_index(package_data, "hooks")
+    all_sensors_by_integration = _prepare_resource_index(package_data, "sensors")
     results = []
 
     for integration in to_display_integration:
@@ -116,7 +116,7 @@ def _prepare_operators_data(tags: set[str] | None):
         if operators:
             item["operators"] = operators
         if sensors:
-            item["hooks"] = sensors
+            item["sensors"] = sensors
         if hooks:
             item["hooks"] = hooks
         if operators or sensors or hooks:


### PR DESCRIPTION
In the "Operators_and_hooks_ref.py" code, "sensors" has  been replaced with "hooks".
As a result, the "Sensors" items are not displayed on the [AWS "Operators and hooks" page.](https://airflow.apache.org/docs/apache-airflow-providers/operators-and-hooks-ref/aws.html)

I fixed it so that they do appear.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
