### PR TITLE
Fix DAG-level permissions disappearance on DAG sync

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -435,7 +435,7 @@ class DagBag(LoggingMixin):
 
         found_dags = []
 
-        for (dag, mod) in top_level_dags:
+        for dag, mod in top_level_dags:
             dag.fileloc = mod.__file__
             try:
                 dag.validate()
@@ -686,11 +686,30 @@ class DagBag(LoggingMixin):
     @classmethod
     @provide_session
     def _sync_perm_for_dag(cls, dag: DAG, session: Session = NEW_SESSION):
+        """Sync DAG specific permissions, if necessary."""
+        from airflow.auth.managers.fab.models import Action, Permission, Resource
+        from airflow.security.permissions import DAG_ACTIONS, resource_name_for_dag
+
         """Sync DAG specific permissions."""
         root_dag_id = dag.parent_dag.dag_id if dag.parent_dag else dag.dag_id
 
-        cls.logger().debug("Syncing DAG permissions: %s to the DB", root_dag_id)
-        from airflow.www.security import ApplessAirflowSecurityManager
+        def needs_perms(dag_id: str) -> bool:
+            dag_resource_name = resource_name_for_dag(dag_id)
+            for permission_name in DAG_ACTIONS:
+                if not (
+                    session.query(Permission)
+                    .join(Action)
+                    .join(Resource)
+                    .filter(Action.name == permission_name)
+                    .filter(Resource.name == dag_resource_name)
+                    .one_or_none()
+                ):
+                    return True
+            return False
 
-        security_manager = ApplessAirflowSecurityManager(session=session)
-        security_manager.sync_perm_for_dag(root_dag_id, dag.access_control)
+        if dag.access_control or needs_perms(root_dag_id):
+            cls.logger().debug("Syncing DAG permissions: %s to the DB", root_dag_id)
+            from airflow.www.security import ApplessAirflowSecurityManager
+
+            security_manager = ApplessAirflowSecurityManager(session=session)
+            security_manager.sync_perm_for_dag(root_dag_id, dag.access_control)

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -908,6 +908,7 @@ class TestDagBag:
     def test_sync_perm_for_dag(self, mock_security_manager):
         """
         Test that dagbag._sync_perm_for_dag will call ApplessAirflowSecurityManager.sync_perm_for_dag
+        when DAG specific perm views don't exist already or the DAG has access_control set.
         """
         db_clean_up()
         with create_session() as session:
@@ -931,7 +932,7 @@ class TestDagBag:
 
             # perms now exist
             _sync_perms()
-            mock_sync_perm_for_dag.assert_called_once_with("test_example_bash_operator", None)
+            mock_sync_perm_for_dag.assert_not_called()
 
             # Always sync if we have access_control
             dag.access_control = {"Public": {"can_read"}}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Closes: #32839 

Adds back the code that was removed in #30340 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
