### PR TITLE
Add config to disable the 'deserialize' XCom API flag

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1178,6 +1178,15 @@ api:
       version_added: 2.2.0
       example: ~
       default: ""
+    enable_xcom_deserialize_support:
+      description: |
+        Indicates whether the *xcomEntries* endpoint supports the *deserialize*
+        flag. If set to False, setting this flag in a request would result in a
+        400 Bad Request error.
+      type: boolean
+      version_added: 2.7.0
+      example: ~
+      default: "False"
 lineage:
   description: ~
   options:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -640,6 +640,11 @@ access_control_allow_methods =
 # Separate URLs with space.
 access_control_allow_origins =
 
+# Indicates whether the *xcomEntries* endpoint supports the *deserialize*
+# flag. If set to False, setting this flag in a request would result in a
+# 400 Bad Request error.
+enable_xcom_deserialize_support = False
+
 [lineage]
 # what lineage backend to use
 backend =

--- a/newsfragments/32176.significant.rst
+++ b/newsfragments/32176.significant.rst
@@ -1,0 +1,10 @@
+The ``xcomEntries`` API disables support for the ``deserialize`` flag by default
+
+For security reasons, the ``/dags/*/dagRuns/*/taskInstances/*/xcomEntries/*``
+API endpoint now disables the ``deserialize`` option to deserialize arbitrary
+XCom values in the webserver. For backward compatibility, server admins may set
+the ``[api] enable_xcom_deserialize_support`` config to *True* to enable the
+flag and restore backward compatibility.
+
+However, it is strongly advised to **not** enable the feature, and perform
+deserialization at the client side instead.


### PR DESCRIPTION
This is a spiritual successor to #27740. Instead of removing the feature outright, a config is added to disable the feature by default. This provides an escape hatch to users that really need this.