### PR TITLE
Add option for storing configuration description in providers

### DIFF
--- a/airflow/provider.yaml.schema.json
+++ b/airflow/provider.yaml.schema.json
@@ -1,345 +1,437 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "properties": {
-    "package-name": {
-      "description": "Package name available under which the package is available in the PyPI repository.",
-      "type": "string"
-    },
-    "name": {
-      "description": "Provider name",
-      "type": "string"
-    },
-    "description": {
-      "description": "Information about the package in RST format",
-      "type": "string"
-    },
-    "versions": {
-      "description": "List of available versions in PyPI. Sorted descending according to release date.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "suspended": {
-      "description": "If set to true, the provider is suspended and it's not a candidate for release nor contributes dependencies to constraint calculations/CI image. Tests are excluded.",
-      "type:": "boolean"
-    },
-    "dependencies": {
-      "description": "Dependencies that should be added to the provider",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "excluded-python-versions": {
-      "description": "List of python versions excluded for that provider",
-      "type": "array",
-      "items": {
-          "type": "string"
-      }
-    },
-    "integrations": {
-      "description": "List of integrations supported by the provider.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "integration-name": {
-            "type": "string",
-            "description": "Name of the integration."
-          },
-          "external-doc-url": {
-            "type": "string",
-            "description": "URL to external documentation for the integration."
-          },
-          "how-to-guide": {
-            "description": "List of paths to how-to-guide for the integration. The path must start with '/docs/'",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "logo": {
-            "description": "Path to the logo for the integration. The path must start with '/integration-logos/'",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "package-name": {
+            "description": "Package name available under which the package is available in the PyPI repository.",
             "type": "string"
-          },
-          "tags": {
-            "description": "List of tags describing the integration. While we're using RST, only one tag is supported per integration.",
-            "type": "array",
-            "items": {
-              "type": "string",
-              "enum": [
-                "alibaba",
-                "apache",
-                "aws",
-                "azure",
-                "dbt",
-                "gcp",
-                "gmp",
-                "google",
-                "kafka",
-                "protocol",
-                "service",
-                "software",
-                "yandex"
-              ]
-            },
-            "minItems": 1,
-            "maxItems": 1
-          }
         },
-        "additionalProperties": false,
-        "required": [
-          "integration-name",
-          "external-doc-url",
-          "tags"
-        ]
-      }
-    },
-    "operators": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "integration-name": {
-            "type": "string",
-            "description": "Integration name. It must have a matching item in the 'integration' section of any provider."
-          },
-          "python-modules": {
-            "description": "List of python modules containing the operators.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "additionalProperties": false,
-        "required": [
-          "integration-name",
-          "python-modules"
-        ]
-      }
-    },
-    "sensors": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "integration-name": {
-            "type": "string",
-            "description": "Integration name. It must have a matching item in the 'integration' section of any provider."
-          },
-          "python-modules": {
-            "description": "List of python modules containing the sensors.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "integration-name",
-          "python-modules"
-        ],
-        "additionalProperties": true
-      }
-    },
-    "hooks": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "integration-name": {
-            "type": "string",
-            "description": "Integration name. It must have a matching item in the 'integration' section of any provider."
-          },
-          "python-modules": {
-            "description": "List of python modules containing the hooks.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "additionalProperties": false,
-        "required": [
-          "integration-name",
-          "python-modules"
-        ]
-      }
-    },
-    "transfers": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "how-to-guide": {
-            "description": "Path to how-to-guide for the transfer. The path must start with '/docs/'",
-            "type": "string"
-          },
-          "source-integration-name": {
-            "type": "string",
-            "description": "Integration name. It must have a matching item in the 'integration' section of any provider."
-          },
-          "target-integration-name": {
-            "type": "string",
-            "description": "Target integration name. It must have a matching item in the 'integration' section of any provider."
-          },
-          "python-module": {
-            "type": "string",
-            "description": "List of python modules containing the transfers."
-          }
-        },
-        "additionalProperties": false,
-        "required": [
-          "source-integration-name",
-          "target-integration-name",
-          "python-module"
-        ]
-      }
-    },
-    "triggers": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "integration-name": {
-            "type": "string",
-            "description": "Integration name. It must have a matching item in the 'integration' section of any provider."
-          },
-          "python-modules": {
-            "description": "List of Python modules containing the triggers.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "additionalProperties": false,
-        "required": [
-          "integration-name",
-          "python-modules"
-        ]
-      }
-    },
-    "connection-types": {
-      "type": "array",
-      "description": "Array of connection types mapped to hook class names",
-      "items": {
-          "type": "object",
-          "properties": {
-              "connection-type": {
-                  "description": "Type of connection defined by the provider",
-                  "type": "string"
-              },
-              "hook-class-name": {
-                  "description": "Hook class name that implements the connection type",
-                  "type": "string"
-              }
-          },
-          "required": [
-              "connection-type",
-              "hook-class-name"
-          ]
-      }
-    },
-    "extra-links": {
-      "type": "array",
-      "description": "Operator class names that provide extra link functionality",
-      "items": {
-        "type": "string"
-      }
-    },
-    "additional-extras": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "description": "Name of the extra",
-            "type": "string"
-          },
-          "dependencies": {
-            "description": "Dependencies that should be added for the extra",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [ "name", "dependencies"]
-      },
-
-      "description": "Additional extras that the provider should have. Replaces auto-generated cross-provider extras, if matching the same prefix, so that you can specify boundaries for existing dependencies."
-    },
-    "task-decorators": {
-        "type": "array",
-        "description": "Decorators to use with the TaskFlow API. Can be accessed by users via '@task.<name>'",
-        "items": {
-            "name": {
-                "type": "string"
-            },
-            "path": {
-                "type": "string"
-            }
-        }
-    },
-    "secrets-backends": {
-      "type": "array",
-      "description": "Secrets Backend class names",
-      "items": {
-          "type": "string"
-      }
-    },
-    "logging": {
-      "type": "array",
-      "description": "Logging Task Handlers class names",
-      "items": {
-          "type": "string"
-      }
-    },
-    "auth-backends": {
-      "type": "array",
-      "description": "API Auth Backend module names",
-      "items": {
-          "type": "string"
-      }
-    },
-    "notifications": {
-          "type": "array",
-          "description": "Notification class names",
-          "items": {
-              "type": "string"
-          }
-    },
-    "executors": {
-          "type": "array",
-          "description": "Executor class names",
-          "items": {
-              "type": "string"
-          }
-      },
-    "plugins": {
-      "type": "array",
-      "description": "Plugins exposed by the provider",
-      "items": {
         "name": {
-           "type": "string"
+            "description": "Provider name",
+            "type": "string"
         },
-        "plugin-class": {
-           "type": "string"
+        "description": {
+            "description": "Information about the package in RST format",
+            "type": "string"
+        },
+        "versions": {
+            "description": "List of available versions in PyPI. Sorted descending according to release date.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "suspended": {
+            "description": "If set to true, the provider is suspended and it's not a candidate for release nor contributes dependencies to constraint calculations/CI image. Tests are excluded.",
+            "type:": "boolean"
+        },
+        "dependencies": {
+            "description": "Dependencies that should be added to the provider",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "excluded-python-versions": {
+            "description": "List of python versions excluded for that provider",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "integrations": {
+            "description": "List of integrations supported by the provider.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "integration-name": {
+                        "type": "string",
+                        "description": "Name of the integration."
+                    },
+                    "external-doc-url": {
+                        "type": "string",
+                        "description": "URL to external documentation for the integration."
+                    },
+                    "how-to-guide": {
+                        "description": "List of paths to how-to-guide for the integration. The path must start with '/docs/'",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "logo": {
+                        "description": "Path to the logo for the integration. The path must start with '/integration-logos/'",
+                        "type": "string"
+                    },
+                    "tags": {
+                        "description": "List of tags describing the integration. While we're using RST, only one tag is supported per integration.",
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "alibaba",
+                                "apache",
+                                "aws",
+                                "azure",
+                                "dbt",
+                                "gcp",
+                                "gmp",
+                                "google",
+                                "kafka",
+                                "protocol",
+                                "service",
+                                "software",
+                                "yandex"
+                            ]
+                        },
+                        "minItems": 1,
+                        "maxItems": 1
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "integration-name",
+                    "external-doc-url",
+                    "tags"
+                ]
+            }
+        },
+        "operators": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "integration-name": {
+                        "type": "string",
+                        "description": "Integration name. It must have a matching item in the 'integration' section of any provider."
+                    },
+                    "python-modules": {
+                        "description": "List of python modules containing the operators.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "integration-name",
+                    "python-modules"
+                ]
+            }
+        },
+        "sensors": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "integration-name": {
+                        "type": "string",
+                        "description": "Integration name. It must have a matching item in the 'integration' section of any provider."
+                    },
+                    "python-modules": {
+                        "description": "List of python modules containing the sensors.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "integration-name",
+                    "python-modules"
+                ],
+                "additionalProperties": true
+            }
+        },
+        "hooks": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "integration-name": {
+                        "type": "string",
+                        "description": "Integration name. It must have a matching item in the 'integration' section of any provider."
+                    },
+                    "python-modules": {
+                        "description": "List of python modules containing the hooks.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "integration-name",
+                    "python-modules"
+                ]
+            }
+        },
+        "transfers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "how-to-guide": {
+                        "description": "Path to how-to-guide for the transfer. The path must start with '/docs/'",
+                        "type": "string"
+                    },
+                    "source-integration-name": {
+                        "type": "string",
+                        "description": "Integration name. It must have a matching item in the 'integration' section of any provider."
+                    },
+                    "target-integration-name": {
+                        "type": "string",
+                        "description": "Target integration name. It must have a matching item in the 'integration' section of any provider."
+                    },
+                    "python-module": {
+                        "type": "string",
+                        "description": "List of python modules containing the transfers."
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "source-integration-name",
+                    "target-integration-name",
+                    "python-module"
+                ]
+            }
+        },
+        "triggers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "integration-name": {
+                        "type": "string",
+                        "description": "Integration name. It must have a matching item in the 'integration' section of any provider."
+                    },
+                    "python-modules": {
+                        "description": "List of Python modules containing the triggers.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "integration-name",
+                    "python-modules"
+                ]
+            }
+        },
+        "connection-types": {
+            "type": "array",
+            "description": "Array of connection types mapped to hook class names",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "connection-type": {
+                        "description": "Type of connection defined by the provider",
+                        "type": "string"
+                    },
+                    "hook-class-name": {
+                        "description": "Hook class name that implements the connection type",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "connection-type",
+                    "hook-class-name"
+                ]
+            }
+        },
+        "extra-links": {
+            "type": "array",
+            "description": "Operator class names that provide extra link functionality",
+            "items": {
+                "type": "string"
+            }
+        },
+        "additional-extras": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "description": "Name of the extra",
+                        "type": "string"
+                    },
+                    "dependencies": {
+                        "description": "Dependencies that should be added for the extra",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "name",
+                    "dependencies"
+                ]
+            },
+            "description": "Additional extras that the provider should have. Replaces auto-generated cross-provider extras, if matching the same prefix, so that you can specify boundaries for existing dependencies."
+        },
+        "task-decorators": {
+            "type": "array",
+            "description": "Decorators to use with the TaskFlow API. Can be accessed by users via '@task.<name>'",
+            "items": {
+                "name": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                }
+            }
+        },
+        "secrets-backends": {
+            "type": "array",
+            "description": "Secrets Backend class names",
+            "items": {
+                "type": "string"
+            }
+        },
+        "logging": {
+            "type": "array",
+            "description": "Logging Task Handlers class names",
+            "items": {
+                "type": "string"
+            }
+        },
+        "auth-backends": {
+            "type": "array",
+            "description": "API Auth Backend module names",
+            "items": {
+                "type": "string"
+            }
+        },
+        "notifications": {
+            "type": "array",
+            "description": "Notification class names",
+            "items": {
+                "type": "string"
+            }
+        },
+        "executors": {
+            "type": "array",
+            "description": "Executor class names",
+            "items": {
+                "type": "string"
+            }
+        },
+        "config": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "options": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/definitions/option"
+                        }
+                    },
+                    "renamed": {
+                        "type": "object",
+                        "properties": {
+                            "previous_name": {
+                                "type": "string"
+                            },
+                            "version": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "description",
+                    "options"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "plugins": {
+            "type": "array",
+            "description": "Plugins exposed by the provider",
+            "items": {
+                "name": {
+                    "type": "string"
+                },
+                "plugin-class": {
+                    "type": "string"
+                }
+            }
         }
-      }
-    }
-  },
-  "additionalProperties": false,
-  "required": [
-    "name",
-    "package-name",
-    "description",
-    "suspended",
-    "dependencies",
-    "versions"
-  ]
+    },
+    "additionalProperties": false,
+    "definitions": {
+        "option": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "version_added": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "string",
+                        "boolean",
+                        "integer",
+                        "float"
+                    ]
+                },
+                "example": {
+                    "type": [
+                        "string",
+                        "null",
+                        "number"
+                    ]
+                },
+                "default": {
+                    "type": [
+                        "string",
+                        "null",
+                        "number"
+                    ]
+                },
+                "sensitive": {
+                    "type": "boolean",
+                    "description": "When true, this option is sensitive and can be specified using AIRFLOW__{section}___{name}__SECRET or AIRFLOW__{section}___{name}_CMD environment variables. See: airflow.configuration.AirflowConfigParser.sensitive_config_values"
+                }
+            },
+            "required": [
+                "description",
+                "version_added",
+                "type",
+                "example",
+                "default"
+            ],
+            "additional_properties": false
+        }
+    },
+    "required": [
+        "name",
+        "package-name",
+        "description",
+        "suspended",
+        "dependencies",
+        "versions"
+    ]
 }

