### PR TITLE
Fix refuse_to_run_test_from_wrongly_named_files to handle system tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -909,8 +909,16 @@ def clear_lru_cache():
 
 @pytest.fixture(autouse=True)
 def refuse_to_run_test_from_wrongly_named_files(request):
+    dirname: str = request.node.fspath.dirname
     filename: str = request.node.fspath.basename
-    if not request.node.fspath.basename.startswith("test_"):
+    is_system_test: bool = "tests/system/" in dirname
+    if is_system_test and not request.node.fspath.basename.startswith("example_"):
+        raise Exception(
+            f"All test method files in tests/system must start with 'example_'. Seems that {filename} "
+            f"contains {request.function} that looks like a test case. Please rename the file to "
+            f"follow the example_* pattern if you want to run the tests in it."
+        )
+    if not is_system_test and not request.node.fspath.basename.startswith("test_"):
         raise Exception(
             f"All test method files in tests/ must start with 'test_'. Seems that {filename} "
             f"contains {request.function} that looks like a test case. Please rename the file to "


### PR DESCRIPTION
A check has been added in #32626 to enforce all test file names to be `test_*`. System tests are not named `test_*` but `example_*`. As a result, any attempt to execute a system test will fail. See AWS system tests dashboard: https://aws-mwaa.github.io/open-source/system-tests/dashboard.html.

This PR handles the system tests and enforce all system test file names to follow the pattern `example_*`.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
