### PR TITLE
feat(providers/azure): cancel pipeline if unexpected exception caught

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -1175,3 +1175,25 @@ class AzureDataFactoryAsyncHook(AzureDataFactoryHook):
             return status
         except Exception as e:
             raise AirflowException(e)
+
+    @provide_targeted_factory_async
+    async def cancel_pipeline_run(
+        self,
+        run_id: str,
+        resource_group_name: str | None = None,
+        factory_name: str | None = None,
+        **config: Any,
+    ) -> None:
+        """
+        Cancel the pipeline run.
+
+        :param run_id: The pipeline run identifier.
+        :param resource_group_name: The resource group name.
+        :param factory_name: The factory name.
+        :param config: Extra parameters for the ADF client.
+        """
+        client = await self.get_async_conn()
+        try:
+            await client.pipeline_runs.cancel(resource_group_name, factory_name, run_id)
+        except Exception as e:
+            raise AirflowException(e)

--- a/airflow/providers/microsoft/azure/operators/data_factory.py
+++ b/airflow/providers/microsoft/azure/operators/data_factory.py
@@ -20,6 +20,8 @@ import time
 import warnings
 from typing import TYPE_CHECKING, Any, Sequence
 
+from azure.mgmt.datafactory.models import PipelineRun
+
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.models import BaseOperator, BaseOperatorLink, XCom
@@ -158,24 +160,40 @@ class AzureDataFactoryRunPipelineOperator(BaseOperator):
         self.check_interval = check_interval
         self.deferrable = deferrable
 
+        self.run_id: str = ""
+        self.pipeline_run_exists = False
+
     def execute(self, context: Context) -> None:
         self.hook = AzureDataFactoryHook(azure_data_factory_conn_id=self.azure_data_factory_conn_id)
         self.log.info("Executing the %s pipeline.", self.pipeline_name)
-        response = self.hook.run_pipeline(
-            pipeline_name=self.pipeline_name,
-            resource_group_name=self.resource_group_name,
-            factory_name=self.factory_name,
-            reference_pipeline_run_id=self.reference_pipeline_run_id,
-            is_recovery=self.is_recovery,
-            start_activity_name=self.start_activity_name,
-            start_from_failure=self.start_from_failure,
-            parameters=self.parameters,
-        )
-        self.run_id = vars(response)["run_id"]
-        # Push the ``run_id`` value to XCom regardless of what happens during execution. This allows for
-        # retrieval the executed pipeline's ``run_id`` for downstream tasks especially if performing an
-        # asynchronous wait.
-        context["ti"].xcom_push(key="run_id", value=self.run_id)
+
+        skip_pipeline_run = False
+        try_number = context["ti"].try_number
+        if try_number > 1:
+            self.run_id = context["ti"].xcom_pull(key="run_id")
+            if self.run_id:
+                pipeline_run: PipelineRun = self.hook.get_pipeline_run(
+                    run_id=self.run_id,
+                    resource_group_name=self.resource_group_name,
+                    factory_name=self.factory_name,
+                )
+
+                if pipeline_run.statuts not in AzureDataFactoryPipelineRunStatus.FAILURE_STATES:
+                    skip_pipeline_run = True
+
+        if not skip_pipeline_run:
+            response = self.hook.run_pipeline(
+                pipeline_name=self.pipeline_name,
+                resource_group_name=self.resource_group_name,
+                factory_name=self.factory_name,
+                reference_pipeline_run_id=self.reference_pipeline_run_id,
+                is_recovery=self.is_recovery,
+                start_activity_name=self.start_activity_name,
+                start_from_failure=self.start_from_failure,
+                parameters=self.parameters,
+            )
+            self.run_id = vars(response)["run_id"]
+            context["ti"].xcom_push(key="run_id", value=self.run_id)
 
         if self.wait_for_termination:
             if self.deferrable is False:

--- a/airflow/providers/microsoft/azure/triggers/data_factory.py
+++ b/airflow/providers/microsoft/azure/triggers/data_factory.py
@@ -191,4 +191,11 @@ class AzureDataFactoryTrigger(BaseTrigger):
                     }
                 )
         except Exception as e:
+            if self.run_id:
+                await hook.cancel_pipeline_run(
+                    run_id=self.run_id,
+                    resource_group_name=self.resource_group_name,
+                    factory_name=self.factory_name,
+                )
+                self.log.info("Unexpected error %s caught. Cancel pipeline run %s", str(e), self.run_id)
             yield TriggerEvent({"status": "error", "message": str(e), "run_id": self.run_id})

--- a/tests/providers/microsoft/azure/operators/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_data_factory.py
@@ -363,7 +363,7 @@ class TestAzureDataFactoryRunPipelineOperatorWithDeferrable:
     )
     @mock.patch("airflow.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHook.run_pipeline")
     def test_azure_data_factory_run_pipeline_operator_async(self, mock_run_pipeline, mock_get_status, status):
-        """Assert that AzureDataFactoryRunPipelineOperatorAsync deferred"""
+        """Assert that AzureDataFactoryRunPipelineOperator(..., deferrable=True) deferred"""
 
         class CreateRunResponse:
             pass

--- a/tests/providers/microsoft/azure/triggers/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/triggers/test_azure_data_factory.py
@@ -316,8 +316,11 @@ class TestAzureDataFactoryTrigger:
         assert expected == actual
 
     @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.cancel_pipeline_run")
     @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_adf_pipeline_run_status")
-    async def test_azure_data_factory_trigger_run_exception(self, mock_pipeline_run_status):
+    async def test_azure_data_factory_trigger_run_exception(
+        self, mock_pipeline_run_status, mock_cancel_pipeline_run
+    ):
         """Assert that run catch exception if Azure API throw exception"""
         mock_pipeline_run_status.side_effect = Exception("Test exception")
 
@@ -331,6 +334,7 @@ class TestAzureDataFactoryTrigger:
         )
         assert len(task) == 1
         assert response in task
+        mock_cancel_pipeline_run.assert_called_once()
 
     @pytest.mark.asyncio
     @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_adf_pipeline_run_status")


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Issue to resolve

When retrying after the 1st failure, the [AzureDataFactoryRunPipelineOperator](https://github.com/apache/airflow/blob/6b4350e89cd1b3cc66347b31b10337105ccb9907/airflow/providers/microsoft/azure/operators/data_factory.py#L77C7-L77C42) [creates a new pipeline run](https://github.com/apache/airflow/blob/6b4350e89cd1b3cc66347b31b10337105ccb9907/airflow/providers/microsoft/azure/operators/data_factory.py#L164) without canceling the original one. This happens when the triggerer fails unexpectedly and gets caught [here](https://github.com/apache/airflow/blob/6b4350e89cd1b3cc66347b31b10337105ccb9907/airflow/providers/microsoft/azure/triggers/data_factory.py#L193).

## What's changed
Clean up the previous pipeline wrong if unexpected error caught

---

I tried to check whether the previous run was still running. But we'll need to pass the job_id from the previous run to the current run. According to https://github.com/apache/airflow/issues/18917, it seems we can not use xcom to achieve it, and I doubt Varaible is a good solution.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
