### PR TITLE
deprecate arbitrary parameter passing to RDS hook

### DIFF
--- a/airflow/providers/amazon/aws/operators/rds.py
+++ b/airflow/providers/amazon/aws/operators/rds.py
@@ -18,12 +18,13 @@
 from __future__ import annotations
 
 import json
+import warnings
 from datetime import timedelta
 from typing import TYPE_CHECKING, Sequence
 
 from mypy_boto3_rds.type_defs import TagTypeDef
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.rds import RdsHook
 from airflow.providers.amazon.aws.triggers.rds import RdsDbInstanceTrigger
@@ -42,6 +43,14 @@ class RdsBaseOperator(BaseOperator):
     ui_fgcolor = "#ffffff"
 
     def __init__(self, *args, aws_conn_id: str = "aws_conn_id", hook_params: dict | None = None, **kwargs):
+        if hook_params is not None:
+            warnings.warn(
+                "The parameter hook_params is deprecated and will be removed. "
+                "If you were using it, please get in touch either on airflow slack, "
+                "or by opening a github issue on the project.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=3,  # 2 is in the operator's init, 3 is in the user code creating the operator
+            )
         self.hook_params = hook_params or {}
         self.hook = RdsHook(aws_conn_id=aws_conn_id, **self.hook_params)
         super().__init__(*args, **kwargs)

--- a/airflow/providers/amazon/aws/operators/rds.py
+++ b/airflow/providers/amazon/aws/operators/rds.py
@@ -47,7 +47,8 @@ class RdsBaseOperator(BaseOperator):
             warnings.warn(
                 "The parameter hook_params is deprecated and will be removed. "
                 "If you were using it, please get in touch either on airflow slack, "
-                "or by opening a github issue on the project.",
+                "or by opening a github issue on the project. "
+                "You can mention https://github.com/apache/airflow/pull/32352",
                 AirflowProviderDeprecationWarning,
                 stacklevel=3,  # 2 is in the operator's init, 3 is in the user code creating the operator
             )


### PR DESCRIPTION
The way RDS operators are built allows passing arbitrary parameters to the hook via a kwarg named `hook_params`. However this is not documented anywhere, and the usefulness of the feature looks pretty dubious to me.

We usually just let users pass the aws conn id and eventually the region, not _anything they want_.
I doubt anyone is using that, so I'm deprecating without any alternative ? If that's an OK thing to do ?