### PR TITLE
Fix reload gunicorn workers

### DIFF
--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -429,7 +429,7 @@ def webserver(args):
             run_args += ["--preload"]
         if reload_on_plugin_change:
             log.warning(
-                "reload_on_plugin_change prevent running gunicorn with --preload option. "
+                "reload_on_plugin_change prevents running gunicorn with the --preload option. "
                 "With the preload option, the app is loaded before the workers are forked, and each worker "
                 "will then have a copy of the app. reload_on_plugin_change may cause IntegrityErrors during "
                 "webserver startup, so avoid using it in production."

--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -426,7 +426,9 @@ def webserver(args):
         # all writing to the database at the same time, we use the --preload option.
         # With the preload option, the app is loaded before the workers are forked, and each worker will
         # then have a copy of the app
-        run_args += ["--preload"]
+        # NOTE: gunicorn can't reload the application with --preload.
+        if not conf.getboolean("webserver", "reload_on_plugin_change", fallback=False):
+            run_args += ["--preload"]
 
         gunicorn_master_proc: psutil.Process | subprocess.Popen
 

--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -431,8 +431,8 @@ def webserver(args):
             log.warning(
                 "reload_on_plugin_change prevent running gunicorn with --preload option. "
                 "With the preload option, the app is loaded before the workers are forked, and each worker "
-                "will then have a copy of the app. It may cause IntegrityError during webserver startup, so "
-                "avoid using reload_on_plugin_change in production."
+                "will then have a copy of the app. reload_on_plugin_change may cause IntegrityErrors during "
+                "webserver startup, so avoid using it in production."
             )
 
         gunicorn_master_proc: psutil.Process | subprocess.Popen

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1445,8 +1445,8 @@ webserver:
     reload_on_plugin_change:
       description: |
         If set to True, Airflow will track files in plugins_folder directory. When it detects changes,
-        then reload the gunicorn. If set to True, gunicorn starts without ``--preload`` setting and uses
-        more memory.
+        then reload the gunicorn. If set to True, gunicorn starts without ``--preload``, which
+        is slower and uses more memory.
       version_added: 1.10.11
       type: boolean
       example: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1445,8 +1445,8 @@ webserver:
     reload_on_plugin_change:
       description: |
         If set to True, Airflow will track files in plugins_folder directory. When it detects changes,
-        then reload the gunicorn. If set to True, gunicorn starts without ``--preload``, which
-        is slower and uses more memory.
+        then reload the gunicorn. If set to True, gunicorn starts without preloading, which is slower, uses
+        more memory, and may cause race conditions. Avoid setting this to True in production.
       version_added: 1.10.11
       type: boolean
       example: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1445,7 +1445,8 @@ webserver:
     reload_on_plugin_change:
       description: |
         If set to True, Airflow will track files in plugins_folder directory. When it detects changes,
-        then reload the gunicorn.
+        then reload the gunicorn. If set to True, gunicorn starts without ``--preload`` setting and uses
+        more memory.
       version_added: 1.10.11
       type: boolean
       example: ~


### PR DESCRIPTION
Since gunicorn can't reload a new code if starts with ``--preload`` setting, we need to check ``reload_on_plugin_change`` before set it up.

Gunicorn can't reload a new code because the code is preloaded into the master process and worker are launched with ``fork``, they will still have the old code.

