### PR TITLE
Add xcom map_index as a filter to xcom endpoint

### DIFF
--- a/airflow/api_connexion/endpoints/xcom_endpoint.py
+++ b/airflow/api_connexion/endpoints/xcom_endpoint.py
@@ -48,6 +48,8 @@ def get_xcom_entries(
     dag_id: str,
     dag_run_id: str,
     task_id: str,
+    map_index: int | None = None,
+    xcom_key: str | None = None,
     limit: int | None,
     offset: int | None = None,
     session: Session = NEW_SESSION,
@@ -67,6 +69,10 @@ def get_xcom_entries(
         query = query.where(XCom.task_id == task_id)
     if dag_run_id != "~":
         query = query.where(DR.run_id == dag_run_id)
+    if map_index is not None:
+        query = query.where(XCom.map_index == map_index)
+    if xcom_key is not None:
+        query = query.where(XCom.key == xcom_key)
     query = query.order_by(DR.execution_date, XCom.task_id, XCom.dag_id, XCom.key)
     total_entries = session.execute(select(func.count()).select_from(query)).scalar()
     query = session.scalars(query.offset(offset).limit(limit))
@@ -88,6 +94,7 @@ def get_xcom_entry(
     task_id: str,
     dag_run_id: str,
     xcom_key: str,
+    map_index: int = -1,
     deserialize: bool = False,
     session: Session = NEW_SESSION,
 ) -> APIResponse:
@@ -97,7 +104,9 @@ def get_xcom_entry(
     else:
         query = select(XCom)
 
-    query = query.where(XCom.dag_id == dag_id, XCom.task_id == task_id, XCom.key == xcom_key)
+    query = query.where(
+        XCom.dag_id == dag_id, XCom.task_id == task_id, XCom.key == xcom_key, XCom.map_index == map_index
+    )
     query = query.join(DR, and_(XCom.dag_id == DR.dag_id, XCom.run_id == DR.run_id))
     query = query.where(DR.run_id == dag_run_id)
 

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1573,6 +1573,8 @@ paths:
       operationId: get_xcom_entries
       tags: [XCom]
       parameters:
+        - $ref: '#/components/parameters/FilterMapIndex'
+        - $ref: '#/components/parameters/FilterXcomKey'
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
       responses:
@@ -1600,6 +1602,7 @@ paths:
       operationId: get_xcom_entry
       tags: [XCom]
       parameters:
+        - $ref: '#/components/parameters/FilterMapIndex'
         - in: query
           name: deserialize
           schema:
@@ -3489,6 +3492,8 @@ components:
         execution_date:
           type: string
           format: datetime
+        map_index:
+          type: integer
         task_id:
           type: string
         dag_id:
@@ -5094,6 +5099,14 @@ components:
         Only filter paused/unpaused DAGs. If absent or null, it returns paused and unpaused DAGs.
 
         *New in version 2.6.0*
+
+    FilterXcomKey:
+      in: query
+      name: xcom_key
+      schema:
+        type: string
+      required: false
+      description: Only filter the XCom records which have the provided key.
 
     # Other parameters
     FileToken:

--- a/airflow/api_connexion/schemas/xcom_schema.py
+++ b/airflow/api_connexion/schemas/xcom_schema.py
@@ -35,6 +35,7 @@ class XComCollectionItemSchema(SQLAlchemySchema):
     key = auto_field()
     timestamp = auto_field()
     execution_date = auto_field()
+    map_index = auto_field()
     task_id = auto_field()
     dag_id = auto_field()
 

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1425,6 +1425,7 @@ export interface components {
       timestamp?: string;
       /** Format: datetime */
       execution_date?: string;
+      map_index?: number;
       task_id?: string;
       dag_id?: string;
     };
@@ -2390,6 +2391,8 @@ export interface components {
      * *New in version 2.6.0*
      */
     Paused: boolean;
+    /** @description Only filter the XCom records which have the provided key. */
+    FilterXcomKey: string;
     /**
      * @description The key containing the encrypted path to the file. Encryption and decryption take place only on
      * the server. This prevents the client from reading an non-DAG file. This also ensures API
@@ -3839,6 +3842,10 @@ export interface operations {
         task_id: components["parameters"]["TaskID"];
       };
       query: {
+        /** Filter on map index for mapped task. */
+        map_index?: components["parameters"]["FilterMapIndex"];
+        /** Only filter the XCom records which have the provided key. */
+        xcom_key?: components["parameters"]["FilterXcomKey"];
         /** The numbers of items to return. */
         limit?: components["parameters"]["PageLimit"];
         /** The number of items to skip before starting to collect the result set. */
@@ -3869,6 +3876,8 @@ export interface operations {
         xcom_key: components["parameters"]["XComKey"];
       };
       query: {
+        /** Filter on map index for mapped task. */
+        map_index?: components["parameters"]["FilterMapIndex"];
         /**
          * Whether to deserialize an XCom value when using a custom XCom backend.
          *

--- a/tests/api_connexion/endpoints/test_xcom_endpoint.py
+++ b/tests/api_connexion/endpoints/test_xcom_endpoint.py
@@ -82,6 +82,20 @@ def configured_app(minimal_app_for_api):
     delete_user(app, username="test_no_permissions")  # type: ignore
 
 
+def _compare_xcom_collections(collection1: dict, collection_2: dict):
+    assert collection1.get("total_entries") == collection_2.get("total_entries")
+    sort_key = lambda record: (
+        record.get("dag_id"),
+        record.get("task_id"),
+        record.get("execution_date"),
+        record.get("map_index"),
+        record.get("key"),
+    )
+    assert sorted(collection1.get("xcom_entries", []), key=sort_key) == sorted(
+        collection_2.get("xcom_entries", []), key=sort_key
+    )
+
+
 class TestXComEndpoint:
     @staticmethod
     def clean_db():
@@ -222,27 +236,30 @@ class TestGetXComEntries(TestXComEndpoint):
         response_data = response.json
         for xcom_entry in response_data["xcom_entries"]:
             xcom_entry["timestamp"] = "TIMESTAMP"
-        assert response_data == {
-            "xcom_entries": [
-                {
-                    "dag_id": dag_id,
-                    "execution_date": execution_date,
-                    "key": "test-xcom-key-1",
-                    "task_id": task_id,
-                    "timestamp": "TIMESTAMP",
-                    "map_index": -1,
-                },
-                {
-                    "dag_id": dag_id,
-                    "execution_date": execution_date,
-                    "key": "test-xcom-key-2",
-                    "task_id": task_id,
-                    "timestamp": "TIMESTAMP",
-                    "map_index": -1,
-                },
-            ],
-            "total_entries": 2,
-        }
+        _compare_xcom_collections(
+            response_data,
+            {
+                "xcom_entries": [
+                    {
+                        "dag_id": dag_id,
+                        "execution_date": execution_date,
+                        "key": "test-xcom-key-1",
+                        "task_id": task_id,
+                        "timestamp": "TIMESTAMP",
+                        "map_index": -1,
+                    },
+                    {
+                        "dag_id": dag_id,
+                        "execution_date": execution_date,
+                        "key": "test-xcom-key-2",
+                        "task_id": task_id,
+                        "timestamp": "TIMESTAMP",
+                        "map_index": -1,
+                    },
+                ],
+                "total_entries": 2,
+            },
+        )
 
     def test_should_respond_200_with_tilde_and_access_to_all_dags(self):
         dag_id_1 = "test-dag-id-1"
@@ -266,43 +283,46 @@ class TestGetXComEntries(TestXComEndpoint):
         response_data = response.json
         for xcom_entry in response_data["xcom_entries"]:
             xcom_entry["timestamp"] = "TIMESTAMP"
-        assert response_data == {
-            "xcom_entries": [
-                {
-                    "dag_id": dag_id_1,
-                    "execution_date": execution_date,
-                    "key": "test-xcom-key-1",
-                    "task_id": task_id_1,
-                    "timestamp": "TIMESTAMP",
-                    "map_index": -1,
-                },
-                {
-                    "dag_id": dag_id_1,
-                    "execution_date": execution_date,
-                    "key": "test-xcom-key-2",
-                    "task_id": task_id_1,
-                    "timestamp": "TIMESTAMP",
-                    "map_index": -1,
-                },
-                {
-                    "dag_id": dag_id_2,
-                    "execution_date": execution_date,
-                    "key": "test-xcom-key-1",
-                    "task_id": task_id_2,
-                    "timestamp": "TIMESTAMP",
-                    "map_index": -1,
-                },
-                {
-                    "dag_id": dag_id_2,
-                    "execution_date": execution_date,
-                    "key": "test-xcom-key-2",
-                    "task_id": task_id_2,
-                    "timestamp": "TIMESTAMP",
-                    "map_index": -1,
-                },
-            ],
-            "total_entries": 4,
-        }
+        _compare_xcom_collections(
+            response_data,
+            {
+                "xcom_entries": [
+                    {
+                        "dag_id": dag_id_1,
+                        "execution_date": execution_date,
+                        "key": "test-xcom-key-1",
+                        "task_id": task_id_1,
+                        "timestamp": "TIMESTAMP",
+                        "map_index": -1,
+                    },
+                    {
+                        "dag_id": dag_id_1,
+                        "execution_date": execution_date,
+                        "key": "test-xcom-key-2",
+                        "task_id": task_id_1,
+                        "timestamp": "TIMESTAMP",
+                        "map_index": -1,
+                    },
+                    {
+                        "dag_id": dag_id_2,
+                        "execution_date": execution_date,
+                        "key": "test-xcom-key-1",
+                        "task_id": task_id_2,
+                        "timestamp": "TIMESTAMP",
+                        "map_index": -1,
+                    },
+                    {
+                        "dag_id": dag_id_2,
+                        "execution_date": execution_date,
+                        "key": "test-xcom-key-2",
+                        "task_id": task_id_2,
+                        "timestamp": "TIMESTAMP",
+                        "map_index": -1,
+                    },
+                ],
+                "total_entries": 4,
+            },
+        )
 
     def test_should_respond_200_with_tilde_and_granular_dag_access(self):
         dag_id_1 = "test-dag-id-1"
@@ -326,27 +346,30 @@ class TestGetXComEntries(TestXComEndpoint):
         response_data = response.json
         for xcom_entry in response_data["xcom_entries"]:
             xcom_entry["timestamp"] = "TIMESTAMP"
-        assert response_data == {
-            "xcom_entries": [
-                {
-                    "dag_id": dag_id_1,
-                    "execution_date": execution_date,
-                    "key": "test-xcom-key-1",
-                    "task_id": task_id_1,
-                    "timestamp": "TIMESTAMP",
-                    "map_index": -1,
-                },
-                {
-                    "dag_id": dag_id_1,
-                    "execution_date": execution_date,
-                    "key": "test-xcom-key-2",
-                    "task_id": task_id_1,
-                    "timestamp": "TIMESTAMP",
-                    "map_index": -1,
-                },
-            ],
-            "total_entries": 2,
-        }
+        _compare_xcom_collections(
+            response_data,
+            {
+                "xcom_entries": [
+                    {
+                        "dag_id": dag_id_1,
+                        "execution_date": execution_date,
+                        "key": "test-xcom-key-1",
+                        "task_id": task_id_1,
+                        "timestamp": "TIMESTAMP",
+                        "map_index": -1,
+                    },
+                    {
+                        "dag_id": dag_id_1,
+                        "execution_date": execution_date,
+                        "key": "test-xcom-key-2",
+                        "task_id": task_id_1,
+                        "timestamp": "TIMESTAMP",
+                        "map_index": -1,
+                    },
+                ],
+                "total_entries": 2,
+            },
+        )
 
     def test_should_respond_200_with_map_index(self):
         dag_id = "test-dag-id"

--- a/tests/api_connexion/schemas/test_xcom_schema.py
+++ b/tests/api_connexion/schemas/test_xcom_schema.py
@@ -41,17 +41,19 @@ def clean_xcom():
 
 @pytest.fixture()
 def create_xcom(create_task_instance, session):
-    def maker(dag_id, task_id, execution_date, key, value=None):
+    def maker(dag_id, task_id, execution_date, key, map_index=-1, value=None):
         ti = create_task_instance(
             dag_id=dag_id,
             task_id=task_id,
             execution_date=execution_date,
+            map_index=map_index,
             session=session,
         )
         run: DagRun = ti.dag_run
         xcom = XCom(
             dag_run_id=run.id,
             task_id=ti.task_id,
+            map_index=map_index,
             key=key,
             value=value,
             timestamp=run.execution_date,
@@ -84,6 +86,7 @@ class TestXComCollectionItemSchema:
             "execution_date": self.default_time,
             "task_id": "test_task_id",
             "dag_id": "test_dag",
+            "map_index": -1,
         }
 
     def test_deserialize(self):
@@ -93,6 +96,7 @@ class TestXComCollectionItemSchema:
             "execution_date": self.default_time,
             "task_id": "test_task_id",
             "dag_id": "test_dag",
+            "map_index": 2,
         }
         result = xcom_collection_item_schema.load(xcom_dump)
         assert result == {
@@ -101,6 +105,7 @@ class TestXComCollectionItemSchema:
             "execution_date": self.default_time_parsed,
             "task_id": "test_task_id",
             "dag_id": "test_dag",
+            "map_index": 2,
         }
 
 
@@ -141,6 +146,7 @@ class TestXComCollectionSchema:
                     "execution_date": self.default_time_1,
                     "task_id": "test_task_id_1",
                     "dag_id": "test_dag_1",
+                    "map_index": -1,
                 },
                 {
                     "key": "test_key_2",
@@ -148,6 +154,7 @@ class TestXComCollectionSchema:
                     "execution_date": self.default_time_2,
                     "task_id": "test_task_id_2",
                     "dag_id": "test_dag_2",
+                    "map_index": -1,
                 },
             ],
             "total_entries": 2,
@@ -175,6 +182,7 @@ class TestXComSchema:
             "task_id": "test_task_id",
             "dag_id": "test_dag",
             "value": "test_binary",
+            "map_index": -1,
         }
 
     def test_deserialize(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -761,6 +761,7 @@ def create_task_instance(dag_maker, create_dummy_dag):
         run_id=None,
         run_type=None,
         data_interval=None,
+        map_index=-1,
         **kwargs,
     ) -> TaskInstance:
         if execution_date is None:
@@ -780,6 +781,7 @@ def create_task_instance(dag_maker, create_dummy_dag):
         (ti,) = dagrun.task_instances
         ti.task = task
         ti.state = state
+        ti.map_index = map_index
 
         dag_maker.session.flush()
         return ti


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #32367

This PR add map_index as filter for Xcom endpoints and to their responses, and adds xcom_key as filter for `get_xcom_entries`.

Here are some examples:
```bash
# get all xcom entries for a task instance
curl -X 'GET' \
  'http://localhost:28080/api/v1/dags/test_dynamic_task_mapping/dagRuns/some_run_id/taskInstances/mapped_task/xcomEntries?limit=100' \
  -H 'accept: application/json'
{
  "total_entries": 6,
  "xcom_entries": [
    {
      "dag_id": "test_dynamic_task_mapping",
      "execution_date": "2023-07-09T10:00:00.00+00:00",
      "key": "return_value",
      "map_index": 0,
      "task_id": "mapped_task",
      "timestamp": "2023-07-09T10:19:02.578137+00:00"
    },
    {
      "dag_id": "test_dynamic_task_mapping",
      "execution_date": "2023-07-09T10:00:00.00+00:00",
      "key": "return_value",
      "map_index": 1,
      "task_id": "mapped_task",
      "timestamp": "2023-07-09T10:19:12.624135+00:00"
    },
    {
      "dag_id": "test_dynamic_task_mapping",
      "execution_date": "2023-07-09T10:00:00.00+00:00",
      "key": "return_value",
      "map_index": 2,
      "task_id": "mapped_task",
      "timestamp": "2023-07-09T10:19:22.626682+00:00"
    },
    {
      "dag_id": "test_dynamic_task_mapping",
      "execution_date": "2023-07-09T10:00:00.00+00:00",
      "key": "some_key",
      "map_index": 0,
      "task_id": "mapped_task",
      "timestamp": "2023-07-09T10:19:02.567293+00:00"
    },
    {
      "dag_id": "test_dynamic_task_mapping",
      "execution_date": "2023-07-09T10:00:00.00+00:00",
      "key": "some_key",
      "map_index": 1,
      "task_id": "mapped_task",
      "timestamp": "2023-07-09T10:19:12.600518+00:00"
    },
    {
      "dag_id": "test_dynamic_task_mapping",
      "execution_date": "2023-07-09T10:00:00.00+00:00",
      "key": "some_key",
      "map_index": 2,
      "task_id": "mapped_task",
      "timestamp": "2023-07-09T10:19:22.609229+00:00"
    }
  ]
}

# get all xcom entries for a task instance with a specific map_index
curl -X 'GET' \
  'http://localhost:28080/api/v1/dags/test_dynamic_task_mapping/dagRuns/some_run_id/taskInstances/mapped_task/xcomEntries?map_index=1&limit=100' \
  -H 'accept: application/json'
{
  "total_entries": 2,
  "xcom_entries": [
    {
      "dag_id": "test_dynamic_task_mapping",
      "execution_date": "2023-07-09T10:00:00.00+00:00",
      "key": "return_value",
      "map_index": 1,
      "task_id": "mapped_task",
      "timestamp": "2023-07-09T10:19:12.624135+00:00"
    },
    {
      "dag_id": "test_dynamic_task_mapping",
      "execution_date": "2023-07-09T10:00:00.00+00:00",
      "key": "some_key",
      "map_index": 1,
      "task_id": "mapped_task",
      "timestamp": "2023-07-09T10:19:12.600518+00:00"
    }
  ]
}

# get all xcom entries for a task instance with a specific map_index and key
curl -X 'GET' \
  'http://localhost:28080/api/v1/dags/test_dynamic_task_mapping/dagRuns/some_run_id/taskInstances/mapped_task/xcomEntries?map_index=1&xcom_key=some_key&limit=100' \
  -H 'accept: application/json'
{
  "total_entries": 1,
  "xcom_entries": [
    {
      "dag_id": "test_dynamic_task_mapping",
      "execution_date": "2023-07-09T10:00:00.00+00:00",
      "key": "some_key",
      "map_index": 1,
      "task_id": "mapped_task",
      "timestamp": "2023-07-09T10:19:12.600518+00:00"
    }
  ]
}
```

And for the value of a single xcom entry:
```bash
# get xcom entry for a task instance
curl -X 'GET' \
  'http://localhost:28080/api/v1/dags/test_dynamic_task_mapping/dagRuns/some_run_id/taskInstances/simple_task/xcomEntries/return_value?deserialize=false' \
  -H 'accept: application/json'
{
  "dag_id": "test_dynamic_task_mapping",
  "execution_date": "2023-07-09T10:00:00.00+00:00",
  "key": "return_value",
  "map_index": -1,
  "task_id": "simple_task",
  "timestamp": "2023-07-09T10:18:51.030130+00:00",
  "value": "[1, 2, 3]"
}

# get xcom entry for a mapped task instance, by default there is no result because the default map_index is -1
curl -X 'GET' \
  'http://localhost:28080/api/v1/dags/test_dynamic_task_mapping/dagRuns/some_run_id/taskInstances/mapped_task/xcomEntries/return_value?deserialize=false' \
  -H 'accept: application/json'
{
  "detail": null,
  "status": 404,
  "title": "XCom entry not found",
  "type": "http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/stable-rest-api-ref.html#section/Errors/NotFound"
}

# get xcom entry for a mapped task instance with a specific map_index
curl -X 'GET' \
  'http://localhost:28080/api/v1/dags/test_dynamic_task_mapping/dagRuns/some_run_id/taskInstances/mapped_task/xcomEntries/return_value?map_index=0&deserialize=false' \
  -H 'accept: application/json'
{
  "dag_id": "test_dynamic_task_mapping",
  "execution_date": "2023-07-09T10:00:00.00+00:00",
  "key": "return_value",
  "map_index": 0,
  "task_id": "mapped_task",
  "timestamp": "2023-07-09T10:19:02.578137+00:00",
  "value": "2"
}
```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
