### PR TITLE
Add documentation generation for CLI commands from executors

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -17,6 +17,7 @@
 """Base executor - this is the base class for all the implemented executors."""
 from __future__ import annotations
 
+import argparse
 import logging
 import sys
 import warnings
@@ -27,7 +28,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple
 
 import pendulum
 
-from airflow.cli.cli_config import GroupCommand
+from airflow.cli.cli_config import DefaultHelpParser, GroupCommand
 from airflow.configuration import conf
 from airflow.exceptions import RemovedInAirflow3Warning
 from airflow.stats import Stats
@@ -489,3 +490,17 @@ class BaseExecutor(LoggingMixin):
         be commands to setup/teardown the executor, inspect state, etc.
         """
         return []
+
+    @classmethod
+    def _get_parser(cls) -> argparse.ArgumentParser:
+        """This method is used by Sphinx argparse to generate documentation.
+
+        :meta private:
+        """
+        from airflow.cli.cli_parser import AirflowHelpFormatter, _add_command
+
+        parser = DefaultHelpParser(prog="airflow", formatter_class=AirflowHelpFormatter)
+        subparsers = parser.add_subparsers(dest="subcommand", metavar="GROUP_OR_COMMAND")
+        for group_command in cls.get_cli_commands():
+            _add_command(subparsers, group_command)
+        return parser

--- a/airflow/providers/celery/executors/celery_executor.py
+++ b/airflow/providers/celery/executors/celery_executor.py
@@ -23,6 +23,7 @@
 """
 from __future__ import annotations
 
+import argparse
 import logging
 import math
 import operator
@@ -480,3 +481,11 @@ class CeleryExecutor(BaseExecutor):
                 subcommands=CELERY_COMMANDS,
             ),
         ]
+
+
+def _get_parser() -> argparse.ArgumentParser:
+    """This method is used by Sphinx to generate documentation.
+
+    :meta private:
+    """
+    return CeleryExecutor._get_parser()

--- a/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -23,6 +23,7 @@ KubernetesExecutor.
 """
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 import multiprocessing
@@ -727,3 +728,11 @@ class KubernetesExecutor(BaseExecutor):
                 subcommands=KUBERNETES_COMMANDS,
             )
         ]
+
+
+def _get_parser() -> argparse.ArgumentParser:
+    """This method is used by Sphinx to generate documentation.
+
+    :meta private:
+    """
+    return KubernetesExecutor._get_parser()

--- a/docs/apache-airflow-providers-celery/cli-ref.rst
+++ b/docs/apache-airflow-providers-celery/cli-ref.rst
@@ -1,0 +1,24 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Celery Executor Commands
+------------------------
+
+.. argparse::
+   :module: airflow.providers.celery.executors.celery_executor
+   :func: _get_parser
+   :prog: airflow

--- a/docs/apache-airflow-providers-celery/index.rst
+++ b/docs/apache-airflow-providers-celery/index.rst
@@ -35,6 +35,7 @@
     :caption: References
 
     Configuration <configurations-ref>
+    CLI <cli-ref>
     Python API <_api/airflow/providers/celery/index>
     PyPI Repository <https://pypi.org/project/apache-airflow-providers-celery/>
     Installing from sources <installing-providers-from-sources>

--- a/docs/apache-airflow-providers-cncf-kubernetes/cli-ref.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/cli-ref.rst
@@ -1,0 +1,24 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Kubernetes Executor Commands
+============================
+
+.. argparse::
+   :module: airflow.providers.cncf.kubernetes.executors.kubernetes_executor
+   :func: _get_parser
+   :prog: airflow

--- a/docs/apache-airflow-providers-cncf-kubernetes/index.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/index.rst
@@ -43,6 +43,7 @@
     :caption: References
 
     Configuration <configurations-ref>
+    CLI <cli-ref>
     Python API <_api/airflow/providers/cncf/kubernetes/index>
 
 .. toctree::


### PR DESCRIPTION
The #29055 moved relevant CLI command definition to executors but it automatically removed the command from generated documentation.

Closes: #27932

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
