### PR TITLE
Fix local OpenLineage import in `SQLExecuteQueryOperator`

### DIFF
--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -330,12 +330,12 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
         return operator_lineage
 
     def get_openlineage_facets_on_complete(self, task_instance) -> OperatorLineage | None:
-        operator_lineage = self.get_openlineage_facets_on_start() or OperatorLineage()
-
         try:
             from airflow.providers.openlineage.extractors import OperatorLineage
         except ImportError:
-            return operator_lineage
+            return None
+
+        operator_lineage = self.get_openlineage_facets_on_start() or OperatorLineage()
 
         hook = self.get_db_hook()
         try:


### PR DESCRIPTION
There's a bug in current `get_openlineage_facets_on_complete` method implementation for `SQLExecuteQueryOperator`. This PR fixes it.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
