### PR TITLE
FIX AWS deferrable operators by using AioCredentials when using `assume_role`

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -197,7 +197,6 @@ class BaseSessionFactory(LoggingMixin):
     def _create_session_with_assume_role(
         self, session_kwargs: dict[str, Any], deferrable: bool = False
     ) -> boto3.session.Session:
-
         if self.conn.assume_role_method == "assume_role_with_web_identity":
             # Deferred credentials have no initial credentials
             credential_fetcher = self._get_web_identity_credential_fetcher()
@@ -206,10 +205,10 @@ class BaseSessionFactory(LoggingMixin):
                 from aiobotocore.credentials import AioDeferredRefreshableCredentials
 
                 credentials = AioDeferredRefreshableCredentials(
-                method="assume-role-with-web-identity",
-                refresh_using=credential_fetcher.fetch_credentials,
-                time_fetcher=lambda: datetime.datetime.now(tz=tzlocal()),
-            )
+                    method="assume-role-with-web-identity",
+                    refresh_using=credential_fetcher.fetch_credentials,
+                    time_fetcher=lambda: datetime.datetime.now(tz=tzlocal()),
+                )
             else:
                 credentials = botocore.credentials.DeferredRefreshableCredentials(
                     method="assume-role-with-web-identity",

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -334,7 +334,8 @@ class TestSessionFactory:
             # It shouldn't be 'explicit' which refers in this case to initial credentials.
             credentials = await session.get_credentials()
 
-            assert inspect.iscoroutinefunction(credentials._refresh)
+            assert inspect.iscoroutinefunction(credentials.get_frozen_credentials)
+
             assert credentials.method == "sts-assume-role"
 
 

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import inspect
 import json
 import os
 from base64 import b64encode
@@ -332,6 +333,8 @@ class TestSessionFactory:
             # Validate method of botocore credentials provider.
             # It shouldn't be 'explicit' which refers in this case to initial credentials.
             credentials = await session.get_credentials()
+
+            assert inspect.iscoroutinefunction(credentials._refresh)
             assert credentials.method == "sts-assume-role"
 
 


### PR DESCRIPTION
Closes: #32732 airflow.providers.amazong.aws.hooks.base_aws.BaseSessionFactory feeds synchronous credentials to aiobotocore when using `assume_role` 

