### PR TITLE
Fix short circuit operator re teardowns

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -69,13 +69,14 @@ from airflow.models.abstractoperator import (
     DEFAULT_WAIT_FOR_PAST_DEPENDS_BEFORE_SKIPPING,
     DEFAULT_WEIGHT_RULE,
     AbstractOperator,
+    Operator,
     TaskStateChangeCallback,
 )
 from airflow.models.mappedoperator import OperatorPartial, validate_mapping_kwargs
 from airflow.models.param import ParamsDict
 from airflow.models.pool import Pool
 from airflow.models.taskinstance import TaskInstance, clear_task_instances
-from airflow.models.taskmixin import DAGNode, DependencyMixin
+from airflow.models.taskmixin import DependencyMixin
 from airflow.serialization.enums import DagAttributeTypes
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
@@ -1373,7 +1374,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
                 self.log.info("Rendering template for %s", field)
                 self.log.info(content)
 
-    def get_direct_relatives(self, upstream: bool = False) -> Iterable[DAGNode]:
+    def get_direct_relatives(self, upstream: bool = False) -> Iterable[Operator]:
         """
         Get list of the direct relatives to the current task, upstream or
         downstream.

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -69,7 +69,6 @@ from airflow.models.abstractoperator import (
     DEFAULT_WAIT_FOR_PAST_DEPENDS_BEFORE_SKIPPING,
     DEFAULT_WEIGHT_RULE,
     AbstractOperator,
-    Operator,
     TaskStateChangeCallback,
 )
 from airflow.models.mappedoperator import OperatorPartial, validate_mapping_kwargs
@@ -101,6 +100,7 @@ if TYPE_CHECKING:
     import jinja2  # Slow import.
 
     from airflow.models.dag import DAG
+    from airflow.models.operator import Operator
     from airflow.models.taskinstancekey import TaskInstanceKey
     from airflow.models.xcom_arg import XComArg
     from airflow.utils.task_group import TaskGroup

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -31,7 +31,7 @@ from collections.abc import Container
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Callable, Collection, Iterable, Mapping, Sequence
+from typing import Any, Callable, Collection, Iterable, Mapping, Sequence, cast
 
 import dill
 from pendulum import DateTime
@@ -258,9 +258,6 @@ class ShortCircuitOperator(PythonOperator, SkipMixin):
             return
 
         dag_run = context["dag_run"]
-        execution_date = dag_run.execution_date
-        if TYPE_CHECKING:
-            assert isinstance(execution_date, DateTime)
 
         def get_tasks_to_skip():
             if self.ignore_downstream_trigger_rules is True:
@@ -280,7 +277,7 @@ class ShortCircuitOperator(PythonOperator, SkipMixin):
         self.log.info("Skipping downstream tasks")
         self.skip(
             dag_run=dag_run,
-            execution_date=execution_date,
+            execution_date=cast(DateTime, dag_run.execution_date),
             tasks=to_skip,
             map_index=context["ti"].map_index,
         )

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -272,10 +272,10 @@ class ShortCircuitOperator(PythonOperator, SkipMixin):
                     yield t
 
         to_skip = get_tasks_to_skip()
+
+        # this let's us avoid an intermediate list unless debug logging
         if self.log.getEffectiveLevel() <= logging.DEBUG:
-            # this let's us avoid an intermediate list unless debug logging
-            to_skip = list(get_tasks_to_skip())
-            self.log.debug("Downstream task IDs %s", to_skip)
+            self.log.debug("Downstream task IDs %s", to_skip := list(get_tasks_to_skip()))
 
         self.log.info("Skipping downstream tasks")
         self.skip(

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -31,10 +31,9 @@ from collections.abc import Container
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from textwrap import dedent
-from typing import Any, Callable, Collection, Iterable, Mapping, Sequence, cast
+from typing import TYPE_CHECKING, Any, Callable, Collection, Iterable, Mapping, Sequence
 
 import dill
-from pendulum import DateTime
 
 from airflow.exceptions import (
     AirflowConfigException,
@@ -50,6 +49,9 @@ from airflow.utils.context import Context, context_copy_partial, context_merge
 from airflow.utils.operator_helpers import KeywordParameters
 from airflow.utils.process_utils import execute_in_subprocess
 from airflow.utils.python_virtualenv import prepare_virtualenv, write_python_script
+
+if TYPE_CHECKING:
+    from pendulum.datetime import DateTime
 
 
 def task(python_callable: Callable | None = None, multiple_outputs: bool | None = None, **kwargs):
@@ -275,9 +277,13 @@ class ShortCircuitOperator(PythonOperator, SkipMixin):
             self.log.debug("Downstream task IDs %s", to_skip := list(get_tasks_to_skip()))
 
         self.log.info("Skipping downstream tasks")
+
+        if TYPE_CHECKING:
+            assert isinstance(dag_run.execution_date, DateTime)
+
         self.skip(
             dag_run=dag_run,
-            execution_date=cast(DateTime, dag_run.execution_date),
+            execution_date=dag_run.execution_date,
             tasks=to_skip,
             map_index=context["ti"].map_index,
         )

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -31,7 +31,7 @@ from collections.abc import Container
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Callable, Collection, Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Collection, Iterable, Mapping, Sequence, cast
 
 import dill
 
@@ -278,12 +278,9 @@ class ShortCircuitOperator(PythonOperator, SkipMixin):
 
         self.log.info("Skipping downstream tasks")
 
-        if TYPE_CHECKING:
-            assert isinstance(dag_run.execution_date, DateTime)
-
         self.skip(
             dag_run=dag_run,
-            execution_date=dag_run.execution_date,
+            execution_date=cast("DateTime", dag_run.execution_date),
             tasks=to_skip,
             map_index=context["ti"].map_index,
         )

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -1184,7 +1184,29 @@ def test_short_circuit_with_teardowns(
         expected_tasks = {dag.task_dict[x] for x in expected}
     if should_skip:
         # we can't use assert_called_with because it's a set and therefore not ordered
-        actual_skipped = set(op1.skip.call_args.args[2])
+        actual_skipped = set(op1.skip.call_args.kwargs["tasks"])
         assert actual_skipped == expected_tasks
     else:
         op1.skip.assert_not_called()
+
+
+def test_short_circuit_with_teardowns_complicated(dag_maker):
+    with dag_maker():
+        s1 = PythonOperator(task_id="s1", python_callable=print).as_setup()
+        s2 = PythonOperator(task_id="s2", python_callable=print).as_setup()
+        op1 = ShortCircuitOperator(
+            task_id="op1",
+            python_callable=lambda: False,
+        )
+        op2 = PythonOperator(task_id="op2", python_callable=print)
+        t1 = PythonOperator(task_id="t1", python_callable=print).as_teardown(setups=s1)
+        t2 = PythonOperator(task_id="t2", python_callable=print).as_teardown(setups=s2)
+        s1 >> op1 >> s2 >> op2 >> [t1, t2]
+        op1.skip = MagicMock()
+        dagrun = dag_maker.create_dagrun()
+        tis = dagrun.get_task_instances()
+        ti: TaskInstance = [x for x in tis if x.task_id == "op1"][0]
+        ti._run_raw_task()
+        # we can't use assert_called_with because it's a set and therefore not ordered
+        actual_skipped = set(op1.skip.call_args.kwargs["tasks"])
+        assert actual_skipped == {s2, op2, t2}

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -27,6 +27,7 @@ from collections import namedtuple
 from datetime import date, datetime, timedelta
 from subprocess import CalledProcessError
 from unittest import mock
+from unittest.mock import MagicMock
 
 import pytest
 from slugify import slugify
@@ -35,7 +36,7 @@ from airflow.decorators import task_group
 from airflow.exceptions import AirflowException, DeserializingResultError, RemovedInAirflow3Warning
 from airflow.models import DAG, DagRun, TaskInstance as TI
 from airflow.models.baseoperator import BaseOperator
-from airflow.models.taskinstance import clear_task_instances, set_current_context
+from airflow.models.taskinstance import TaskInstance, clear_task_instances, set_current_context
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import (
     BranchPythonOperator,
@@ -1145,3 +1146,45 @@ class TestCurrentContextRuntime:
         with DAG(dag_id="edge_case_context_dag", default_args=DEFAULT_ARGS, schedule="@once"):
             op = PythonOperator(python_callable=get_all_the_context, task_id="get_all_the_context")
             op.run(ignore_first_depends_on_past=True, ignore_ti_state=True)
+
+
+@pytest.mark.parametrize(
+    "ignore_downstream_trigger_rules, with_teardown, should_skip, expected",
+    [
+        (False, True, True, ["op2"]),
+        (False, True, False, []),
+        (False, False, True, ["op2"]),
+        (False, False, False, []),
+        (True, True, True, ["op2", "op3"]),
+        (True, True, False, []),
+        (True, False, True, ["op2", "op3", "op4"]),
+        (True, False, False, []),
+    ],
+)
+def test_short_circuit_with_teardowns(
+    dag_maker, ignore_downstream_trigger_rules, should_skip, with_teardown, expected
+):
+    with dag_maker() as dag:
+        op1 = ShortCircuitOperator(
+            task_id="op1",
+            python_callable=lambda: not should_skip,
+            ignore_downstream_trigger_rules=ignore_downstream_trigger_rules,
+        )
+        op2 = PythonOperator(task_id="op2", python_callable=print)
+        op3 = PythonOperator(task_id="op3", python_callable=print)
+        op4 = PythonOperator(task_id="op4", python_callable=print)
+        if with_teardown:
+            op4.as_teardown()
+        op1 >> op2 >> op3 >> op4
+        op1.skip = MagicMock()
+        dagrun = dag_maker.create_dagrun()
+        tis = dagrun.get_task_instances()
+        ti: TaskInstance = [x for x in tis if x.task_id == "op1"][0]
+        ti._run_raw_task()
+        expected_tasks = {dag.task_dict[x] for x in expected}
+    if should_skip:
+        # we can't use assert_called_with because it's a set and therefore not ordered
+        actual_skipped = set(op1.skip.call_args.args[2])
+        assert actual_skipped == expected_tasks
+    else:
+        op1.skip.assert_not_called()

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -1241,5 +1241,7 @@ class TestShortCircuitWithTeardown:
             ti: TaskInstance = [x for x in tis if x.task_id == "op1"][0]
             ti._run_raw_task()
             # we can't use assert_called_with because it's a set and therefore not ordered
-            actual_skipped = set(op1.skip.call_args.kwargs["tasks"])
+            actual_kwargs = op1.skip.call_args.kwargs
+            actual_skipped = set(actual_kwargs["tasks"])
+            assert actual_kwargs["execution_date"] == dagrun.logical_date
             assert actual_skipped == {op3}


### PR DESCRIPTION
Short circuit operator should by default not skip teardowns for which the object task is in scope.

So for example if you have `s1 >> w1 >> w2 >> t1` and t1 is teardown for s1, then if w1 is short circuit, w2 should be skipped but not t1.

A more interesting scenario is 
```
s1 >> op1 >> s2 >> op2 >> [t1, t2]
```

or 
```
s1 >> op1 >> s2 >> op2 >> t2 >> t1
```

In both of these cases, if op1 is short circuit (and s1 >> t1, s2 >> t2), then tasks `s2, op2, t2` should all be skipped but t1 should not! BUT... importantly, we don't need to do the skipping for t2 in short circuit operator.  This will be handled automatically by the scheduler when applying the trigger rules (if the setup was skipped, the teardown will be skipped).  Handling it here would be more complexity and duplication of logic than we need.  Particularly in weirder examples like `s1 >> w1 >> t1, w2 >> t1` where w2 is short circuit.

@vatsrahul1001
