### PR TITLE
Open links in new tab that take us away from Airflow UI

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -110,18 +110,18 @@
     {% call show_message(category='warning', dismissible=false) %}
       Do not use <b>SQLite</b> as metadata DB in production &#8211; it should only be used for dev/testing.
       We recommend using Postgres or MySQL.
-      <a href={{ get_docs_url("howto/set-up-database.html") }}><b>Click here</b></a> for more information.
+      <a href={{ get_docs_url("howto/set-up-database.html") }} target="_blank"><b>Click here</b></a> for more information.
     {% endcall %}
   {% endif %}
   {% if production_executor_warning | default(false) %}
     {% call show_message(category='warning', dismissible=false) %}
       Do not use the <b>{{ production_executor_warning }}</b> in production.
-      <a href={{ get_docs_url("executor/index.html") }}><b>Click here</b></a> for more information.
+      <a href={{ get_docs_url("executor/index.html") }}  target="_blank"><b>Click here</b></a> for more information.
     {% endcall %}
   {% endif %}
   {% if otel_on | default(false) %}
     {% call show_message(category='warning', dismissible=false) %}
-      OpenTelemetry support is experimental. <a href="https://github.com/apache/airflow/blob/main/BREEZE.rst#running-breeze-with-an-opentelemetry-metrics-stack">
+      OpenTelemetry support is experimental. <a href="https://github.com/apache/airflow/blob/main/BREEZE.rst#running-breeze-with-an-opentelemetry-metrics-stack" target="_blank">
         <b>Click here</b></a> for more information.
     {% endcall %}
   {% endif %}


### PR DESCRIPTION
I am observing that clicking on the "Click here" links take us 
away from Airflow UI to the docs domain and I need to press 
on back button in the browser to get back to Airflow UI. Ideally, 
we could open these links in new tab and trying to do the same 
here with this commit using the `target="_blank"` attribute for 
the anchor tags.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
