### PR TITLE
Updating pyenv instructions for quick start guide

### DIFF
--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -179,8 +179,14 @@ extra while installing airflow.
 
 .. code-block:: bash
 
+For Architectures other than MacOS/ARM
   $ pyenv install --list
   $ pyenv install 3.8.5
+  $ pyenv versions
+
+For MacOS/Arm (3.9.1 is the first version of Python to support MacOS/ARM, but 3.8.10 works too)
+  $ pyenv install --list
+  $ pyenv install 3.8.10
   $ pyenv versions
 
 5. Creating new virtual environment named ``airflow-env`` for installed version python. In next chapter virtual
@@ -188,7 +194,11 @@ extra while installing airflow.
 
 .. code-block:: bash
 
+For Architectures other than MacOS/ARM
   $ pyenv virtualenv 3.8.5 airflow-env
+
+For MacOS/Arm (3.9.1 is the first version of Python to support MacOS/ARM, but 3.8.10 works too)
+  $ pyenv virtualenv 3.8.10 airflow-env
 
 6. Entering virtual environment ``airflow-env``
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Pyenv 3.8.5 is not supported for ARM/MacOS architectures. The instructions in the quick start guide should mention this. 
Came across this while setting up airflow on the mentioned arch.
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
