### PR TITLE
Normalising the helm service account tests

### DIFF
--- a/helm_tests/airflow_aux/test_migrate_database_job.py
+++ b/helm_tests/airflow_aux/test_migrate_database_job.py
@@ -25,28 +25,6 @@ from tests.charts.helm_template_generator import render_chart
 class TestMigrateDatabaseJob:
     """Tests migrate DB job."""
 
-    def test_default_automount_service_account_token(self):
-        docs = render_chart(
-            values={
-                "migrateDatabaseJob": {
-                    "serviceAccount": {"create": True},
-                },
-            },
-            show_only=["templates/jobs/migrate-database-job-serviceaccount.yaml"],
-        )
-        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
-
-    def test_overriden_automount_service_account_token(self):
-        docs = render_chart(
-            values={
-                "migrateDatabaseJob": {
-                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
-                },
-            },
-            show_only=["templates/jobs/migrate-database-job-serviceaccount.yaml"],
-        )
-        assert jmespath.search("automountServiceAccountToken", docs[0]) is False
-
     def test_should_run_by_default(self):
         docs = render_chart(show_only=["templates/jobs/migrate-database-job.yaml"])
         assert "Job" == docs[0]["kind"]
@@ -345,3 +323,29 @@ class TestMigrateDatabaseJob:
             "subPath": "airflow_local_settings.py",
             "readOnly": True,
         } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+
