### PR TITLE
Add airflow to docs packages if only docs/apache-airflow/* files changed

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -723,7 +723,9 @@ class SelectiveChecks:
         ):
             return _ALL_DOCS_LIST
         packages = []
-        if any([file.startswith("airflow/") for file in self._files]):
+        if any(
+            [file.startswith("airflow/") or file.startswith("docs/apache-airflow/") for file in self._files]
+        ):
             packages.append("apache-airflow")
         if any([file.startswith("chart/") or file.startswith("docs/helm-chart") for file in self._files]):
             packages.append("helm-chart")

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1015,6 +1015,22 @@ def test_upgrade_to_newer_dependencies(files: tuple[str, ...], expected_outputs:
             id="Airbyte provider docs changed",
         ),
         pytest.param(
+            ("docs/apache-airflow-providers-airbyte/docs.rst", "docs/apache-airflow/docs.rst"),
+            {
+                "docs-filter-list-as-string": "--package-filter apache-airflow "
+                "--package-filter apache-airflow-providers-airbyte "
+                "--package-filter apache-airflow-providers-http",
+            },
+            id="Airbyte provider and airflow core docs changed",
+        ),
+        pytest.param(
+            ("docs/apache-airflow/docs.rst",),
+            {
+                "docs-filter-list-as-string": "--package-filter apache-airflow",
+            },
+            id="Only Airflow docs changed",
+        ),
+        pytest.param(
             ("airflow/providers/celery/file.py",),
             {
                 "docs-filter-list-as-string": "--package-filter apache-airflow "


### PR DESCRIPTION
Selective checks for docs building missed the case where airflow package docs should also be build when docs/appache-airflow/* files changed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
