### PR TITLE
fix: save codemirror content to extra textarea

### DIFF
--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -202,6 +202,21 @@ $(document).ready(() => {
     $("form#model_form div.well.well-sm button:submit")
   );
 
+  // Change conn.extra TextArea widget to CodeMirror
+  const textArea = document.getElementById("extra");
+  const editor = CodeMirror.fromTextArea(textArea, {
+    mode: { name: "javascript", json: true },
+    gutters: ["CodeMirror-lint-markers"],
+    lineWrapping: true,
+    lint: true,
+  });
+
+  // beautify JSON
+  const jsonData = editor.getValue();
+  const data = JSON.parse(jsonData);
+  const formattedData = JSON.stringify(data, null, 2);
+  editor.setValue(formattedData);
+
   /**
    * Changes the connection type.
    * @param {string} connType The connection type to change to.
@@ -296,6 +311,8 @@ $(document).ready(() => {
         // payload.
         if (this.name === "extra") {
           let extra;
+          // save the contents of the CodeMirror editor to the textArea
+          editor.save();
           try {
             extra = JSON.parse(this.value);
           } catch (e) {
@@ -353,19 +370,4 @@ $(document).ready(() => {
 
   // Initialize the form by setting a connection type.
   changeConnType(connTypeElem.value);
-
-  // Change conn.extra TextArea widget to CodeMirror
-  const textArea = document.getElementById("extra");
-  const editor = CodeMirror.fromTextArea(textArea, {
-    mode: { name: "javascript", json: true },
-    gutters: ["CodeMirror-lint-markers"],
-    lineWrapping: true,
-    lint: true,
-  });
-
-  // beautify JSON
-  const jsonData = editor.getValue();
-  const data = JSON.parse(jsonData);
-  const formattedData = JSON.stringify(data, null, 2);
-  editor.setValue(formattedData);
 });

--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -213,8 +213,8 @@ $(document).ready(() => {
 
   // beautify JSON
   const jsonData = editor.getValue();
-  const data = JSON.parse(jsonData);
-  const formattedData = JSON.stringify(data, null, 2);
+  const parsedData = JSON.parse(jsonData);
+  const formattedData = JSON.stringify(parsedData, null, 2);
   editor.setValue(formattedData);
 
   /**


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE 
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Saves CodeMirror editor content to `extra` textarea when `test-connection` is invoked.

closes: #32890 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