--- a/airflow/provider_info.schema.json
+++ b/airflow/provider_info.schema.json
@@ -1,105 +1,198 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "properties": {
-    "package-name": {
-      "description": "Package name available under which the package is available in the PyPI repository.",
-      "type": "string"
-    },
-    "name": {
-      "description": "Provider name",
-      "type": "string"
-    },
-    "description": {
-      "description": "Information about the package in RST format",
-      "type": "string"
-    },
-    "hook-class-names": {
-      "type": "array",
-      "description": "Hook class names that provide connection types to core (deprecated by connection-types)",
-      "items": {
-        "type": "string"
-      },
-      "deprecated": {
-        "description": "The hook-class-names property has been deprecated in favour of connection-types which is more performant version allowing to only import individual Hooks rather than all hooks at once",
-        "deprecatedVersion": "2.2.0"
-      }
-    },
-    "connection-types": {
-      "type": "array",
-      "description": "Map of connection types mapped to hook class names.",
-      "items": {
-        "type": "object",
-        "properties": {
-          "connection-type": {
-            "description": "Type of connection defined by the provider",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "package-name": {
+            "description": "Package name available under which the package is available in the PyPI repository.",
             "type": "string"
-          },
-          "hook-class-name": {
-            "description": "Hook class name that implements the connection type",
+        },
+        "name": {
+            "description": "Provider name",
             "type": "string"
-          }
-        }
-      },
-      "required": ["connection-type", "hook-class-name"]
-    },
-    "extra-links": {
-      "type": "array",
-      "description": "Operator class names that provide extra link functionality",
-      "items": {
-        "type": "string"
-      }
-    },
-    "secrets-backends": {
-      "type": "array",
-      "description": "Secrets Backend class names",
-      "items": {
-        "type": "string"
-      }
-    },
-    "logging": {
-      "type": "array",
-      "description": "Logging Task Handlers class names",
-      "items": {
-          "type": "string"
-      }
-    },
-    "auth-backends": {
-      "type": "array",
-      "description": "API Auth Backend module names",
-      "items": {
-          "type": "string"
-      }
-    },
-    "notifications": {
-          "type": "array",
-          "description": "Notification class names",
-          "items": {
-              "type": "string"
-          }
-    },
-    "executors": {
-          "type": "array",
-          "description": "Executor class names",
-          "items": {
-              "type": "string"
-          }
-    },
-    "task-decorators": {
-        "type": "array",
-        "description": "Apply custom decorators to the TaskFlow API. Can be accessed by users via '@task.<name>'",
-        "items": {
-            "name": {
+        },
+        "description": {
+            "description": "Information about the package in RST format",
+            "type": "string"
+        },
+        "hook-class-names": {
+            "type": "array",
+            "description": "Hook class names that provide connection types to core (deprecated by connection-types)",
+            "items": {
                 "type": "string"
             },
-            "path": {
+            "deprecated": {
+                "description": "The hook-class-names property has been deprecated in favour of connection-types which is more performant version allowing to only import individual Hooks rather than all hooks at once",
+                "deprecatedVersion": "2.2.0"
+            }
+        },
+        "connection-types": {
+            "type": "array",
+            "description": "Map of connection types mapped to hook class names.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "connection-type": {
+                        "description": "Type of connection defined by the provider",
+                        "type": "string"
+                    },
+                    "hook-class-name": {
+                        "description": "Hook class name that implements the connection type",
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "connection-type",
+                "hook-class-name"
+            ]
+        },
+        "extra-links": {
+            "type": "array",
+            "description": "Operator class names that provide extra link functionality",
+            "items": {
                 "type": "string"
             }
+        },
+        "secrets-backends": {
+            "type": "array",
+            "description": "Secrets Backend class names",
+            "items": {
+                "type": "string"
+            }
+        },
+        "logging": {
+            "type": "array",
+            "description": "Logging Task Handlers class names",
+            "items": {
+                "type": "string"
+            }
+        },
+        "auth-backends": {
+            "type": "array",
+            "description": "API Auth Backend module names",
+            "items": {
+                "type": "string"
+            }
+        },
+        "notifications": {
+            "type": "array",
+            "description": "Notification class names",
+            "items": {
+                "type": "string"
+            }
+        },
+        "executors": {
+            "type": "array",
+            "description": "Executor class names",
+            "items": {
+                "type": "string"
+            }
+        },
+        "config": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "options": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/definitions/option"
+                        }
+                    },
+                    "renamed": {
+                        "type": "object",
+                        "properties": {
+                            "previous_name": {
+                                "type": "string"
+                            },
+                            "version": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "description",
+                    "options"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "task-decorators": {
+            "type": "array",
+            "description": "Apply custom decorators to the TaskFlow API. Can be accessed by users via '@task.<name>'",
+            "items": {
+                "name": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                }
+            }
         }
-    }
-  },
-  "required": [
-    "name",
-    "description"
-  ]
+    },
+    "definitions": {
+        "option": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "version_added": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "string",
+                        "boolean",
+                        "integer",
+                        "float"
+                    ]
+                },
+                "example": {
+                    "type": [
+                        "string",
+                        "null",
+                        "number"
+                    ]
+                },
+                "default": {
+                    "type": [
+                        "string",
+                        "null",
+                        "number"
+                    ]
+                },
+                "sensitive": {
+                    "type": "boolean",
+                    "description": "When true, this option is sensitive and can be specified using AIRFLOW__{section}___{name}__SECRET or AIRFLOW__{section}___{name}_CMD environment variables. See: airflow.configuration.AirflowConfigParser.sensitive_config_values"
+                }
+            },
+            "required": [
+                "description",
+                "version_added",
+                "type",
+                "example",
+                "default"
+            ],
+            "additional_properties": false
+        }
+    },
+    "required": [
+        "name",
+        "description"
+    ]
 }


### PR DESCRIPTION
This is mostly for the capacity of adding configuration to provider.yaml files.

This change adds capavilty of adding "config" option to provider yaml and provider_info. This is not yet used, but it has been extracted as separate PR from #32604 in an attempt to make it more reviewable and readable.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
