### PR TITLE
Update openlineage provider to min version of airflow 2.7.0

### DIFF
--- a/airflow/providers/openlineage/provider.yaml
+++ b/airflow/providers/openlineage/provider.yaml
@@ -26,7 +26,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.6.0
+  - apache-airflow>=2.7.0
   - apache-airflow-providers-common-sql>=1.3.1
   - attrs>=22.2
   - openlineage-integration-common>=0.28.0

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -653,7 +653,7 @@
   "openlineage": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.6.0",
+      "apache-airflow>=2.7.0",
       "attrs>=22.2",
       "openlineage-integration-common>=0.28.0",
       "openlineage-python>=0.28.0"


### PR DESCRIPTION
openlineage provider can work only on apache-airflow>=2.7.0