### PR TITLE
Add example for list-import-errors as a CI check

### DIFF
--- a/docs/apache-airflow/howto/usage-cli.rst
+++ b/docs/apache-airflow/howto/usage-cli.rst
@@ -377,7 +377,8 @@ JSON example output:
 
 Testing for DAG Import Errors
 -----------------------------
-The CLI can be used to check whether any discovered DAGs have import errors via the `dags` `list-import-errors` command. The output is predictable for situations where there are no errors, such as `[]` for the json style output, so it is possible to create an automation step which fails if any DAGs cannot be imported. For instance, the check could be run in CI or pre-commit.
+The CLI can be used to check whether any discovered DAGs have import errors via the ``list-import-errors`` subcommand. It is possible to create an automation step which fails if any DAGs cannot be imported by checking the command output, particularly when used with ``--output`` to generate a standard file format. 
+For example, the default output when there are no errors is ``No data found``, and the json output is ``[]``. The check can then be run in CI or pre-commit to speed up the review process and testing.
 
 Example command that fails if there are any errors:
 
@@ -385,20 +386,32 @@ Example command that fails if there are any errors:
 
     airflow dags list-import-errors | grep -q "No data found"
 
-This line can be added to automation as-is, or if you want to include the output you can tee the output:
+This can be done more reliably with `jq <https://jqlang.github.io/jq/>`__:
+
+.. code-block:: bash
+
+    airflow dags list-import-errors --output=json | jq -e \'select(type=="array" and length == 0)\'
+
+The line can be added to automation as-is, or if you want to print the output you can use ``tee``:
 
 .. code-block:: bash
 
     airflow dags list-import-errors | tee import_errors.txt && grep -q "No data found" import_errors.txt
+    # or
+    airflow dags list-import-errors | tee import_errors.txt && jq -e \'select(type=="array" and length == 0)\' import_errors.txt
 
 Example in a Jenkins pipeline:
 
 .. code-block:: groovy
 
-    stage('All DAGs can load') {
+    stage('All DAGs are loadable') {
         steps {
             sh 'airflow dags list-import-errors | tee import_errors.txt && grep -q "No data found" import_errors.txt'
+            // or
+            sh 'airflow dags list-import-errors | tee import_errors.txt && jq -e \'select(type=="array" and length == 0)\' import_errors.txt'
         }
     }
 
-NOTE: For this to work accurately, you must ensure Airflow does not log any additional text to stdout. For example, you may need to fix any deprecation warnings, or you may need to set `lazy_load_plugins = True` in the Airflow config if you have a plugin that logs when loaded.
+.. note::
+
+For this to work accurately, you must ensure Airflow does not log any additional text to stdout. For example, you may need to fix any deprecation warnings, add ``2>/dev/null`` to your command, or set ``lazy_load_plugins = True`` in the Airflow config if you have a plugin that generates logs when loaded.

--- a/docs/apache-airflow/howto/usage-cli.rst
+++ b/docs/apache-airflow/howto/usage-cli.rst
@@ -377,7 +377,7 @@ JSON example output:
 
 Testing for DAG Import Errors
 -----------------------------
-The CLI can be used to check whether any discovered DAGs have import errors via the ``list-import-errors`` subcommand. It is possible to create an automation step which fails if any DAGs cannot be imported by checking the command output, particularly when used with ``--output`` to generate a standard file format. 
+The CLI can be used to check whether any discovered DAGs have import errors via the ``list-import-errors`` subcommand. It is possible to create an automation step which fails if any DAGs cannot be imported by checking the command output, particularly when used with ``--output`` to generate a standard file format.
 For example, the default output when there are no errors is ``No data found``, and the json output is ``[]``. The check can then be run in CI or pre-commit to speed up the review process and testing.
 
 Example command that fails if there are any errors, using `jq <https://jqlang.github.io/jq/>`__ to parse the output:
@@ -404,4 +404,4 @@ Example in a Jenkins pipeline:
 
 .. note::
 
-For this to work accurately, you must ensure Airflow does not log any additional text to stdout. For example, you may need to fix any deprecation warnings, add ``2>/dev/null`` to your command, or set ``lazy_load_plugins = True`` in the Airflow config if you have a plugin that generates logs when loaded.
+  For this to work accurately, you must ensure Airflow does not log any additional text to stdout. For example, you may need to fix any deprecation warnings, add ``2>/dev/null`` to your command, or set ``lazy_load_plugins = True`` in the Airflow config if you have a plugin that generates logs when loaded.

--- a/docs/apache-airflow/howto/usage-cli.rst
+++ b/docs/apache-airflow/howto/usage-cli.rst
@@ -380,25 +380,17 @@ Testing for DAG Import Errors
 The CLI can be used to check whether any discovered DAGs have import errors via the ``list-import-errors`` subcommand. It is possible to create an automation step which fails if any DAGs cannot be imported by checking the command output, particularly when used with ``--output`` to generate a standard file format. 
 For example, the default output when there are no errors is ``No data found``, and the json output is ``[]``. The check can then be run in CI or pre-commit to speed up the review process and testing.
 
-Example command that fails if there are any errors:
+Example command that fails if there are any errors, using `jq <https://jqlang.github.io/jq/>`__ to parse the output:
 
 .. code-block:: bash
 
-    airflow dags list-import-errors | grep -q "No data found"
-
-This can be done more reliably with `jq <https://jqlang.github.io/jq/>`__:
-
-.. code-block:: bash
-
-    airflow dags list-import-errors --output=json | jq -e \'select(type=="array" and length == 0)\'
+    airflow dags list-import-errors --output=json | jq -e 'select(type=="array" and length == 0)'
 
 The line can be added to automation as-is, or if you want to print the output you can use ``tee``:
 
 .. code-block:: bash
 
-    airflow dags list-import-errors | tee import_errors.txt && grep -q "No data found" import_errors.txt
-    # or
-    airflow dags list-import-errors | tee import_errors.txt && jq -e \'select(type=="array" and length == 0)\' import_errors.txt
+    airflow dags list-import-errors | tee import_errors.txt && jq -e 'select(type=="array" and length == 0)' import_errors.txt
 
 Example in a Jenkins pipeline:
 
@@ -406,8 +398,6 @@ Example in a Jenkins pipeline:
 
     stage('All DAGs are loadable') {
         steps {
-            sh 'airflow dags list-import-errors | tee import_errors.txt && grep -q "No data found" import_errors.txt'
-            // or
             sh 'airflow dags list-import-errors | tee import_errors.txt && jq -e \'select(type=="array" and length == 0)\' import_errors.txt'
         }
     }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

As a followup to https://github.com/apache/airflow/issues/31655, adds an example for using the CLI list-import-errors command to test for import errors as part of a CI job, including a note about how to avoid unexpected logging that can interfere with the test.

related: #31655
