### PR TITLE
Add initial docs for setup / teardown

### DIFF
--- a/airflow/example_dags/example_setup_teardown_taskflow.py
+++ b/airflow/example_dags/example_setup_teardown_taskflow.py
@@ -31,68 +31,71 @@ with DAG(
 ) as dag:
 
     @task
-    def task_1():
+    def my_first_task():
         print("Hello 1")
 
     @task
-    def task_2():
+    def my_second_task():
         print("Hello 2")
 
     @task
-    def task_3():
+    def my_third_task():
         print("Hello 3")
 
     # you can set setup / teardown relationships with the `as_teardown` method.
-    t1 = task_1()
-    t2 = task_2()
-    t3 = task_3()
-    t1 >> t2 >> t3.as_teardown(setups=t1)
+    task_1 = my_first_task()
+    task_2 = my_second_task()
+    task_3 = my_third_task()
+    task_1 >> task_2 >> task_3.as_teardown(setups=task_1)
 
-    # the method `as_teadrown` will mark t3 as teardown, t1 as setup, and arrow t1 >> t3
-    # now if you clear t2 (downstream), then t1 will be cleared in addition to t3
+    # The method `as_teardown` will mark task_3 as teardown, task_1 as setup, and
+    # arrow task_1 >> task_3.
+    # Now if you clear task_2, then it's setup task, task_1, will be cleared in
+    # addition to its teardown task, task_3
 
     # it's also possible to use a decorator to mark a task as setup or
     # teardown when you define it. see below.
 
     @setup
-    def dag_setup():
-        print("I am dag_setup")
+    def outer_setup():
+        print("I am outer_setup")
 
     @teardown
-    def dag_teardown():
-        print("I am dag_teardown")
+    def outer_teardown():
+        print("I am outer_teardown")
 
     @task
-    def dag_normal_task():
+    def outer_normal_task():
         print("I am just a normal task")
 
-    s = dag_setup()
-    t = dag_teardown()
+    s = outer_setup()
+    t = outer_teardown()
 
-    # by using the decorators, dag_setup and dag_teardown are already marked as setup / teardown
+    # by using the decorators, outer_setup and outer_teardown are already marked as setup / teardown
     # now we just need to make sure they are linked directly
     # what we need to do is this::
     #     s >> t
-    #     s >> dag_normal_task() >> t
+    #     s >> outer_normal_task() >> t
     # but we can use a context manager to make it cleaner
     with s >> t:
-        dag_normal_task()
+        outer_normal_task()
 
     @task_group
     def section_1():
         @task
-        def my_setup():
+        def inner_setup():
             print("I set up")
+            return "some_cluster_id"
 
         @task
-        def my_teardown():
-            print("I tear down")
+        def inner_normal_task(cluster_id):
+            print(f"doing some work with {cluster_id=}")
 
         @task
-        def hello():
-            print("I say hello")
+        def inner_teardown(cluster_id):
+            print(f"tearing down {cluster_id=}")
 
-        (s := my_setup()) >> hello() >> my_teardown().as_teardown(setups=s)
+        inner_normal_task(s := inner_setup()) >> inner_teardown(s).as_teardown()
 
-    # and let's put section 1 inside the "dag setup" and "dag teardown"
+    # and let's put section 1 inside the outer setup and teardown tasks
     s >> section_1() >> t

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -543,7 +543,7 @@ Let's look at an example:
     s1 >> w1 >> w2 >> t1.as_teardown(setups=s1) >> w3
     w2 >> w4
 
-In the above example, w1 and w2 are "between" s1 and t1 and therefore are assumed to require s1. Thus if w1 or w2 is cleared, so too will be s1 and t1.  But if w3 or w4 is cleared, neither s1 nor t1 will be cleared.
+In the above example, ``w1`` and ``w2`` are "between" ``s1`` and ``t1`` and therefore are assumed to require ``s1``. Thus if ``w1`` or ``w2`` is cleared, so too will be ``s1`` and ``t1``.  But if ``w3`` or ``w4`` is cleared, neither ``s1`` nor ``t1`` will be cleared.
 
 You can have multiple setup tasks wired to a single teardown.  The teardown will run if at least one of the setups completed successfully.
 

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -529,7 +529,7 @@ Observations:
 
   * If you clear ``run_query`` to run it again, then both ``create_cluster`` and ``delete_cluster`` will be cleared.
   * If ``run_query`` fails, then ``delete_cluster`` will still run.
