### PR TITLE
Fix truncated execution_date in UI

### DIFF
--- a/airflow/www/static/js/datetime_utils.js
+++ b/airflow/www/static/js/datetime_utils.js
@@ -20,6 +20,7 @@
 /* global moment, $, document */
 export const defaultFormat = "YYYY-MM-DD, HH:mm:ss";
 export const isoFormatWithoutTZ = "YYYY-MM-DDTHH:mm:ss.SSS";
+export const isoFormatWithTZ = "YYYY-MM-DDTHH:mm:ss.SSSZ";
 export const defaultFormatWithTZ = "YYYY-MM-DD, HH:mm:ss z";
 export const defaultTZFormat = "z (Z)";
 export const dateTimeAttrFormat = "YYYY-MM-DDThh:mm:ssTZD";
@@ -83,6 +84,12 @@ export const secondsToString = (seconds) => {
 
 export function updateAllDateTimes() {
   // Called after `moment.tz.setDefault` has changed the default TZ to display.
+  const formatMap = {
+    execution_date: isoFormatWithTZ,
+    "dag_run.execution_date": isoFormatWithTZ,
+    ti_log: defaultFormatWithTZ,
+    default: defaultFormat,
+  };
 
   $('time[data-datetime-convert!="false"]').each((_, el) => {
     const $el = $(el);
@@ -90,7 +97,7 @@ export function updateAllDateTimes() {
     // eslint-disable-next-line no-underscore-dangle
     if (dt._isValid) {
       $el.text(
-        dt.format($el.data("with-tz") ? defaultFormatWithTZ : defaultFormat)
+        dt.format(formatMap[$el.data("attribute")] || formatMap.default)
       );
     }
     if ($el.attr("title") !== undefined) {

--- a/airflow/www/static/js/task.js
+++ b/airflow/www/static/js/task.js
@@ -32,10 +32,7 @@ document.addEventListener("DOMContentLoaded", () => {
       attr.innerHTML = "";
       const timeElement = document.createElement("time");
       timeElement.setAttribute("datetime", value);
-      timeElement.setAttribute(
-        "data-datetime-convert",
-        attrName === "execution_date" ? "false" : "true"
-      );
+      timeElement.dataset.attribute = attrName;
       const textNode = document.createTextNode(value);
       timeElement.appendChild(textNode);
       attr.appendChild(timeElement);

--- a/airflow/www/static/js/task.js
+++ b/airflow/www/static/js/task.js
@@ -25,12 +25,17 @@ import validator from "validator";
 document.addEventListener("DOMContentLoaded", () => {
   document.querySelectorAll(".js-ti-attr").forEach((attr) => {
     const value = attr.innerHTML;
+    const attrName = attr.previousElementSibling.textContent.trim();
     if (value.length === 32 && moment(value, "YYYY-MM-DD").isValid()) {
       // 32 is the length of our timestamps
       // eslint-disable-next-line no-param-reassign
       attr.innerHTML = "";
       const timeElement = document.createElement("time");
       timeElement.setAttribute("datetime", value);
+      timeElement.setAttribute(
+        "data-datetime-convert",
+        attrName === "execution_date" ? "false" : "true"
+      );
       const textNode = document.createTextNode(value);
       timeElement.appendChild(textNode);
       attr.appendChild(timeElement);

--- a/airflow/www/static/js/task_instances.js
+++ b/airflow/www/static/js/task_instances.js
@@ -21,7 +21,11 @@
 
 // We don't re-import moment again, otherwise webpack will include it twice in the bundle!
 import { escapeHtml } from "./main";
-import { defaultFormat, formatDateTime } from "./datetime_utils";
+import {
+  defaultFormat,
+  isoFormatWithTZ,
+  formatDateTime,
+} from "./datetime_utils";
 import { dagTZ } from "./dag";
 import { finalStatesMap } from "./utils";
 
@@ -100,7 +104,7 @@ export default function tiTooltip(ti, task, { includeTryNumber = false } = {}) {
     tt += `Task_id: ${escapeHtml(ti.task_id)}<br>`;
   }
   if (ti.execution_date !== undefined) {
-    tt += `Run: ${formatDateTime(ti.execution_date)}<br>`;
+    tt += `Run: ${moment(ti.execution_date).format(isoFormatWithTZ)}<br>`;
   }
   if (ti.run_id !== undefined) {
     tt += `Run Id: <nobr>${escapeHtml(ti.run_id)}</nobr><br>`;

--- a/airflow/www/static/js/ti_log.js
+++ b/airflow/www/static/js/ti_log.js
@@ -138,14 +138,14 @@ function autoTailingLog(tryNumber, metadata = null, autoTailing = false) {
           .replaceAll(
             dateRegex,
             (date) =>
-              `<time datetime="${date}+00:00" data-with-tz="true">${formatDateTime(
+              `<time datetime="${date}+00:00" data-attribute="ti_log">${formatDateTime(
                 `${date}+00:00`
               )}</time>`
           )
           .replaceAll(
             iso8601Regex,
             (date) =>
-              `<time datetime="${date}" data-with-tz="true">${formatDateTime(
+              `<time datetime="${date}" data-attribute="ti_log">${formatDateTime(
                 `${date}`
               )}</time>`
           );

--- a/airflow/www/templates/airflow/dag_audit_log.html
+++ b/airflow/www/templates/airflow/dag_audit_log.html
@@ -85,7 +85,7 @@
               <!--     Event    -->
               <td>{{ log.event if log.event else None }}</td>
               <!--     Execution Date     -->
-              <td>{{ log.execution_date if log.execution_date else None }}</td>
+              <td>{% if log.execution_date %}<time datetime="{{ log.execution_date }}" data-attribute="execution_date">{{ log.execution_date }}</time>{% endif %}</td>
               <!--     By User     -->
               <td>{{ log.owner if log.owner else None }}</td>
               <!--     Details     -->

--- a/airflow/www/templates/airflow/task_instance.html
+++ b/airflow/www/templates/airflow/task_instance.html
@@ -26,7 +26,7 @@
   <br>
   <h4>
     <span class="text-muted">Task Instance:</span> <span>{{ task_id }}</span>
-    <span class="text-muted">at</span> <time datetime="{{ execution_date }}" data-datetime-convert="false">{{ execution_date }}</time>
+    <span class="text-muted">at</span> <time datetime="{{ execution_date }}" data-attribute="execution_date">{{ execution_date }}</time>
     {% if map_index is defined and map_index >= 0 %}
       <span class="text-muted">Map Index:</span> <span>{{ map_index }}</span>
     {% endif %}

--- a/airflow/www/templates/airflow/task_instance.html
+++ b/airflow/www/templates/airflow/task_instance.html
@@ -26,7 +26,7 @@
   <br>
   <h4>
     <span class="text-muted">Task Instance:</span> <span>{{ task_id }}</span>
-    <span class="text-muted">at</span> <time datetime="{{ execution_date }}">{{ execution_date }}</time>
+    <span class="text-muted">at</span> <time datetime="{{ execution_date }}" data-datetime-convert="false">{{ execution_date }}</time>
     {% if map_index is defined and map_index >= 0 %}
       <span class="text-muted">Map Index:</span> <span>{{ map_index }}</span>
     {% endif %}

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -463,12 +463,12 @@ def datetime_f(attr_name):
 
     def dt(attr):
         f = attr.get(attr_name)
-        return datetime_html(f)
+        return datetime_html(f, attr_name)
 
     return dt
 
 
-def datetime_html(dttm: DateTime | None) -> str:
+def datetime_html(dttm: DateTime | None, attr_name: str) -> str:
     """Return an HTML formatted string with time element to support timezone changes in UI."""
     as_iso = dttm.isoformat() if dttm else ""
     if not as_iso:
@@ -477,7 +477,9 @@ def datetime_html(dttm: DateTime | None) -> str:
     if timezone.utcnow().isoformat()[:4] == as_iso[:4]:
         as_iso_short = as_iso[5:]
     # The empty title will be replaced in JS code when non-UTC dates are displayed
-    return Markup('<nobr><time title="" datetime="{}">{}</time></nobr>').format(as_iso, as_iso_short)
+    return Markup('<nobr><time title="" datetime="{}" data-attribute="{}">{}</time></nobr>').format(
+        as_iso, attr_name, as_iso_short
+    )
 
 
 def json_f(attr_name):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Add `data-attribute` to time elements in HTML. Configure datetime formatting based on this attribute, all instances of `execution_date` and `dag_run.execution_date` will be formatted as isoformat with milliseconds and timezone. Microseconds precision is unfortunately not possible, because the datetimes are formatted in Javascript.

closes: #28482
Examples:

Task instance details:
![image](https://github.com/apache/airflow/assets/18099224/c5445148-0abf-4f12-8995-cb6e9382c276)

DAG runs:
![image](https://github.com/apache/airflow/assets/18099224/7552deab-5265-4c9f-a8d3-377eb3ea4b68)

Task Instances:
![image](https://github.com/apache/airflow/assets/18099224/f8682d9e-80f5-4e14-85ca-08c4ed3c80e5)

Task instance logs (nothing changed here):
![image](https://github.com/apache/airflow/assets/18099224/b2f6f764-4f6d-48b6-a428-4c198d8e8e7a)

DAG Audit log:
![image](https://github.com/apache/airflow/assets/18099224/b70aa8ef-c3b4-45bc-9668-d820af1a1d8e)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
