### PR TITLE
Adding support for disabling token mounts using automountServiceAccountToken

### DIFF
--- a/chart/templates/cleanup/cleanup-serviceaccount.yaml
+++ b/chart/templates/cleanup/cleanup-serviceaccount.yaml
@@ -23,6 +23,7 @@
 {{- if and .Values.cleanup.serviceAccount.create .Values.cleanup.enabled }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.cleanup.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "cleanup.serviceAccountName" . }}
   labels:

--- a/chart/templates/dag-processor/dag-processor-serviceaccount.yaml
+++ b/chart/templates/dag-processor/dag-processor-serviceaccount.yaml
@@ -24,6 +24,7 @@
 {{- if and .Values.dagProcessor.serviceAccount.create .Values.dagProcessor.enabled }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.dagProcessor.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "dagProcessor.serviceAccountName" . }}
   labels:

--- a/chart/templates/flower/flower-serviceaccount.yaml
+++ b/chart/templates/flower/flower-serviceaccount.yaml
@@ -23,6 +23,7 @@
 {{- if and .Values.flower.enabled (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")) .Values.flower.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.flower.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "flower.serviceAccountName" . }}
   labels:

--- a/chart/templates/jobs/create-user-job-serviceaccount.yaml
+++ b/chart/templates/jobs/create-user-job-serviceaccount.yaml
@@ -23,6 +23,7 @@
 {{- if and .Values.createUserJob.serviceAccount.create .Values.webserver.defaultUser.enabled }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.createUserJob.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "createUserJob.serviceAccountName" . }}
   labels:

--- a/chart/templates/jobs/migrate-database-job-serviceaccount.yaml
+++ b/chart/templates/jobs/migrate-database-job-serviceaccount.yaml
@@ -23,6 +23,7 @@
 {{- if .Values.migrateDatabaseJob.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.migrateDatabaseJob.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "migrateDatabaseJob.serviceAccountName" . }}
   labels:

--- a/chart/templates/pgbouncer/pgbouncer-serviceaccount.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-serviceaccount.yaml
@@ -23,6 +23,7 @@
 {{- if and .Values.pgbouncer.serviceAccount.create .Values.pgbouncer.enabled }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.pgbouncer.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "pgbouncer.serviceAccountName" . }}
   labels:

--- a/chart/templates/redis/redis-serviceaccount.yaml
+++ b/chart/templates/redis/redis-serviceaccount.yaml
@@ -23,6 +23,7 @@
 {{- if and .Values.redis.enabled .Values.redis.serviceAccount.create (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")) }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.redis.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "redis.serviceAccountName" . }}
   labels:

--- a/chart/templates/scheduler/scheduler-serviceaccount.yaml
+++ b/chart/templates/scheduler/scheduler-serviceaccount.yaml
@@ -23,6 +23,7 @@
 {{- if .Values.scheduler.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.scheduler.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "scheduler.serviceAccountName" . }}
   labels:

--- a/chart/templates/statsd/statsd-serviceaccount.yaml
+++ b/chart/templates/statsd/statsd-serviceaccount.yaml
@@ -23,6 +23,7 @@
 {{- if and .Values.statsd.enabled .Values.statsd.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.statsd.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "statsd.serviceAccountName" . }}
   labels:

--- a/chart/templates/triggerer/triggerer-serviceaccount.yaml
+++ b/chart/templates/triggerer/triggerer-serviceaccount.yaml
@@ -24,6 +24,7 @@
 {{- if and .Values.triggerer.serviceAccount.create .Values.triggerer.enabled }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.triggerer.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "triggerer.serviceAccountName" . }}
   labels:

--- a/chart/templates/webserver/webserver-serviceaccount.yaml
+++ b/chart/templates/webserver/webserver-serviceaccount.yaml
@@ -23,6 +23,7 @@
 {{- if .Values.webserver.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.webserver.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "webserver.serviceAccountName" . }}
   labels:

--- a/chart/templates/workers/worker-serviceaccount.yaml
+++ b/chart/templates/workers/worker-serviceaccount.yaml
@@ -23,6 +23,7 @@
 {{- if and .Values.workers.serviceAccount.create (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") (eq .Values.executor "KubernetesExecutor") (eq .Values.executor "LocalKubernetesExecutor")) }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.workers.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "worker.serviceAccountName" . }}
   labels:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1388,6 +1388,11 @@
                     "description": "Create ServiceAccount.",
                     "type": "object",
                     "properties": {
+                        "automountServiceAccountToken": {
+                            "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "create": {
                             "description": "Specifies whether a ServiceAccount should be created.",
                             "type": "boolean",
@@ -2015,6 +2020,11 @@
                     "description": "Create ServiceAccount.",
                     "type": "object",
                     "properties": {
+                        "automountServiceAccountToken": {
+                            "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "create": {
                             "description": "Specifies whether a ServiceAccount should be created.",
                             "type": "boolean",
@@ -2444,6 +2454,11 @@
                     "description": "Create ServiceAccount.",
                     "type": "object",
                     "properties": {
+                        "automountServiceAccountToken": {
+                            "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "create": {
                             "description": "Specifies whether a ServiceAccount should be created.",
                             "type": "boolean",
@@ -2873,6 +2888,11 @@
                     "description": "Create ServiceAccount.",
                     "type": "object",
                     "properties": {
+                        "automountServiceAccountToken": {
+                            "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "create": {
                             "description": "Specifies whether a ServiceAccount should be created.",
                             "type": "boolean",
@@ -3221,6 +3241,11 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
+                        "automountServiceAccountToken": {
+                            "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "create": {
                             "description": "Specifies whether a ServiceAccount should be created.",
                             "type": "boolean",
@@ -3467,6 +3492,11 @@
                     "description": "Create ServiceAccount.",
                     "type": "object",
                     "properties": {
+                        "automountServiceAccountToken": {
+                            "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "create": {
                             "description": "Specifies whether a ServiceAccount should be created.",
                             "type": "boolean",
@@ -3784,6 +3814,11 @@
                     "description": "Create ServiceAccount.",
                     "type": "object",
                     "properties": {
+                        "automountServiceAccountToken": {
+                            "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "create": {
                             "description": "Specifies whether a ServiceAccount should be created.",
                             "type": "boolean",
@@ -4514,6 +4549,11 @@
                     "description": "Create ServiceAccount.",
                     "type": "object",
                     "properties": {
+                        "automountServiceAccountToken": {
+                            "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "create": {
                             "description": "Specifies whether a ServiceAccount should be created.",
                             "type": "boolean",
@@ -4765,6 +4805,11 @@
                     "description": "Create ServiceAccount.",
                     "type": "object",
                     "properties": {
+                        "automountServiceAccountToken": {
+                            "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "create": {
                             "description": "Specifies whether a ServiceAccount should be created.",
                             "type": "boolean",
@@ -5249,6 +5294,11 @@
                     "description": "Create ServiceAccount.",
                     "type": "object",
                     "properties": {
+                        "automountServiceAccountToken": {
+                            "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "create": {
                             "description": "Specifies whether a ServiceAccount should be created.",
                             "type": "boolean",
@@ -5548,6 +5598,11 @@
                     "description": "Create ServiceAccount.",
                     "type": "object",
                     "properties": {
+                        "automountServiceAccountToken": {
+                            "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "create": {
                             "description": "Specifies whether a ServiceAccount should be created.",
                             "type": "boolean",
@@ -5950,6 +6005,11 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
+                        "automountServiceAccountToken": {
+                            "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "create": {
                             "description": "Specifies whether a ServiceAccount should be created.",
                             "type": "boolean",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -515,6 +515,9 @@ workers:
 
   # Create ServiceAccount
   serviceAccount:
+    # default value is true
+    # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    automountServiceAccountToken: true
     # Specifies whether a ServiceAccount should be created
     create: true
     # The name of the ServiceAccount to use.
@@ -750,6 +753,9 @@ scheduler:
 
   # Create ServiceAccount
   serviceAccount:
+    # default value is true
+    # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    automountServiceAccountToken: true
     # Specifies whether a ServiceAccount should be created
     create: true
     # The name of the ServiceAccount to use.
@@ -905,6 +911,9 @@ createUserJob:
 
   # Create ServiceAccount
   serviceAccount:
+    # default value is true
+    # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    automountServiceAccountToken: true
     # Specifies whether a ServiceAccount should be created
     create: true
     # The name of the ServiceAccount to use.
@@ -985,6 +994,9 @@ migrateDatabaseJob:
 
   # Create ServiceAccount
   serviceAccount:
+    # default value is true
+    # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    automountServiceAccountToken: true
     # Specifies whether a ServiceAccount should be created
     create: true
     # The name of the ServiceAccount to use.
@@ -1066,6 +1078,9 @@ webserver:
 
   # Create ServiceAccount
   serviceAccount:
+    # default value is true
+    # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    automountServiceAccountToken: true
     # Specifies whether a ServiceAccount should be created
     create: true
     # The name of the ServiceAccount to use.
@@ -1259,6 +1274,9 @@ triggerer:
 
   # Create ServiceAccount
   serviceAccount:
+    # default value is true
+    # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    automountServiceAccountToken: true
     # Specifies whether a ServiceAccount should be created
     create: true
     # The name of the ServiceAccount to use.
@@ -1412,6 +1430,9 @@ dagProcessor:
 
   # Create ServiceAccount
   serviceAccount:
+    # default value is true
+    # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    automountServiceAccountToken: true
     # Specifies whether a ServiceAccount should be created
     create: true
     # The name of the ServiceAccount to use.
@@ -1563,6 +1584,9 @@ flower:
 
   # Create ServiceAccount
   serviceAccount:
+    # default value is true
+    # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    automountServiceAccountToken: true
     # Specifies whether a ServiceAccount should be created
     create: true
     # The name of the ServiceAccount to use.
@@ -1645,6 +1669,9 @@ statsd:
 
   # Create ServiceAccount
   serviceAccount:
+    # default value is true
+    # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    automountServiceAccountToken: true
     # Specifies whether a ServiceAccount should be created
     create: true
     # The name of the ServiceAccount to use.
@@ -1723,6 +1750,9 @@ pgbouncer:
 
   # Create ServiceAccount
   serviceAccount:
+    # default value is true
+    # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    automountServiceAccountToken: true
     # Specifies whether a ServiceAccount should be created
     create: true
     # The name of the ServiceAccount to use.
@@ -1867,6 +1897,9 @@ redis:
 
   # Create ServiceAccount
   serviceAccount:
+    # default value is true
+    # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    automountServiceAccountToken: true
     # Specifies whether a ServiceAccount should be created
     create: true
     # The name of the ServiceAccount to use.
@@ -2010,6 +2043,9 @@ cleanup:
 
   # Create ServiceAccount
   serviceAccount:
+    # default value is true
+    # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    automountServiceAccountToken: true
     # Specifies whether a ServiceAccount should be created
     create: true
     # The name of the ServiceAccount to use.

--- a/helm_tests/airflow_aux/test_cleanup_pods.py
+++ b/helm_tests/airflow_aux/test_cleanup_pods.py
@@ -361,3 +361,23 @@ class TestCleanupServiceAccount:
 
         assert "test_label" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
+
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "cleanup": {
+                    "enabled": True,
+                },
+            },
+            show_only=["templates/webserver/cleanup-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_overriden_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "cleanup": {"enabled": True, "automountServiceAccountToken": False},
+            },
+            show_only=["templates/webserver/cleanup-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False

--- a/helm_tests/airflow_aux/test_cleanup_pods.py
+++ b/helm_tests/airflow_aux/test_cleanup_pods.py
@@ -369,15 +369,15 @@ class TestCleanupServiceAccount:
                     "enabled": True,
                 },
             },
-            show_only=["templates/webserver/cleanup-serviceaccount.yaml"],
+            show_only=["templates/cleanup/cleanup-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
     def test_overriden_automount_service_account_token(self):
         docs = render_chart(
             values={
-                "cleanup": {"enabled": True, "automountServiceAccountToken": False},
+                "cleanup": {"enabled": True, "serviceAccount": {"automountServiceAccountToken": False}},
             },
-            show_only=["templates/webserver/cleanup-serviceaccount.yaml"],
+            show_only=["templates/cleanup/cleanup-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is False

--- a/helm_tests/airflow_aux/test_create_user_job.py
+++ b/helm_tests/airflow_aux/test_create_user_job.py
@@ -396,3 +396,25 @@ class TestCreateUserJobServiceAccount:
 
         assert "test_label" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
+
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "createUserJob": {
+                    "serviceAccount": {"create": True},
+                },
+            },
+            show_only=["templates/webserver/create-user-job-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_overriden_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "createUserJob": {
+                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
+                },
+            },
+            show_only=["templates/webserver/create-user-job-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False

--- a/helm_tests/airflow_aux/test_create_user_job.py
+++ b/helm_tests/airflow_aux/test_create_user_job.py
@@ -404,7 +404,7 @@ class TestCreateUserJobServiceAccount:
                     "serviceAccount": {"create": True},
                 },
             },
-            show_only=["templates/webserver/create-user-job-serviceaccount.yaml"],
+            show_only=["templates/jobs/create-user-job-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
@@ -415,6 +415,6 @@ class TestCreateUserJobServiceAccount:
                     "serviceAccount": {"create": True, "automountServiceAccountToken": False},
                 },
             },
-            show_only=["templates/webserver/create-user-job-serviceaccount.yaml"],
+            show_only=["templates/jobs/create-user-job-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is False

--- a/helm_tests/airflow_aux/test_migrate_database_job.py
+++ b/helm_tests/airflow_aux/test_migrate_database_job.py
@@ -25,6 +25,28 @@ from tests.charts.helm_template_generator import render_chart
 class TestMigrateDatabaseJob:
     """Tests migrate DB job."""
 
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "migrateDatabaseJob": {
+                    "serviceAccount": {"create": True},
+                },
+            },
+            show_only=["templates/webserver/migrate-database-job-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_overriden_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "migrateDatabaseJob": {
+                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
+                },
+            },
+            show_only=["templates/webserver/migrate-database-job-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False
+
     def test_should_run_by_default(self):
         docs = render_chart(show_only=["templates/jobs/migrate-database-job.yaml"])
         assert "Job" == docs[0]["kind"]

--- a/helm_tests/airflow_aux/test_migrate_database_job.py
+++ b/helm_tests/airflow_aux/test_migrate_database_job.py
@@ -32,7 +32,7 @@ class TestMigrateDatabaseJob:
                     "serviceAccount": {"create": True},
                 },
             },
-            show_only=["templates/webserver/migrate-database-job-serviceaccount.yaml"],
+            show_only=["templates/jobs/migrate-database-job-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
@@ -43,7 +43,7 @@ class TestMigrateDatabaseJob:
                     "serviceAccount": {"create": True, "automountServiceAccountToken": False},
                 },
             },
-            show_only=["templates/webserver/migrate-database-job-serviceaccount.yaml"],
+            show_only=["templates/jobs/migrate-database-job-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is False
 

--- a/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm_tests/airflow_core/test_dag_processor.py
@@ -30,10 +30,11 @@ class TestDagProcessor:
         docs = render_chart(
             values={
                 "dagProcessor": {
+                    "enabled": True,
                     "serviceAccount": {"create": True},
                 },
             },
-            show_only=["templates/webserver/dag-processor-serviceaccount.yaml"],
+            show_only=["templates/dag-processor/dag-processor-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
@@ -41,10 +42,11 @@ class TestDagProcessor:
         docs = render_chart(
             values={
                 "dagProcessor": {
+                    "enabled": True,
                     "serviceAccount": {"create": True, "automountServiceAccountToken": False},
                 },
             },
-            show_only=["templates/webserver/dag-processor-serviceaccount.yaml"],
+            show_only=["templates/dag-processor/dag-processor-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is False
 

--- a/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm_tests/airflow_core/test_dag_processor.py
@@ -26,6 +26,28 @@ from tests.charts.log_groomer import LogGroomerTestBase
 class TestDagProcessor:
     """Tests DAG processor."""
 
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "dagProcessor": {
+                    "serviceAccount": {"create": True},
+                },
+            },
+            show_only=["templates/webserver/dag-processor-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_overriden_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "dagProcessor": {
+                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
+                },
+            },
+            show_only=["templates/webserver/dag-processor-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False
+
     @pytest.mark.parametrize(
         "airflow_version, num_docs",
         [

--- a/helm_tests/airflow_core/test_scheduler.py
+++ b/helm_tests/airflow_core/test_scheduler.py
@@ -803,3 +803,25 @@ class TestSchedulerServiceAccount:
 
         assert "test_label" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
+
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "scheduler": {
+                    "serviceAccount": {"create": True},
+                },
+            },
+            show_only=["templates/webserver/scheduler-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_overriden_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "scheduler": {
+                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
+                },
+            },
+            show_only=["templates/webserver/scheduler-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False

--- a/helm_tests/airflow_core/test_scheduler.py
+++ b/helm_tests/airflow_core/test_scheduler.py
@@ -811,7 +811,7 @@ class TestSchedulerServiceAccount:
                     "serviceAccount": {"create": True},
                 },
             },
-            show_only=["templates/webserver/scheduler-serviceaccount.yaml"],
+            show_only=["templates/scheduler/scheduler-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
@@ -822,6 +822,6 @@ class TestSchedulerServiceAccount:
                     "serviceAccount": {"create": True, "automountServiceAccountToken": False},
                 },
             },
-            show_only=["templates/webserver/scheduler-serviceaccount.yaml"],
+            show_only=["templates/scheduler/scheduler-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is False

--- a/helm_tests/airflow_core/test_triggerer.py
+++ b/helm_tests/airflow_core/test_triggerer.py
@@ -598,7 +598,7 @@ class TestTriggererServiceAccount:
                     "serviceAccount": {"create": True},
                 },
             },
-            show_only=["templates/webserver/triggerer-serviceaccount.yaml"],
+            show_only=["templates/triggerer/triggerer-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
@@ -609,7 +609,7 @@ class TestTriggererServiceAccount:
                     "serviceAccount": {"create": True, "automountServiceAccountToken": False},
                 },
             },
-            show_only=["templates/webserver/triggerer-serviceaccount.yaml"],
+            show_only=["templates/triggerer/triggerer-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is False
 

--- a/helm_tests/airflow_core/test_triggerer.py
+++ b/helm_tests/airflow_core/test_triggerer.py
@@ -591,6 +591,28 @@ class TestTriggererServiceAccount:
         assert "test_label" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
 
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "triggerer": {
+                    "serviceAccount": {"create": True},
+                },
+            },
+            show_only=["templates/webserver/triggerer-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_overriden_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "triggerer": {
+                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
+                },
+            },
+            show_only=["templates/webserver/triggerer-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False
+
 
 class TestTriggererLogGroomer(LogGroomerTestBase):
     """Triggerer log groomer."""

--- a/helm_tests/airflow_core/test_worker.py
+++ b/helm_tests/airflow_core/test_worker.py
@@ -792,7 +792,7 @@ class TestWorkerServiceAccount:
                     "serviceAccount": {"create": True},
                 },
             },
-            show_only=["templates/webserver/worker-serviceaccount.yaml"],
+            show_only=["templates/workers/worker-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
@@ -803,6 +803,6 @@ class TestWorkerServiceAccount:
                     "serviceAccount": {"create": True, "automountServiceAccountToken": False},
                 },
             },
-            show_only=["templates/webserver/worker-serviceaccount.yaml"],
+            show_only=["templates/workers/worker-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is False

--- a/helm_tests/airflow_core/test_worker.py
+++ b/helm_tests/airflow_core/test_worker.py
@@ -784,3 +784,25 @@ class TestWorkerServiceAccount:
             assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
         else:
             assert docs == []
+
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "workers": {
+                    "serviceAccount": {"create": True},
+                },
+            },
+            show_only=["templates/webserver/worker-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_overriden_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "workers": {
+                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
+                },
+            },
+            show_only=["templates/webserver/worker-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False

--- a/helm_tests/other/test_flower.py
+++ b/helm_tests/other/test_flower.py
@@ -583,15 +583,23 @@ class TestFlowerServiceAccount:
             values={
                 "flower": {
                     "enabled": True,
+                    "serviceAccount": {
+                        "create": True,
+                    },
                 }
             },
-            show_only=["templates/webserver/flower-serviceaccount.yaml"],
+            show_only=["templates/flower/flower-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
     def test_overriden_automount_service_account_token(self):
         docs = render_chart(
-            values={"flower": {"enabled": True, "automountServiceAccountToken": False}},
-            show_only=["templates/webserver/flower-serviceaccount.yaml"],
+            values={
+                "flower": {
+                    "enabled": True,
+                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
+                }
+            },
+            show_only=["templates/flower/flower-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is False

--- a/helm_tests/other/test_flower.py
+++ b/helm_tests/other/test_flower.py
@@ -577,3 +577,21 @@ class TestFlowerServiceAccount:
 
         assert "test_label" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
+
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "flower": {
+                    "enabled": True,
+                }
+            },
+            show_only=["templates/webserver/flower-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_overriden_automount_service_account_token(self):
+        docs = render_chart(
+            values={"flower": {"enabled": True, "automountServiceAccountToken": False}},
+            show_only=["templates/webserver/flower-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False

--- a/helm_tests/other/test_pgbouncer.py
+++ b/helm_tests/other/test_pgbouncer.py
@@ -27,6 +27,28 @@ from tests.charts.helm_template_generator import render_chart
 class TestPgbouncer:
     """Tests PgBouncer."""
 
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "pgbouncer": {
+                    "serviceAccount": {"create": True},
+                },
+            },
+            show_only=["templates/webserver/pgbouncer-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_overriden_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "pgbouncer": {
+                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
+                },
+            },
+            show_only=["templates/webserver/pgbouncer-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False
+
     @pytest.mark.parametrize("yaml_filename", ["pgbouncer-deployment", "pgbouncer-service"])
     def test_pgbouncer_resources_not_created_by_default(self, yaml_filename):
         docs = render_chart(

--- a/helm_tests/other/test_pgbouncer.py
+++ b/helm_tests/other/test_pgbouncer.py
@@ -31,10 +31,11 @@ class TestPgbouncer:
         docs = render_chart(
             values={
                 "pgbouncer": {
+                    "enabled": True,
                     "serviceAccount": {"create": True},
                 },
             },
-            show_only=["templates/webserver/pgbouncer-serviceaccount.yaml"],
+            show_only=["templates/pgbouncer/pgbouncer-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
@@ -42,10 +43,11 @@ class TestPgbouncer:
         docs = render_chart(
             values={
                 "pgbouncer": {
+                    "enabled": True,
                     "serviceAccount": {"create": True, "automountServiceAccountToken": False},
                 },
             },
-            show_only=["templates/webserver/pgbouncer-serviceaccount.yaml"],
+            show_only=["templates/pgbouncer/pgbouncer-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is False
 

--- a/helm_tests/other/test_redis.py
+++ b/helm_tests/other/test_redis.py
@@ -42,6 +42,28 @@ CELERY_EXECUTORS_PARAMS = ["CeleryExecutor", "CeleryKubernetesExecutor"]
 class TestRedis:
     """Tests redis."""
 
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "redis": {
+                    "serviceAccount": {"create": True},
+                },
+            },
+            show_only=["templates/webserver/redis-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_overriden_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "redis": {
+                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
+                },
+            },
+            show_only=["templates/webserver/redis-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False
+
     @staticmethod
     def get_broker_url_in_broker_url_secret(k8s_obj_by_key):
         broker_url_in_obj = b64decode(

--- a/helm_tests/other/test_redis.py
+++ b/helm_tests/other/test_redis.py
@@ -49,7 +49,7 @@ class TestRedis:
                     "serviceAccount": {"create": True},
                 },
             },
-            show_only=["templates/webserver/redis-serviceaccount.yaml"],
+            show_only=["templates/redis/redis-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
@@ -60,7 +60,7 @@ class TestRedis:
                     "serviceAccount": {"create": True, "automountServiceAccountToken": False},
                 },
             },
-            show_only=["templates/webserver/redis-serviceaccount.yaml"],
+            show_only=["templates/redis/redis-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is False
 

--- a/helm_tests/other/test_statsd.py
+++ b/helm_tests/other/test_statsd.py
@@ -33,7 +33,7 @@ class TestStatsd:
                     "serviceAccount": {"create": True},
                 },
             },
-            show_only=["templates/webserver/statsd-serviceaccount.yaml"],
+            show_only=["templates/statsd/statsd-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
@@ -44,7 +44,7 @@ class TestStatsd:
                     "serviceAccount": {"create": True, "automountServiceAccountToken": False},
                 },
             },
-            show_only=["templates/webserver/statsd-serviceaccount.yaml"],
+            show_only=["templates/statsd/statsd-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is False
 

--- a/helm_tests/other/test_statsd.py
+++ b/helm_tests/other/test_statsd.py
@@ -26,6 +26,28 @@ from tests.charts.helm_template_generator import render_chart
 class TestStatsd:
     """Tests statsd."""
 
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "statsd": {
+                    "serviceAccount": {"create": True},
+                },
+            },
+            show_only=["templates/webserver/statsd-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_overriden_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "statsd": {
+                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
+                },
+            },
+            show_only=["templates/webserver/statsd-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False
+
     def test_should_create_statsd_default(self):
         docs = render_chart(show_only=["templates/statsd/statsd-deployment.yaml"])
 

--- a/helm_tests/webserver/test_webserver.py
+++ b/helm_tests/webserver/test_webserver.py
@@ -1014,3 +1014,25 @@ class TestWebserverServiceAccount:
         )
         assert "test_label" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
+
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "webserver": {
+                    "serviceAccount": {"create": True},
+                },
+            },
+            show_only=["templates/webserver/webserver-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_overriden_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "webserver": {
+                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
+                },
+            },
+            show_only=["templates/webserver/webserver-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

To control mounting of the serviceAccount's API credentials onto pods, automountServiceAccountToken property can be used. The changes can either be in serviceAccount definitions or at pod level. 

This PR adds support by allowing this through helm templates while not changing the regular/default behaviour. ie. automountServiceAccountToken = true.

closes: https://github.com/apache/airflow/issues/30722

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
