### PR TITLE
feat(chart): Add pod security context to pgbouncer.

### DIFF
--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -26,8 +26,9 @@
 {{- $tolerations := or .Values.pgbouncer.tolerations .Values.tolerations }}
 {{- $topologySpreadConstraints := or .Values.pgbouncer.topologySpreadConstraints .Values.topologySpreadConstraints }}
 {{- $revisionHistoryLimit := or .Values.pgbouncer.revisionHistoryLimit .Values.revisionHistoryLimit }}
-{{- $containerSecurityContext := include "containerSecurityContext" (list . .Values.pgbouncer) }}
-{{- $containerSecurityContextMetricsExporter := include "containerSecurityContext" (list . .Values.pgbouncer.metricsExporterSidecar) }}
+{{- $securityContext := include "localPodSecurityContext" .Values.pgbouncer }}
+{{- $containerSecurityContext := include "externalContainerSecurityContext" .Values.pgbouncer }}
+{{- $containerSecurityContextMetricsExporter := include "externalContainerSecurityContext" .Values.pgbouncer.metricsExporterSidecar }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -82,8 +83,7 @@ spec:
       tolerations: {{- toYaml $tolerations | nindent 8 }}
       topologySpreadConstraints: {{- toYaml $topologySpreadConstraints | nindent 8 }}
       serviceAccountName: {{ include "pgbouncer.serviceAccountName" . }}
-      securityContext:
-        runAsUser: {{ .Values.pgbouncer.uid }}
+      securityContext: {{ $securityContext | nindent 8 }}
       restartPolicy: Always
       {{- if or .Values.registry.secretName .Values.registry.connection }}
       imagePullSecrets:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -5080,10 +5080,24 @@
                     "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
                 },
                 "securityContexts": {
-                    "description": "Security context definition for the PgBouncer. If not set, the values from global `securityContexts` will be used.",
+                    "description": "Security context definition for the PgBouncer.",
                     "type": "object",
                     "x-docsSection": "Kubernetes",
                     "properties": {
+                        "pod": {
+                            "description": "Pod security context definition for the PgBouncer.",
+                            "type": "object",
+                            "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+                            "default": {},
+                            "x-docsSection": "Kubernetes",
+                            "examples": [
+                                {
+                                    "runAsUser": 65534,
+                                    "runAsGroup": 0,
+                                    "fsGroup": 0
+                                }
+                            ]
+                        },
                         "container": {
                             "description": "Container security context definition for the PgBouncer.",
                             "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1833,6 +1833,7 @@ pgbouncer:
 
   # Detailed default security context for pgbouncer for container level
   securityContexts:
+    pod: {}
     container: {}
 
   metricsExporterSidecar:

--- a/helm_tests/security/test_security_context.py
+++ b/helm_tests/security/test_security_context.py
@@ -244,20 +244,20 @@ class TestSecurityContext:
                 "templates/redis/redis-statefulset.yaml",
             ],
         )
-        for index in range(len(docs) - 3):
+        for doc in docs[:-3]:
             assert ctx_value_container == jmespath.search(
-                "spec.template.spec.containers[0].securityContext", docs[index]
+                "spec.template.spec.containers[0].securityContext", doc
             )
-            assert ctx_value_pod == jmespath.search("spec.template.spec.securityContext", docs[index])
+            assert ctx_value_pod == jmespath.search("spec.template.spec.securityContext", doc)
 
         # Global security context is not propagated to pgbouncer, redis and statsd, so we test default value
         default_ctx_value_container = {"allowPrivilegeEscalation": False, "capabilities": {"drop": ["ALL"]}}
         default_ctx_value_pod_pgbouncer = {"runAsUser": 65534}
         default_ctx_value_pod_statsd = {"runAsUser": 65534}
         default_ctx_value_pod_redis = {"runAsUser": 0}
-        for index in range(len(docs) - 3, len(docs)):
+        for doc in docs[-3:]:
             assert default_ctx_value_container == jmespath.search(
-                "spec.template.spec.containers[0].securityContext", docs[index]
+                "spec.template.spec.containers[0].securityContext", doc
             )
         # Test pgbouncer metrics-exporter container
         assert default_ctx_value_container == jmespath.search(

--- a/helm_tests/security/test_security_context.py
+++ b/helm_tests/security/test_security_context.py
@@ -57,6 +57,14 @@ class TestSCBackwardsCompatibility:
 
         assert 3000 == jmespath.search("spec.template.spec.securityContext.runAsUser", docs[0])
 
+    def test_check_pgbouncer_uid(self):
+        docs = render_chart(
+            values={"pgbouncer": {"enabled": True, "uid": 3000}},
+            show_only=["templates/pgbouncer/pgbouncer-deployment.yaml"],
+        )
+
+        assert 3000 == jmespath.search("spec.template.spec.securityContext.runAsUser", docs[0])
+
     def test_check_cleanup_job(self):
         docs = render_chart(
             values={"uid": 3000, "gid": 30, "cleanup": {"enabled": True}},
@@ -219,7 +227,10 @@ class TestSecurityContext:
         ctx_value_pod = {"runAsUser": 7000}
         ctx_value_container = {"allowPrivilegeEscalation": False}
         docs = render_chart(
-            values={"securityContexts": {"containers": ctx_value_container, "pod": ctx_value_pod}},
+            values={
+                "securityContexts": {"containers": ctx_value_container, "pod": ctx_value_pod},
+                "pgbouncer": {"enabled": True},
+            },
             show_only=[
                 "templates/flower/flower-deployment.yaml",
                 "templates/scheduler/scheduler-deployment.yaml",
@@ -228,31 +239,35 @@ class TestSecurityContext:
                 "templates/jobs/create-user-job.yaml",
                 "templates/jobs/migrate-database-job.yaml",
                 "templates/triggerer/triggerer-deployment.yaml",
+                "templates/pgbouncer/pgbouncer-deployment.yaml",
                 "templates/statsd/statsd-deployment.yaml",
                 "templates/redis/redis-statefulset.yaml",
             ],
         )
-
-        for index in range(len(docs) - 2):
+        for index in range(len(docs) - 3):
             assert ctx_value_container == jmespath.search(
                 "spec.template.spec.containers[0].securityContext", docs[index]
             )
             assert ctx_value_pod == jmespath.search("spec.template.spec.securityContext", docs[index])
 
-        # Global security context is not propagated to redis and statsd, so we test default value
+        # Global security context is not propagated to pgbouncer, redis and statsd, so we test default value
         default_ctx_value_container = {"allowPrivilegeEscalation": False, "capabilities": {"drop": ["ALL"]}}
+        default_ctx_value_pod_pgbouncer = {"runAsUser": 65534}
         default_ctx_value_pod_statsd = {"runAsUser": 65534}
         default_ctx_value_pod_redis = {"runAsUser": 0}
-        for index in range(len(docs) - 2, len(docs)):
+        for index in range(len(docs) - 3, len(docs)):
             assert default_ctx_value_container == jmespath.search(
                 "spec.template.spec.containers[0].securityContext", docs[index]
             )
-        assert default_ctx_value_pod_statsd == jmespath.search(
-            "spec.template.spec.securityContext", docs[len(docs) - 2]
+        # Test pgbouncer metrics-exporter container
+        assert default_ctx_value_container == jmespath.search(
+            "spec.template.spec.containers[1].securityContext", docs[-3]
         )
-        assert default_ctx_value_pod_redis == jmespath.search(
-            "spec.template.spec.securityContext", docs[len(docs) - 1]
+        assert default_ctx_value_pod_pgbouncer == jmespath.search(
+            "spec.template.spec.securityContext", docs[-3]
         )
+        assert default_ctx_value_pod_statsd == jmespath.search("spec.template.spec.securityContext", docs[-2])
+        assert default_ctx_value_pod_redis == jmespath.search("spec.template.spec.securityContext", docs[-1])
 
     # Test securityContexts for main containers
     def test_main_container_setting(self):


### PR DESCRIPTION
Follow up to #31043, this adds Pod Security Context to Pgbouncer which was previously hard coded. 

Follow up to #31865, this switches to `externalContainerSecurityContext` for both pgbouncer containers. I believe Pgbouncer (like statsd and redis) should not propagate the global security context because it isn't an Airflow pod. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
