### PR TITLE
Move security team details into contributing docs

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -63,54 +63,6 @@ not apply to the Airflow core package. There are also Airflow providers released
 Airflow community is not responsible for releasing and announcing security vulnerabilities in them, this
 is handled entirely by the 3rd-parties that release their own providers.
 
-## Handling security issues in Airflow
+## How are security issues handled in Airflow
 
-The security issues in Airflow are handled by the Airflow Security Team. The team consists
-of selected PMC members that are interested in looking at, discussing about and fixing the
-security issues, but it can also include committers and non-committer contributors that are
-not PMC members yet and have been approved by the PMC members in a vote. You can request to
-be added to the team by sending a message to private@airflow.apache.org. However, the team
-should be small and focused on solving security issues, so the requests will be evaluated
-on-case-by-case and the team size will be kept relatively small, limited to only actively
-security-focused contributors.
-
-There are certain expectations from the members of the security team:
-
-* They are supposed to be active in assessing, discussing, fixing and releasing the
-  security issues in Airflow. While it is perfectly understood that as volunteers, we might have
-  periods of lower activity, prolonged lack of activity and participation will result in removal
-  from the team, pending PMC decision (the decision on removal can be taken by LAZY CONSENSUS among
-  all the PMC members on private@airflow.apache.org mailing list).
-
-* They are not supposed to reveal the information about pending and unfixed security issues to anyone
-  (including their employers) unless specifically authorised by the security team members, specifically
-  if diagnosing and solving the issue might involve the need of external experts - for example security
-  experts that are available through Airflow stakeholders. The intent about involving 3rd parties has
-  to be discussed and agreed up at security@airflow.apache.org.
-
-* They have to have an [ICLA](https://www.apache.org/licenses/contributor-agreements.html) signed with
-  Apache Software Foundation.
-
-* The security team members might inform 3rd parties about fixes, for example in order to assess if the fix
-  is solving the problem or in order to assess its applicability to be applied by 3rd parties, as soon
-  as a PR solving the issue is opened in the public airflow repository.
-
-* In case of critical security issues, the members of the security team might iterate on a fix in a
-  private repository and only open the PR in the public repository once the fix is ready to be released,
-  with the intent of minimizing the time between the fix being available and the fix being released. In this
-  case the PR might be sent to review and comment to the PMC members on private list, in order to request
-  an expedited voting on the release. The voting for such release might be done on the
-  `private@airflow.apache.org` mailing list and should be made public at the `dev@apache.airflow.org`
-  mailing list as soon as the release is ready to be announced.
-
-* The security team members working on the fix might be mentioned as remediation developers in the CVE
-  including their job affiliation if they want to.
-
-* Community members acting as release managers are by default members of the security team and unless they
-  want to, they do not have to be involved in discussing and solving the issues. They are responsible for
-  releasing the CVE information (announcement and publishing to security indexes) as part of the
-  release process. This is facilitated by the security tool provided by the Apache Software Foundation.
-
-* Severity of the issue is determined based on the criteria described in the
-  [Severity Rating blog post](https://security.apache.org/blog/severityrating/)  by the Apache Software
-  Foundation Security team
+Security issues in Airflow are handled by the Airflow Security Team. Details about the Airflow Security Team and how members of it are chosen can be found in the [Contributing documentation](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#security-team).

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -162,6 +162,59 @@ Contributors are responsible for:
 * Adding features
 * Championing one or more items on the `Roadmap <https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Home>`__.
 
+Security Team
+-------------
+
+Security issues in Airflow are handled by the Airflow Security Team. The team consists
+of selected PMC members that are interested in looking at, discussing and fixing
+security issues, but it can also include committers and non-committer contributors that are
+not PMC members yet and have been approved by the PMC members in a vote. You can request to
+be added to the team by sending a message to private@airflow.apache.org. However, the team
+should be small and focused on solving security issues, so the requests will be evaluated
+on a case-by-case basis and the team size will be kept relatively small, limited to only actively
+security-focused contributors.
+
+There are certain expectations from the members of the security team:
+
+* They are supposed to be active in assessing, discussing, fixing and releasing the
+  security issues in Airflow. While it is perfectly understood that as volunteers, we might have
+  periods of lower activity, prolonged lack of activity and participation will result in removal
+  from the team, pending PMC decision (the decision on removal can be taken by LAZY CONSENSUS among
+  all the PMC members on private@airflow.apache.org mailing list).
+
+* They are not supposed to reveal the information about pending and unfixed security issues to anyone
+  (including their employers) unless specifically authorised by the security team members, specifically
+  if diagnosing and solving the issue might involve the need of external experts - for example security
+  experts that are available through Airflow stakeholders. The intent about involving 3rd parties has
+  to be discussed and agreed upon at security@airflow.apache.org.
+
+* They have to have an [ICLA](https://www.apache.org/licenses/contributor-agreements.html) signed with
+  Apache Software Foundation.
+
+* The security team members might inform 3rd parties about fixes, for example in order to assess if the fix
+  is solving the problem or in order to assess its applicability to be applied by 3rd parties, as soon
+  as a PR solving the issue is opened in the public airflow repository.
+
+* In case of critical security issues, the members of the security team might iterate on a fix in a
+  private repository and only open the PR in the public repository once the fix is ready to be released,
+  with the intent of minimizing the time between the fix being available and the fix being released. In this
+  case the PR might be sent to review and comment to the PMC members on private list, in order to request
+  an expedited voting on the release. The voting for such release might be done on the
+  private@airflow.apache.org mailing list and should be made public at the dev@apache.airflow.org
+  mailing list as soon as the release is ready to be announced.
+
+* The security team members working on the fix might be mentioned as remediation developers in the CVE
+  including their job affiliation if they want to.
+
+* Community members acting as release managers are by default members of the security team and unless they
+  want to, they do not have to be involved in discussing and solving the issues. They are responsible for
+  releasing the CVE information (announcement and publishing to security indexes) as part of the
+  release process. This is facilitated by the security tool provided by the Apache Software Foundation.
+
+* Severity of the issue is determined based on the criteria described in the
+  [Severity Rating blog post](https://security.apache.org/blog/severityrating/)  by the Apache Software
+  Foundation Security team
+
 Contribution Workflow
 =====================
 


### PR DESCRIPTION
I think it makes sense to move the details about the security team into the normal contributing docs roles area. This 1) keeps the roles in the community in 1 place and 2) keeps out security policy in GH smaller/simpler.