### PR TITLE
Add Executors discovery and documentation

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -1807,6 +1807,12 @@ PROVIDERS_COMMANDS = (
         func=lazy_load_command("airflow.cli.commands.provider_command.auth_backend_list"),
         args=(ARG_OUTPUT, ARG_VERBOSE),
     ),
+    ActionCommand(
+        name="executors",
+        help="Get information about executors provided",
+        func=lazy_load_command("airflow.cli.commands.provider_command.executors_list"),
+        args=(ARG_OUTPUT, ARG_VERBOSE),
+    ),
 )
 
 USERS_COMMANDS = (

--- a/airflow/cli/commands/provider_command.py
+++ b/airflow/cli/commands/provider_command.py
@@ -167,3 +167,15 @@ def auth_backend_list(args):
             "api_auth_backand_module": x,
         },
     )
+
+
+@suppress_logs_and_warning
+def executors_list(args):
+    """Lists all executors at the command line."""
+    AirflowConsole().print_as(
+        data=list(ProvidersManager().executor_class_names),
+        output=args.output,
+        mapper=lambda x: {
+            "executor_class_names": x,
+        },
+    )

--- a/airflow/provider.yaml.schema.json
+++ b/airflow/provider.yaml.schema.json
@@ -306,13 +306,20 @@
           "type": "string"
       }
     },
-      "notifications": {
+    "notifications": {
           "type": "array",
           "description": "Notification class names",
           "items": {
               "type": "string"
           }
     },
+    "executors": {
+          "type": "array",
+          "description": "Executor class names",
+          "items": {
+              "type": "string"
+          }
+      },
     "plugins": {
       "type": "array",
       "description": "Plugins exposed by the provider",

--- a/airflow/provider_info.schema.json
+++ b/airflow/provider_info.schema.json
@@ -71,13 +71,20 @@
           "type": "string"
       }
     },
