### PR TITLE
openlineage: remove eager test for auth headers, fix example dag

### DIFF
--- a/airflow/example_dags/plugins/event_listener.py
+++ b/airflow/example_dags/plugins/event_listener.py
@@ -111,7 +111,7 @@ def on_task_instance_failed(previous_state: TaskInstanceState, task_instance: Ta
 
 # [START howto_listen_dagrun_success_task]
 @hookimpl
-def on_dag_run_success(dag_run: DagRun, message: str):
+def on_dag_run_success(dag_run: DagRun, msg: str):
     """
     This method is called when dag run state changes to SUCCESS.
     """
@@ -126,7 +126,7 @@ def on_dag_run_success(dag_run: DagRun, message: str):
 
 # [START howto_listen_dagrun_failure_task]
 @hookimpl
-def on_dag_run_failed(dag_run: DagRun, message: str):
+def on_dag_run_failed(dag_run: DagRun, msg: str):
     """
     This method is called when dag run state changes to FAILED.
     """
@@ -142,7 +142,7 @@ def on_dag_run_failed(dag_run: DagRun, message: str):
 
 # [START howto_listen_dagrun_running_task]
 @hookimpl
-def on_dag_run_running(dag_run: DagRun, message: str):
+def on_dag_run_running(dag_run: DagRun, msg: str):
     """
     This method is called when dag run state changes to RUNNING.
     """

--- a/tests/providers/openlineage/plugins/test_openlineage_adapter.py
+++ b/tests/providers/openlineage/plugins/test_openlineage_adapter.py
@@ -43,7 +43,6 @@ def test_create_client_from_ol_env():
 
     assert client.transport.url == "http://ol-api:5000"
     assert "Authorization" in client.transport.session.headers
-    assert client.transport.session.headers["Authorization"] == "Bearer api-key"
 
 
 @conf_vars(
@@ -57,8 +56,6 @@ def test_create_client_from_config_with_options():
 
     assert client.transport.kind == "http"
     assert client.transport.url == "http://ol-api:5000"
-    assert "Authorization" in client.transport.session.headers
-    assert client.transport.session.headers["Authorization"] == "Bearer api-key"
 
 
 @conf_vars(


### PR DESCRIPTION
OL is now not generating Auth headers on HTTP transport initialization - Airflow tests should not check for that.

Additionally fix wrong signatures of example dagrun listener.