### PR TITLE
EKS Create/Delete Nodegroup Deferrable mode

### DIFF
--- a/airflow/providers/amazon/aws/triggers/eks.py
+++ b/airflow/providers/amazon/aws/triggers/eks.py
@@ -23,6 +23,7 @@ from botocore.exceptions import WaiterError
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.eks import EksHook
+from airflow.providers.amazon.aws.utils.waiter_with_logging import async_wait
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 
@@ -164,3 +165,75 @@ class EksDeleteFargateProfileTrigger(BaseTrigger):
             )
         else:
             yield TriggerEvent({"status": "success", "message": "Fargate Profile Deleted"})
+
+
+class EksNodegroupTrigger(BaseTrigger):
+    """
+    Trigger for EksCreateNodegroupOperator and EksDeleteNodegroupOperator.
+
+    The trigger will asynchronously poll the boto3 API and wait for the
+    nodegroup to be in the state specified by the waiter.
+
+    :param waiter_name: Name of the waiter to use, for instance 'nodegroup_active' or 'nodegroup_deleted'
+    :param cluster_name: The name of the EKS cluster associated with the node group.
+    :param nodegroup_name: The name of the nodegroup to check.
+    :param waiter_delay: The amount of time in seconds to wait between attempts.
+    :param waiter_max_attempts: The maximum number of attempts to be made.
+    :param aws_conn_id: The Airflow connection used for AWS credentials.
+    :param region: Which AWS region the connection should use. (templated)
+        If this is None or empty then the default boto3 behaviour is used.
+    """
+
+    def __init__(
+        self,
+        waiter_name: str,
+        cluster_name: str,
+        nodegroup_name: str,
+        waiter_delay: int,
+        waiter_max_attempts: int,
+        aws_conn_id: str,
+        region: str | None,
+    ):
+        self.waiter_name = waiter_name
+        self.cluster_name = cluster_name
+        self.nodegroup_name = nodegroup_name
+        self.aws_conn_id = aws_conn_id
+        self.waiter_delay = waiter_delay
+        self.waiter_max_attempts = waiter_max_attempts
+        self.region = region
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        return (
+            self.__class__.__module__ + "." + self.__class__.__qualname__,
+            {
+                "waiter_name": self.waiter_name,
+                "cluster_name": self.cluster_name,
+                "nodegroup_name": self.nodegroup_name,
+                "waiter_delay": str(self.waiter_delay),
+                "waiter_max_attempts": str(self.waiter_max_attempts),
+                "aws_conn_id": self.aws_conn_id,
+                "region": self.region,
+            },
+        )
+
+    async def run(self):
+        self.hook = EksHook(aws_conn_id=self.aws_conn_id, region_name=self.region)
+        async with self.hook.async_conn as client:
+            waiter = client.get_waiter(self.waiter_name)
+            await async_wait(
+                waiter=waiter,
+                max_attempts=int(self.waiter_max_attempts),
+                waiter_delay=int(self.waiter_delay),
+                args={"clusterName": self.cluster_name, "nodegroupName": self.nodegroup_name},
+                failure_message="Error checking nodegroup",
+                status_message="Nodegroup status is",
+                status_args=["nodegroup.status"],
+            )
+
+        yield TriggerEvent(
+            {
+                "status": "success",
+                "cluster_name": self.cluster_name,
+                "nodegroup_name": self.nodegroup_name,
+            }
+        )

--- a/airflow/providers/amazon/aws/triggers/eks.py
+++ b/airflow/providers/amazon/aws/triggers/eks.py
@@ -222,7 +222,7 @@ class EksNodegroupTrigger(BaseTrigger):
             waiter = client.get_waiter(self.waiter_name)
             await async_wait(
                 waiter=waiter,
-                max_attempts=int(self.waiter_max_attempts),
+                waiter_max_attempts=int(self.waiter_max_attempts),
                 waiter_delay=int(self.waiter_delay),
                 args={"clusterName": self.cluster_name, "nodegroupName": self.nodegroup_name},
                 failure_message="Error checking nodegroup",

--- a/docs/apache-airflow-providers-amazon/operators/eks.rst
+++ b/docs/apache-airflow-providers-amazon/operators/eks.rst
@@ -121,6 +121,7 @@ Create an Amazon EKS managed node group
 
 To create an Amazon EKS managed node group you can use
 :class:`~airflow.providers.amazon.aws.operators.eks.EksCreateNodegroupOperator`.
+You can also run this operator in deferrable mode by setting ``deferrable`` param to ``True``.
 
 Note:  An AWS IAM role with the following permissions is required:
   ``ec2.amazon.aws.com`` must be in the Trusted Relationships
@@ -140,6 +141,7 @@ Delete an Amazon EKS managed node group
 
 To delete an existing Amazon EKS managed node group you can use
 :class:`~airflow.providers.amazon.aws.operators.eks.EksDeleteNodegroupOperator`.
+You can also run this operator in deferrable mode by setting ``deferrable`` param to ``True``.
 
 .. exampleinclude:: /../../tests/system/providers/amazon/aws/example_eks_with_nodegroups.py
     :language: python


### PR DESCRIPTION
This PR add the deferrable mode option to `EksCreateNodegroupOperator` and `EksDeleteNodegroupOperator`, as well as the associated tests.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
