### PR TITLE
Ensure DAG-level references are filled on unmap

### DIFF
--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -660,7 +660,7 @@ class MappedOperator(AbstractOperator):
         op = SerializedBaseOperator(task_id=self.task_id, params=self.params, _airflow_from_mapped=True)
         SerializedBaseOperator.populate_operator(op, self.operator_class)
         if self.dag is not None:  # For Mypy; we only serialize tasks in a DAG so the check always satisfies.
-            SerializedBaseOperator.add_operator_to_dag(op, self.dag)
+            SerializedBaseOperator.set_task_dag_references(op, self.dag)
         return op
 
     def _get_specified_expand_input(self) -> ExpandInput:

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -659,6 +659,8 @@ class MappedOperator(AbstractOperator):
 
         op = SerializedBaseOperator(task_id=self.task_id, params=self.params, _airflow_from_mapped=True)
         SerializedBaseOperator.populate_operator(op, self.operator_class)
+        if self.dag is not None:  # For Mypy; we only serialize tasks in a DAG so the check always satisfies.
+            SerializedBaseOperator.add_operator_to_dag(op, self.dag)
         return op
 
     def _get_specified_expand_input(self) -> ExpandInput:


### PR DESCRIPTION
Previously, a serialized mapped operator's unmapped SerializedOperator misses some DAG-level references because they were established separately in BaseSerialization and were overlooked when the unmap() function was implemented. This extracts those post-population ref-fixing code into a function, and call it as needed in unmap(), so an unmapped SerializedOperator is consistent with a non-mapped SerializedOperator that comes straightly out of a database.

This was not an issue prior to 2.6 since the scheduler mostly did not access DAG-level references on a serialized operator (mapped or not). The introduction of the fail_fast flag requires accessing the DAG much later in a task's lifetime in the scheduler, and thus needs the references to be properly set.