### PR TITLE
Only update crawler tags if present in config dict

### DIFF
--- a/airflow/providers/amazon/aws/hooks/glue_crawler.py
+++ b/airflow/providers/amazon/aws/hooks/glue_crawler.py
@@ -87,7 +87,9 @@ class GlueCrawlerHook(AwsBaseHook):
         crawler_name = crawler_kwargs["Name"]
         current_crawler = self.get_crawler(crawler_name)
 
-        tags_updated = self.update_tags(crawler_name, crawler_kwargs.pop("Tags", {}))
+        tags_updated = (
+            self.update_tags(crawler_name, crawler_kwargs.pop("Tags")) if "Tags" in crawler_kwargs else False
+        )
 
         update_config = {
             key: value

--- a/tests/providers/amazon/aws/hooks/test_glue_crawler.py
+++ b/tests/providers/amazon/aws/hooks/test_glue_crawler.py
@@ -162,6 +162,18 @@ class TestGlueCrawlerHook:
 
     @mock_sts
     @mock.patch.object(GlueCrawlerHook, "get_conn")
+    def test_update_missing_tags(self, mock_get_conn):
+        mock_config_missing_tags = deepcopy(mock_config)
+        mock_config_missing_tags.pop("Tags")
+        mock_get_conn.return_value.get_crawler.return_value = {"Crawler": mock_config_missing_tags}
+
+        assert self.hook.update_crawler(**mock_config_missing_tags) is False
+        mock_get_conn.return_value.get_tags.assert_not_called()
+        mock_get_conn.return_value.tag_resource.assert_not_called()
+        mock_get_conn.return_value.untag_resource.assert_not_called()
+
+    @mock_sts
+    @mock.patch.object(GlueCrawlerHook, "get_conn")
     def test_replace_tag(self, mock_get_conn):
         mock_get_conn.return_value.get_crawler.return_value = {"Crawler": mock_config}
         mock_get_conn.return_value.get_tags.return_value = {"Tags": mock_config["Tags"]}

--- a/tests/providers/amazon/aws/hooks/test_glue_crawler.py
+++ b/tests/providers/amazon/aws/hooks/test_glue_crawler.py
@@ -178,8 +178,6 @@ class TestGlueCrawlerHook:
         mock_get_conn.return_value.get_crawler.return_value = {"Crawler": mock_config}
         mock_get_conn.return_value.get_tags.return_value = {"Tags": mock_config["Tags"]}
 
-        mock_config_two = deepcopy(mock_config)
-        mock_config_two.pop("Tags")
         assert self.hook.update_tags(mock_crawler_name, {"test": "bla", "bar": "test"}) is True
         mock_get_conn.return_value.get_tags.assert_called_once_with(ResourceArn=self.crawler_arn)
         mock_get_conn.return_value.untag_resource.assert_not_called()


### PR DESCRIPTION
Closes: #32330 

This PR modifies the GlueCrawlerHook to only update the crawlers tags if the `Tags` key is present in the `config` dict. This prevent situations where tags that are set by external processes are overwritten whenever the crawler is run from Airflow.