### PR TITLE
Fix returned value when ShortCircuitOperator condition is falsy

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -273,6 +273,8 @@ class ShortCircuitOperator(PythonOperator, SkipMixin):
                 )
 
         self.log.info("Done.")
+        # returns the result of the super execute method as it is instead of returning None
+        return condition
 
 
 class _BasePythonVirtualenvOperator(PythonOperator, metaclass=ABCMeta):

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -254,6 +254,19 @@ class TestAirflowTaskDecorator(BasePythonTest):
         with pytest.raises(AirflowException):
             ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
+    def test_multiple_outputs_empty_dict(self):
+        @task_decorator(multiple_outputs=True)
+        def empty_dict():
+            return {}
+
+        with self.dag:
+            ret = empty_dict()
+
+        dr = self.create_dag_run()
+        ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+        ti = dr.get_task_instances()[0]
+        assert ti.xcom_pull() == {}
+
     def test_python_callable_arguments_are_templatized(self):
         """Test @task op_args are templatized"""
 

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -617,7 +617,7 @@ class TestShortCircuitOperator(BasePythonTest):
 
         tis = dr.get_task_instances()
         assert tis[0].xcom_pull(task_ids=short_op_push_xcom.task_id, key="return_value") == "signature"
-        assert tis[0].xcom_pull(task_ids=short_op_no_push_xcom.task_id, key="return_value") is None
+        assert tis[0].xcom_pull(task_ids=short_op_no_push_xcom.task_id, key="return_value") is False
 
     def test_xcom_push_skipped_tasks(self):
         with self.dag:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #32553

Currently when we the python callable in the short circuit operator returns an non empty list or dict (truthy object), we return it without skipping the downstream tasks. And when it returns a falsy object like an empty dict, we evaluate it as a False and we skip the downstream tasks, but we return nothing, which is similar to return `None`.

This returned `None` raise an exception when we use the decorator with `multiple_outputs=True`, the only way to skip the downstream tasks is returning an empty dict, but the returned `None` brakes the post-processing method which push the returned Xcom. This PR returns the callable result as it is to fix this problem and to avoid any future problem.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
