### PR TITLE
Use mapIndex to display extra links per mapped task.

### DIFF
--- a/airflow/www/static/js/api/useExtraLinks.ts
+++ b/airflow/www/static/js/api/useExtraLinks.ts
@@ -32,38 +32,44 @@ export default function useExtraLinks({
   dagId,
   taskId,
   executionDate,
+  mapIndex,
   extraLinks,
 }: {
   dagId: string;
   taskId: string;
   executionDate: string;
+  mapIndex?: number | undefined;
   extraLinks: string[];
 }) {
-  return useQuery(["extraLinks", dagId, taskId, executionDate], async () => {
-    const data = await Promise.all(
-      extraLinks.map(async (link) => {
-        const url = `${extraLinksUrl}?task_id=${encodeURIComponent(
-          taskId
-        )}&dag_id=${encodeURIComponent(
-          dagId
-        )}&execution_date=${encodeURIComponent(
-          executionDate
-        )}&link_name=${encodeURIComponent(link)}`;
-        try {
-          const datum = await axios.get<AxiosResponse, LinkData>(url);
-          return {
-            name: link,
-            url: datum.url,
-          };
-        } catch (e) {
-          console.error(e);
-          return {
-            name: link,
-            url: "",
-          };
-        }
-      })
-    );
-    return data;
-  });
+  return useQuery(
+    ["extraLinks", dagId, taskId, executionDate, mapIndex],
+    async () => {
+      const data = await Promise.all(
+        extraLinks.map(async (link) => {
+          mapIndex ??= -1;
+          const url = `${extraLinksUrl}?task_id=${encodeURIComponent(
+            taskId
+          )}&dag_id=${encodeURIComponent(
+            dagId
+          )}&execution_date=${encodeURIComponent(
+            executionDate
+          )}&link_name=${encodeURIComponent(link)}&map_index=${mapIndex}`;
+          try {
+            const datum = await axios.get<AxiosResponse, LinkData>(url);
+            return {
+              name: link,
+              url: datum.url,
+            };
+          } catch (e) {
+            console.error(e);
+            return {
+              name: link,
+              url: "",
+            };
+          }
+        })
+      );
+      return data;
+    }
+  );
 }

--- a/airflow/www/static/js/dag/details/taskInstance/ExtraLinks.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/ExtraLinks.tsx
@@ -26,14 +26,22 @@ interface Props {
   dagId: string;
   taskId: string;
   executionDate: string;
+  mapIndex?: number | undefined;
   extraLinks: string[];
 }
 
-const ExtraLinks = ({ dagId, taskId, executionDate, extraLinks }: Props) => {
+const ExtraLinks = ({
+  dagId,
+  taskId,
+  executionDate,
+  mapIndex,
+  extraLinks,
+}: Props) => {
   const { data: links } = useExtraLinks({
     dagId,
     taskId,
     executionDate,
+    mapIndex,
     extraLinks,
   });
 

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -99,6 +99,15 @@ const TaskInstance = ({ taskId, runId, mapIndex }: Props) => {
           key={dagId + runId + taskId + instance.mapIndex}
         />
       )}
+      {isMapped && group.extraLinks && isMapIndexDefined && (
+        <ExtraLinks
+          taskId={taskId}
+          dagId={dagId}
+          mapIndex={mapIndex}
+          executionDate={executionDate}
+          extraLinks={group?.extraLinks}
+        />
+      )}
       {!isMapped && group.extraLinks && (
         <ExtraLinks
           taskId={taskId}


### PR DESCRIPTION
Use mapIndex to display extra links per mapped task. In case of normal unmapped tasks we have the old block present. Since mapIndex needs to be passed through the API -1 acts as a default for unmapped tasks where mapIndex is undefined. This is useful in cases where there are many mapped tasks linked to an external resource.

closes: #32153
related: #32153