### PR TITLE
add dag_run_ids and task_ids filter for the batch task instance API endpoint

### DIFF
--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -400,6 +400,8 @@ def get_task_instances_batch(session: Session = NEW_SESSION) -> APIResponse:
     base_query = select(TI).join(TI.dag_run)
 
     base_query = _apply_array_filter(base_query, key=TI.dag_id, values=data["dag_ids"])
+    base_query = _apply_array_filter(base_query, key=TI.run_id, values=data["dag_run_ids"])
+    base_query = _apply_array_filter(base_query, key=TI.task_id, values=data["task_ids"])
     base_query = _apply_range_filter(
         base_query,
         key=DR.execution_date,

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -4418,6 +4418,8 @@ components:
             Return objects with specific DAG Run IDs.
 
             The value can be repeated to retrieve multiple matching values (OR condition).
+
+            *New in version 2.6.4*
         task_ids:
           type: array
           items:
@@ -4426,6 +4428,8 @@ components:
             Return objects with specific task IDs.
 
             The value can be repeated to retrieve multiple matching values (OR condition).
+
+            *New in version 2.6.4*
         execution_date_gte:
           type: string
           format: date-time

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -4419,7 +4419,7 @@ components:
 
             The value can be repeated to retrieve multiple matching values (OR condition).
 
-            *New in version 2.6.4*
+            *New in version 2.7.1*
         task_ids:
           type: array
           items:
@@ -4429,7 +4429,7 @@ components:
 
             The value can be repeated to retrieve multiple matching values (OR condition).
 
-            *New in version 2.6.4*
+            *New in version 2.7.1*
         execution_date_gte:
           type: string
           format: date-time

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -4410,6 +4410,22 @@ components:
             Return objects with specific DAG IDs.
 
             The value can be repeated to retrieve multiple matching values (OR condition).
+        dag_run_ids:
+          type: array
+          items:
+            type: string
+          description:
+            Return objects with specific DAG Run IDs.
+
+            The value can be repeated to retrieve multiple matching values (OR condition).
+        task_ids:
+          type: array
+          items:
+            type: string
+          description:
+            Return objects with specific task IDs.
+
+            The value can be repeated to retrieve multiple matching values (OR condition).
         execution_date_gte:
           type: string
           format: date-time

--- a/airflow/api_connexion/schemas/task_instance_schema.py
+++ b/airflow/api_connexion/schemas/task_instance_schema.py
@@ -100,6 +100,8 @@ class TaskInstanceBatchFormSchema(Schema):
     page_offset = fields.Int(load_default=0, validate=validate.Range(min=0))
     page_limit = fields.Int(load_default=100, validate=validate.Range(min=1))
     dag_ids = fields.List(fields.Str(), load_default=None)
+    dag_run_ids = fields.List(fields.Str(), load_default=None)
+    task_ids = fields.List(fields.Str(), load_default=None)
     execution_date_gte = fields.DateTime(load_default=None, validate=validate_istimezone)
     execution_date_lte = fields.DateTime(load_default=None, validate=validate_istimezone)
     start_date_gte = fields.DateTime(load_default=None, validate=validate_istimezone)

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1986,13 +1986,13 @@ export interface components {
       /**
        * @description Return objects with specific DAG Run IDs.
        * The value can be repeated to retrieve multiple matching values (OR condition).
-       * *New in version 2.6.4*
+       * *New in version 2.7.1*
        */
       dag_run_ids?: string[];
       /**
        * @description Return objects with specific task IDs.
        * The value can be repeated to retrieve multiple matching values (OR condition).
-       * *New in version 2.6.4*
+       * *New in version 2.7.1*
        */
       task_ids?: string[];
       /**

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1986,11 +1986,13 @@ export interface components {
       /**
        * @description Return objects with specific DAG Run IDs.
        * The value can be repeated to retrieve multiple matching values (OR condition).
+       * *New in version 2.6.4*
        */
       dag_run_ids?: string[];
       /**
        * @description Return objects with specific task IDs.
        * The value can be repeated to retrieve multiple matching values (OR condition).
+       * *New in version 2.6.4*
        */
       task_ids?: string[];
       /**

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1984,6 +1984,16 @@ export interface components {
        */
       dag_ids?: string[];
       /**
+       * @description Return objects with specific DAG Run IDs.
+       * The value can be repeated to retrieve multiple matching values (OR condition).
+       */
+      dag_run_ids?: string[];
+      /**
+       * @description Return objects with specific task IDs.
+       * The value can be repeated to retrieve multiple matching values (OR condition).
+       */
+      task_ids?: string[];
+      /**
        * Format: date-time
        * @description Returns objects greater or equal to the specified date.
        *

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -778,6 +778,36 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
                 "test",
                 id="with execution date filter",
             ),
+            pytest.param(
+                [
+                    {"execution_date": DEFAULT_DATETIME_1},
+                    {"execution_date": DEFAULT_DATETIME_1 + dt.timedelta(days=1)},
+                    {"execution_date": DEFAULT_DATETIME_1 + dt.timedelta(days=2)},
+                    {"execution_date": DEFAULT_DATETIME_1 + dt.timedelta(days=3)},
+                ],
+                False,
+                {
+                    "dag_run_ids": ["TEST_DAG_RUN_ID_0", "TEST_DAG_RUN_ID_1"],
+                },
+                2,
+                "test",
+                id="test dag run id filter",
+            ),
+            pytest.param(
+                [
+                    {"execution_date": DEFAULT_DATETIME_1},
+                    {"execution_date": DEFAULT_DATETIME_1 + dt.timedelta(days=1)},
+                    {"execution_date": DEFAULT_DATETIME_1 + dt.timedelta(days=2)},
+                    {"execution_date": DEFAULT_DATETIME_1 + dt.timedelta(days=3)},
+                ],
+                False,
+                {
+                    "task_ids": ["print_the_context", "log_sql_query"],
+                },
+                2,
+                "test",
+                id="test task id filter",
+            ),
         ],
     )
     def test_should_respond_200(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR introduces two new filters for the batch task instance endpoint:
- `dag_run_ids`: a set of DAG Run IDs to filter the instances that were in those runs
- `task_ids`: a set of task IDs that the instances were for

Let me know if you have any feedback.

