### PR TITLE
Override base log folder by using task handler's base_log_folder

### DIFF
--- a/airflow/utils/serve_logs.py
+++ b/airflow/utils/serve_logs.py
@@ -34,9 +34,9 @@ from jwt.exceptions import (
 from setproctitle import setproctitle
 
 from airflow.configuration import conf
-from airflow.logging_config import configure_logging
 from airflow.utils.docs import get_docs_url
 from airflow.utils.jwt_signer import JWTSigner
+from airflow.utils.module_loading import import_string
 
 logger = logging.getLogger(__name__)
 
@@ -45,12 +45,10 @@ def create_app():
     flask_app = Flask(__name__, static_folder=None)
     expiration_time_in_seconds = conf.getint("webserver", "log_request_clock_grace", fallback=30)
     log_directory = os.path.expanduser(conf.get("logging", "BASE_LOG_FOLDER"))
-    log_config_class = configure_logging()
-    if log_config_class is not None:
+    log_config_class = conf.get("logging", "logging_config_class")
+    if log_config_class:
         logger.info("Detected user-defined logging config. Attempting to load %s", log_config_class)
         try:
-            from airflow.utils.module_loading import import_string
-
             logging_config = import_string(log_config_class)
             try:
                 base_log_folder = logging_config["handlers"]["task"]["base_log_folder"]

--- a/airflow/utils/serve_logs.py
+++ b/airflow/utils/serve_logs.py
@@ -44,7 +44,31 @@ def create_app():
     flask_app = Flask(__name__, static_folder=None)
     expiration_time_in_seconds = conf.getint("webserver", "log_request_clock_grace", fallback=30)
     log_directory = os.path.expanduser(conf.get("logging", "BASE_LOG_FOLDER"))
+    log_config_class = conf.get("logging", "logging_config_class")
+    if log_config_class is not None:
+        logger.info(f"Detected user-defined logging config. Attempting to load {log_config_class}")
+        try:
+            import importlib
 
+            module_name, dict_name = log_config_class.split(".")
+            module = importlib.import_module(module_name)
+            logging_config = getattr(module, dict_name)
+            handler_config = logging_config.get("handlers", {})
+            task_config = handler_config.get("task", {})
+            base_log_folder = task_config.get("base_log_folder", None)
+            if base_log_folder is not None:
+                log_directory = base_log_folder
+                logger.info(
+                    f"Successfully imported user-defined logging config. "
+                    f"Flask App will serve log from {log_directory}"
+                )
+            else:
+                logger.warning(
+                    f"User-defined logging config does not specify 'base_log_folder'. "
+                    f"Flask App will use default log directory {log_directory}"
+                )
+        except Exception as e:
+            raise ImportError(f"Unable to load {log_config_class} due to error: {e}")
     signer = JWTSigner(
         secret_key=conf.get("webserver", "secret_key"),
         expiration_time_in_seconds=expiration_time_in_seconds,

--- a/tests/utils/test_serve_logs.py
+++ b/tests/utils/test_serve_logs.py
@@ -22,7 +22,9 @@ from typing import TYPE_CHECKING
 import jwt
 import pytest
 import time_machine
+from py import path
 
+from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.utils.jwt_signer import JWTSigner
 from airflow.utils.serve_logs import create_app
 from tests.test_utils.config import conf_vars
@@ -34,7 +36,7 @@ LOG_DATA = "Airflow log data" * 20
 
 
 @pytest.fixture
-def client(tmpdir):
+def client_without_config(tmpdir):
     with conf_vars({("logging", "base_log_folder"): str(tmpdir)}):
         app = create_app()
 
@@ -42,10 +44,38 @@ def client(tmpdir):
 
 
 @pytest.fixture
-def sample_log(tmpdir):
-    f = tmpdir / "sample.log"
-    f.write(LOG_DATA.encode())
+def client_with_config(tmpdir):
+    with conf_vars(
+        {
+            (
+                "logging",
+                "logging_config_class",
+            ): "airflow.config_templates.airflow_local_settings.DEFAULT_LOGGING_CONFIG"
+        }
+    ):
+        app = create_app()
 
+        yield app.test_client()
+
+
+@pytest.fixture(params=["client_without_config", "client_with_config"])
+def client(request):
+    return request.getfixturevalue(request.param)
+
+
+@pytest.fixture
+def sample_log(request, tmpdir):
+    client = request.getfixturevalue("client")
+
+    if client == request.getfixturevalue("client_without_config"):
+        f = tmpdir / "sample.log"
+    elif client == request.getfixturevalue("client_with_config"):
+        log_folder = DEFAULT_LOGGING_CONFIG["handlers"]["task"]["base_log_folder"]
+        f = path.local(log_folder) / "sample.log"
+    else:
+        raise ValueError(f"Unknown client fixture: {client}")
+
+    f.write(LOG_DATA.encode())
     return f
 
 

--- a/tests/utils/test_serve_logs.py
+++ b/tests/utils/test_serve_logs.py
@@ -17,12 +17,12 @@
 from __future__ import annotations
 
 import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import jwt
 import pytest
 import time_machine
-from py import path
 
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.utils.jwt_signer import JWTSigner
@@ -68,14 +68,14 @@ def sample_log(request, tmpdir):
     client = request.getfixturevalue("client")
 
     if client == request.getfixturevalue("client_without_config"):
-        f = tmpdir / "sample.log"
+        f = Path(tmpdir) / "sample.log"
     elif client == request.getfixturevalue("client_with_config"):
-        log_folder = DEFAULT_LOGGING_CONFIG["handlers"]["task"]["base_log_folder"]
-        f = path.local(log_folder) / "sample.log"
+        log_folder = Path(DEFAULT_LOGGING_CONFIG["handlers"]["task"]["base_log_folder"])
+        f = log_folder / "sample.log"
     else:
         raise ValueError(f"Unknown client fixture: {client}")
 
-    f.write(LOG_DATA.encode())
+    f.write_bytes(LOG_DATA.encode())
     return f
 
 

--- a/tests/utils/test_serve_logs.py
+++ b/tests/utils/test_serve_logs.py
@@ -36,15 +36,15 @@ LOG_DATA = "Airflow log data" * 20
 
 
 @pytest.fixture
-def client_without_config(tmpdir):
-    with conf_vars({("logging", "base_log_folder"): str(tmpdir)}):
+def client_without_config(tmp_path):
+    with conf_vars({("logging", "base_log_folder"): tmp_path.as_posix()}):
         app = create_app()
 
         yield app.test_client()
 
 
 @pytest.fixture
-def client_with_config(tmpdir):
+def client_with_config():
     with conf_vars(
         {
             (
@@ -64,17 +64,17 @@ def client(request):
 
 
 @pytest.fixture
-def sample_log(request, tmpdir):
+def sample_log(request, tmp_path):
     client = request.getfixturevalue("client")
 
     if client == request.getfixturevalue("client_without_config"):
-        f = Path(tmpdir) / "sample.log"
+        base_log_dir = tmp_path
     elif client == request.getfixturevalue("client_with_config"):
-        log_folder = Path(DEFAULT_LOGGING_CONFIG["handlers"]["task"]["base_log_folder"])
-        f = log_folder / "sample.log"
+        base_log_dir = Path(DEFAULT_LOGGING_CONFIG["handlers"]["task"]["base_log_folder"])
     else:
         raise ValueError(f"Unknown client fixture: {client}")
 
+    f = base_log_dir.joinpath("sample.log")
     f.write_bytes(LOG_DATA.encode())
     return f
 


### PR DESCRIPTION
Fixes #23967 

Original code use `log_directory` defined in `airflow.cfg` even though another `base_log_folder` is defined in logging config. 

This PR adds logic to attempt to override `log_directory` if `logging_config_class` and `base_log_folder` are both defined, and fall back to original default log directory if they don't

How to test if it works: 

1. execute `breeze start-airflow --executor CeleryExecutor --backend postgres --load-example-dags --db-reset`
2. go to `$AIRFLOW_HOME`, create a directory called `config`, and create an empty `__init__.py` and `log_config.py` file inside
3. Inside `airflow/config_templates/airflow_local_settings.py`, modify `DEFAULT_LOGGING_CONFIG[handlers][task][base_log_folder]` to some other different locations
4. copy all the contents inside `airflow/config_templates/airflow_local_settings.py` into `log_config.py`
5. In `/root/airflow/airflow.cfg` , under `logging` section,  modify `logging_config_class` to `log_config.DEFAULT_LOGGING_CONFIG`
6. Restart everything
7. Run a DAG in webUI, check the log, and you should be about to see the logs are served. 
8. Go to the location that you defined in step 3, and you should see the dag log
