### PR TITLE
Support setting dependencies for tasks called outside setup/teardown context manager

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -966,6 +966,14 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     def __exit__(self, exc_type, exc_val, exc_tb):
         SetupTeardownContext.set_work_task_roots_and_leaves()
 
+    @staticmethod
+    def add_ctx_task(task):
+        from airflow.models.xcom_arg import PlainXComArg
+
+        if isinstance(task, PlainXComArg):
+            task = task.operator
+        SetupTeardownContext.update_context_map(task)
+
     def __eq__(self, other):
         if type(self) is type(other):
             # Use getattr() instead of __dict__ as __dict__ doesn't return

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -961,7 +961,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         if not self.is_setup and not self.is_teardown:
             raise AirflowException("Only setup/teardown tasks can be used as context managers.")
         SetupTeardownContext.push_setup_teardown_task(self)
-        return self
+        return SetupTeardownContext
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         SetupTeardownContext.set_work_task_roots_and_leaves()

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -967,7 +967,10 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         SetupTeardownContext.set_work_task_roots_and_leaves()
 
     @staticmethod
-    def add_ctx_task(task):
+    def add_task_to_context(task):
+        """Add tasks to context manager."""
+        if not SetupTeardownContext.active:
+            raise AirflowException("Cannot add task to context outside the context manager.")
         from airflow.models.xcom_arg import PlainXComArg
 
         if isinstance(task, PlainXComArg):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -966,17 +966,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     def __exit__(self, exc_type, exc_val, exc_tb):
         SetupTeardownContext.set_work_task_roots_and_leaves()
 
-    @staticmethod
-    def add_task_to_context(task):
-        """Add tasks to context manager."""
-        if not SetupTeardownContext.active:
-            raise AirflowException("Cannot add task to context outside the context manager.")
-        from airflow.models.xcom_arg import PlainXComArg
-
-        if isinstance(task, PlainXComArg):
-            task = task.operator
-        SetupTeardownContext.update_context_map(task)
-
     def __eq__(self, other):
         if type(self) is type(other):
             # Use getattr() instead of __dict__ as __dict__ doesn't return

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -24,6 +24,7 @@ import pendulum
 
 from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
 from airflow.serialization.enums import DagAttributeTypes
+from airflow.utils.setup_teardown import SetupTeardownContext
 from airflow.utils.types import NOTSET, ArgNotSet
 
 if TYPE_CHECKING:
@@ -95,11 +96,13 @@ class DependencyMixin:
     def __lshift__(self, other: DependencyMixin | Sequence[DependencyMixin]):
         """Implements Task << Task."""
         self.set_upstream(other)
+        self.set_setup_teardown_ctx_dependencies(other)
         return other
 
     def __rshift__(self, other: DependencyMixin | Sequence[DependencyMixin]):
         """Implements Task >> Task."""
         self.set_downstream(other)
+        self.set_setup_teardown_ctx_dependencies(other)
         return other
 
     def __rrshift__(self, other: DependencyMixin | Sequence[DependencyMixin]):
@@ -111,6 +114,22 @@ class DependencyMixin:
         """Called for Task << [Task] because list don't have __lshift__ operators."""
         self.__rshift__(other)
         return self
+
+    def set_setup_teardown_ctx_dependencies(self, other):
+        if not SetupTeardownContext.active:
+            return
+        from airflow.models.xcom_arg import PlainXComArg
+
+        op1 = self
+        op2 = other
+        if isinstance(self, PlainXComArg):
+            op1 = self.operator
+        if isinstance(other, PlainXComArg):
+            op2 = other.operator
+        if op1.is_setup or op1.is_teardown or op2.is_setup or op2.is_teardown:
+            return
+        SetupTeardownContext.update_context_map(op1)
+        SetupTeardownContext.update_context_map(op2)
 
 
 class TaskMixin(DependencyMixin):

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -216,6 +216,12 @@ class XComArg(ResolveMixin, DependencyMixin):
     def __exit__(self, exc_type, exc_val, exc_tb):
         SetupTeardownContext.set_work_task_roots_and_leaves()
 
