### PR TITLE
Fix dagProcessor not including webserver-config volume

### DIFF
--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -220,6 +220,11 @@ spec:
         - name: config
           configMap:
             name: {{ template "airflow_config" . }}
+        {{- if or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName }}
+        - name: webserver-config
+          configMap:
+            name: {{ template "airflow_webserver_config_configmap_name" . }}
+        {{- end }}
         {{- if .Values.dags.persistence.enabled }}
         - name: dags
           persistentVolumeClaim:

--- a/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm_tests/airflow_core/test_dag_processor.py
@@ -579,6 +579,45 @@ class TestDagProcessor:
         assert "annotations" in jmespath.search("metadata", docs[0])
         assert jmespath.search("metadata.annotations", docs[0])["test_annotation"] == "test_annotation_value"
 
+    @pytest.mark.parametrize(
+        "webserver_config, should_add_volume",
+        [
+            ("CSRF_ENABLED = True", True),
+            (None, False),
+        ],
+    )
+    def test_should_add_webserver_config_volume_and_volume_mount_when_exists(
+        self, webserver_config, should_add_volume
+    ):
+        expected_volume = {
+            "name": "webserver-config",
+            "configMap": {"name": "release-name-webserver-config"},
+        }
+        expected_volume_mount = {
+            "name": "webserver-config",
+            "mountPath": "/opt/airflow/webserver_config.py",
+            "subPath": "webserver_config.py",
+            "readOnly": True,
+        }
+
+        docs = render_chart(
+            values={
+                "dagProcessor": {"enabled": True},
+                "webserver": {"webserverConfig": webserver_config},
+            },
+            show_only=["templates/dag-processor/dag-processor-deployment.yaml"],
+        )
+
+        created_volumes = jmespath.search("spec.template.spec.volumes", docs[0])
+        created_volume_mounts = jmespath.search("spec.template.spec.containers[1].volumeMounts", docs[0])
+
+        if should_add_volume:
+            assert expected_volume in created_volumes
+            assert expected_volume_mount in created_volume_mounts
+        else:
+            assert expected_volume not in created_volumes
+            assert expected_volume_mount not in created_volume_mounts
+
 
 class TestDagProcessorLogGroomer(LogGroomerTestBase):
     """DAG processor log groomer."""


### PR DESCRIPTION
https://github.com/apache/airflow/pull/30726 added the webserver-config volumeMount to the dagProcessor, but the volume itself was not added, so the deployment fails

Before the change:
<img width="1637" alt="image" src="https://github.com/apache/airflow/assets/28935464/c267b1c1-ac4c-4471-94a2-4e799aabfafa">

After the change:

<img width="1639" alt="image" src="https://github.com/apache/airflow/assets/28935464/dbd8576a-d31a-4746-b64e-7159869d5b5d">
