### PR TITLE
Refactor system tests for DataprocSubmitJobOperator (PySpark, SparkR jobs)

### DIFF
--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_pyspark.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_pyspark.py
@@ -24,24 +24,18 @@ import os
 from datetime import datetime
 
 from airflow import models
-from airflow.decorators import task
 from airflow.providers.google.cloud.operators.dataproc import (
     DataprocCreateClusterOperator,
     DataprocDeleteClusterOperator,
     DataprocSubmitJobOperator,
 )
-from airflow.providers.google.cloud.operators.gcs import (
-    GCSCreateBucketOperator,
-    GCSDeleteBucketOperator,
-)
-from airflow.providers.google.cloud.transfers.local_to_gcs import LocalFilesystemToGCSOperator
 from airflow.utils.trigger_rule import TriggerRule
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 DAG_ID = "dataproc_pyspark"
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT")
 
-BUCKET_NAME = f"bucket_{DAG_ID}_{ENV_ID}"
+JOB_FILE_URI = "gs://airflow-system-tests-resources/dataproc/pyspark/dataproc-pyspark-job-pi.py"
 CLUSTER_NAME = f"cluster-{ENV_ID}-{DAG_ID}".replace("_", "-")
 REGION = "europe-west1"
 
@@ -59,35 +53,12 @@ CLUSTER_CONFIG = {
     },
 }
 
-JOB_FILE_NAME = "dataproc-pyspark-job.py"
-JOB_FILE_LOCAL_PATH = f"/tmp/{JOB_FILE_NAME}"
-JOB_FILE_CONTENT = """from operator import add
-from random import random
-
-from pyspark.sql import SparkSession
-
-
-def f(_: int) -> float:
-    x = random() * 2 - 1
-    y = random() * 2 - 1
-    return 1 if x**2 + y**2 <= 1 else 0
-
-
-spark = SparkSession.builder.appName("PythonPi").getOrCreate()
-partitions = 2
-n = 100000 * partitions
-count = spark.sparkContext.parallelize(range(1, n + 1), partitions).map(f).reduce(add)
-print(f"Pi is roughly {4.0 * count / n:f}")
-
-spark.stop()
-"""
-
 # Jobs definitions
 # [START how_to_cloud_dataproc_pyspark_config]
 PYSPARK_JOB = {
     "reference": {"project_id": PROJECT_ID},
     "placement": {"cluster_name": CLUSTER_NAME},
-    "pyspark_job": {"main_python_file_uri": f"gs://{BUCKET_NAME}/{JOB_FILE_NAME}"},
+    "pyspark_job": {"main_python_file_uri": JOB_FILE_URI},
 }
 # [END how_to_cloud_dataproc_pyspark_config]
 
@@ -99,23 +70,6 @@ with models.DAG(
     catchup=False,
     tags=["example", "dataproc", "pyspark"],
 ) as dag:
-    create_bucket = GCSCreateBucketOperator(
-        task_id="create_bucket", bucket_name=BUCKET_NAME, project_id=PROJECT_ID
-    )
-
-    @task
-    def create_job_file():
-        with open(JOB_FILE_LOCAL_PATH, "w") as job_file:
-            job_file.write(JOB_FILE_CONTENT)
-
-    create_job_file_task = create_job_file()
-
-    upload_file = LocalFilesystemToGCSOperator(
-        task_id="upload_file",
-        src=JOB_FILE_LOCAL_PATH,
-        dst=JOB_FILE_NAME,
-        bucket=BUCKET_NAME,
-    )
 
     create_cluster = DataprocCreateClusterOperator(
         task_id="create_cluster",
@@ -139,27 +93,13 @@ with models.DAG(
         trigger_rule=TriggerRule.ALL_DONE,
     )
 
-    delete_bucket = GCSDeleteBucketOperator(
-        task_id="delete_bucket", bucket_name=BUCKET_NAME, trigger_rule=TriggerRule.ALL_DONE
-    )
-
-    @task(trigger_rule=TriggerRule.ALL_DONE)
-    def delete_job_file():
-        try:
-            os.remove(JOB_FILE_LOCAL_PATH)
-        except FileNotFoundError:
-            pass
-        return 0
-
-    delete_job_file_task = delete_job_file()
-
     (
         # TEST SETUP
-        [[create_job_file_task, create_bucket] >> upload_file, create_cluster]
+        create_cluster
         # TEST BODY
         >> pyspark_task
         # TEST TEARDOWN
-        >> [delete_cluster, delete_bucket, delete_job_file_task]
+        >> delete_cluster
     )
 
     from tests.system.utils.watcher import watcher

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_sparkr.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_sparkr.py
@@ -24,24 +24,18 @@ import os
 from datetime import datetime
 
 from airflow import models
-from airflow.decorators import task
 from airflow.providers.google.cloud.operators.dataproc import (
     DataprocCreateClusterOperator,
     DataprocDeleteClusterOperator,
     DataprocSubmitJobOperator,
 )
-from airflow.providers.google.cloud.operators.gcs import (
-    GCSCreateBucketOperator,
-    GCSDeleteBucketOperator,
-)
-from airflow.providers.google.cloud.transfers.local_to_gcs import LocalFilesystemToGCSOperator
 from airflow.utils.trigger_rule import TriggerRule
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 DAG_ID = "dataproc_sparkr"
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT")
 
-BUCKET_NAME = f"bucket_{DAG_ID}_{ENV_ID}"
+JOB_FILE_URI = "gs://airflow-system-tests-resources/dataproc/sparkr/dataproc-sparkr-job.r"
 CLUSTER_NAME = f"cluster-{ENV_ID}-{DAG_ID}".replace("_", "-")
 REGION = "europe-west1"
 
@@ -59,20 +53,12 @@ CLUSTER_CONFIG = {
     },
 }
 
