### PR TITLE
Add 'parameters' to DatabricksSQLOperator template_fields

### DIFF
--- a/airflow/providers/databricks/operators/databricks_sql.py
+++ b/airflow/providers/databricks/operators/databricks_sql.py
@@ -56,7 +56,7 @@ class DatabricksSqlOperator(SQLExecuteQueryOperator):
     :param sql: the SQL code to be executed as a single string, or
         a list of str (sql statements), or a reference to a template file. (templated)
         Template references are recognized by str ending in '.sql'
-    :param parameters: (optional) the parameters to render the SQL query with.
+    :param parameters: (optional, templated) the parameters to render the SQL query with.
     :param session_configuration: An optional dictionary of Spark session parameters. Defaults to None.
         If not specified, it could be specified in the Databricks connection's extra parameters.
     :param client_parameters: Additional parameters internal to Databricks SQL Connector parameters
@@ -71,7 +71,7 @@ class DatabricksSqlOperator(SQLExecuteQueryOperator):
     """
 
     template_fields: Sequence[str] = tuple(
-        {"_output_path", "schema", "catalog", "http_headers", "databricks_conn_id"}
+        {"_output_path", "schema", "catalog", "http_headers", "databricks_conn_id", "parameters"}
         | set(SQLExecuteQueryOperator.template_fields)
     )
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

discussion: [#32252](https://github.com/apache/airflow/discussions/32252)

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Adds 'parameters' to the list of templated fields for the DatabricksSQLOperator. 'parameters' are used to render the sql statement. Parameters is passed to the parent class SQLExecuteQueryOperator and it templated. 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
