### PR TITLE
Do not create redis secrets for kubernetes executors

### DIFF
--- a/chart/templates/secrets/redis-secrets.yaml
+++ b/chart/templates/secrets/redis-secrets.yaml
@@ -28,7 +28,7 @@
 ## Airflow Redis Password Secret
 #################################
 {{- $random_redis_password := randAlphaNum 10 }}
-{{- if and .Values.redis.enabled (not .Values.redis.passwordSecretName) }}
+{{- if and (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")) .Values.redis.enabled (not .Values.redis.passwordSecretName) }}
 # If passwordSecretName is not set, we will either use the set password, or use the generated one
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Create the redis secrets only for Celery based executors and not for Kubernetes executor. This is to stay consistent with other redis elements in airflow helm charts.

closes: https://github.com/apache/airflow/issues/30420
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
