### PR TITLE
Fix MIN_AIRFLOW_VERSION_EXCEPTIONS for openlineage

### DIFF
--- a/airflow/providers/openlineage/__init__.py
+++ b/airflow/providers/openlineage/__init__.py
@@ -35,7 +35,7 @@ try:
 except ImportError:
     from airflow.version import version as airflow_version
 
-if packaging.version.parse(airflow_version) < packaging.version.parse("2.6.0"):
+if packaging.version.parse(airflow_version) < packaging.version.parse("2.7.0"):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-openlineage:{__version__}` requires Apache Airflow 2.6.0+"
+        f"The package `apache-airflow-providers-openlineage:{__version__}` requires Apache Airflow 2.7.0+"
     )

--- a/airflow/providers/openlineage/__init__.py
+++ b/airflow/providers/openlineage/__init__.py
@@ -35,7 +35,9 @@ try:
 except ImportError:
     from airflow.version import version as airflow_version
 
-if packaging.version.parse(airflow_version) < packaging.version.parse("2.7.0"):
+if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
+    "2.7.0"
+):
     raise RuntimeError(
         f"The package `apache-airflow-providers-openlineage:{__version__}` requires Apache Airflow 2.7.0+"
     )

--- a/dev/provider_packages/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
+++ b/dev/provider_packages/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
@@ -53,7 +53,9 @@ try:
 except ImportError:
     from airflow.version import version as airflow_version
 
-if packaging.version.parse(airflow_version) < packaging.version.parse("{{ MIN_AIRFLOW_VERSION }}"):
+if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
+    "{{ MIN_AIRFLOW_VERSION }}"
+):
     raise RuntimeError(
         f"The package `{{ PACKAGE_PIP_NAME }}:{__version__}` requires Apache Airflow {{ MIN_AIRFLOW_VERSION }}+"  # NOQA: E501
     )

--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -59,7 +59,7 @@ MIN_AIRFLOW_VERSION = "2.4.0"
 # In case you have some providers that you want to have different min-airflow version for,
 # Add them as exceptions here. Make sure to remove it once the min-airflow version is bumped
 # to the same version that is required by the exceptional provider
-MIN_AIRFLOW_VERSION_EXCEPTIONS = {"openlineage": "2.6.0"}
+MIN_AIRFLOW_VERSION_EXCEPTIONS = {"openlineage": "2.7.0"}
 
 INITIAL_CHANGELOG_CONTENT = """
  .. Licensed to the Apache Software Foundation (ASF) under one


### PR DESCRIPTION
Followup of https://github.com/apache/airflow/pull/32882