### PR TITLE
Update type hint for ElasticsearchTaskHandler.es_read to reflect integer usage

### DIFF
--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -274,7 +274,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
         # Just a safe-guard to preserve backwards-compatibility
         return log_line.message
 
-    def es_read(self, log_id: str, offset: str, metadata: dict) -> list | ElasticSearchResponse:
+    def es_read(self, log_id: str, offset: int | str, metadata: dict) -> list | ElasticSearchResponse:
         """
         Return the logs matching log_id in Elasticsearch and next offset or ''.
 


### PR DESCRIPTION
## Description

In the context of lines 232 and 234 within the `ElasticsearchTaskHandler._read` method, `metadata["offset"]` is initialized with an integer value of `0`. This integer is subsequently passed to the `self.es_read` method, an action which the current type hint does not account for.

Relevant code selections:
https://github.com/apache/airflow/blob/3b97eb08c0280a5a63b6b165a31a0413b98f7032/airflow/providers/elasticsearch/log/es_task_handler.py#L231-L238
https://github.com/apache/airflow/blob/3b97eb08c0280a5a63b6b165a31a0413b98f7032/airflow/providers/elasticsearch/log/es_task_handler.py#L302

This pull request proposes the modification  of the `offset` parameter's type hint from `str` to `int | str` in order to reflect its accurate usage within the aforementioned code sections.