### PR TITLE
Updates health check endpoint to include dag_processor status.

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3084,6 +3084,8 @@ components:
           $ref: '#/components/schemas/SchedulerStatus'
         triggerer:
           $ref: '#/components/schemas/TriggererStatus'
+        dag_processor:
+          $ref: '#/components/schemas/DagProcessorStatus'
 
     MetadatabaseStatus:
       type: object
@@ -3116,6 +3118,22 @@ components:
           $ref: '#/components/schemas/HealthStatus'
         latest_triggerer_heartbeat:
           description: The time the triggerer last did a heartbeat.
+          type: string
+          format: datetime
+          readOnly: true
+          nullable: true
+
+    DagProcessorStatus:
+      type: object
+      description: |
+        The status and the latest dag processor heartbeat.
+
+        *New in version 2.6.3*
+      properties:
+        status:
+          $ref: '#/components/schemas/HealthStatus'
+        latest_dag_processor_heartbeat:
+          description: The time the dag processor last did a heartbeat.
           type: string
           format: datetime
           readOnly: true

--- a/airflow/api_connexion/schemas/health_schema.py
+++ b/airflow/api_connexion/schemas/health_schema.py
@@ -41,12 +41,19 @@ class TriggererInfoSchema(BaseInfoSchema):
     latest_triggerer_heartbeat = fields.String(dump_only=True)
 
 
+class DagProcessorInfoSchema(BaseInfoSchema):
+    """Schema for DagProcessor info."""
+
+    latest_dag_processor_heartbeat = fields.String(dump_only=True)
+
+
 class HealthInfoSchema(Schema):
     """Schema for the Health endpoint."""
 
     metadatabase = fields.Nested(MetaDatabaseInfoSchema)
     scheduler = fields.Nested(SchedulerInfoSchema)
     triggerer = fields.Nested(TriggererInfoSchema)
