### PR TITLE
Validate connection host field for Sqoop connection

### DIFF
--- a/airflow/providers/apache/sqoop/hooks/sqoop.py
+++ b/airflow/providers/apache/sqoop/hooks/sqoop.py
@@ -113,6 +113,9 @@ class SqoopHook(BaseHook):
                 raise AirflowException(f"Sqoop command failed: {masked_cmd}")
 
     def _prepare_command(self, export: bool = False) -> list[str]:
+        if "?" in self.conn.host:
+            raise ValueError("The sqoop connection host should not contain a '?' character")
+
         sqoop_cmd_type = "export" if export else "import"
         connection_cmd = ["sqoop", sqoop_cmd_type]
 

--- a/tests/providers/apache/sqoop/hooks/test_sqoop.py
+++ b/tests/providers/apache/sqoop/hooks/test_sqoop.py
@@ -101,6 +101,16 @@ class TestSqoopHook:
                 extra=None,
             )
         )
+        db.merge_conn(
+            Connection(
+                conn_id="invalid_host_conn",
+                conn_type="mssql",
+                schema="schema",
+                host="rmdbs?query_param1=value1",
+                port=5050,
+                extra=None,
+            )
+        )
 
     @patch("subprocess.Popen")
     def test_popen(self, mock_popen):
@@ -370,3 +380,8 @@ class TestSqoopHook:
         # Case no mssql
         hook = SqoopHook(conn_id="sqoop_test")
         assert f"{hook.conn.host}:{hook.conn.port}/{hook.conn.schema}" in hook._prepare_command()
+
+    def test_invalid_host(self):
+        hook = SqoopHook(conn_id="invalid_host_conn")
+        with pytest.raises(ValueError, match="host should not contain a"):
+            hook._prepare_command()


### PR DESCRIPTION
The connection `host` field should not contain a `?` for the 
sqoop connection as it is not intended to include query 
params in the `host` field.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
