### PR TITLE
Refactor setup/teardown ctx mgr to operate freely with other task definitions

### DIFF
--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -181,9 +181,8 @@ class BaseSetupTeardownContext:
 
     @classmethod
     def _update_teardown_downstream(cls, operator: AbstractOperator | list[AbstractOperator]):
-        """This recursively go through the tasks downstream of the setup in the context manager,
+        """This recursively goes through the tasks downstream of the setup in the context manager,
         if found, updates the _teardown_downstream_of_setup accordingly.
-
         """
         operator = operator[0] if isinstance(operator, list) else operator
 
@@ -210,9 +209,8 @@ class BaseSetupTeardownContext:
 
     @classmethod
     def _update_setup_upstream(cls, operator: AbstractOperator | list[AbstractOperator]):
-        """This recursively go through the tasks upstream of the teardown task in the context manager,
+        """This recursively goes through the tasks upstream of the teardown task in the context manager,
         if found, updates the _setup_upstream_of_teardown accordingly.
-
         """
         operator = operator[0] if isinstance(operator, list) else operator
 

--- a/airflow/utils/setup_teardown.py
+++ b/airflow/utils/setup_teardown.py
@@ -39,16 +39,22 @@ class BaseSetupTeardownContext:
     _previous_context_managed_setup_task: list[AbstractOperator | list[AbstractOperator]] = []
     _context_managed_teardown_task: AbstractOperator | list[AbstractOperator] = []
     _previous_context_managed_teardown_task: list[AbstractOperator | list[AbstractOperator]] = []
+    _teardown_downstream_of_setup: AbstractOperator | list[AbstractOperator] = []
+    _previous_teardown_downstream_of_setup: list[AbstractOperator | list[AbstractOperator]] = []
+    _setup_upstream_of_teardown: AbstractOperator | list[AbstractOperator] = []
+    _previous_setup_upstream_of_teardown: list[AbstractOperator | list[AbstractOperator]] = []
 
     @classmethod
     def push_context_managed_setup_task(cls, task: AbstractOperator | list[AbstractOperator]):
-        if cls._context_managed_setup_task:
+        setup_task = cls._context_managed_setup_task
+        if setup_task and setup_task != task:
             cls._previous_context_managed_setup_task.append(cls._context_managed_setup_task)
         cls._context_managed_setup_task = task
 
     @classmethod
     def push_context_managed_teardown_task(cls, task: AbstractOperator | list[AbstractOperator]):
-        if cls._context_managed_teardown_task:
+        teardown_task = cls._context_managed_teardown_task
+        if teardown_task and teardown_task != task:
             cls._previous_context_managed_teardown_task.append(cls._context_managed_teardown_task)
         cls._context_managed_teardown_task = task
 
@@ -59,14 +65,66 @@ class BaseSetupTeardownContext:
             cls._context_managed_setup_task = cls._previous_context_managed_setup_task.pop()
             setup_task = cls._context_managed_setup_task
             if setup_task and old_setup_task:
-                if isinstance(setup_task, list):
-                    for task in setup_task:
-                        task.set_downstream(old_setup_task)
-                else:
-                    setup_task.set_downstream(old_setup_task)
+                cls.set_dependency(old_setup_task, setup_task, upstream=False)
         else:
             cls._context_managed_setup_task = []
         return old_setup_task
