### PR TITLE
Fix behaviour of LazyDictWithCache when import fails

### DIFF
--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -109,8 +109,7 @@ class LazyDictWithCache(MutableMapping):
             # callable itself
             value = value()
             self._resolved.add(key)
-            if value:
-                self._raw_dict.__setitem__(key, value)
+            self._raw_dict.__setitem__(key, value)
         return value
 
     def __delitem__(self, key):

--- a/tests/always/test_providers_manager.py
+++ b/tests/always/test_providers_manager.py
@@ -28,7 +28,7 @@ from flask_babel import lazy_gettext
 from wtforms import BooleanField, Field, StringField
 
 from airflow.exceptions import AirflowOptionalProviderFeatureException
-from airflow.providers_manager import HookClassProvider, ProviderInfo, ProvidersManager
+from airflow.providers_manager import HookClassProvider, LazyDictWithCache, ProviderInfo, ProvidersManager
 
 
 class TestProviderManager:
@@ -373,3 +373,32 @@ class TestProviderManager:
             assert [
                 "Optional provider feature disabled when importing 'HookClass' from 'test_package' package"
             ] == self._caplog.messages
+
+
+@pytest.mark.parametrize(
+    "value, expected_outputs,",
+    [
+        ("a", "a"),
+        (1, 1),
+        (None, None),
+        (lambda: 0, 0),
+        (lambda: None, None),
+        (lambda: "z", "z"),
+    ],
+)
+def test_lazy_cache_dict_resolving(value, expected_outputs):
+    lazy_cache_dict = LazyDictWithCache()
+    lazy_cache_dict["key"] = value
+    assert lazy_cache_dict["key"] == expected_outputs
+    # Retrieve it again to see if it is correctly returned again
+    assert lazy_cache_dict["key"] == expected_outputs
+
+
+def test_lazy_cache_dict_raises_error():
+    def raise_method():
+        raise Exception("test")
+
+    lazy_cache_dict = LazyDictWithCache()
+    lazy_cache_dict["key"] = raise_method
+    with pytest.raises(Exception, match="test"):
+        _ = lazy_cache_dict["key"]


### PR DESCRIPTION
When #15330 added docker.task, it also optimized replacement of the callable with it's result in LazyDictWithCache. LazyDictWithCache is used by Provider's Manager to optimize access to hooks - basically hook is only actually imported, when it is accessed. This helps with speeding up importing of connection information

The optimization added result of running callable to _resolved set, but it missed the case when None was returned. Previously, when None was returned, the callable was not replaced and it was called again. After the change - the _resolved set was updated with the key and None was returned. But since the key has not been replaced, next time when the same key was retrieved, the original "callable" was returned, not the None value. So if callable returned None, and the same key was retrieved twice, the second time, instead of None, the dictionary returned Callable.

This PR fixes it by setting the value to dictionary even if it was None.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