+    dag_processor = fields.Nested(DagProcessorInfoSchema)
 
 
 health_schema = HealthInfoSchema()

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1192,6 +1192,7 @@ export interface components {
       metadatabase?: components["schemas"]["MetadatabaseStatus"];
       scheduler?: components["schemas"]["SchedulerStatus"];
       triggerer?: components["schemas"]["TriggererStatus"];
+      dag_processor?: components["schemas"]["DagProcessorStatus"];
     };
     /** @description The status of the metadatabase. */
     MetadatabaseStatus: {
@@ -1218,6 +1219,19 @@ export interface components {
        * @description The time the triggerer last did a heartbeat.
        */
       latest_triggerer_heartbeat?: string | null;
+    };
+    /**
+     * @description The status and the latest dag processor heartbeat.
+     *
+     * *New in version 2.6.3*
+     */
+    DagProcessorStatus: {
+      status?: components["schemas"]["HealthStatus"];
+      /**
+       * Format: datetime
+       * @description The time the dag processor last did a heartbeat.
+       */
+      latest_dag_processor_heartbeat?: string | null;
     };
     /** @description The pool */
     Pool: {
@@ -4666,6 +4680,9 @@ export type SchedulerStatus = CamelCasedPropertiesDeep<
 >;
 export type TriggererStatus = CamelCasedPropertiesDeep<
   components["schemas"]["TriggererStatus"]
+>;
+export type DagProcessorStatus = CamelCasedPropertiesDeep<
+  components["schemas"]["DagProcessorStatus"]
 >;
 export type Pool = CamelCasedPropertiesDeep<components["schemas"]["Pool"]>;
 export type PoolCollection = CamelCasedPropertiesDeep<

--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/check-health.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/check-health.rst
@@ -51,6 +51,10 @@ To check the health status of your Airflow instance, you can simply access the e
     "triggerer":{
       "status":"healthy",
       "latest_triggerer_heartbeat":"2018-12-26 17:16:12+00:00"
+    },
+    "dag_processor":{
+      "status":"healthy",
+      "latest_dag_processor_heartbeat":"2018-12-26 17:16:12+00:00"
     }
   }
 
@@ -70,6 +74,10 @@ To check the health status of your Airflow instance, you can simply access the e
   * The status of the ``triggerer`` behaves exactly like that of the ``scheduler`` as described above.
     Note that the ``status`` and ``latest_triggerer_heartbeat`` fields in the health check response will be null for
     deployments that do not include a ``triggerer`` component.
+
+  * The status of the ``dag_processor`` behaves exactly like that of the ``scheduler`` as described above.
+    Note that the ``status`` and ``latest_dag_processor_heartbeat`` fields in the health check response will be null for
+    deployments that do not include a ``dag_processor`` component.
 
 Please keep in mind that the HTTP response code of ``/health`` endpoint **should not** be used to determine the health
 status of the application. The return code is only indicative of the state of the rest call (200 for success).

--- a/tests/api/common/test_airflow_health.py
+++ b/tests/api/common/test_airflow_health.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock
 from airflow.api.common.airflow_health import (
     HEALTHY,
     UNHEALTHY,
+    DagProcessorJobRunner,
     SchedulerJobRunner,
     TriggererJobRunner,
     get_airflow_health,
@@ -31,13 +32,14 @@ from airflow.api.common.airflow_health import (
 def test_get_airflow_health_only_metadatabase_healthy():
     SchedulerJobRunner.most_recent_job = MagicMock(return_value=None)
     TriggererJobRunner.most_recent_job = MagicMock(return_value=None)
-
+    DagProcessorJobRunner.most_recent_job = MagicMock(return_value=None)
     health_status = get_airflow_health()
 
     expected_status = {
         "metadatabase": {"status": HEALTHY},
         "scheduler": {"status": UNHEALTHY, "latest_scheduler_heartbeat": None},
         "triggerer": {"status": None, "latest_triggerer_heartbeat": None},
+        "dag_processor": {"status": None, "latest_dag_processor_heartbeat": None},
     }
 
     assert health_status == expected_status
@@ -46,6 +48,7 @@ def test_get_airflow_health_only_metadatabase_healthy():
 def test_get_airflow_health_metadatabase_unhealthy():
     SchedulerJobRunner.most_recent_job = MagicMock(side_effect=Exception)
     TriggererJobRunner.most_recent_job = MagicMock(side_effect=Exception)
+    DagProcessorJobRunner.most_recent_job = MagicMock(side_effect=Exception)
 
     health_status = get_airflow_health()
 
@@ -53,6 +56,7 @@ def test_get_airflow_health_metadatabase_unhealthy():
         "metadatabase": {"status": UNHEALTHY},
         "scheduler": {"status": UNHEALTHY, "latest_scheduler_heartbeat": None},
         "triggerer": {"status": UNHEALTHY, "latest_triggerer_heartbeat": None},
+        "dag_processor": {"status": UNHEALTHY, "latest_dag_processor_heartbeat": None},
     }
 
     assert health_status == expected_status
@@ -64,6 +68,7 @@ def test_get_airflow_health_scheduler_healthy_no_triggerer():
     latest_scheduler_job_mock.is_alive = MagicMock(return_value=True)
     SchedulerJobRunner.most_recent_job = MagicMock(return_value=latest_scheduler_job_mock)
     TriggererJobRunner.most_recent_job = MagicMock(return_value=None)
+    DagProcessorJobRunner.most_recent_job = MagicMock(return_value=None)
 
     health_status = get_airflow_health()
 
@@ -74,6 +79,7 @@ def test_get_airflow_health_scheduler_healthy_no_triggerer():
             "latest_scheduler_heartbeat": latest_scheduler_job_mock.latest_heartbeat.isoformat(),
         },
         "triggerer": {"status": None, "latest_triggerer_heartbeat": None},
+        "dag_processor": {"status": None, "latest_dag_processor_heartbeat": None},
     }
 
     assert health_status == expected_status
@@ -83,8 +89,13 @@ def test_get_airflow_health_triggerer_healthy_no_scheduler_job_record():
     latest_triggerer_job_mock = MagicMock()
     latest_triggerer_job_mock.latest_heartbeat = datetime.now()
     latest_triggerer_job_mock.is_alive = MagicMock(return_value=True)
+    latest_dag_processor_job_mock = MagicMock()
+    latest_dag_processor_job_mock.latest_heartbeat = datetime.now()
+    latest_dag_processor_job_mock.is_alive = MagicMock(return_value=True)
+
     SchedulerJobRunner.most_recent_job = MagicMock(return_value=None)
     TriggererJobRunner.most_recent_job = MagicMock(return_value=latest_triggerer_job_mock)
+    DagProcessorJobRunner.most_recent_job = MagicMock(return_value=latest_dag_processor_job_mock)
 
     health_status = get_airflow_health()
 
@@ -94,6 +105,10 @@ def test_get_airflow_health_triggerer_healthy_no_scheduler_job_record():
         "triggerer": {
             "status": HEALTHY,
             "latest_triggerer_heartbeat": latest_triggerer_job_mock.latest_heartbeat.isoformat(),
+        },
+        "dag_processor": {
+            "status": HEALTHY,
+            "latest_dag_processor_heartbeat": latest_dag_processor_job_mock.latest_heartbeat.isoformat(),
         },
     }
 


### PR DESCRIPTION
Fixes #32279 

Add dag_processor status to health endpoint. Update docs and openapi spec. This follows almost same code changes as triggerer changes in https://github.com/apache/airflow/pull/31579 , https://github.com/apache/airflow/pull/31529, https://github.com/apache/airflow/pull/27755