### PR TITLE
Move webserver config writing to main

### DIFF
--- a/airflow/__main__.py
+++ b/airflow/__main__.py
@@ -34,6 +34,7 @@ import argcomplete
 # any possible import cycles with settings downstream.
 from airflow import configuration
 from airflow.cli import cli_parser
+from airflow.configuration import write_webserver_configuration_if_needed
 
 
 def main():
@@ -52,7 +53,11 @@ def main():
         # in main ensures that it is not done during tests and other ways airflow imports are used
         from airflow.configuration import write_default_airflow_configuration_if_needed
 
-        write_default_airflow_configuration_if_needed()
+        conf = write_default_airflow_configuration_if_needed()
+
+        if args.subcommand == "webserver":
+            write_webserver_configuration_if_needed(conf)
+
     args.func(args)
 
 

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -24,7 +24,7 @@ from unittest import mock
 
 import pytest
 
-from airflow.configuration import initialize_config
+from airflow.configuration import initialize_config, write_webserver_configuration_if_needed
 from airflow.plugins_manager import AirflowPlugin, EntryPointSource
 from airflow.utils.task_group import TaskGroup
 from airflow.www import views
@@ -68,7 +68,8 @@ def test_webserver_configuration_config_file(mock_webserver_config_global, admin
 
     config_file = str(tmp_path / "my_custom_webserver_config.py")
     with mock.patch.dict(os.environ, {"AIRFLOW__WEBSERVER__CONFIG_FILE": config_file}):
-        initialize_config()
+        conf = initialize_config()
+        write_webserver_configuration_if_needed(conf)
         assert airflow.configuration.WEBSERVER_CONFIG == config_file
 
     assert os.path.isfile(config_file)


### PR DESCRIPTION
So far configuration was automatically written no matter what command
has been invoked. This means tha webserver configuration is stored
for all components, where it was only really needed for webserver.

This small change moves the place where configuration writing is
invoked  - webserver configuration will only be automatically
checked for and written when webserver command has been invoked
via __main__ entrypoint.

This has also the nice side-effect that it is not written during
tests, or when airflow is just imported.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
