### PR TITLE
Limit Asana Python client until provider is adapted to 4.* version

### DIFF
--- a/airflow/providers/asana/provider.yaml
+++ b/airflow/providers/asana/provider.yaml
@@ -36,7 +36,11 @@ versions:
 
 dependencies:
   - apache-airflow>=2.4.0
-  - asana>=0.10
+  # The Asana provider uses Asana Python API https://github.com/Asana/python-asana/ and version
+  # 4.* of it introduced 31.07.2023 is heavily incompatible with previous versions
+  # (new way of generating API client from specification has been used). Until we convert to the new API
+  # - as described in https://github.com/apache/airflow/issues/32994 - we need to limit the version to < 4.
+  - asana>=0.10,<4.0.0
 
 integrations:
   - integration-name: Asana

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -228,7 +228,7 @@
   "asana": {
     "deps": [
       "apache-airflow>=2.4.0",
-      "asana>=0.10"
+      "asana>=0.10,<4.0.0"
     ],
     "cross-providers-deps": [],
     "excluded-python-versions": []


### PR DESCRIPTION
The Asana provider uses Asana Python API
https://github.com/Asana/python-asana/ and version 4.* of it introduced 31.07.2023 is heavily incompatible with previous versions (new way of generating API client from specification has been used). Until we convert to the new API - as described in #32994 - we need to limit the version to < 4.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
