### PR TITLE
Improve the readability of the conn view tests

### DIFF
--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -314,16 +314,17 @@ def test_duplicate_connection(admin_client):
 
     data = {"action": "mulduplicate", "rowid": [conn1.id, conn3.id]}
     resp = admin_client.post("/connection/action_post", data=data, follow_redirects=True)
-    expected_result = {
+    assert resp.status_code == 200
+
+    expected_connections_ids = {
         "test_duplicate_gcp_connection",
         "test_duplicate_gcp_connection_copy1",
         "test_duplicate_mysql_connection",
         "test_duplicate_postgres_connection_copy1",
         "test_duplicate_postgres_connection_copy2",
     }
-    response = {conn[0] for conn in session.query(Connection.conn_id).all()}
-    assert resp.status_code == 200
-    assert expected_result == response
+    connections_ids = {conn.conn_id for conn in session.query(Connection.conn_id).all()}
+    assert expected_connections_ids == connections_ids
 
 
 def test_duplicate_connection_error(admin_client):
@@ -350,12 +351,11 @@ def test_duplicate_connection_error(admin_client):
 
     data = {"action": "mulduplicate", "rowid": [connections[0].id]}
     resp = admin_client.post("/connection/action_post", data=data, follow_redirects=True)
-
-    expected_result = {f"test_duplicate_postgres_connection_copy{i}" for i in range(1, 11)}
-
     assert resp.status_code == 200
-    response = {conn[0] for conn in session.query(Connection.conn_id).all()}
-    assert expected_result == response
+
+    expected_connections_ids = {f"test_duplicate_postgres_connection_copy{i}" for i in range(1, 11)}
+    connections_ids = {conn.conn_id for conn in session.query(Connection.conn_id).all()}
+    assert expected_connections_ids == connections_ids
 
 
 @pytest.fixture()

--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -323,7 +323,7 @@ def test_duplicate_connection(admin_client):
         "test_duplicate_postgres_connection_copy1",
         "test_duplicate_postgres_connection_copy2",
     }
-    connections_ids = {conn.conn_id for conn in session.query(Connection.conn_id).all()}
+    connections_ids = {conn.conn_id for conn in session.query(Connection.conn_id)}
     assert expected_connections_ids == connections_ids
 
 
@@ -354,7 +354,7 @@ def test_duplicate_connection_error(admin_client):
     assert resp.status_code == 200
 
     expected_connections_ids = {f"test_duplicate_postgres_connection_copy{i}" for i in range(1, 11)}
-    connections_ids = {conn.conn_id for conn in session.query(Connection.conn_id).all()}
+    connections_ids = {conn.conn_id for conn in session.query(Connection.conn_id)}
     assert expected_connections_ids == connections_ids
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Make the  conn view tests more readable by renaming some variables and access the row fields by field name instead of index.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
