### PR TITLE
Fix dags list counts

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -797,9 +797,7 @@ class Airflow(AirflowBaseView):
 
             is_paused_count = dict(
                 session.execute(
-                    select(DagModel.is_paused, func.count(DagModel.dag_id))
-                    .group_by(DagModel.is_paused)
-                    .select_from(all_dags)
+                    select(DagModel.is_paused, func.count(DagModel.dag_id)).group_by(DagModel.is_paused)
                 ).all()
             )
 


### PR DESCRIPTION
Fixing a bug added in #32350

Before:
<img width="359" alt="Screenshot 2023-07-13 at 3 50 33 PM" src="https://github.com/apache/airflow/assets/4600967/4cb1b103-c12f-4340-8d05-589725b93881">


After (the correct count):
<img width="315" alt="Screenshot 2023-07-13 at 3 50 54 PM" src="https://github.com/apache/airflow/assets/4600967/27261c7c-1149-44c0-b6b9-da80b58b880c">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