+    @staticmethod
+    def add_ctx_task(ctx_task: Operator | PlainXComArg):
+        if isinstance(ctx_task, PlainXComArg):
+            ctx_task = ctx_task.operator
+        SetupTeardownContext.update_context_map(ctx_task)
+
 
 class PlainXComArg(XComArg):
     """Reference to one single XCom without any additional semantics.

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -211,19 +211,10 @@ class XComArg(ResolveMixin, DependencyMixin):
         if not self.operator.is_setup and not self.operator.is_teardown:
             raise AirflowException("Only setup/teardown tasks can be used as context managers.")
         SetupTeardownContext.push_setup_teardown_task(self.operator)
-        return self
+        return SetupTeardownContext
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         SetupTeardownContext.set_work_task_roots_and_leaves()
-
-    @staticmethod
-    def add_task_to_context(ctx_task: Operator | PlainXComArg):
-        """Add task to context manager."""
-        if not SetupTeardownContext.active:
-            raise AirflowException("Cannot add task to context outside the context manager.")
-        if isinstance(ctx_task, PlainXComArg):
-            ctx_task = ctx_task.operator
-        SetupTeardownContext.update_context_map(ctx_task)
 
 
 class PlainXComArg(XComArg):

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -217,7 +217,10 @@ class XComArg(ResolveMixin, DependencyMixin):
         SetupTeardownContext.set_work_task_roots_and_leaves()
 
     @staticmethod
-    def add_ctx_task(ctx_task: Operator | PlainXComArg):
+    def add_task_to_context(ctx_task: Operator | PlainXComArg):
+        """Add task to context manager."""
+        if not SetupTeardownContext.active:
+            raise AirflowException("Cannot add task to context outside the context manager.")
         if isinstance(ctx_task, PlainXComArg):
             ctx_task = ctx_task.operator
         SetupTeardownContext.update_context_map(ctx_task)

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 
 if TYPE_CHECKING:
     from airflow.models.operator import Operator

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from airflow.models.operator import Operator
 
 
-class AbstractSetupTeardownContext:
+class BaseSetupTeardownContext:
     """Context manager for setup/teardown tasks.
 
     :meta private:
@@ -68,15 +68,15 @@ class AbstractSetupTeardownContext:
 
     @classmethod
     def update_context_map(cls, operator):
-        ctx = AbstractSetupTeardownContext.context_map
-        if setup_task := AbstractSetupTeardownContext.get_context_managed_setup_task():
+        ctx = BaseSetupTeardownContext.context_map
+        if setup_task := BaseSetupTeardownContext.get_context_managed_setup_task():
             if isinstance(setup_task, list):
                 setup_task = tuple(setup_task)
             if ctx.get(setup_task) is None:
                 ctx[setup_task] = [operator]
             else:
                 ctx[setup_task].append(operator)
-        if teardown_task := AbstractSetupTeardownContext.get_context_managed_teardown_task():
+        if teardown_task := BaseSetupTeardownContext.get_context_managed_teardown_task():
             if isinstance(teardown_task, list):
                 teardown_task = tuple(teardown_task)
             if ctx.get(teardown_task) is None:
@@ -121,10 +121,10 @@ class AbstractSetupTeardownContext:
                         raise ValueError(
                             "All upstream tasks in the context manager must be a setup or teardown task"
                         )
-                AbstractSetupTeardownContext.push_context_managed_teardown_task(operator)
+                BaseSetupTeardownContext.push_context_managed_teardown_task(operator)
                 upstream_setup: list[Operator] = [task for task in upstream_tasks if task.is_setup]
                 if upstream_setup:
-                    AbstractSetupTeardownContext.push_context_managed_setup_task(upstream_setup)
+                    BaseSetupTeardownContext.push_context_managed_setup_task(upstream_setup)
             elif first_task.is_setup:
                 if not all(task.is_setup == first_task.is_setup for task in operator):
                     raise ValueError("All tasks in the list must be either setup or teardown tasks")
@@ -133,12 +133,12 @@ class AbstractSetupTeardownContext:
                         raise ValueError(
                             "All upstream tasks in the context manager must be a setup or teardown task"
                         )
-                AbstractSetupTeardownContext.push_context_managed_setup_task(operator)
+                BaseSetupTeardownContext.push_context_managed_setup_task(operator)
                 downstream_teardown: list[Operator] = [
                     task for task in first_task.downstream_list if task.is_teardown
                 ]
                 if downstream_teardown:
-                    AbstractSetupTeardownContext.push_context_managed_teardown_task(downstream_teardown)
+                    BaseSetupTeardownContext.push_context_managed_teardown_task(downstream_teardown)
         elif operator.is_teardown:
             upstream_tasks = operator.upstream_list
             for task in upstream_tasks:
@@ -146,21 +146,21 @@ class AbstractSetupTeardownContext:
                     raise ValueError(
                         "All upstream tasks in the context manager must be a setup or teardown task"
                     )
