### PR TITLE
Fix logic of trigger rule one failed inside mapped group

### DIFF
--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -159,9 +159,9 @@ class TriggerRuleDep(BaseTIDep):
             # Not actually an upstream task.
             if upstream.task_id not in task.upstream_task_ids:
                 return False
-            # The current task is not in a mapped task group. All tis from an
+            # The current task is not in a mapped task group or if it isn't expanded yet. All tis from an
             # upstream task are relevant.
-            if task.get_closest_mapped_task_group() is None:
+            if task.get_closest_mapped_task_group() is None or ti.map_index < 0:
                 return True
             # The upstream ti is not expanded. The upstream may be mapped or
             # not, but the ti is relevant either way.
@@ -195,9 +195,9 @@ class TriggerRuleDep(BaseTIDep):
         skipped_setup = upstream_states.skipped_setup
 
         def _iter_upstream_conditions() -> Iterator[ColumnOperators]:
-            # Optimization: If the current task is not in a mapped task group,
+            # Optimization: If the current task is not in a mapped task group or if it isn't expanded yet,
             # it depends on all upstream task instances.
-            if task.get_closest_mapped_task_group() is None:
+            if task.get_closest_mapped_task_group() is None or ti.map_index < 0:
                 yield TaskInstance.task_id.in_(upstream_tasks)
                 return
             # Otherwise we need to figure out which map indexes are depended on


### PR DESCRIPTION
#### Description:
The TriggerRule.ONE_FAILED inside the mapped task group was working incorrectly due to a task with that trigger rule can be not expanded yet so related map_idex for the upstream task inside the task group was calculated incorrectly and the task was marked as skipped due to the upstream task was determined as all success even if there was a fail. So I've added additional check to insure that task is expanded before find appropriate index in upstream dynamic tasks

#### Relates: https://github.com/apache/airflow/issues/30333