### PR TITLE
Adding `src_fmt_configs` to the list of template fields.

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -178,6 +178,7 @@ class GCSToBigQueryOperator(BaseOperator):
         "schema_object_bucket",
         "destination_project_dataset_table",
         "impersonation_chain",
+        "src_fmt_configs",
     )
     template_ext: Sequence[str] = (".sql",)
     ui_color = "#f0eee4"


### PR DESCRIPTION
We have scenarios where we need to use Jinja templating on `src_fmt_configs` and currently have to create our own version of `GCSToBigQueryOperator` to achieve this.