### PR TITLE
Fix get_conn test for ImpalaHook

### DIFF
--- a/tests/providers/apache/impala/hooks/test_impala.py
+++ b/tests/providers/apache/impala/hooks/test_impala.py
@@ -35,17 +35,22 @@ def impala_hook_fixture() -> ImpalaHook:
     return hook
 
 
-@patch("airflow.providers.apache.impala.hooks.impala.connect")
+@patch("airflow.providers.apache.impala.hooks.impala.connect", autospec=True)
 def test_get_conn(mock_connect):
     hook = ImpalaHook()
     hook.get_connection = MagicMock(
         return_value=Connection(
-            login="login", password="password", host="host", port=21050, schema="test", extra={"ssl": True}
+            login="login",
+            password="password",
+            host="host",
+            port=21050,
+            schema="test",
+            extra={"use_ssl": True},
         )
     )
     hook.get_conn()
     mock_connect.assert_called_once_with(
-        host="host", port=21050, user="login", password="password", database="test", ssl=True
+        host="host", port=21050, user="login", password="password", database="test", use_ssl=True
     )
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Small fix for the ImpalaHook:
Impyla doesn't has any `ssl` parameter, but a `use_ssl` instead.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
