### PR TITLE
Strong-type single-state enum values

### DIFF
--- a/airflow/jobs/backfill_job_runner.py
+++ b/airflow/jobs/backfill_job_runner.py
@@ -696,7 +696,7 @@ class BackfillJobRunner(BaseJobRunner[Job], LoggingMixin):
             _dag_runs = ti_status.active_runs[:]
             for run in _dag_runs:
                 run.update_state(session=session)
-                if run.state in State.finished:
+                if run.state in State.finished_dr_states:
                     ti_status.finished_runs += 1
                     ti_status.active_runs.remove(run)
                     executed_run_dates.append(run.execution_date)
@@ -824,7 +824,7 @@ class BackfillJobRunner(BaseJobRunner[Job], LoggingMixin):
         """
         for dag_run in dag_runs:
             dag_run.update_state()
-            if dag_run.state not in State.finished:
+            if dag_run.state not in State.finished_dr_states:
                 dag_run.set_state(DagRunState.FAILED)
             session.merge(dag_run)
 

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -625,7 +625,7 @@ class SchedulerJobRunner(BaseJobRunner[Job], LoggingMixin):
         """
         # actually enqueue them
         for ti in task_instances:
-            if ti.dag_run.state in State.finished:
+            if ti.dag_run.state in State.finished_dr_states:
                 ti.set_state(None, session=session)
                 continue
             command = ti.command_as_list(
@@ -1449,7 +1449,7 @@ class SchedulerJobRunner(BaseJobRunner[Job], LoggingMixin):
         # TODO[HA]: Rename update_state -> schedule_dag_run, ?? something else?
         schedulable_tis, callback_to_run = dag_run.update_state(session=session, execute_callbacks=False)
         # Check if DAG not scheduled then skip interval calculation to same scheduler runtime
-        if dag_run.state in State.finished:
+        if dag_run.state in State.finished_dr_states:
             # Work out if we should allow creating a new DagRun now?
             if self._should_update_dag_next_dagruns(dag, dag_model, session=session):
                 dag_model.calculate_dagrun_date_fields(dag, dag.get_run_data_interval(dag_run))

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -270,7 +270,7 @@ class DagRun(Base, LoggingMixin):
             raise ValueError(f"invalid DagRun state: {state}")
         if self._state != state:
             self._state = state
-            self.end_date = timezone.utcnow() if self._state in State.finished else None
+            self.end_date = timezone.utcnow() if self._state in State.finished_dr_states else None
             if state == DagRunState.QUEUED:
                 self.queued_at = timezone.utcnow()
 

--- a/airflow/models/pool.py
+++ b/airflow/models/pool.py
@@ -175,12 +175,12 @@ class Pool(Base):
 
         state_count_by_pool = session.execute(
             select(TaskInstance.pool, TaskInstance.state, func.sum(TaskInstance.pool_slots))
-            .filter(TaskInstance.state.in_(list(EXECUTION_STATES)))
+            .filter(TaskInstance.state.in_(EXECUTION_STATES))
             .group_by(TaskInstance.pool, TaskInstance.state)
         )
 
         # calculate queued and running metrics
-        for (pool_name, state, count) in state_count_by_pool:
+        for pool_name, state, count in state_count_by_pool:
             # Some databases return decimal.Decimal here.
             count = int(count)
 
@@ -188,9 +188,9 @@ class Pool(Base):
             if not stats_dict:
                 continue
             # TypedDict key must be a string literal, so we use if-statements to set value
-            if state == "running":
+            if state == TaskInstanceState.RUNNING:
                 stats_dict["running"] = count
-            elif state == "queued":
+            elif state == TaskInstanceState.QUEUED:
                 stats_dict["queued"] = count
             else:
                 raise AirflowException(f"Unexpected state. Expected values: {EXECUTION_STATES}.")

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1348,7 +1348,7 @@ class TaskInstance(Base, LoggingMixin):
         self._try_number += 1
 
         if not test_mode:
-            session.add(Log(State.RUNNING, self))
+            session.add(Log(TaskInstanceState.RUNNING.value, self))
 
         self.state = TaskInstanceState.RUNNING
         self.emit_state_change_metric(TaskInstanceState.RUNNING)
@@ -1937,7 +1937,7 @@ class TaskInstance(Base, LoggingMixin):
         Stats.incr("ti_failures", tags=self.stats_tags)
 
         if not test_mode:
-            session.add(Log(State.FAILED, self))
+            session.add(Log(TaskInstanceState.FAILED.value, self))
 
             # Log failure duration
             session.add(TaskFail(ti=self))

--- a/airflow/ti_deps/dependencies_states.py
+++ b/airflow/ti_deps/dependencies_states.py
@@ -16,38 +16,38 @@
 # under the License.
 from __future__ import annotations
 
-from airflow.utils.state import State
+from airflow.utils.state import TaskInstanceState
 
 EXECUTION_STATES = {
-    State.RUNNING,
-    State.QUEUED,
+    TaskInstanceState.RUNNING,
+    TaskInstanceState.QUEUED,
 }
 
 # In order to be able to get queued a task must have one of these states
 SCHEDULEABLE_STATES = {
-    State.NONE,
-    State.UP_FOR_RETRY,
-    State.UP_FOR_RESCHEDULE,
+    None,
+    TaskInstanceState.UP_FOR_RETRY,
+    TaskInstanceState.UP_FOR_RESCHEDULE,
 }
 
 RUNNABLE_STATES = {
     # For cases like unit tests and run manually
-    State.NONE,
-    State.UP_FOR_RETRY,
-    State.UP_FOR_RESCHEDULE,
+    None,
+    TaskInstanceState.UP_FOR_RETRY,
+    TaskInstanceState.UP_FOR_RESCHEDULE,
     # For normal scheduler/backfill cases
-    State.QUEUED,
+    TaskInstanceState.QUEUED,
 }
 
 QUEUEABLE_STATES = {
-    State.SCHEDULED,
+    TaskInstanceState.SCHEDULED,
 }
 
 BACKFILL_QUEUEABLE_STATES = {
     # For cases like unit tests and run manually
-    State.NONE,
-    State.UP_FOR_RESCHEDULE,
-    State.UP_FOR_RETRY,
+    None,
+    TaskInstanceState.UP_FOR_RESCHEDULE,
+    TaskInstanceState.UP_FOR_RETRY,
     # For normal backfill cases
-    State.SCHEDULED,
+    TaskInstanceState.SCHEDULED,
 }

--- a/airflow/triggers/external_task.py
+++ b/airflow/triggers/external_task.py
@@ -27,6 +27,7 @@ from sqlalchemy.orm import Session
 from airflow.models import DagRun, TaskInstance
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.utils.session import NEW_SESSION, provide_session
+from airflow.utils.state import DagRunState
 
 
 class TaskStateTrigger(BaseTrigger):
@@ -110,7 +111,7 @@ class DagStateTrigger(BaseTrigger):
     def __init__(
         self,
         dag_id: str,
-        states: list[str],
+        states: list[DagRunState],
         execution_dates: list[datetime.datetime],
         poll_interval: float = 5.0,
     ):


### PR DESCRIPTION
More State constant conversions. Also switch `State.finished` to `State.finished_dr_states` when used to compare against DagRunState. `State.finished` is a set of TaskInstanceState so the comparison was not technically correct. Calls to save a state to Log are converted to use a string value instead of enum since Log data are free-form.