### PR TITLE
Adding missing hyperlink to the tutorial documentation

### DIFF
--- a/docs/apache-airflow/tutorial/fundamentals.rst
+++ b/docs/apache-airflow/tutorial/fundamentals.rst
@@ -82,7 +82,7 @@ of default parameters that we can use when creating tasks.
     :end-before: [END default_args]
 
 For more information about the BaseOperator's parameters and what they do,
-refer to the :py:class:`airflow.models.BaseOperator <https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/baseoperator/index.html>` documentation.
+refer to the :py:class:`airflow.models.BaseOperator <https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/baseoperator/index.html>`_ documentation.
 
 Also, note that you could easily define different sets of arguments that
 would serve different purposes. An example of that would be to have

--- a/docs/apache-airflow/tutorial/fundamentals.rst
+++ b/docs/apache-airflow/tutorial/fundamentals.rst
@@ -82,7 +82,7 @@ of default parameters that we can use when creating tasks.
     :end-before: [END default_args]
 
 For more information about the BaseOperator's parameters and what they do,
-refer to the :py:class:`airflow.models.BaseOperator <https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/baseoperator/index.html>`_ documentation.
+refer to the :py:class:`airflow.models.baseoperator.BaseOperator` documentation.
 
 Also, note that you could easily define different sets of arguments that
 would serve different purposes. An example of that would be to have

--- a/docs/apache-airflow/tutorial/fundamentals.rst
+++ b/docs/apache-airflow/tutorial/fundamentals.rst
@@ -82,7 +82,7 @@ of default parameters that we can use when creating tasks.
     :end-before: [END default_args]
 
 For more information about the BaseOperator's parameters and what they do,
-refer to the :py:class:`airflow.models.BaseOperator` documentation.
+refer to the :py:class:`airflow.models.BaseOperator <https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/baseoperator/index.html>` documentation.
 
 Also, note that you could easily define different sets of arguments that
 would serve different purposes. An example of that would be to have


### PR DESCRIPTION
Adding missing hyperlink to the tutorial documentation
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
