### PR TITLE
Name change for the util wait method

### DIFF
--- a/airflow/providers/amazon/aws/hooks/athena.py
+++ b/airflow/providers/amazon/aws/hooks/athena.py
@@ -254,7 +254,7 @@ class AthenaHook(AwsBaseHook):
             wait(
                 waiter=self.get_waiter("query_complete"),
                 waiter_delay=sleep_time or self.sleep_time,
-                max_attempts=max_polling_attempts or 120,
+                waiter_max_attempts=max_polling_attempts or 120,
                 args={"QueryExecutionId": query_execution_id},
                 failure_message=f"Error while waiting for query {query_execution_id} to complete",
                 status_message=f"Query execution id: {query_execution_id}, "

--- a/airflow/providers/amazon/aws/operators/eks.py
+++ b/airflow/providers/amazon/aws/operators/eks.py
@@ -98,7 +98,7 @@ def _create_compute(
             wait(
                 waiter=eks_hook.conn.get_waiter("nodegroup_active"),
                 waiter_delay=waiter_delay,
-                max_attempts=waiter_max_attempts,
+                waiter_max_attempts=waiter_max_attempts,
                 args={"clusterName": cluster_name, "nodegroupName": nodegroup_name},
                 failure_message="Nodegroup creation failed",
                 status_message="Nodegroup status is",
@@ -122,7 +122,7 @@ def _create_compute(
             wait(
                 waiter=eks_hook.conn.get_waiter("fargate_profile_active"),
                 waiter_delay=waiter_delay,
-                max_attempts=waiter_max_attempts,
+                waiter_max_attempts=waiter_max_attempts,
                 args={"clusterName": cluster_name, "fargateProfileName": fargate_profile_name},
                 failure_message="Fargate profile creation failed",
                 status_message="Fargate profile status is",

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -1025,7 +1025,7 @@ class EmrServerlessCreateApplicationOperator(BaseOperator):
         wait(
             waiter=waiter,
             waiter_delay=self.waiter_delay,
-            max_attempts=self.waiter_max_attempts,
+            waiter_max_attempts=self.waiter_max_attempts,
             args={"applicationId": application_id},
             failure_message="Serverless Application creation failed",
             status_message="Serverless Application status is",
@@ -1038,7 +1038,7 @@ class EmrServerlessCreateApplicationOperator(BaseOperator):
             waiter = self.hook.get_waiter("serverless_app_started")
             wait(
                 waiter=waiter,
-                max_attempts=self.waiter_max_attempts,
+                waiter_max_attempts=self.waiter_max_attempts,
                 waiter_delay=self.waiter_delay,
                 args={"applicationId": application_id},
                 failure_message="Serverless Application failed to start",
@@ -1158,7 +1158,7 @@ class EmrServerlessStartJobOperator(BaseOperator):
 
             wait(
                 waiter=waiter,
-                max_attempts=self.waiter_max_attempts,
+                waiter_max_attempts=self.waiter_max_attempts,
                 waiter_delay=self.waiter_delay,
                 args={"applicationId": self.application_id},
                 failure_message="Serverless Application failed to start",
@@ -1185,7 +1185,7 @@ class EmrServerlessStartJobOperator(BaseOperator):
             waiter = self.hook.get_waiter("serverless_job_completed")
             wait(
                 waiter=waiter,
-                max_attempts=self.waiter_max_attempts,
+                waiter_max_attempts=self.waiter_max_attempts,
                 waiter_delay=self.waiter_delay,
                 args={"applicationId": self.application_id, "jobRunId": self.job_id},
                 failure_message="Serverless Job failed",
@@ -1314,7 +1314,7 @@ class EmrServerlessStopApplicationOperator(BaseOperator):
             waiter = self.hook.get_waiter("serverless_app_stopped")
             wait(
                 waiter=waiter,
-                max_attempts=self.waiter_max_attempts,
+                waiter_max_attempts=self.waiter_max_attempts,
                 waiter_delay=self.waiter_delay,
                 args={"applicationId": self.application_id},
                 failure_message="Error stopping application",
@@ -1409,7 +1409,7 @@ class EmrServerlessDeleteApplicationOperator(EmrServerlessStopApplicationOperato
 
             wait(
                 waiter=waiter,
-                max_attempts=self.waiter_max_attempts,
+                waiter_max_attempts=self.waiter_max_attempts,
                 waiter_delay=self.waiter_delay,
                 args={"applicationId": self.application_id},
                 failure_message="Error terminating application",

--- a/airflow/providers/amazon/aws/utils/waiter_with_logging.py
+++ b/airflow/providers/amazon/aws/utils/waiter_with_logging.py
@@ -32,7 +32,7 @@ from airflow.exceptions import AirflowException
 def wait(
     waiter: Waiter,
     waiter_delay: int,
-    max_attempts: int,
+    waiter_max_attempts: int,
     args: dict[str, Any],
     failure_message: str,
     status_message: str,
@@ -45,7 +45,7 @@ def wait(
 
     :param waiter: The boto waiter to use.
     :param waiter_delay: The amount of time in seconds to wait between attempts.
-    :param max_attempts: The maximum number of attempts to be made.
+    :param waiter_max_attempts: The maximum number of attempts to be made.
     :param args: The arguments to pass to the waiter.
     :param failure_message: The message to log if a failure state is reached.
     :param status_message: The message logged when printing the status of the service.
@@ -72,7 +72,7 @@ def wait(
                 raise AirflowException(f"{failure_message}: {error}")
 
             log.info("%s: %s", status_message, _LazyStatusFormatter(status_args, error.last_response))
-            if attempt >= max_attempts:
+            if attempt >= waiter_max_attempts:
                 raise AirflowException("Waiter error: max attempts reached")
 
             time.sleep(waiter_delay)
@@ -81,7 +81,7 @@ def wait(
 async def async_wait(
     waiter: Waiter,
     waiter_delay: int,
-    max_attempts: int,
+    waiter_max_attempts: int,
     args: dict[str, Any],
     failure_message: str,
     status_message: str,
@@ -94,7 +94,7 @@ async def async_wait(
 
     :param waiter: The boto waiter to use.
     :param waiter_delay: The amount of time in seconds to wait between attempts.
-    :param max_attempts: The maximum number of attempts to be made.
+    :param waiter_max_attempts: The maximum number of attempts to be made.
     :param args: The arguments to pass to the waiter.
     :param failure_message: The message to log if a failure state is reached.
     :param status_message: The message logged when printing the status of the service.
@@ -121,7 +121,7 @@ async def async_wait(
                 raise AirflowException(f"{failure_message}: {error}")
 
             log.info("%s: %s", status_message, _LazyStatusFormatter(status_args, error.last_response))
-            if attempt >= max_attempts:
+            if attempt >= waiter_max_attempts:
                 raise AirflowException("Waiter error: max attempts reached")
 
             await asyncio.sleep(waiter_delay)

--- a/tests/providers/amazon/aws/utils/test_waiter_with_logging.py
+++ b/tests/providers/amazon/aws/utils/test_waiter_with_logging.py
@@ -51,7 +51,7 @@ class TestWaiter:
         wait(
             waiter=mock_waiter,
             waiter_delay=123,
-            max_attempts=456,
+            waiter_max_attempts=456,
             args={"test_arg": "test_value"},
             failure_message="test failure message",
             status_message="test status message",
@@ -92,7 +92,7 @@ class TestWaiter:
         await async_wait(
             waiter=mock_waiter,
             waiter_delay=0,
-            max_attempts=456,
+            waiter_max_attempts=456,
             args={"test_arg": "test_value"},
             failure_message="test failure message",
             status_message="test status message",
@@ -122,7 +122,7 @@ class TestWaiter:
             wait(
                 waiter=mock_waiter,
                 waiter_delay=123,
-                max_attempts=2,
+                waiter_max_attempts=2,
                 args={"test_arg": "test_value"},
                 failure_message="test failure message",
                 status_message="test status message",
@@ -169,7 +169,7 @@ class TestWaiter:
             wait(
                 waiter=mock_waiter,
                 waiter_delay=123,
-                max_attempts=10,
+                waiter_max_attempts=10,
                 args={"test_arg": "test_value"},
                 failure_message="test failure message",
                 status_message="test status message",
@@ -217,7 +217,7 @@ class TestWaiter:
         wait(
             waiter=mock_waiter,
             waiter_delay=123,
-            max_attempts=456,
+            waiter_max_attempts=456,
             args={"test_arg": "test_value"},
             failure_message="test failure message",
             status_message="test status message",
@@ -266,7 +266,7 @@ class TestWaiter:
         wait(
             waiter=mock_waiter,
             waiter_delay=123,
-            max_attempts=456,
+            waiter_max_attempts=456,
             args={"test_arg": "test_value"},
             failure_message="test failure message",
             status_message="test status message",
@@ -314,7 +314,7 @@ class TestWaiter:
         wait(
             waiter=mock_waiter,
             waiter_delay=123,
-            max_attempts=456,
+            waiter_max_attempts=456,
             args={"test_arg": "test_value"},
             failure_message="test failure message",
             status_message="test status message",
@@ -348,7 +348,7 @@ class TestWaiter:
             wait(
                 waiter=mock_waiter,
                 waiter_delay=0,
-                max_attempts=456,
+                waiter_max_attempts=456,
                 args={"test_arg": "test_value"},
                 failure_message="test failure message",
                 status_message="test status message",


### PR DESCRIPTION
The `wait` method in the utils folder has a parameter named `max_attempts`. It should have been named `waiter_max_attempts` to be consistent with the naming conventions. 
We shouldn't need to deprecate here because the `wait` method has not been part of a release.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