-            AbstractSetupTeardownContext.push_context_managed_teardown_task(operator)
+            BaseSetupTeardownContext.push_context_managed_teardown_task(operator)
             upstream_setup = [task for task in upstream_tasks if task.is_setup]
             if upstream_setup:
-                AbstractSetupTeardownContext.push_context_managed_setup_task(upstream_setup)
+                BaseSetupTeardownContext.push_context_managed_setup_task(upstream_setup)
         elif operator.is_setup:
             for task in operator.upstream_list:
                 if not task.is_setup and not task.is_teardown:
                     raise ValueError(
                         "All upstream tasks in the context manager must be a setup or teardown task"
                     )
-            AbstractSetupTeardownContext.push_context_managed_setup_task(operator)
+            BaseSetupTeardownContext.push_context_managed_setup_task(operator)
             downstream_teardown = [task for task in operator.downstream_list if task.is_teardown]
             if downstream_teardown:
-                AbstractSetupTeardownContext.push_context_managed_teardown_task(downstream_teardown)
-        AbstractSetupTeardownContext.active = True
+                BaseSetupTeardownContext.push_context_managed_teardown_task(downstream_teardown)
+        BaseSetupTeardownContext.active = True
 
     @classmethod
     def set_work_task_roots_and_leaves(cls):
@@ -190,18 +190,18 @@ class AbstractSetupTeardownContext:
                         task << leaves
                 else:
                     teardown_task << leaves
-        setup_task = AbstractSetupTeardownContext.pop_context_managed_setup_task()
-        teardown_task = AbstractSetupTeardownContext.pop_context_managed_teardown_task()
+        setup_task = BaseSetupTeardownContext.pop_context_managed_setup_task()
+        teardown_task = BaseSetupTeardownContext.pop_context_managed_teardown_task()
         if isinstance(setup_task, list):
             setup_task = tuple(setup_task)
         if isinstance(teardown_task, list):
             teardown_task = tuple(teardown_task)
-        AbstractSetupTeardownContext.active = False
-        AbstractSetupTeardownContext.context_map.pop(setup_task, None)
-        AbstractSetupTeardownContext.context_map.pop(teardown_task, None)
+        BaseSetupTeardownContext.active = False
+        BaseSetupTeardownContext.context_map.pop(setup_task, None)
+        BaseSetupTeardownContext.context_map.pop(teardown_task, None)
 
 
-class SetupTeardownContext(AbstractSetupTeardownContext):
+class SetupTeardownContext(BaseSetupTeardownContext):
     """Context manager for setup and teardown tasks."""
 
     @staticmethod

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -1245,7 +1245,7 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             task1 = mytask()
             with setuptask() >> teardowntask() as scope:
-                scope.add_ctx_task(task1)
+                scope.add_task_to_context(task1)
 
         assert len(dag.task_group.children) == 3
         assert not dag.task_group.children["setuptask"].upstream_task_ids
@@ -1261,7 +1261,7 @@ class TestSetupTearDownTask:
             teardowntask = BashOperator.as_teardown(task_id="teardowntask", bash_command="echo 1")
             mytask = BashOperator(task_id="mytask", bash_command="echo 1")
             with setuptask >> teardowntask as scope:
-                scope.add_ctx_task(mytask)
+                scope.add_task_to_context(mytask)
 
         assert len(dag.task_group.children) == 3
         assert not dag.task_group.children["setuptask"].upstream_task_ids
@@ -1285,7 +1285,7 @@ class TestSetupTearDownTask:
         with dag_maker() as dag:
             task1 = BashOperator(task_id="mytask", bash_command="echo 1")
             with setuptask() >> teardowntask() as scope:
-                scope.add_ctx_task(task1)
+                scope.add_task_to_context(task1)
 
         assert len(dag.task_group.children) == 3
         assert not dag.task_group.children["setuptask"].upstream_task_ids
@@ -1306,7 +1306,7 @@ class TestSetupTearDownTask:
             setuptask = BashOperator.as_setup(task_id="setuptask", bash_command="echo 1")
             teardowntask = BashOperator.as_teardown(task_id="teardowntask", bash_command="echo 1")
             with setuptask >> teardowntask as scope:
-                scope.add_ctx_task(mytask())
+                scope.add_task_to_context(mytask())
 
         assert len(dag.task_group.children) == 3
         assert not dag.task_group.children["setuptask"].upstream_task_ids
