### PR TITLE
[bugfix] fix AWS triggers where deserialization would crash if region was not specified

### DIFF
--- a/airflow/providers/amazon/aws/triggers/batch.py
+++ b/airflow/providers/amazon/aws/triggers/batch.py
@@ -209,7 +209,7 @@ class BatchJobTrigger(AwsBaseWaiterTrigger):
     def __init__(
         self,
         job_id: str | None,
-        region_name: str | None,
+        region_name: str | None = None,
         aws_conn_id: str | None = "aws_default",
         waiter_delay: int = 5,
         waiter_max_attempts: int = 720,

--- a/airflow/providers/amazon/aws/triggers/ecs.py
+++ b/airflow/providers/amazon/aws/triggers/ecs.py
@@ -49,7 +49,7 @@ class ClusterActiveTrigger(AwsBaseWaiterTrigger):
         waiter_delay: int,
         waiter_max_attempts: int,
         aws_conn_id: str | None,
-        region_name: str | None,
+        region_name: str | None = None,
     ):
         super().__init__(
             serialized_fields={"cluster_arn": cluster_arn},
@@ -88,7 +88,7 @@ class ClusterInactiveTrigger(AwsBaseWaiterTrigger):
         waiter_delay: int,
         waiter_max_attempts: int,
         aws_conn_id: str | None,
-        region_name: str | None,
+        region_name: str | None = None,
     ):
         super().__init__(
             serialized_fields={"cluster_arn": cluster_arn},

--- a/airflow/providers/amazon/aws/triggers/eks.py
+++ b/airflow/providers/amazon/aws/triggers/eks.py
@@ -47,7 +47,7 @@ class EksCreateClusterTrigger(AwsBaseWaiterTrigger):
         waiter_delay: int,
         waiter_max_attempts: int,
         aws_conn_id: str,
-        region_name: str | None,
+        region_name: str | None = None,
     ):
         super().__init__(
             serialized_fields={"cluster_name": cluster_name, "region_name": region_name},
@@ -309,7 +309,7 @@ class EksCreateNodegroupTrigger(AwsBaseWaiterTrigger):
         waiter_delay: int,
         waiter_max_attempts: int,
         aws_conn_id: str,
-        region_name: str | None,
+        region_name: str | None = None,
     ):
         super().__init__(
             serialized_fields={
@@ -357,7 +357,7 @@ class EksDeleteNodegroupTrigger(AwsBaseWaiterTrigger):
         waiter_delay: int,
         waiter_max_attempts: int,
         aws_conn_id: str,
-        region_name: str | None,
+        region_name: str | None = None,
     ):
         super().__init__(
             serialized_fields={"cluster_name": cluster_name, "nodegroup_name": nodegroup_name},

--- a/airflow/providers/amazon/aws/triggers/rds.py
+++ b/airflow/providers/amazon/aws/triggers/rds.py
@@ -126,9 +126,9 @@ class RdsDbAvailableTrigger(AwsBaseWaiterTrigger):
         waiter_delay: int,
         waiter_max_attempts: int,
         aws_conn_id: str,
-        region_name: str | None,
         response: dict[str, Any],
         db_type: RdsDbType,
+        region_name: str | None = None,
     ) -> None:
         super().__init__(
             serialized_fields={
@@ -172,9 +172,9 @@ class RdsDbDeletedTrigger(AwsBaseWaiterTrigger):
         waiter_delay: int,
         waiter_max_attempts: int,
         aws_conn_id: str,
-        region_name: str | None,
         response: dict[str, Any],
         db_type: RdsDbType,
+        region_name: str | None = None,
     ) -> None:
         super().__init__(
             serialized_fields={
@@ -218,9 +218,9 @@ class RdsDbStoppedTrigger(AwsBaseWaiterTrigger):
         waiter_delay: int,
         waiter_max_attempts: int,
         aws_conn_id: str,
-        region_name: str | None,
         response: dict[str, Any],
         db_type: RdsDbType,
+        region_name: str | None = None,
     ) -> None:
         super().__init__(
             serialized_fields={


### PR DESCRIPTION
the region is not serialized if it's None, so if a trigger has a non-optional region and we pass `None` to it manually, it doesn't get serialized, and the code crashes when trying to rebuild the trigger from the serialized params, complaining about a missing "region_name" argument.

https://github.com/apache/airflow/blob/05f1acfcb708a6785d5b60dd6a2a1ef930a73a7d/airflow/providers/amazon/aws/triggers/base.py#L103-L105