### PR TITLE
Removing hardcoded flag value and using constant

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/docs_errors.py
+++ b/dev/breeze/src/airflow_breeze/utils/docs_errors.py
@@ -23,13 +23,13 @@ from typing import NamedTuple
 
 from rich.console import Console
 
-from airflow_breeze.utils.publish_docs_helpers import prepare_code_snippet
+from airflow_breeze.utils.publish_docs_helpers import CONSOLE_WIDTH, prepare_code_snippet
 
 CURRENT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 ROOT_PROJECT_DIR = Path(__file__).parents[5].resolve()
 DOCS_DIR = os.path.join(ROOT_PROJECT_DIR, "docs")
 
-console = Console(force_terminal=True, color_system="standard", width=180)
+console = Console(force_terminal=True, color_system="standard", width=CONSOLE_WIDTH)
 
 
 @total_ordering

--- a/dev/breeze/src/airflow_breeze/utils/publish_docs_builder.py
+++ b/dev/breeze/src/airflow_breeze/utils/publish_docs_builder.py
@@ -29,11 +29,10 @@ from rich.console import Console
 from airflow_breeze.global_constants import get_airflow_version
 from airflow_breeze.utils.docs_errors import DocBuildError, parse_sphinx_warnings
 from airflow_breeze.utils.helm_chart_utils import chart_version
-from airflow_breeze.utils.publish_docs_helpers import load_package_data, pretty_format_path
+from airflow_breeze.utils.publish_docs_helpers import CONSOLE_WIDTH, load_package_data, pretty_format_path
 from airflow_breeze.utils.spelling_checks import SpellingError, parse_spelling_warnings
 
 PROCESS_TIMEOUT = 15 * 60
-CONSOLE_WIDTH = 180
 
 ROOT_PROJECT_DIR = Path(__file__).parents[5].resolve()
 DOCS_DIR = os.path.join(ROOT_PROJECT_DIR, "docs")

--- a/dev/breeze/src/airflow_breeze/utils/publish_docs_helpers.py
+++ b/dev/breeze/src/airflow_breeze/utils/publish_docs_helpers.py
@@ -26,6 +26,8 @@ from typing import Any
 
 import yaml
 
+CONSOLE_WIDTH = 180
+
 ROOT_DIR = Path(__file__).parents[5].resolve()
 PROVIDER_DATA_SCHEMA_PATH = ROOT_DIR / "airflow" / "provider.yaml.schema.json"
 

--- a/dev/breeze/src/airflow_breeze/utils/spelling_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/spelling_checks.py
@@ -24,13 +24,13 @@ from typing import NamedTuple
 
 from rich.console import Console
 
-from airflow_breeze.utils.publish_docs_helpers import prepare_code_snippet
+from airflow_breeze.utils.publish_docs_helpers import CONSOLE_WIDTH, prepare_code_snippet
 
 CURRENT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 ROOT_PROJECT_DIR = Path(__file__).parents[5].resolve()
 DOCS_DIR = os.path.join(ROOT_PROJECT_DIR, "docs")
 
-console = Console(force_terminal=True, color_system="standard", width=180)
+console = Console(force_terminal=True, color_system="standard", width=CONSOLE_WIDTH)
 
 
 @total_ordering


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
The CONSOLE_WIDTH flag was defined but some scripts didn't use it and hardcoded a value. This is needed so that in future if the constant changes, unexpected console width doesn't happen



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