-  * The success of the dag run will depend on the success of ``run_query``.
+  * The success of the dag run will depend *only* on the success of ``run_query``.
 
 Setup "scope"
 """""""""""""
@@ -615,6 +615,20 @@ This is equivalent to the following:
     s >> b() >> c() >> t
 
 Passing data between setup, teardown, and normal task
+
+Running setups and teardowns in parallel
+""""""""""""""""""""""""""""""""""""""""
+
+You can run setup tasks in parallel:
+
+.. code-block:: python
+
+    (
+        [create_cluster, create_bucket]
+        >> run_query
+        >> [delete_cluster.as_teardown(setups=create_cluster), delete_bucket.as_teardown(setups=create_bucket)]
+    )
+
 
 Dynamic DAGs
 ------------

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -596,7 +596,7 @@ Now let's consider an example with nesting:
     dag_t1 = dag_teardown1()
     dag_s1 >> [tg, w2] >> dag_t1.as_teardown(dag_s1)
 
-In this example s1 is downstream of dag_s1, so it must wait for dag_s1 to complete successfully.  But t1 and dag_t1 can run concurrently, because t1 is ignored in the expression ``tg >> dag_t1``.  If you clear w1, it will clear dag_s1 and dag_t1, but not anything in the task group.
+In this example ``s1`` is downstream of ``dag_s1``, so it must wait for ``dag_s1`` to complete successfully.  But ``t1`` and ``dag_t1`` can run concurrently, because ``t1`` is ignored in the expression ``tg >> dag_t1``.  If you clear ``w2``, it will clear ``dag_s1`` and ``dag_t1``, but not anything in the task group.
 
 Setup / teardown context manager
 """"""""""""""""""""""""""""""""

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -498,13 +498,16 @@ Features of setup and teardown tasks:
   * A teardown task will run if it's setup was successful, even if its work tasks failed.
   * Teardown tasks are ignored when setting dependencies against task groups.
 
-Suppose you have a dag that creates a cluster, runs a query, and deletes the cluster:
+Basic usage
+-----------
+
+Suppose you have a dag that creates a cluster, runs a query, and deletes the cluster. Without using setup and teardown tasks you might set these relationships:
 
 .. code-block:: python
 
   create_cluster >> run_query >> delete_cluster
 
-We can mark ``create_cluster`` as a setup task and ``delete_cluster`` as its teardown with the ``as_teardown`` method:
+We can use the ``as_teardown`` let airflow know that ``create_cluster`` is a setup task and ``delete_cluster`` is its teardown:
 
 .. code-block:: python
 
@@ -516,11 +519,21 @@ Observations:
   * If ``run_query`` fails, then ``delete_cluster`` will still run.
   * The success of the dag run will depend on the success of ``run_query``.
 
-Suppose that you want the dag run's success to depend on ``delete_cluster``.  Then set property ``on_failure_fail_dagrun=True`` when setting ``delete_cluster`` as teardown:
+Controlling dag run state
+-------------------------
+
+Another feature of setup / teardown tasks is you can choose whether or not the teardown task should have an impact on dag run state.  Perhaps you don't care if the "cleanup" work performed by your teardown task fails, and you only consider the dag run a failure if the "work" tasks fail.  By default, teardown tasks are not considered for dag run state.
+
+Continuing with the example above, if you want the run's success to depend on ``delete_cluster``.  Then set property ``on_failure_fail_dagrun=True`` when setting ``delete_cluster`` as teardown:
 
 .. code-block:: python
 
   create_cluster >> run_query >> delete_cluster.as_teardown(setups=create_cluster, on_failure_fail_dagrun=True)
+
+Authoring with task groups
+--------------------------
+
+TODO!!!
 
 
 Dynamic DAGs

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -533,8 +533,23 @@ Continuing with the example above, if you want the run's success to depend on ``
 Authoring with task groups
 --------------------------
 
-TODO!!!
+When arrowing from task group to task group, or from task group to task, we ignore teardowns.  This allows teardowns to run in parallel, and allows dag execution to proceed even if teardown tasks fail.
 
+Consider this example:
+
+.. code-block:: python
+
+    with TaskGroup("my_group") as tg:
+        s1 = my_setup()
+        w1 = my_work()
+        t1 = my_teardown()
+        s1 >> w1 >> t1.as_teardown(setups=s1)
+    w2 = other_work()
+    dag_s1 = dag_setup1()
+    dag_t1 = dag_teardown1()
+    dag_s1 >> [tg, w2] >> dag_t1.as_teardown(dag_s1)
+
+In this example s1 is downstream of dag_s1, so it must wait for dag_s1 to complete successfully.  But t1 and dag_t1 can run concurrently, because t1 is ignored in the expression ``tg >> dag_t1``.
 
 Dynamic DAGs
 ------------

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -300,8 +300,8 @@ Control Flow
 By default, a DAG will only run a Task when all the Tasks it depends on are successful. There are several ways of modifying this, however:
 
 * :ref:`concepts:branching` - select which Task to move onto based on a condition
-* :ref:`concepts:trigger-rules` - set the conditions under which a DAG will run a task.
-* :doc:`howto/setup-and-teardown` - define setup and teardown relationships
+* :ref:`concepts:trigger-rules` - set the conditions under which a DAG will run a task
+* :doc:`/howto/setup-and-teardown` - define setup and teardown relationships
 * :ref:`concepts:latest-only` - a special form of branching that only runs on DAGs running against the present
 * :ref:`concepts:depends-on-past` - tasks can depend on themselves *from a previous run*
 
@@ -489,7 +489,7 @@ Setup and teardown
 
 In data workflows it's common to create a resource (such as a compute resource), use it to do some work, and then tear it down. Airflow provides setup and teardown tasks to support this need.
 
-Please see main article :doc:`howto/setup-and-teardown` for details on how to use this feature.
+Please see main article :doc:`/howto/setup-and-teardown` for details on how to use this feature.
 
 
 Dynamic DAGs

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -545,6 +545,8 @@ Let's look at an example:
 
 In the above example, w1 and w2 are "between" s1 and t1 and therefore are assumed to require s1. Thus if w1 or w2 is cleared, so too will be s1 and t1.  But if w3 or w4 is cleared, neither s1 nor t1 will be cleared.
 
+You can have multiple setup tasks wired to a single teardown.  The teardown will run if at least one of the setups completed successfully.
+
 Controlling dag run state
 """""""""""""""""""""""""
 
@@ -628,6 +630,12 @@ You can run setup tasks in parallel:
         >> run_query
         >> [delete_cluster.as_teardown(setups=create_cluster), delete_bucket.as_teardown(setups=create_bucket)]
     )
+
+When a setup fails or is skipped
+""""""""""""""""""""""""""""""""
+
+If a setup fails, its downstreams are failed, though with a non-teardown downstream tasks, you can override this behavior with trigger rules.  When a setup is skipped, its downstreams are skipped.
+
 
 
 Dynamic DAGs

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -495,7 +495,7 @@ Key features of setup and teardown tasks:
 
   * If you clear a task, its setups and teardowns will be cleared.
   * By default, teardown tasks are ignored for the purpose of evaluating dag run state.
-  * A teardown task will run if it's setup was successful, even if its work tasks failed.
+  * A teardown task will run if its setup was successful, even if its work tasks failed.
   * Teardown tasks are ignored when setting dependencies against task groups.
   * A setup task must always have a teardown and vice versa. You may use EmptyOperator as a setup or teardown.
 

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -301,7 +301,7 @@ By default, a DAG will only run a Task when all the Tasks it depends on are succ
 
 * :ref:`concepts:branching` - select which Task to move onto based on a condition
 * :ref:`concepts:trigger-rules` - set the conditions under which a DAG will run a task.
-* :doc:`howto/setup-and-teardown` - define setup and teardown relationships
+* :ref:`howto:setup-and-teardown` - define setup and teardown relationships
 * :ref:`concepts:latest-only` - a special form of branching that only runs on DAGs running against the present
 * :ref:`concepts:depends-on-past` - tasks can depend on themselves *from a previous run*
 

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -301,7 +301,7 @@ By default, a DAG will only run a Task when all the Tasks it depends on are succ
 
 * :ref:`concepts:branching` - select which Task to move onto based on a condition
 * :ref:`concepts:trigger-rules` - set the conditions under which a DAG will run a task.
-* :ref:`howto:setup-and-teardown` - define setup and teardown relationships
+* :doc:`howto/setup-and-teardown` - define setup and teardown relationships
 * :ref:`concepts:latest-only` - a special form of branching that only runs on DAGs running against the present
 * :ref:`concepts:depends-on-past` - tasks can depend on themselves *from a previous run*
 

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -552,7 +552,7 @@ Controlling dag run state
 
 Another feature of setup / teardown tasks is you can choose whether or not the teardown task should have an impact on dag run state.  Perhaps you don't care if the "cleanup" work performed by your teardown task fails, and you only consider the dag run a failure if the "work" tasks fail.  By default, teardown tasks are not considered for dag run state.
 
-Continuing with the example above, if you want the run's success to depend on ``delete_cluster``.  Then set property ``on_failure_fail_dagrun=True`` when setting ``delete_cluster`` as teardown:
+Continuing with the example above, if you want the run's success to depend on ``delete_cluster``, then set``on_failure_fail_dagrun=True`` when setting ``delete_cluster`` as teardown. For example:
 
 .. code-block:: python
 

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -496,7 +496,7 @@ Features of setup and teardown tasks:
   * If you clear a task, its setups and teardowns will be cleared.
   * By default, teardown tasks are ignored for the purpose of evaluating dag run state.
   * A teardown task will run if it's setup was successful, even if its work tasks failed.
-  * Teardown tasks are ignore when setting dependencies against task groups.
+  * Teardown tasks are ignored when setting dependencies against task groups.
 
 Suppose you have a dag that creates a cluster, runs a query, and deletes the cluster:
 

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -499,6 +499,9 @@ Key features of setup and teardown tasks:
   * Teardown tasks are ignored when setting dependencies against task groups.
   * A setup task must always have a teardown and vice versa. You may use EmptyOperator as a setup or teardown.
 
+How setup and teardown works
+""""""""""""""""""""""""""""
+
 Basic usage
 """""""""""
 
@@ -508,7 +511,15 @@ Suppose you have a dag that creates a cluster, runs a query, and deletes the clu
 
   create_cluster >> run_query >> delete_cluster
 
-We can use the ``as_teardown`` let airflow know that ``create_cluster`` is a setup task and ``delete_cluster`` is its teardown:
+To enable create_cluster and delete_cluster as setup and teardown tasks, we mark them as such methods ``as_setup`` and ``as_teardown`` and add an upstream / downstream relationship between them:
+
+
+.. code-block:: python
+
+  create_cluster.as_setup() >> run_query >> delete_cluster.as_teardown()
+  create_cluster >> delete_cluster
+
+For convenience we can do this in one line by passing ``create_cluster`` to the ``as_teardown`` method:
 
 .. code-block:: python
 
@@ -523,9 +534,9 @@ Observations:
 Setup "scope"
 """""""""""""
 
-We require that a setup always have a teardown in order to have a well-defined scope. If you wish to only add a teardown task or only a setup task, you may use EmptyOperator as your "empty setup" or "empty teardown".
+Tasks between a setup and its teardown are in the "scope" of the setup / teardown pair.  We require that a setup always have a teardown in order to have a well-defined scope. If you wish to only add a teardown task or only a setup task, you may use EmptyOperator as your "empty setup" or "empty teardown".
 
-The "scope" of a setup will be determined by where the teardown is.  Tasks between a setup and its teardown are in the "scope" of the setup / teardown pair. Example:
+Let's look at an example:
 
 .. code-block:: python
 
@@ -602,6 +613,8 @@ This is equivalent to the following:
 
     s >> a() >> t.as_teardown(setups=s)
     s >> b() >> c() >> t
+
+Passing data between setup, teardown, and normal task
 
 Dynamic DAGs
 ------------

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -489,7 +489,7 @@ You can also combine this with the :ref:`concepts:depends-on-past` functionality
 Setup and Teardown
 ~~~~~~~~~~~~~~~~~~
 
-In data workflows it's common to create resources (such as a compute resource), use it to do some work, and then tear it down. Airflow provides setup and teardown tasks to support this need.
+In data workflows it's common to create a resource (such as a compute resource), use it to do some work, and then tear it down. Airflow provides setup and teardown tasks to support this need.
 
 Key features of setup and teardown tasks:
 

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -301,7 +301,7 @@ By default, a DAG will only run a Task when all the Tasks it depends on are succ
 
 * :ref:`concepts:branching` - select which Task to move onto based on a condition
 * :ref:`concepts:trigger-rules` - set the conditions under which a DAG will run a task.
-* :ref:`concepts:setup-and-teardown` - define setup and teardown relationships
+* :doc:`howto/setup-and-teardown` - define setup and teardown relationships
 * :ref:`concepts:latest-only` - a special form of branching that only runs on DAGs running against the present
 * :ref:`concepts:depends-on-past` - tasks can depend on themselves *from a previous run*
 
@@ -484,154 +484,12 @@ You can also combine this with the :ref:`concepts:depends-on-past` functionality
     .. image:: /img/branch_with_trigger.png
 
 
-.. _concepts:setup-and-teardown:
-
-Setup and Teardown
-~~~~~~~~~~~~~~~~~~
+Setup and teardown
+------------------
 
 In data workflows it's common to create a resource (such as a compute resource), use it to do some work, and then tear it down. Airflow provides setup and teardown tasks to support this need.
 
-Key features of setup and teardown tasks:
-
-  * If you clear a task, its setups and teardowns will be cleared.
-  * By default, teardown tasks are ignored for the purpose of evaluating dag run state.
-  * A teardown task will run if its setup was successful, even if its work tasks failed.
-  * Teardown tasks are ignored when setting dependencies against task groups.
-  * A setup task must always have a teardown and vice versa. You may use EmptyOperator as a setup or teardown.
-
-How setup and teardown works
-""""""""""""""""""""""""""""
-
-Basic usage
-"""""""""""
-
-Suppose you have a dag that creates a cluster, runs a query, and deletes the cluster. Without using setup and teardown tasks you might set these relationships:
-
-.. code-block:: python
-
-  create_cluster >> run_query >> delete_cluster
-
-To enable create_cluster and delete_cluster as setup and teardown tasks, we mark them as such methods ``as_setup`` and ``as_teardown`` and add an upstream / downstream relationship between them:
-
-.. code-block:: python
-
-  create_cluster.as_setup() >> run_query >> delete_cluster.as_teardown()
-  create_cluster >> delete_cluster
-
-For convenience we can do this in one line by passing ``create_cluster`` to the ``as_teardown`` method:
-
-.. code-block:: python
-
-  create_cluster >> run_query >> delete_cluster.as_teardown(setups=create_cluster)
-
-Additionally, if we have multiple tasks to wrap, we can use the teardown as a context manager:
-
-.. code-block:: python
-
-  with delete_cluster.as_teardown(setups=create_cluster):
-      [RunQueryOne(), RunQueryTwo()] >> DoSomeOtherStuff()
-      WorkOne() >> [do_this_stuff(), do_other_stuff()]
-
-This will set create_cluster to run before the tasks in the context, and delete_cluster after them.
-
-Note that if you are attempting to add an already-instantiated task to a setup context you need to do it explicitly:
-
-.. code-block:: python
-
-  with my_teardown_task as scope:
-      scope.add_task(work_task)  # work_task was already instantiated elsewhere
-
-Observations:
-
-  * If you clear ``run_query`` to run it again, then both ``create_cluster`` and ``delete_cluster`` will be cleared.
-  * If ``run_query`` fails, then ``delete_cluster`` will still run.
-  * The success of the dag run will depend *only* on the success of ``run_query``.
-
-Setup "scope"
-"""""""""""""
-
-Tasks between a setup and its teardown are in the "scope" of the setup / teardown pair.  We require that a setup always have a teardown in order to have a well-defined scope. If you wish to only add a teardown task or only a setup task, you may use EmptyOperator as your "empty setup" or "empty teardown".
-
-Let's look at an example:
-
-.. code-block:: python
-
-    s1 >> w1 >> w2 >> t1.as_teardown(setups=s1) >> w3
-    w2 >> w4
-
-In the above example, ``w1`` and ``w2`` are "between" ``s1`` and ``t1`` and therefore are assumed to require ``s1``. Thus if ``w1`` or ``w2`` is cleared, so too will be ``s1`` and ``t1``.  But if ``w3`` or ``w4`` is cleared, neither ``s1`` nor ``t1`` will be cleared.
-
-You can have multiple setup tasks wired to a single teardown.  The teardown will run if at least one of the setups completed successfully.
-
-Controlling dag run state
-"""""""""""""""""""""""""
-
-Another feature of setup / teardown tasks is you can choose whether or not the teardown task should have an impact on dag run state.  Perhaps you don't care if the "cleanup" work performed by your teardown task fails, and you only consider the dag run a failure if the "work" tasks fail.  By default, teardown tasks are not considered for dag run state.
-
-Continuing with the example above, if you want the run's success to depend on ``delete_cluster``, then set``on_failure_fail_dagrun=True`` when setting ``delete_cluster`` as teardown. For example:
-
-.. code-block:: python
-
-  create_cluster >> run_query >> delete_cluster.as_teardown(setups=create_cluster, on_failure_fail_dagrun=True)
-
-Authoring with task groups
-""""""""""""""""""""""""""
-
-When arrowing from task group to task group, or from task group to task, we ignore teardowns.  This allows teardowns to run in parallel, and allows dag execution to proceed even if teardown tasks fail.
-
-Consider this example:
-
-.. code-block:: python
-
-    with TaskGroup("my_group") as tg:
-        s1 = my_setup()
-        w1 = my_work()
-        t1 = my_teardown()
-        s1 >> w1 >> t1.as_teardown(setups=s1)
-    w2 = other_work()
-    tg >> w2
-
-If ``t1`` were not a teardown task, then this dag would effectively be ``s1 >> w1 >> t1 >> w2``.  But since we have marked ``t1`` as a teardown, it's ignored in ``tg >> w2``.  So the dag is equivalent to the following:
-
-.. code-block:: python
-
-    s1 >> w1 >> [t1.as_teardown(setups=s1), w2]
-
-Now let's consider an example with nesting:
-
-.. code-block:: python
-
-    with TaskGroup("my_group") as tg:
-        s1 = my_setup()
-        w1 = my_work()
-        t1 = my_teardown()
-        s1 >> w1 >> t1.as_teardown(setups=s1)
-    w2 = other_work()
-    tg >> w2
-    dag_s1 = dag_setup1()
-    dag_t1 = dag_teardown1()
-    dag_s1 >> [tg, w2] >> dag_t1.as_teardown(dag_s1)
-
-In this example ``s1`` is downstream of ``dag_s1``, so it must wait for ``dag_s1`` to complete successfully.  But ``t1`` and ``dag_t1`` can run concurrently, because ``t1`` is ignored in the expression ``tg >> dag_t1``.  If you clear ``w2``, it will clear ``dag_s1`` and ``dag_t1``, but not anything in the task group.
-
-Running setups and teardowns in parallel
-""""""""""""""""""""""""""""""""""""""""
-
-You can run setup tasks in parallel:
-
-.. code-block:: python
-
-    (
-        [create_cluster, create_bucket]
-        >> run_query
-        >> [delete_cluster.as_teardown(setups=create_cluster), delete_bucket.as_teardown(setups=create_bucket)]
-    )
-
-When a setup fails or is skipped
-""""""""""""""""""""""""""""""""
-
-If a setup fails, its downstreams are failed, though with a non-teardown downstream tasks, you can override this behavior with trigger rules.  When a setup is skipped, its downstreams are skipped.
-
+Please see main article :doc:`howto/setup-and-teardown` for details on how to use this feature.
 
 
 Dynamic DAGs

