### PR TITLE
Fix broken getting webserver config file from settings.WEBSERVER

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -2011,9 +2011,6 @@ def load_standard_airflow_configuration(airflow_config_parser: AirflowConfigPars
             # there
             AIRFLOW_HOME = airflow_config_parser.get("core", "airflow_home")  # type: ignore[assignment]
             warnings.warn(msg, category=DeprecationWarning)
-    # Set the WEBSERVER_CONFIG variable
-    global WEBSERVER_CONFIG
-    WEBSERVER_CONFIG = airflow_config_parser.get("webserver", "config_file")
 
 
 def initialize_config() -> AirflowConfigParser:
@@ -2032,7 +2029,9 @@ def initialize_config() -> AirflowConfigParser:
         # file on top of it.
         if airflow_config_parser.getboolean("core", "unit_test_mode"):
             airflow_config_parser.load_test_config()
-
+    # Set the WEBSERVER_CONFIG variable
+    global WEBSERVER_CONFIG
+    WEBSERVER_CONFIG = airflow_config_parser.get("webserver", "config_file")
     return airflow_config_parser
 
 

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -2011,6 +2011,13 @@ def load_standard_airflow_configuration(airflow_config_parser: AirflowConfigPars
             # there
             AIRFLOW_HOME = airflow_config_parser.get("core", "airflow_home")  # type: ignore[assignment]
             warnings.warn(msg, category=DeprecationWarning)
+    # Set the WEBSERVER_CONFIG variable
+    set_webserver_config(airflow_config_parser)
+
+
+def set_webserver_config(airflow_config_parser: AirflowConfigParser):
+    global WEBSERVER_CONFIG
+    WEBSERVER_CONFIG = airflow_config_parser.get("webserver", "config_file")
 
 
 def initialize_config() -> AirflowConfigParser:

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -2012,10 +2012,6 @@ def load_standard_airflow_configuration(airflow_config_parser: AirflowConfigPars
             AIRFLOW_HOME = airflow_config_parser.get("core", "airflow_home")  # type: ignore[assignment]
             warnings.warn(msg, category=DeprecationWarning)
     # Set the WEBSERVER_CONFIG variable
-    set_webserver_config(airflow_config_parser)
-
-
-def set_webserver_config(airflow_config_parser: AirflowConfigParser):
     global WEBSERVER_CONFIG
     WEBSERVER_CONFIG = airflow_config_parser.get("webserver", "config_file")
 
@@ -2042,14 +2038,13 @@ def initialize_config() -> AirflowConfigParser:
 
 @providers_configuration_loaded
 def write_webserver_configuration_if_needed(airflow_config_parser: AirflowConfigParser):
-    global WEBSERVER_CONFIG
-    WEBSERVER_CONFIG = airflow_config_parser.get("webserver", "config_file")
-    if not os.path.isfile(WEBSERVER_CONFIG):
+    webserver_config = airflow_config_parser.get("webserver", "config_file")
+    if not os.path.isfile(webserver_config):
         import shutil
 
-        pathlib.Path(WEBSERVER_CONFIG).parent.mkdir(parents=True, exist_ok=True)
-        log.info("Creating new FAB webserver config file in: %s", WEBSERVER_CONFIG)
-        shutil.copy(_default_config_file_path("default_webserver_config.py"), WEBSERVER_CONFIG)
+        pathlib.Path(webserver_config).parent.mkdir(parents=True, exist_ok=True)
+        log.info("Creating new FAB webserver config file in: %s", webserver_config)
+        shutil.copy(_default_config_file_path("default_webserver_config.py"), webserver_config)
 
 
 def make_group_other_inaccessible(file_path: str):

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -81,7 +81,10 @@ def create_app(config=None, testing=False):
     flask_app.secret_key = conf.get("webserver", "SECRET_KEY")
 
     flask_app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(minutes=settings.get_session_lifetime_config())
-    flask_app.config.from_pyfile(settings.WEBSERVER_CONFIG, silent=True)
+
+    webserver_config = conf.get_mandatory_value("webserver", "config_file")
+    flask_app.config.from_pyfile(webserver_config, silent=True)
+
     flask_app.config["TESTING"] = testing
     flask_app.config["SQLALCHEMY_DATABASE_URI"] = conf.get("database", "SQL_ALCHEMY_CONN")
 

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -24,7 +24,11 @@ from unittest import mock
 
 import pytest
 
-from airflow.configuration import initialize_config, write_webserver_configuration_if_needed
+from airflow.configuration import (
+    initialize_config,
+    write_default_airflow_configuration_if_needed,
+    write_webserver_configuration_if_needed,
+)
 from airflow.plugins_manager import AirflowPlugin, EntryPointSource
 from airflow.utils.task_group import TaskGroup
 from airflow.www import views
@@ -68,8 +72,9 @@ def test_webserver_configuration_config_file(mock_webserver_config_global, admin
 
     config_file = str(tmp_path / "my_custom_webserver_config.py")
     with mock.patch.dict(os.environ, {"AIRFLOW__WEBSERVER__CONFIG_FILE": config_file}):
-        conf = initialize_config()
+        conf = write_default_airflow_configuration_if_needed()
         write_webserver_configuration_if_needed(conf)
+        initialize_config()
         assert airflow.configuration.WEBSERVER_CONFIG == config_file
 
     assert os.path.isfile(config_file)


### PR DESCRIPTION
At the point of creating the webserver app, settings.WEBSERVER returns an empty string. This started after this commit: https://github.com/apache/airflow/commit/6362ba5ab45a38008814616df4e17717cc3726c3 and I wonder why we are not getting this value from the airflow configuration. I think the airflow config file should be the source of truth for anything configuration, so I'm changing it to get the configuration from airflow config file while we look for a fix for the settings.WEBSERVER being empty.

The current problem with not getting value from settings.WEBSERVER means that changes in webserver_config are not picked by airflow. So if you want to enable user registration, for example, it will fail. This fixes it.

cc @potiuk 

