### PR TITLE
Restore cloud formation tests because openapi_schema_validator 0.6.0 is released

### DIFF
--- a/tests/providers/amazon/aws/hooks/test_cloud_formation.py
+++ b/tests/providers/amazon/aws/hooks/test_cloud_formation.py
@@ -18,88 +18,10 @@
 from __future__ import annotations
 
 import json
-from unittest import mock
+
+from moto import mock_cloudformation
 
 from airflow.providers.amazon.aws.hooks.cloud_formation import CloudFormationHook
-
-# TODO: restore this test with moto when openapi_schema_validator 0.6.0 is released
-# class TestCloudFormationHook:
-#     from moto import mock_cloudformation
-
-#     def setup_method(self):
-#         self.hook = CloudFormationHook(aws_conn_id="aws_default")
-#
-#     def create_stack(self, stack_name):
-#         timeout = 15
-#         template_body = json.dumps(
-#             {
-#                 "Resources": {
-#                     "myResource": {
-#                         "Type": "AWS::EC2::VPC",
-#                         "Properties": {
-#                             "CidrBlock": {"Ref": "VPCCidr"},
-#                             "Tags": [{"Key": "Name", "Value": "Primary_CF_VPC"}],
-#                         },
-#                     }
-#                 },
-#                 "Parameters": {
-#                     "VPCCidr": {
-#                         "Type": "String",
-#                         "Default": "10.0.0.0/16",
-#                         "Description": "Enter the CIDR block for the VPC. Default is 10.0.0.0/16.",
-#                     }
-#                 },
-#             }
-#         )
-#
-#         self.hook.create_stack(
-#             stack_name=stack_name,
-#             cloudformation_parameters={
-#                 "TimeoutInMinutes": timeout,
-#                 "TemplateBody": template_body,
-#                 "Parameters": [{"ParameterKey": "VPCCidr", "ParameterValue": "10.0.0.0/16"}],
-#             },
-#         )
-#
-#     @mock_cloudformation
-#     def test_get_conn_returns_a_boto3_connection(self):
-#         assert self.hook.get_conn().describe_stacks() is not None
-#
-#     @mock_cloudformation
-#     def test_get_stack_status(self):
-#         stack_name = "my_test_get_stack_status_stack"
-#
-#         stack_status = self.hook.get_stack_status(stack_name=stack_name)
-#         assert stack_status is None
-#
-#         self.create_stack(stack_name)
-#         stack_status = self.hook.get_stack_status(stack_name=stack_name)
-#         assert stack_status == "CREATE_COMPLETE", "Incorrect stack status returned."
-#
-#     @mock_cloudformation
-#     def test_create_stack(self):
-#         stack_name = "my_test_create_stack_stack"
-#         self.create_stack(stack_name)
-#
-#         stacks = self.hook.get_conn().describe_stacks()["Stacks"]
-#         assert len(stacks) > 0, "CloudFormation should have stacks"
-#
-#         matching_stacks = [x for x in stacks if x["StackName"] == stack_name]
-#         assert len(matching_stacks) == 1, f"stack with name {stack_name} should exist"
-#
-#         stack = matching_stacks[0]
-#         assert stack["StackStatus"] == "CREATE_COMPLETE", "Stack should be in status CREATE_COMPLETE"
-#
-#     @mock_cloudformation
-#     def test_delete_stack(self):
-#         stack_name = "my_test_delete_stack_stack"
-#         self.create_stack(stack_name)
-#
-#         self.hook.delete_stack(stack_name=stack_name)
-#
-#         stacks = self.hook.get_conn().describe_stacks()["Stacks"]
-#         matching_stacks = [x for x in stacks if x["StackName"] == stack_name]
-#         assert not matching_stacks, f"stack with name {stack_name} should not exist"
 
 
 class TestCloudFormationHook:
@@ -138,51 +60,42 @@ class TestCloudFormationHook:
             },
         )
 
-    @mock.patch("airflow.providers.amazon.aws.hooks.cloud_formation.CloudFormationHook.get_conn")
-    def test_get_conn_returns_a_boto3_connection(self, cloudformation_conn_mock):
+    @mock_cloudformation
+    def test_get_conn_returns_a_boto3_connection(self):
         assert self.hook.get_conn().describe_stacks() is not None
 
-    @mock.patch("airflow.providers.amazon.aws.hooks.cloud_formation.CloudFormationHook.get_conn")
-    def test_get_stack_status(self, cloudformation_conn_mock):
+    @mock_cloudformation
+    def test_get_stack_status(self):
         stack_name = "my_test_get_stack_status_stack"
 
-        self.hook.get_stack_status(stack_name=stack_name)
-        cloudformation_conn_mock.return_value.describe_stacks.assert_called_once_with(StackName=stack_name)
+        stack_status = self.hook.get_stack_status(stack_name=stack_name)
+        assert stack_status is None
 
-    @mock.patch("airflow.providers.amazon.aws.hooks.cloud_formation.CloudFormationHook.get_conn")
-    def test_create_stack(self, cloudformation_conn_mock):
+        self.create_stack(stack_name)
+        stack_status = self.hook.get_stack_status(stack_name=stack_name)
+        assert stack_status == "CREATE_COMPLETE", "Incorrect stack status returned."
+
+    @mock_cloudformation
+    def test_create_stack(self):
         stack_name = "my_test_create_stack_stack"
         self.create_stack(stack_name)
-        cloudformation_conn_mock.return_value.create_stack.assert_called_once_with(
-            StackName=stack_name,
-            TimeoutInMinutes=15,
-            TemplateBody=json.dumps(
-                {
-                    "Resources": {
-                        "myResource": {
-                            "Type": "AWS::EC2::VPC",
-                            "Properties": {
-                                "CidrBlock": {"Ref": "VPCCidr"},
-                                "Tags": [{"Key": "Name", "Value": "Primary_CF_VPC"}],
-                            },
-                        }
-                    },
-                    "Parameters": {
-                        "VPCCidr": {
-                            "Type": "String",
-                            "Default": "10.0.0.0/16",
-                            "Description": "Enter the CIDR block for the VPC. Default is 10.0.0.0/16.",
-                        }
-                    },
-                }
-            ),
-            Parameters=[{"ParameterKey": "VPCCidr", "ParameterValue": "10.0.0.0/16"}],
-        )
 
-    @mock.patch("airflow.providers.amazon.aws.hooks.cloud_formation.CloudFormationHook.get_conn")
-    def test_delete_stack(self, cloudformation_conn_mock):
+        stacks = self.hook.get_conn().describe_stacks()["Stacks"]
+        assert len(stacks) > 0, "CloudFormation should have stacks"
+
+        matching_stacks = [x for x in stacks if x["StackName"] == stack_name]
+        assert len(matching_stacks) == 1, f"stack with name {stack_name} should exist"
+
+        stack = matching_stacks[0]
+        assert stack["StackStatus"] == "CREATE_COMPLETE", "Stack should be in status CREATE_COMPLETE"
+
+    @mock_cloudformation
+    def test_delete_stack(self):
         stack_name = "my_test_delete_stack_stack"
+        self.create_stack(stack_name)
 
         self.hook.delete_stack(stack_name=stack_name)
 
-        cloudformation_conn_mock.return_value.delete_stack.assert_called_once_with(StackName=stack_name)
+        stacks = self.hook.get_conn().describe_stacks()["Stacks"]
+        matching_stacks = [x for x in stacks if x["StackName"] == stack_name]
+        assert not matching_stacks, f"stack with name {stack_name} should not exist"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Restore cloud formation tests which use moto because openapi_schema_validator 0.6.0 is released

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
