### PR TITLE
feat: allow creating unique pod name from task_instance.job_id

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -156,6 +156,7 @@ class KubernetesPodOperator(BaseOperator):
         suffix if random_name_suffix is True) to generate a pod id (DNS-1123 subdomain,
         containing only [a-z0-9.-]).
     :param random_name_suffix: if True, will generate a random suffix.
+    :param job_id_as_suffix: if True, will add ti.job_id to the pod name.
     :param cmds: entrypoint of the container. (templated)
         The docker images's entrypoint is used if this is not provided.
     :param arguments: arguments of the entrypoint. (templated)
@@ -257,6 +258,7 @@ class KubernetesPodOperator(BaseOperator):
         image: str | None = None,
         name: str | None = None,
         random_name_suffix: bool = True,
+        job_id_as_suffix: bool = False,
         cmds: list[str] | None = None,
         arguments: list[str] | None = None,
         ports: list[k8s.V1ContainerPort] | None = None,
@@ -369,6 +371,7 @@ class KubernetesPodOperator(BaseOperator):
         self.pod_template_file = pod_template_file
         self.name = self._set_name(name)
         self.random_name_suffix = random_name_suffix
+        self.job_id_as_suffix = job_id_as_suffix
         self.termination_grace_period = termination_grace_period
         self.pod_request_obj: k8s.V1Pod | None = None
         self.pod: k8s.V1Pod | None = None
@@ -832,6 +835,8 @@ class KubernetesPodOperator(BaseOperator):
             pod.metadata.name = _create_pod_id(
                 task_id=self.task_id, unique=self.random_name_suffix, max_length=80
             )
+        elif self.job_id_as_suffix:
+            pod.metadata.name = pod.metadata.name + "-{{ ti.job.id }}"
         elif self.random_name_suffix:
             # user has supplied pod name, we're just adding suffix
             pod.metadata.name = _add_pod_suffix(pod_name=pod.metadata.name)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR provides support for creating unique but sensible names to k8s pods based on the job_id which is an incremental unique identifier for tasks run in a DAG. The KubernetesPodOperator supports adding random suffix but that isn't suitable for our use case, where the pod name needs to be provided to Spark executor that are launched by the k8s pod. The random suffix can't be templated and isn't available via DAG context.

The background for this is need to run Spark tasks in k8s. In order to allow using the preferred `client` mode, the pod name needs to be given to spark so that driver-executor communication can take place via a headless k8s service. This requires that the name of the (driver) pod is unique and known at the time the pod is created. The `task_instance.job_id` seems to be a good way to make pod names unique and is available via pod context when pod is created.

The change adds a new argument `job_id_as_suffix` to the `KubernetesPodOperator` class with a backwards compatible default to `random_suffix`. In case `job_id_as_suffix=True` and `random_name_suffix=False`, the `ti.job_id` value will be appended to the pod name, separated by `-`. The same value can then be provided to spark configuration to use as the driver hostname for the headless service. The additional pod configurations can use the normal Airflow templating system.

We considered using the  Spark k8s operator in https://github.com/GoogleCloudPlatform/spark-on-k8s-operator but that only supports cluster mode and has not been updated for a while. We have experience in running Spark on k8s with client mode and have found it very useful. This PR will allow using Spark client mode on k8s more easily.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
