### PR TITLE
fix: Fix GCS to BigQuery Operator

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -248,7 +248,7 @@ class GCSToBigQueryOperator(BaseOperator):
 
         # BQ config
         self.destination_project_dataset_table = destination_project_dataset_table
-        self.project_id = project_id
+        self.project_id = project_id if project_id is not None else self.hook.project_id
         self.schema_fields = schema_fields
         if source_format.upper() not in ALLOWED_FORMATS:
             raise ValueError(
@@ -575,7 +575,7 @@ class GCSToBigQueryOperator(BaseOperator):
         return table_obj_api_repr
 
     def _use_existing_table(self):
-        self.project_id, destination_dataset, destination_table = self.hook.split_tablename(
+        destination_project, destination_dataset, destination_table = self.hook.split_tablename(
             table_input=self.destination_project_dataset_table,
             default_project_id=self.project_id or self.hook.project_id,
             var_name="destination_project_dataset_table",
@@ -597,7 +597,7 @@ class GCSToBigQueryOperator(BaseOperator):
                 "autodetect": self.autodetect,
                 "createDisposition": self.create_disposition,
                 "destinationTable": {
-                    "projectId": self.project_id,
+                    "projectId": destination_project,
                     "datasetId": destination_dataset,
                     "tableId": destination_table,
                 },

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -38,6 +38,7 @@ TASK_ID = "test-gcs-to-bq-operator"
 TEST_EXPLICIT_DEST = "test-project.dataset.table"
 TEST_BUCKET = "test-bucket"
 PROJECT_ID = "test-project"
+OTHER_PROJECT_ID = "other-test-project"
 DATASET = "dataset"
 TABLE = "table"
 WRITE_DISPOSITION = "WRITE_TRUNCATE"
@@ -85,6 +86,7 @@ class TestGCSToBigQueryOperator:
             schema_fields=SCHEMA_FIELDS,
             max_id_key=MAX_ID_KEY,
             external_table=True,
+            project_id=OTHER_PROJECT_ID
         )
 
         result = operator.execute(context=MagicMock())
@@ -93,7 +95,7 @@ class TestGCSToBigQueryOperator:
         hook.return_value.create_empty_table.assert_called_once_with(
             exists_ok=True,
             location=None,
-            project_id=PROJECT_ID,
+            project_id=OTHER_PROJECT_ID,
             table_resource={
                 "tableReference": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
                 "labels": {},
@@ -172,7 +174,7 @@ class TestGCSToBigQueryOperator:
                 job_id=pytest.real_job_id,
                 location=None,
                 nowait=True,
-                project_id=hook.return_value.split_tablename.return_value[0],
+                project_id=PROJECT_ID,
                 retry=DEFAULT_RETRY,
                 timeout=None,
             ),
@@ -233,7 +235,7 @@ class TestGCSToBigQueryOperator:
                 job_id=pytest.real_job_id,
                 location=None,
                 nowait=True,
-                project_id=hook.return_value.split_tablename.return_value[0],
+                project_id=PROJECT_ID
                 retry=DEFAULT_RETRY,
                 timeout=None,
             ),
@@ -316,6 +318,7 @@ class TestGCSToBigQueryOperator:
             schema_fields=SCHEMA_FIELDS,
             external_table=False,
             labels=LABELS,
+            project_id=PROJECT_ID
         )
 
         operator.execute(context=MagicMock())
@@ -342,7 +345,7 @@ class TestGCSToBigQueryOperator:
                 job_id=pytest.real_job_id,
                 location=None,
                 nowait=True,
-                project_id=hook.return_value.split_tablename.return_value[0],
+                project_id=PROJECT_ID
                 retry=DEFAULT_RETRY,
                 timeout=None,
             )
@@ -441,7 +444,7 @@ class TestGCSToBigQueryOperator:
                         fieldDelimiter=",",
                     ),
                 },
-                project_id=hook.return_value.split_tablename.return_value[0],
+                project_id=PROJECT_ID
                 location=None,
                 job_id=pytest.real_job_id,
                 timeout=None,
@@ -545,7 +548,7 @@ class TestGCSToBigQueryOperator:
                 job_id=pytest.real_job_id,
                 location=None,
                 nowait=True,
-                project_id=hook.return_value.split_tablename.return_value[0],
+                project_id=PROJECT_ID
                 retry=DEFAULT_RETRY,
                 timeout=None,
             )
@@ -645,7 +648,7 @@ class TestGCSToBigQueryOperator:
                 job_id=pytest.real_job_id,
                 location=None,
                 nowait=True,
-                project_id=hook.return_value.split_tablename.return_value[0],
+                project_id=PROJECT_ID
                 retry=DEFAULT_RETRY,
                 timeout=None,
             )
@@ -842,7 +845,7 @@ class TestGCSToBigQueryOperator:
                         "encoding": "UTF-8",
                     }
                 },
-                project_id=hook.return_value.split_tablename.return_value[0],
+                project_id=PROJECT_ID
                 location=None,
                 job_id=pytest.real_job_id,
                 timeout=None,
@@ -1129,7 +1132,7 @@ class TestGCSToBigQueryOperator:
                 job_id=pytest.real_job_id,
                 location=None,
                 nowait=True,
-                project_id=hook.return_value.split_tablename.return_value[0],
+                project_id=PROJECT_ID
                 retry=DEFAULT_RETRY,
                 timeout=None,
             )


### PR DESCRIPTION
We have different definition for both of the project where we run the job, destination project, and hook project. We shouldn't hardcode the value of the runner project id into the destination project id.

related: https://github.com/apache/airflow/issues/32093

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
