### PR TITLE
add mixin interface describing OpenLineage methods to operators

### DIFF
--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -27,6 +27,7 @@ from airflow.hooks.base import BaseHook
 from airflow.models import BaseOperator, SkipMixin
 from airflow.providers.common.sql.hooks.sql import DbApiHook, fetch_all_handler, return_single_query_results
 from airflow.utils.helpers import merge_dicts
+from airflow.utils.openlineage_mixin import OpenLineageMixin
 
 if TYPE_CHECKING:
     from airflow.providers.openlineage.extractors import OperatorLineage
@@ -188,7 +189,7 @@ class BaseSQLOperator(BaseOperator):
         raise AirflowFailException(exception_string)
 
 
-class SQLExecuteQueryOperator(BaseSQLOperator):
+class SQLExecuteQueryOperator(BaseSQLOperator, OpenLineageMixin):
     """
     Executes SQL code in a specific database.
 

--- a/airflow/providers/ftp/operators/ftp.py
+++ b/airflow/providers/ftp/operators/ftp.py
@@ -27,6 +27,7 @@ from typing import Any, Sequence
 
 from airflow.models import BaseOperator
 from airflow.providers.ftp.hooks.ftp import FTPHook, FTPSHook
+from airflow.utils.openlineage_mixin import OpenLineageMixin
 
 
 class FTPOperation:
@@ -36,7 +37,7 @@ class FTPOperation:
     GET = "get"
 
 
-class FTPFileTransmitOperator(BaseOperator):
+class FTPFileTransmitOperator(BaseOperator, OpenLineageMixin):
     """
     FTPFileTransmitOperator for transferring files from remote host to local or vice a versa.
 

--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Sequence
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
+from airflow.utils.openlineage_mixin import OpenLineageMixin
 
 WILDCARD = "*"
 
@@ -31,7 +32,7 @@ if TYPE_CHECKING:
     from airflow.utils.context import Context
 
 
-class GCSToGCSOperator(BaseOperator):
+class GCSToGCSOperator(BaseOperator, OpenLineageMixin):
     """
     Copies objects from a bucket to another, with renaming if requested.
 

--- a/airflow/providers/openlineage/extractors/bash.py
+++ b/airflow/providers/openlineage/extractors/bash.py
@@ -25,13 +25,14 @@ from airflow.providers.openlineage.plugins.facets import (
     UnknownOperatorInstance,
 )
 from airflow.providers.openlineage.utils.utils import get_filtered_unknown_operator_keys, is_source_enabled
+from airflow.utils.openlineage_mixin import OpenLineageMixin
 
 """
 :meta private:
 """
 
 
-class BashExtractor(BaseExtractor):
+class BashExtractor(BaseExtractor, OpenLineageMixin):
     """
     Extract executed bash command and put it into SourceCodeJobFacet.
 

--- a/airflow/providers/openlineage/extractors/python.py
+++ b/airflow/providers/openlineage/extractors/python.py
@@ -28,13 +28,14 @@ from airflow.providers.openlineage.plugins.facets import (
     UnknownOperatorInstance,
 )
 from airflow.providers.openlineage.utils.utils import get_filtered_unknown_operator_keys, is_source_enabled
+from airflow.utils.openlineage_mixin import OpenLineageMixin
 
 """
 :meta private:
 """
 
 
-class PythonExtractor(BaseExtractor):
+class PythonExtractor(BaseExtractor, OpenLineageMixin):
     """
     Extract executed source code and put it into SourceCodeJobFacet.
 

--- a/airflow/providers/openlineage/plugins/listener.py
+++ b/airflow/providers/openlineage/plugins/listener.py
@@ -42,9 +42,15 @@ class OpenLineageListener:
 
     def __init__(self):
         self.log = logging.getLogger(__name__)
-        self.executor: Executor = None  # type: ignore
         self.extractor_manager = ExtractorManager()
         self.adapter = OpenLineageAdapter()
+        self._executor: Executor | None = None
+
+    @property
+    def executor(self) -> Executor:
+        if self._executor is None:
+            self._executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="openlineage_")
+        return self._executor
 
     @hookimpl
     def on_task_instance_running(
@@ -151,7 +157,7 @@ class OpenLineageListener:
     @hookimpl
     def on_starting(self, component):
         self.log.debug("on_starting: %s", component.__class__.__name__)
-        self.executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="openlineage_")
+        self.executor
 
     @hookimpl
     def before_stopping(self, component):

--- a/airflow/providers/sftp/operators/sftp.py
+++ b/airflow/providers/sftp/operators/sftp.py
@@ -30,6 +30,7 @@ from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarni
 from airflow.models import BaseOperator
 from airflow.providers.sftp.hooks.sftp import SFTPHook
 from airflow.providers.ssh.hooks.ssh import SSHHook
+from airflow.utils.openlineage_mixin import OpenLineageMixin
 
 
 class SFTPOperation:
@@ -39,7 +40,7 @@ class SFTPOperation:
     GET = "get"
 
 
-class SFTPOperator(BaseOperator):
+class SFTPOperator(BaseOperator, OpenLineageMixin):
     """
     SFTPOperator for transferring files from remote host to local or vice a versa.
 

--- a/airflow/utils/openlineage_mixin.py
+++ b/airflow/utils/openlineage_mixin.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import typing
+
+if typing.TYPE_CHECKING:
+    from airflow.models import TaskInstance
+    from airflow.providers.openlineage.extractors import OperatorLineage
+
+
+class OpenLineageMixin:
+    """
+    This interface marks implementation of OpenLineage methods,
+    allowing us to check for its existence rather than existence of particular methods on BaseOperator.
+    """
+
+    def get_openlineage_facets_on_start(self) -> OperatorLineage | None:
+        raise NotImplementedError()
+
+    def get_openlineage_facets_on_complete(self, task_instance: TaskInstance) -> OperatorLineage | None:
+        return self.get_openlineage_facets_on_start()
+
+    def get_openlineage_facets_on_fail(self, task_instance: TaskInstance) -> OperatorLineage | None:
+        return self.get_openlineage_facets_on_complete(task_instance)

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1044,6 +1044,7 @@ Oozie
 openapi
 openfaas
 openlineage
+OpenLineageMixin
 oper
 Opsgenie
 opsgenie


### PR DESCRIPTION
Following [discussion](https://github.com/apache/airflow/pull/32956), this PR adds `OpenLineageMixin` interface describing OpenLineage implementation methods. It allows us to mark operators implementing OpenLineage methods. 

However, we can't rely only on that in provider implementation, since we also want to handle other, community operators that do not yet base their implementation on `OpenLineageMixin`. 

EDIT: will get looked at by 2.8
