### PR TITLE
OpenAPI Spec fix nullable alongside $ref

### DIFF
--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -268,7 +268,7 @@ def get_mapped_task_instances(
 def _convert_ti_states(states: Iterable[str] | None) -> list[TaskInstanceState | None] | None:
     if not states:
         return None
-    return [None if s == "none" else TaskInstanceState(s) for s in states]
+    return [None if s in ("none", None) else TaskInstanceState(s) for s in states]
 
 
 def _apply_array_filter(query: Select, key: ClauseElement, values: Iterable[Any] | None) -> Select:

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3228,7 +3228,6 @@ components:
           items:
             $ref: '#/components/schemas/Provider'
 
-
     SLAMiss:
       type: object
       properties:
@@ -3254,6 +3253,11 @@ components:
           type: boolean
       nullable: true
 
+    NullableSLAMiss:
+      nullable: true
+      allOf:
+        - $ref: '#/components/schemas/SLAMiss'
+
     Trigger:
       type: object
       properties:
@@ -3269,6 +3273,11 @@ components:
         triggerer_id:
           type: integer
           nullable: true
+
+    NullableTrigger:
+      nullable: true
+      allOf:
+        - $ref: '#/components/schemas/Trigger'
 
     Job:
       type: object
@@ -3306,6 +3315,11 @@ components:
           type: string
           nullable: true
 
+    NullableJob:
+      nullable: true
+      allOf:
+        - $ref: '#/components/schemas/Job'
+
     TaskInstance:
       type: object
       properties:
@@ -3334,8 +3348,7 @@ components:
           type: number
           nullable: true
         state:
-          $ref: '#/components/schemas/TaskState'
-          nullable: true
+          $ref: '#/components/schemas/NullableTaskState'
         try_number:
           type: integer
         map_index:
@@ -3370,8 +3383,7 @@ components:
         executor_config:
           type: string
         sla_miss:
-          $ref: '#/components/schemas/SLAMiss'
-          nullable: true
+          $ref: '#/components/schemas/NullableSLAMiss'
         rendered_fields:
           description: |
             JSON object describing rendered fields.
@@ -3379,11 +3391,9 @@ components:
             *New in version 2.3.0*
           type: object
         trigger:
-          $ref: '#/components/schemas/Trigger'
-          nullable: true
+          $ref: '#/components/schemas/NullableTrigger'
         triggerer_job:
-          $ref: '#/components/schemas/Job'
-          nullable: true
+          $ref: '#/components/schemas/NullableJob'
         note:
           type: string
           description: |
@@ -3561,8 +3571,7 @@ components:
 
                 *Changed in version 2.0.1*&#58; Field becomes nullable.
             dag_run_timeout:
-              nullable: true
-              $ref: '#/components/schemas/TimeDelta'
+              $ref: '#/components/schemas/NullableTimeDelta'
             doc_md:
               type: string
               readOnly: true
@@ -3698,11 +3707,9 @@ components:
           type: number
           readOnly: true
         execution_timeout:
-          $ref: '#/components/schemas/TimeDelta'
-          nullable: true
+          $ref: '#/components/schemas/NullableTimeDelta'
         retry_delay:
-          $ref: '#/components/schemas/TimeDelta'
-          nullable: true
+          $ref: '#/components/schemas/NullableTimeDelta'
         retry_exponential_backoff:
           type: boolean
           readOnly: true
@@ -4517,6 +4524,11 @@ components:
         seconds: {type: integer}
         microseconds: {type: integer}
 
+    NullableTimeDelta:
+      nullable: true
+      allOf:
+        - $ref: '#/components/schemas/TimeDelta'
+
     RelativeDelta:
       description: Relative delta
       # TODO: Why we need these fields?
@@ -4661,6 +4673,11 @@ components:
         - deferred
         - removed
         - restarting
+
+    NullableTaskState:
+      nullable: true
+      allOf:
+        - $ref: '#/components/schemas/TaskState'
 
     DagState:
       description: |

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3253,13 +3253,9 @@ components:
           type: boolean
       nullable: true
 
-    NullableSLAMiss:
-      nullable: true
-      allOf:
-        - $ref: '#/components/schemas/SLAMiss'
-
     Trigger:
       type: object
+      nullable: true
       properties:
         id:
           type: integer
@@ -3274,13 +3270,9 @@ components:
           type: integer
           nullable: true
 
-    NullableTrigger:
-      nullable: true
-      allOf:
-        - $ref: '#/components/schemas/Trigger'
-
     Job:
       type: object
+      nullable: true
       properties:
         id:
           type: integer
@@ -3315,11 +3307,6 @@ components:
           type: string
           nullable: true
 
-    NullableJob:
-      nullable: true
-      allOf:
-        - $ref: '#/components/schemas/Job'
-
     TaskInstance:
       type: object
       properties:
@@ -3348,7 +3335,7 @@ components:
           type: number
           nullable: true
         state:
-          $ref: '#/components/schemas/NullableTaskState'
+          $ref: '#/components/schemas/TaskState'
         try_number:
           type: integer
         map_index:
@@ -3383,7 +3370,7 @@ components:
         executor_config:
           type: string
         sla_miss:
-          $ref: '#/components/schemas/NullableSLAMiss'
+          $ref: '#/components/schemas/SLAMiss'
         rendered_fields:
           description: |
             JSON object describing rendered fields.
@@ -3391,9 +3378,9 @@ components:
             *New in version 2.3.0*
           type: object
         trigger:
-          $ref: '#/components/schemas/NullableTrigger'
+          $ref: '#/components/schemas/Trigger'
         triggerer_job:
-          $ref: '#/components/schemas/NullableJob'
+          $ref: '#/components/schemas/Job'
         note:
           type: string
           description: |
@@ -3571,7 +3558,7 @@ components:
 
                 *Changed in version 2.0.1*&#58; Field becomes nullable.
             dag_run_timeout:
-              $ref: '#/components/schemas/NullableTimeDelta'
+              $ref: '#/components/schemas/TimeDelta'
             doc_md:
               type: string
               readOnly: true
@@ -3707,9 +3694,9 @@ components:
           type: number
           readOnly: true
         execution_timeout:
-          $ref: '#/components/schemas/NullableTimeDelta'
+          $ref: '#/components/schemas/TimeDelta'
         retry_delay:
-          $ref: '#/components/schemas/NullableTimeDelta'
+          $ref: '#/components/schemas/TimeDelta'
         retry_exponential_backoff:
           type: boolean
           readOnly: true
@@ -4513,6 +4500,7 @@ components:
     TimeDelta:
       description: Time delta
       type: object
+      nullable: true
       required:
         - __type
         - days
@@ -4523,11 +4511,6 @@ components:
         days: {type: integer}
         seconds: {type: integer}
         microseconds: {type: integer}
-
-    NullableTimeDelta:
-      nullable: true
-      allOf:
-        - $ref: '#/components/schemas/TimeDelta'
 
     RelativeDelta:
       description: Relative delta
@@ -4659,7 +4642,9 @@ components:
         *Changed in version 2.4.0*&#58; 'sensing' state has been removed.
         *Changed in version 2.4.2*&#58; 'restarting' is added as a possible value
       type: string
+      nullable: true
       enum:
+        - null
         - success
         - running
         - failed
@@ -4673,11 +4658,6 @@ components:
         - deferred
         - removed
         - restarting
-
-    NullableTaskState:
-      nullable: true
-      allOf:
-        - $ref: '#/components/schemas/TaskState'
 
     DagState:
       description: |

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -4641,6 +4641,10 @@ components:
 
         *Changed in version 2.4.0*&#58; 'sensing' state has been removed.
         *Changed in version 2.4.2*&#58; 'restarting' is added as a possible value
+
+        *Changed in version 2.7.0*&#58; Field becomes nullable and null primitive is added as a possible value.
+        *Changed in version 2.7.0*&#58; 'none' state is deprecated in favor of null.
+
       type: string
       nullable: true
       enum:

--- a/airflow/api_connexion/schemas/task_instance_schema.py
+++ b/airflow/api_connexion/schemas/task_instance_schema.py
@@ -108,7 +108,7 @@ class TaskInstanceBatchFormSchema(Schema):
     end_date_lte = fields.DateTime(load_default=None, validate=validate_istimezone)
     duration_gte = fields.Int(load_default=None)
     duration_lte = fields.Int(load_default=None)
-    state = fields.List(fields.Str(), load_default=None)
+    state = fields.List(fields.Str(allow_none=True), load_default=None)
     pool = fields.List(fields.Str(), load_default=None)
     queue = fields.List(fields.Str(), load_default=None)
 

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1298,6 +1298,7 @@ export interface components {
       description?: string | null;
       notification_sent?: boolean;
     } | null;
+    NullableSLAMiss: components["schemas"]["SLAMiss"] | null;
     Trigger: {
       id?: number;
       classpath?: string;
@@ -1306,6 +1307,7 @@ export interface components {
       created_date?: string;
       triggerer_id?: number | null;
     };
+    NullableTrigger: components["schemas"]["Trigger"] | null;
     Job: {
       id?: number;
       dag_id?: string | null;
@@ -1321,6 +1323,7 @@ export interface components {
       hostname?: string | null;
       unixname?: string | null;
     };
+    NullableJob: components["schemas"]["Job"] | null;
     TaskInstance: {
       task_id?: string;
       dag_id?: string;
@@ -1337,7 +1340,7 @@ export interface components {
       /** Format: datetime */
       end_date?: string | null;
       duration?: number | null;
-      state?: components["schemas"]["TaskState"] | null;
+      state?: components["schemas"]["NullableTaskState"];
       try_number?: number;
       map_index?: number;
       max_tries?: number;
@@ -1352,15 +1355,15 @@ export interface components {
       queued_when?: string | null;
       pid?: number | null;
       executor_config?: string;
-      sla_miss?: components["schemas"]["SLAMiss"] | null;
+      sla_miss?: components["schemas"]["NullableSLAMiss"];
       /**
        * @description JSON object describing rendered fields.
        *
        * *New in version 2.3.0*
        */
       rendered_fields?: { [key: string]: unknown };
-      trigger?: components["schemas"]["Trigger"] | null;
-      triggerer_job?: components["schemas"]["Job"] | null;
+      trigger?: components["schemas"]["NullableTrigger"];
+      triggerer_job?: components["schemas"]["NullableJob"];
       /**
        * @description Contains manually entered notes by the user about the TaskInstance.
        *
@@ -1460,7 +1463,7 @@ export interface components {
        * *Changed in version 2.0.1*&#58; Field becomes nullable.
        */
       start_date?: string | null;
-      dag_run_timeout?: components["schemas"]["TimeDelta"] | null;
+      dag_run_timeout?: components["schemas"]["NullableTimeDelta"];
       doc_md?: string | null;
       default_view?: string;
       /**
@@ -1535,8 +1538,8 @@ export interface components {
       queue?: string | null;
       pool?: string;
       pool_slots?: number;
-      execution_timeout?: components["schemas"]["TimeDelta"] | null;
-      retry_delay?: components["schemas"]["TimeDelta"] | null;
+      execution_timeout?: components["schemas"]["NullableTimeDelta"];
+      retry_delay?: components["schemas"]["NullableTimeDelta"];
       retry_exponential_backoff?: boolean;
       priority_weight?: number;
       weight_rule?: components["schemas"]["WeightRule"];
@@ -2060,6 +2063,7 @@ export interface components {
       seconds: number;
       microseconds: number;
     };
+    NullableTimeDelta: components["schemas"]["TimeDelta"] | null;
     /** @description Relative delta */
     RelativeDelta: {
       __type: string;
@@ -2150,6 +2154,7 @@ export interface components {
       | "deferred"
       | "removed"
       | "restarting";
+    NullableTaskState: components["schemas"]["TaskState"] | null;
     /**
      * @description DAG State.
      *
@@ -4707,10 +4712,19 @@ export type ProviderCollection = CamelCasedPropertiesDeep<
 export type SLAMiss = CamelCasedPropertiesDeep<
   components["schemas"]["SLAMiss"]
 >;
+export type NullableSLAMiss = CamelCasedPropertiesDeep<
+  components["schemas"]["NullableSLAMiss"]
+>;
 export type Trigger = CamelCasedPropertiesDeep<
   components["schemas"]["Trigger"]
 >;
+export type NullableTrigger = CamelCasedPropertiesDeep<
+  components["schemas"]["NullableTrigger"]
+>;
 export type Job = CamelCasedPropertiesDeep<components["schemas"]["Job"]>;
+export type NullableJob = CamelCasedPropertiesDeep<
+  components["schemas"]["NullableJob"]
+>;
 export type TaskInstance = CamelCasedPropertiesDeep<
   components["schemas"]["TaskInstance"]
 >;
@@ -4830,6 +4844,9 @@ export type ScheduleInterval = CamelCasedPropertiesDeep<
 export type TimeDelta = CamelCasedPropertiesDeep<
   components["schemas"]["TimeDelta"]
 >;
+export type NullableTimeDelta = CamelCasedPropertiesDeep<
+  components["schemas"]["NullableTimeDelta"]
+>;
 export type RelativeDelta = CamelCasedPropertiesDeep<
   components["schemas"]["RelativeDelta"]
 >;
@@ -4850,6 +4867,9 @@ export type CollectionInfo = CamelCasedPropertiesDeep<
 >;
 export type TaskState = CamelCasedPropertiesDeep<
   components["schemas"]["TaskState"]
+>;
+export type NullableTaskState = CamelCasedPropertiesDeep<
+  components["schemas"]["NullableTaskState"]
 >;
 export type DagState = CamelCasedPropertiesDeep<
   components["schemas"]["DagState"]

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -2134,6 +2134,9 @@ export interface components {
      * *Changed in version 2.4.0*&#58; 'sensing' state has been removed.
      * *Changed in version 2.4.2*&#58; 'restarting' is added as a possible value
      *
+     * *Changed in version 2.7.0*&#58; Field becomes nullable and null primitive is added as a possible value.
+     * *Changed in version 2.7.0*&#58; 'none' state is deprecated in favor of null.
+     *
      * @enum {string|null}
      */
     TaskState:

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1298,7 +1298,6 @@ export interface components {
       description?: string | null;
       notification_sent?: boolean;
     } | null;
-    NullableSLAMiss: components["schemas"]["SLAMiss"] | null;
     Trigger: {
       id?: number;
       classpath?: string;
@@ -1306,8 +1305,7 @@ export interface components {
       /** Format: datetime */
       created_date?: string;
       triggerer_id?: number | null;
-    };
-    NullableTrigger: components["schemas"]["Trigger"] | null;
+    } | null;
     Job: {
       id?: number;
       dag_id?: string | null;
@@ -1322,8 +1320,7 @@ export interface components {
       executor_class?: string | null;
       hostname?: string | null;
       unixname?: string | null;
-    };
-    NullableJob: components["schemas"]["Job"] | null;
+    } | null;
     TaskInstance: {
       task_id?: string;
       dag_id?: string;
@@ -1340,7 +1337,7 @@ export interface components {
       /** Format: datetime */
       end_date?: string | null;
       duration?: number | null;
-      state?: components["schemas"]["NullableTaskState"];
+      state?: components["schemas"]["TaskState"];
       try_number?: number;
       map_index?: number;
       max_tries?: number;
@@ -1355,15 +1352,15 @@ export interface components {
       queued_when?: string | null;
       pid?: number | null;
       executor_config?: string;
-      sla_miss?: components["schemas"]["NullableSLAMiss"];
+      sla_miss?: components["schemas"]["SLAMiss"];
       /**
        * @description JSON object describing rendered fields.
        *
        * *New in version 2.3.0*
        */
       rendered_fields?: { [key: string]: unknown };
-      trigger?: components["schemas"]["NullableTrigger"];
-      triggerer_job?: components["schemas"]["NullableJob"];
+      trigger?: components["schemas"]["Trigger"];
+      triggerer_job?: components["schemas"]["Job"];
       /**
        * @description Contains manually entered notes by the user about the TaskInstance.
        *
@@ -1463,7 +1460,7 @@ export interface components {
        * *Changed in version 2.0.1*&#58; Field becomes nullable.
        */
       start_date?: string | null;
-      dag_run_timeout?: components["schemas"]["NullableTimeDelta"];
+      dag_run_timeout?: components["schemas"]["TimeDelta"];
       doc_md?: string | null;
       default_view?: string;
       /**
@@ -1538,8 +1535,8 @@ export interface components {
       queue?: string | null;
       pool?: string;
       pool_slots?: number;
-      execution_timeout?: components["schemas"]["NullableTimeDelta"];
-      retry_delay?: components["schemas"]["NullableTimeDelta"];
+      execution_timeout?: components["schemas"]["TimeDelta"];
+      retry_delay?: components["schemas"]["TimeDelta"];
       retry_exponential_backoff?: boolean;
       priority_weight?: number;
       weight_rule?: components["schemas"]["WeightRule"];
@@ -2062,8 +2059,7 @@ export interface components {
       days: number;
       seconds: number;
       microseconds: number;
-    };
-    NullableTimeDelta: components["schemas"]["TimeDelta"] | null;
+    } | null;
     /** @description Relative delta */
     RelativeDelta: {
       __type: string;
@@ -2138,23 +2134,26 @@ export interface components {
      * *Changed in version 2.4.0*&#58; 'sensing' state has been removed.
      * *Changed in version 2.4.2*&#58; 'restarting' is added as a possible value
      *
-     * @enum {string}
+     * @enum {string|null}
      */
     TaskState:
-      | "success"
-      | "running"
-      | "failed"
-      | "upstream_failed"
-      | "skipped"
-      | "up_for_retry"
-      | "up_for_reschedule"
-      | "queued"
-      | "none"
-      | "scheduled"
-      | "deferred"
-      | "removed"
-      | "restarting";
-    NullableTaskState: components["schemas"]["TaskState"] | null;
+      | (
+          | null
+          | "success"
+          | "running"
+          | "failed"
+          | "upstream_failed"
+          | "skipped"
+          | "up_for_retry"
+          | "up_for_reschedule"
+          | "queued"
+          | "none"
+          | "scheduled"
+          | "deferred"
+          | "removed"
+          | "restarting"
+        )
+      | null;
     /**
      * @description DAG State.
      *
@@ -4712,19 +4711,10 @@ export type ProviderCollection = CamelCasedPropertiesDeep<
 export type SLAMiss = CamelCasedPropertiesDeep<
   components["schemas"]["SLAMiss"]
 >;
-export type NullableSLAMiss = CamelCasedPropertiesDeep<
-  components["schemas"]["NullableSLAMiss"]
->;
 export type Trigger = CamelCasedPropertiesDeep<
   components["schemas"]["Trigger"]
 >;
-export type NullableTrigger = CamelCasedPropertiesDeep<
-  components["schemas"]["NullableTrigger"]
->;
 export type Job = CamelCasedPropertiesDeep<components["schemas"]["Job"]>;
-export type NullableJob = CamelCasedPropertiesDeep<
-  components["schemas"]["NullableJob"]
->;
 export type TaskInstance = CamelCasedPropertiesDeep<
   components["schemas"]["TaskInstance"]
 >;
@@ -4844,9 +4834,6 @@ export type ScheduleInterval = CamelCasedPropertiesDeep<
 export type TimeDelta = CamelCasedPropertiesDeep<
   components["schemas"]["TimeDelta"]
 >;
-export type NullableTimeDelta = CamelCasedPropertiesDeep<
-  components["schemas"]["NullableTimeDelta"]
->;
 export type RelativeDelta = CamelCasedPropertiesDeep<
   components["schemas"]["RelativeDelta"]
 >;
@@ -4867,9 +4854,6 @@ export type CollectionInfo = CamelCasedPropertiesDeep<
 >;
 export type TaskState = CamelCasedPropertiesDeep<
   components["schemas"]["TaskState"]
->;
-export type NullableTaskState = CamelCasedPropertiesDeep<
-  components["schemas"]["NullableTaskState"]
 >;
 export type DagState = CamelCasedPropertiesDeep<
   components["schemas"]["DagState"]


### PR DESCRIPTION
Fix wrong usage of nullable prop next to a ref. TLDR $ref shouldn’t have sibling. (unless OpenAPI 3.1 that allows description and summary only I believe).
This induce wrong api documentation and most importantly bugs in our python clients such as:
- https://github.com/apache/airflow-client-python/commit/ddd6fc0545a8066f474c765e1644a5202eebd256 That needs to be manually cherry picked on each new release.
- https://github.com/apache/airflow-client-python/pull/89 another occurence that we forgot to also manually patch post client generation.-


This allows to generate the expected api doc and the correct client.
I Tried that locally by regenerating the client and making the problematic call, such as:
```
# The one that cancelled 2.6.2rc1 client.
dag_api_instance.get_tasks(DAG_ID)
```
It is working with this spec.

After this we can:
- Update the client release process to remove the cherry picking part. (manual fix)
- Close https://github.com/apache/airflow-client-python/pull/89
- Add a pre-commit hook to prevent siblings on $ref elements. (check why the current spec validator wrongfully allows it)
