### PR TITLE
openlineage: add default port to authority method.

### DIFF
--- a/airflow/providers/common/sql/hooks/sql.py
+++ b/airflow/providers/common/sql/hooks/sql.py
@@ -598,13 +598,19 @@ class DbApiHook(BaseForDbApiHook):
         """
 
     @staticmethod
-    def get_openlineage_authority_part(connection) -> str:
+    def get_openlineage_authority_part(connection, default_port: int | None = None) -> str:
         """
         This method serves as common method for several hooks to get authority part from Airflow Connection.
 
         The authority represents the hostname and port of the connection
         and conforms OpenLineage naming convention for a number of databases (e.g. MySQL, Postgres, Trino).
+
+        :param default_port: (optional) used if no port parsed from connection URI
         """
         parsed = urlparse(connection.get_uri())
-        authority = f"{parsed.hostname}:{parsed.port}"
+        port = parsed.port or default_port
+        if port:
+            authority = f"{parsed.hostname}:{port}"
+        else:
+            authority = parsed.hostname
         return authority

--- a/airflow/providers/mysql/hooks/mysql.py
+++ b/airflow/providers/mysql/hooks/mysql.py
@@ -305,7 +305,7 @@ class MySqlHook(DbApiHook):
 
         return DatabaseInfo(
             scheme=self.get_openlineage_database_dialect(connection),
-            authority=DbApiHook.get_openlineage_authority_part(connection),
+            authority=DbApiHook.get_openlineage_authority_part(connection, default_port=3306),
             information_schema_columns=[
                 "table_schema",
                 "table_name",

--- a/tests/providers/mysql/operators/test_mysql.py
+++ b/tests/providers/mysql/operators/test_mysql.py
@@ -137,7 +137,8 @@ class TestMySql:
             assert len(lineage_on_complete.outputs) == 1
 
 
-def test_execute_openlineage_events():
+@pytest.mark.parametrize("connection_port", [None, 1234])
+def test_execute_openlineage_events(connection_port):
     class MySqlHookForTests(MySqlHook):
         conn_name_attr = "sql_default"
         get_conn = MagicMock(name="conn")
@@ -163,7 +164,7 @@ FORGOT TO COMMENT"""
         (DB_SCHEMA_NAME, "popular_orders_day_of_week", "orders_placed", 3, "int4"),
     ]
     dbapi_hook.get_connection.return_value = Connection(
-        conn_id="mysql_default", conn_type="mysql", host="host", port=1234
+        conn_id="mysql_default", conn_type="mysql", host="host", port=connection_port
     )
     dbapi_hook.get_conn.return_value.cursor.return_value.fetchall.side_effect = [rows, []]
 
@@ -171,7 +172,7 @@ FORGOT TO COMMENT"""
     assert len(lineage.inputs) == 0
     assert lineage.outputs == [
         Dataset(
-            namespace="mysql://host:1234",
+            namespace=f"mysql://host:{connection_port or 3306}",
             name="PUBLIC.popular_orders_day_of_week",
             facets={
                 "schema": SchemaDatasetFacet(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

This PR adds possibility to provide `default_port` to static method `get_openlineage_authority_part`.