### PR TITLE
Exit asset compilation fork in start-airflow after it completed

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -481,5 +481,6 @@ def run_compile_www_assets(
                 # and create a new process group where we are the leader
                 os.setpgid(0, 0)
             _run_compile_internally(command_to_execute, dev)
+            sys.exit(0)
     else:
         return _run_compile_internally(command_to_execute, dev)


### PR DESCRIPTION
The `start-airflow` command uses fork to start parallell asset compilation in the background so that it can happen while docker compose initializes. Unfortunately this fork child did not have sys.exit() so it returned from the function and continued to run second docker-compose in the background. In case asset compilation was not needed this could happen in parallel and both processes attempted to start two docker-compose commands in parallel.

This was not visible in "dev" mode - because asset compilation never completed there also - when asset compilation was needed, it took some time before it completed, and the effect of it were not visible, because the forked process did not get terminal output (it has been taken over by tmux by the time it started to use it) and could not grab forwarded ports, so it was running but largely invisible.

However when asset compilation was not needed, the two processes started to do the same things at the same time - so a lot of the output has been duplicated and for example the line output has been broken because the same messages were overwriting over each other and canceling the effect of EOL printed to terminal.

With this change, the forked process exits as soon as the asset compilation is completed and does not repeat the same steps that the parent process is doiing.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
