### PR TITLE
Use WebEncoder to encode DagRun.conf in DagRun's list view

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -49,6 +49,7 @@ from airflow.models.taskinstance import TaskInstance
 from airflow.utils import timezone
 from airflow.utils.code_utils import get_python_source
 from airflow.utils.helpers import alchemy_to_dict
+from airflow.utils.json import WebEncoder
 from airflow.utils.state import State, TaskInstanceState
 from airflow.www.forms import DateTimeWithTimezoneField
 from airflow.www.widgets import AirflowDateTimePickerWidget
@@ -476,12 +477,12 @@ def datetime_html(dttm: DateTime | None) -> str:
     return Markup('<nobr><time title="" datetime="{}">{}</time></nobr>').format(as_iso, as_iso_short)
 
 
-def json_f(attr_name, json_encoder: type[json.JSONEncoder] = json.JSONEncoder):
+def json_f(attr_name):
     """Returns a formatted string with HTML for given JSON serializable."""
 
     def json_(attr):
         f = attr.get(attr_name)
-        serialized = json.dumps(f, cls=json_encoder)
+        serialized = json.dumps(f, cls=WebEncoder)
         return Markup("<nobr>{}</nobr>").format(serialized)
 
     return json_

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -476,12 +476,12 @@ def datetime_html(dttm: DateTime | None) -> str:
     return Markup('<nobr><time title="" datetime="{}">{}</time></nobr>').format(as_iso, as_iso_short)
 
 
-def json_f(attr_name):
+def json_f(attr_name, json_encoder: type[json.JSONEncoder] = json.JSONEncoder):
     """Returns a formatted string with HTML for given JSON serializable."""
 
     def json_(attr):
         f = attr.get(attr_name)
-        serialized = json.dumps(f)
+        serialized = json.dumps(f, cls=json_encoder)
         return Markup("<nobr>{}</nobr>").format(serialized)
 
     return json_

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -5408,7 +5408,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         "queued_at": wwwutils.datetime_f("queued_at"),
         "dag_id": wwwutils.dag_link,
         "run_id": wwwutils.dag_run_link,
-        "conf": wwwutils.json_f("conf", utils_json.WebEncoder),
+        "conf": wwwutils.json_f("conf"),
         "duration": duration_f,
     }
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -5408,7 +5408,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         "queued_at": wwwutils.datetime_f("queued_at"),
         "dag_id": wwwutils.dag_link,
         "run_id": wwwutils.dag_run_link,
-        "conf": wwwutils.json_f("conf"),
+        "conf": wwwutils.json_f("conf", utils_json.WebEncoder),
         "duration": duration_f,
     }
 

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -259,7 +259,7 @@ class TestAttrRenderer:
         )
         expected_markup = Markup("<nobr>{}</nobr>").format(expected_encoded_dag_run_conf)
 
-        formatter = json_f("conf", utils_json.WebEncoder)
+        formatter = json_f("conf")
         dagrun = Mock()
         dagrun.get = Mock(return_value=dag_run_conf)
 

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -19,13 +19,15 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
+from unittest.mock import Mock
 from urllib.parse import parse_qs
 
 from bs4 import BeautifulSoup
+from markupsafe import Markup
 
 from airflow.utils import json as utils_json
 from airflow.www import utils
-from airflow.www.utils import wrapped_markdown
+from airflow.www.utils import json_f, wrapped_markdown
 
 
 class TestUtils:
@@ -242,6 +244,26 @@ class TestAttrRenderer:
             dag_run_conf, json_encoder=utils_json.WebEncoder
         )
         assert expected_encoded_dag_run_conf == encoded_dag_run_conf
+
+    def test_json_f_webencoder(self):
+        dag_run_conf = {
+            "1": "string",
+            "2": b"bytes",
+            "3": 123,
+            "4": "à".encode("latin"),
+            "5": datetime(2023, 1, 1),
+        }
+        expected_encoded_dag_run_conf = (
+            # HTML sanitization is insane
+            '{"1": "string", "2": "bytes", "3": 123, "4": "\\u00e0", "5": "2023-01-01T00:00:00+00:00"}'
+        )
+        expected_markup = Markup("<nobr>{}</nobr>").format(expected_encoded_dag_run_conf)
+
+        formatter = json_f("conf", utils_json.WebEncoder)
+        dagrun = Mock()
+        dagrun.get = Mock(return_value=dag_run_conf)
+
+        assert formatter(dagrun) == expected_markup
 
 
 class TestWrappedMarkdown:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #32287, #28777, #32288, #28772 

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR is related to the following issues and PRs: #32287, #28777, #32288, #28772.

Previous efforts related to JSON-serializing DagRun configuration have provided an elegant solution in the form of a custom JSON encoder class named `WebEncoder`, which is used to encode non-JSON serializable objects stored in `DagRun.conf`. This allows DAG run conf to be correctly rendered in the grid view, but the fix was not applied to the list view, hence breaking `/dagrun/list` if there are conf values that are not JSON serializable.

This PR attempts to address the incompleteness of the previous fix by using `WebEncoder` in `formatters_columns`, which should allow non-JSON-serializable conf to be rendered in list view in the same way it is rendered in grid view.

Note that `www.utils.json_f` is used exactly once where the code change happened, and the code change seems trivial, so I am not sure if unit tests or other forms of validation is warranted, but I am happy to write tests if necessary.

Thank you for considering my contribution!

---


Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
