### PR TITLE
Allow to sort Grid View alphabetically

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1545,6 +1545,13 @@ webserver:
       type: string
       example: ~
       default: "LR"
+    grid_view_sorting_order:
+      description: |
+        Sorting order in grid view. Valid values are: ``topological``, ``hierarchical_alphabetical``
+      version_added: 2.7.0
+      type: string
+      example: ~
+      default: "topological"
     log_fetch_timeout_sec:
       description: |
         The amount of time (in secs) webserver will wait for initial handshake

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -810,6 +810,9 @@ dag_default_view = grid
 # ``LR`` (Left->Right), ``TB`` (Top->Bottom), ``RL`` (Right->Left), ``BT`` (Bottom->Top)
 dag_orientation = LR
 
+# Sorting order in grid view. Valid values are: ``topological``, ``hierarchical_alphabetical``
+grid_view_sorting_order = topological
+
 # The amount of time (in secs) webserver will wait for initial handshake
 # while fetching logs from other worker machine
 log_fetch_timeout_sec = 5

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -26,7 +26,6 @@ import functools
 import operator
 import re
 import weakref
-from functools import cmp_to_key
 from typing import TYPE_CHECKING, Any, Generator, Iterator, Sequence
 
 from airflow.compat.functools import cache
@@ -447,20 +446,9 @@ class TaskGroup(DAGNode):
 
         :return: list of tasks in hierarchical alphabetical order
         """
-
-        def compare_str(a: str, b: str) -> int:
-            return (a > b) - (a < b)
-
-        def compare(a: DAGNode, b: DAGNode) -> int:
-            is_a_group = isinstance(a, TaskGroup)
-            is_b_group = isinstance(b, TaskGroup)
-            if is_a_group == is_b_group:
-                return compare_str(a.node_id, b.node_id)
-            if is_a_group:
-                return -1
-            return 1
-
-        return sorted(self.children.values(), key=cmp_to_key(compare))
+        return sorted(
+            self.children.values(), key=lambda node: (not isinstance(node, TaskGroup), node.node_id)
+        )
 
     def topological_sort(self, _include_subdag_tasks: bool = False):
         """

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -1175,6 +1175,48 @@ def test_topological_nested_groups():
     ]
 
 
+def test_hierarchical_alphabetical_sort():
+    execution_date = pendulum.parse("20200101")
+    with DAG("test_dag_edges", start_date=execution_date) as dag:
+        task1 = EmptyOperator(task_id="task1")
+        task5 = EmptyOperator(task_id="task5")
+        with TaskGroup("group_c"):
+            task7 = EmptyOperator(task_id="task7")
+        with TaskGroup("group_b"):
+            task6 = EmptyOperator(task_id="task6")
+        with TaskGroup("group_a"):
+            with TaskGroup("group_d"):
+                task2 = EmptyOperator(task_id="task2")
+                task3 = EmptyOperator(task_id="task3")
+                task4 = EmptyOperator(task_id="task4")
+            task9 = EmptyOperator(task_id="task9")
+            task8 = EmptyOperator(task_id="task8")
+
+    def nested(group):
+        return [
+            nested(node) if isinstance(node, TaskGroup) else node
+            for node in group.hierarchical_alphabetical_sort()
+        ]
+
+    sorted_list = nested(dag.task_group)
+
+    assert sorted_list == [
+        [  # group_a
+            [  # group_d
+                task2,
+                task3,
+                task4,
+            ],
+            task8,
+            task9,
+        ],
+        [task6],  # group_b
+        [task7],  # group_c
+        task1,
+        task5,
+    ]
+
+
 def test_topological_group_dep():
     execution_date = pendulum.parse("20200101")
     with DAG("test_dag_edges", start_date=execution_date) as dag:


### PR DESCRIPTION
If DAG is big the existing `topological_sort` is hard to understand and navigate. At some level alphabetical sort is more important than counting for the dependencies.

Also, this sorting keeps the groups first. So it's easier to find the specific group to expand.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
