### PR TITLE
Add graph-easy dag rendering

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -450,8 +450,8 @@ ARG_DAG_REGEX = Arg(
 
 # show_dag
 ARG_SAVE = Arg(("-s", "--save"), help="Saves the result to the indicated file.")
-
 ARG_IMGCAT = Arg(("--imgcat",), help="Displays graph using the imgcat tool.", action="store_true")
+ARG_GRAPH_EASY = Arg(("--graph-easy",), help="Displays graph using the graph-easy tool.", action="store_true")
 
 # trigger_dag
 ARG_RUN_ID = Arg(("-r", "--run-id"), help="Helps to identify this run")
@@ -1256,6 +1256,7 @@ DAGS_COMMANDS = (
             ARG_SUBDIR,
             ARG_SAVE,
             ARG_IMGCAT,
+            ARG_GRAPH_EASY,
             ARG_VERBOSE,
         ),
     ),


### PR DESCRIPTION
There is a perl library called Graph::Easy or some such which, if installed, can be used to render an ascii version of the dag graph.

For complicated dags, or with long task names, it can be a very ugly result.  But for simple cases it can be convenient.

See here for install instructions for graph easy on mac: https://stackoverflow.com/a/55403011

Once installed, you can invoke it in an ad hoc manner from your dag file with this:

```python
    dot = render_dag(dag)
    _display_dot_via_graph_easy(dot)
```

example
```
>>> with DAG(
>>>         dag_id="example_setup_teardown_2",
>>>         start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
>>>         catchup=False,
>>>         tags=["example"],
>>> ) as dag1:
>>>     s1 = BashOperator(task_id="s1", bash_command="").as_setup()
>>>     t1 = BashOperator(task_id="t1", bash_command="").as_teardown(setups=[s1])
>>>     with t1:
>>>         w1 = BashOperator(task_id="w1", bash_command="")
>>>     # w2 = BashOperator(task_id="w2", bash_command="")
>>>     # w3 = BashOperator(task_id="w3", bash_command="")
>>>     dot = render_dag(dag1)
>>>     _display_dot_via_graph_easy(dot)
 example_setup_teardown_2
  +---------------------+
  |                     v
 ----       ----       ----
| s1 | --> | w1 | --> | t1 |
 ----       ----       ----
```