### PR TITLE
Add setup/teardown info to grid/graph view

### DIFF
--- a/airflow/utils/dag_edges.py
+++ b/airflow/utils/dag_edges.py
@@ -63,35 +63,35 @@ def dag_edges(dag: DAG):
             # For every TaskGroup immediately downstream, add edges between downstream_join_id
             # and upstream_join_id. Skip edges between individual tasks of the TaskGroups.
             target_group = task_group_map[target_id]
-            edges_to_add.add((task_group.downstream_join_id, target_group.upstream_join_id))
+            edges_to_add.add((task_group.downstream_join_id, target_group.upstream_join_id, False))
 
             for child in task_group.get_leaves():
-                edges_to_add.add((child.task_id, task_group.downstream_join_id))
+                edges_to_add.add((child.task_id, task_group.downstream_join_id, False))
                 for target in target_group.get_roots():
                     edges_to_skip.add((child.task_id, target.task_id))
                 edges_to_skip.add((child.task_id, target_group.upstream_join_id))
 
             for child in target_group.get_roots():
-                edges_to_add.add((target_group.upstream_join_id, child.task_id))
+                edges_to_add.add((target_group.upstream_join_id, child.task_id, False))
                 edges_to_skip.add((task_group.downstream_join_id, child.task_id))
 
         # For every individual task immediately downstream, add edges between downstream_join_id and
         # the downstream task. Skip edges between individual tasks of the TaskGroup and the
         # downstream task.
         for target_id in task_group.downstream_task_ids:
-            edges_to_add.add((task_group.downstream_join_id, target_id))
+            edges_to_add.add((task_group.downstream_join_id, target_id, False))
 
             for child in task_group.get_leaves():
-                edges_to_add.add((child.task_id, task_group.downstream_join_id))
+                edges_to_add.add((child.task_id, task_group.downstream_join_id, False))
                 edges_to_skip.add((child.task_id, target_id))
 
         # For every individual task immediately upstream, add edges between the upstream task
         # and upstream_join_id. Skip edges between the upstream task and individual tasks
         # of the TaskGroup.
         for source_id in task_group.upstream_task_ids:
-            edges_to_add.add((source_id, task_group.upstream_join_id))
+            edges_to_add.add((source_id, task_group.upstream_join_id, False))
             for child in task_group.get_roots():
-                edges_to_add.add((task_group.upstream_join_id, child.task_id))
+                edges_to_add.add((task_group.upstream_join_id, child.task_id, False))
                 edges_to_skip.add((source_id, child.task_id))
 
         for child in task_group.children.values():
@@ -107,7 +107,7 @@ def dag_edges(dag: DAG):
         tasks_to_trace_next: list[Operator] = []
         for task in tasks_to_trace:
             for child in task.downstream_list:
-                edge = (task.task_id, child.task_id)
+                edge = (task.task_id, child.task_id, task.is_setup and child.is_teardown)
                 if edge in edges:
                     continue
                 edges.add(edge)
@@ -117,9 +117,11 @@ def dag_edges(dag: DAG):
     result = []
     # Build result dicts with the two ends of the edge, plus any extra metadata
     # if we have it.
-    for source_id, target_id in sorted(edges.union(edges_to_add) - edges_to_skip):
+    for source_id, target_id, is_setup_teardown in sorted(edges.union(edges_to_add) - edges_to_skip):
         record = {"source_id": source_id, "target_id": target_id}
         label = dag.get_edge_info(source_id, target_id).get("label")
+        if is_setup_teardown is True:
+            record["is_setup_teardown"] = True
         if label:
             record["label"] = label
         result.append(record)

--- a/airflow/www/static/js/components/Graph/Edge.tsx
+++ b/airflow/www/static/js/components/Graph/Edge.tsx
@@ -35,6 +35,7 @@ interface EdgeProps {
       id: string;
       labels?: ElkLabel[];
       layoutOptions?: LayoutOptions;
+      isSetupTeardown?: boolean;
     };
   };
 }
@@ -63,6 +64,7 @@ const CustomEdge = ({ data }: EdgeProps) => {
           x={(d) => d.x || 0}
           y={(d) => d.y || 0}
           data={[s.startPoint, ...(s.bendPoints || []), s.endPoint]}
+          strokeDasharray={rest.isSetupTeardown ? "10,5" : undefined}
         />
       ))}
     </>

