### PR TITLE
Support setting dependencies for tasks called outside TaskGroup context manager

### DIFF
--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
     from airflow.models.mappedoperator import MappedOperator
     from airflow.models.operator import Operator
     from airflow.models.taskinstance import TaskInstance
+    from airflow.utils.task_group import TaskGroup
 
 DEFAULT_OWNER: str = conf.get_mandatory_value("operators", "default_owner")
 DEFAULT_POOL_SLOTS: int = 1
@@ -381,6 +382,14 @@ class AbstractOperator(Templater, DAGNode):
             if isinstance(parent, MappedTaskGroup):
                 yield parent
             parent = parent.task_group
+
+    def add_to_taskgroup(self, task_group: TaskGroup) -> None:
+        """Add the task to the given task group.
+
+        :meta private:
+        """
+        if self.node_id not in task_group.children:
+            task_group.add(self)
 
     def get_closest_mapped_task_group(self) -> MappedTaskGroup | None:
         """Get the mapped task group "closest" to this task in the DAG.

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -129,7 +129,7 @@ class DependencyMixin:
 
         if isinstance(obj, AbstractOperator):
             yield obj, "operator"
-        elif isinstance(obj, PlainXComArg):
+        elif isinstance(obj, ResolveMixin):
             yield from obj.iter_references()
         elif isinstance(obj, Sequence):
             for o in obj:

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -146,8 +146,10 @@ class DependencyMixin:
 
         if not TaskGroupContext.active:
             return
+        task_group = TaskGroupContext.get_current_task_group(None)
         for op in DependencyMixin._iter_references([self, other]):
-            TaskGroupContext.add_task(op)
+            if task_group:
+                op.add_to_taskgroup(task_group)
 
 
 class TaskMixin(DependencyMixin):

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -125,7 +125,7 @@ class DependencyMixin:
     @classmethod
     def _iter_references(cls, obj: Any) -> Iterable[tuple[DependencyMixin, str]]:
         from airflow.models.baseoperator import AbstractOperator
-        from airflow.models.xcom_arg import PlainXComArg
+        from airflow.utils.mixins import ResolveMixin
 
         if isinstance(obj, AbstractOperator):
             yield obj, "operator"

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -42,6 +42,7 @@ from airflow.utils.xcom import XCOM_RETURN_KEY
 if TYPE_CHECKING:
     from airflow.models.dag import DAG
     from airflow.models.operator import Operator
+    from airflow.utils.task_group import TaskGroup
 
 # Callable objects contained by MapXComArg. We only accept callables from
 # the user, but deserialize them into strings in a serialized XComArg for
@@ -206,6 +207,15 @@ class XComArg(ResolveMixin, DependencyMixin):
         :meta private:
         """
         raise NotImplementedError()
+
+    def add_to_taskgroup(self, task_group: TaskGroup) -> None:
+        """Add the task to the given task group.
+
+        :meta private:
+        """
+        for op, _ in self.iter_references():
+            if op.node_id not in task_group.children:
+                task_group.add(op)
 
     def __enter__(self):
         if not self.operator.is_setup and not self.operator.is_teardown:

--- a/airflow/utils/edgemodifier.py
+++ b/airflow/utils/edgemodifier.py
@@ -172,6 +172,13 @@ class EdgeModifier(DependencyMixin):
         """
         dag.set_edge_info(upstream_id, downstream_id, {"label": self.label})
 
+    def add_to_taskgroup(self, task_group: TaskGroup) -> None:
+        """
+        No-op, since we're not a task.
+
+        :meta private:
+        """
+
 
 # Factory functions
 def Label(label: str):

--- a/airflow/utils/edgemodifier.py
+++ b/airflow/utils/edgemodifier.py
@@ -173,8 +173,10 @@ class EdgeModifier(DependencyMixin):
         dag.set_edge_info(upstream_id, downstream_id, {"label": self.label})
 
     def add_to_taskgroup(self, task_group: TaskGroup) -> None:
-        """
-        No-op, since we're not a task.
+        """No-op, since we're not a task.
+
+        We only add tasks to TaskGroups and not EdgeModifiers, but we need
+        this to satisfy the interface.
 
         :meta private:
         """

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -22,7 +22,7 @@ from datetime import timedelta
 import pendulum
 import pytest
 
-from airflow.decorators import dag, task_group as task_group_decorator
+from airflow.decorators import dag, task as task_decorator, task_group as task_group_decorator
 from airflow.exceptions import TaskAlreadyInTaskGroup
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG
@@ -33,6 +33,20 @@ from airflow.operators.python import PythonOperator
 from airflow.utils.dag_edges import dag_edges
 from airflow.utils.task_group import TaskGroup, task_group_to_dict
 from tests.models import DEFAULT_DATE
