### PR TITLE
D205 Support - Executors

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -82,10 +82,7 @@ class RunningRetryAttemptType:
         return (pendulum.now("UTC") - self.first_attempt_time).total_seconds()
 
     def can_try_again(self):
-        """
-        If there has been at least one try greater than MIN_SECONDS after first attempt,
-        then return False.  Otherwise, return True.
-        """
+        """Return False if there has been at least one try greater than MIN_SECONDS, otherwise return True."""
         if self.tries_after_min > 0:
             return False
 
@@ -100,11 +97,9 @@ class RunningRetryAttemptType:
 
 class BaseExecutor(LoggingMixin):
     """
-    Class to derive in order to implement concrete executors.
-    Such as, Celery, Kubernetes, Local, Sequential and the likes.
+    Base class to inherit for concrete executors such as Celery, Kubernetes, Local, Sequential, etc.
 
-    :param parallelism: how many jobs should run at one time. Set to
-        ``0`` for infinity.
+    :param parallelism: how many jobs should run at one time. Set to ``0`` for infinity.
     """
 
     supports_ad_hoc_ti_run: bool = False
@@ -201,6 +196,7 @@ class BaseExecutor(LoggingMixin):
     def sync(self) -> None:
         """
         Sync will get called periodically by the heartbeat method.
+
         Executors should override this to perform gather statuses.
         """
 
@@ -390,6 +386,7 @@ class BaseExecutor(LoggingMixin):
     def cleanup_stuck_queued_tasks(self, tis: list[TaskInstance]) -> list[str]:  # pragma: no cover
         """
         Handle remnants of tasks that were failed because they were stuck in queued.
+
         Tasks can get stuck in queued. If such a task is detected, it will be marked
         as `UP_FOR_RETRY` if the task instance has remaining retries or marked as `FAILED`
         if it doesn't.

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -295,6 +295,7 @@ class CeleryExecutor(BaseExecutor):
     def cleanup_stuck_queued_tasks(self, tis: list[TaskInstance]) -> list[str]:
         """
         Handle remnants of tasks that were failed because they were stuck in queued.
+
         Tasks can get stuck in queued. If such a task is detected, it will be marked
         as `UP_FOR_RETRY` if the task instance has remaining retries or marked as `FAILED`
         if it doesn't.

--- a/airflow/executors/celery_executor_utils.py
+++ b/airflow/executors/celery_executor_utils.py
@@ -16,6 +16,7 @@
 # under the License.
 """
 Utilities and classes used by the Celery Executor.
+
 Much of this code is expensive to import/load, be careful where this module is imported.
 """
 

--- a/airflow/executors/celery_kubernetes_executor.py
+++ b/airflow/executors/celery_kubernetes_executor.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 class CeleryKubernetesExecutor(LoggingMixin):
     """
     CeleryKubernetesExecutor consists of CeleryExecutor and KubernetesExecutor.
+
     It chooses an executor to use based on the queue defined on the task.
     When the queue is the value of ``kubernetes_queue`` in section ``[celery_kubernetes_executor]``
     of the configuration (default value: `kubernetes`), KubernetesExecutor is selected to run the task,

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -432,12 +432,9 @@ class AirflowKubernetesScheduler(LoggingMixin):
 
     def sync(self) -> None:
         """
-        The sync function checks the status of all currently running kubernetes jobs.
-        If a job is completed, its status is placed in the result queue to
-        be sent back to the scheduler.
+        Checks the status of all currently running kubernetes jobs.
 
-        :return:
-
+        If a job is completed, its status is placed in the result queue to be sent back to the scheduler.
         """
         self.log.debug("Syncing KubernetesExecutor")
         self._health_check_kube_watchers()
@@ -880,6 +877,7 @@ class KubernetesExecutor(BaseExecutor):
     def cleanup_stuck_queued_tasks(self, tis: list[TaskInstance]) -> list[str]:
         """
         Handle remnants of tasks that were failed because they were stuck in queued.
+
         Tasks can get stuck in queued. If such a task is detected, it will be marked
         as `UP_FOR_RETRY` if the task instance has remaining retries or marked as `FAILED`
         if it doesn't.

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -203,8 +203,8 @@ class QueuedLocalWorker(LocalWorkerBase):
 class LocalExecutor(BaseExecutor):
     """
     LocalExecutor executes tasks locally in parallel.
-    It uses the multiprocessing Python library and queues to parallelize the execution
-    of tasks.
+
+    It uses the multiprocessing Python library and queues to parallelize the execution of tasks.
 
     :param parallelism: how many parallel processes are run in the executor
     """

--- a/airflow/executors/local_kubernetes_executor.py
+++ b/airflow/executors/local_kubernetes_executor.py
@@ -33,8 +33,8 @@ if TYPE_CHECKING:
 
 class LocalKubernetesExecutor(LoggingMixin):
     """
-    LocalKubernetesExecutor consists of LocalExecutor and KubernetesExecutor.
-    It chooses the executor to use based on the queue defined on the task.
+    Chooses between LocalExecutor and KubernetesExecutor based on the queue defined on the task.
+
     When the task's queue is the value of ``kubernetes_queue`` in section ``[local_kubernetes_executor]``
     of the configuration (default value: `kubernetes`), KubernetesExecutor is selected to run the task,
     otherwise, LocalExecutor is used.


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/10742

D205 asserts that all docstrings must have a one-line summary ending in a period.  If there is more than one sentence then there must be a blank line before the rest of the docstring.  Meeting these requirements could be as simple as adding a newline, or might require some rephrasing.

There are almost a thousand violations in the repo so we're going to have to take this in bites.

### Included in this chunk

All files related to Executors should be included in this batch.

### To test

If you comment out [this line](https://github.com/apache/airflow/blob/main/pyproject.toml#L68) and run pre-commit in main you will get around 937 errors.  After these changes, "only" 926 remain and none of the files in `airflow/executors` or similar locations should be on the list.  After uncommenting that line and rerunning pre-commits, there should be zero regressions. 


((...take one down, pass it around.... ))