### PR TITLE
Remove atlas config

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1289,40 +1289,6 @@ openlineage:
       example: ~
       type: boolean
       version_added: ~
-atlas:
-  description: ~
-  options:
-    sasl_enabled:
-      description: ~
-      version_added: ~
-      type: string
-      example: ~
-      default: "False"
-    host:
-      description: ~
-      version_added: ~
-      type: string
-      example: ~
-      default: ""
-    port:
-      description: ~
-      version_added: ~
-      type: string
-      example: ~
-      default: "21000"
-    username:
-      description: ~
-      version_added: ~
-      type: string
-      example: ~
-      default: ""
-    password:
-      description: ~
-      version_added: ~
-      type: string
-      sensitive: true
-      example: ~
-      default: ""
 operators:
   description: ~
   options:

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -1600,7 +1600,6 @@ def test_sensitive_values():
     sensitive_values = {
         ("database", "sql_alchemy_conn"),
         ("core", "fernet_key"),
-        ("atlas", "password"),
         ("smtp", "smtp_password"),
         ("webserver", "secret_key"),
         ("secrets", "backend_kwargs"),


### PR DESCRIPTION
Atlas does not have its own provider, the only thing we have with
atlas extra is an extra dependency to atlasclient. Abd we also had
the atlas configuration for some reason that even the eldest don't
know. With hard-coded defaults, we are still keeping backwards
compatibility if someone used those values. However we should
remove it from "core" configuration because it has absolutely no
meaning for Airflow. Users are free to define their own sections
and variables following Airflow schema and this squarely fits into
this category.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
