### PR TITLE
[Models] [Postgres] Check if the dynamically-added index is in the table schema before adding

### DIFF
--- a/airflow/auth/managers/fab/models/__init__.py
+++ b/airflow/auth/managers/fab/models/__init__.py
@@ -255,11 +255,15 @@ class RegisterUser(Model):
 def add_index_on_ab_user_username_postgres(table, conn, **kw):
     if conn.dialect.name != "postgresql":
         return
-    table.indexes.add(Index("idx_ab_user_username", func.lower(table.c.username), unique=True))
+    index_name = "idx_ab_user_username"
+    if not any(table_index.name == index_name for table_index in table.indexes):
+        table.indexes.add(Index(index_name, func.lower(table.c.username), unique=True))
 
 
 @event.listens_for(RegisterUser.__table__, "before_create")
 def add_index_on_ab_register_user_username_postgres(table, conn, **kw):
     if conn.dialect.name != "postgresql":
         return
-    table.indexes.add(Index("idx_ab_register_user_username", func.lower(table.c.username), unique=True))
+    index_name = "idx_ab_register_user_username"
+    if not any(table_index.name == index_name for table_index in table.indexes):
+        table.indexes.add(Index(index_name, func.lower(table.c.username), unique=True))

--- a/tests/auth/managers/fab/test_models.py
+++ b/tests/auth/managers/fab/test_models.py
@@ -20,7 +20,7 @@ from unittest import mock
 
 from sqlalchemy import Column, MetaData, String, Table
 
-from airflow.www.fab_security.sqla.models import (
+from airflow.auth.managers.fab.models import (
     add_index_on_ab_register_user_username_postgres,
     add_index_on_ab_user_username_postgres,
 )

--- a/tests/www/fab_security/sqla/test_models.py
+++ b/tests/www/fab_security/sqla/test_models.py
@@ -31,6 +31,8 @@ _mock_conn.dialect.name = "postgresql"
 def test_add_index_on_ab_user_username_postgres():
     table = Table('test_table', MetaData(), Column("username", String))
 
+    assert len(table.indexes) == 0
+
     add_index_on_ab_user_username_postgres(table, _mock_conn)
 
     # Assert that the index was added to the table
@@ -44,6 +46,8 @@ def test_add_index_on_ab_user_username_postgres():
 
 def test_add_index_on_ab_register_user_username_postgres():
     table = Table('test_table', MetaData(), Column("username", String))
+
+    assert len(table.indexes) == 0
 
     add_index_on_ab_register_user_username_postgres(table, _mock_conn)
 

--- a/tests/www/fab_security/sqla/test_models.py
+++ b/tests/www/fab_security/sqla/test_models.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from unittest import mock
 
-from sqlalchemy import Table, Column, MetaData, String, create_mock_engine
+from sqlalchemy import Column, MetaData, String, Table
 
 from airflow.www.fab_security.sqla.models import (
     add_index_on_ab_register_user_username_postgres,

--- a/tests/www/fab_security/sqla/test_models.py
+++ b/tests/www/fab_security/sqla/test_models.py
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest import mock
+
+from airflow.www.fab_security.sqla.models import (
+    add_index_on_ab_user_username_postgres,
+    add_index_on_ab_register_user_username_postgres
+)
+
+from sqlalchemy import Table, Column, MetaData, String, create_mock_engine
+
+_mock_conn = mock.MagicMock()
+_mock_conn.dialect = mock.MagicMock()
+_mock_conn.dialect.name = "postgresql"
+
+
+def test_add_index_on_ab_user_username_postgres():
+    table = Table('test_table', MetaData(), Column("username", String))
+
+    add_index_on_ab_user_username_postgres(table, _mock_conn)
+
+    # Assert that the index was added to the table
+    assert len(table.indexes) == 1
+
+    add_index_on_ab_user_username_postgres(table, _mock_conn)
+
+    # Assert that index is not re-added when the schema is recreated
+    assert len(table.indexes) == 1
+
+
+def test_add_index_on_ab_register_user_username_postgres():
+    table = Table('test_table', MetaData(), Column("username", String))
+
+    add_index_on_ab_register_user_username_postgres(table, _mock_conn)
+
+    # Assert that the index was added to the table
+    assert len(table.indexes) == 1
+
+    add_index_on_ab_register_user_username_postgres(table, _mock_conn)
+
+    # Assert that index is not re-added when the schema is recreated
+    assert len(table.indexes) == 1

--- a/tests/www/fab_security/sqla/test_models.py
+++ b/tests/www/fab_security/sqla/test_models.py
@@ -14,14 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
 from unittest import mock
 
-from airflow.www.fab_security.sqla.models import (
-    add_index_on_ab_user_username_postgres,
-    add_index_on_ab_register_user_username_postgres
-)
-
 from sqlalchemy import Table, Column, MetaData, String, create_mock_engine
+
+from airflow.www.fab_security.sqla.models import (
+    add_index_on_ab_register_user_username_postgres,
+    add_index_on_ab_user_username_postgres,
+)
 
 _mock_conn = mock.MagicMock()
 _mock_conn.dialect = mock.MagicMock()
@@ -29,7 +31,7 @@ _mock_conn.dialect.name = "postgresql"
 
 
 def test_add_index_on_ab_user_username_postgres():
-    table = Table('test_table', MetaData(), Column("username", String))
+    table = Table("test_table", MetaData(), Column("username", String))
 
     assert len(table.indexes) == 0
 
@@ -45,7 +47,7 @@ def test_add_index_on_ab_user_username_postgres():
 
 
 def test_add_index_on_ab_register_user_username_postgres():
-    table = Table('test_table', MetaData(), Column("username", String))
+    table = Table("test_table", MetaData(), Column("username", String))
 
     assert len(table.indexes) == 0
 


### PR DESCRIPTION
We are utilizing the new `dag.test()` functionality with a Postgres-backed SQLAlchemy engine/session. We use the `airflow.utils.initdb()` and `airflow.utils.resetdb()` functions for test case setup/teardown.

When the schema is created for the second time, these event listeners add duplicate indexes to the SQLAlchemy `Table` definition, which causes the `metadata.create_all()` function to fail with a `DatabaseError` as it issues multiple `CREATE UNIQUE INDEX` statements for `idx_ab_user_username` and `idx_ab_register_user_username`.

This updates the listeners to check if the indexes have already been added before adding them to the `Table` definition.