### PR TITLE
Add Service Principal OAuth for Databricks.

### DIFF
--- a/docs/apache-airflow-providers-databricks/connections/databricks.rst
+++ b/docs/apache-airflow-providers-databricks/connections/databricks.rst
@@ -70,6 +70,10 @@ Extra (optional)
 
     * ``token``: Specify PAT to use. Consider to switch to specification of PAT in the Password field as it's more secure.
 
+    Following parameters are necessary if using Service Principal with Oauth token:
+
+    * ``service_principal_oauth``: Specify as 'true', and use Client ID and Client Secret as the Username and Password.
+
     Following parameters are necessary if using authentication with AAD token:
 
     * ``azure_tenant_id``: ID of the Azure Active Directory tenant

--- a/docs/apache-airflow-providers-databricks/connections/databricks.rst
+++ b/docs/apache-airflow-providers-databricks/connections/databricks.rst
@@ -55,13 +55,15 @@ Host (required)
 
 Login (optional)
     * If authentication with *Databricks login credentials* is used then specify the ``username`` used to login to Databricks.
-    * If *authentication with Azure Service Principal* is used then specify the ID of the Azure Service Principal
+    * If authentication with *Azure Service Principal* is used then specify the ID of the Azure Service Principal
     * If authentication with *PAT* is used then either leave this field empty or use 'token' as login (both work, the only difference is that if login is empty then token will be sent in request header as Bearer token, if login is 'token' then it will be sent using Basic Auth which is allowed by Databricks API, this may be useful if you plan to reuse this connection with e.g. SimpleHttpOperator)
+    * If authentication with *Databricks Service Principal OAuth* is used then specify the ID of the Service Principal (Databricks on AWS)
 
 Password (optional)
-    * If authentication with *Databricks login credentials*  is used then specify the ``password`` used to login to Databricks.
+    * If authentication with *Databricks login credentials* is used then specify the ``password`` used to login to Databricks.
     * If authentication with *Azure Service Principal* is used then specify the secret of the Azure Service Principal
     * If authentication with *PAT* is used, then specify PAT (recommended)
+    * If authentication with *Databricks Service Principal OAuth* is used then specify the secret of the Service Principal (Databricks on AWS)
 
 Extra (optional)
     Specify the extra parameter (as json dictionary) that can be used in the Databricks connection.
@@ -70,9 +72,9 @@ Extra (optional)
 
     * ``token``: Specify PAT to use. Consider to switch to specification of PAT in the Password field as it's more secure.
 
-    Following parameters are necessary if using Service Principal with Oauth token:
+    Following parameters are necessary if using authentication with OAuth token for AWS Databricks Service Principal:
 
-    * ``service_principal_oauth``: Specify as 'true', and use Client ID and Client Secret as the Username and Password.
+    * ``service_principal_oauth``: required boolean flag.  If specified as ``true``, use the Client ID and Client Secret as the Username and Password. See `Authentication using OAuth for service principals <https://docs.databricks.com/en/dev-tools/authentication-oauth.html>`_.
 
     Following parameters are necessary if using authentication with AAD token:
 

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -43,6 +43,7 @@ from airflow.providers.databricks.hooks.databricks_base import (
     AZURE_METADATA_SERVICE_INSTANCE_URL,
     AZURE_TOKEN_SERVICE_URL,
     DEFAULT_DATABRICKS_SCOPE,
+    OIDC_TOKEN_SERVICE_URL,
     TOKEN_REFRESH_LEAD_TIME,
     BearerAuth,
 )
@@ -1514,7 +1515,7 @@ class TestDatabricksHookSpToken:
         run_id = self.hook.submit_run(data)
 
         ad_call_args = mock_requests.method_calls[0]
-        assert ad_call_args[1][0] == "xx.cloud.databricks.com/oidc/v1/token"
+        assert ad_call_args[1][0] == OIDC_TOKEN_SERVICE_URL.format(HOST)
         assert ad_call_args[2]["data"] == "grant_type=client_credentials&scope=all-apis"
 
         assert run_id == "1"


### PR DESCRIPTION
Update the Databricks Hook so that a Service Principal OAuth Client ID and Client Secret can be used like a username and password.  The Hook will perform the token retrieval as needed.

closes: https://github.com/apache/airflow/issues/32969