### PR TITLE
D205 Support - Providers: Stragglers and New Additions

### DIFF
--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -646,8 +646,7 @@ class S3Hook(AwsBaseHook):
         last_activity_time: datetime | None = None,
     ) -> dict[str, Any]:
         """
-        Checks whether new objects have been uploaded and the inactivity_period
-        has passed and updates the state of the sensor accordingly.
+        Check if new objects have been uploaded and the period has passed; update sensor state accordingly.
 
         :param client: aiobotocore client
         :param bucket_name: the name of the bucket

--- a/airflow/providers/amazon/aws/sensors/s3.py
+++ b/airflow/providers/amazon/aws/sensors/s3.py
@@ -356,8 +356,8 @@ class S3KeysUnchangedSensor(BaseSensorOperator):
     def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> None:
         """
         Callback for when the trigger fires - returns immediately.
-        Relies on trigger to throw an exception, otherwise it assumes execution was
-        successful.
+
+        Relies on trigger to throw an exception, otherwise it assumes execution was successful.
         """
         if event and event["status"] == "error":
             raise AirflowException(event["message"])

--- a/airflow/providers/amazon/aws/transfers/dynamodb_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/dynamodb_to_s3.py
@@ -84,7 +84,8 @@ class DynamoDBToS3Operator(AwsToAwsBaseOperator):
     :param dynamodb_table_name: Dynamodb table to replicate data from
     :param s3_bucket_name: S3 bucket to replicate data to
     :param file_size: Flush file to s3 if file size >= file_size
-    :param dynamodb_scan_kwargs: kwargs pass to <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Table.scan>
+    :param dynamodb_scan_kwargs: kwargs pass to
+        <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Table.scan>
     :param s3_key_prefix: Prefix of s3 object key
     :param process_func: How we transform a dynamodb item to bytes. By default, we dump the json
     :param export_time: Time in the past from which to export table data, counted in seconds from the start of

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -129,6 +129,7 @@ def container_is_running(pod: V1Pod, container_name: str) -> bool:
 def container_is_completed(pod: V1Pod, container_name: str) -> bool:
     """
     Examines V1Pod ``pod`` to determine whether ``container_name`` is completed.
+
     If that container is present and completed, returns True.  Returns False otherwise.
     """
     container_status = get_container_status(pod, container_name)
@@ -430,8 +431,9 @@ class PodManager(LoggingMixin):
         self, pod: V1Pod, container_logs: Iterable[str] | str | Literal[True], follow_logs=False
     ) -> list[PodLoggingStatus]:
         """
-        Follow the logs of containers in the pod specified by input parameter and publish
-        it to airflow logging. Returns when all the containers exit.
+        Follow the logs of containers in the specified pod and publish it to airflow logging.
+
+        Returns when all the containers exit.
         """
         pod_logging_statuses = []
         all_containers = self.get_container_names(pod)

--- a/airflow/providers/microsoft/azure/transfers/azure_blob_to_gcs.py
+++ b/airflow/providers/microsoft/azure/transfers/azure_blob_to_gcs.py
@@ -28,7 +28,9 @@ from airflow.providers.google.cloud.transfers.azure_blob_to_gcs import (
 class AzureBlobStorageToGCSOperator(AzureBlobStorageToGCSOperatorFromGoogleProvider):
     """
     This class is deprecated.
-    Please use `airflow.providers.google.cloud.transfers.azure_blob_to_gcs.AzureBlobStorageToGCSOperator`.
+
+    Please use
+    :class:`airflow.providers.google.cloud.transfers.azure_blob_to_gcs.AzureBlobStorageToGCSOperator`.
     """
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This completes the updates to all provider packages!  Only around 280 remain in core Airflow.

Part of https://github.com/apache/airflow/issues/10742

D205 asserts that all docstrings must have a one-line summary ending in a period.  If there is more than one sentence then there must be a blank line before the rest of the docstring.  Meeting these requirements could be as simple as adding a newline, or might require some rephrasing.

There are almost a thousand violations in the repo so we're going to have to take this in bites.

### PLEASE NOTE

There should be zero logic changes in this PR, only changes to docstrings and whitespace.  If you see otherwise, please call it out.

### Included in this chunk

A couple of violations that were either added after my pass and/or that I missed in my initial pass.

### To test

If you comment out [this line](https://github.com/apache/airflow/blob/main/pyproject.toml#L68) and run pre-commit in main you will get 285 errors.  After these changes, "only" 280 remain and no files in any provider packages should be on the list.  After uncommenting that line and rerunning pre-commits, there should be zero regressions. 