### PR TITLE
Catch arbitrary exception from run_job to prevent zombie scheduler

### DIFF
--- a/airflow/cli/commands/scheduler_command.py
+++ b/airflow/cli/commands/scheduler_command.py
@@ -17,6 +17,7 @@
 """Scheduler command."""
 from __future__ import annotations
 
+import logging
 import signal
 from contextlib import contextmanager
 from multiprocessing import Process
@@ -35,12 +36,17 @@ from airflow.utils.cli import process_subdir, setup_locations, setup_logging, si
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 from airflow.utils.scheduler_health import serve_health_check
 
+log = logging.getLogger(__name__)
+
 
 def _run_scheduler_job(job_runner: SchedulerJobRunner, *, skip_serve_logs: bool) -> None:
     InternalApiConfig.force_database_direct_access()
     enable_health_check = conf.getboolean("scheduler", "ENABLE_HEALTH_CHECK")
     with _serve_logs(skip_serve_logs), _serve_health_check(enable_health_check):
-        run_job(job=job_runner.job, execute_callable=job_runner._execute)
+        try:
+            run_job(job=job_runner.job, execute_callable=job_runner._execute)
+        except Exception:
+            log.exception("Exception when running scheduler job")
 
 
 @cli_utils.action_cli

--- a/tests/cli/commands/test_scheduler_command.py
+++ b/tests/cli/commands/test_scheduler_command.py
@@ -153,11 +153,15 @@ class TestSchedulerCommand:
         args = self.parser.parse_args(["scheduler"])
         scheduler_command.scheduler(args)
 
-        mock_run_job.assert_called()
-        mock_log.exception.assert_called()
-        mock_scheduler_job.assert_called()
+        # Make sure that run_job is called, that the exception has been logged, and that the serve_logs
+        # sub-process has been terminated
+        mock_run_job.assert_called_once_with(
+            job=mock_scheduler_job().job,
+            execute_callable=mock_scheduler_job()._execute,
+        )
+        mock_log.exception.assert_called_once_with("Exception when running scheduler job")
         mock_process.assert_has_calls([mock.call(target=serve_logs)])
-        mock_process().terminate.assert_called()
+        mock_process().terminate.assert_called_once()
 
 
 # Creating MockServer subclass of the HealthServer handler so that we can test the do_GET logic

--- a/tests/cli/commands/test_scheduler_command.py
+++ b/tests/cli/commands/test_scheduler_command.py
@@ -160,8 +160,8 @@ class TestSchedulerCommand:
             execute_callable=mock_scheduler_job()._execute,
         )
         mock_log.exception.assert_called_once_with("Exception when running scheduler job")
-        mock_process.assert_has_calls([mock.call(target=serve_logs)])
-        mock_process().terminate.assert_called_once()
+        mock_process.assert_called_once_with(target=serve_logs)
+        mock_process().terminate.assert_called_once_with()
 
 
 # Creating MockServer subclass of the HealthServer handler so that we can test the do_GET logic


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #32706

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR attempts to address issue #32706

When `run_job` raises unhandled exception, the scheduler process will become zombie. Placing `run_job` inside a try-catch block will allow `serve_logs` and `health_check` to properly terminate the sub-processes.