### PR TITLE
Add a utility to safely join URLs using urllib.parse.urljoin

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -33,7 +33,7 @@ from functools import partial
 from pathlib import PurePath
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Callable, Collection, Generator, Iterable, Tuple
-from urllib.parse import quote, urljoin
+from urllib.parse import quote
 
 import dill
 import jinja2
@@ -112,7 +112,7 @@ from airflow.utils.email import send_email
 from airflow.utils.helpers import prune_dict, render_template_to_string
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.module_loading import qualname
-from airflow.utils.net import get_hostname
+from airflow.utils.net import get_hostname, safe_urljoin
 from airflow.utils.operator_helpers import context_to_airflow_vars
 from airflow.utils.platform import getuser
 from airflow.utils.retries import run_with_db_retries
@@ -779,7 +779,7 @@ class TaskInstance(Base, LoggingMixin):
         """Log URL for TaskInstance."""
         iso = quote(self.execution_date.isoformat())
         base_url = conf.get_mandatory_value("webserver", "BASE_URL")
-        return urljoin(
+        return safe_urljoin(
             base_url,
             f"log?execution_date={iso}"
             f"&task_id={self.task_id}"
@@ -791,7 +791,7 @@ class TaskInstance(Base, LoggingMixin):
     def mark_success_url(self) -> str:
         """URL to mark TI success."""
         base_url = conf.get_mandatory_value("webserver", "BASE_URL")
-        return urljoin(
+        return safe_urljoin(
             base_url,
             f"confirm?task_id={self.task_id}"
             f"&dag_id={self.dag_id}"

--- a/airflow/utils/net.py
+++ b/airflow/utils/net.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import socket
 from functools import lru_cache
+from urllib.parse import urljoin
 
 from airflow.configuration import conf
 
@@ -54,3 +55,20 @@ def get_host_ip_address():
 def get_hostname():
     """Fetch the hostname using the callable from config or use `airflow.utils.net.getfqdn` as a fallback."""
     return conf.getimport("core", "hostname_callable", fallback="airflow.utils.net.getfqdn")()
+
+
+def safe_urljoin(base_url: str, relative_url: str, **kwargs) -> str:
+    """Safely join the given URLs."""
+    # Since 'urljoin' strips everything after the last trailing slash, the last part of the path in the
+    # base URL would be skipped if it does not end with a slash. Hence, we ensure here and update the
+    # base_url so that it has a trailing slash.
+    if not base_url.endswith("/"):
+        base_url += "/"
+
+    # Ensure relative_url does not have a leading slash and if it has one remove it. This is because if
+    # the relative URL has a leading slash, urljoin skips the base URL altogether and just returns the
+    # relative URL as the output.
+    if relative_url.startswith("/"):
+        relative_url = relative_url[1:]
+
+    return urljoin(base_url, relative_url, **kwargs)


### PR DESCRIPTION
While working with `log_url` property of the task instances, 
it is observed that `urljoin` ignores the part of the path after 
the last slash specified in the base_url when it does not end 
with a trailing slash and Airflow webserver does not allow 
setting the base_url with a trailing slash. Additionally, it is also 
observed that if the relative URL has a leading slash, `urljoin` 
just ingores the base URL and returns the relative URL. 
Hence, we add a new utlity method `safe_urljoin` to handle 
these cases.

closes: #32996

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
