### PR TITLE
fix(chart): CeleryExecutor namespace depends on Airflow version

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -371,6 +371,14 @@ If release name contains chart name it will be used as a full name.
   {{- printf "%s/%s" .Values.kerberos.ccacheMountPath .Values.kerberos.ccacheFileName }}
 {{- end }}
 
+{{- define "celery_executor_namespace" -}}
+  {{- if semverCompare ">=2.7.0" .Values.airflowVersion }}
+    {{- print "airflow.providers.celery.executors.celery_executor.app" -}}
+  {{- else }}
+    {{- print "airflow.executors.celery_executor.app" -}}
+  {{- end }}
+{{- end }}
+
 {{- define "pgbouncer_config" -}}
 {{ $resultBackendConnection := .Values.data.resultBackendConnection | default .Values.data.metadataConnection }}
 {{ $pgMetadataHost := .Values.data.metadataConnection.host | default (printf "%s-%s.%s" .Release.Name "postgresql" .Release.Namespace) }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -205,7 +205,7 @@ spec:
                 {{- else }}
                 - sh
                 - -c
-                - CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -m celery --app airflow.providers.celery.executors.celery_executor.app inspect ping -d celery@$(hostname)
+                - CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -m celery --app {{ include "celery_executor_namespace" . }} inspect ping -d celery@$(hostname)
                 {{- end }}
           {{- end }}
           ports:


### PR DESCRIPTION
CeleryExecutor is being decoupled from Airflow in version 2.7.0. This work was done in PR #32526.
However, the changed [Celery Worker liveness probe command](https://github.com/apache/airflow/commit/40d54eac1a2f35167bdd179fda3fd018fe32d116#diff-d15292314311e66e5f15e30cee25dc3ce6e914050d9900e62283a5d7e5b5eea8) breaks backward compatibility. 

This PR adds a `semverCompare` to use the right import namespace depending on the Airflow version defined in the chart.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
