### PR TITLE
Bugfix, prevent force of unpause on trigger DAG

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -221,9 +221,9 @@
       <div class="col-md-2">
         <div class="btn-group pull-right">
           {% if 'dag_id' in request.args %}
-            <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=url_for(request.endpoint, **request.args), unpause=True) }}"
+            <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=url_for(request.endpoint, **request.args)) }}"
           {% else %}
-            <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=url_for(request.endpoint, dag_id=dag.dag_id, **request.args), unpause=True) }}"
+            <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=url_for(request.endpoint, dag_id=dag.dag_id, **request.args)) }}"
           {% endif %}
               title="Trigger&nbsp;DAG"
               aria-label="Trigger DAG"

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -364,7 +364,7 @@
               <div class="btn-group">
                 {# Use dag_id instead of dag.dag_id, because the DAG might not exist in the webserver's DagBag #}
                 {% if dag %}
-                  <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, redirect_url=url_for(request.endpoint), unpause=True) }}"
+                  <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, redirect_url=url_for(request.endpoint)) }}"
                     title="Trigger&nbsp;DAG"
                     aria-label="Trigger DAG"
                     class="btn btn-sm btn-default btn-icon-only{{ ' disabled' if not dag.can_trigger }} trigger-dropdown-btn">

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2159,10 +2159,17 @@ class Airflow(AirflowBaseView):
                     recent_confs=recent_confs,
                 )
 
-        if unpause and dag.get_is_paused():
-            dag_model = models.DagModel.get_dagmodel(dag_id)
-            if dag_model is not None:
-                dag_model.set_is_paused(is_paused=False)
+        if dag.get_is_paused():
+            if unpause or not ui_fields_defined:
+                flash(f"Unpaused DAG {dag_id}.")
+                dag_model = models.DagModel.get_dagmodel(dag_id)
+                if dag_model is not None:
+                    dag_model.set_is_paused(is_paused=False)
+            else:
+                flash(
+                    f"DAG {dag_id} is paused, unpause if you want to have the triggered run being executed.",
+                    "warning",
+                )
 
         try:
             dag.create_dagrun(


### PR DESCRIPTION
### Apache Airflow version

main (development) (not released)

### What happened

This PR fixes a new bug introduced when finalizing AIP-50 and adjusting the trigger button behavior: Irrespective of the flag to unpause a DAG when using the Trigger UI, calling always un-pauses.

### What you think should happen instead

Like advertised in the UI it should only be un-paused if the user selects so.

### How to reproduce

* Start Airflow, open the UI, use a *disabled* DAG with parameters. Click on the trigger UI
* Disable the "un-pause when paused" switch and trigger. Un-pause will be made even if not desired

Root cause: The un-pause flag was added into the trigger URL and irrespective of the form value the URL parameter overrules the form setting.

### Operating System

Ubuntu 20.04 / Breeze Dev setup in Py 3.8 Container

### Versions of Apache Airflow Providers

No specific setup, execution in Breeze from latest main

### Deployment

Other

### Deployment details

Development setup via `breeze start-airflow...`
Python 3.8
Postgres
Celery worker

### Anything else

To improve visibility I added a flash() message as a reminder that unpause is needed. Removed the unpause URL parameter.

With this PR the behavior changes as follows:
* If DAG has no parameters and user triggers (w/o) form: A flash message will be shown if DAG is un-paused implicitly/automatically
* If DAG has parameters and user switches off the "Un-pause" button a warning will be displayed that DAG is paused.

This PR will very probably generate a merge conflict with PR #31301 which is still not merged :-( Will resolve it...

### Are you willing to submit PR?

- [X] Yes I am willing to submit a PR!

### Code of Conduct

- [X] I agree to follow this project's [Code of Conduct](https://github.com/apache/airflow/blob/main/CODE_OF_CONDUCT.md)
