### PR TITLE
Allow templates in cleanup.schedule

### DIFF
--- a/chart/templates/cleanup/cleanup-cronjob.yaml
+++ b/chart/templates/cleanup/cleanup-cronjob.yaml
@@ -43,7 +43,7 @@ metadata:
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  schedule: "{{ .Values.cleanup.schedule }}"
+  schedule: "{{ tpl .Values.cleanup.schedule . }}"
   # The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn't finished yet, the cron job skips the new job run
   concurrencyPolicy: Forbid
   {{- if .Values.cleanup.failedJobsHistoryLimit }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -5822,7 +5822,7 @@
                     "default": false
                 },
                 "schedule": {
-                    "description": "Cleanup schedule.",
+                    "description": "Cleanup schedule (templated).",
                     "type": "string",
                     "default": "*/15 * * * *"
                 },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1969,8 +1969,13 @@ limits: []
 # This runs as a CronJob to cleanup old pods.
 cleanup:
   enabled: false
-  # Run every 15 minutes
+  # Run every 15 minutes (templated).
   schedule: "*/15 * * * *"
+  # To select a random-ish, deterministic starting minute between 3 and 12 inclusive for each release:
+  #     '{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *'
+  # To select the last digit of unix epoch time as the starting minute on each deploy:
+  #     '{{- now | unixEpoch | trunc -1 -}}-59/* * * * *'
+
   # Command to use when running the cleanup cronjob (templated).
   command: ~
   # Args to use when running the cleanup cronjob (templated).

--- a/helm_tests/airflow_aux/test_cleanup_pods.py
+++ b/helm_tests/airflow_aux/test_cleanup_pods.py
@@ -22,6 +22,54 @@ import pytest
 from tests.charts.helm_template_generator import render_chart
 
 
+class TestCleanupDeployment:
+    """Tests cleanup pods deployments."""
+
+    def test_should_have_a_schedule_with_defaults(self):
+        doc = render_chart(
+            values={
+                "cleanup": {"enabled": True},
+            },
+            show_only=["templates/cleanup/cleanup-cronjob.yaml"],
+        )[0]
+
+        assert doc["spec"]["schedule"] == "*/15 * * * *"
+
+    cron_tests = [
+        ("release-name", "*/5 * * * *", "*/5 * * * *"),
+        ("something-else", "@hourly", "@hourly"),
+        (
+            "custom-name",
+            '{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *',
+            "7-59/15 * * * *",
+        ),
+        (
+            "airflow-rules",
+            '{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *',
+            "10-59/15 * * * *",
+        ),
+    ]
+
+    @pytest.mark.parametrize(
+        "release_name,schedule_value,schedule_result",
+        cron_tests,
+        ids=[x[0] for x in cron_tests],
+    )
+    def test_should_work_with_custom_schedule_string(self, release_name, schedule_value, schedule_result):
+        doc = render_chart(
+            name=release_name,
+            values={
+                "cleanup": {
+                    "enabled": True,
+                    "schedule": schedule_value,
+                },
+            },
+            show_only=["templates/cleanup/cleanup-cronjob.yaml"],
+        )[0]
+
+        assert doc["spec"]["schedule"] == schedule_result
+
+
 class TestCleanupPods:
     """Tests cleanup of pods."""
 


### PR DESCRIPTION
This change is quite simple in that it allows helm templates to be used in the value of `cleanup.schedule`. This also works with strings, which makes the change backwards compatible, so it will have no impact on existing installations. Shout out to @jedcunningham and @dstandish for helping me settle on this very simple syntax change.

There were no tests for `cleanup.schedule`, so I added tests, including tests for using strings and for using helm template logic.

FWIW, the test logic shows an example of using adler32sum to select a deterministic random-ish number, seeded by `.Release.Name`, to use as the starting minute for the cleanup cronjob. This mechanism will avoid starting all cleanup jobs across all deployments on minute 0, and was the impetus for changing from string to a template.