### PR TITLE
Avoid permission error when asset compilation exists before killing it

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -444,6 +444,18 @@ def _run_compile_internally(command_to_execute: list[str], dev: bool) -> RunComm
             sys.exit(1)
 
 
+def kill_process_group(gid: int):
+    """
+    Kills all processes in the process group and ignore if the group is missing.
+
+    :param gid: process group id
+    """
+    try:
+        os.killpg(gid, signal.SIGTERM)
+    except OSError:
+        pass
+
+
 def run_compile_www_assets(
     dev: bool,
     run_in_background: bool,
@@ -474,7 +486,7 @@ def run_compile_www_assets(
         pid = os.fork()
         if pid:
             # Parent process - send signal to process group of the child process
-            atexit.register(os.killpg, pid, signal.SIGTERM)
+            atexit.register(kill_process_group, pid)
         else:
             # Check if we are not a group leader already (We should not be)
             if os.getpid() != os.getsid(0):


### PR DESCRIPTION
After #32114 the atexit registered killpg produces Permission Error in stdout when the group was missing (basically when the asset compilation stopped).

Changing it to ignore the error avoids the false negative appear in the output.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
