### PR TITLE
Limit Appflow mypy - exclude 1.28.12 as it introduces strange typing issue

### DIFF
--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -76,7 +76,9 @@ dependencies:
   - sqlalchemy_redshift>=0.8.6
   - mypy-boto3-rds>=1.24.0
   - mypy-boto3-redshift-data>=1.24.0
-  - mypy-boto3-appflow>=1.24.0
+  # exclude 1.28.12 as it causes strange typing inconsistency
+  # https://github.com/youtype/mypy_boto3_builder/issues/209
+  - mypy-boto3-appflow>=1.24.0,!=1.28.12
   - asgiref
   - mypy-boto3-s3>=1.24.0
 

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -28,7 +28,7 @@
       "asgiref",
       "boto3>=1.24.0",
       "jsonpath_ng>=1.5.3",
-      "mypy-boto3-appflow>=1.24.0",
+      "mypy-boto3-appflow>=1.24.0,!=1.28.12",
       "mypy-boto3-rds>=1.24.0",
       "mypy-boto3-redshift-data>=1.24.0",
       "mypy-boto3-s3>=1.24.0",


### PR DESCRIPTION
The 1.28.12 release of appflow mypy typeshed introduces inconsistency that we have no idea how to fix

https://github.com/youtype/mypy_boto3_builder/issues/209

Limiting it to unblock main

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