--- a/docs/apache-airflow/howto/index.rst
+++ b/docs/apache-airflow/howto/index.rst
@@ -45,6 +45,7 @@ configuring an Airflow environment.
     export-more-env-vars
     connection
     variable
+    setup-and-teardown
     run-behind-proxy
     run-with-systemd
     use-test-config

--- a/docs/apache-airflow/howto/setup-and-teardown.rst
+++ b/docs/apache-airflow/howto/setup-and-teardown.rst
@@ -53,6 +53,12 @@ For convenience we can do this in one line by passing ``create_cluster`` to the 
 
   create_cluster >> run_query >> delete_cluster.as_teardown(setups=create_cluster)
 
+Observations:
+
+  * If you clear ``run_query`` to run it again, then both ``create_cluster`` and ``delete_cluster`` will be cleared.
+  * If ``run_query`` fails, then ``delete_cluster`` will still run.
+  * The success of the dag run will depend *only* on the success of ``run_query``.
+
 Additionally, if we have multiple tasks to wrap, we can use the teardown as a context manager:
 
 .. code-block:: python
@@ -69,12 +75,6 @@ Note that if you are attempting to add an already-instantiated task to a setup c
 
   with my_teardown_task as scope:
       scope.add_task(work_task)  # work_task was already instantiated elsewhere
