### PR TITLE
fix: Fix hardcoded BigQuery to GCS project id

### DIFF
--- a/airflow/providers/google/cloud/transfers/bigquery_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_gcs.py
@@ -143,6 +143,10 @@ class BigQueryToGCSOperator(BaseOperator):
             raise AirflowException(f"BigQuery job {job.job_id} failed: {job.error_result}")
 
     def _prepare_configuration(self):
+        """
+        This configuration define necessary argument for the data transfer, which related to project
+        where the BigQuery table resides.
+        """
         source_project, source_dataset, source_table = self.hook.split_tablename(
             table_input=self.source_project_dataset_table,
             default_project_id=self.project_id or self.hook.project_id,
@@ -183,7 +187,7 @@ class BigQueryToGCSOperator(BaseOperator):
 
         return hook.insert_job(
             configuration=configuration,
-            project_id=configuration["extract"]["sourceTable"]["projectId"],
+            project_id=self.project_id if self.project_id is not None else hook.project_id,
             location=self.location,
             job_id=job_id,
             timeout=self.result_timeout,


### PR DESCRIPTION
In the airflow configuration, we defined the self.project_id where we pass the information regarding the project_id where we run the job. There's another configuration that is defined in _prepare_configuration regarding how we define the job id given for the BQ table source.

closes: https://github.com/apache/airflow/issues/32106
related: https://github.com/apache/airflow/issues/32106

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
