### PR TITLE
Fix rendering of dagRunTimeout

### DIFF
--- a/airflow/www/static/js/components/ViewTimeDelta.tsx
+++ b/airflow/www/static/js/components/ViewTimeDelta.tsx
@@ -24,7 +24,7 @@ interface Props {
   data: Record<string, number | null>;
 }
 
-const ViewScheduleInterval = ({ data }: Props) => {
+const ViewTimeDelta = ({ data }: Props) => {
   const genericTimeDeltaUnits = [
     "days",
     "day",
@@ -58,4 +58,4 @@ const ViewScheduleInterval = ({ data }: Props) => {
   );
 };
 
-export default ViewScheduleInterval;
+export default ViewTimeDelta;

--- a/airflow/www/static/js/dag/details/Dag.tsx
+++ b/airflow/www/static/js/dag/details/Dag.tsx
@@ -45,7 +45,7 @@ import {
 } from "src/utils";
 import { useGridData, useDagDetails } from "src/api";
 import Time from "src/components/Time";
-import ViewScheduleInterval from "src/components/ViewScheduleInterval";
+import ViewTimeDelta from "src/components/ViewTimeDelta";
 import type { TaskState } from "src/types";
 
 import type { DAG, DAGDetail } from "src/types/api-generated";
@@ -283,7 +283,7 @@ const Dag = () => {
                     <Text>{dagDetailsData.scheduleInterval?.value}</Text>
                   ) : (
                     // for TimeDelta and RelativeDelta
-                    <ViewScheduleInterval
+                    <ViewTimeDelta
                       data={omit(dagDetailsData.scheduleInterval, [
                         "type",
                         "value",
@@ -299,7 +299,7 @@ const Dag = () => {
                     <Text>null</Text>
                   ) : (
                     // for TimeDelta and RelativeDelta
-                    <ViewScheduleInterval
+                    <ViewTimeDelta
                       data={omit(dagDetailsData.dagRunTimeout, ["type"])}
                     />
                   )}

--- a/airflow/www/static/js/dag/details/Dag.tsx
+++ b/airflow/www/static/js/dag/details/Dag.tsx
@@ -74,6 +74,7 @@ const Dag = () => {
     "tags",
     "owners",
     "params",
+    "dagRunTimeout",
   ];
 
   const listParams = new URLSearchParamsWrapper({
@@ -287,6 +288,19 @@ const Dag = () => {
                         "type",
                         "value",
                       ])}
+                    />
+                  )}
+                </Td>
+              </Tr>
+              <Tr>
+                <Td>Dag run timeout</Td>
+                <Td>
+                  {dagDetailsData.dagRunTimeout?.type === undefined ? (
+                    <Text>null</Text>
+                  ) : (
+                    // for TimeDelta and RelativeDelta
+                    <ViewScheduleInterval
+                      data={omit(dagDetailsData.dagRunTimeout, ["type"])}
                     />
                   )}
                 </Td>


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

This resolves the below issue:
closes: #32442 
The dag details page originally rendered the timedelta value as string. Causing the value of dagRunTImeout to be rendered as [object Object]. This change will handle the rendering of dagRunTimeout separately like scheduleInterval

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
