### PR TITLE
postgres: deprecate `runtime_parameters` in favor of options in `hook_params`

### DIFF
--- a/airflow/providers/postgres/operators/postgres.py
+++ b/airflow/providers/postgres/operators/postgres.py
@@ -20,8 +20,6 @@ from __future__ import annotations
 import warnings
 from typing import Mapping, Sequence
 
-from psycopg2.sql import SQL, Identifier
-
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
@@ -41,6 +39,7 @@ class PostgresOperator(SQLExecuteQueryOperator):
     :param database: name of database which overwrite defined one in connection
     :param runtime_parameters: a mapping of runtime params added to the final sql being executed.
         For example, you could set the schema via `{"search_path": "CUSTOM_SCHEMA"}`.
+        Deprecated - use `hook_params={'options': '-c <connection_options>'}` instead.
     """
 
     template_fields: Sequence[str] = ("sql",)
@@ -61,26 +60,15 @@ class PostgresOperator(SQLExecuteQueryOperator):
             kwargs["hook_params"] = {"schema": database, **hook_params}
 
         if runtime_parameters:
-            sql = kwargs.pop("sql")
-            parameters = kwargs.pop("parameters", {})
-
-            final_sql = []
-            sql_param = {}
-            for param in runtime_parameters:
-                set_param_sql = f"SET {{}} TO %({param})s;"
-                dynamic_sql = SQL(set_param_sql).format(Identifier(f"{param}"))
-                final_sql.append(dynamic_sql)
-            for param, val in runtime_parameters.items():
-                sql_param.update({f"{param}": f"{val}"})
-            if parameters:
-                sql_param.update(parameters)
-            if isinstance(sql, str):
-                final_sql.append(SQL(sql))
-            else:
-                final_sql.extend(list(map(SQL, sql)))
-
-            kwargs["sql"] = final_sql
-            kwargs["parameters"] = sql_param
+            warnings.warn(
+                """`runtime_parameters` is deprecated.
+                Please use `hook_params={'options': '-c <connection_options>}`.""",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
+            hook_params = kwargs.pop("hook_params", {})
+            options = " ".join(f"-c {param}={val}" for param, val in runtime_parameters.items())
+            kwargs["hook_params"] = {"options": options, **hook_params}
 
         super().__init__(conn_id=postgres_conn_id, **kwargs)
         warnings.warn(

--- a/docs/apache-airflow-providers-postgres/operators/postgres_operator_howto_guide.rst
+++ b/docs/apache-airflow-providers-postgres/operators/postgres_operator_howto_guide.rst
@@ -159,8 +159,9 @@ class.
 Passing Server Configuration Parameters into PostgresOperator
 -------------------------------------------------------------
 
-PostgresOperator provides the optional ``runtime_parameters`` attribute which makes it possible to set
-the `server configuration parameter values <https://www.postgresql.org/docs/current/runtime-config-client.html>`_ for the SQL request during runtime.
+PostgresOperator provides ``hook_params`` attribute that allows you to pass add parameters to PostgresHook.
+You can pass ``options`` argument this way so that you specify `command-line options <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-OPTIONS>`_
+sent to the server at connection start.
 
 .. exampleinclude:: /../../tests/system/providers/postgres/example_postgres.py
     :language: python
@@ -186,5 +187,5 @@ In this how-to guide we explored the Apache Airflow PostgreOperator. Let's quick
 It is best practice to create subdirectory called ``sql`` in your ``dags`` directory where you can store your sql files.
 This will make your code more elegant and more maintainable.
 And finally, we looked at the different ways you can dynamically pass parameters into our PostgresOperator
-tasks using ``parameters`` or ``params`` attribute and how you can control the server configuration parameters by passing
-the ``runtime_parameters`` attribute.
+tasks using ``parameters`` or ``params`` attribute and how you can control the session parameters by passing
+options in the ``hook_params`` attribute.

--- a/tests/providers/postgres/hooks/test_postgres.py
+++ b/tests/providers/postgres/hooks/test_postgres.py
@@ -102,6 +102,20 @@ class TestPostgresHookConn:
         )
 
     @mock.patch("airflow.providers.postgres.hooks.postgres.psycopg2.connect")
+    def test_get_conn_from_connection_with_options(self, mock_connect):
+        conn = Connection(login="login-conn", password="password-conn", host="host", schema="database")
+        hook = PostgresHook(connection=conn, options="-c statement_timeout=3000ms")
+        hook.get_conn()
+        mock_connect.assert_called_once_with(
+            user="login-conn",
+            password="password-conn",
+            host="host",
+            dbname="database",
+            port=None,
+            options="-c statement_timeout=3000ms",
+        )
+
+    @mock.patch("airflow.providers.postgres.hooks.postgres.psycopg2.connect")
     @mock.patch("airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook")
     @pytest.mark.parametrize("aws_conn_id", [NOTSET, None, "mock_aws_conn"])
     @pytest.mark.parametrize("port", [65432, 5432, None])

--- a/tests/providers/postgres/operators/test_postgres.py
+++ b/tests/providers/postgres/operators/test_postgres.py
@@ -112,3 +112,4 @@ class TestPostgres:
             runtime_parameters={"statement_timeout": "3000ms"},
         )
         op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        assert op.get_db_hook().get_first("SHOW statement_timeout;")[0] == "3s"

--- a/tests/system/providers/postgres/example_postgres.py
+++ b/tests/system/providers/postgres/example_postgres.py
@@ -73,7 +73,7 @@ with DAG(
         task_id="get_birth_date",
         sql="SELECT * FROM pet WHERE birth_date BETWEEN SYMMETRIC %(begin_date)s AND %(end_date)s",
         parameters={"begin_date": "2020-01-01", "end_date": "2020-12-31"},
-        runtime_parameters={"statement_timeout": "3000ms"},
+        hook_params={"options": "-c statement_timeout=3000ms"},
     )
     # [END postgres_operator_howto_guide_get_birth_date]
 


### PR DESCRIPTION
Currently you need to pass `runtime_parameters` argument to explicitly set e.g. search_path in PostgresOperator.
The solution IMO is not that good. It introduces use of `psycopg2.SQL` which is not compatible with `sql` attribute type.
Moreover, it overcomplicates things, does not maintain same session variables outside of `PostgresOperator` execution and would be problematic to implement when removing `PostgresOperator` which is marked as deprecated class.

Additional motivation is that I'd like to use `PostgresOperator`'s hook after it's execution but with the same session params in OpenLineage integration. This PR allows to do this easily.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