-
-Observations:
-
-  * If you clear ``run_query`` to run it again, then both ``create_cluster`` and ``delete_cluster`` will be cleared.
-  * If ``run_query`` fails, then ``delete_cluster`` will still run.
-  * The success of the dag run will depend *only* on the success of ``run_query``.
 
 Setup "scope"
 """""""""""""

--- a/docs/apache-airflow/howto/setup-and-teardown.rst
+++ b/docs/apache-airflow/howto/setup-and-teardown.rst
@@ -1,0 +1,162 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Setup and Teardown
+~~~~~~~~~~~~~~~~~~
+
+In data workflows it's common to create a resource (such as a compute resource), use it to do some work, and then tear it down. Airflow provides setup and teardown tasks to support this need.
+
+Key features of setup and teardown tasks:
+
+  * If you clear a task, its setups and teardowns will be cleared.
+  * By default, teardown tasks are ignored for the purpose of evaluating dag run state.
+  * A teardown task will run if its setup was successful, even if its work tasks failed.
+  * Teardown tasks are ignored when setting dependencies against task groups.
+  * A setup task must always have a teardown and vice versa. You may use EmptyOperator as a setup or teardown.
+
+How setup and teardown works
+""""""""""""""""""""""""""""
+
+Basic usage
+"""""""""""
+
+Suppose you have a dag that creates a cluster, runs a query, and deletes the cluster. Without using setup and teardown tasks you might set these relationships:
+
+.. code-block:: python
+
+  create_cluster >> run_query >> delete_cluster
+
+To enable create_cluster and delete_cluster as setup and teardown tasks, we mark them as such methods ``as_setup`` and ``as_teardown`` and add an upstream / downstream relationship between them:
+
+.. code-block:: python
+
+  create_cluster.as_setup() >> run_query >> delete_cluster.as_teardown()
+  create_cluster >> delete_cluster
+
+For convenience we can do this in one line by passing ``create_cluster`` to the ``as_teardown`` method:
+
+.. code-block:: python
+
+  create_cluster >> run_query >> delete_cluster.as_teardown(setups=create_cluster)
+
+Additionally, if we have multiple tasks to wrap, we can use the teardown as a context manager:
+
+.. code-block:: python
+
+  with delete_cluster.as_teardown(setups=create_cluster):
+      [RunQueryOne(), RunQueryTwo()] >> DoSomeOtherStuff()
+      WorkOne() >> [do_this_stuff(), do_other_stuff()]
+
+This will set create_cluster to run before the tasks in the context, and delete_cluster after them.
+
+Note that if you are attempting to add an already-instantiated task to a setup context you need to do it explicitly:
+
+.. code-block:: python
+
+  with my_teardown_task as scope:
+      scope.add_task(work_task)  # work_task was already instantiated elsewhere
+
+Observations:
+
+  * If you clear ``run_query`` to run it again, then both ``create_cluster`` and ``delete_cluster`` will be cleared.
+  * If ``run_query`` fails, then ``delete_cluster`` will still run.
+  * The success of the dag run will depend *only* on the success of ``run_query``.
+
+Setup "scope"
+"""""""""""""
+
+Tasks between a setup and its teardown are in the "scope" of the setup / teardown pair.  We require that a setup always have a teardown in order to have a well-defined scope. If you wish to only add a teardown task or only a setup task, you may use EmptyOperator as your "empty setup" or "empty teardown".
+
+Let's look at an example:
+
+.. code-block:: python
+
+    s1 >> w1 >> w2 >> t1.as_teardown(setups=s1) >> w3
+    w2 >> w4
+
+In the above example, ``w1`` and ``w2`` are "between" ``s1`` and ``t1`` and therefore are assumed to require ``s1``. Thus if ``w1`` or ``w2`` is cleared, so too will be ``s1`` and ``t1``.  But if ``w3`` or ``w4`` is cleared, neither ``s1`` nor ``t1`` will be cleared.
+
+You can have multiple setup tasks wired to a single teardown.  The teardown will run if at least one of the setups completed successfully.
+
+Controlling dag run state
+"""""""""""""""""""""""""
+
+Another feature of setup / teardown tasks is you can choose whether or not the teardown task should have an impact on dag run state.  Perhaps you don't care if the "cleanup" work performed by your teardown task fails, and you only consider the dag run a failure if the "work" tasks fail.  By default, teardown tasks are not considered for dag run state.
+
+Continuing with the example above, if you want the run's success to depend on ``delete_cluster``, then set``on_failure_fail_dagrun=True`` when setting ``delete_cluster`` as teardown. For example:
+
+.. code-block:: python
+
+  create_cluster >> run_query >> delete_cluster.as_teardown(setups=create_cluster, on_failure_fail_dagrun=True)
+
+Authoring with task groups
+""""""""""""""""""""""""""
+
+When arrowing from task group to task group, or from task group to task, we ignore teardowns.  This allows teardowns to run in parallel, and allows dag execution to proceed even if teardown tasks fail.
+
+Consider this example:
+
+.. code-block:: python
+
+    with TaskGroup("my_group") as tg:
+        s1 = my_setup()
+        w1 = my_work()
+        t1 = my_teardown()
+        s1 >> w1 >> t1.as_teardown(setups=s1)
+    w2 = other_work()
+    tg >> w2
+
+If ``t1`` were not a teardown task, then this dag would effectively be ``s1 >> w1 >> t1 >> w2``.  But since we have marked ``t1`` as a teardown, it's ignored in ``tg >> w2``.  So the dag is equivalent to the following:
+
+.. code-block:: python
+
+    s1 >> w1 >> [t1.as_teardown(setups=s1), w2]
+
+Now let's consider an example with nesting:
+
+.. code-block:: python
+
+    with TaskGroup("my_group") as tg:
+        s1 = my_setup()
+        w1 = my_work()
+        t1 = my_teardown()
+        s1 >> w1 >> t1.as_teardown(setups=s1)
+    w2 = other_work()
+    tg >> w2
+    dag_s1 = dag_setup1()
+    dag_t1 = dag_teardown1()
+    dag_s1 >> [tg, w2] >> dag_t1.as_teardown(dag_s1)
+
+In this example ``s1`` is downstream of ``dag_s1``, so it must wait for ``dag_s1`` to complete successfully.  But ``t1`` and ``dag_t1`` can run concurrently, because ``t1`` is ignored in the expression ``tg >> dag_t1``.  If you clear ``w2``, it will clear ``dag_s1`` and ``dag_t1``, but not anything in the task group.
+
+Running setups and teardowns in parallel
+""""""""""""""""""""""""""""""""""""""""
+
+You can run setup tasks in parallel:
+
+.. code-block:: python
+
+    (
+        [create_cluster, create_bucket]
+        >> run_query
+        >> [delete_cluster.as_teardown(setups=create_cluster), delete_bucket.as_teardown(setups=create_bucket)]
+    )
+
+When a setup fails or is skipped
+""""""""""""""""""""""""""""""""
+
+If a setup fails, its downstreams are failed, though with a non-teardown downstream tasks, you can override this behavior with trigger rules.  When a setup is skipped, its downstreams are skipped.

--- a/docs/apache-airflow/howto/setup-and-teardown.rst
+++ b/docs/apache-airflow/howto/setup-and-teardown.rst
@@ -78,7 +78,7 @@ Note that if you are attempting to add an already-instantiated task to a setup c
 Setup "scope"
 """""""""""""
 
-Tasks between a setup and its teardown are in the "scope" of the setup / teardown pair.  We require that a setup always have a teardown in order to have a well-defined scope. If you wish to only add a teardown task or only a setup task, you may use EmptyOperator as your "empty setup" or "empty teardown".
+Tasks between a setup and its teardown are in the "scope" of the setup / teardown pair.
 
 Let's look at an example:
 

--- a/docs/apache-airflow/howto/setup-and-teardown.rst
+++ b/docs/apache-airflow/howto/setup-and-teardown.rst
@@ -15,6 +15,8 @@
     specific language governing permissions and limitations
     under the License.
 
+.. _howto:setup-and-teardown:
+
 Setup and Teardown
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/apache-airflow/howto/setup-and-teardown.rst
+++ b/docs/apache-airflow/howto/setup-and-teardown.rst
@@ -15,8 +15,6 @@
     specific language governing permissions and limitations
     under the License.
 
-.. _howto:setup-and-teardown:
-
 Setup and Teardown
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1599,6 +1599,7 @@ Upsert
 upsert
 upserts
 Upsight
+upstreams
 Uptime
 uri
 uris

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1493,6 +1493,7 @@ tblproperties
 TCP
 tcp
 teardown
+teardowns
 templatable
 templateable
 Templated

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -481,6 +481,7 @@ Dont
 DOS'ing
 DownloadReportV
 downscaling
+downstreams
 Drillbit
 Drivy
 dropdown


### PR DESCRIPTION
Add basic docs for setup / teardown tasks.

~One bit of uncertainty is whether, by the time this is released, we'll still require setups have a teardown and vice versa.  I.e. if you want to have a setup with no teardown, you have to add an empty teardown, e.g. with the empty operator.   Alternatively we could just say that if a setup has no teardown, all its downstreams are assumed to require it a.k.a. assumed to be within scope.  I think either way is pretty much fine, but for now we require empty teardown.~
Ok, raised "empty teardown" question, on the list, so for now we simply move forward with requiring empty teardown.  Conveniently, it's a constraint we could remove without breaking backcompat.