-JOB_FILE_NAME = "dataproc-sparkr-job.r"
-JOB_FILE_LOCAL_PATH = f"/tmp/{JOB_FILE_NAME}"
-JOB_FILE_CONTENT = """library(SparkR)
-sparkR.session()
-df <- as.DataFrame(faithful)
-head(df)
-"""
-
 # Jobs definitions
 # [START how_to_cloud_dataproc_sparkr_config]
 SPARKR_JOB = {
     "reference": {"project_id": PROJECT_ID},
     "placement": {"cluster_name": CLUSTER_NAME},
-    "spark_r_job": {"main_r_file_uri": f"gs://{BUCKET_NAME}/{JOB_FILE_NAME}"},
+    "spark_r_job": {"main_r_file_uri": JOB_FILE_URI},
 }
 # [END how_to_cloud_dataproc_sparkr_config]
 
@@ -84,23 +70,6 @@ with models.DAG(
     catchup=False,
     tags=["example", "dataproc", "sparkr"],
 ) as dag:
-    create_bucket = GCSCreateBucketOperator(
-        task_id="create_bucket", bucket_name=BUCKET_NAME, project_id=PROJECT_ID
-    )
-
-    @task
-    def create_job_file():
-        with open(JOB_FILE_LOCAL_PATH, "w") as job_file:
-            job_file.write(JOB_FILE_CONTENT)
-
-    create_job_file_task = create_job_file()
-
-    upload_file = LocalFilesystemToGCSOperator(
-        task_id="upload_file",
-        src=JOB_FILE_LOCAL_PATH,
-        dst=JOB_FILE_NAME,
-        bucket=BUCKET_NAME,
-    )
 
     create_cluster = DataprocCreateClusterOperator(
         task_id="create_cluster",
@@ -122,25 +91,14 @@ with models.DAG(
         trigger_rule=TriggerRule.ALL_DONE,
     )
 
-    delete_bucket = GCSDeleteBucketOperator(
-        task_id="delete_bucket", bucket_name=BUCKET_NAME, trigger_rule=TriggerRule.ALL_DONE
+    (
+        # TEST SETUP
+        create_cluster
+        # TEST BODY
+        >> sparkr_task
+        # TEST TEARDOWN
+        >> delete_cluster
     )
-
-    @task(trigger_rule=TriggerRule.ALL_DONE)
-    def delete_job_file():
-        try:
-            os.remove(JOB_FILE_LOCAL_PATH)
-        except FileNotFoundError:
-            pass
-
-    delete_job_file_task = delete_job_file()
-
-    # TEST SETUP
-    [create_bucket, create_job_file_task] >> upload_file
-    # TEST BODY
-    [upload_file, create_cluster] >> sparkr_task
-    # TEST TEARDOWN
-    sparkr_task >> [delete_cluster, delete_bucket, delete_job_file_task]
 
     from tests.system.utils.watcher import watcher
 


### PR DESCRIPTION
Enhancement for `DataprocSubmitJobOperator` system tests (PySpark, SparkR jobs).

Dynamic creation of the job file was replaced by pulling it from the public GCS bucket `airflow-system-tests-resources`. This change resolves the following problems:
1. Tests were creating a job file and uploading it into a GCS bucket. If these two tasks run in different workers, then tests fail because the second task can't find the file.
2. After refactoring tests look shorter and simpler.  