### PR TITLE
Fix permissions on `/blocked` endpoint

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2384,7 +2384,7 @@ class Airflow(AirflowBaseView):
     @expose("/blocked", methods=["POST"])
     @auth.has_access(
         [
-            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
         ]
     )

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -98,6 +98,7 @@ def acl_app(app):
         "all_dag_role": [
             (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_WEBSITE),
         ],
@@ -641,14 +642,19 @@ def test_failure(dag_faker_client, url, unexpected_content):
 
 
 def test_blocked_success(client_all_dags_dagruns):
-    resp = client_all_dags_dagruns.post("blocked", follow_redirects=True)
+    resp = client_all_dags_dagruns.post("blocked")
     check_content_in_response("example_bash_operator", resp)
 
 
 def test_blocked_success_for_all_dag_user(all_dag_user_client):
-    resp = all_dag_user_client.post("blocked", follow_redirects=True)
+    resp = all_dag_user_client.post("blocked")
     check_content_in_response("example_bash_operator", resp)
     check_content_in_response("example_subdag_operator", resp)
+
+
+def test_blocked_viewer(viewer_client):
+    resp = viewer_client.post("blocked")
+    check_content_in_response("example_bash_operator", resp)
 
 
 @pytest.mark.parametrize(
@@ -670,11 +676,7 @@ def test_blocked_success_when_selecting_dags(
     dags_to_block,
     unexpected_dag_ids,
 ):
-    resp = admin_client.post(
-        "blocked",
-        data={"dag_ids": dags_to_block},
-        follow_redirects=True,
-    )
+    resp = admin_client.post("blocked", data={"dag_ids": dags_to_block})
     assert resp.status_code == 200
     for dag_id in unexpected_dag_ids:
         check_content_not_in_response(dag_id, resp)


### PR DESCRIPTION
This endpoint is used to update the UI with how many dagruns are running out of the max active dagruns per dag. It requires no elevated perms.

This also fixes the test coverage on this endpoint.

This PR doesn't fix the UI side of this feature, but does fix the endpoint behavior.