### PR TITLE
Fix ts/eslint warnings

### DIFF
--- a/airflow/www/alias-rest-types.js
+++ b/airflow/www/alias-rest-types.js
@@ -225,6 +225,7 @@ function generate(file) {
 
   fs.writeFileSync(file, finalText, (err) => {
     if (err) {
+      // eslint-disable-next-line no-console
       console.error(err);
     }
   });

--- a/airflow/www/babel.config.js
+++ b/airflow/www/babel.config.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-module.exports = function (api) {
+module.exports = (api) => {
   api.cache(true);
 
   const presets = [

--- a/airflow/www/jest-setup.js
+++ b/airflow/www/jest-setup.js
@@ -32,8 +32,10 @@ axios.defaults.adapter = require("axios/lib/adapters/http");
 axios.interceptors.response.use((res) => res.data || res);
 
 setLogger({
+  /* eslint-disable no-console */
   log: console.log,
   warn: console.warn,
+  /* eslint-enable no-console */
   // ✅ no more errors on the console
   error: () => {},
 });

--- a/airflow/www/package.json
+++ b/airflow/www/package.json
@@ -7,7 +7,7 @@
     "dev": "NODE_ENV=development webpack --watch --progress --devtool eval-cheap-source-map --mode development",
     "prod": "NODE_ENV=production node --max_old_space_size=4096 ./node_modules/webpack/bin/webpack.js --mode production --progress",
     "build": "NODE_ENV=production webpack --progress --mode production",
-    "lint": "eslint --ignore-path=.eslintignore --ext .js,.jsx,.ts,.tsx . && tsc",
+    "lint": "eslint --ignore-path=.eslintignore --max-warnings=0 --ext .js,.jsx,.ts,.tsx . && tsc",
     "lint:fix": "eslint --fix --ignore-path=.eslintignore --ext .js,.jsx,.ts,.tsx . && tsc",
     "format": "yarn prettier --write .",
     "generate-api-types": "npx openapi-typescript \"../api_connexion/openapi/v1.yaml\" --output static/js/types/api-generated.ts && node alias-rest-types.js static/js/types/api-generated.ts"

--- a/airflow/www/static/js/api/useDatasets.ts
+++ b/airflow/www/static/js/api/useDatasets.ts
@@ -24,7 +24,7 @@ import { getMetaValue } from "src/utils";
 import type { DatasetListItem } from "src/types";
 import type { unitOfTime } from "moment";
 
-interface DatasetsData {
+export interface DatasetsData {
   datasets: DatasetListItem[];
   totalEntries: number;
 }

--- a/airflow/www/static/js/api/useExtraLinks.ts
+++ b/airflow/www/static/js/api/useExtraLinks.ts
@@ -46,14 +46,16 @@ export default function useExtraLinks({
     async () => {
       const data = await Promise.all(
         extraLinks.map(async (link) => {
-          mapIndex ??= -1;
+          const definedMapIndex = mapIndex ?? -1;
           const url = `${extraLinksUrl}?task_id=${encodeURIComponent(
             taskId
           )}&dag_id=${encodeURIComponent(
             dagId
           )}&execution_date=${encodeURIComponent(
             executionDate
-          )}&link_name=${encodeURIComponent(link)}&map_index=${mapIndex}`;
+          )}&link_name=${encodeURIComponent(
+            link
+          )}&map_index=${definedMapIndex}`;
           try {
             const datum = await axios.get<AxiosResponse, LinkData>(url);
             return {
@@ -61,6 +63,7 @@ export default function useExtraLinks({
               url: datum.url,
             };
           } catch (e) {
+            // eslint-disable-next-line no-console
             console.error(e);
             return {
               name: link,

--- a/airflow/www/static/js/callModal.js
+++ b/airflow/www/static/js/callModal.js
@@ -56,6 +56,7 @@ const showExternalLogRedirect =
 const buttons = Array.from(
   document.querySelectorAll('a[id^="btn_"][data-base-url]')
 ).reduce((obj, elm) => {
+  // eslint-disable-next-line no-param-reassign
   obj[elm.id.replace("btn_", "")] = elm;
   return obj;
 }, {});
@@ -64,12 +65,14 @@ function updateButtonUrl(elm, params) {
   let url = elm.dataset.baseUrl;
   if (params.dag_id && elm.dataset.baseUrl.indexOf(dagId) !== -1) {
     url = url.replace(dagId, params.dag_id);
+    // eslint-disable-next-line no-param-reassign
     delete params.dag_id;
   }
   if (
     Object.prototype.hasOwnProperty.call(params, "map_index") &&
     params.map_index === undefined
   ) {
+    // eslint-disable-next-line no-param-reassign
     delete params.map_index;
   }
   elm.setAttribute("href", `${url}?${$.param(params)}`);

--- a/airflow/www/static/js/cluster-activity/index.test.tsx
+++ b/airflow/www/static/js/cluster-activity/index.test.tsx
@@ -29,6 +29,8 @@ import * as useHealthModule from "src/api/useHealth";
 import { render } from "@testing-library/react";
 
 import { Wrapper } from "src/utils/testUtils";
+import type { UseQueryResult } from "react-query";
+import type { API, HistoricalMetricsData } from "src/types";
 import ClusterActivity from ".";
 
 const mockHistoricalMetricsData = {
@@ -100,7 +102,7 @@ describe("Test ToggleGroups", () => {
         ({
           data: mockHistoricalMetricsData,
           isSuccess: true,
-        } as any)
+        } as never as UseQueryResult<HistoricalMetricsData>)
     );
 
     jest.spyOn(useHealthModule, "default").mockImplementation(
@@ -108,7 +110,7 @@ describe("Test ToggleGroups", () => {
         ({
           data: mockHealthData,
           isSuccess: true,
-        } as any)
+        } as never as UseQueryResult<API.HealthInfo>)
     );
 
     jest.spyOn(useDagsModule, "default").mockImplementation(
@@ -116,7 +118,7 @@ describe("Test ToggleGroups", () => {
         ({
           data: mockDagsData,
           isSuccess: true,
-        } as any)
+        } as never as UseQueryResult<API.DAGCollection>)
     );
 
     jest.spyOn(useDagRunsModule, "default").mockImplementation(
@@ -124,7 +126,7 @@ describe("Test ToggleGroups", () => {
         ({
           data: mockDagRunsData,
           isSuccess: true,
-        } as any)
+        } as never as UseQueryResult<API.DAGRunCollection>)
     );
 
     jest.spyOn(usePoolsModule, "default").mockImplementation(
@@ -132,7 +134,7 @@ describe("Test ToggleGroups", () => {
         ({
           data: mockPoolsData,
           isSuccess: true,
-        } as any)
+        } as never as UseQueryResult<API.PoolCollection>)
     );
   });
 

--- a/airflow/www/static/js/components/Table/Cells.tsx
+++ b/airflow/www/static/js/components/Table/Cells.tsx
@@ -41,8 +41,10 @@ import { SimpleStatus } from "src/dag/StatusBox";
 
 interface CellProps {
   cell: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     value: any;
     row: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       original: Record<string, any>;
     };
   };

--- a/airflow/www/static/js/components/Table/Table.test.tsx
+++ b/airflow/www/static/js/components/Table/Table.test.tsx
@@ -28,7 +28,7 @@ import type { SortingRule } from "react-table";
 import { ChakraWrapper } from "src/utils/testUtils";
 import { Table } from ".";
 
-const data: Record<string, any>[] = [
+const data: Record<string, string>[] = [
   { firstName: "Lamont", lastName: "Grimes", country: "United States" },
   { firstName: "Alysa", lastName: "Armstrong", country: "Spain" },
   { firstName: "Petra", lastName: "Blick", country: "France" },

--- a/airflow/www/static/js/components/Table/index.tsx
+++ b/airflow/www/static/js/components/Table/index.tsx
@@ -89,7 +89,7 @@ interface TableProps {
   pageSize?: number;
   isLoading?: boolean;
   selectRows?: (selectedRows: number[]) => void;
-  onRowClicked?: (row: Row<object>, e: any) => void;
+  onRowClicked?: (row: Row<object>, e: unknown) => void;
 }
 
 export const Table = ({
@@ -244,7 +244,9 @@ export const Table = ({
                   }
                 }
                 onClick={
-                  onRowClicked ? (e: any) => onRowClicked(row, e) : undefined
+                  onRowClicked
+                    ? (e: unknown) => onRowClicked(row, e)
+                    : undefined
                 }
               >
                 {row.cells.map((cell) => (

--- a/airflow/www/static/js/components/Tooltip.tsx
+++ b/airflow/www/static/js/components/Tooltip.tsx
@@ -136,7 +136,7 @@ const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
    * Ensure tooltip has only one child node
    */
   const child = React.Children.only(children) as React.ReactElement & {
-    ref?: React.Ref<any>;
+    ref?: React.Ref<HTMLElement>;
   };
   const trigger: React.ReactElement = React.cloneElement(
     child,
@@ -168,6 +168,7 @@ const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
             >
               <StyledTooltip
                 variants={scale}
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 {...(tooltipProps as any)}
                 initial="exit"
                 animate="enter"

--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -70,12 +70,15 @@ function getControlsContainer() {
 function restoreFieldBehaviours() {
   Array.from(document.querySelectorAll("label[data-orig-text]")).forEach(
     (elem) => {
+      // eslint-disable-next-line no-param-reassign
       elem.innerText = elem.dataset.origText;
+      // eslint-disable-next-line no-param-reassign
       delete elem.dataset.origText;
     }
   );
 
   Array.from(document.querySelectorAll(".form-control")).forEach((elem) => {
+    // eslint-disable-next-line no-param-reassign
     elem.placeholder = "";
     elem.parentElement.parentElement.classList.remove("hide");
   });
@@ -259,6 +262,7 @@ $(document).ready(() => {
         - All other custom form fields (i.e. fields that are named ``extra__...``) in
           alphabetical order
     */
+    // eslint-disable-next-line func-names
     $.each(inArray, function () {
       if (this.name === "conn_id") {
         outObj.connection_id = this.value;

--- a/airflow/www/static/js/dag/details/graph/utils.ts
+++ b/airflow/www/static/js/dag/details/graph/utils.ts
@@ -131,7 +131,7 @@ export const nodeColor = ({
 
 export const nodeStrokeColor = (
   { data: { isSelected } }: ReactFlowNode<CustomNodeProps>,
-  colors: any
+  colors: Record<string, string>
 ) => (isSelected ? colors.blue[500] : "");
 
 interface BuildEdgesProps {

--- a/airflow/www/static/js/dag/grid/dagRuns/index.test.tsx
+++ b/airflow/www/static/js/dag/grid/dagRuns/index.test.tsx
@@ -48,6 +48,7 @@ const generateRuns = (length: number): DagRun[] =>
     note: "someRandomValue",
   }));
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 describe("Test DagRuns", () => {
   test("Durations and manual run arrow render correctly, but without any date ticks", () => {
     const dagRuns: DagRun[] = [

--- a/airflow/www/static/js/dag/grid/index.test.tsx
+++ b/airflow/www/static/js/dag/grid/index.test.tsx
@@ -135,6 +135,7 @@ describe("Test ToggleGroups", () => {
     const returnValue = {
       data: mockGridData,
       isSuccess: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
 
     jest

--- a/airflow/www/static/js/dag_dependencies.js
+++ b/airflow/www/static/js/dag_dependencies.js
@@ -97,6 +97,7 @@ function setUpZoomSupport() {
 }
 
 function setUpNodeHighlighting(focusItem = null) {
+  // eslint-disable-next-line func-names
   d3.selectAll("g.node").on("mouseover", function (d) {
     d3.select(this).selectAll("rect").style("stroke", highlightColor);
     highlightNodes(g.predecessors(d), upstreamColor, highlightStrokeWidth);
@@ -114,6 +115,7 @@ function setUpNodeHighlighting(focusItem = null) {
       });
   });
 
+  // eslint-disable-next-line func-names
   d3.selectAll("g.node").on("mouseout", function (d) {
     d3.select(this).selectAll("rect,circle").style("stroke", null);
     highlightNodes(g.predecessors(d), null, initialStrokeWidth);

--- a/airflow/www/static/js/dags.js
+++ b/airflow/www/static/js/dags.js
@@ -320,6 +320,7 @@ function getDagIds({ activeDagsOnly = false } = {}) {
     dagIds = dagIds.filter(":checked");
   }
   dagIds = dagIds
+    // eslint-disable-next-line func-names
     .map(function () {
       return $(this).data("dag-id");
     })

--- a/airflow/www/static/js/datasets/List.test.tsx
+++ b/airflow/www/static/js/datasets/List.test.tsx
@@ -25,6 +25,8 @@ import { render } from "@testing-library/react";
 import * as useDatasetsModule from "src/api/useDatasets";
 import { Wrapper } from "src/utils/testUtils";
 
+import type { UseQueryResult } from "react-query";
+import type { DatasetListItem } from "src/types";
 import DatasetsList from "./List";
 
 const datasets = [
@@ -57,22 +59,26 @@ const datasets = [
   },
 ];
 
+type UseDatasetsReturn = UseQueryResult<useDatasetsModule.DatasetsData> & {
+  data: useDatasetsModule.DatasetsData;
+};
+
 const returnValue = {
   data: {
     datasets,
     totalEntries: datasets.length,
   },
   isSuccess: true,
-} as any;
+} as UseDatasetsReturn;
 
 const emptyReturnValue = {
   data: {
-    datasets: [],
+    datasets: [] as DatasetListItem[],
     totalEntries: 0,
   },
   isSuccess: true,
   isLoading: false,
-} as any;
+} as UseDatasetsReturn;
 
 describe("Test Datasets List", () => {
   test("Displays a list of datasets", () => {

--- a/airflow/www/static/js/datasets/List.tsx
+++ b/airflow/www/static/js/datasets/List.tsx
@@ -49,8 +49,10 @@ interface Props {
 
 interface CellProps {
   cell: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     value: any;
     row: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       original: Record<string, any>;
     };
   };

--- a/airflow/www/static/js/datetime_utils.js
+++ b/airflow/www/static/js/datetime_utils.js
@@ -104,6 +104,7 @@ export function updateAllDateTimes() {
   // Since we have set the default timezone for moment, it will automatically
   // convert it to the new target for us
   $(".datetime input").each((_, el) => {
+    // eslint-disable-next-line no-param-reassign
     el.value = moment(el.value).format();
   });
 }

--- a/airflow/www/static/js/gantt.js
+++ b/airflow/www/static/js/gantt.js
@@ -74,7 +74,7 @@ const replacements = {
   "%": "%",
 };
 
-moment.fn.strftime = function (format) {
+moment.fn.strftime = function formatTime(format) {
   // Break up format string based on strftime tokens
   const tokens = format.split(/(%-?.)/);
   const momentFormat = tokens
@@ -173,12 +173,15 @@ d3.gantt = () => {
 
       tasks.forEach((a) => {
         if (!(a.start_date instanceof moment)) {
+          // eslint-disable-next-line no-param-reassign
           a.start_date = moment(a.start_date);
         }
         if (!(a.end_date instanceof moment)) {
+          // eslint-disable-next-line no-param-reassign
           a.end_date = moment(a.end_date);
         }
         if (a.queued_dttm && !(a.queued_dttm instanceof moment)) {
+          // eslint-disable-next-line no-param-reassign
           a.queued_dttm = moment(a.queued_dttm);
         }
       });
@@ -349,12 +352,14 @@ d3.gantt = () => {
     return gantt;
   };
 
+  // eslint-disable-next-line func-names
   gantt.margin = function (value) {
     if (!arguments.length) return margin;
     margin = value;
     return gantt;
   };
 
+  // eslint-disable-next-line func-names
   gantt.timeDomain = function (value) {
     if (!arguments.length) return [timeDomainStart, timeDomainEnd];
     timeDomainStart = +value[0];
@@ -367,36 +372,42 @@ d3.gantt = () => {
    *                vale The value can be "fit" - the domain fits the data or
    *                "fixed" - fixed domain.
    */
+  // eslint-disable-next-line func-names
   gantt.timeDomainMode = function (value) {
     if (!arguments.length) return timeDomainMode;
     timeDomainMode = value;
     return gantt;
   };
 
+  // eslint-disable-next-line func-names
   gantt.taskTypes = function (value) {
     if (!arguments.length) return taskTypes;
     taskTypes = value;
     return gantt;
   };
 
+  // eslint-disable-next-line func-names
   gantt.width = function (value) {
     if (!arguments.length) return width;
     width = +value;
     return gantt;
   };
 
+  // eslint-disable-next-line func-names
   gantt.height = function (value) {
     if (!arguments.length) return height;
     height = +value;
     return gantt;
   };
 
+  // eslint-disable-next-line func-names
   gantt.tickFormat = function (value) {
     if (!arguments.length) return tickFormat;
     tickFormat = value;
     return gantt;
   };
 
+  // eslint-disable-next-line func-names
   gantt.selector = function (value) {
     if (!arguments.length) return selector;
     selector = value;

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -153,6 +153,7 @@ function collapseGroup(nodeId, node) {
 
   getChildrenIds(node).forEach((childId) => mapTaskToNode.set(childId, nodeId));
 
+  // eslint-disable-next-line no-param-reassign
   node = g.node(nodeId);
 
   // Set children edges onto the group edge

--- a/airflow/www/static/js/main.js
+++ b/airflow/www/static/js/main.js
@@ -69,19 +69,20 @@ export function escapeHtml(text) {
 window.escapeHtml = escapeHtml;
 
 export function convertSecsToHumanReadable(seconds) {
+  let processedSeconds = seconds;
   const oriSeconds = seconds;
   const floatingPart = oriSeconds - Math.floor(oriSeconds);
 
-  seconds = Math.floor(seconds);
+  processedSeconds = Math.floor(processedSeconds);
 
   const secondsPerHour = 60 * 60;
   const secondsPerMinute = 60;
 
-  const hours = Math.floor(seconds / secondsPerHour);
-  seconds -= hours * secondsPerHour;
+  const hours = Math.floor(processedSeconds / secondsPerHour);
+  processedSeconds -= hours * secondsPerHour;
 
-  const minutes = Math.floor(seconds / secondsPerMinute);
-  seconds -= minutes * secondsPerMinute;
+  const minutes = Math.floor(processedSeconds / secondsPerMinute);
+  processedSeconds -= minutes * secondsPerMinute;
 
   let readableFormat = "";
   if (hours > 0) {
@@ -90,12 +91,12 @@ export function convertSecsToHumanReadable(seconds) {
   if (minutes > 0) {
     readableFormat += `${minutes}Min `;
   }
-  if (seconds + floatingPart > 0) {
+  if (processedSeconds + floatingPart > 0) {
     if (Math.floor(oriSeconds) === oriSeconds) {
-      readableFormat += `${seconds}Sec`;
+      readableFormat += `${processedSeconds}Sec`;
     } else {
-      seconds += floatingPart;
-      readableFormat += `${seconds.toFixed(3)}Sec`;
+      processedSeconds += floatingPart;
+      readableFormat += `${processedSeconds.toFixed(3)}Sec`;
     }
   }
   return readableFormat;

--- a/airflow/www/static/js/task.js
+++ b/airflow/www/static/js/task.js
@@ -27,6 +27,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const value = attr.innerHTML;
     if (value.length === 32 && moment(value, "YYYY-MM-DD").isValid()) {
       // 32 is the length of our timestamps
+      // eslint-disable-next-line no-param-reassign
       attr.innerHTML = "";
       const timeElement = document.createElement("time");
       timeElement.setAttribute("datetime", value);
@@ -35,6 +36,7 @@ document.addEventListener("DOMContentLoaded", () => {
       attr.appendChild(timeElement);
     } else if (validator.isURL(value)) {
       // very basic url detection
+      // eslint-disable-next-line no-param-reassign
       attr.innerHTML = "";
       const linkElement = document.createElement("a");
       linkElement.setAttribute("href", value);

--- a/airflow/www/static/js/task_instances.js
+++ b/airflow/www/static/js/task_instances.js
@@ -119,12 +119,14 @@ export default function tiTooltip(ti, task, { includeTryNumber = false } = {}) {
   if (ti.state === "running") {
     const startDate =
       ti.start_date instanceof moment ? ti.start_date : moment(ti.start_date);
+    // eslint-disable-next-line no-param-reassign
     ti.duration = moment().diff(startDate, "second");
   } else if (!ti.duration && ti.end_date) {
     const startDate =
       ti.start_date instanceof moment ? ti.start_date : moment(ti.start_date);
     const endDate =
       ti.end_date instanceof moment ? ti.end_date : moment(ti.end_date);
+    // eslint-disable-next-line no-param-reassign
     ti.duration = moment(endDate).diff(startDate, "second");
   }
 

--- a/airflow/www/static/js/ti_log.js
+++ b/airflow/www/static/js/ti_log.js
@@ -37,6 +37,7 @@ function recurse(delay = DELAY) {
     setTimeout(resolve, delay);
   });
 }
+/* eslint-disable no-console */
 
 // Enable auto tailing only when users scroll down to the bottom
 // of the page. This prevent auto tailing the page if users want
@@ -166,15 +167,16 @@ function autoTailingLog(tryNumber, metadata = null, autoTailing = false) {
 }
 
 function setDownloadUrl(tryNumber) {
-  if (!tryNumber) {
+  let tryNumberData = tryNumber;
+  if (!tryNumberData) {
     // default to the currently selected tab
-    tryNumber = $("#ti_log_try_number_list .active a").data("try-number");
+    tryNumberData = $("#ti_log_try_number_list .active a").data("try-number");
   }
   const query = new URLSearchParams({
     dag_id: dagId,
     task_id: taskId,
     execution_date: executionDate,
-    try_number: tryNumber,
+    try_number: tryNumberData,
     metadata: "null",
     format: "file",
   });
@@ -187,6 +189,7 @@ $(document).ready(() => {
   autoTailingLog(TOTAL_ATTEMPTS, null, true);
 
   setDownloadUrl();
+  // eslint-disable-next-line func-names
   $("#ti_log_try_number_list a").click(function () {
     const tryNumber = $(this).data("try-number");
 

--- a/airflow/www/static/js/types/react-table-config.d.ts
+++ b/airflow/www/static/js/types/react-table-config.d.ts
@@ -87,7 +87,7 @@ declare module "react-table" {
       // this matches the spirit of the underlying js library,
       // but might be cleaner if it's replaced by a more specific type that matches your
       // feature set, this is a safe default.
-      Record<string, any> {}
+      Record<string, unknown> {}
 
   export interface Hooks<
     D extends Record<string, unknown> = Record<string, unknown>
@@ -139,7 +139,7 @@ declare module "react-table" {
   export interface Cell<
     D extends Record<string, unknown> = Record<string, unknown>,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    V = any
+    V = unknown
   > extends UseGroupByCellProps<D>,
       UseRowStateCellProps<D> {}
 

--- a/airflow/www/static/js/utils/URLSearchParamWrapper.ts
+++ b/airflow/www/static/js/utils/URLSearchParamWrapper.ts
@@ -18,7 +18,8 @@
  */
 
 class URLSearchParamsWrapper extends URLSearchParams {
-  constructor(init?: { [keys: string]: any }) {
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+  constructor(init?: Record<string, any>) {
     if (init) {
       const stringValues: { [keys: string]: string } = {};
       Object.keys(init).forEach((key) => {

--- a/airflow/www/static/js/utils/graph.ts
+++ b/airflow/www/static/js/utils/graph.ts
@@ -77,13 +77,21 @@ const generateGraph = ({
 }: GenerateProps) => {
   const closedGroupIds: string[] = [];
 
-  const formatChildNode = (node: any) => {
+  const formatChildNode = (
+    node: DepNode
+  ): DepNode & {
+    label: string;
+    layoutOptions?: Record<string, string>;
+    width?: number;
+    height?: number;
+  } => {
     const { id, value, children } = node;
     const isOpen = openGroupIds?.includes(value.label);
     const childCount =
-      children?.filter((c: any) => !c.id.includes("join_id")).length || 0;
-    if (isOpen && children.length) {
+      children?.filter((c: DepNode) => !c.id.includes("join_id")).length || 0;
+    if (isOpen && children?.length) {
       return {
+        ...node,
         id,
         value: {
           ...value,


### PR DESCRIPTION
Small PR to fix eslint warnings.

The ones I could fix easily have been fixed, some of them are trickier and I simply applied the appropriate one line ignore rule.

We now have 0 warnings, and should try to not introduce more. (And also remove some of those ignore rule when possible)

Also add a setting for `yarn eslint` to break on warnings. This way developer needs to fix it or explicitly add an ignore rule, we will not have unexpected or unknown new warnings.

### Before
![image](https://github.com/apache/airflow/assets/14861206/20ff2050-d8dc-4e77-8f9a-4e51d05539b9)

### After
![image](https://github.com/apache/airflow/assets/14861206/eaffe11e-720f-44ef-b91a-4843abb0cac5)
