### PR TITLE
Refresh GKE OAuth2 tokens

### DIFF
--- a/airflow/providers/google/cloud/hooks/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/hooks/kubernetes_engine.py
@@ -387,10 +387,10 @@ class GKEPodHook(GoogleBaseHook, PodOperatorHookProtocol):
 
     def get_conn(self) -> client.ApiClient:
         configuration = self._get_config()
-        configuration.refresh_api_hook = self._refresh_hook
+        configuration.refresh_api_key_hook = self._refresh_api_key_hook
         return client.ApiClient(configuration)
-    
-    def _refresh_hook(self, configuration: client.configuration.Configuration):
+
+    def _refresh_api_key_hook(self, configuration: client.configuration.Configuration):
         creds = self.get_credentials()
         if not GKEPodHook._is_credentials_valid(creds):
             GKEPodHook._refresh_token(creds)

--- a/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
@@ -29,6 +29,7 @@ from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.kubernetes_engine import (
     GKEAsyncHook,
     GKEHook,
+    GKEPodHook,
     GKEPodAsyncHook,
 )
 from airflow.providers.google.common.consts import CLIENT_INFO
@@ -397,3 +398,48 @@ class TestGKEAsyncHook:
         mock_async_gke_cluster_client.get_operation.assert_called_once_with(
             name=operation_path,
         )
+
+
+class TestGKEPodHook:
+
+    def setup_method(self):
+        with mock.patch(
+            BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id
+        ):
+            self.gke_hook = GKEPodHook(gcp_conn_id="test", ssl_ca_cert=None, cluster_url=None)
+        self.gke_hook._client = mock.Mock()
+
+        def refresh_token(creds):
+            creds.token = "New"
+
+        self.old_refresh_token_method = GKEPodHook._refresh_token
+        GKEPodHook._refresh_token = refresh_token
+
+    def teardown_method(self):
+        GKEPodHook._refresh_token = self.old_refresh_token_method
+
+    def _get_config(self):
+        return kubernetes.client.configuration.Configuration()
+
+    @mock.patch(GKE_STRING.format("GKEPodHook._is_credentials_valid"))
+    def test_get_connection_update_hook_with_invalid_token(self,
+                                                           is_credentials_valid_mock):
+        self.gke_hook._get_config = self._get_config
+        is_credentials_valid_mock.return_value = False
+        the_client: kubernetes.client.ApiClient = self.gke_hook.get_conn()
+        self.gke_hook.get_credentials().token = 'Old'
+        the_client.configuration.refresh_api_key_hook(the_client.configuration)
+
+        assert self.gke_hook.get_credentials().token == 'New'
+
+    @mock.patch(GKE_STRING.format("GKEPodHook._is_credentials_valid"))
+    def test_get_connection_update_hook_with_valid_token(self,
+                                                         is_credentials_valid_mock):
+
+        self.gke_hook._get_config = self._get_config
+        is_credentials_valid_mock.return_value = True
+        the_client: kubernetes.client.ApiClient = self.gke_hook.get_conn()
+        self.gke_hook.get_credentials().token = 'Old'
+        the_client.configuration.refresh_api_key_hook(the_client.configuration)
+
+        assert self.gke_hook.get_credentials().token == 'Old'


### PR DESCRIPTION
closes: #31648

When GKEStartPodOperator is taking more than one hour to complete, it is failing with "unauthorised" error messages because the OAuth2 token that was used wasn't being refreshed before API calls.

In this PR we are making sure to refresh expired tokens before API calls to kubernetes.