### PR TITLE
Fixup system test for DataprocSubmitJobOperator (Hive job)

### DIFF
--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -1204,6 +1204,10 @@ class DataprocSubmitPigJobOperator(DataprocJobBaseOperator):
 class DataprocSubmitHiveJobOperator(DataprocJobBaseOperator):
     """Start a Hive query Job on a Cloud DataProc cluster.
 
+    .. seealso::
+        This operator is deprecated, please use
+        :class:`~airflow.providers.google.cloud.operators.dataproc.DataprocSubmitJobOperator`:
+
     :param query: The query or reference to the query file (q extension).
     :param query_uri: The HCFS URI of the script that contains the Hive queries.
     :param variables: Map of named parameters for the query.

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_hive.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_hive.py
@@ -74,7 +74,7 @@ with models.DAG(
     schedule="@once",
     start_date=datetime(2021, 1, 1),
     catchup=False,
-    tags=["example", "dataproc"],
+    tags=["example", "dataproc", "hive"],
 ) as dag:
     # [START how_to_cloud_dataproc_create_cluster_operator]
     create_cluster = DataprocCreateClusterOperator(
@@ -100,7 +100,14 @@ with models.DAG(
     # [END how_to_cloud_dataproc_delete_cluster_operator]
     delete_cluster.trigger_rule = TriggerRule.ALL_DONE
 
-    create_cluster >> hive_task >> delete_cluster
+    (
+        # TEST SETUP
+        create_cluster
+        # TEST BODY
+        >> hive_task
+        # TEST TEARDOWN
+        >> delete_cluster
+    )
 
     from tests.system.utils.watcher import watcher
 


### PR DESCRIPTION
Fix for system test for `DataprocSubmitJobOperator` (Hive job):
1. Refactored system test (AIP-47).
2. Update docstrings for generating more explicit documentation with a deprecation message in `DataprocSubmitHiveJobOperator` and link to the new class `DataprocSubmitJobOperator`.