### PR TITLE
refresh connection if an exception is caught in "AzureDataFactory"

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -214,6 +214,10 @@ class AzureDataFactoryHook(BaseHook):
 
         return self._conn
 
+    def refresh_conn(self) -> DataFactoryManagementClient:
+        self._conn = None
+        return self.get_conn()
+
     @provide_targeted_factory
     def get_factory(
         self, resource_group_name: str | None = None, factory_name: str | None = None, **config: Any
@@ -1131,6 +1135,10 @@ class AzureDataFactoryAsyncHook(AzureDataFactoryHook):
         )
 
         return self._async_conn
+
+    async def refresh_conn(self) -> AsyncDataFactoryManagementClient:
+        self._conn = None
+        return await self.get_async_conn()
 
     @provide_targeted_factory_async
     async def get_pipeline_run(

--- a/airflow/providers/microsoft/azure/triggers/data_factory.py
+++ b/airflow/providers/microsoft/azure/triggers/data_factory.py
@@ -20,6 +20,8 @@ import asyncio
 import time
 from typing import Any, AsyncIterator
 
+from azure.core.exceptions import ServiceRequestError
+
 from airflow.providers.microsoft.azure.hooks.data_factory import (
     AzureDataFactoryAsyncHook,
     AzureDataFactoryPipelineRunStatus,
@@ -89,8 +91,7 @@ class ADFPipelineRunStatusSensorTrigger(BaseTrigger):
                         msg = f"Pipeline run {self.run_id} has been Succeeded."
                         yield TriggerEvent({"status": "success", "message": msg})
                     await asyncio.sleep(self.poke_interval)
-
-                except Exception:
+                except ServiceRequestError:
                     # conn might expire during long running pipeline.
                     # If expcetion is caught, it tries to refresh connection once.
                     # If it still doesn't fix the issue,
@@ -192,7 +193,7 @@ class AzureDataFactoryTrigger(BaseTrigger):
                             "Sleeping for %s. The pipeline state is %s.", self.check_interval, pipeline_status
                         )
                         await asyncio.sleep(self.check_interval)
-                    except Exception:
+                    except ServiceRequestError:
                         # conn might expire during long running pipeline.
                         # If expcetion is caught, it tries to refresh connection once.
                         # If it still doesn't fix the issue,

--- a/airflow/providers/microsoft/azure/triggers/data_factory.py
+++ b/airflow/providers/microsoft/azure/triggers/data_factory.py
@@ -222,10 +222,13 @@ class AzureDataFactoryTrigger(BaseTrigger):
                 )
         except Exception as e:
             if self.run_id:
-                await hook.cancel_pipeline_run(
-                    run_id=self.run_id,
-                    resource_group_name=self.resource_group_name,
-                    factory_name=self.factory_name,
-                )
-                self.log.info("Unexpected error %s caught. Cancel pipeline run %s", str(e), self.run_id)
+                try:
+                    await hook.cancel_pipeline_run(
+                        run_id=self.run_id,
+                        resource_group_name=self.resource_group_name,
+                        factory_name=self.factory_name,
+                    )
+                    self.log.info("Unexpected error %s caught. Cancel pipeline run %s", str(e), self.run_id)
+                except Exception as err:
+                    yield TriggerEvent({"status": "error", "message": str(err), "run_id": self.run_id})
             yield TriggerEvent({"status": "error", "message": str(e), "run_id": self.run_id})

--- a/airflow/providers/microsoft/azure/triggers/data_factory.py
+++ b/airflow/providers/microsoft/azure/triggers/data_factory.py
@@ -84,12 +84,15 @@ class ADFPipelineRunStatusSensorTrigger(BaseTrigger):
                         yield TriggerEvent(
                             {"status": "error", "message": f"Pipeline run {self.run_id} has Failed."}
                         )
+                        return
                     elif pipeline_status == AzureDataFactoryPipelineRunStatus.CANCELLED:
                         msg = f"Pipeline run {self.run_id} has been Cancelled."
                         yield TriggerEvent({"status": "error", "message": msg})
+                        return
                     elif pipeline_status == AzureDataFactoryPipelineRunStatus.SUCCEEDED:
                         msg = f"Pipeline run {self.run_id} has been Succeeded."
                         yield TriggerEvent({"status": "success", "message": msg})
+                        return
                     await asyncio.sleep(self.poke_interval)
                 except ServiceRequestError:
                     # conn might expire during long running pipeline.
@@ -181,6 +184,7 @@ class AzureDataFactoryTrigger(BaseTrigger):
                                     "run_id": self.run_id,
                                 }
                             )
+                            return
                         elif pipeline_status == AzureDataFactoryPipelineRunStatus.SUCCEEDED:
                             yield TriggerEvent(
                                 {
@@ -189,6 +193,7 @@ class AzureDataFactoryTrigger(BaseTrigger):
                                     "run_id": self.run_id,
                                 }
                             )
+                            return
                         self.log.info(
                             "Sleeping for %s. The pipeline state is %s.", self.check_interval, pipeline_status
                         )

--- a/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
@@ -789,16 +789,6 @@ class TestAzureDataFactoryAsyncHook:
         assert response == mock_status
 
     @pytest.mark.asyncio
