### PR TITLE
listener: move success hook to after SQLAlchemy commit

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1583,11 +1583,13 @@ class TaskInstance(Base, LoggingMixin):
             session.merge(self).task = self.task
             if self.state == TaskInstanceState.SUCCESS:
                 self._register_dataset_changes(session=session)
+
+            session.commit()
+            if self.state == TaskInstanceState.SUCCESS:
                 get_listener_manager().hook.on_task_instance_success(
                     previous_state=TaskInstanceState.RUNNING, task_instance=self, session=session
                 )
 
-            session.commit()
         return None
 
     def _register_dataset_changes(self, *, session: Session) -> None:


### PR DESCRIPTION
Similarly to https://github.com/apache/airflow/pull/32716 - slightly change the place of where `on_task_instance_success` listener is called. 

This currently takes place between when SQLAlchemy session is merged, and when it's committed. 
It's more safe to call it after the SQLAlchemy transaction has been committed. 