+
+    @classmethod
+    def pop_context_managed_teardown_task(cls) -> AbstractOperator | list[AbstractOperator]:
+        old_teardown_task = cls._context_managed_teardown_task
+        if cls._previous_context_managed_teardown_task:
+            cls._context_managed_teardown_task = cls._previous_context_managed_teardown_task.pop()
+            teardown_task = cls._context_managed_teardown_task
+            if teardown_task and old_teardown_task:
+                cls.set_dependency(old_teardown_task, teardown_task)
+        else:
+            cls._context_managed_teardown_task = []
+        return old_teardown_task
+
+    @classmethod
+    def pop_teardown_downstream_of_setup(cls) -> AbstractOperator | list[AbstractOperator]:
+        old_teardown_task = cls._teardown_downstream_of_setup
+        if cls._previous_teardown_downstream_of_setup:
+            cls._teardown_downstream_of_setup = cls._previous_teardown_downstream_of_setup.pop()
+            teardown_task = cls._teardown_downstream_of_setup
+            if teardown_task and old_teardown_task:
+                cls.set_dependency(old_teardown_task, teardown_task)
+        else:
+            cls._teardown_downstream_of_setup = []
+        return old_teardown_task
+
+    @classmethod
+    def pop_setup_upstream_of_teardown(cls) -> AbstractOperator | list[AbstractOperator]:
+        old_setup_task = cls._setup_upstream_of_teardown
+        if cls._previous_setup_upstream_of_teardown:
+            cls._setup_upstream_of_teardown = cls._previous_setup_upstream_of_teardown.pop()
+            setup_task = cls._setup_upstream_of_teardown
+            if setup_task and old_setup_task:
+                cls.set_dependency(old_setup_task, setup_task, upstream=False)
+        else:
+            cls._setup_upstream_of_teardown = []
+        return old_setup_task
+
+    @classmethod
+    def set_dependency(
+        cls,
+        receiving_task: AbstractOperator | list[AbstractOperator],
+        new_task: AbstractOperator | list[AbstractOperator],
+        upstream=True,
+    ):
+        if isinstance(new_task, (list, tuple)):
+            for task in new_task:
+                cls._set_dependency(task, receiving_task, upstream)
+        else:
+            cls._set_dependency(new_task, receiving_task, upstream)
+
+    @staticmethod
+    def _set_dependency(task, receiving_task, upstream):
+        if upstream:
+            task.set_upstream(receiving_task)
+        else:
+            task.set_downstream(receiving_task)
 
     @classmethod
     def update_context_map(cls, task: DependencyMixin):
@@ -83,40 +141,16 @@ class BaseSetupTeardownContext:
             else:
                 ctx[item].append(task_)
 
-        if setup_task := cls.get_context_managed_setup_task():
+        if setup_task := cls._context_managed_setup_task:
             if isinstance(setup_task, list):
                 _get_or_set_item(tuple(setup_task))
             else:
                 _get_or_set_item(setup_task)
-        if teardown_task := cls.get_context_managed_teardown_task():
+        if teardown_task := cls._context_managed_teardown_task:
             if isinstance(teardown_task, list):
                 _get_or_set_item(tuple(teardown_task))
             else:
                 _get_or_set_item(teardown_task)
-
-    @classmethod
-    def pop_context_managed_teardown_task(cls) -> AbstractOperator | list[AbstractOperator]:
-        old_teardown_task = cls._context_managed_teardown_task
-        if cls._previous_context_managed_teardown_task:
-            cls._context_managed_teardown_task = cls._previous_context_managed_teardown_task.pop()
-            teardown_task = cls._context_managed_teardown_task
-            if teardown_task and old_teardown_task:
-                if isinstance(teardown_task, list):
-                    for task in teardown_task:
-                        task.set_upstream(old_teardown_task)
-                else:
-                    teardown_task.set_upstream(old_teardown_task)
-        else:
-            cls._context_managed_teardown_task = []
-        return old_teardown_task
-
-    @classmethod
-    def get_context_managed_setup_task(cls) -> AbstractOperator | list[AbstractOperator]:
-        return cls._context_managed_setup_task
-
-    @classmethod
-    def get_context_managed_teardown_task(cls) -> AbstractOperator | list[AbstractOperator]:
-        return cls._context_managed_teardown_task
 
     @classmethod
     def push_setup_teardown_task(cls, operator: AbstractOperator | list[AbstractOperator]):
@@ -134,57 +168,147 @@ class BaseSetupTeardownContext:
     @classmethod
     def _push_tasks(cls, operator: AbstractOperator | list[AbstractOperator], setup: bool = False):
         if isinstance(operator, list):
-            upstream_tasks = operator[0].upstream_list
-            downstream_list = operator[0].downstream_list
             if not all(task.is_setup == operator[0].is_setup for task in operator):
                 cls.error("All tasks in the list must be either setup or teardown tasks")