-    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_async_conn")
-    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_pipeline_run")
-    async def test_get_adf_pipeline_run_status_exception(self, mock_get_pipeline_run, mock_conn):
-        """Test get_adf_pipeline_run_status function with exception"""
-        mock_get_pipeline_run.side_effect = Exception("Test exception")
-        hook = AzureDataFactoryAsyncHook(AZURE_DATA_FACTORY_CONN_ID)
-        with pytest.raises(AirflowException):
-            await hook.get_adf_pipeline_run_status(RUN_ID, RESOURCE_GROUP_NAME, DATAFACTORY_NAME)
-
-    @pytest.mark.asyncio
     @mock.patch("azure.mgmt.datafactory.models._models_py3.PipelineRun")
     @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_connection")
     @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_async_conn")
@@ -817,15 +807,6 @@ class TestAzureDataFactoryAsyncHook:
         hook = AzureDataFactoryAsyncHook(AZURE_DATA_FACTORY_CONN_ID)
         with pytest.raises(AirflowException):
             await hook.get_pipeline_run(RUN_ID, None, DATAFACTORY_NAME)
-
-    @pytest.mark.asyncio
-    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_async_conn")
-    async def test_get_pipeline_run_exception(self, mock_conn):
-        """Test get_pipeline_run function with exception"""
-        mock_conn.return_value.pipeline_runs.get.side_effect = Exception("Test exception")
-        hook = AzureDataFactoryAsyncHook(AZURE_DATA_FACTORY_CONN_ID)
-        with pytest.raises(AirflowException):
-            await hook.get_pipeline_run(RUN_ID, RESOURCE_GROUP_NAME, DATAFACTORY_NAME)
 
     @pytest.mark.asyncio
     @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_connection")

--- a/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
@@ -720,6 +720,14 @@ def test_backcompat_prefix_both_prefers_short(mock_connect):
         mock_connect.return_value.factories.delete.assert_called_with("non-prefixed", "n/a")
 
 
+def test_refresh_conn(hook):
+    """Test refresh_conn method _conn is reset and get_conn is called"""
+    with patch.object(hook, "get_conn") as mock_get_conn:
+        hook.refresh_conn()
+        assert not hook._conn
+        assert mock_get_conn.called
+
+
 class TestAzureDataFactoryAsyncHook:
     @pytest.mark.asyncio
     @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_async_conn")
@@ -958,3 +966,12 @@ class TestAzureDataFactoryAsyncHook:
         assert get_field(extras, "factory_name", strict=True) == DATAFACTORY_NAME
         with pytest.raises(KeyError):
             get_field(extras, "non-existent-field", strict=True)
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_async_conn")
+    async def test_refresh_conn(self, mock_get_async_conn):
+        """Test refresh_conn method _conn is reset and get_async_conn is called"""
+        hook = AzureDataFactoryAsyncHook(AZURE_DATA_FACTORY_CONN_ID)
+        await hook.refresh_conn()
+        assert not hook._conn
+        assert mock_get_async_conn.called

--- a/tests/providers/microsoft/azure/triggers/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/triggers/test_azure_data_factory.py
@@ -163,10 +163,14 @@ class TestADFPipelineRunStatusSensorTrigger:
         assert TriggerEvent({"status": "error", "message": mock_message}) == actual
 
     @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.refresh_conn")
     @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryAsyncHook.get_adf_pipeline_run_status")
-    async def test_adf_pipeline_run_status_sensors_trigger_exception(self, mock_data_factory):
+    async def test_adf_pipeline_run_status_sensors_trigger_exception(
+        self, mock_data_factory, mock_refresh_token
+    ):
         """Test EMR container sensors with raise exception"""
         mock_data_factory.side_effect = Exception("Test exception")
+        mock_refresh_token.side_effect = Exception("Test exception")
 
         task = [i async for i in self.TRIGGER.run()]
         assert len(task) == 1


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What's the issue?
When waiting for a long-running data factory pipeline run, it's possible that the Azure connection is expired and will need to be refreshed. This happens in ([AzureDataFactoryPipelineRunStatusSensor(..., deferrable=True)](https://github.com/apache/airflow/blob/1f22db7ed395ab88270faa3c1eee6c7ade53fcc7/airflow/providers/microsoft/azure/sensors/data_factory.py#L36), and [AzureDataFactoryRunPipelineOperator](https://github.com/apache/airflow/blob/1f22db7ed395ab88270faa3c1eee6c7ade53fcc7/airflow/providers/microsoft/azure/operators/data_factory.py#L77) which will need changes in the following code sections.

### AzureDataFactoryPipelineRunStatusSensor(..., deferrable=True)

https://github.com/apache/airflow/blob/1f22db7ed395ab88270faa3c1eee6c7ade53fcc7/airflow/providers/microsoft/azure/triggers/data_factory.py#L73-L77

### AzureDataFactoryRunPipelineOperator(..., deferrable=True)

https://github.com/apache/airflow/blob/1f22db7ed395ab88270faa3c1eee6c7ade53fcc7/airflow/providers/microsoft/azure/triggers/data_factory.py#L145-L149

### AzureDataFactoryRunPipelineOperator(..., deferrable=False)

https://github.com/apache/airflow/blob/1f22db7ed395ab88270faa3c1eee6c7ade53fcc7/airflow/providers/microsoft/azure/hooks/data_factory.py#L831

## What's changed?
Re-establish connection if an exception is caught in these sections, and set `executed_after_refresh_token` to `False`. If the exception does not relate to connection refresh, then the next round of status checking will still raise an exception and won't refresh the toekn

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
