### PR TITLE
Fix breaking change when Active Directory ID is used as host in WASB

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -210,6 +210,9 @@ class WasbHook(BaseHook):
             if sas_token.startswith("https"):
                 return BlobServiceClient(account_url=sas_token, **extra)
             else:
+                if not account_url.startswith("https://"):
+                    # TODO: require url in the host field in the next major version?
+                    account_url = f"https://{conn.login}.blob.core.windows.net"
                 return BlobServiceClient(account_url=f"{account_url}/{sas_token}", **extra)
 
         # Fall back to old auth (password) or use managed identity if not provided.
@@ -217,6 +220,9 @@ class WasbHook(BaseHook):
         if not credential:
             credential = DefaultAzureCredential()
             self.log.info("Using DefaultAzureCredential as credential")
+        if not account_url.startswith("https://"):
+            # TODO: require url in the host field in the next major version?
+            account_url = f"https://{conn.login}.blob.core.windows.net/"
         return BlobServiceClient(
             account_url=account_url,
             credential=credential,

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -213,7 +213,7 @@ class WasbHook(BaseHook):
                 if not account_url.startswith("https://"):
                     # TODO: require url in the host field in the next major version?
                     account_url = f"https://{conn.login}.blob.core.windows.net"
-                return BlobServiceClient(account_url=f"{account_url}/{sas_token}", **extra)
+                return BlobServiceClient(account_url=f"{account_url.rstrip('/')}/{sas_token}", **extra)
 
         # Fall back to old auth (password) or use managed identity if not provided.
         credential = conn.password

--- a/tests/providers/microsoft/azure/hooks/test_wasb.py
+++ b/tests/providers/microsoft/azure/hooks/test_wasb.py
@@ -56,7 +56,6 @@ class TestWasbHook:
         self.public_read_conn_id_without_host = "pub_read_id_without_host"
         self.managed_identity_conn_id = "managed_identity"
         self.authority = "https://test_authority.com"
-        self.test_account_name_as_hostname = "testaccountname"
 
         self.proxies = {"http": "http_proxy_uri", "https": "https_proxy_uri"}
         self.client_secret_auth_config = {

--- a/tests/providers/microsoft/azure/hooks/test_wasb.py
+++ b/tests/providers/microsoft/azure/hooks/test_wasb.py
@@ -56,6 +56,7 @@ class TestWasbHook:
         self.public_read_conn_id_without_host = "pub_read_id_without_host"
         self.managed_identity_conn_id = "managed_identity"
         self.authority = "https://test_authority.com"
+        self.test_account_name_as_hostname = "testaccountname"
 
         self.proxies = {"http": "http_proxy_uri", "https": "https_proxy_uri"}
         self.client_secret_auth_config = {
@@ -199,6 +200,42 @@ class TestWasbHook:
         hook = WasbHook(wasb_conn_id=self.ad_conn_id)
         assert isinstance(hook.get_conn(), BlobServiceClient)
         assert isinstance(hook.get_conn().credential, ClientSecretCredential)
+
+    @mock.patch("airflow.providers.microsoft.azure.hooks.wasb.BlobServiceClient")
+    @mock.patch("airflow.providers.microsoft.azure.hooks.wasb.DefaultAzureCredential")
+    @mock.patch("airflow.providers.microsoft.azure.hooks.wasb.WasbHook.get_connection")
+    def test_active_directory_ID_used_as_host(self, mock_get_conn, mock_credential, mock_blob_service_client):
+        hook = WasbHook(wasb_conn_id="testconn")
+        mock_get_conn.return_value = Connection(
+            conn_id="testconn",
+            conn_type=self.connection_type,
+            login="testaccountname",
+            host="testaccountID",
+        )
+        hook.get_conn()
+        assert mock_blob_service_client.call_args == mock.call(
+            account_url="https://testaccountname.blob.core.windows.net/",
+            credential=mock_credential.return_value,
+        )
+
+    @mock.patch("airflow.providers.microsoft.azure.hooks.wasb.BlobServiceClient")
+    @mock.patch("airflow.providers.microsoft.azure.hooks.wasb.WasbHook.get_connection")
+    def test_sas_token_provided_and_active_directory_ID_used_as_host(
+        self, mock_get_conn, mock_blob_service_client
+    ):
+        hook = WasbHook(wasb_conn_id="testconn")
+        mock_get_conn.return_value = Connection(
+            conn_id="testconn",
+            conn_type=self.connection_type,
+            login="testaccountname",
+            host="testaccountID",
+            extra=json.dumps({"sas_token": "SAStoken"}),
+        )
+        hook.get_conn()
+        assert mock_blob_service_client.call_args == mock.call(
+            account_url="https://testaccountname.blob.core.windows.net/SAStoken",
+            sas_token="SAStoken",
+        )
 
     @pytest.mark.parametrize(
         argnames="conn_id_str",


### PR DESCRIPTION
A recent change: https://github.com/apache/airflow/commit/46ee1c2c8d3d0e5793f42fd10bcd80150caa538b,
to build account url if not provided broke backward compatibility in Wasb hook by assuming that
host is always provided as a fully qualified url. Previously, we generate the account url
as the last resort to getting the connection.

This change restores the previous behaviour of generating a URL if the host was provided with an ID
instead of a URL



