### PR TITLE
Update references to restructured documentation from airflow core

### DIFF
--- a/docs/apache-airflow-providers-google/logging/stackdriver.rst
+++ b/docs/apache-airflow-providers-google/logging/stackdriver.rst
@@ -67,7 +67,7 @@ be used. Make sure that with those credentials, you can read and write the logs.
   an important security measure.
 
 By using the ``logging_config_class`` option you can get
-:doc:`advanced features <apache-airflow:administration-and-deployment/logging-monitoring/advanced-logging-configuration>` of
+:ref:`advanced features <write-logs-advanced>` of
 this handler. Details are available in the handler's documentation -
 :class:`~airflow.providers.google.cloud.log.stackdriver_task_handler.StackdriverTaskHandler`.
 

--- a/docs/apache-airflow-providers/core-extensions/logging.rst
+++ b/docs/apache-airflow-providers/core-extensions/logging.rst
@@ -20,7 +20,7 @@ Writing logs
 
 This is a summary of all Apache Airflow Community provided implementations of writing task logs
 exposed via community-managed providers. You can also see logging options available in the core Airflow in
-:doc:`/administration-and-deployment/logging-monitoring/logging-tasks` and here you can see those
+:doc:`apache-airflow:administration-and-deployment/logging-monitoring/logging-tasks` and here you can see those
 provided by the community-managed providers:
 
 .. airflow-logging::

--- a/docs/apache-airflow-providers/core-extensions/secrets-backends.rst
+++ b/docs/apache-airflow-providers/core-extensions/secrets-backends.rst
@@ -28,7 +28,7 @@ via providers that implement secrets backends for services Airflow integrates wi
 
 You can also take a
 look at Secret backends available in the core Airflow in
-:doc:`/administration-and-deployment/security/secrets/secrets-backend/index` and here you can see the ones
+:doc:`apache-airflow:administration-and-deployment/security/secrets/secrets-backend/index` and here you can see the ones
 provided by the community-managed providers:
 
 .. airflow-secrets-backends::

--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/advanced-logging-configuration.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/advanced-logging-configuration.rst
@@ -16,6 +16,7 @@
     under the License.
 
 
+.. _write-logs-advanced:
 
 Advanced logging configuration
 ------------------------------


### PR DESCRIPTION
The change #32131 restructured some of the code for documentation and it broke references to apache-airlfow from "providers" doc package - it has not been visible in selective PR (not sure the reason) but this PR fixes it.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
