### PR TITLE
openlineage: pass SQLAlchemy engine to construct information schema query.

### DIFF
--- a/airflow/providers/common/sql/hooks/sql.py
+++ b/airflow/providers/common/sql/hooks/sql.py
@@ -538,7 +538,7 @@ class DbApiHook(BaseForDbApiHook):
         """
         return "generic"
 
-    def get_openlineage_default_schema(self) -> str:
+    def get_openlineage_default_schema(self) -> str | None:
         """
         Returns default schema specific to database.
 

--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -320,7 +320,11 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
             return None
 
         operator_lineage = sql_parser.generate_openlineage_metadata_from_sql(
-            sql=self.sql, hook=hook, database_info=database_info, database=self.database
+            sql=self.sql,
+            hook=hook,
+            database_info=database_info,
+            database=self.database,
+            sqlalchemy_engine=hook.get_sqlalchemy_engine(),
         )
 
         return operator_lineage

--- a/airflow/providers/openlineage/sqlparser.py
+++ b/airflow/providers/openlineage/sqlparser.py
@@ -33,6 +33,8 @@ from openlineage.client.run import Dataset
 from openlineage.common.sql import DbTableMeta, SqlMeta, parse
 
 if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
+
     from airflow.hooks.base import BaseHook
 
 DEFAULT_NAMESPACE = "default"
@@ -113,6 +115,7 @@ class SQLParser:
         database_info: DatabaseInfo,
         namespace: str = DEFAULT_NAMESPACE,
         database: str | None = None,
+        sqlalchemy_engine: Engine | None = None,
     ) -> tuple[list[Dataset], ...]:
         """Parse schemas for input and output tables."""
         database_kwargs: GetTableSchemasParams = {
@@ -128,8 +131,16 @@ class SQLParser:
             namespace,
             self.default_schema,
             database or database_info.database,
-            self.create_information_schema_query(tables=inputs, **database_kwargs) if inputs else None,
-            self.create_information_schema_query(tables=outputs, **database_kwargs) if outputs else None,
+            self.create_information_schema_query(
+                tables=inputs, sqlalchemy_engine=sqlalchemy_engine, **database_kwargs
+            )
+            if inputs
+            else None,
+            self.create_information_schema_query(
+                tables=outputs, sqlalchemy_engine=sqlalchemy_engine, **database_kwargs
+            )
+            if outputs
+            else None,
         )
 
     def generate_openlineage_metadata_from_sql(
@@ -138,6 +149,7 @@ class SQLParser:
         hook: BaseHook,
         database_info: DatabaseInfo,
         database: str | None = None,
+        sqlalchemy_engine: Engine | None = None,
     ) -> OperatorLineage:
         """Parses SQL statement(s) and generates OpenLineage metadata.
 
@@ -152,6 +164,7 @@ class SQLParser:
         :param hook: Airflow Hook used to connect to the database
         :param database_info: database specific information
         :param database: when passed it takes precedence over parsed database name
+        :param sqlalchemy_engine: when passed, engine's dialect is used to compile SQL queries
         """
         job_facets: dict[str, BaseFacet] = {"sql": SqlJobFacet(query=self.normalize_sql(sql))}
         parse_result = self.parse(self.split_sql_string(sql))
@@ -182,6 +195,7 @@ class SQLParser:
             namespace=namespace,
             database=database,
             database_info=database_info,
+            sqlalchemy_engine=sqlalchemy_engine,
         )
 
         return OperatorLineage(
@@ -236,6 +250,7 @@ class SQLParser:
         information_schema_table,
         is_uppercase_names,
         database: str | None = None,
+        sqlalchemy_engine: Engine | None = None,
     ) -> str:
         """Creates SELECT statement to query information schema table."""
         tables_hierarchy = cls._get_tables_hierarchy(
@@ -249,6 +264,7 @@ class SQLParser:
             information_schema_table_name=information_schema_table,
             tables_hierarchy=tables_hierarchy,
             uppercase_names=is_uppercase_names,
+            sqlalchemy_engine=sqlalchemy_engine,
         )
 
     @staticmethod

--- a/tests/providers/common/sql/operators/test_sql_execute.py
+++ b/tests/providers/common/sql/operators/test_sql_execute.py
@@ -316,7 +316,7 @@ FORGOT TO COMMENT"""
         (DB_SCHEMA_NAME, "popular_orders_day_of_week", "orders_placed", 3, "int4"),
     ]
     dbapi_hook.get_connection.return_value = Connection(
-        conn_id="sql_default", conn_type="postgres", host="host", port=1234
+        conn_id="sql_default", conn_type="postgresql", host="host", port=1234
     )
     dbapi_hook.get_conn.return_value.cursor.return_value.fetchall.side_effect = [rows, []]
 


### PR DESCRIPTION
The OpenLineage provider SQL utils already has an implemented feature for constructing information schema queries using the SQLAlchemy engine as a parameter. This PR allows to pass the engine to SQL utility methods.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
