### PR TITLE
Remove unclear (referring to CI) paragraph from "support python"

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,18 +307,11 @@ They are based on the official release schedule of Python and Kubernetes, nicely
    means that we will drop support in main right after 27.06.2023, and the first MAJOR or MINOR version of
    Airflow released after will not have it.
 
-2. The "oldest" supported version of Python/Kubernetes is the default one until we decide to switch to
-   later version. "Default" is only meaningful in terms of "smoke tests" in CI PRs, which are run using this
-   default version and the default reference image available. Currently `apache/airflow:latest`
-   and `apache/airflow:2.6.2` images are Python 3.8 images. This means that default reference image will
-   become the default at the time when we start preparing for dropping 3.8 support which is few months
-   before the end of life for Python 3.8.
-
-3. We support a new version of Python/Kubernetes in main after they are officially released, as soon as we
+2. We support a new version of Python/Kubernetes in main after they are officially released, as soon as we
    make them work in our CI pipeline (which might not be immediate due to dependencies catching up with
    new versions of Python mostly) we release new images/support in Airflow based on the working CI setup.
 
-4. This policy is best-effort which means there may be situations where we might terminate support earlier
+3. This policy is best-effort which means there may be situations where we might terminate support earlier
    if circumstances require it.
 
 ## Base OS support for reference Airflow images


### PR DESCRIPTION
The paragraph was supposed to clarify things but it makes it confusing - it attempted to explain the difference vs "default" and supported versions of Python, referring to CI. Unfortunately this relation changes over time especially in transition phase like we are now where some CI runs on 3.7 (in v2-6-test branch) but some CI runs on 3.8 (in main branch).

Removal of the paragraph does not change anything, it actually makes the whole chapter consistent and previous paragraph already explains the rules.

I believe we should remove it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
