### PR TITLE
Update graph nodes with operator style attributes.

### DIFF
--- a/airflow/www/static/js/dag/details/graph/Node.tsx
+++ b/airflow/www/static/js/dag/details/graph/Node.tsx
@@ -48,6 +48,8 @@ export interface CustomNodeProps {
   isActive?: boolean;
   setupTeardownType?: "setup" | "teardown";
   fullParentNode?: string;
+  labelStyle?: string;
+  style?: string;
 }
 
 export const BaseNode = ({
@@ -65,6 +67,8 @@ export const BaseNode = ({
     isOpen,
     isActive,
     setupTeardownType,
+    labelStyle,
+    style,
   },
 }: NodeProps<CustomNodeProps>) => {
   const { colors } = useTheme();
@@ -73,6 +77,8 @@ export const BaseNode = ({
 
   if (!task) return null;
 
+  let bg = isOpen ? "blackAlpha.50" : "white";
+  let textColor = "";
   const { isMapped } = task;
   const mappedStates = instance?.mappedStates;
 
@@ -82,7 +88,13 @@ export const BaseNode = ({
     ? `${label} [${instance ? totalTasks : " "}]`
     : label;
 
-  const bg = isOpen ? "blackAlpha.50" : "white";
+  if (style) {
+    [, bg] = style.split(":");
+  }
+
+  if (labelStyle) {
+    [, textColor] = labelStyle.split(":");
+  }
 
   return (
     <Tooltip
@@ -128,7 +140,11 @@ export const BaseNode = ({
               alignItems="center"
               width="100%"
             >
-              <Text noOfLines={1} maxWidth={`calc(${width}px - 8px)`}>
+              <Text
+                noOfLines={1}
+                maxWidth={`calc(${width}px - 8px)`}
+                color={isSelected ? "black" : textColor}
+              >
                 {taskName}
               </Text>
               {setupTeardownType === "setup" && (

--- a/airflow/www/static/js/dag/details/graph/Node.tsx
+++ b/airflow/www/static/js/dag/details/graph/Node.tsx
@@ -77,8 +77,7 @@ export const BaseNode = ({
 
   if (!task) return null;
 
-  let bg = isOpen ? "blackAlpha.50" : "white";
-  let textColor = "";
+  const bg = isOpen ? "blackAlpha.50" : "white";
   const { isMapped } = task;
   const mappedStates = instance?.mappedStates;
 
@@ -88,12 +87,14 @@ export const BaseNode = ({
     ? `${label} [${instance ? totalTasks : " "}]`
     : label;
 
+  let operatorTextColor = "";
+  let operatorBG = "";
   if (style) {
-    [, bg] = style.split(":");
+    [, operatorBG] = style.split(":");
   }
 
   if (labelStyle) {
-    [, textColor] = labelStyle.split(":");
+    [, operatorTextColor] = labelStyle.split(":");
   }
 
   return (
@@ -140,11 +141,7 @@ export const BaseNode = ({
               alignItems="center"
               width="100%"
             >
-              <Text
-                noOfLines={1}
-                maxWidth={`calc(${width}px - 8px)`}
-                color={isSelected ? "black" : textColor}
-              >
+              <Text noOfLines={1} maxWidth={`calc(${width}px - 8px)`}>
                 {taskName}
               </Text>
               {setupTeardownType === "setup" && (
@@ -157,13 +154,21 @@ export const BaseNode = ({
             {!!instance && instance.state && (
               <Flex alignItems="center">
                 <SimpleStatus state={instance.state} />
-                <Text ml={2} color="gray.500" fontSize="sm">
+                <Text ml={2} color="gray.500" fontSize="md">
                   {instance.state}
                 </Text>
               </Flex>
             )}
             {task?.operator && (
-              <Text color="gray.500" fontWeight={400} fontSize="md">
+              <Text
+                fontWeight={400}
+                fontSize="md"
+                width="fit-content"
+                borderRadius={5}
+                bg={operatorBG}
+                color={operatorTextColor || "gray.500"}
+                px={1}
+              >
                 {task.operator}
               </Text>
             )}

--- a/airflow/www/static/js/types/index.ts
+++ b/airflow/www/static/js/types/index.ts
@@ -119,6 +119,8 @@ interface DepNode {
     isOpen?: boolean;
     isJoinNode?: boolean;
     childCount?: number;
+    labelStyle: string;
+    style: string;
     setupTeardownType?: "setup" | "teardown";
   };
   children?: DepNode[];

--- a/airflow/www/static/js/utils/graph.ts
+++ b/airflow/www/static/js/utils/graph.ts
@@ -147,7 +147,7 @@ const generateGraph = ({
         childCount,
       },
       width: isJoinNode ? 10 : 200,
-      height: isJoinNode ? 10 : 60,
+      height: isJoinNode ? 10 : 70,
     };
   };
 


### PR DESCRIPTION
closes: #31949
related: #31949

The value from graph_data API is "fill:#ffee00;" . Please let me know if there is a simpler way to parse this instead of string manipulation. Sample dag with screenshot

```python
from datetime import datetime
from airflow.decorators import dag, task
from airflow.models.baseoperator import BaseOperator
from airflow.operators.bash import BashOperator


class HelloOperator(BaseOperator):
    ui_color = "#ffee00"
    ui_fgcolor = "#00ff04"
    custom_operator_name = "Howdy"


@dag(dag_id="gh32757", start_date=datetime(2023, 1, 1), catchup=False)
def mydag():

    @task
    def input(i):
        return i

    @task
    def output(i):
        return i

    bash = BashOperator(task_id="t1", bash_command="echo hello")
    hello = HelloOperator(task_id="t2")
    bash2 = BashOperator(task_id="t3", bash_command="echo bye")

    inputs = input.expand(i=[1, 2])
    output.expand(i=inputs)
    bash >> hello
    bash2

mydag()
```

![image](https://github.com/apache/airflow/assets/3972343/d072af96-5940-4906-94af-0abd4c33fe31)

