### PR TITLE
quick fix on RDS operator to prevent parameter collision

### DIFF
--- a/airflow/providers/amazon/aws/operators/rds.py
+++ b/airflow/providers/amazon/aws/operators/rds.py
@@ -64,7 +64,7 @@ class RdsBaseOperator(BaseOperator):
             )
         hook_params = hook_params or {}
         self.region_name = region_name or hook_params.pop("region_name", None)
-        self.hook = RdsHook(aws_conn_id=aws_conn_id, region_name=region_name, **(hook_params))
+        self.hook = RdsHook(aws_conn_id=aws_conn_id, region_name=self.region_name, **(hook_params))
         super().__init__(*args, **kwargs)
 
         self._await_interval = 60  # seconds

--- a/airflow/providers/amazon/aws/operators/rds.py
+++ b/airflow/providers/amazon/aws/operators/rds.py
@@ -62,8 +62,9 @@ class RdsBaseOperator(BaseOperator):
                 AirflowProviderDeprecationWarning,
                 stacklevel=3,  # 2 is in the operator's init, 3 is in the user code creating the operator
             )
-        self.region_name = region_name
-        self.hook = RdsHook(aws_conn_id=aws_conn_id, region_name=region_name, **(hook_params or {}))
+        hook_params = hook_params or {}
+        self.region_name = region_name or hook_params.pop("region_name", None)
+        self.hook = RdsHook(aws_conn_id=aws_conn_id, region_name=region_name, **(hook_params))
         super().__init__(*args, **kwargs)
 
         self._await_interval = 60  # seconds


### PR DESCRIPTION
without this code, if the user specified a region in the hook params, it'd create an error about the param being specified twice

bugfixes #32386