### PR TITLE
Add kerberos dependency to Impala Provider

### DIFF
--- a/airflow/providers/apache/impala/provider.yaml
+++ b/airflow/providers/apache/impala/provider.yaml
@@ -28,7 +28,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - impyla[kerberos]>=0.18.0,<1.0
+  - impyla>=0.18.0,<1.0
   - apache-airflow>=2.4.0
 
 integrations:
@@ -44,3 +44,8 @@ hooks:
 connection-types:
   - hook-class-name: airflow.providers.apache.impala.hooks.impala.ImpalaHook
     connection-type: impala
+
+additional-extras:
+  - name: kerberos
+    dependencies:
+      - kerberos>=1.3.0

--- a/airflow/providers/apache/impala/provider.yaml
+++ b/airflow/providers/apache/impala/provider.yaml
@@ -28,7 +28,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - impyla>=0.18.0,<1.0
+  - impyla[kerberos]>=0.18.0,<1.0
   - apache-airflow>=2.4.0
 
 integrations:

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -138,7 +138,7 @@
   "apache.impala": {
     "deps": [
       "apache-airflow>=2.4.0",
-      "impyla[kerberos]>=0.18.0,<1.0"
+      "impyla>=0.18.0,<1.0"
     ],
     "cross-providers-deps": [
       "common.sql"

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -138,7 +138,7 @@
   "apache.impala": {
     "deps": [
       "apache-airflow>=2.4.0",
-      "impyla>=0.18.0,<1.0"
+      "impyla[kerberos]>=0.18.0,<1.0"
     ],
     "cross-providers-deps": [
       "common.sql"

--- a/tests/providers/apache/impala/hooks/test_impala.py
+++ b/tests/providers/apache/impala/hooks/test_impala.py
@@ -54,6 +54,31 @@ def test_get_conn(mock_connect):
     )
 
 
+@patch("airflow.providers.apache.impala.hooks.impala.connect", autospec=True)
+def test_get_conn_kerberos(mock_connect):
+    hook = ImpalaHook()
+    hook.get_connection = MagicMock(
+        return_value=Connection(
+            login="login",
+            password="password",
+            host="host",
+            port=21050,
+            schema="test",
+            extra={"auth_mechanism": "GSSAPI", "use_ssl": True},
+        )
+    )
+    hook.get_conn()
+    mock_connect.assert_called_once_with(
+        host="host",
+        port=21050,
+        user="login",
+        password="password",
+        database="test",
+        use_ssl=True,
+        auth_mechanism="GSSAPI",
+    )
+
+
 @patch("airflow.providers.common.sql.hooks.sql.DbApiHook.insert_rows")
 def test_insert_rows(mock_insert_rows, impala_hook_fixture):
     table = "table"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Hello,

Using the ImpalaHook with kerberos ([`"auth_mechanism": "GSSAPI"`](https://github.com/cloudera/impyla/blob/master/impala/dbapi.py#L74)) fails with the following error:
```python
[2023-06-26, 11:00:42 UTC] {base.py:73} INFO - Using connection ID 'impala_conn' for task execution.
[2023-06-26, 11:00:42 UTC] {warnings.py:109} WARNING - /opt/app-root/lib64/python3.9/site-packages/puresasl/client.py:215: SASLWarning: kerberos module not installed, GSSAPI will be ignored
  warn('kerberos module not installed, {0} will be ignored'.format(
[2023-06-26, 11:00:42 UTC] {taskinstance.py:1824} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.9/site-packages/airflow/operators/python.py", line 181, in execute
    return_value = self.execute_callable()
  File "/opt/app-root/lib64/python3.9/site-packages/airflow/operators/python.py", line 198, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/usr/local/airflow/dags/impala_hook_connection_test.py", line 19, in sample_select
    connection = impala_hook.get_conn()
  File "/opt/app-root/lib64/python3.9/site-packages/airflow/providers/apache/impala/hooks/impala.py", line 35, in get_conn
    return connect(
  File "/opt/app-root/lib64/python3.9/site-packages/impala/dbapi.py", line 194, in connect
    service = hs2.connect(host=host, port=port,
  File "/opt/app-root/lib64/python3.9/site-packages/impala/hiveserver2.py", line 865, in connect
    transport.open()
  File "/opt/app-root/lib64/python3.9/site-packages/thrift_sasl/__init__.py", line 84, in open
    raise TTransportException(type=TTransportException.NOT_OPEN,
thrift.transport.TTransport.TTransportException: Could not start SASL: None of the mechanisms listed meet all required properties
```

### Solution

The [kerberos](https://pypi.org/project/kerberos/) module, an optional dependency of [impyla](https://github.com/cloudera/impyla), is not bundled with Airflow. (Only requests-kerberos for hdfs and pykerberos come default with Airflow, if I'm not mistaken)

**This PR add `kerberos` as dependency**. Fixing the above error.

### About license
The package is under Apache 2.0 license (see [github repo](https://github.com/apple/ccs-pykerberos/blob/master/LICENSE.txt), and [pypi](https://pypi.org/project/kerberos/)).

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
