### PR TITLE
Remove comment re cli fallbacks, they have been removed

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -823,17 +823,6 @@ ARG_DO_PICKLE = Arg(
     action="store_true",
 )
 
-# IMPORTANT NOTE! ONLY FOR CELERY ARGUMENTS
-#
-# Celery configs below have explicit fallback values because celery provider defaults are not yet loaded
-# via provider at the time we parse the command line, so in case it is not set, we need to have manual
-# fallback. After ProvidersManager.initialize_providers_configuration() is called, the fallbacks are
-# not needed anymore and everywhere where you access configuration in provider-specific code and when
-# you are sure that providers configuration has been initialized, you can use conf.get() without fallbacks.
-#
-# DO NOT REMOVE THE FALLBACKS in args parsing even if you are tempted to.
-# TODO: possibly move the commands to providers but that could be big performance hit on the CLI
-# worker
 ARG_QUEUES = Arg(
     ("-q", "--queues"),
     help="Comma delimited list of queues to serve",


### PR DESCRIPTION
There was a code comment warning that the fallbacks for celery cli commands should not be removed until some conditions are met, but the fallbacks were removed in #32775

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
