### PR TITLE
Make the decorators of `PythonOperator` sub-classes extend its decorator

### DIFF
--- a/airflow/decorators/branch_python.py
+++ b/airflow/decorators/branch_python.py
@@ -16,41 +16,17 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Callable, Sequence
+from typing import Callable
 
-from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
+from airflow.decorators.base import TaskDecorator, task_decorator_factory
+from airflow.decorators.python import _PythonDecoratedOperator
 from airflow.operators.python import BranchPythonOperator
 
 
-class _BranchPythonDecoratedOperator(DecoratedOperator, BranchPythonOperator):
-    """
-    Wraps a Python callable and captures args/kwargs when called for execution.
-
-    :param python_callable: A reference to an object that is callable
-    :param op_kwargs: a dictionary of keyword arguments that will get unpacked
-        in your function (templated)
-    :param op_args: a list of positional arguments that will get unpacked when
-        calling your callable (templated)
-    :param multiple_outputs: if set, function return value will be
-        unrolled to multiple XCom values. Dict will unroll to xcom values with keys as keys.
-        Defaults to False.
-    """
-
-    template_fields: Sequence[str] = ("templates_dict", "op_args", "op_kwargs")
-    template_fields_renderers = {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}
+class _BranchPythonDecoratedOperator(_PythonDecoratedOperator, BranchPythonOperator):
+    """Wraps a Python callable and captures args/kwargs when called for execution."""
 
     custom_operator_name: str = "@task.branch"
