### PR TITLE
openlineage,gcs: use proper name for openlineage methods

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -553,7 +553,7 @@ class GCSToGCSOperator(BaseOperator):
         if self.move_object:
             hook.delete(self.source_bucket, source_object)
 
-    def get_openlineage_events_on_complete(self, task_instance):
+    def get_openlineage_facets_on_complete(self, task_instance):
         """
         Implementing _on_complete because execute method does preprocessing on internals.
         This means we won't have to normalize self.source_object and self.source_objects,

--- a/docs/apache-airflow-providers-openlineage/guides/developer.rst
+++ b/docs/apache-airflow-providers-openlineage/guides/developer.rst
@@ -81,7 +81,7 @@ Here's example of properly implemented ``get_openlineage_facets_on_complete`` me
 
 .. code-block::
 
-    def get_openlineage_events_on_complete(self, task_instance):
+    def get_openlineage_facets_on_complete(self, task_instance):
         """
         Implementing _on_complete because execute method does preprocessing on internals.
         This means we won't have to normalize self.source_object and self.source_objects,

--- a/tests/providers/google/cloud/transfers/test_gcs_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_gcs.py
@@ -840,7 +840,7 @@ class TestGoogleCloudStorageToCloudStorageOperator:
 
         operator.execute(None)
 
-        lineage = operator.get_openlineage_events_on_complete(None)
+        lineage = operator.get_openlineage_facets_on_complete(None)
         assert len(lineage.inputs) == 1
         assert len(lineage.outputs) == 1
         assert lineage.inputs[0] == Dataset(
@@ -862,7 +862,7 @@ class TestGoogleCloudStorageToCloudStorageOperator:
 
         operator.execute(None)
 
-        lineage = operator.get_openlineage_events_on_complete(None)
+        lineage = operator.get_openlineage_facets_on_complete(None)
         assert len(lineage.inputs) == 3
         assert len(lineage.outputs) == 1
         assert lineage.inputs == [
@@ -889,7 +889,7 @@ class TestGoogleCloudStorageToCloudStorageOperator:
 
         operator.execute(None)
 
-        lineage = operator.get_openlineage_events_on_complete(None)
+        lineage = operator.get_openlineage_facets_on_complete(None)
         assert len(lineage.inputs) == 2
         assert len(lineage.outputs) == 2
         assert lineage.inputs == [


### PR DESCRIPTION
The `GCSToGCSOperator` uses wrong names for OpenLineage methods. Those should be `get_openlineage_facets_on_complete`. 

BTW, maybe we should make it "official" interface in `BaseOperator` to prevent those mistakes.