--- a/airflow/www/static/js/dag/InstanceTooltip.tsx
+++ b/airflow/www/static/js/dag/InstanceTooltip.tsx
@@ -81,7 +81,7 @@ const InstanceTooltip = ({
       {startDate && (
         <>
           <Text>
-            yar Started: <Time dateTime={startDate} />
+            Started: <Time dateTime={startDate} />
           </Text>
           <Text>
             Duration: {formatDuration(getDuration(startDate, endDate))}

--- a/airflow/www/static/js/dag/InstanceTooltip.tsx
+++ b/airflow/www/static/js/dag/InstanceTooltip.tsx
@@ -62,6 +62,9 @@ const InstanceTooltip = ({
   return (
     <Box py="2px">
       <Text>Task Id: {taskId}</Text>
+      {!!group.setupTeardownType && (
+        <Text>Type: {group.setupTeardownType}</Text>
+      )}
       {group.tooltip && <Text>{group.tooltip}</Text>}
       {isMapped && totalTasks > 0 && (
         <Text>
@@ -78,7 +81,7 @@ const InstanceTooltip = ({
       {startDate && (
         <>
           <Text>
-            Started: <Time dateTime={startDate} />
+            yar Started: <Time dateTime={startDate} />
           </Text>
           <Text>
             Duration: {formatDuration(getDuration(startDate, endDate))}

--- a/airflow/www/static/js/dag/details/graph/Node.tsx
+++ b/airflow/www/static/js/dag/details/graph/Node.tsx
@@ -18,7 +18,7 @@
  */
 
 import React from "react";
-import { Box, Text, Flex } from "@chakra-ui/react";
+import { Box, Text, Flex, useTheme } from "@chakra-ui/react";
 import { Handle, NodeProps, Position } from "reactflow";
 
 import { SimpleStatus } from "src/dag/StatusBox";
@@ -28,6 +28,10 @@ import { getGroupAndMapSummary, hoverDelay } from "src/utils";
 import Tooltip from "src/components/Tooltip";
 import InstanceTooltip from "src/dag/InstanceTooltip";
 import { useContainerRef } from "src/context/containerRef";
+import {
+  MdOutlineArrowCircleUp,
+  MdOutlineArrowCircleDown,
+} from "react-icons/md";
 
 export interface CustomNodeProps {
   label: string;
@@ -42,6 +46,7 @@ export interface CustomNodeProps {
   onToggleCollapse: () => void;
   isOpen?: boolean;
   isActive?: boolean;
+  setupTeardownType?: "setup" | "teardown";
 }
 
 export const BaseNode = ({
@@ -58,8 +63,10 @@ export const BaseNode = ({
     onToggleCollapse,
     isOpen,
     isActive,
+    setupTeardownType,
   },
 }: NodeProps<CustomNodeProps>) => {
+  const { colors } = useTheme();
   const { onSelect } = useSelection();
   const containerRef = useContainerRef();
 
@@ -114,10 +121,22 @@ export const BaseNode = ({
           p={2}
           flexWrap="wrap"
         >
-          <Flex flexDirection="column">
-            <Text noOfLines={1} maxWidth={`calc(${width}px - 8px)`}>
-              {taskName}
-            </Text>
+          <Flex flexDirection="column" width="100%">
+            <Flex
+              justifyContent="space-between"
+              alignItems="center"
+              width="100%"
+            >
+              <Text noOfLines={1} maxWidth={`calc(${width}px - 8px)`}>
+                {taskName}
+              </Text>
+              {setupTeardownType === "setup" && (
+                <MdOutlineArrowCircleUp size={18} color={colors.gray[800]} />
+              )}
+              {setupTeardownType === "teardown" && (
+                <MdOutlineArrowCircleDown size={18} color={colors.gray[800]} />
+              )}
+            </Flex>
             {!!instance && instance.state && (
               <Flex alignItems="center">
                 <SimpleStatus state={instance.state} />

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -133,6 +133,16 @@ const Details = ({ instance, group, dagId }: Props) => {
               </Flex>
             </Td>
           </Tr>
+          {!!group.setupTeardownType && (
+            <Tr>
+              <Td>Type</Td>
+              <Td>
+                <Text textTransform="capitalize">
+                  {group.setupTeardownType}
+                </Text>
+              </Td>
+            </Tr>
+          )}
           {mappedStates && totalTasks > 0 && (
             <Tr>
               <Td colSpan={2}>

--- a/airflow/www/static/js/types/index.ts
+++ b/airflow/www/static/js/types/index.ts
@@ -99,6 +99,7 @@ interface Task {
   operator?: string;
   hasOutletDatasets?: boolean;
   triggerRule?: API.TriggerRule;
+  setupTeardownType?: "setup" | "teardown";
 }
 
 type RunOrdering = (
@@ -137,6 +138,7 @@ export interface WebserverEdge {
   label?: string;
   sourceId: string;
   targetId: string;
+  isSetupTeardown?: boolean;
 }
 
 interface DatasetListItem extends API.Dataset {

--- a/airflow/www/static/js/utils/graph.ts
+++ b/airflow/www/static/js/utils/graph.ts
@@ -169,6 +169,7 @@ const generateGraph = ({
       id: `${e.sourceId}-${e.targetId}`,
       sources: [e.sourceId],
       targets: [e.targetId],
+      isSetupTeardown: e.isSetupTeardown,
       labels: e.label
         ? [
             {

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -383,6 +383,12 @@ def dag_to_grid(dag: DagModel, dag_runs: Sequence[DagRun], session: Session):
             else:
                 instances = list(map(_get_summary, grouped_tis.get(item.task_id, [])))
 
+            setup_teardown_type = {}
+            if item.is_setup is True:
+                setup_teardown_type["setupTeardownType"] = "setup"
+            elif item.is_teardown is True:
+                setup_teardown_type["setupTeardownType"] = "teardown"
+
             return {
                 "id": item.task_id,
                 "instances": instances,
@@ -392,6 +398,7 @@ def dag_to_grid(dag: DagModel, dag_runs: Sequence[DagRun], session: Session):
                 "has_outlet_datasets": any(isinstance(i, Dataset) for i in (item.outlets or [])),
                 "operator": item.operator_name,
                 "trigger_rule": item.trigger_rule,
+                **setup_teardown_type,
             }
 
         # Task Group


### PR DESCRIPTION
Continuation of https://github.com/apache/airflow/pull/32268.
Use the updated graph_data to show which nodes are setup or teardown tasks.
Update grid_data to include the same info to include it in the task details and tooltip.
Add `is_setup_teardown` to `dag_edges()` so that we can render a dashed line for edges directly in between setup/teardown tasks.

<img width="1170" alt="Screenshot 2023-07-13 at 3 37 39 PM" src="https://github.com/apache/airflow/assets/4600967/9c67676a-57a5-4f55-b1d7-327cc0140c1d">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
