### PR TITLE
Add apache-airflow-providers to filter in selective checks if needed

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -727,6 +727,8 @@ class SelectiveChecks:
             [file.startswith("airflow/") or file.startswith("docs/apache-airflow/") for file in self._files]
         ):
             packages.append("apache-airflow")
+        if any([file.startswith("docs/apache-airflow-providers/") for file in self._files]):
+            packages.append("apache-airflow-providers")
         if any([file.startswith("chart/") or file.startswith("docs/helm-chart") for file in self._files]):
             packages.append("helm-chart")
         if any([file.startswith("docs/docker-stack/") for file in self._files]):

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1025,6 +1025,20 @@ def test_upgrade_to_newer_dependencies(files: tuple[str, ...], expected_outputs:
             id="Airbyte provider and airflow core docs changed",
         ),
         pytest.param(
+            (
+                "docs/apache-airflow-providers-airbyte/docs.rst",
+                "docs/apache-airflow/docs.rst",
+                "docs/apache-airflow-providers/docs.rst",
+            ),
+            {
+                "docs-filter-list-as-string": "--package-filter apache-airflow "
+                "--package-filter apache-airflow-providers "
+                "--package-filter apache-airflow-providers-airbyte "
+                "--package-filter apache-airflow-providers-http",
+            },
+            id="Airbyte provider and airflow core and common provider docs changed",
+        ),
+        pytest.param(
             ("docs/apache-airflow/docs.rst",),
             {
                 "docs-filter-list-as-string": "--package-filter apache-airflow",


### PR DESCRIPTION
When provider docs in "docs/apache-airflow-providers" changed, and selective docs build was used, the "apache-airflow-providers" package was not added to the filter - thus errors in those docs were not checked. This caused  #32131 to fail the main build (fixed in the #32282). Added logic to handle this case.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
