### PR TITLE
Fix system-test pytest marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ filterwarnings = [
 ]
 python_files = [
     "test_*.py",
+    "example_*.py",
 ]
 testpaths = [
     "tests",

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -52,7 +52,7 @@ def pytest_collection_modifyitems(config, items):
     rootdir = Path(config.rootdir)
     for item in items:
         rel_path = Path(item.fspath).relative_to(rootdir)
-        match = re.match(".+/providers/([^/]+)", str(rel_path))
+        match = re.match(".+/system/providers/([^/]+)", str(rel_path))
         if not match:
             continue
         provider = match.group(1)


### PR DESCRIPTION
We have an automated system-test pytest marker that applies the pytest.mark.system marker to all system tests. It has been implemented in a strange way as it was applying the marker to all provider tests if the whole "tests" directory was used for test collection.

This caused quarantine tests from providers folder to be skipped because they were automatically marked with pytest.mark.system marker.

Also system tests were generally excluded from running after we brought back the "test_*" prefix.

This PR updates the auto-marker to only apply system marker to tests in "system/providers" folder and adds the "example_*" prefix to the prefixes automatically collected by pytest.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
