### PR TITLE
Fix invalid rule name in example_eventbridge.py

### DIFF
--- a/tests/system/providers/amazon/aws/example_eventbridge.py
+++ b/tests/system/providers/amazon/aws/example_eventbridge.py
@@ -56,7 +56,7 @@ with DAG(
     # [START howto_operator_eventbridge_put_rule]
     put_rule = EventBridgePutRuleOperator(
         task_id="put_rule_task",
-        name="Example Rule",
+        name="example_rule",
         event_pattern='{"source": ["example.myapp"]}',
         description="This rule matches events from example.myapp.",
     )


### PR DESCRIPTION
Small change to fix failing EventBridge system test.