### PR TITLE
Fix `S3ToRedshiftOperator` does not support default values on UPSERT

### DIFF
--- a/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -178,7 +178,7 @@ class S3ToRedshiftOperator(BaseOperator):
             where_statement = " AND ".join([f"{self.table}.{k} = {copy_destination}.{k}" for k in keys])
 
             sql = [
-                f"CREATE TABLE {copy_destination} (LIKE {destination});",
+                f"CREATE TABLE {copy_destination} (LIKE {destination} INCLUDING DEFAULTS);",
                 copy_statement,
                 "BEGIN;",
                 f"DELETE FROM {destination} USING {copy_destination} WHERE {where_statement};",

--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -222,7 +222,7 @@ class TestS3ToRedshiftTransfer:
                         ;
                      """
         transaction = f"""
-                    CREATE TABLE #{table} (LIKE {schema}.{table});
+                    CREATE TABLE #{table} (LIKE {schema}.{table} INCLUDING DEFAULTS);
                     {copy_statement}
                     BEGIN;
                     DELETE FROM {schema}.{table} USING #{table} WHERE {table}.id = #{table}.id;


### PR DESCRIPTION
This commit corrects a bug where upserts fail into tables with default, non-null columns

closes: #30341 
