### PR TITLE
Add information on ARM MySQL support in Docker images

### DIFF
--- a/docs/docker-stack/changelog.rst
+++ b/docs/docker-stack/changelog.rst
@@ -107,6 +107,7 @@ Airflow 2.3
     This can be done by setting ``DOCKER_BUILDKIT=1`` as an environment variable
     or by installing `the buildx plugin <https://docs.docker.com/buildx/working-with-buildx/>`_
     and running ``docker buildx build`` command.
+  * MySQL is experimentally supported on ARM through MariaDB client library
   * Add Python 3.10 support
   * Switch to ``Debian Bullseye`` based images. ``Debian Buster`` is deprecated and only available for
     customized image building.

--- a/docs/docker-stack/index.rst
+++ b/docs/docker-stack/index.rst
@@ -124,14 +124,23 @@ Support
 The reference Docker Image supports the following platforms and database:
 
 
-* Intel platform (x86_64)
-   * Postgres Client
-   * MySQL Client
-   * MSSQL Client
+Intel platform (x86_64)
+-----------------------
 
-* ARM platform (aarch64) - experimental support, might change any time
-   * Postgres Client
-   * MSSQL Client
+* Postgres Client
+* MySQL Client
+* MSSQL Client
+
+ARM platform (aarch64)
+----------------------
+
+ARM support is experimental, might change any time.
+
+* Postgres Client
+* MySQL Client (MySQL 8)
+* MSSQL Client
+
+Note that MySQL on arm has experimental support through MariaDB client library.
 
 Usage
 =====


### PR DESCRIPTION
The change #29519 added experimental MariaDB client support for MySQL for ARM images but we missed that in the changelog.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
