### PR TITLE
Add explicit browsers list and correct rel for blank target links

### DIFF
--- a/airflow/www/package.json
+++ b/airflow/www/package.json
@@ -29,6 +29,18 @@
     "database",
     "flask"
   ],
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
   "devDependencies": {
     "@babel/core": "^7.18.5",
     "@babel/eslint-parser": "^7.18.2",

--- a/airflow/www/static/js/ti_log.js
+++ b/airflow/www/static/js/ti_log.js
@@ -133,7 +133,8 @@ function autoTailingLog(tryNumber, metadata = null, autoTailing = false) {
         const linkifiedMessage = escapedMessage
           .replace(
             urlRegex,
-            (url) => `<a href="${url}" target="_blank">${url}</a>`
+            (url) =>
+              `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`
           )
           .replaceAll(
             dateRegex,

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -110,18 +110,18 @@
     {% call show_message(category='warning', dismissible=false) %}
       Do not use <b>SQLite</b> as metadata DB in production &#8211; it should only be used for dev/testing.
       We recommend using Postgres or MySQL.
-      <a href={{ get_docs_url("howto/set-up-database.html") }} target="_blank"><b>Click here</b></a> for more information.
+      <a href={{ get_docs_url("howto/set-up-database.html") }} target="_blank" rel="noopener noreferrer"><b>Click here</b></a> for more information.
     {% endcall %}
   {% endif %}
   {% if production_executor_warning | default(false) %}
     {% call show_message(category='warning', dismissible=false) %}
       Do not use the <b>{{ production_executor_warning }}</b> in production.
-      <a href={{ get_docs_url("executor/index.html") }}  target="_blank"><b>Click here</b></a> for more information.
+      <a href={{ get_docs_url("executor/index.html") }}  target="_blank" rel="noopener noreferrer"><b>Click here</b></a> for more information.
     {% endcall %}
   {% endif %}
   {% if otel_on | default(false) %}
     {% call show_message(category='warning', dismissible=false) %}
-      OpenTelemetry support is experimental. <a href="https://github.com/apache/airflow/blob/main/BREEZE.rst#running-breeze-with-an-opentelemetry-metrics-stack" target="_blank">
+      OpenTelemetry support is experimental. <a href="https://github.com/apache/airflow/blob/main/BREEZE.rst#running-breeze-with-an-opentelemetry-metrics-stack" target="_blank" rel="noopener noreferrer">
         <b>Click here</b></a> for more information.
     {% endcall %}
   {% endif %}
@@ -273,7 +273,7 @@
               {% for owner in dag.owners.split(",") %}
                 <a class="label label-default"
                  {% if owner_links and owner.strip() in owner_links.get(dag.dag_id, {}) %}
-                   href="{{ owner_links[dag.dag_id].get(owner.strip()) }}" target="_blank"
+                   href="{{ owner_links[dag.dag_id].get(owner.strip()) }}" target="_blank" rel="noopener noreferrer"
                  {% else %}
                    href="?search={{ owner | trim }}"
                  {% endif %}

--- a/airflow/www/templates/airflow/main.html
+++ b/airflow/www/templates/airflow/main.html
@@ -96,7 +96,7 @@
     <footer class="footer">
       <div class="container">
         <div>
-          {{ version_label }}: {% if airflow_version %}<a href="https://pypi.python.org/pypi/apache-airflow/{{ airflow_version }}" target="_blank">v{{ airflow_version }}</a>{% else %} N/A{% endif %}
+          {{ version_label }}: {% if airflow_version %}<a href="https://pypi.python.org/pypi/apache-airflow/{{ airflow_version }}" target="_blank" rel="noopener noreferrer">v{{ airflow_version }}</a>{% else %} N/A{% endif %}
           {% if git_version %}<br>Git Version: <strong>{{ git_version }}</strong>{% endif %}
         </div>
         <div></div>

--- a/airflow/www/templates/airflow/plugin.html
+++ b/airflow/www/templates/airflow/plugin.html
@@ -27,7 +27,7 @@ under the License.
   <h2>{{ title }}</h2>
   {% if plugins|length == 0 %}
     <p>No plugins loaded. Learn more in the
-      <a href="{{ doc_url }}" target="_blank">plugins documentation</a>.
+      <a href="{{ doc_url }}" target="_blank" rel="noopener noreferrer">plugins documentation</a>.
     </p>
   {% endif %}
   {% for plugin in plugins %}

--- a/airflow/www/templates/airflow/providers.html
+++ b/airflow/www/templates/airflow/providers.html
@@ -27,7 +27,7 @@ under the License.
   <h2>{{ title }}</h2>
   {% if providers|length == 0 %}
     <p>No providers loaded. Learn more in the
-      <a href="{{ doc_url }}" target="_blank">provider packages documentation</a>.
+      <a href="{{ doc_url }}" target="_blank" rel="noopener noreferrer">provider packages documentation</a>.
     </p>
   {% endif %}
 

--- a/airflow/www/yarn.lock
+++ b/airflow/www/yarn.lock
@@ -4427,9 +4427,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001349:
-  version "1.0.30001439"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz"
-  integrity sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==
+  version "1.0.30001516"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001516.tgz#621b1be7d85a8843ee7d210fd9d87b52e3daab3a"
+  integrity sha512-Wmec9pCBY8CWbmI4HsjBeQLqDTqV91nFVR83DnZpYyRnPI1wePDsTg0bGLPC5VU/3OIZV1fmxEea1b+tFKe86g==
 
 ccount@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Add `noopener` and `noreferrer` to all `target="_blank"` link.

Also add the browserslist query in our `package.json`. Use the same as [create-react-app](https://create-react-app.dev/docs/supported-browsers-features/) that sets a standard.
 [support](https://browsersl.ist/#q=%3E+0.2%25%2C+not+dead%2C+not+op_mini+all&region=FR) is a little bit wider than the [defaults](https://browsersl.ist/#q=defaults&region=FR) query.
 
 > Note: Also update `caniuse-lite` to remove warnings at build time.
 
![image](https://github.com/apache/airflow/assets/14861206/46baa0c3-ff7e-4552-bd95-e0c1fe43afb4)


