### PR TITLE
Bring back mysql-connector-python as required dependency

### DIFF
--- a/airflow/providers/apache/hive/transfers/mysql_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/mysql_to_hive.py
@@ -151,7 +151,7 @@ class MySqlToHiveOperator(BaseOperator):
                     if cursor.description is not None:
                         for field in cursor.description:
                             field_dict[field[0]] = self.type_map(field[1])
-                    csv_writer.writerows(cursor)
+                    csv_writer.writerows(cursor)  # type: ignore[arg-type]
             f.flush()
             self.log.info("Loading file into Hive")
             hive.load_file(

--- a/airflow/providers/mysql/CHANGELOG.rst
+++ b/airflow/providers/mysql/CHANGELOG.rst
@@ -26,6 +26,9 @@
 Changelog
 ---------
 
+This release brings back mysql-connector-python as required dependency of the provider - since 8.1.0
+version has been released with Protobuf 4 support, removing dependency conflicts with other providers.
+
 5.2.0
 .....
 

--- a/airflow/providers/mysql/provider.yaml
+++ b/airflow/providers/mysql/provider.yaml
@@ -52,6 +52,7 @@ dependencies:
   - apache-airflow>=2.4.0
   - apache-airflow-providers-common-sql>=1.3.1
   - mysqlclient>=1.3.6
+  - mysql-connector-python>=8.0.11
 
 integrations:
   - integration-name: MySQL
@@ -92,6 +93,6 @@ connection-types:
     connection-type: mysql
 
 additional-extras:
+  # only needed for backwards compatibility
   - name: mysql-connector-python
-    dependencies:
-      - mysql-connector-python>=8.0.11
+    dependencies: []

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -615,6 +615,7 @@
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.4.0",
+      "mysql-connector-python>=8.0.11",
       "mysqlclient>=1.3.6"
     ],
     "cross-providers-deps": [

--- a/tests/providers/mysql/hooks/test_mysql_connector_python.py
+++ b/tests/providers/mysql/hooks/test_mysql_connector_python.py
@@ -20,13 +20,8 @@ from __future__ import annotations
 import json
 from unittest import mock
 
-import pytest
-
 from airflow.models import Connection
 from airflow.providers.mysql.hooks.mysql import MySqlHook
-
-# Make sure that the optional package 'mysql-connector-python' is installed (which is not by default)
-pytest.importorskip("mysql")
 
 
 class TestMySqlHookConnMySqlConnectorPython:


### PR DESCRIPTION
The mysql-connector-python 8.1.0 was released 18th of July with Protobuf 4 support - thus resolving dependency conflicts we had.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
