### PR TITLE
Always show gantt and code tabs

### DIFF
--- a/airflow/www/static/js/dag/details/gantt/index.tsx
+++ b/airflow/www/static/js/dag/details/gantt/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Box, Divider, Text } from "@chakra-ui/react";
+import { Alert, AlertIcon, Box, Divider, Text } from "@chakra-ui/react";
 
 import useSelection from "src/dag/useSelection";
 import { useGridData } from "src/api";
@@ -114,6 +114,12 @@ const Gantt = ({ openGroupIds, gridScrollRef, ganttScrollRef }: Props) => {
 
   return (
     <Box ref={ganttRef} position="relative" height="100%" overflow="hidden">
+      {!runId && (
+        <Alert status="warning" position="absolute" top={2}>
+          <AlertIcon />
+          Please select a dag run in order to see a gantt chart
+        </Alert>
+      )}
       <Box borderBottomWidth={1} pt={`${top}px`} pointerEvents="none">
         {Array.from(Array(numBars)).map((_, i) => (
           <Box

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -154,13 +154,11 @@ const Details = ({
   );
 
   useEffect(() => {
-    // We only have 3 tabs for when nothing or a task group are selected
-    const tabCount =
-      (runId && !taskId) || (runId && taskId && !isGroup) ? 4 : 3;
-    if (tabCount === 3 && tabIndex > 2) {
+    // We only have 3 tabs for when a task group are selected
+    if (isGroup && taskId && tabIndex > 2) {
       onChangeTab(1);
     }
-  }, [taskId, runId, tabIndex, isGroup, onChangeTab]);
+  }, [taskId, tabIndex, isGroup, onChangeTab]);
 
   const run = dagRuns.find((r) => r.runId === runId);
   const { data: mappedTaskInstance } = useTaskInstance({
@@ -240,14 +238,12 @@ const Details = ({
               Graph
             </Text>
           </Tab>
-          {run && (
-            <Tab>
-              <MdOutlineViewTimeline size={16} />
-              <Text as="strong" ml={1}>
-                Gantt
-              </Text>
-            </Tab>
-          )}
+          <Tab>
+            <MdOutlineViewTimeline size={16} />
+            <Text as="strong" ml={1}>
+              Gantt
+            </Text>
+          </Tab>
           {showDagCode && (
             <Tab>
               <MdCode size={16} />
@@ -298,15 +294,13 @@ const Details = ({
               hoveredTaskState={hoveredTaskState}
             />
           </TabPanel>
-          {run && (
-            <TabPanel p={0} height="100%">
-              <Gantt
-                openGroupIds={openGroupIds}
-                gridScrollRef={gridScrollRef}
-                ganttScrollRef={ganttScrollRef}
-              />
-            </TabPanel>
-          )}
+          <TabPanel p={0} height="100%">
+            <Gantt
+              openGroupIds={openGroupIds}
+              gridScrollRef={gridScrollRef}
+              ganttScrollRef={ganttScrollRef}
+            />
+          </TabPanel>
           {showDagCode && (
             <TabPanel height="100%">
               <DagCode />

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -155,11 +155,12 @@ const Details = ({
   );
 
   useEffect(() => {
-    // We only have 3 tabs for when a task group are selected
-    if (isGroup && taskId && tabIndex > 3) {
+    // Default to graph tab when navigating from a task instance to a group/dag/dagrun
+    const tabCount = runId && taskId && !isGroup ? 5 : 4;
+    if (tabCount === 4 && tabIndex > 3) {
       onChangeTab(1);
     }
-  }, [taskId, tabIndex, isGroup, onChangeTab]);
+  }, [runId, taskId, tabIndex, isGroup, onChangeTab]);
 
   const run = dagRuns.find((r) => r.runId === runId);
   const { data: mappedTaskInstance } = useTaskInstance({

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -76,9 +76,10 @@ const tabToIndex = (tab?: string) => {
     case "gantt":
       return 2;
     case "code":
+      return 3;
     case "logs":
     case "mapped_tasks":
-      return 3;
+      return 4;
     case "details":
     default:
       return 0;
@@ -97,7 +98,8 @@ const indexToTab = (
     case 2:
       return "gantt";
     case 3:
-      if (!taskId) return "code";
+      return "code";
+    case 4:
       if (showMappedTasks) return "mapped_tasks";
       if (showLogs) return "logs";
       return undefined;
@@ -135,7 +137,6 @@ const Details = ({
   const isGroup = !!children;
   const isGroupOrMappedTaskSummary = isGroup || isMappedTaskSummary;
   const showLogs = !!(isTaskInstance && !isGroupOrMappedTaskSummary);
-  const showDagCode = !taskId;
   const showMappedTasks = !!(isTaskInstance && isMappedTaskSummary && !isGroup);
 
   const [searchParams, setSearchParams] = useSearchParams();
@@ -155,7 +156,7 @@ const Details = ({
 
   useEffect(() => {
     // We only have 3 tabs for when a task group are selected
-    if (isGroup && taskId && tabIndex > 2) {
+    if (isGroup && taskId && tabIndex > 3) {
       onChangeTab(1);
     }
   }, [taskId, tabIndex, isGroup, onChangeTab]);
@@ -244,14 +245,12 @@ const Details = ({
               Gantt
             </Text>
           </Tab>
-          {showDagCode && (
-            <Tab>
-              <MdCode size={16} />
-              <Text as="strong" ml={1}>
-                Code
-              </Text>
-            </Tab>
-          )}
+          <Tab>
+            <MdCode size={16} />
+            <Text as="strong" ml={1}>
+              Code
+            </Text>
+          </Tab>
           {showLogs && (
             <Tab>
               <MdReorder size={16} />
@@ -301,11 +300,9 @@ const Details = ({
               ganttScrollRef={ganttScrollRef}
             />
           </TabPanel>
-          {showDagCode && (
-            <TabPanel height="100%">
-              <DagCode />
-            </TabPanel>
-          )}
+          <TabPanel height="100%">
+            <DagCode />
+          </TabPanel>
           {showLogs && run && (
             <TabPanel
               pt={mapIndex !== undefined ? "0px" : undefined}


### PR DESCRIPTION
Previously, we didn't show the gantt tab in the grid view if a dag run or task instance were selected. Instead we should show a blank chart with an alert

Also, always show the code tab

<img width="1146" alt="Screenshot 2023-08-02 at 5 23 01 PM" src="https://github.com/apache/airflow/assets/4600967/8f9f71ec-76c1-4dd6-bddf-f5cb5b0b4f3b">




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
