### PR TITLE
Do not fail when docker context cannot be used

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -845,8 +845,6 @@ def get_and_use_docker_context(context: str):
     output = run_command(["docker", "context", "use", context], check=False)
     if output.returncode != 0:
         get_console().print(
-            "[error] Error when switching context. Add `--builder default` to your command "
-            "and report the issue on #airflow-breeze channel in Airflow Slack[/]"
+            f"[warning] Could no use the context {context}. Continuing with current context[/]"
         )
-        sys.exit(output.returncode)
     return context


### PR DESCRIPTION
This is a follow-up after #32494 and #32463, where autodetection of docker context has been added. There is a weird relation between builders and docker context - sometimes they have to be used in sync, and sometimes not. For example when we are creating a new context manually (airxflow_cache) to build images in parallel on ARM/x86, we should use airflow_cache as buider, but the context should remain "default". On the other hand when we are using "desktop-linux" builder, we MUST switch the context to "desktop-linux".

This PR is an attempt to make best effort to switch to the same context as the builder, but instead of failing, we just warn if can't and continue.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
