### PR TITLE
Affix webserver access_denied warning to be configurable

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1351,7 +1351,7 @@ webserver:
   options:
     access_denied_message:
       description: |
-        The message displayed when an user tries to perform operations outside their rights.
+        The message displayed when a user attempts to execute actions beyond their authorised privileges.
       version_added: 2.7.0
       type: string
       example: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1349,6 +1349,13 @@ operators:
 webserver:
   description: ~
   options:
+    access_denied_message:
+      description: |
+        The message displayed when an user tries to perform operations outside their rights.
+      version_added: 2.7.0
+      type: string
+      example: ~
+      default: "Access is Denied"
     config_file:
       description: |
         Path of webserver config file used for configuring the webserver parameters

--- a/airflow/www/auth.py
+++ b/airflow/www/auth.py
@@ -28,6 +28,10 @@ from airflow.www.extensions.init_auth_manager import get_auth_manager
 T = TypeVar("T", bound=Callable)
 
 
+def get_access_denied_message():
+    return conf.get("webserver", "access_denied_message")
+
+
 def has_access(permissions: Sequence[tuple[str, str]] | None = None) -> Callable[[T], T]:
     """Factory for decorator that checks current user's permissions against required permissions."""
 
@@ -59,7 +63,7 @@ def has_access(permissions: Sequence[tuple[str, str]] | None = None) -> Callable
                     403,
                 )
             else:
-                access_denied = "Access is Denied"
+                access_denied = get_access_denied_message()
                 flash(access_denied, "danger")
             return redirect(get_auth_manager().get_url_login(next=request.url))
 

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import contextlib
 import datetime
 import logging
+import os
 from unittest import mock
 from unittest.mock import patch
 
@@ -32,6 +33,7 @@ from sqlalchemy import Column, Date, Float, Integer, String
 from airflow.auth.managers.fab.auth.anonymous_user import AnonymousUser
 from airflow.auth.managers.fab.fab_auth_manager import FabAuthManager
 from airflow.auth.managers.fab.models import User, assoc_permission_role
+from airflow.configuration import conf, initialize_config
 from airflow.exceptions import AirflowException
 from airflow.models import DagModel
 from airflow.models.base import Base
@@ -969,3 +971,16 @@ def test_users_can_be_found(app, security_manager, session, caplog):
     assert len(users) == 1
     delete_user(app, "Test")
     assert "Error adding new user to database" in caplog.text
+
+
+def test_access_denied_message():
+    with mock.patch.dict(
+        os.environ,
+        {"AIRFLOW__WEBSERVER__ACCESS_DENIED_MESSAGE": "My custom access denied message"},
+        clear=True,
+    ):
+        initialize_config()
+        assert conf.get("webserver", "access_denied_message") == "My custom access denied message"
+
+    initialize_config()
+    assert conf.get("webserver", "access_denied_message") == "Access is Denied"

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -33,13 +33,14 @@ from sqlalchemy import Column, Date, Float, Integer, String
 from airflow.auth.managers.fab.auth.anonymous_user import AnonymousUser
 from airflow.auth.managers.fab.fab_auth_manager import FabAuthManager
 from airflow.auth.managers.fab.models import User, assoc_permission_role
-from airflow.configuration import conf, initialize_config
+from airflow.configuration import initialize_config
 from airflow.exceptions import AirflowException
 from airflow.models import DagModel
 from airflow.models.base import Base
 from airflow.models.dag import DAG
 from airflow.security import permissions
 from airflow.www import app as application
+from airflow.www.auth import get_access_denied_message
 from airflow.www.utils import CustomSQLAInterface
 from tests.test_utils.api_connexion_utils import (
     create_user,
@@ -973,14 +974,16 @@ def test_users_can_be_found(app, security_manager, session, caplog):
     assert "Error adding new user to database" in caplog.text
 
 
-def test_access_denied_message():
+def test_default_access_denied_message():
+    initialize_config()
+    assert get_access_denied_message() == "Access is Denied"
+
+
+def test_custom_access_denied_message():
     with mock.patch.dict(
         os.environ,
         {"AIRFLOW__WEBSERVER__ACCESS_DENIED_MESSAGE": "My custom access denied message"},
         clear=True,
     ):
         initialize_config()
-        assert conf.get("webserver", "access_denied_message") == "My custom access denied message"
-
-    initialize_config()
-    assert conf.get("webserver", "access_denied_message") == "Access is Denied"
+        assert get_access_denied_message() == "My custom access denied message"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Add a possibility to make the airflow webserver's access denied message - which occurs when an user tries to perform some operation outside their user rights. Allow this to be configurable through config so that every webserver installation can have a custom message without changing the airflow code.

Note: This message is not per call to the `has_access` function, but per webserver installation which is a more realistic case.

Took suggestions from community and approached the problem accordingly.
- Made a function `get_access_denied_message` so that the "unit" is testable.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
