### PR TITLE
switching to use the project_id specified to the operator

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -429,7 +429,7 @@ class GCSToBigQueryOperator(BaseOperator):
                     trigger=BigQueryInsertJobTrigger(
                         conn_id=self.gcp_conn_id,
                         job_id=self.job_id,
-                        project_id=self.hook.project_id,
+                        project_id=self.project_id,
                     ),
                     method_name="execute_complete",
                 )


### PR DESCRIPTION
closes: #32093 
