### PR TITLE
Fix prefix group false graph

### DIFF
--- a/airflow/www/static/js/dag/details/graph/Node.tsx
+++ b/airflow/www/static/js/dag/details/graph/Node.tsx
@@ -47,6 +47,7 @@ export interface CustomNodeProps {
   isOpen?: boolean;
   isActive?: boolean;
   setupTeardownType?: "setup" | "teardown";
+  fullParentNode?: string;
 }
 
 export const BaseNode = ({

--- a/airflow/www/static/js/dag/details/graph/utils.ts
+++ b/airflow/www/static/js/dag/details/graph/utils.ts
@@ -155,8 +155,21 @@ export const buildEdges = ({
       type: "custom",
     }))
     .map((e) => {
-      const sourceIds = e.source.split(".");
-      const targetIds = e.target.split(".");
+      const sourceNode = nodes.find((n) => n.id === e.source);
+      const targetNode = nodes.find((n) => n.id === e.target);
+
+      // Before finding the depth of the edge, append the parentNode in case prefix_group_id is false
+      const sourceIds = (
+        sourceNode?.parentNode && e.source.includes(sourceNode.parentNode)
+          ? e.source
+          : `${sourceNode?.parentNode}.${e.source}`
+      ).split(".");
+      const targetIds = (
+        targetNode?.parentNode && e.target.includes(targetNode.parentNode)
+          ? e.target
+          : `${targetNode?.parentNode}.${e.target}`
+      ).split(".");
+
       const isSelected =
         selectedTaskId &&
         (e.source === selectedTaskId || e.target === selectedTaskId);

--- a/airflow/www/static/js/dag/details/graph/utils.ts
+++ b/airflow/www/static/js/dag/details/graph/utils.ts
@@ -51,10 +51,18 @@ export const flattenNodes = ({
 }: FlattenNodesProps) => {
   let nodes: ReactFlowNode<CustomNodeProps>[] = [];
   const parentNode = parent ? { parentNode: parent.id } : undefined;
+
+  let fullParentNode: string | undefined;
+  if (parent) {
+    fullParentNode =
+      parent.parentNode && !parent.id.startsWith(parent.parentNode)
+        ? `${parent.parentNode}.${parent.id}`
+        : parent.id;
+  }
   children.forEach((node) => {
     let instance: TaskInstance | undefined;
     const group = getTask({ taskId: node.id, task: groups });
-    if (!node.id.includes("join_id") && selected.runId) {
+    if (!node.id.endsWith("join_id") && selected.runId) {
       instance = group?.instances.find((ti) => ti.runId === selected.runId);
     }
     const isSelected = node.id === selected.taskId && !!instance;
@@ -82,6 +90,7 @@ export const flattenNodes = ({
           }
           onToggleGroups(newGroupIds);
         },
+        fullParentNode,
         ...node.value,
       },
       type: "custom",
@@ -160,14 +169,16 @@ export const buildEdges = ({
 
       // Before finding the depth of the edge, append the parentNode in case prefix_group_id is false
       const sourceIds = (
-        sourceNode?.parentNode && e.source.includes(sourceNode.parentNode)
+        sourceNode?.data.fullParentNode &&
+        e.source.startsWith(sourceNode.data.fullParentNode)
           ? e.source
-          : `${sourceNode?.parentNode}.${e.source}`
+          : `${sourceNode?.data.fullParentNode}.${e.source}`
       ).split(".");
       const targetIds = (
-        targetNode?.parentNode && e.target.includes(targetNode.parentNode)
+        targetNode?.data.fullParentNode &&
+        e.target.startsWith(targetNode.data.fullParentNode)
           ? e.target
-          : `${targetNode?.parentNode}.${e.target}`
+          : `${targetNode?.data.fullParentNode}.${e.target}`
       ).split(".");
 
       const isSelected =


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/31025

Rearrange how we determine which edges to show and their positions for nested edges when the group has `prefix_group_id=False` and if prefix=False groups are nested inside of one another.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
