### PR TITLE
Fix endless loop of defer in google cloud_build

### DIFF
--- a/airflow/providers/google/cloud/triggers/cloud_build.py
+++ b/airflow/providers/google/cloud/triggers/cloud_build.py
@@ -95,6 +95,7 @@ class CloudBuildCreateBuildTrigger(BaseTrigger):
                             "message": "Build completed",
                         }
                     )
+                    return
                 elif cloud_build_instance._pb.status in (
                     Build.Status.WORKING,
                     Build.Status.PENDING,
@@ -111,14 +112,17 @@ class CloudBuildCreateBuildTrigger(BaseTrigger):
                     Build.Status.EXPIRED,
                 ):
                     yield TriggerEvent({"status": "error", "message": cloud_build_instance.status_detail})
+                    return
                 else:
                     yield TriggerEvent(
                         {"status": "error", "message": "Unidentified status of Cloud Build instance"}
                     )
+                    return
 
             except Exception as e:
                 self.log.exception("Exception occurred while checking for Cloud Build completion")
                 yield TriggerEvent({"status": "error", "message": str(e)})
+                return
 
     def _get_async_hook(self) -> CloudBuildAsyncHook:
         return CloudBuildAsyncHook(gcp_conn_id=self.gcp_conn_id)


### PR DESCRIPTION
Fix endless loop of defer in google cloud_build.

### Summary
The loop continues because it does not return with the yield of trigger.
So many get requests occur at the end of defer, and quota exceede.
```
429 Quota exceeded for quota metric 'Build and Operation Get requests' and limit 'Build and Operation Get requests per minute' of service 'cloudbuild.googleapis.com'
```