### PR TITLE
enable db access for dag run listeners

### DIFF
--- a/airflow/example_dags/plugins/event_listener.py
+++ b/airflow/example_dags/plugins/event_listener.py
@@ -111,7 +111,7 @@ def on_task_instance_failed(previous_state: TaskInstanceState, task_instance: Ta
 
 # [START howto_listen_dagrun_success_task]
 @hookimpl
-def on_dag_run_success(dag_run: DagRun, message: str):
+def on_dag_run_success(dag_run: DagRun, message: str, session):
     """
     This method is called when dag run state changes to SUCCESS.
     """
@@ -126,7 +126,7 @@ def on_dag_run_success(dag_run: DagRun, message: str):
 
 # [START howto_listen_dagrun_failure_task]
 @hookimpl
-def on_dag_run_failed(dag_run: DagRun, message: str):
+def on_dag_run_failed(dag_run: DagRun, message: str, session):
     """
     This method is called when dag run state changes to FAILED.
     """
@@ -142,7 +142,7 @@ def on_dag_run_failed(dag_run: DagRun, message: str):
 
 # [START howto_listen_dagrun_running_task]
 @hookimpl
-def on_dag_run_running(dag_run: DagRun, message: str):
+def on_dag_run_running(dag_run: DagRun, message: str, session):
     """
     This method is called when dag run state changes to RUNNING.
     """

--- a/airflow/jobs/backfill_job_runner.py
+++ b/airflow/jobs/backfill_job_runner.py
@@ -365,7 +365,7 @@ class BackfillJobRunner(BaseJobRunner[Job], LoggingMixin):
         run.run_type = DagRunType.BACKFILL_JOB
         run.verify_integrity(session=session)
 
-        run.notify_dagrun_state_changed(msg="started")
+        run.notify_dagrun_state_changed(session=session, msg="started")
         return run
 
     @provide_session

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1369,7 +1369,7 @@ class SchedulerJobRunner(BaseJobRunner[Job], LoggingMixin):
             else:
                 active_runs_of_dags[dag_run.dag_id] += 1
                 _update_state(dag, dag_run)
-                dag_run.notify_dagrun_state_changed()
+                dag_run.notify_dagrun_state_changed(session=session)
 
     @retry_db_transaction
     def _schedule_all_dag_runs(
@@ -1433,7 +1433,7 @@ class SchedulerJobRunner(BaseJobRunner[Job], LoggingMixin):
                 msg="timed_out",
             )
 
-            dag_run.notify_dagrun_state_changed()
+            dag_run.notify_dagrun_state_changed(session=session)
             duration = dag_run.end_date - dag_run.start_date
             Stats.timing(f"dagrun.duration.failed.{dag_run.dag_id}", duration)
             Stats.timing("dagrun.duration.failed", duration, tags={"dag_id": dag_run.dag_id})

--- a/airflow/listeners/spec/dagrun.py
+++ b/airflow/listeners/spec/dagrun.py
@@ -23,20 +23,21 @@ from pluggy import HookspecMarker
 
 if TYPE_CHECKING:
     from airflow.models.dagrun import DagRun
+    from sqlalchemy.orm.session import Session
 
 hookspec = HookspecMarker("airflow")
 
 
 @hookspec
-def on_dag_run_running(dag_run: DagRun, msg: str):
+def on_dag_run_running(dag_run: DagRun, msg: str, session: Session | None):
     """Called when dag run state changes to RUNNING."""
 
 
 @hookspec
-def on_dag_run_success(dag_run: DagRun, msg: str):
+def on_dag_run_success(dag_run: DagRun, msg: str, session: Session | None):
     """Called when dag run state changes to SUCCESS."""
 
 
 @hookspec
-def on_dag_run_failed(dag_run: DagRun, msg: str):
+def on_dag_run_failed(dag_run: DagRun, msg: str, session: Session | None):
     """Called when dag run state changes to FAIL."""

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2730,6 +2730,7 @@ class DAG(LoggingMixin):
             conf=run_conf,
             data_interval=data_interval,
         )
+        dr.notify_dagrun_state_changed(session=session)
 
         tasks = self.task_dict
         self.log.debug("starting dagrun")

--- a/airflow/providers/openlineage/plugins/listener.py
+++ b/airflow/providers/openlineage/plugins/listener.py
@@ -161,7 +161,7 @@ class OpenLineageListener:
             self.executor.shutdown(wait=True)
 
     @hookimpl
-    def on_dag_run_running(self, dag_run: DagRun, msg: str):
+    def on_dag_run_running(self, dag_run: DagRun, msg: str, session):
         if not self.executor:
             self.log.error("Executor have not started before `on_dag_run_running`")
             return
@@ -174,14 +174,14 @@ class OpenLineageListener:
         )
 
     @hookimpl
-    def on_dag_run_success(self, dag_run: DagRun, msg: str):
+    def on_dag_run_success(self, dag_run: DagRun, msg: str, session):
         if not self.executor:
             self.log.error("Executor have not started before `on_dag_run_success`")
             return
         self.executor.submit(self.adapter.dag_success, dag_run=dag_run, msg=msg)
 
     @hookimpl
