### PR TITLE
Move redis subscribe to poke() method in Redis Sensor

### DIFF
--- a/tests/integration/providers/redis/sensors/test_redis_pub_sub.py
+++ b/tests/integration/providers/redis/sensors/test_redis_pub_sub.py
@@ -46,10 +46,10 @@ class TestRedisPubSubSensor:
 
         hook = RedisHook(redis_conn_id="redis_default")
         redis = hook.get_conn()
-        redis.publish("test", "message")
 
         result = sensor.poke(self.mock_context)
         assert not result
+        redis.publish("test", "message")
 
         for _ in range(1, 10):
             result = sensor.poke(self.mock_context)


### PR DESCRIPTION
In RedisPubSubSensor subscription has been done in constructor, which was pretty wrong - for example it means that when scheduler parses the sensor, it involves subscribing to the messages and commmunication with redis DB.

This PR moves subscription to "poke()" method, which is executed on worker instead.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