@@ -1315,3 +1315,68 @@ class TestSetupTearDownTask:
         assert dag.task_group.children["mytask"].downstream_task_ids == {"teardowntask"}
         assert dag.task_group.children["teardowntask"].upstream_task_ids == {"mytask", "setuptask"}
         assert not dag.task_group.children["teardowntask"].downstream_task_ids
+
+    def test_cannot_add_task_to_context_outside_the_context_manager(self, dag_maker):
+        task1 = BashOperator(task_id="mytask", bash_command="echo 1")
+
+        @task
+        def mytask2():
+            return 1
+
+        task2 = mytask2()
+
+        with dag_maker():
+            with pytest.raises(
+                AirflowException, match="Cannot add task to context outside the context manager."
+            ):
+                task1.add_task_to_context(task2)
+
+        with dag_maker():
+            with pytest.raises(
+                AirflowException, match="Cannot add task to context outside the context manager."
+            ):
+                task2.add_task_to_context(task1)
+
+    def test_add_tasks_to_context_for_different_context_level(self, dag_maker):
+        @setup
+        def setuptask():
+            print("setup")
+
+        @teardown
+        def teardowntask():
+            print("teardown")
+
+        @task
+        def mytask():
+            return 1
+
+        with dag_maker() as dag:
+            task1 = mytask()
+            setuptask2 = BashOperator.as_setup(task_id="setuptask2", bash_command="echo 1")
+            teardowntask2 = BashOperator.as_teardown(task_id="teardowntask2", bash_command="echo 1")
+            task2 = BashOperator(task_id="mytask2", bash_command="echo 1")
+
+            with setuptask() >> teardowntask() as scope:
+                scope.add_task_to_context(task1)
+                with setuptask2 >> teardowntask2 as scope2:
+                    scope2.add_task_to_context(task2)
+
+        assert len(dag.task_group.children) == 6
+        assert not dag.task_group.children["setuptask"].upstream_task_ids
+        assert dag.task_group.children["setuptask"].downstream_task_ids == {
+            "setuptask2",
+            "mytask",
+            "teardowntask",
+        }
+        assert dag.task_group.children["mytask"].upstream_task_ids == {"setuptask"}
+        assert dag.task_group.children["mytask"].downstream_task_ids == {"teardowntask"}
+        assert dag.task_group.children["teardowntask"].upstream_task_ids == {
+            "mytask",
+            "setuptask",
+            "teardowntask2",
+        }
+        assert dag.task_group.children["setuptask2"].upstream_task_ids == {"setuptask"}
+        assert dag.task_group.children["setuptask2"].downstream_task_ids == {"mytask2", "teardowntask2"}
+        assert dag.task_group.children["mytask2"].upstream_task_ids == {"setuptask2"}
+        assert dag.task_group.children["mytask2"].downstream_task_ids == {"teardowntask2"}
+        assert dag.task_group.children["teardowntask2"].upstream_task_ids == {"mytask2", "setuptask2"}

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -1212,8 +1212,8 @@ class TestSetupTearDownTask:
     def test_classic_tasks_called_outside_context_manager_can_link_up(self, dag_maker):
 
         with dag_maker() as dag:
-            setuptask = BashOperator.as_setup(task_id="setuptask", bash_command="echo 1")
-            teardowntask = BashOperator.as_teardown(task_id="teardowntask", bash_command="echo 1")
+            setuptask = BashOperator(task_id="setuptask", bash_command="echo 1").as_setup()
+            teardowntask = BashOperator(task_id="teardowntask", bash_command="echo 1").as_teardown()
             mytask = BashOperator(task_id="mytask", bash_command="echo 1")
             mytask2 = BashOperator(task_id="mytask2", bash_command="echo 1")
             with setuptask >> teardowntask:
@@ -1257,8 +1257,8 @@ class TestSetupTearDownTask:
 
     def test_classic_tasks_called_outside_context_manager_can_link_up_with_scope(self, dag_maker):
         with dag_maker() as dag:
-            setuptask = BashOperator.as_setup(task_id="setuptask", bash_command="echo 1")
-            teardowntask = BashOperator.as_teardown(task_id="teardowntask", bash_command="echo 1")
+            setuptask = BashOperator(task_id="setuptask", bash_command="echo 1").as_setup()
+            teardowntask = BashOperator(task_id="teardowntask", bash_command="echo 1").as_teardown()
             mytask = BashOperator(task_id="mytask", bash_command="echo 1")
             with setuptask >> teardowntask as scope:
                 scope.add_task(mytask)
@@ -1303,8 +1303,8 @@ class TestSetupTearDownTask:
             return 1
 
         with dag_maker() as dag:
-            setuptask = BashOperator.as_setup(task_id="setuptask", bash_command="echo 1")
-            teardowntask = BashOperator.as_teardown(task_id="teardowntask", bash_command="echo 1")
+            setuptask = BashOperator(task_id="setuptask", bash_command="echo 1").as_setup()
+            teardowntask = BashOperator(task_id="teardowntask", bash_command="echo 1").as_teardown()
             with setuptask >> teardowntask as scope:
                 scope.add_task(mytask())
 
@@ -1331,8 +1331,8 @@ class TestSetupTearDownTask:
 
         with dag_maker() as dag:
             task1 = mytask()
-            setuptask2 = BashOperator.as_setup(task_id="setuptask2", bash_command="echo 1")
-            teardowntask2 = BashOperator.as_teardown(task_id="teardowntask2", bash_command="echo 1")
+            setuptask2 = BashOperator(task_id="setuptask2", bash_command="echo 1").as_setup()
+            teardowntask2 = BashOperator(task_id="teardowntask2", bash_command="echo 1").as_teardown()
             task2 = BashOperator(task_id="mytask2", bash_command="echo 1")
 
             with setuptask() >> teardowntask() as scope:

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -1175,3 +1175,56 @@ class TestSetupTearDownTask:
             with dag_maker():
                 with mytask() >> context_wrapper([setuptask(), setuptask2()]):
                     ...
+
+    def test_tasks_decorators_called_outside_context_manager_can_link_up(self, dag_maker):
+        @setup
+        def setuptask():
+            print("setup")
+
+        @task()
+        def mytask():
+            print("mytask")
+
+        @task()
+        def mytask2():
+            print("mytask 2")
+
+        @teardown
+        def teardowntask():
+            print("teardown")
+
+        with dag_maker() as dag:
+            task1 = mytask()
+            task2 = mytask2()
+            with setuptask() >> teardowntask():
+                task1 >> task2
+
+        assert len(dag.task_group.children) == 4
+        assert not dag.task_group.children["setuptask"].upstream_task_ids
+        assert dag.task_group.children["setuptask"].downstream_task_ids == {"mytask", "teardowntask"}
+        assert dag.task_group.children["mytask"].upstream_task_ids == {"setuptask"}
+        assert dag.task_group.children["mytask"].downstream_task_ids == {"mytask2"}
+        assert dag.task_group.children["mytask2"].upstream_task_ids == {"mytask"}
+        assert dag.task_group.children["mytask2"].downstream_task_ids == {"teardowntask"}
+        assert dag.task_group.children["teardowntask"].upstream_task_ids == {"mytask2", "setuptask"}
+        assert not dag.task_group.children["teardowntask"].downstream_task_ids
+
+    def test_classic_tasks_called_outside_context_manager_can_link_up(self, dag_maker):
+
+        with dag_maker() as dag:
+            setuptask = BashOperator.as_setup(task_id="setuptask", bash_command="echo 1")
+            teardowntask = BashOperator.as_teardown(task_id="teardowntask", bash_command="echo 1")
+            mytask = BashOperator(task_id="mytask", bash_command="echo 1")
+            mytask2 = BashOperator(task_id="mytask2", bash_command="echo 1")
+            with setuptask >> teardowntask:
+                mytask >> mytask2
+
+        assert len(dag.task_group.children) == 4
+        assert not dag.task_group.children["setuptask"].upstream_task_ids
+        assert dag.task_group.children["setuptask"].downstream_task_ids == {"mytask", "teardowntask"}
+        assert dag.task_group.children["mytask"].upstream_task_ids == {"setuptask"}
+        assert dag.task_group.children["mytask"].downstream_task_ids == {"mytask2"}
+        assert dag.task_group.children["mytask2"].upstream_task_ids == {"mytask"}
+        assert dag.task_group.children["mytask2"].downstream_task_ids == {"teardowntask"}
+        assert dag.task_group.children["teardowntask"].upstream_task_ids == {"mytask2", "setuptask"}
+        assert not dag.task_group.children["teardowntask"].downstream_task_ids

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 
 import pytest
 
-from airflow import AirflowException
 from airflow.decorators import setup, task, task_group, teardown
 from airflow.decorators.setup_teardown import context_wrapper
+from airflow.exceptions import AirflowException
 from airflow.operators.bash import BashOperator
 
 


### PR DESCRIPTION
This commit adds support for the setting of task dependencies w.r.t setup/teardown tasks even when the tasks are called outside the setup/teardown context manager. Previously, the dependencies can only work if the tasks are called within the context manager.

