### PR TITLE
docs: Note Apache Beam requires `gcloud` to execute Dataflow jobs

### DIFF
--- a/docs/apache-airflow-providers-apache-beam/operators.rst
+++ b/docs/apache-airflow-providers-apache-beam/operators.rst
@@ -24,6 +24,11 @@ streaming data-parallel processing pipelines. Using one of the open source Beam 
 that defines the pipeline. The pipeline is then executed by one of Beam's supported distributed processing
 back-ends, which include Apache Flink, Apache Spark, and Google Cloud Dataflow.
 
+.. warning::
+    This operator requires ``gcloud`` command (Google Cloud SDK) to be installed on the Airflow worker
+    <https://cloud.google.com/sdk/docs/install> when the Apache Beam pipeline runs on the
+    [Dataflow service](https://cloud.google.com/dataflow/docs).
+
 
 .. _howto/operator:BeamRunPythonPipelineOperator:
 

--- a/docs/apache-airflow-providers-apache-beam/operators.rst
+++ b/docs/apache-airflow-providers-apache-beam/operators.rst
@@ -24,7 +24,7 @@ streaming data-parallel processing pipelines. Using one of the open source Beam 
 that defines the pipeline. The pipeline is then executed by one of Beam's supported distributed processing
 back-ends, which include Apache Flink, Apache Spark, and Google Cloud Dataflow.
 
-.. warning::
+.. note::
     This operator requires ``gcloud`` command (Google Cloud SDK) to be installed on the Airflow worker
     <https://cloud.google.com/sdk/docs/install> when the Apache Beam pipeline runs on the
     [Dataflow service](https://cloud.google.com/dataflow/docs).


### PR DESCRIPTION
Include warning that gcloud is required to submit Apache Beam pipelines to Dataflow.

closes: https://github.com/apache/airflow/issues/32621