+
+
+def make_task(name, type_="classic"):
+    if type_ == "classic":
+        return BashOperator(task_id=name, bash_command="echo 1")
+
+    else:
+
+        @task_decorator
+        def my_task():
+            pass
+
+        return my_task.override(task_id=name)()
+
 
 EXPECTED_JSON = {
     "id": None,
@@ -1465,3 +1479,62 @@ def test_task_group_arrow_with_setups_teardowns():
         tg1 >> w2
     assert t1.downstream_task_ids == set()
     assert w1.downstream_task_ids == {"tg1.t1", "w2"}
+
+
+def test_tasks_defined_outside_taskgrooup(dag_maker):
+    # Test that classic tasks defined outside a task group are added to the root task group
+    # when the relationships are defined inside the task group
+    with dag_maker() as dag:
+        t1 = make_task("t1")
+        t2 = make_task("t2")
+        t3 = make_task("t3")
+        with TaskGroup(group_id="tg1"):
+            t1 >> t2 >> t3
+    assert dag.task_group.children.keys() == {"tg1"}
+    assert dag.task_group.children["tg1"].children.keys() == {"t1", "t2", "t3"}
+    assert dag.task_group.children["tg1"].children["t1"].upstream_task_ids == set()
+    assert dag.task_group.children["tg1"].children["t1"].downstream_task_ids == {"t2"}
+    assert dag.task_group.children["tg1"].children["t2"].upstream_task_ids == {"t1"}
+    assert dag.task_group.children["tg1"].children["t2"].downstream_task_ids == {"t3"}
+    assert dag.task_group.children["tg1"].children["t3"].upstream_task_ids == {"t2"}
+    assert dag.task_group.children["tg1"].children["t3"].downstream_task_ids == set()
+
+    # Test that decorated tasks defined outside a task group are added to the root task group
+    # when relationships are defined inside the task group
+    with dag_maker() as dag:
+        t1 = make_task("t1", type_="decorated")
+        t2 = make_task("t2", type_="decorated")
+        t3 = make_task("t3", type_="decorated")
+        with TaskGroup(group_id="tg1"):
+            t1 >> t2 >> t3
+
+    assert dag.task_group.children.keys() == {"tg1"}
+    assert dag.task_group.children["tg1"].children.keys() == {"t1", "t2", "t3"}
+    assert dag.task_group.children["tg1"].children["t1"].upstream_task_ids == set()
+    assert dag.task_group.children["tg1"].children["t1"].downstream_task_ids == {"t2"}
+    assert dag.task_group.children["tg1"].children["t2"].upstream_task_ids == {"t1"}
+    assert dag.task_group.children["tg1"].children["t2"].downstream_task_ids == {"t3"}
+    assert dag.task_group.children["tg1"].children["t3"].upstream_task_ids == {"t2"}
+    assert dag.task_group.children["tg1"].children["t3"].downstream_task_ids == set()
+
+    # Test adding single decorated task defined outside a task group to a task group
+    with dag_maker() as dag:
+        t1 = make_task("t1", type_="decorated")
+        with TaskGroup(group_id="tg1") as tg1:
+            tg1.add(t1)
+
+    assert dag.task_group.children.keys() == {"tg1"}
+    assert dag.task_group.children["tg1"].children.keys() == {"t1"}
+    assert dag.task_group.children["tg1"].children["t1"].upstream_task_ids == set()
+    assert dag.task_group.children["tg1"].children["t1"].downstream_task_ids == set()
+
+    # Test adding single classic task defined outside a task group to a task group
+    with dag_maker() as dag:
+        t1 = make_task("t1")
+        with TaskGroup(group_id="tg1") as tg1:
+            tg1.add(t1)
+
+    assert dag.task_group.children.keys() == {"tg1"}
+    assert dag.task_group.children["tg1"].children.keys() == {"t1"}
+    assert dag.task_group.children["tg1"].children["t1"].upstream_task_ids == set()
+    assert dag.task_group.children["tg1"].children["t1"].downstream_task_ids == set()


### PR DESCRIPTION
Currently, you must instantiate a classic operator or call a decorated operator inside the context manager before it will link up with the context manager. For example, tasks 1 and 2 below will be outside the group1 context:
```
   task1 = BashOperator(task_id="task1", bash_command="echo task1")
   task2 = BashOperator(task_id="task2", bash_command="echo task2")
   with TaskGroup('group1'):
        task1 >> task2
```
This PR addresses the above such that when you do that, the tasks will be inside the group1 context.
For a single task, you can do:
```
   task1 = BashOperator(task_id="task1", bash_command="echo task1")
   with TaskGroup('group1') as scope:
        scope.add_task(task1)
```

