### PR TITLE
Remove explicit annotaion for Mypy to infer type

### DIFF
--- a/airflow/decorators/__init__.py
+++ b/airflow/decorators/__init__.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Callable
 
 from airflow.decorators.base import TaskDecorator
 from airflow.decorators.branch_external_python import branch_external_python_task
@@ -64,7 +64,7 @@ class TaskDecoratorCollection:
     short_circuit = staticmethod(short_circuit_task)
     sensor = staticmethod(sensor_task)
 
-    __call__: Any = python  # Alias '@task' to '@task.python'.
+    __call__ = python  # Alias '@task' to '@task.python'.
 
     def __getattr__(self, name: str) -> TaskDecorator:
         """Dynamically get provider-registered task decorators, e.g. ``@task.docker``."""


### PR DESCRIPTION
This allows `task()` to have the correct return type instead of being Any and make everything untyped.

I’m not sure why `Any` was added in the first place, but Mypy seems to be fine with this change  locally on my machine, so let’s see how it goes in CI. It did improve a lot since a year ago.

Fix #32384.