### PR TITLE
Revert the Python 3.11 exclusion for date isoformat

### DIFF
--- a/tests/models/test_param.py
+++ b/tests/models/test_param.py
@@ -20,7 +20,6 @@ from contextlib import nullcontext
 
 import pytest
 
-from airflow import PY311
 from airflow.decorators import task
 from airflow.exceptions import ParamValidationError, RemovedInAirflow3Warning
 from airflow.models.param import Param, ParamsDict
@@ -127,25 +126,20 @@ class TestParam:
         "date_string",
         [
             "2021-01-01",
-            pytest.param(
-                "20120503",
-                marks=pytest.mark.skipif(not PY311, reason="Improved fromisoformat() in 3.11."),
-            ),
         ],
     )
     def test_string_date_format(self, date_string):
         """Test string date format."""
         assert Param(date_string, type="string", format="date").resolve() == date_string
 
+    # Note that 20120503 behaved differently in 3.11.3 Official python image. It was validated as a date
+    # there but it started to fail again in 3.11.4 released on 2023-07-05.
     @pytest.mark.parametrize(
         "date_string",
         [
             "01/01/2021",
             "21 May 1975",
-            pytest.param(
-                "20120503",
-                marks=pytest.mark.skipif(PY311, reason="Improved fromisoformat() in 3.11."),
-            ),
+            "20120503",
         ],
     )
     def test_string_date_format_error(self, date_string):


### PR DESCRIPTION
The official Python image for 3.11 had a brief period when the date `20120503` has been an acceptable date, but it is not accepted as of 3.11.4 release on 5th of July.

This PR reverts  the changes in tests implemented in #27264 to accomodate for it and brings back the date as error case.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
