### PR TITLE
fix bugged singleton implementation

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -53,6 +53,7 @@ from airflow.kubernetes.pod_generator import PodGenerator
 from airflow.utils.event_scheduler import EventScheduler
 from airflow.utils.log.logging_mixin import LoggingMixin, remove_escape_codes
 from airflow.utils.session import NEW_SESSION, provide_session
+from airflow.utils.singleton import Singleton
 from airflow.utils.state import State, TaskInstanceState
 
 if TYPE_CHECKING:
@@ -73,16 +74,10 @@ ALL_NAMESPACES = "ALL_NAMESPACES"
 POD_EXECUTOR_DONE_KEY = "airflow_executor_done"
 
 
-class ResourceVersion:
+class ResourceVersion(metaclass=Singleton):
     """Singleton for tracking resourceVersion from Kubernetes."""
 
-    _instance: ResourceVersion | None = None
     resource_version: dict[str, str] = {}
-
-    def __new__(cls):
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-        return cls._instance
 
 
 class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -39,6 +39,7 @@ from airflow.utils import yaml
 from airflow.utils.entry_points import entry_points_with_dist
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.module_loading import import_string
+from airflow.utils.singleton import Singleton
 
 log = logging.getLogger(__name__)
 
@@ -355,7 +356,7 @@ def provider_info_cache(cache_name: str) -> Callable[[T], T]:
     return provider_info_cache_decorator
 
 
-class ProvidersManager(LoggingMixin):
+class ProvidersManager(LoggingMixin, metaclass=Singleton):
     """
     Manages all provider packages.
 
@@ -364,13 +365,7 @@ class ProvidersManager(LoggingMixin):
     local source folders (if airflow is run from sources).
     """
 
-    _instance = None
     resource_version = "0"
-
-    def __new__(cls):
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-        return cls._instance
 
     def __init__(self):
         """Initializes the manager."""

--- a/airflow/utils/singleton.py
+++ b/airflow/utils/singleton.py
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+
+class Singleton(type):
+    """Metaclass that allows to implement singleton pattern."""
+
+    _instances: dict = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+        return cls._instances[cls]

--- a/airflow/utils/singleton.py
+++ b/airflow/utils/singleton.py
@@ -17,13 +17,17 @@
 # under the License.
 from __future__ import annotations
 
+from typing import Generic, TypeVar
 
-class Singleton(type):
+T = TypeVar("T")
+
+
+class Singleton(type, Generic[T]):
     """Metaclass that allows to implement singleton pattern."""
 
-    _instances: dict = {}
+    _instances: dict[Singleton[T], T] = {}
 
-    def __call__(cls, *args, **kwargs):
+    def __call__(cls: Singleton[T], *args, **kwargs) -> T:
         if cls not in cls._instances:
             cls._instances[cls] = super().__call__(*args, **kwargs)
         return cls._instances[cls]

--- a/tests/always/test_providers_manager.py
+++ b/tests/always/test_providers_manager.py
@@ -36,6 +36,11 @@ class TestProviderManager:
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
+    @pytest.fixture(autouse=True, scope="function")
+    def clean(self):
+        """The tests depend on a clean state of a ProvidersManager."""
+        ProvidersManager().__init__()
+
     def test_providers_are_loaded(self):
         with self._caplog.at_level(logging.WARNING):
             provider_manager = ProvidersManager()

--- a/tests/utils/test_singleton.py
+++ b/tests/utils/test_singleton.py
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.utils.singleton import Singleton
+
+
+class A(metaclass=Singleton):
+    pass
+
+
+def test_singleton_refers_to_same_instance():
+    a, b = A(), A()
+    assert a == b
+
+
+def test_singleton_out_of_context_does_refer_to_same_instance():
+    def x():
+        a = A()
+        a.a = "a"
+
+    x()
+    b = A()
+    assert b.a == "a"

--- a/tests/utils/test_singleton.py
+++ b/tests/utils/test_singleton.py
@@ -23,12 +23,25 @@ class A(metaclass=Singleton):
     pass
 
 
+class Counter(metaclass=Singleton):
+    """Singleton class that counts how much __init__ and count was called."""
+
+    counter = 0
+
+    def __init__(self):
+        self.counter += 1
+
+    def count(self):
+        self.counter += 1
+
+
 def test_singleton_refers_to_same_instance():
     a, b = A(), A()
-    assert a == b
+    assert a is b
 
 
-def test_singleton_out_of_context_does_refer_to_same_instance():
+def test_singleton_after_out_of_context_does_refer_to_same_instance():
+    # check if setting something on singleton is preserved after instance goes out of context
     def x():
         a = A()
         a.a = "a"
@@ -36,3 +49,17 @@ def test_singleton_out_of_context_does_refer_to_same_instance():
     x()
     b = A()
     assert b.a == "a"
+
+
+def test_singleton_does_not_call_init_second_time():
+    # first creation of Counter, check if __init__ is called
+    c = Counter()
+    assert c.counter == 1
+
+    # check if "new instance" calls __init__ - it shouldn't
+    d = Counter()
+    assert c.counter == 1
+
+    # check if incrementing "new instance" increments counter on previous one
+    d.count()
+    assert c.counter == 2


### PR DESCRIPTION
Singleton implementation using overloaded `__new__` did not work - it always called init on instance creation.

> If [__new__()](https://docs.python.org/3/reference/datamodel.html#object.__new__) does not return an instance of cls, then the new instance’s [__init__()](https://docs.python.org/3/reference/datamodel.html#object.__init__) method will not be invoked.

But it is an cls instance in this case.

```python
Python 3.9.9 (main, Nov 29 2021, 15:18:55)
[Clang 13.0.0 (clang-1300.0.29.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> class A:
...     _instance = None
...     def __new__(cls):
...         if cls._instance is None:
...             cls._instance = super().__new__(cls)
...         return cls._instance
...
>>> class A:
...     _instance = None
...     def __new__(cls):
...         if cls._instance is None:
...             cls._instance = super().__new__(cls)
...         return cls._instance
...     def __init__(self):
...         print("init")
...
>>> A()
init
<__main__.A object at 0x1028c4a60>
>>> A()
init
<__main__.A object at 0x1028c4a60>
>>>
```

This changes it to metaclass-based approach that does not have this bug.

```python
Python 3.9.9 (main, Nov 29 2021, 15:18:55)
[Clang 13.0.0 (clang-1300.0.29.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> class Singleton(type):
...     """Metaclass that allows to implement singleton pattern."""
...     _instances: dict = {}
...     def __call__(cls, *args, **kwargs):
...         if cls not in cls._instances:
...             cls._instances[cls] = super().__call__(*args, **kwargs)
...         return cls._instances[cls]
...
>>> class A(metaclass=Singleton):
...     def __init__(self):
...         print("init")
...
>>> A()
init
<__main__.A object at 0x10268b0a0>
>>> A()
<__main__.A object at 0x10268b0a0>
>>>
```

I would prefer to have singletons implemented as modules, as in some other places, but in this case those are already classes - I think metaclass based approach it does not change their API while fixing the issue.