### PR TITLE
Use kubeconfig file to auth to GKE instead of oauth2 token

### DIFF
--- a/airflow/providers/google/cloud/triggers/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/triggers/kubernetes_engine.py
@@ -69,6 +69,7 @@ class GKEStartPodTrigger(KubernetesPodTrigger):
         pod_namespace: str,
         cluster_url: str,
         ssl_ca_cert: str,
+        kubeconfig_dict: dict[str, Any],
         base_container_name: str,
         trigger_start_time: datetime,
         cluster_context: str | None = None,
@@ -98,6 +99,7 @@ class GKEStartPodTrigger(KubernetesPodTrigger):
         self.in_cluster = in_cluster
         self.get_logs = get_logs
         self.startup_timeout = startup_timeout
+        self.kubeconfig_dict = kubeconfig_dict
 
         if should_delete_pod is not None:
             warnings.warn(
@@ -132,6 +134,7 @@ class GKEStartPodTrigger(KubernetesPodTrigger):
                 "base_container_name": self.base_container_name,
                 "should_delete_pod": self.should_delete_pod,
                 "on_finish_action": self.on_finish_action.value,
+                "kubeconfig_dict": self.kubeconfig_dict,
             },
         )
 
@@ -139,6 +142,7 @@ class GKEStartPodTrigger(KubernetesPodTrigger):
         return GKEPodAsyncHook(
             cluster_url=self._cluster_url,
             ssl_ca_cert=self._ssl_ca_cert,
+            kubeconfig_dict=self.kubeconfig_dict,
         )
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #31648

Before the PR #29266, we used to create a temporary configuration file by running the command gcloud container clusters get-credentials. We would then use this file in the Kubernetes client. The get-credentials command configures kubectl to automatically refresh its credentials using the same identity as gcloud.

However, the #29266 introduced a new pod GKE hook that uses the following client code:
```python
ApiClient(
    configuration,
    header_name="Authorization",
    header_value=f"Bearer {access_token}",
)
```
This client uses static oauth2 credentials and cannot refresh them when they expire. Since the default lifetime for GCP credentials is 3600 seconds, the operator fails with an Unauthorized exception after one hour.



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
