### PR TITLE
fix(helm): dagprocessor livenessProbe include --local and --job-type args

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -695,11 +695,20 @@ server_tls_key_file = /etc/pgbouncer/server.key
 {{- end }}
 
 {{- define "dag_processor_liveness_check_command" }}
+  {{- $commandArgs := (list) -}}
+  {{- if semverCompare ">=2.5.0" .Values.airflowVersion }}
+    {{- $commandArgs = append $commandArgs "--local" -}}
+    {{- if semverCompare ">=2.5.2" .Values.airflowVersion }}
+      {{- $commandArgs = concat $commandArgs (list "--job-type" "DagProcessorJob") -}}
+    {{- end }}
+  {{- else }}
+    {{- $commandArgs = concat $commandArgs (list "--hostname" "$(hostname)") -}}
+  {{- end }}
   - sh
   - -c
   - |
     CONNECTION_CHECK_MAX_COUNT=0 AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR exec /entrypoint \
-    airflow jobs check --hostname $(hostname)
+    airflow jobs check {{ join " " $commandArgs }}
 {{- end }}
 
 {{- define "registry_docker_config" }}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -690,7 +690,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   - -c
   - |
     CONNECTION_CHECK_MAX_COUNT=0 AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR exec /entrypoint \
-    airflow jobs check --job-type TriggererJob  --hostname $(hostname)
+    airflow jobs check --job-type TriggererJob --hostname $(hostname)
   {{- end }}
 {{- end }}
 

--- a/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm_tests/airflow_core/test_dag_processor.py
@@ -348,12 +348,13 @@ class TestDagProcessor:
     )
     def test_livenessprobe_command_depends_on_airflow_version(self, airflow_version, probe_command):
         docs = render_chart(
-            values={"airflowVersion": f"{airflow_version}","dagProcessor": {"enabled": True}},
+            values={"airflowVersion": f"{airflow_version}", "dagProcessor": {"enabled": True}},
             show_only=["templates/dag-processor/dag-processor-deployment.yaml"],
         )
