### PR TITLE
Update the place where committer list should be updated

### DIFF
--- a/COMMITTERS.rst
+++ b/COMMITTERS.rst
@@ -193,5 +193,7 @@ To be able to merge PRs, committers have to integrate their GitHub ID with Apach
 3.  Merge your Apache and GitHub accounts using `GitBox (Apache Account Linking utility) <https://gitbox.apache.org/setup/>`__. You should see 3 green checks in GitBox.
 4.  Wait at least 30  minutes for an email inviting you to Apache GitHub Organization and accept invitation.
 5.  After accepting the GitHub Invitation verify that you are a member of the `Airflow committers team on GitHub <https://github.com/orgs/apache/teams/airflow-committers>`__.
-6.  Ask in ``#internal-airflow-ci-cd`` channel to be `configured in self-hosted runners <https://github.com/apache/airflow-ci-infra/blob/main/scripts/list_committers>`_ by the CI maintainers
-7.  After confirming that step 6 is done, open a PR to include your GitHub ID in `ci.yml <https://github.com/apache/airflow/blob/main/.github/workflows/ci.yml#L72>`__ as well as your name and GitHub ID in `project.rst <https://github.com/apache/airflow/blob/main/docs/apache-airflow/project.rst>`__.
+6.  Ask in ``#internal-airflow-ci-cd`` channel to be `configured in self-hosted runners <https://github.com/apache/airflow-ci-infra/blob/main/scripts/list_committers>`_
+    by the CI maintainers
+7.  After confirming that step 6 is done, open a PR to include your GitHub ID in ``dev/breeze/src/airflow_breeze/global_constants.py`` (COMMITTERS variable)
+    as well as your name and GitHub ID in `project.rst <https://github.com/apache/airflow/blob/main/docs/apache-airflow/project.rst>`__.


### PR DESCRIPTION
Onboardig steps included instructions to old place where the commiter ids should be updated. They moved from ci.yaml to breeze's global constants in #31451

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