-
-    def __init__(
-        self,
-        **kwargs,
-    ) -> None:
-        kwargs_to_upstream = {
-            "python_callable": kwargs["python_callable"],
-            "op_args": kwargs["op_args"],
-            "op_kwargs": kwargs["op_kwargs"],
-        }
-        super().__init__(kwargs_to_upstream=kwargs_to_upstream, **kwargs)
 
 
 def branch_task(

--- a/airflow/decorators/branch_python.py
+++ b/airflow/decorators/branch_python.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Sequence
 
 from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
 from airflow.operators.python import BranchPythonOperator
@@ -35,6 +35,9 @@ class _BranchPythonDecoratedOperator(DecoratedOperator, BranchPythonOperator):
         unrolled to multiple XCom values. Dict will unroll to xcom values with keys as keys.
         Defaults to False.
     """
+
+    template_fields: Sequence[str] = ("templates_dict", "op_args", "op_kwargs")
+    template_fields_renderers = {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}
 
     custom_operator_name: str = "@task.branch"
 

--- a/airflow/decorators/external_python.py
+++ b/airflow/decorators/external_python.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Sequence
 
 from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
 from airflow.operators.python import ExternalPythonOperator
@@ -37,6 +37,9 @@ class _PythonExternalDecoratedOperator(DecoratedOperator, ExternalPythonOperator
     :param multiple_outputs: If set to True, the decorated function's return value will be unrolled to
         multiple XCom values. Dict will unroll to XCom values with its keys as XCom keys. Defaults to False.
     """
+
+    template_fields: Sequence[str] = ("templates_dict", "op_args", "op_kwargs")
+    template_fields_renderers = {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}
 
     custom_operator_name: str = "@task.external_python"
 

--- a/airflow/decorators/external_python.py
+++ b/airflow/decorators/external_python.py
@@ -16,46 +16,17 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Callable, Sequence
+from typing import Callable
 
-from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
+from airflow.decorators.base import TaskDecorator, task_decorator_factory
+from airflow.decorators.python import _PythonDecoratedOperator
 from airflow.operators.python import ExternalPythonOperator
 
 
-class _PythonExternalDecoratedOperator(DecoratedOperator, ExternalPythonOperator):
-    """
-    Wraps a Python callable and captures args/kwargs when called for execution.
-
-    :param python: Full path string (file-system specific) that points to a Python binary inside
-        a virtualenv that should be used (in ``VENV/bin`` folder). Should be absolute path
-        (so usually start with "/" or "X:/" depending on the filesystem/os used).
-    :param python_callable: A reference to an object that is callable
-    :param op_kwargs: a dictionary of keyword arguments that will get unpacked
-        in your function (templated)
-    :param op_args: a list of positional arguments that will get unpacked when
-        calling your callable (templated)
-    :param multiple_outputs: If set to True, the decorated function's return value will be unrolled to
-        multiple XCom values. Dict will unroll to XCom values with its keys as XCom keys. Defaults to False.
-    """
-
-    template_fields: Sequence[str] = ("templates_dict", "op_args", "op_kwargs")
-    template_fields_renderers = {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}
+class _PythonExternalDecoratedOperator(_PythonDecoratedOperator, ExternalPythonOperator):
+    """Wraps a Python callable and captures args/kwargs when called for execution."""
 
     custom_operator_name: str = "@task.external_python"
-
-    def __init__(self, *, python_callable, op_args, op_kwargs, **kwargs) -> None:
-        kwargs_to_upstream = {
-            "python_callable": python_callable,
-            "op_args": op_args,
-            "op_kwargs": op_kwargs,
-        }
-        super().__init__(
-            kwargs_to_upstream=kwargs_to_upstream,
-            python_callable=python_callable,
-            op_args=op_args,
-            op_kwargs=op_kwargs,
-            **kwargs,
-        )
 
 
 def external_python_task(

--- a/airflow/decorators/python_virtualenv.py
+++ b/airflow/decorators/python_virtualenv.py
@@ -16,43 +16,17 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Callable, Sequence
+from typing import Callable
 
-from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
+from airflow.decorators.base import TaskDecorator, task_decorator_factory
+from airflow.decorators.python import _PythonDecoratedOperator
 from airflow.operators.python import PythonVirtualenvOperator
 
 
-class _PythonVirtualenvDecoratedOperator(DecoratedOperator, PythonVirtualenvOperator):
-    """
-    Wraps a Python callable and captures args/kwargs when called for execution.
-
-    :param python_callable: A reference to an object that is callable
-    :param op_kwargs: a dictionary of keyword arguments that will get unpacked
-        in your function (templated)
-    :param op_args: a list of positional arguments that will get unpacked when
-        calling your callable (templated)
-    :param multiple_outputs: If set to True, the decorated function's return value will be unrolled to
-        multiple XCom values. Dict will unroll to XCom values with its keys as XCom keys. Defaults to False.
-    """
-
-    template_fields: Sequence[str] = ("templates_dict", "op_args", "op_kwargs")
-    template_fields_renderers = {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}
+class _PythonVirtualenvDecoratedOperator(_PythonDecoratedOperator, PythonVirtualenvOperator):
+    """Wraps a Python callable and captures args/kwargs when called for execution."""
 
     custom_operator_name: str = "@task.virtualenv"
-
-    def __init__(self, *, python_callable, op_args, op_kwargs, **kwargs) -> None:
-        kwargs_to_upstream = {
-            "python_callable": python_callable,
-            "op_args": op_args,
-            "op_kwargs": op_kwargs,
-        }
-        super().__init__(
-            kwargs_to_upstream=kwargs_to_upstream,
-            python_callable=python_callable,
-            op_args=op_args,
-            op_kwargs=op_kwargs,
-            **kwargs,
-        )
 
 
 def virtualenv_task(

--- a/airflow/decorators/python_virtualenv.py
+++ b/airflow/decorators/python_virtualenv.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Sequence
 
 from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
 from airflow.operators.python import PythonVirtualenvOperator
@@ -34,6 +34,9 @@ class _PythonVirtualenvDecoratedOperator(DecoratedOperator, PythonVirtualenvOper
     :param multiple_outputs: If set to True, the decorated function's return value will be unrolled to
         multiple XCom values. Dict will unroll to XCom values with its keys as XCom keys. Defaults to False.
     """
+
+    template_fields: Sequence[str] = ("templates_dict", "op_args", "op_kwargs")
+    template_fields_renderers = {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}
 
     custom_operator_name: str = "@task.virtualenv"
 

--- a/airflow/decorators/short_circuit.py
+++ b/airflow/decorators/short_circuit.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Sequence
 
 from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
 from airflow.operators.python import ShortCircuitOperator
@@ -34,6 +34,9 @@ class _ShortCircuitDecoratedOperator(DecoratedOperator, ShortCircuitOperator):
     :param multiple_outputs: If set to True, the decorated function's return value will be unrolled to
         multiple XCom values. Dict will unroll to XCom values with its keys as XCom keys. Defaults to False.
     """
+
+    template_fields: Sequence[str] = ("templates_dict", "op_args", "op_kwargs")
+    template_fields_renderers = {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}
 
     custom_operator_name: str = "@task.short_circuit"
 

--- a/airflow/decorators/short_circuit.py
+++ b/airflow/decorators/short_circuit.py
@@ -16,43 +16,17 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Callable, Sequence
+from typing import Callable
 
-from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
+from airflow.decorators.base import TaskDecorator, task_decorator_factory
+from airflow.decorators.python import _PythonDecoratedOperator
 from airflow.operators.python import ShortCircuitOperator
 
 
-class _ShortCircuitDecoratedOperator(DecoratedOperator, ShortCircuitOperator):
-    """
-    Wraps a Python callable and captures args/kwargs when called for execution.
-
-    :param python_callable: A reference to an object that is callable
-    :param op_kwargs: a dictionary of keyword arguments that will get unpacked
-        in your function (templated)
-    :param op_args: a list of positional arguments that will get unpacked when
-        calling your callable (templated)
-    :param multiple_outputs: If set to True, the decorated function's return value will be unrolled to
-        multiple XCom values. Dict will unroll to XCom values with its keys as XCom keys. Defaults to False.
-    """
-
-    template_fields: Sequence[str] = ("templates_dict", "op_args", "op_kwargs")
-    template_fields_renderers = {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}
+class _ShortCircuitDecoratedOperator(_PythonDecoratedOperator, ShortCircuitOperator):
+    """Wraps a Python callable and captures args/kwargs when called for execution."""
 
     custom_operator_name: str = "@task.short_circuit"
-
-    def __init__(self, *, python_callable, op_args, op_kwargs, **kwargs) -> None:
-        kwargs_to_upstream = {
-            "python_callable": python_callable,
-            "op_args": op_args,
-            "op_kwargs": op_kwargs,
-        }
-        super().__init__(
-            kwargs_to_upstream=kwargs_to_upstream,
-            python_callable=python_callable,
-            op_args=op_args,
-            op_kwargs=op_kwargs,
-            **kwargs,
-        )
 
 
 def short_circuit_task(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #32840

This PR makes the decorator classes for the sub-classes of `PythonOperator` extend `_PythonDecoratedOperator` instead of `DecoratedOperator`, in this case they inherit its constructor and its attributes (including `template_fields` and `template_fields_renderers` which are missing).

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
