### PR TITLE
Fixing internal class name to have small lettered abbreviations instead of capital

### DIFF
--- a/airflow/providers/sftp/decorators/sensors/sftp.py
+++ b/airflow/providers/sftp/decorators/sensors/sftp.py
@@ -23,7 +23,7 @@ from airflow.decorators.base import TaskDecorator, get_unique_task_id, task_deco
 from airflow.providers.sftp.sensors.sftp import SFTPSensor
 
 
-class _DecoratedSFTPSensor(SFTPSensor):
+class _DecoratedSftpSensor(SFTPSensor):
     """
     Wraps a Python callable and captures args/kwargs when called for execution.
 
@@ -67,6 +67,6 @@ def sftp_sensor_task(python_callable: Callable | None = None, **kwargs) -> TaskD
     return task_decorator_factory(
         python_callable=python_callable,
         multiple_outputs=False,
-        decorated_operator_class=_DecoratedSFTPSensor,
+        decorated_operator_class=_DecoratedSftpSensor,
         **kwargs,
     )


### PR DESCRIPTION
Fixing error in main - 
> The class airflow.providers.sftp.decorators.sensors.sftp._DecoratedSFTPSensor is wrongly named. The class name should be CamelCaseWithACRONYMS !

Coverted `_DecoratedSFTPSensor` to `_DecoratedSftpSensor`
A followup of #32475 
cc - @uranusjr 
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
