### PR TITLE
Get rid of Python2 numeric relics

### DIFF
--- a/airflow/example_dags/example_python_operator.py
+++ b/airflow/example_dags/example_python_operator.py
@@ -81,7 +81,7 @@ with DAG(
             """This is a function that will run within the DAG execution"""
             time.sleep(random_base)
 
-        sleeping_task = my_sleeping_function(random_base=float(i) / 10)
+        sleeping_task = my_sleeping_function(random_base=i / 10)
 
         run_this >> log_the_sql >> sleeping_task
     # [END howto_operator_python_kwargs]

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1195,7 +1195,7 @@ class TaskInstance(Base, LoggingMixin):
             # If the min_backoff calculation is below 1, it will be converted to 0 via int. Thus,
             # we must round up prior to converting to an int, otherwise a divide by zero error
             # will occur in the modded_hash calculation.
-            min_backoff = int(math.ceil(delay.total_seconds() * (2 ** (self.try_number - 2))))
+            min_backoff = math.ceil(delay.total_seconds() * (2 ** (self.try_number - 2)))
 
             # In the case when delay.total_seconds() is 0, min_backoff will not be rounded up to 1.
             # To address this, we impose a lower bound of 1 on min_backoff. This effectively makes

--- a/airflow/providers/celery/executors/celery_executor.py
+++ b/airflow/providers/celery/executors/celery_executor.py
@@ -264,7 +264,7 @@ class CeleryExecutor(BaseExecutor):
 
         :return: Number of tasks that should be sent per process
         """
-        return max(1, int(math.ceil(1.0 * to_send_count / self._sync_parallelism)))
+        return max(1, math.ceil(to_send_count / self._sync_parallelism))
 
     def _process_tasks(self, task_tuples: list[TaskTuple]) -> None:
         from airflow.providers.celery.executors.celery_executor_utils import execute_command

--- a/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/airflow/providers/celery/executors/celery_executor_utils.py
@@ -298,7 +298,7 @@ class BulkStateFetcher(LoggingMixin):
         num_process = min(len(async_results), self._sync_parallelism)
 
         with ProcessPoolExecutor(max_workers=num_process) as sync_pool:
-            chunksize = max(1, math.floor(math.ceil(1.0 * len(async_results) / self._sync_parallelism)))
+            chunksize = max(1, math.ceil(len(async_results) / self._sync_parallelism))
 
             task_id_to_states_and_info = list(
                 sync_pool.map(fetch_celery_task_state, async_results, chunksize=chunksize)

--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -903,8 +903,8 @@ class SQLIntervalCheckOperator(BaseSQLOperator):
     ui_color = "#fff7e6"
 
     ratio_formulas = {
-        "max_over_min": lambda cur, ref: float(max(cur, ref)) / min(cur, ref),
-        "relative_diff": lambda cur, ref: float(abs(cur - ref)) / ref,
+        "max_over_min": lambda cur, ref: max(cur, ref) / min(cur, ref),
+        "relative_diff": lambda cur, ref: abs(cur - ref) / ref,
     }
 
     def __init__(

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -374,7 +374,7 @@ class DockerOperator(BaseOperator):
                 shm_size=self.shm_size,
                 dns=self.dns,
                 dns_search=self.dns_search,
-                cpu_shares=int(round(self.cpus * 1024)),
+                cpu_shares=round(self.cpus * 1024),
                 port_bindings=self.port_bindings,
                 mem_limit=self.mem_limit,
                 cap_add=self.cap_add,

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -3261,8 +3261,8 @@ class BigQueryAsyncHook(GoogleBaseAsyncHook):
             raise AirflowException("The first SQL query returned None")
 
         ratio_formulas = {
-            "max_over_min": lambda cur, ref: float(max(cur, ref)) / min(cur, ref),
-            "relative_diff": lambda cur, ref: float(abs(cur - ref)) / ref,
+            "max_over_min": lambda cur, ref: max(cur, ref) / min(cur, ref),
+            "relative_diff": lambda cur, ref: abs(cur - ref) / ref,
         }
 
         metrics_sorted = sorted(metrics_thresholds.keys())

--- a/airflow/providers/google/cloud/hooks/gcs.py
+++ b/airflow/providers/google/cloud/hooks/gcs.py
@@ -356,7 +356,7 @@ class GCSHook(GoogleBaseHook):
                     raise
 
                 # Wait with exponential backoff scheme before retrying.
-                timeout_seconds = 1.0 * 2 ** (num_file_attempts - 1)
+                timeout_seconds = 2 ** (num_file_attempts - 1)
                 time.sleep(timeout_seconds)
                 continue
 
@@ -524,7 +524,7 @@ class GCSHook(GoogleBaseHook):
                         raise e
 
                     # Wait with exponential backoff scheme before retrying.
-                    timeout_seconds = 1.0 * 2 ** (num_file_attempts - 1)
+                    timeout_seconds = 2 ** (num_file_attempts - 1)
                     time.sleep(timeout_seconds)
                     continue
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -939,7 +939,7 @@ class Airflow(AirflowBaseView):
                 "error",
             )
 
-        num_of_pages = int(math.ceil(num_of_all_dags / float(dags_per_page)))
+        num_of_pages = math.ceil(num_of_all_dags / dags_per_page)
 
         state_color_mapping = State.state_color.copy()
         state_color_mapping["null"] = state_color_mapping.pop(None)
@@ -4003,7 +4003,7 @@ class Airflow(AirflowBaseView):
 
         logs_per_page = PAGE_SIZE
         audit_logs_count = get_query_count(query, session=session)
-        num_of_pages = int(math.ceil(audit_logs_count / float(logs_per_page)))
+        num_of_pages = math.ceil(audit_logs_count / logs_per_page)
 
         start = current_page * logs_per_page
         end = start + logs_per_page

--- a/dev/breeze/src/airflow_breeze/utils/parallel.py
+++ b/dev/breeze/src/airflow_breeze/utils/parallel.py
@@ -209,7 +209,7 @@ def bytes2human(n):
         prefix[s] = 1 << (i + 1) * 10
     for s in reversed(symbols):
         if n >= prefix[s]:
-            value = float(n) / prefix[s]
+            value = n / prefix[s]
             return f"{value:.1f}{s}"
     return f"{n}B"
 

--- a/dev/stats/get_important_pr_candidates.py
+++ b/dev/stats/get_important_pr_candidates.py
@@ -243,12 +243,11 @@ class PrStat:
         self.adjust_interaction_score()
 
         return round(
-            1.0
-            * self.interaction_score
+            self.interaction_score
             * self.label_score
             * self.length_score
             * self.change_score
-            / (math.log10(self.num_changed_files) if self.num_changed_files > 20 else 1.0),
+            / (math.log10(self.num_changed_files) if self.num_changed_files > 20 else 1),
             3,
         )
 

--- a/tests/test_utils/perf/perf_kit/repeat_and_time.py
+++ b/tests/test_utils/perf/perf_kit/repeat_and_time.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import contextlib
 import functools
-import math
 import random
 import signal
 import time
@@ -120,10 +119,10 @@ if __name__ == "__main__":
         for _ in range(0, total):
             x_val = random.random() ** 2
             y_val = random.random() ** 2
-            if math.sqrt(x_val + y_val) < 1.0:
+            if x_val + y_val < 1:
                 inside += 1
 
-        return (float(inside) / total) * 4
+        return (inside / total) * 4
 
     # Example 1:s
     with timeout(1):

--- a/tests/test_utils/perf/perf_kit/repeat_and_time.py
+++ b/tests/test_utils/perf/perf_kit/repeat_and_time.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import math
 import random
 import signal
 import time
@@ -119,7 +120,7 @@ if __name__ == "__main__":
         for _ in range(0, total):
             x_val = random.random() ** 2
             y_val = random.random() ** 2
-            if x_val + y_val < 1:
+            if math.sqrt(x_val + y_val) < 1:
                 inside += 1
 
         return (inside / total) * 4


### PR DESCRIPTION
Migration from Python2 to Python3 changes some numeric behavior. In Python3:

- `round()`, `math.ceil()` and `math.floor()` return `int` instead of `float`
- true division `int / int` returns `float` and therefore it is not necessary to convert one of the parts to `float` or to multiply the expression by `1.0`

The code has been simplified. No functionality has been changed.