### PR TITLE
Add Dag Processor status to cluster activity page.

### DIFF
--- a/airflow/www/static/js/cluster-activity/index.test.tsx
+++ b/airflow/www/static/js/cluster-activity/index.test.tsx
@@ -59,12 +59,21 @@ const mockHistoricalMetricsData = {
   },
 };
 
+const heartbeat = "2023-05-19T12:00:36.109924+00:00";
 const mockHealthData = {
   metadatabase: {
     status: "healthy",
   },
   scheduler: {
-    latest_scheduler_heartbeat: "2023-05-19T12:00:36.109924+00:00",
+    latestSchedulerHeartbeat: heartbeat,
+    status: "healthy",
+  },
+  triggerer: {
+    latestTriggererHeartbeat: heartbeat,
+    status: "healthy",
+  },
+  dagProcessor: {
+    latestDagProcessorHeartbeat: heartbeat,
     status: "healthy",
   },
 };
@@ -148,7 +157,8 @@ describe("Test ToggleGroups", () => {
 
     expect(getAllByTestId("echart-container")).toHaveLength(4);
 
-    expect(getAllByText("healthy")).toHaveLength(2);
+    expect(getAllByText("healthy")).toHaveLength(4);
+    expect(getAllByText("last heartbeat:")).toHaveLength(3);
     expect(getByText("Unpaused DAGs")).toBeInTheDocument();
     expect(getByText("No dag running")).toBeInTheDocument();
   });

--- a/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
+++ b/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
@@ -106,6 +106,11 @@ const Health = (props: CenterProps) => {
               status={data?.triggerer?.status}
               latestHeartbeat={data?.triggerer?.latestTriggererHeartbeat}
             />
+            <HealthSection
+              title="Dag Processor"
+              status={data?.dagProcessor?.status}
+              latestHeartbeat={data?.dagProcessor?.latestDagProcessorHeartbeat}
+            />
           </CardBody>
         </Card>
       </LoadingWrapper>


### PR DESCRIPTION
Dag processor status was added to health endpoint in #32279 . This adds it to the cluster activity page.