-      "notifications": {
+    "notifications": {
           "type": "array",
           "description": "Notification class names",
           "items": {
               "type": "string"
           }
-      },
+    },
+    "executors": {
+          "type": "array",
+          "description": "Executor class names",
+          "items": {
+              "type": "string"
+          }
+    },
     "task-decorators": {
         "type": "array",
         "description": "Apply custom decorators to the TaskFlow API. Can be accessed by users via '@task.<name>'",

--- a/airflow/providers/celery/provider.yaml
+++ b/airflow/providers/celery/provider.yaml
@@ -56,3 +56,7 @@ sensors:
   - integration-name: Celery
     python-modules:
       - airflow.providers.celery.sensors.celery_queue
+
+executors:
+  - airflow.providers.celery.executors.celery_executor.CeleryExecutor
+  - airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor

--- a/docs/apache-airflow-providers/core-extensions/executors.rst
+++ b/docs/apache-airflow-providers/core-extensions/executors.rst
@@ -1,0 +1,33 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Executors
+---------
+
+This is a summary of all Apache Airflow Community provided implementations of Executors
+exposed via community-managed providers.
+
+Airflow can be extended by providers with Executors. Each provider can define their own Executors,
+that can be configured to handle executing tasks
+
+The executors are explained in
+:doc:`apache-airflow:core-concepts/executor/index` and you can also see those
+provided by the community-managed providers:
+
+.. airflow-executors::
+   :tags: None
+   :header-separator: "

--- a/docs/exts/executors.rst.jinja2
+++ b/docs/exts/executors.rst.jinja2
@@ -1,0 +1,27 @@
+{#
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+#}
+{%for provider, provider_dict in items.items() %}
+{{ provider_dict['name'] }}
+{{ header_separator * (provider_dict['name']|length) }}
+
+{% for executor in provider_dict['executors'] -%}
+- :class:`~{{ executor }}`
+{% endfor -%}
+
+{% endfor %}

--- a/docs/exts/operators_and_hooks_ref.py
+++ b/docs/exts/operators_and_hooks_ref.py
@@ -284,10 +284,29 @@ def _prepare_notifications_data():
     return all_notifiers
 
 
+def _prepare_executors_data():
+    package_data = load_package_data()
+    all_executors = {}
+    for provider in package_data:
+        if executors := provider.get("executors"):
+            package_name = provider["package-name"]
+            all_executors[package_name] = {
+                "name": provider["name"],
+                "executors": executors,
+            }
+    return all_executors
+
+
 def _render_notification_content(*, header_separator: str):
     tabular_data = _prepare_notifications_data()
 
     return _render_template("notifications.rst.jinja2", items=tabular_data, header_separator=header_separator)
+
+
+def _render_executors_content(*, header_separator: str):
+    tabular_data = _prepare_executors_data()
+
+    return _render_template("executors.rst.jinja2", items=tabular_data, header_separator=header_separator)
 
 
 class BaseJinjaReferenceDirective(Directive):
@@ -396,6 +415,15 @@ class NotificationsDirective(BaseJinjaReferenceDirective):
         )
 
 
+class ExecutorsDirective(BaseJinjaReferenceDirective):
+    """Generate list of executors"""
+
+    def render_content(self, *, tags: set[str] | None, header_separator: str = DEFAULT_HEADER_SEPARATOR):
+        return _render_executors_content(
+            header_separator=header_separator,
+        )
+
+
 def setup(app):
     """Setup plugin"""
     app.add_directive("operators-hooks-ref", OperatorsHooksReferenceDirective)
@@ -406,6 +434,7 @@ def setup(app):
     app.add_directive("airflow-connections", ConnectionsDirective)
     app.add_directive("airflow-extra-links", ExtraLinksDirective)
     app.add_directive("airflow-notifications", NotificationsDirective)
+    app.add_directive("airflow-executors", ExecutorsDirective)
 
     return {"parallel_read_safe": True, "parallel_write_safe": True}
 

--- a/scripts/in_container/verify_providers.py
+++ b/scripts/in_container/verify_providers.py
@@ -722,7 +722,7 @@ def run_provider_discovery():
         subprocess.run(["airflow", "providers", "triggers"], check=True)
     if packaging.version.parse(airflow.version.version) >= packaging.version.parse("2.7.0.dev0"):
         # CI also check if our providers are installable and discoverable in airflow older versions
-        # But the triggers command is not available till airflow-2-7-0
+        # But the executors command is not available till airflow-2-7-0
         console.print("[bright_blue]List all executors[/]\n")
         subprocess.run(["airflow", "providers", "executors"], check=True)
 

--- a/scripts/in_container/verify_providers.py
+++ b/scripts/in_container/verify_providers.py
@@ -714,12 +714,17 @@ def run_provider_discovery():
     subprocess.run(["airflow", "providers", "secrets"], check=True)
     console.print("[bright_blue]List all auth backends[/]\n")
     subprocess.run(["airflow", "providers", "auth"], check=True)
-    if packaging.version.parse(airflow.version.version) >= packaging.version.parse("2.7.0.dev0"):
+    if packaging.version.parse(airflow.version.version) >= packaging.version.parse("2.6.0.dev0"):
         # CI also check if our providers are installable and discoverable in airflow older versions
         # But the triggers command is not available till airflow-2-6-0
         # TODO: Remove this block once airflow dependency in providers are > 2-6-0
         console.print("[bright_blue]List all triggers[/]\n")
         subprocess.run(["airflow", "providers", "triggers"], check=True)
+    if packaging.version.parse(airflow.version.version) >= packaging.version.parse("2.7.0.dev0"):
+        # CI also check if our providers are installable and discoverable in airflow older versions
+        # But the triggers command is not available till airflow-2-7-0
+        console.print("[bright_blue]List all executors[/]\n")
+        subprocess.run(["airflow", "providers", "executors"], check=True)
 
 
 AIRFLOW_LOCAL_SETTINGS_PATH = Path("/opt/airflow") / "airflow_local_settings.py"


### PR DESCRIPTION
The Executors can now be added via providers. This PR adds
mechanism of discovering the executors via Providers Manager,
exposing them via CLI and documenting in core-extensions.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
