### PR TITLE
doc: local executors - rephrase scheduler process

### DIFF
--- a/docs/apache-airflow/core-concepts/executor/index.rst
+++ b/docs/apache-airflow/core-concepts/executor/index.rst
@@ -77,4 +77,4 @@ There are two types of executor - those that run tasks *locally* (inside the ``s
 
 .. note::
 
-    Something that often confuses new users of Airflow is that they don't need to run a separate ``executor`` process using one of the Local Executors or Remote Executors (because executor's logic runs *inside* the ``scheduler`` process and this logic will run the tasks locally or not depending the executor selected).
+    New Airflow users may assume they need to run a separate executor process using one of the Local or Remote Executors. This is not correct. The executor logic runs *inside* the scheduler process, and will run the tasks locally or not depending the executor selected.

--- a/docs/apache-airflow/core-concepts/executor/index.rst
+++ b/docs/apache-airflow/core-concepts/executor/index.rst
@@ -77,4 +77,4 @@ There are two types of executor - those that run tasks *locally* (inside the ``s
 
 .. note::
 
-    Something that often confuses new users of Airflow is that they don't need to run a separate ``executor`` process when using one of the Local Executors (because in this case the executor's logic runs *inside* the ``scheduler`` process).
+    Something that often confuses new users of Airflow is that they don't need to run a separate ``executor`` process using one of the Local Executors or Remote Executors (because executor's logic runs *inside* the ``scheduler`` process and this logic will run the tasks locally or not depending the executor selected).

--- a/docs/apache-airflow/core-concepts/executor/index.rst
+++ b/docs/apache-airflow/core-concepts/executor/index.rst
@@ -77,4 +77,4 @@ There are two types of executor - those that run tasks *locally* (inside the ``s
 
 .. note::
 
-    Something that often confuses new users of Airflow is that they don't need to run a separate ``executor`` process. This is because the executor's logic runs *inside* the ``scheduler`` process - if you're running a scheduler, you're running the executor.
+    Something that often confuses new users of Airflow is that they don't need to run a separate ``executor`` process when using one of the Local Executors (because in this case the executor's logic runs *inside* the ``scheduler`` process).


### PR DESCRIPTION
this note is at the end of the page (after the listing of the Remote Executors) let's make it super explicit