### PR TITLE
Ensure BaseOperator in MappedTaskGroup is expanded

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -78,6 +78,7 @@ from airflow.models.taskinstance import TaskInstance, clear_task_instances
 from airflow.models.taskmixin import DependencyMixin
 from airflow.serialization.enums import DagAttributeTypes
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.ti_deps.deps.mapped_task_expanded import MappedTaskIsExpanded
 from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
 from airflow.ti_deps.deps.not_previously_skipped_dep import NotPreviouslySkippedDep
 from airflow.ti_deps.deps.prev_dagrun_dep import PrevDagrunDep
@@ -1115,12 +1116,13 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         return self._dag is not None
 
     deps: frozenset[BaseTIDep] = frozenset(
-        {
+        (
             NotInRetryPeriodDep(),
             PrevDagrunDep(),
+            MappedTaskIsExpanded(),
             TriggerRuleDep(),
             NotPreviouslySkippedDep(),
-        }
+        )
     )
     """
     Returns the set of dependencies for the operator. These differ from execution

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -59,7 +59,6 @@ from airflow.models.param import ParamsDict
 from airflow.models.pool import Pool
 from airflow.serialization.enums import DagAttributeTypes
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
-from airflow.ti_deps.deps.mapped_task_expanded import MappedTaskIsExpanded
 from airflow.typing_compat import Literal
 from airflow.utils.context import Context, context_update_for_unmapped
 from airflow.utils.helpers import is_container, prevent_duplicates
@@ -368,7 +367,7 @@ class MappedOperator(AbstractOperator):
                 f"'deps' must be a set defined as a class-level variable on {operator_class.__name__}, "
                 f"not a {type(operator_deps).__name__}"
             )
-        return operator_deps | {MappedTaskIsExpanded()}
+        return operator_deps
 
     @property
     def task_type(self) -> str:

--- a/airflow/ti_deps/deps/mapped_task_expanded.py
+++ b/airflow/ti_deps/deps/mapped_task_expanded.py
@@ -28,9 +28,13 @@ class MappedTaskIsExpanded(BaseTIDep):
     IS_TASK_DEP = False
 
     def _get_dep_statuses(self, ti, session, dep_context):
+        from airflow.models.operator import needs_expansion
+
         if dep_context.ignore_unmapped_tasks:
             return
-        if ti.map_index == -1:
-            yield self._failing_status(reason="The task has yet to be mapped!")
+        if not needs_expansion(ti.task):
             return
-        yield self._passing_status(reason="The task has been mapped")
+        if ti.map_index == -1:
+            yield self._failing_status(reason="The task has yet to be expanded!")
+            return
+        yield self._passing_status(reason="The task has been expanded")


### PR DESCRIPTION
This applies MappedTaskIsExpanded to BaseOperator (as well as MappedOperator), so it is checked to be expanded if it's in a mapped task group.

Fix #30333
Fix #30334
Close #32701

cc @antonio-antuan @dzhigimont Would be nice if you both could give this a try. I’ll add a test case if this works.