### PR TITLE
Reconnect on read_pods when k8s auth fails

### DIFF
--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import contextlib
 import tempfile
-from functools import cached_property
 from typing import TYPE_CHECKING, Any, Generator
 
 from asgiref.sync import sync_to_async
@@ -151,7 +150,7 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
             else:
                 raise
 
-    @cached_property
+    @property
     def conn_extras(self):
         if self.conn_id:
             connection = self.get_connection(self.conn_id)
@@ -263,16 +262,16 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
             assert self._is_in_cluster is not None
         return self._is_in_cluster
 
-    @cached_property
+    @property
     def api_client(self) -> client.ApiClient:
         """Cached Kubernetes API client."""
         return self.get_conn()
 
-    @cached_property
+    @property
     def core_v1_client(self) -> client.CoreV1Api:
         return client.CoreV1Api(api_client=self.api_client)
 
-    @cached_property
+    @property
     def custom_object_client(self) -> client.CustomObjectsApi:
         return client.CustomObjectsApi(api_client=self.api_client)
 

--- a/airflow/providers/cncf/kubernetes/utils/delete_from.py
+++ b/airflow/providers/cncf/kubernetes/utils/delete_from.py
@@ -51,7 +51,6 @@ def delete_from_dict(k8s_client, data, body, namespace, verbose=False, **kwargs)
             except client.rest.ApiException as api_exception:
                 api_exceptions.append(api_exception)
     else:
-
         try:
             _delete_from_yaml_single_item(
                 k8s_client=k8s_client,

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -43,6 +43,7 @@ from urllib3.exceptions import HTTPError as BaseHTTPError
 from urllib3.response import HTTPResponse
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.providers.cncf.kubernetes.kube_client import get_kube_client
 from airflow.providers.cncf.kubernetes.pod_generator import PodDefaults
 from airflow.typing_compat import Literal, Protocol
 from airflow.utils.log.logging_mixin import LoggingMixin


### PR DESCRIPTION
closes: #32718 

I have a patch from my client that they use to reconnect pods with KPO in the case of an expiring token.

Opening this up as is and happy to discuss better ideas!

Essentially we want to reconnect/reauthenticate on read_pods as we found that when the token expires our tasks start getting 401 errors.  

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