-        assert probe_command in jmespath.search(
-            "spec.template.spec.containers[0].livenessProbe.exec.command", docs[0]
-        )[-1]
+        assert (
+            probe_command
+            in jmespath.search("spec.template.spec.containers[0].livenessProbe.exec.command", docs[0])[-1]
+        )
 
     @pytest.mark.parametrize(
         "log_persistence_values, expected_volume",

--- a/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm_tests/airflow_core/test_dag_processor.py
@@ -339,6 +339,27 @@ class TestDagProcessor:
         )
 
     @pytest.mark.parametrize(
+        "airflow_version, probe_command",
+        [
+            ("2.4.9", "airflow jobs check --hostname $(hostname)"),
+            ("2.5.0", "airflow jobs check --local"),
+            ("2.5.2", "airflow jobs check --local --job-type DagProcessorJob")
+        ],
+    )
+    def test_livenessprobe_command_depends_on_airflow_version(self, airflow_version, probe_command):
+        docs = render_chart(
+            values={
+                "airflowVersion": f"{airflow_version}",
+                "dagProcessor": {"enabled": True}
+            },
+            show_only=["templates/dag-processor/dag-processor-deployment.yaml"],
+        )
+        command_prefix = "CONNECTION_CHECK_MAX_COUNT=0 AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR exec /entrypoint"
+        assert ["sh", "-c", f"{command_prefix} \\\n{probe_command}\n"] == jmespath.search(
+            "spec.template.spec.containers[0].livenessProbe.exec.command", docs[0]
+        )
+
+    @pytest.mark.parametrize(
         "log_persistence_values, expected_volume",
         [
             ({"enabled": False}, {"emptyDir": {}}),

--- a/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm_tests/airflow_core/test_dag_processor.py
@@ -343,21 +343,17 @@ class TestDagProcessor:
         [
             ("2.4.9", "airflow jobs check --hostname $(hostname)"),
             ("2.5.0", "airflow jobs check --local"),
-            ("2.5.2", "airflow jobs check --local --job-type DagProcessorJob")
+            ("2.5.2", "airflow jobs check --local --job-type DagProcessorJob"),
         ],
     )
     def test_livenessprobe_command_depends_on_airflow_version(self, airflow_version, probe_command):
         docs = render_chart(
-            values={
-                "airflowVersion": f"{airflow_version}",
-                "dagProcessor": {"enabled": True}
-            },
+            values={"airflowVersion": f"{airflow_version}","dagProcessor": {"enabled": True}},
             show_only=["templates/dag-processor/dag-processor-deployment.yaml"],
         )
-        command_prefix = "CONNECTION_CHECK_MAX_COUNT=0 AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR exec /entrypoint"
-        assert ["sh", "-c", f"{command_prefix} \\\n{probe_command}\n"] == jmespath.search(
+        assert probe_command in jmespath.search(
             "spec.template.spec.containers[0].livenessProbe.exec.command", docs[0]
-        )
+        )[-1]
 
     @pytest.mark.parametrize(
         "log_persistence_values, expected_volume",

--- a/helm_tests/airflow_core/test_scheduler.py
+++ b/helm_tests/airflow_core/test_scheduler.py
@@ -358,6 +358,23 @@ class TestScheduler:
         )
 
     @pytest.mark.parametrize(
+        "airflow_version, probe_command",
+        [
+            ("1.9.0", "from airflow.jobs.scheduler_job import SchedulerJob"),
+            ("2.1.0", "airflow jobs check --job-type SchedulerJob --hostname $(hostname)"),
+            ("2.5.0", "airflow jobs check --job-type SchedulerJob --local"),
+        ],
+    )
+    def test_livenessprobe_command_depends_on_airflow_version(self, airflow_version, probe_command):
+        docs = render_chart(
+            values={"airflowVersion": f"{airflow_version}"},
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+        assert probe_command in jmespath.search(
+            "spec.template.spec.containers[0].livenessProbe.exec.command", docs[0]
+        )[-1]
+
+    @pytest.mark.parametrize(
         "log_persistence_values, expected_volume",
         [
             ({"enabled": False}, {"emptyDir": {}}),

--- a/helm_tests/airflow_core/test_scheduler.py
+++ b/helm_tests/airflow_core/test_scheduler.py
@@ -370,9 +370,10 @@ class TestScheduler:
             values={"airflowVersion": f"{airflow_version}"},
             show_only=["templates/scheduler/scheduler-deployment.yaml"],
         )
-        assert probe_command in jmespath.search(
-            "spec.template.spec.containers[0].livenessProbe.exec.command", docs[0]
-        )[-1]
+        assert (
+            probe_command
+            in jmespath.search("spec.template.spec.containers[0].livenessProbe.exec.command", docs[0])[-1]
+        )
 
     @pytest.mark.parametrize(
         "log_persistence_values, expected_volume",

--- a/helm_tests/airflow_core/test_triggerer.py
+++ b/helm_tests/airflow_core/test_triggerer.py
@@ -360,6 +360,22 @@ class TestTriggerer:
         )
 
     @pytest.mark.parametrize(
+        "airflow_version, probe_command",
+        [
+            ("2.4.9", "airflow jobs check --job-type TriggererJob --hostname $(hostname)"),
+            ("2.5.0", "airflow jobs check --job-type TriggererJob --local"),
+        ],
+    )
+    def test_livenessprobe_command_depends_on_airflow_version(self, airflow_version, probe_command):
+        docs = render_chart(
+            values={"airflowVersion": f"{airflow_version}"},
+            show_only=["templates/triggerer/triggerer-deployment.yaml"],
+        )
+        assert probe_command in jmespath.search(
+            "spec.template.spec.containers[0].livenessProbe.exec.command", docs[0]
+        )[-1]
+
+    @pytest.mark.parametrize(
         "log_persistence_values, expected_volume",
         [
             ({"enabled": False}, {"emptyDir": {}}),

--- a/helm_tests/airflow_core/test_triggerer.py
+++ b/helm_tests/airflow_core/test_triggerer.py
@@ -371,9 +371,10 @@ class TestTriggerer:
             values={"airflowVersion": f"{airflow_version}"},
             show_only=["templates/triggerer/triggerer-deployment.yaml"],
         )
-        assert probe_command in jmespath.search(
-            "spec.template.spec.containers[0].livenessProbe.exec.command", docs[0]
-        )[-1]
+        assert (
+            probe_command
+            in jmespath.search("spec.template.spec.containers[0].livenessProbe.exec.command", docs[0])[-1]
+        )
 
     @pytest.mark.parametrize(
         "log_persistence_values, expected_volume",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

As of Airflow 2.5.0, the `--local` argument was introduced to the `airflow jobs check` command.
Without this argument, when a user has redefined the following configuration:
```
[core]
hostname_callable = ....
```
The livenessProbes using the command would fail due to "No alive jobs found", since the `$(hostname)` value may not align with what was set in `hostname_callable`.

As of Airflow 2.5.2, there is now also a `DagProcessorJob` job type which can be additionally checked for, to ensure that the livenessProbes do not incorrectly validate different Jobs on the same host as counting towards the dagprocessor being **alive**

**DISCLAIMER**: the Helm template in this PR deviates from the existing probe templates, to avoid unnecessary duplication. This refactoring can also be applied to the `scheduler_liveness_check_command` and `triggerer_liveness_check_command` if that is requested.
Inversely, I can also refactor to comply with the existing if/else duplication of the templates.

related: https://github.com/apache/airflow/pull/28799

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
