### PR TITLE
D205 Support - Providers: Pagerduty to SMTP (inclusive)

### DIFF
--- a/airflow/providers/plexus/hooks/plexus.py
+++ b/airflow/providers/plexus/hooks/plexus.py
@@ -29,9 +29,9 @@ from airflow.models import Variable
 
 class PlexusHook(BaseHook):
     """
-    Used for jwt token generation and storage to
-    make Plexus API calls. Requires email and password
-    Airflow variables be created.
+    Used for jwt token generation and storage to make Plexus API calls.
+
+    Requires email and password Airflow variables be created.
 
     Example:
         - export AIRFLOW_VAR_EMAIL = user@corescientific.com

--- a/airflow/providers/plexus/operators/job.py
+++ b/airflow/providers/plexus/operators/job.py
@@ -131,8 +131,7 @@ class PlexusJobOperator(BaseOperator):
 
     def construct_job_params(self, hook: Any) -> dict[Any, Any | None]:
         """
-        Creates job_params dict for api call to
-        launch a Plexus job.
+        Creates job_params dict for api call to launch a Plexus job.
 
         Some parameters required to launch a job
         are not available to the user in the Plexus

--- a/airflow/providers/presto/hooks/presto.py
+++ b/airflow/providers/presto/hooks/presto.py
@@ -220,8 +220,7 @@ class PrestoHook(DbApiHook):
     @staticmethod
     def _serialize_cell(cell: Any, conn: Connection | None = None) -> Any:
         """
-        Presto will adapt all arguments to the execute() method internally,
-        hence we return cell without any conversion.
+        Presto will adapt all execute() args internally, hence we return cell without any conversion.
 
         :param cell: The cell to insert into the table
         :param conn: The database connection

--- a/airflow/providers/qubole/operators/qubole_check.py
+++ b/airflow/providers/qubole/operators/qubole_check.py
@@ -45,7 +45,8 @@ class _QuboleCheckOperatorMixin:
 
     def get_hook(self) -> QuboleCheckHook:
         """
-        Reinitialising the hook, as some template fields might have changed
+        Reinitialising the hook, as some template fields might have changed.
+
         This method overwrites the original QuboleOperator.get_hook() which returns a QuboleHook.
         """
         return QuboleCheckHook(
@@ -55,8 +56,9 @@ class _QuboleCheckOperatorMixin:
 
 class QuboleCheckOperator(_QuboleCheckOperatorMixin, SQLCheckOperator, QuboleOperator):
     """
-    Performs checks against Qubole Commands. ``QuboleCheckOperator`` expects
-    a command that will be executed on QDS.
+    Performs checks against Qubole Commands.
+
+    ``QuboleCheckOperator`` expects a command that will be executed on QDS.
     By default, each value on first row of the result of this Qubole Command
     is evaluated using python ``bool`` casting. If any of the
     values return ``False``, the check is failed and errors out.
