### PR TITLE
Fix cache builing on CI and building CI images locally

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -214,6 +214,7 @@ jobs:
       DEFAULT_CONSTRAINTS_BRANCH: ${{ needs.build-info.outputs.default-constraints-branch }}
       RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
       BACKEND: sqlite
+      VERSION_SUFFIX_FOR_PYPI: "dev0"
     steps:
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,7 @@ jobs:
     env:
       RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
       UPGRADE_TO_NEWER_DEPENDENCIES: false
+      VERSION_SUFFIX_FOR_PYPI: "dev0"
     continue-on-error: true
     steps:
       - name: Cleanup repo
@@ -1628,6 +1629,7 @@ jobs:
         platform: ["linux/amd64", "linux/arm64"]
     env:
       RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
+      VERSION_SUFFIX_FOR_PYPI: "dev0"
     steps:
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"

--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -460,11 +460,16 @@ def run_build_ci_image(
       * update cached information that the build completed and saves checksums of all files
         for quick future check if the build is needed
 
-
-
     :param ci_image_params: CI image parameters
     :param output: output redirection
     """
+    if not ci_image_params.version_suffix_for_pypi:
+        # We need that to handle the >= 2.7.0 limit we have for openlineage provider at least until
+        # Airflow 2.7.0 release is out, in order to avoid conflicting dependencies while building the image
+        # We are setting version_suffix_for_pypi to dev0 for CI builds where cache is prepared, so in
+        # order to have the cache used effectively, we should also locally force the version_suffix_for_pypi
+        # to dev0. We might evan leave it as default value in the future (to be decided after 2.7.0 release)
+        ci_image_params.version_suffix_for_pypi = "dev0"
     if (
         ci_image_params.is_multi_platform()
         and not ci_image_params.push


### PR DESCRIPTION
Buildig cache on our CI has been broken since we added open lineage provider with >=2.7.0 limit. This should be handled by also adding VERSION_SUFFIX_FOR_PYPI to the cache builds (which is anyhow needed because otherwise cache would not be really functional.

We actually also have to add it to ci-image-build automatically in this case otherwise users won't be able to build their images locally.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