+
+class TestMigrateDatabaseJobServiceAccount:
+    """Tests migrate database job service account."""
+
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "migrateDatabaseJob": {
+                    "serviceAccount": {"create": True},
+                },
+            },
+            show_only=["templates/jobs/migrate-database-job-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_overriden_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "migrateDatabaseJob": {
+                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
+                },
+            },
+            show_only=["templates/jobs/migrate-database-job-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False

--- a/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm_tests/airflow_core/test_dag_processor.py
@@ -26,30 +26,6 @@ from tests.charts.log_groomer import LogGroomerTestBase
 class TestDagProcessor:
     """Tests DAG processor."""
 
-    def test_default_automount_service_account_token(self):
-        docs = render_chart(
-            values={
-                "dagProcessor": {
-                    "enabled": True,
-                    "serviceAccount": {"create": True},
-                },
-            },
-            show_only=["templates/dag-processor/dag-processor-serviceaccount.yaml"],
-        )
-        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
-
-    def test_overriden_automount_service_account_token(self):
-        docs = render_chart(
-            values={
-                "dagProcessor": {
-                    "enabled": True,
-                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
-                },
-            },
-            show_only=["templates/dag-processor/dag-processor-serviceaccount.yaml"],
-        )
-        assert jmespath.search("automountServiceAccountToken", docs[0]) is False
-
     @pytest.mark.parametrize(
         "airflow_version, num_docs",
         [
@@ -648,3 +624,31 @@ class TestDagProcessorLogGroomer(LogGroomerTestBase):
 
     obj_name = "dag-processor"
     folder = "dag-processor"
+
+
+class TestDagProcessorServiceAccount:
+    """Tests DAG processor service account."""
+
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "dagProcessor": {
+                    "enabled": True,
+                    "serviceAccount": {"create": True},
+                },
+            },
+            show_only=["templates/dag-processor/dag-processor-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_overriden_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "dagProcessor": {
+                    "enabled": True,
+                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
+                },
+            },
+            show_only=["templates/dag-processor/dag-processor-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False

--- a/helm_tests/other/test_pgbouncer.py
+++ b/helm_tests/other/test_pgbouncer.py
@@ -27,30 +27,6 @@ from tests.charts.helm_template_generator import render_chart
 class TestPgbouncer:
     """Tests PgBouncer."""
 
-    def test_default_automount_service_account_token(self):
-        docs = render_chart(
-            values={
-                "pgbouncer": {
-                    "enabled": True,
-                    "serviceAccount": {"create": True},
-                },
-            },
-            show_only=["templates/pgbouncer/pgbouncer-serviceaccount.yaml"],
-        )
-        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
-
-    def test_overriden_automount_service_account_token(self):
-        docs = render_chart(
-            values={
-                "pgbouncer": {
-                    "enabled": True,
-                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
-                },
-            },
-            show_only=["templates/pgbouncer/pgbouncer-serviceaccount.yaml"],
-        )
-        assert jmespath.search("automountServiceAccountToken", docs[0]) is False
-
     @pytest.mark.parametrize("yaml_filename", ["pgbouncer-deployment", "pgbouncer-service"])
     def test_pgbouncer_resources_not_created_by_default(self, yaml_filename):
         docs = render_chart(
@@ -591,3 +567,31 @@ class TestPgbouncerExporter:
             "postgresql://username%40123123:password%40%21%40%23$%5E&%2A%28%29@127.0.0.1:1111"
             "/pgbouncer?sslmode=require" == connection
         )
+
+
+class TestPgBouncerServiceAccount:
+    """Tests PgBouncer Service Account."""
+
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "pgbouncer": {
+                    "enabled": True,
+                    "serviceAccount": {"create": True},
+                },
+            },
+            show_only=["templates/pgbouncer/pgbouncer-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_overriden_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "pgbouncer": {
+                    "enabled": True,
+                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
+                },
+            },
+            show_only=["templates/pgbouncer/pgbouncer-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False

--- a/helm_tests/other/test_redis.py
+++ b/helm_tests/other/test_redis.py
@@ -42,28 +42,6 @@ CELERY_EXECUTORS_PARAMS = ["CeleryExecutor", "CeleryKubernetesExecutor"]
 class TestRedis:
     """Tests redis."""
 
-    def test_default_automount_service_account_token(self):
-        docs = render_chart(
-            values={
-                "redis": {
-                    "serviceAccount": {"create": True},
-                },
-            },
-            show_only=["templates/redis/redis-serviceaccount.yaml"],
-        )
-        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
-
-    def test_overriden_automount_service_account_token(self):
-        docs = render_chart(
-            values={
-                "redis": {
-                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
-                },
-            },
-            show_only=["templates/redis/redis-serviceaccount.yaml"],
-        )
-        assert jmespath.search("automountServiceAccountToken", docs[0]) is False
-
     @staticmethod
     def get_broker_url_in_broker_url_secret(k8s_obj_by_key):
         broker_url_in_obj = b64decode(
@@ -350,3 +328,29 @@ class TestRedis:
             show_only=["templates/redis/redis-statefulset.yaml"],
         )
         assert {"foo": "bar"} == jmespath.search("spec.volumeClaimTemplates[0].metadata.annotations", docs[0])
+
+
+class TestRedisServiceAccount:
+    """Tests redis service account."""
+
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "redis": {
+                    "serviceAccount": {"create": True},
+                },
+            },
+            show_only=["templates/redis/redis-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_overriden_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "redis": {
+                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
+                },
+            },
+            show_only=["templates/redis/redis-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False

--- a/helm_tests/other/test_statsd.py
+++ b/helm_tests/other/test_statsd.py
@@ -26,28 +26,6 @@ from tests.charts.helm_template_generator import render_chart
 class TestStatsd:
     """Tests statsd."""
 
-    def test_default_automount_service_account_token(self):
-        docs = render_chart(
-            values={
-                "statsd": {
-                    "serviceAccount": {"create": True},
-                },
-            },
-            show_only=["templates/statsd/statsd-serviceaccount.yaml"],
-        )
-        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
-
-    def test_overriden_automount_service_account_token(self):
-        docs = render_chart(
-            values={
-                "statsd": {
-                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
-                },
-            },
-            show_only=["templates/statsd/statsd-serviceaccount.yaml"],
-        )
-        assert jmespath.search("automountServiceAccountToken", docs[0]) is False
-
     def test_should_create_statsd_default(self):
         docs = render_chart(show_only=["templates/statsd/statsd-deployment.yaml"])
 
@@ -317,3 +295,29 @@ class TestStatsd:
             jmespath.search("spec.template.metadata.annotations", docs[0])["test_pod_annotation"]
             == "test_pod_annotation_value"
         )
+
+
+class TestStatsdServiceAccount:
+    """Tests statsd service account."""
+
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "statsd": {
+                    "serviceAccount": {"create": True},
+                },
+            },
+            show_only=["templates/statsd/statsd-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_overriden_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "statsd": {
+                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
+                },
+            },
+            show_only=["templates/statsd/statsd-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
A small refactor where I noticed that the service account tests were part of the main test classes for some of the helm test files while not for other. Normalised this behaviour.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
