### PR TITLE
Add deprecation info to the Airflow modules and classes docstring

### DIFF
--- a/airflow/api/common/experimental/delete_dag.py
+++ b/airflow/api/common/experimental/delete_dag.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""This module is deprecated. Please use :mod:`airflow.api.common.delete_dag` instead."""
 from __future__ import annotations
 
 import warnings

--- a/airflow/api/common/experimental/mark_tasks.py
+++ b/airflow/api/common/experimental/mark_tasks.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Task Instance APIs."""
+"""Task Instance APIs. This module is deprecated. Please use :mod:`airflow.api.common.mark_tasks` instead."""
 from __future__ import annotations
 
 import warnings

--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""This module is deprecated. Please use :mod:`airflow.api.common.trigger_dag` instead."""
 from __future__ import annotations
 
 import warnings

--- a/airflow/contrib/secrets/__init__.py
+++ b/airflow/contrib/secrets/__init__.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This package is deprecated. Please use `airflow.secrets` or `airflow.providers.*.secrets`."""
+"""This package is deprecated. Please use :mod:`airflow.secrets` or `airflow.providers.*.secrets`."""
 from __future__ import annotations
 
 import warnings

--- a/airflow/contrib/task_runner/__init__.py
+++ b/airflow/contrib/task_runner/__init__.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This package is deprecated. Please use `airflow.task.task_runner`."""
+"""This package is deprecated. Please use :mod:`airflow.task.task_runner`."""
 from __future__ import annotations
 
 import warnings

--- a/airflow/contrib/utils/__init__.py
+++ b/airflow/contrib/utils/__init__.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This package is deprecated. Please use `airflow.utils`."""
+"""This package is deprecated. Please use :mod:`airflow.utils`."""
 from __future__ import annotations
 
 import warnings

--- a/airflow/contrib/utils/log/__init__.py
+++ b/airflow/contrib/utils/log/__init__.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This package is deprecated. Please use `airflow.utils.log`."""
+"""This package is deprecated. Please use :mod:`airflow.utils.log`."""
 from __future__ import annotations
 
 import warnings

--- a/airflow/hooks/dbapi.py
+++ b/airflow/hooks/dbapi.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""This module is deprecated. Please use :mod:`airflow.providers.common.sql.hooks.sql`."""
 from __future__ import annotations
 
 import warnings

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -17,6 +17,7 @@
 # under the License.
 """
 This module is deprecated.
+
 Please use :mod:`kubernetes.client.models` for V1ResourceRequirements and Port.
 """
 from __future__ import annotations

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -17,7 +17,6 @@
 # under the License.
 """
 This module is deprecated.
-
 Please use :mod:`kubernetes.client.models` for V1ResourceRequirements and Port.
 """
 from __future__ import annotations

--- a/airflow/operators/subdag.py
+++ b/airflow/operators/subdag.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-This module is deprecated, please use :mod:`airflow.utils.task_group`.
+This module is deprecated. Please use :mod:`airflow.utils.task_group`.
 
 The module which provides a way to nest your DAGs and so your levels of complexity.
 """
@@ -50,7 +50,7 @@ class SkippedStatePropagationOptions(Enum):
 
 class SubDagOperator(BaseSensorOperator):
     """
-    This class is deprecated, please use `airflow.utils.task_group.TaskGroup`.
+    This class is deprecated, please use :class:`airflow.utils.task_group.TaskGroup`.
 
     This runs a sub dag. By convention, a sub dag's dag_id
     should be prefixed by its parent and a dot. As in `parent.child`.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR adds missing deprecation warning and improve exiting ones in Airflow modules and classes docstring.

related: #32535

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
