### PR TITLE
Fix issue with using the various state enum value in logs

### DIFF
--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -42,6 +42,7 @@ import re2
 from airflow import settings
 from airflow.compat.functools import cache
 from airflow.typing_compat import TypeGuard
+from airflow.utils.state import DagRunState, JobState, State, TaskInstanceState
 
 if TYPE_CHECKING:
     from kubernetes.client import V1EnvVar
@@ -143,6 +144,10 @@ def _is_v1_env_var(v: Any) -> TypeGuard[V1EnvVar]:
     return isinstance(v, _get_v1_env_var_type())
 
 
+def _is_state_enum(v: Any) -> bool:
+    return isinstance(v, (TaskInstanceState, DagRunState, JobState, State))
+
+
 class SecretsMasker(logging.Filter):
     """Redact secrets from logs."""
 
@@ -242,6 +247,8 @@ class SecretsMasker(logging.Filter):
                     for dict_key, subval in item.items()
                 }
                 return to_return
+            elif _is_state_enum(item):
+                return self._redact(item=str(item), name=name, depth=depth, max_depth=max_depth)
             elif _is_v1_env_var(item):
                 tmp: dict = item.to_dict()
                 if should_hide_value_for_key(tmp.get("name", "")) and "value" in tmp:

--- a/tests/utils/log/test_secrets_masker.py
+++ b/tests/utils/log/test_secrets_masker.py
@@ -36,6 +36,7 @@ from airflow.utils.log.secrets_masker import (
     redact,
     should_hide_value_for_key,
 )
+from airflow.utils.state import DagRunState, JobState, State, TaskInstanceState
 from tests.test_utils.config import conf_vars
 
 settings.MASK_SECRETS_IN_LOGS = True
@@ -298,6 +299,21 @@ class TestSecretsMasker:
         with patch("airflow.utils.log.secrets_masker._secrets_masker", return_value=secrets_masker):
             got = redact(val, max_depth=max_depth)
             assert got == expected
+
+    @pytest.mark.parametrize(
+        "state, expected",
+        [
+            (DagRunState.SUCCESS, "success"),
+            (TaskInstanceState.FAILED, "failed"),
+            (JobState.RUNNING, "running"),
+            ([DagRunState.SUCCESS, DagRunState.RUNNING], ["success", "running"]),
+            ([TaskInstanceState.FAILED, TaskInstanceState.SUCCESS], ["failed", "success"]),
+            (State.failed_states, frozenset([TaskInstanceState.FAILED, TaskInstanceState.UPSTREAM_FAILED])),
+        ],
+    )
+    def test_redact_state_enum(self, logger, caplog, state, expected):
+        logger.info("State: %s", state)
+        assert caplog.text == f"INFO State: {expected}\n"
 
 
 class TestShouldHideValueForKey:

--- a/tests/utils/log/test_secrets_masker.py
+++ b/tests/utils/log/test_secrets_masker.py
@@ -314,6 +314,7 @@ class TestSecretsMasker:
     def test_redact_state_enum(self, logger, caplog, state, expected):
         logger.info("State: %s", state)
         assert caplog.text == f"INFO State: {expected}\n"
+        assert "TypeError" not in caplog.text
 
 
 class TestShouldHideValueForKey:

--- a/tests/utils/log/test_secrets_masker.py
+++ b/tests/utils/log/test_secrets_masker.py
@@ -24,6 +24,7 @@ import logging.config
 import os
 import sys
 import textwrap
+from enum import Enum
 from unittest.mock import patch
 
 import pytest
@@ -42,6 +43,10 @@ from tests.test_utils.config import conf_vars
 settings.MASK_SECRETS_IN_LOGS = True
 
 p = "password"
+
+
+class MyEnum(str, Enum):
+    testname = "testvalue"
 
 
 @pytest.fixture
@@ -309,6 +314,7 @@ class TestSecretsMasker:
             ([DagRunState.SUCCESS, DagRunState.RUNNING], ["success", "running"]),
             ([TaskInstanceState.FAILED, TaskInstanceState.SUCCESS], ["failed", "success"]),
             (State.failed_states, frozenset([TaskInstanceState.FAILED, TaskInstanceState.UPSTREAM_FAILED])),
+            (MyEnum.testname, "testvalue"),
         ],
     )
     def test_redact_state_enum(self, logger, caplog, state, expected):


### PR DESCRIPTION
The secrets masker is unable to work on the various state enums: DagRunState, TaskInstanceState, JobState, and State enums in logs.
This PR fixes this by converting the enums to strings during the secrets mask search

closes: https://github.com/apache/airflow/issues/33061