-    def on_dag_run_failed(self, dag_run: DagRun, msg: str):
+    def on_dag_run_failed(self, dag_run: DagRun, msg: str, session):
         if not self.executor:
             self.log.error("Executor have not started before `on_dag_run_failed`")
             return

--- a/tests/listeners/dag_listener.py
+++ b/tests/listeners/dag_listener.py
@@ -24,7 +24,7 @@ from airflow.listeners import hookimpl
 
 if typing.TYPE_CHECKING:
     from airflow.models.dagrun import DagRun
-
+    from sqlalchemy.orm.session import Session
 
 running: list[DagRun] = []
 success: list[DagRun] = []
@@ -32,17 +32,17 @@ failure: list[DagRun] = []
 
 
 @hookimpl
-def on_dag_run_running(dag_run: DagRun, msg: str):
+def on_dag_run_running(dag_run: DagRun, msg: str, session):
     running.append(copy.deepcopy(dag_run))
 
 
 @hookimpl
-def on_dag_run_success(dag_run: DagRun, msg: str):
+def on_dag_run_success(dag_run: DagRun, msg: str, session):
     success.append(copy.deepcopy(dag_run))
 
 
 @hookimpl
-def on_dag_run_failed(dag_run: DagRun, msg: str):
+def on_dag_run_failed(dag_run: DagRun, msg: str, session):
     failure.append(dag_run)
 
 

--- a/tests/listeners/test_dag_listeners.py
+++ b/tests/listeners/test_dag_listeners.py
@@ -1,0 +1,122 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pendulum
+import pytest as pytest
+from sqlalchemy.orm import Session
+
+from airflow import AirflowException, DAG
+from airflow.decorators import task
+from airflow.listeners import hookimpl
+from airflow.listeners.listener import get_listener_manager
+from airflow.models import DagRun
+from airflow.operators.empty import EmptyOperator
+
+
+@pytest.fixture(autouse=True)
+def clean_listener_manager():
+    lm = get_listener_manager()
+    lm.clear()
+    yield
+    lm = get_listener_manager()
+    lm.clear()
+
+
+mock_running_object = mock.MagicMock()
+mock_success_object = mock.MagicMock()
+mock_failure_object = mock.MagicMock()
+
+
+class TestDagListeners:
+    @hookimpl
+    def on_dag_run_running(dag_run: DagRun, msg: str, session):
+        assert session is not None
+        assert isinstance(session, Session)
+        assert session.is_active
+        mock_running_object(f'invoked with dag_run={dag_run}, msg={msg}, session={session}')
+
+    @hookimpl
+    def on_dag_run_success(dag_run: DagRun, msg: str, session):
+        assert session is not None
+        assert isinstance(session, Session)
+        assert session.is_active
+        mock_success_object(f'invoked with dag_run={dag_run}, msg={msg}, session={session}')
+
+    @hookimpl
+    def on_dag_run_failed(dag_run: DagRun, msg: str, session):
+        assert session is not None
+        assert isinstance(session, Session)
+        assert session.is_active
+        mock_failure_object(f'invoked with dag_run={dag_run}, msg={msg}, session={session}')
+
+
+def test_dag_run_listener_success(create_task_instance, dag_maker):
+    with DAG(
+        dag_id='test_dag_run_listener_success',
+        start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+        catchup=False,
+        schedule=None
+    ) as dag:
+        task1 = EmptyOperator(task_id="run_this_first")
+        task2 = EmptyOperator(task_id="run_this_last")
+
+        task1 >> task2
+
+    lm = get_listener_manager()
+    lm.add_listener(TestDagListeners)
+
+    mock_running_object.reset_mock()
+    mock_success_object.reset_mock()
+    mock_failure_object.reset_mock()
+
+    dag.test()
+
+    mock_running_object.assert_called_once()
+    mock_success_object.assert_called_once()
+    mock_failure_object.assert_not_called()
+
+
+def test_dag_run_listener_fail(create_task_instance, dag_maker):
+    with DAG(
+        dag_id='test_dag_run_listener_fail',
+        start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+        catchup=False,
+        schedule=None
+    ) as dag:
+        task1 = EmptyOperator(task_id="run_this_first")
+
+        @task
+        def task2(ds=None, **kwargs):
+            raise AirflowException("boooooooom")
+
+        task1 >> task2()
+
+    lm = get_listener_manager()
+    lm.add_listener(TestDagListeners)
+
+    mock_running_object.reset_mock()
+    mock_success_object.reset_mock()
+    mock_failure_object.reset_mock()
+
+    dag.test()
+
+    mock_running_object.assert_called_once()
+    mock_success_object.assert_not_called()
+    mock_failure_object.assert_called_once()


### PR DESCRIPTION
I have a case which needs db access in dag run listener:
1. I collect error message in task instance fail listeners, save it into XCom
2. in dag run fail listener, I summarize all error messages from XCom and send it to an external restful API.

XCom need to access db. If we use `@provide_session` to open a new session for it, it will get exception `UNEXPECTED COMMIT - THIS WILL BREAK HA LOCKS` in HA environment.
So I have to pass the original session which created by scheduler to dag run listener, to avoid the exception.