### PR TITLE
[AIP-49] Fix task_instance_created metric name

### DIFF
--- a/airflow/metrics/validators.py
+++ b/airflow/metrics/validators.py
@@ -63,7 +63,7 @@ BACK_COMPAT_METRIC_NAME_PATTERNS: set[str] = {
     r"^ti.finish.(?P<dag_id>.*)\.(?P<task_id>.*)\.(?P<state>.*)$",
     r"^task_removed_from_dag\.(?P<dag_id>.*)$",
     r"^task_restored_to_dag\.(?P<dag_id>.*)$",
-    r"^task_instance_created-(?P<operator_name>.*)$",
+    r"^task_instance_created_(?P<operator_name>.*)$",
     r"^dag_processing\.last_run\.seconds_ago\.(?P<dag_file>.*)$",
     r"^pool\.open_slots\.(?P<pool_name>.*)$",
     r"^pool\.queued_slots\.(?P<pool_name>.*)$",

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1187,7 +1187,7 @@ class DagRun(Base, LoggingMixin):
                 session.bulk_save_objects(tasks)
 
             for task_type, count in created_counts.items():
-                Stats.incr(f"task_instance_created-{task_type}", count, tags=self.stats_tags)
+                Stats.incr(f"task_instance_created_{task_type}", count, tags=self.stats_tags)
                 # Same metric with tagging
                 Stats.incr("task_instance_created", count, tags={**self.stats_tags, "task_type": task_type})
             session.flush()

--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
@@ -164,7 +164,7 @@ Name                                                                   Descripti
 ``task_removed_from_dag.<dag_id>``                                     Number of tasks removed for a given dag (i.e. task no longer exists in DAG)
 ``task_restored_to_dag.<dag_id>``                                      Number of tasks restored for a given dag (i.e. task instance which was
                                                                        previously in REMOVED state in the DB is added to DAG file)
-``task_instance_created-<operator_name>``                              Number of tasks instances created for a given Operator
+``task_instance_created_<operator_name>``                              Number of tasks instances created for a given Operator
 ``triggers.blocked_main_thread``                                       Number of triggers that blocked the main thread (likely due to not being
                                                                        fully asynchronous)
 ``triggers.failed``                                                    Number of triggers that errored before they could fire an event

--- a/tests/core/test_otel_logger.py
+++ b/tests/core/test_otel_logger.py
@@ -91,7 +91,7 @@ class TestOtelMetrics:
         self.meter.assert_not_called()
 
     def test_old_name_exception_works(self, caplog):
-        name = "task_instance_created-OperatorNameWhichIsSuperLongAndExceedsTheOpenTelemetryCharacterLimit"
+        name = "task_instance_created_OperatorNameWhichIsSuperLongAndExceedsTheOpenTelemetryCharacterLimit"
         assert len(name) > OTEL_NAME_MAX_LENGTH
 
         with pytest.warns(MetricNameLengthExemptionWarning):

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -984,7 +984,7 @@ def test_verify_integrity_task_start_and_end_date(Stats_incr, session, run_type,
     assert len(tis) == expected_tis
 
     Stats_incr.assert_any_call(
-        "task_instance_created-EmptyOperator", expected_tis, tags={"dag_id": "test", "run_type": run_type}
+        "task_instance_created_EmptyOperator", expected_tis, tags={"dag_id": "test", "run_type": run_type}
     )
     Stats_incr.assert_any_call(
         "task_instance_created",


### PR DESCRIPTION
Both StatsD and OTel replace the hyphen in the name with an underscore.  A user looking for `task_instance_created-<operator_name>` would not find it and may not think to look for `task_instance_created_<operator_name>`.  Also updated related test logic and docs to make that more obvious.

Since both metrics backends make this name change behind the scenes anyway, I don't feel thins needs a deprecation period; nothing should visibly change to the user.  If someone feels otherwise, I can roll this back and just update the rst file to make it more obvious instead.

![image](https://github.com/apache/airflow/assets/1920178/6d643e24-d431-43fc-b9a7-3ad70bd9480f)