-        else:
-            upstream_tasks = operator.upstream_list
-            downstream_list = operator.downstream_list
         if setup:
             cls.push_context_managed_setup_task(operator)
-            if downstream_list:
-                cls.push_context_managed_teardown_task(list(downstream_list))
+            # workout the teardown
+            cls._update_teardown_downstream(operator)
         else:
             cls.push_context_managed_teardown_task(operator)
-            if upstream_tasks:
-                cls.push_context_managed_setup_task(list(upstream_tasks))
+            # workout the setups
+            cls._update_setup_upstream(operator)
+
+    @classmethod
+    def _update_teardown_downstream(cls, operator: AbstractOperator | list[AbstractOperator]):
+        """This recursively go through the tasks downstream of the setup in the context manager,
+        if found, updates the _teardown_downstream_of_setup accordingly.
+
+        """
+        operator = operator[0] if isinstance(operator, list) else operator
+
+        def _get_teardowns(tasks):
+            teardowns = [i for i in tasks if i.is_teardown]
+            if not teardowns:
+                all_lists = [task.downstream_list + task.upstream_list for task in tasks]
+                new_list = [
+                    x
+                    for sublist in all_lists
+                    for x in sublist
+                    if (isinstance(operator, list) and x in operator) or x != operator
+                ]
+                if not new_list:
+                    return []
+                return _get_teardowns(new_list)
+            return teardowns
+
+        teardowns = _get_teardowns(operator.downstream_list)
+        teardown_task = cls._teardown_downstream_of_setup
+        if teardown_task and teardown_task != teardowns:
+            cls._previous_teardown_downstream_of_setup.append(cls._teardown_downstream_of_setup)
+        cls._teardown_downstream_of_setup = teardowns
+
+    @classmethod
+    def _update_setup_upstream(cls, operator: AbstractOperator | list[AbstractOperator]):
+        """This recursively go through the tasks upstream of the teardown task in the context manager,
+        if found, updates the _setup_upstream_of_teardown accordingly.
+
+        """
+        operator = operator[0] if isinstance(operator, list) else operator
+
+        def _get_setups(tasks):
+            setups = [i for i in tasks if i.is_setup]
+            if not setups:
+                all_lists = [task.downstream_list + task.upstream_list for task in tasks]
+                new_list = [
+                    x
+                    for sublist in all_lists
+                    for x in sublist
+                    if (isinstance(operator, list) and x in operator) or x != operator
+                ]
+                if not new_list:
+                    return []
+                return _get_setups(new_list)
+            return setups
+
+        setups = _get_setups(operator.upstream_list)
+        setup_task = cls._setup_upstream_of_teardown
+        if setup_task and setup_task != setups:
+            cls._previous_setup_upstream_of_teardown.append(cls._setup_upstream_of_teardown)
+        cls._setup_upstream_of_teardown = setups
+
+    @classmethod
+    def set_teardown_task_as_leaves(cls, leaves):
+        teardown_task = cls._teardown_downstream_of_setup
+        if cls._context_managed_teardown_task:
+            cls.set_dependency(cls._context_managed_teardown_task, teardown_task)
+        else:
+            cls.set_dependency(leaves, teardown_task)
+
+    @classmethod
+    def set_setup_task_as_roots(cls, roots):
+        setup_task = cls._setup_upstream_of_teardown
+        if cls._context_managed_setup_task:
+            cls.set_dependency(cls._context_managed_setup_task, setup_task, upstream=False)
+        else:
+            cls.set_dependency(roots, setup_task, upstream=False)
 
     @classmethod
     def set_work_task_roots_and_leaves(cls):
-        if setup_task := cls.get_context_managed_setup_task():
+        """Sets the work task roots and leaves."""
+        if setup_task := cls._context_managed_setup_task:
             if isinstance(setup_task, list):
                 setup_task = tuple(setup_task)
-            tasks_in_context = cls.context_map.get(setup_task, [])
+            tasks_in_context = [
+                x for x in cls.context_map.get(setup_task, []) if not x.is_teardown and not x.is_setup
+            ]
             if tasks_in_context:
                 roots = [task for task in tasks_in_context if not task.upstream_list]
                 if not roots:
-                    setup_task >> tasks_in_context[0]
-                elif isinstance(setup_task, tuple):
-                    for task in setup_task:
-                        task >> roots
+                    setup_task >> list(tasks_in_context)[0]
                 else:
-                    setup_task >> roots
-        if teardown_task := cls.get_context_managed_teardown_task():
+                    cls.set_dependency(roots, setup_task, upstream=False)
+                leaves = [task for task in tasks_in_context if not task.downstream_list]
+                cls.set_teardown_task_as_leaves(leaves)
+
+        if teardown_task := cls._context_managed_teardown_task:
             if isinstance(teardown_task, list):
                 teardown_task = tuple(teardown_task)
-            tasks_in_context = cls.context_map.get(teardown_task, [])
+            tasks_in_context = [
+                x for x in cls.context_map.get(teardown_task, []) if not x.is_teardown and not x.is_setup
+            ]
             if tasks_in_context:
                 leaves = [task for task in tasks_in_context if not task.downstream_list]
                 if not leaves:
-                    teardown_task << tasks_in_context[-1]
-                elif isinstance(teardown_task, tuple):
-                    for task in teardown_task:
-                        task << leaves
+                    teardown_task << list(tasks_in_context).pop()
                 else:
-                    teardown_task << leaves
+                    cls.set_dependency(leaves, teardown_task)
+                roots = [task for task in tasks_in_context if not task.upstream_list]
+                cls.set_setup_task_as_roots(roots)
+        cls.set_setup_teardown_relationships()
+        cls.active = False
+
+    @classmethod
+    def set_setup_teardown_relationships(cls):
+        """
+        Here we set relationship between setup to setup and
+        teardown to teardown.
+
+        code:: python
+            with setuptask >> teardowntask:
+                with setuptask2 >> teardowntask2:
+                    ...
+
+        We set setuptask >> setuptask2, teardowntask >> teardowntask2
+        """
         setup_task = cls.pop_context_managed_setup_task()
         teardown_task = cls.pop_context_managed_teardown_task()
         if isinstance(setup_task, list):
             setup_task = tuple(setup_task)
         if isinstance(teardown_task, list):
             teardown_task = tuple(teardown_task)
-        cls.active = False
+        cls.pop_teardown_downstream_of_setup()
+        cls.pop_setup_upstream_of_teardown()
         cls.context_map.pop(setup_task, None)
         cls.context_map.pop(teardown_task, None)
 

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -1336,3 +1336,24 @@ class TestSetupTearDownTask:
         assert dag.task_group.children["s1"].downstream_task_ids == {"s2", "work_task", "t1", "t2"}
         assert dag.task_group.children["s2"].downstream_task_ids == {"work_task", "t1", "t2"}
         assert dag.task_group.children["t2"].downstream_task_ids == {"t1"}
+
+    def test_mixing_construct_with_add_task(self, dag_maker):
+
+        with dag_maker() as dag:
+            s1 = make_task("s1", type_="classic")
+            s2 = make_task("s2", type_="classic")
+            t1 = make_task("t1", type_="classic")
+            t2 = make_task("t2", type_="classic")
+            t1.as_teardown(setups=s1)
+            t2.as_teardown(setups=s2)
+            with t1:
+                work = make_task("work", type_="classic")
+            with t2 as scope:
+                scope.add_task(work)
+
+        assert dag.task_group.children.keys() == {"s1", "s2", "t1", "t2", "work"}
+        assert dag.task_group.children["s1"].downstream_task_ids == {"work", "t1"}
+        assert dag.task_group.children["s2"].downstream_task_ids == {"work", "t2"}
+        assert not dag.task_group.children["t1"].downstream_task_ids
+        assert not dag.task_group.children["t2"].downstream_task_ids
+        assert dag.task_group.children["work"].downstream_task_ids == {"t1", "t2"}


### PR DESCRIPTION
This refactor is aimed at both simplifying the code for easy understanding and reducing assumption of how setups/teardowns should link. Only link when necessary and don't force a link.

This is particularly important as we now have .as_teardown(setups=[])

