### PR TITLE
Remove duplicate and unsupported keys unchanged task

### DIFF
--- a/docs/apache-airflow-providers-amazon/operators/s3/s3.rst
+++ b/docs/apache-airflow-providers-amazon/operators/s3/s3.rst
@@ -289,12 +289,6 @@ You can also run this sensor in deferrable mode by setting the parameter ``defer
 This will lead to efficient utilization of Airflow workers as polling for job status happens on
 the triggerer asynchronously. Note that this will need triggerer to be available on your Airflow deployment.
 
-.. exampleinclude:: /../../tests/system/providers/amazon/aws/example_s3.py
-    :language: python
-    :dedent: 4
-    :start-after: [START howto_sensor_s3_keys_unchanged_deferrable]
-    :end-before: [END howto_sensor_s3_keys_unchanged_deferrable]
-
 Reference
 ---------
 

--- a/tests/system/providers/amazon/aws/example_s3.py
+++ b/tests/system/providers/amazon/aws/example_s3.py
@@ -244,19 +244,9 @@ with DAG(
         task_id="sensor_keys_unchanged",
         bucket_name=bucket_name_2,
         prefix=PREFIX,
-        inactivity_period=10,
+        inactivity_period=10,  # inactivity_period in seconds
     )
     # [END howto_sensor_s3_keys_unchanged]
-
-    # [START howto_sensor_s3_keys_unchanged_deferrable]
-    sensor_keys_unchanged = S3KeysUnchangedSensor(
-        task_id="sensor_keys_unchanged",
-        bucket_name=bucket_name_2,
-        prefix=PREFIX,
-        inactivity_period=10,  # inactivity_period in seconds
-        deferrable=True,
-    )
-    # [END howto_sensor_s3_keys_unchanged_deferrable]
 
     # [START howto_operator_s3_delete_objects]
     delete_objects = S3DeleteObjectsOperator(


### PR DESCRIPTION
A new task was added to the S3 system test for the new deferrable keys unchanged operator. However it used a duplicate task key and also deferrable tasks are not yet supported for the AWS system tests

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