@@ -129,6 +131,7 @@ class QuboleCheckOperator(_QuboleCheckOperatorMixin, SQLCheckOperator, QuboleOpe
 class QuboleValueCheckOperator(_QuboleCheckOperatorMixin, SQLValueCheckOperator, QuboleOperator):
     """
     Performs a simple value check using Qubole command.
+
     By default, each value on the first row of this
     Qubole command is compared with a pre-defined value.
     The check fails and errors out if the output of the command

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -16,8 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-This module contains a Salesforce Hook which allows you to connect to your Salesforce instance,
-retrieve data from it, and write that data to a file for other uses.
+Connect to your Salesforce instance, retrieve data from it, and write that data to a file for other uses.
 
 .. note:: this hook also relies on the simple_salesforce package:
       https://github.com/simple-salesforce/simple-salesforce
@@ -180,6 +179,7 @@ class SalesforceHook(BaseHook):
     def describe_object(self, obj: str) -> dict:
         """
         Get the description of an object from Salesforce.
+
         This description is the object's schema and
         some extra metadata that Salesforce stores for each object.
 
@@ -204,6 +204,7 @@ class SalesforceHook(BaseHook):
     def get_object_from_salesforce(self, obj: str, fields: Iterable[str]) -> dict:
         """
         Get all instances of the `object` from Salesforce.
+
         For each model, only get the fields specified in fields.
 
         All we really do underneath the hood is run:

--- a/airflow/providers/segment/hooks/segment.py
+++ b/airflow/providers/segment/hooks/segment.py
@@ -16,9 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-This module contains a Segment Hook
-which allows you to connect to your Segment account,
-retrieve data from it or write to that file.
+Connect to your Segment account, retrieve data from it or write to that file.
 
 NOTE:   this hook also relies on the Segment analytics package:
         https://github.com/segmentio/analytics-python
@@ -33,8 +31,7 @@ from airflow.hooks.base import BaseHook
 
 class SegmentHook(BaseHook):
     """
-    Create new connection to Segment
-    and allows you to pull data out of Segment or write to it.
+    Create new connection to Segment and allows you to pull data out of Segment or write to it.
 
     You can then use that file with other
     Airflow operators to move the data around or interact with segment.

--- a/airflow/providers/sftp/operators/sftp.py
+++ b/airflow/providers/sftp/operators/sftp.py
@@ -39,8 +39,8 @@ class SFTPOperation:
 class SFTPOperator(BaseOperator):
     """
     SFTPOperator for transferring files from remote host to local or vice a versa.
-    This operator uses sftp_hook to open sftp transport channel that serve as basis
-    for file transfer.
+
+    This operator uses sftp_hook to open sftp transport channel that serve as basis for file transfer.
 
     :param ssh_conn_id: :ref:`ssh connection id<howto/connection:ssh>`
         from airflow Connections. `ssh_conn_id` will be ignored if `ssh_hook`

--- a/airflow/providers/slack/hooks/slack.py
+++ b/airflow/providers/slack/hooks/slack.py
@@ -38,12 +38,8 @@ if TYPE_CHECKING:
 
 
 def _ensure_prefixes(conn_type):
-    """
-    Deprecated.
-
-    Remove when provider min airflow version >= 2.5.0 since this is handled by
-    provider manager from that version.
-    """
+    # TODO: Remove when provider min airflow version >= 2.5.0 since
+    #       this is handled by provider manager from that version.
 
     def dec(func):
         @wraps(func)

--- a/airflow/providers/slack/hooks/slack.py
+++ b/airflow/providers/slack/hooks/slack.py
@@ -39,6 +39,8 @@ if TYPE_CHECKING:
 
 def _ensure_prefixes(conn_type):
     """
+    Deprecated.
+
     Remove when provider min airflow version >= 2.5.0 since this is handled by
     provider manager from that version.
     """

--- a/airflow/providers/slack/hooks/slack_webhook.py
+++ b/airflow/providers/slack/hooks/slack_webhook.py
@@ -55,12 +55,8 @@ def check_webhook_response(func: Callable) -> Callable:
 
 
 def _ensure_prefixes(conn_type):
-    """
-    Deprecated.
-
-    Remove when provider min airflow version >= 2.5.0 since this is handled by
-    provider manager from that version.
-    """
+    # TODO: Remove when provider min airflow version >= 2.5.0 since
+    #       this is handled by provider manager from that version.
 
     def dec(func):
         @wraps(func)

--- a/airflow/providers/slack/hooks/slack_webhook.py
+++ b/airflow/providers/slack/hooks/slack_webhook.py
@@ -56,6 +56,8 @@ def check_webhook_response(func: Callable) -> Callable:
 
 def _ensure_prefixes(conn_type):
     """
+    Deprecated.
+
     Remove when provider min airflow version >= 2.5.0 since this is handled by
     provider manager from that version.
     """
@@ -85,6 +87,7 @@ def _ensure_prefixes(conn_type):
 class SlackWebhookHook(BaseHook):
     """
     This class provide a thin wrapper around the ``slack_sdk.WebhookClient``.
+
     This hook allows you to post messages to Slack by using Incoming Webhooks.
 
     .. seealso::

--- a/airflow/providers/slack/transfers/sql_to_slack.py
+++ b/airflow/providers/slack/transfers/sql_to_slack.py
@@ -80,12 +80,15 @@ class BaseSqlToSlackOperator(BaseOperator):
 
 class SqlToSlackOperator(BaseSqlToSlackOperator):
     """
-    Executes an SQL statement in a given SQL connection and sends the results to Slack. The results of the
-    query are rendered into the 'slack_message' parameter as a Pandas dataframe using a JINJA variable called
-    '{{ results_df }}'. The 'results_df' variable name can be changed by specifying a different
-    'results_df_name' parameter. The Tabulate library is added to the JINJA environment as a filter to
-    allow the dataframe to be rendered nicely. For example, set 'slack_message' to {{ results_df |
-    tabulate(tablefmt="pretty", headers="keys") }} to send the results to Slack as an ascii rendered table.
+    Executes an SQL statement in a given SQL connection and sends the results to Slack.
+
+    The results of the query are rendered into the 'slack_message' parameter as a Pandas
+    dataframe using a JINJA variable called '{{ results_df }}'. The 'results_df' variable
+    name can be changed by specifying a different 'results_df_name' parameter. The Tabulate
+    library is added to the JINJA environment as a filter to allow the dataframe to be
+    rendered nicely. For example, set 'slack_message' to {{ results_df |
+    tabulate(tablefmt="pretty", headers="keys") }} to send the results to Slack as an ascii
+    rendered table.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:

--- a/airflow/providers/smtp/hooks/smtp.py
+++ b/airflow/providers/smtp/hooks/smtp.py
@@ -16,8 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-This module provides everything to be able to search in mails for a specific attachment
-and also to download it.
+Search in emails for a specific attachment and also to download it.
+
 It uses the smtplib library that is already integrated in python 3.
 """
 from __future__ import annotations
@@ -302,8 +302,9 @@ class SmtpHook(BaseHook):
 
     def _get_email_list_from_str(self, addresses: str) -> list[str]:
         """
-        Extract a list of email addresses from a string. The string
-        can contain multiple email addresses separated by
+        Extract a list of email addresses from a string.
+
+        The string can contain multiple email addresses separated by
         any of the following delimiters: ',' or ';'.
 
         :param addresses: A string containing one or more email addresses.

--- a/airflow/providers/snowflake/operators/snowflake.py
+++ b/airflow/providers/snowflake/operators/snowflake.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import time
 import warnings
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence, SupportsAbs, cast
+from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, Sequence, SupportsAbs, cast
 
 from airflow import AirflowException
 from airflow.exceptions import AirflowProviderDeprecationWarning
@@ -548,7 +548,7 @@ class SnowflakeSqlApiOperator(SQLExecuteQueryOperator):
                 raise AirflowException(msg)
             elif "status" in event and event["status"] == "success":
                 hook = SnowflakeSqlApiHook(snowflake_conn_id=self.snowflake_conn_id)
-                query_ids = cast(list[str], event["statement_query_ids"])
+                query_ids = cast(List[str], event["statement_query_ids"])
                 hook.check_query_output(query_ids)
                 self.log.info("%s completed successfully.", self.task_id)
         else:

--- a/airflow/providers/snowflake/operators/snowflake.py
+++ b/airflow/providers/snowflake/operators/snowflake.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import time
 import warnings
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, Sequence, SupportsAbs, cast
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence, SupportsAbs, cast
 
 from airflow import AirflowException
 from airflow.exceptions import AirflowProviderDeprecationWarning
@@ -548,7 +548,7 @@ class SnowflakeSqlApiOperator(SQLExecuteQueryOperator):
                 raise AirflowException(msg)
             elif "status" in event and event["status"] == "success":
                 hook = SnowflakeSqlApiHook(snowflake_conn_id=self.snowflake_conn_id)
-                query_ids = cast(List[str], event["statement_query_ids"])
+                query_ids = cast(list[str], event["statement_query_ids"])
                 hook.check_query_output(query_ids)
                 self.log.info("%s completed successfully.", self.task_id)
         else:


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/10742

D205 asserts that all docstrings must have a one-line summary ending in a period.  If there is more than one sentence then there must be a blank line before the rest of the docstring.  Meeting these requirements could be as simple as adding a newline, or might require some rephrasing.

There are almost a thousand violations in the repo so we're going to have to take this in bites.

### PLEASE NOTE

There should be zero logic changes in this PR, only changes to docstrings and whitespace.  If you see otherwise, please call it out.

### Included in this chunk

All files contained in the following provider packages:
- pagerduty
- papermill
- plexus
- postgress
- presto
- qubole
- redis
- salesforce
- samba
- segment
- sendgrid
- sftp
- singularity
- slack
- smtp

### To test

If you comment out [this line](https://github.com/apache/airflow/blob/main/pyproject.toml#L68) and run pre-commit in main you will get 642 errors.  After these changes, "only" 624 remain and no files in any of the above provider packages should be on the list.  After uncommenting that line and rerunning pre-commits, there should be zero regressions. 