### PR TITLE
Rework provider manager to treat Airflow core hooks like other provider hooks

### DIFF
--- a/airflow/cli/commands/connection_command.py
+++ b/airflow/cli/commands/connection_command.py
@@ -150,7 +150,7 @@ def _valid_uri(uri: str) -> bool:
 @cache
 def _get_connection_types() -> list[str]:
     """Returns connection types available."""
-    _connection_types = ["fs", "mesos_framework-id", "email", "generic"]
+    _connection_types = []
     providers_manager = ProvidersManager()
     for connection_type, provider_info in providers_manager.hooks.items():
         if provider_info:

--- a/airflow/hooks/filesystem.py
+++ b/airflow/hooks/filesystem.py
@@ -17,6 +17,9 @@
 # under the License.
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any
+
 from airflow.hooks.base import BaseHook
 
 
@@ -33,9 +36,37 @@ class FSHook(BaseHook):
     Extra: {"path": "/tmp"}
     """
 
-    def __init__(self, conn_id: str = "fs_default"):
+    conn_name_attr = "fs_conn_id"
+    default_conn_name = "fs_default"
+    conn_type = "fs"
+    hook_name = "File (path)"
+
+    @staticmethod
+    def get_connection_form_widgets() -> dict[str, Any]:
+        """Returns connection widgets to add to connection form."""
+        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+        from flask_babel import lazy_gettext
+        from wtforms import StringField
+        from wtforms.validators import InputRequired
+
+        return {
+            "path": StringField(
+                lazy_gettext("Path"), validators=[InputRequired()], widget=BS3TextFieldWidget()
+            ),
+        }
+
+    @staticmethod
+    def get_ui_field_behaviour() -> dict[str, Any]:
+        """Returns custom field behaviour."""
+        return {
+            "hidden_fields": ["host", "schema", "port", "login", "password", "extra"],
+            "relabeling": {},
+            "placeholders": {},
+        }
+
+    def __init__(self, fs_conn_id: str = default_conn_name):
         super().__init__()
-        conn = self.get_connection(conn_id)
+        conn = self.get_connection(fs_conn_id)
         self.basepath = conn.extra_dejson.get("path", "")
         self.conn = conn
 
@@ -49,3 +80,15 @@ class FSHook(BaseHook):
         :return: the path.
         """
         return self.basepath
+
+    def test_connection(self):
+        """Test File connection."""
+        try:
+            p = self.get_path()
+            if not p:
+                return False, "File Path is undefined."
+            if not Path(p).exists():
+                return False, f"Path {p} does not exist."
+            return True, f"Path {p} is existing."
+        except Exception as e:
+            return False, str(e)

--- a/airflow/hooks/filesystem.py
+++ b/airflow/hooks/filesystem.py
@@ -47,13 +47,8 @@ class FSHook(BaseHook):
         from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
         from flask_babel import lazy_gettext
         from wtforms import StringField
-        from wtforms.validators import InputRequired
 
-        return {
-            "path": StringField(
-                lazy_gettext("Path"), validators=[InputRequired()], widget=BS3TextFieldWidget()
-            ),
-        }
+        return {"path": StringField(lazy_gettext("Path"), widget=BS3TextFieldWidget())}
 
     @staticmethod
     def get_ui_field_behaviour() -> dict[str, Any]:

--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -195,10 +195,6 @@ def create_connection_form_class() -> type[DynamicForm]:
 
     def _iter_connection_types() -> Iterator[tuple[str, str]]:
         """List available connection types."""
-        yield ("email", "Email")
-        yield ("fs", "File (path)")
-        yield ("generic", "Generic")
-        yield ("mesos_framework-id", "Mesos Framework ID")
         for connection_type, provider_info in providers_manager.hooks.items():
             if provider_info:
                 yield (connection_type, provider_info.hook_name)

--- a/tests/always/test_connection.py
+++ b/tests/always/test_connection.py
@@ -753,14 +753,14 @@ class TestConnection:
     @mock.patch.dict(
         "os.environ",
         {
-            "AIRFLOW_CONN_TEST_URI_NO_HOOK": "fs://",
+            "AIRFLOW_CONN_TEST_URI_NO_HOOK": "unknown://",
         },
     )
     def test_connection_test_no_hook(self):
-        conn = Connection(conn_id="test_uri_no_hook", conn_type="fs")
+        conn = Connection(conn_id="test_uri_no_hook", conn_type="unknown")
         res = conn.test_connection()
         assert res[0] is False
-        assert res[1] == 'Unknown hook type "fs"'
+        assert res[1] == 'Unknown hook type "unknown"'
 
     @mock.patch.dict(
         "os.environ",


### PR DESCRIPTION
This PR makes the ground-work to a follow-up PR #33017

I realized that the providers-manager is implemented inconsistently and treats core hooks other than provider contributed hooks. Core hooks are not providing extended web UI fields (feature is ignored) as well as the list of provided generic hooks is redundant in CLI and UI code.

This PR cleans this up and:

- Treats Airflow core hooks like provider hooks in terms on loading and initialization
- Implements UI feature for FileSystem hook (so that a user does not need to provide JSON dict)
- Removed redundant hard-coded lists from CLI and UI code

Point of discussion would be if we still should further carry the generic hook type "Mesos Framework ID" which seems to be a legacy leftover from Airflow 1.x. This was a former executor type but the code is gone completely since Airflow 2.0 and besides the traces in code I could find no reference. I assume nobody is using this anymore.

How to test:

- Pipeline green obviously
- Open the Web UI connections form and see that "File (Path)" connection type now has a proper form