### PR TITLE
Don't ignore setups when arrowing from group

### DIFF
--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -370,21 +370,21 @@ class TaskGroup(DAGNode):
         tasks = list(self)
         ids = {x.task_id for x in tasks}
 
-        def recurse_for_first_non_setup_teardown(task):
+        def recurse_for_first_non_teardown(task):
             for upstream_task in task.upstream_list:
                 if upstream_task.task_id not in ids:
                     continue
-                if upstream_task.is_setup or upstream_task.is_teardown:
-                    yield from recurse_for_first_non_setup_teardown(upstream_task)
+                if upstream_task.is_teardown:
+                    yield from recurse_for_first_non_teardown(upstream_task)
                 else:
                     yield upstream_task
 
         for task in tasks:
             if task.downstream_task_ids.isdisjoint(ids):
-                if not (task.is_teardown or task.is_setup):
+                if not task.is_teardown:
                     yield task
                 else:
-                    yield from recurse_for_first_non_setup_teardown(task)
+                    yield from recurse_for_first_non_teardown(task)
 
     def child_id(self, label):
         """Prefix label with group_id if prefix_group_id is True. Otherwise return the label as-is."""

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -373,9 +373,13 @@ class TaskGroup(DAGNode):
         def recurse_for_first_non_teardown(task):
             for upstream_task in task.upstream_list:
                 if upstream_task.task_id not in ids:
+                    # upstream task is not in task group
                     continue
-                if upstream_task.is_teardown:
+                elif upstream_task.is_teardown:
                     yield from recurse_for_first_non_teardown(upstream_task)
+                elif task.is_teardown and upstream_task.is_setup:
+                    # don't go through the teardown-to-setup path
+                    continue
                 else:
                     yield upstream_task
 

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -1487,7 +1487,7 @@ def test_task_group_arrow_with_setups_teardowns():
     assert w1.downstream_task_ids == {"tg1.t1", "w2"}
 
 
-def test_tasks_defined_outside_taskgrooup(dag_maker):
+def test_tasks_defined_outside_task_group(dag_maker):
     # Test that classic tasks defined outside a task group are added to the root task group
     # when the relationships are defined inside the task group
     with dag_maker() as dag:
@@ -1497,14 +1497,14 @@ def test_tasks_defined_outside_taskgrooup(dag_maker):
         with TaskGroup(group_id="tg1"):
             t1 >> t2 >> t3
     dag.validate()
-    assert dag.task_group.children.keys() == {"tg1"}
-    assert dag.task_group.children["tg1"].children.keys() == {"t1", "t2", "t3"}
-    assert dag.task_group.children["tg1"].children["t1"].upstream_task_ids == set()
-    assert dag.task_group.children["tg1"].children["t1"].downstream_task_ids == {"t2"}
-    assert dag.task_group.children["tg1"].children["t2"].upstream_task_ids == {"t1"}
-    assert dag.task_group.children["tg1"].children["t2"].downstream_task_ids == {"t3"}
-    assert dag.task_group.children["tg1"].children["t3"].upstream_task_ids == {"t2"}
-    assert dag.task_group.children["tg1"].children["t3"].downstream_task_ids == set()
+    assert set(dag.task_group.children.keys()) == {"t1", "t2", "t3", "tg1"}
+    assert set(dag.task_group.children["tg1"].children.keys()) == set()
+    assert dag.task_group.children["t1"].upstream_task_ids == set()
+    assert dag.task_group.children["t1"].downstream_task_ids == {"t2"}
+    assert dag.task_group.children["t2"].upstream_task_ids == {"t1"}
+    assert dag.task_group.children["t2"].downstream_task_ids == {"t3"}
+    assert dag.task_group.children["t3"].upstream_task_ids == {"t2"}
+    assert dag.task_group.children["t3"].downstream_task_ids == set()
 
     # Test that decorated tasks defined outside a task group are added to the root task group
     # when relationships are defined inside the task group
@@ -1515,14 +1515,14 @@ def test_tasks_defined_outside_taskgrooup(dag_maker):
         with TaskGroup(group_id="tg1"):
             t1 >> t2 >> t3
     dag.validate()
-    assert dag.task_group.children.keys() == {"tg1"}
-    assert dag.task_group.children["tg1"].children.keys() == {"t1", "t2", "t3"}
-    assert dag.task_group.children["tg1"].children["t1"].upstream_task_ids == set()
-    assert dag.task_group.children["tg1"].children["t1"].downstream_task_ids == {"t2"}
-    assert dag.task_group.children["tg1"].children["t2"].upstream_task_ids == {"t1"}
-    assert dag.task_group.children["tg1"].children["t2"].downstream_task_ids == {"t3"}
-    assert dag.task_group.children["tg1"].children["t3"].upstream_task_ids == {"t2"}
-    assert dag.task_group.children["tg1"].children["t3"].downstream_task_ids == set()
+    assert set(dag.task_group.children.keys()) == {"tg1", "t1", "t2", "t3"}
+    assert dag.task_group.children["tg1"].children.keys() == set()
+    assert dag.task_group.children["t1"].upstream_task_ids == set()
+    assert dag.task_group.children["t1"].downstream_task_ids == {"t2"}
+    assert dag.task_group.children["t2"].upstream_task_ids == {"t1"}
+    assert dag.task_group.children["t2"].downstream_task_ids == {"t3"}
+    assert dag.task_group.children["t3"].upstream_task_ids == {"t2"}
+    assert dag.task_group.children["t3"].downstream_task_ids == set()
 
     # Test adding single decorated task defined outside a task group to a task group
     with dag_maker() as dag:

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -22,8 +22,14 @@ from datetime import timedelta
 import pendulum
 import pytest
 
-from airflow.decorators import dag, task as task_decorator, task_group as task_group_decorator
-from airflow.exceptions import TaskAlreadyInTaskGroup
+from airflow.decorators import (
+    dag,
+    setup,
+    task as task_decorator,
+    task_group as task_group_decorator,
+    teardown,
+)
+from airflow.exceptions import AirflowException, TaskAlreadyInTaskGroup
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG
 from airflow.models.xcom_arg import XComArg
@@ -1479,3 +1485,197 @@ def test_task_group_arrow_with_setups_teardowns():
         tg1 >> w2
     assert t1.downstream_task_ids == set()
     assert w1.downstream_task_ids == {"tg1.t1", "w2"}
+
+
+def test_tasks_defined_outside_taskgrooup(dag_maker):
+    # Test that classic tasks defined outside a task group are added to the root task group
+    # when the relationships are defined inside the task group
+    with dag_maker() as dag:
+        t1 = make_task("t1")
+        t2 = make_task("t2")
+        t3 = make_task("t3")
+        with TaskGroup(group_id="tg1"):
+            t1 >> t2 >> t3
+    dag.validate()
+    assert dag.task_group.children.keys() == {"tg1"}
+    assert dag.task_group.children["tg1"].children.keys() == {"t1", "t2", "t3"}
+    assert dag.task_group.children["tg1"].children["t1"].upstream_task_ids == set()
+    assert dag.task_group.children["tg1"].children["t1"].downstream_task_ids == {"t2"}
+    assert dag.task_group.children["tg1"].children["t2"].upstream_task_ids == {"t1"}
+    assert dag.task_group.children["tg1"].children["t2"].downstream_task_ids == {"t3"}
+    assert dag.task_group.children["tg1"].children["t3"].upstream_task_ids == {"t2"}
+    assert dag.task_group.children["tg1"].children["t3"].downstream_task_ids == set()
+
+    # Test that decorated tasks defined outside a task group are added to the root task group
+    # when relationships are defined inside the task group
+    with dag_maker() as dag:
+        t1 = make_task("t1", type_="decorated")
+        t2 = make_task("t2", type_="decorated")
+        t3 = make_task("t3", type_="decorated")
+        with TaskGroup(group_id="tg1"):
+            t1 >> t2 >> t3
+    dag.validate()
+    assert dag.task_group.children.keys() == {"tg1"}
+    assert dag.task_group.children["tg1"].children.keys() == {"t1", "t2", "t3"}
+    assert dag.task_group.children["tg1"].children["t1"].upstream_task_ids == set()
+    assert dag.task_group.children["tg1"].children["t1"].downstream_task_ids == {"t2"}
+    assert dag.task_group.children["tg1"].children["t2"].upstream_task_ids == {"t1"}
+    assert dag.task_group.children["tg1"].children["t2"].downstream_task_ids == {"t3"}
+    assert dag.task_group.children["tg1"].children["t3"].upstream_task_ids == {"t2"}
+    assert dag.task_group.children["tg1"].children["t3"].downstream_task_ids == set()
+
+    # Test adding single decorated task defined outside a task group to a task group
+    with dag_maker() as dag:
+        t1 = make_task("t1", type_="decorated")
+        with TaskGroup(group_id="tg1") as tg1:
+            tg1.add_task(t1)
+    dag.validate()
+    assert dag.task_group.children.keys() == {"tg1"}
+    assert dag.task_group.children["tg1"].children.keys() == {"t1"}
+    assert dag.task_group.children["tg1"].children["t1"].upstream_task_ids == set()
+    assert dag.task_group.children["tg1"].children["t1"].downstream_task_ids == set()
+
+    # Test adding single classic task defined outside a task group to a task group
+    with dag_maker() as dag:
+        t1 = make_task("t1")
+        with TaskGroup(group_id="tg1") as tg1:
+            tg1.add_task(t1)
+    dag.validate()
+    assert dag.task_group.children.keys() == {"tg1"}
+    assert dag.task_group.children["tg1"].children.keys() == {"t1"}
+    assert dag.task_group.children["tg1"].children["t1"].upstream_task_ids == set()
+    assert dag.task_group.children["tg1"].children["t1"].downstream_task_ids == set()
+
+    with pytest.raises(
+        AirflowException,
+        match="Using this method on a task group that's not a context manager is not supported.",
+    ):
+        with dag_maker():
+            t1 = make_task("t1")
+            tg1 = TaskGroup(group_id="tg1")
+            tg1.add_task(t1)
+
+
+def test_task_group_arrow_with_setup_group():
+    with DAG(dag_id="setup_group_teardown_group", start_date=pendulum.now()):
+        with TaskGroup("group_1") as g1:
+
+            @setup
+            def setup_1():
+                ...
+
+            @setup
+            def setup_2():
+                ...
+
+            s1 = setup_1()
+            s2 = setup_2()
+
+        with TaskGroup("group_2") as g2:
+
+            @teardown
+            def teardown_1():
+                ...
+
+            @teardown
+            def teardown_2():
+                ...
+
+            t1 = teardown_1()
+            t2 = teardown_2()
+
+        @task_decorator
+        def work():
+            ...
+
+        w1 = work()
+        g1 >> w1 >> g2
+        t1.as_teardown(setups=s1)
+        t2.as_teardown(setups=s2)
+    assert set(s1.operator.downstream_task_ids) == {"work", "group_2.teardown_1"}
+    assert set(s2.operator.downstream_task_ids) == {"work", "group_2.teardown_2"}
+    assert set(w1.operator.downstream_task_ids) == {"group_2.teardown_1", "group_2.teardown_2"}
+    assert set(t1.operator.downstream_task_ids) == set()
+    assert set(t2.operator.downstream_task_ids) == set()
+
+    def get_nodes(group):
+        d = task_group_to_dict(group)
+        new_d = {}
+        new_d["id"] = d["id"]
+        new_d["children"] = [{"id": x["id"]} for x in d["children"]]
+        return new_d
+
+    assert get_nodes(g1) == {
+        "id": "group_1",
+        "children": [
+            {"id": "group_1.setup_1"},
+            {"id": "group_1.setup_2"},
+            {"id": "group_1.downstream_join_id"},
+        ],
+    }
+
+
+def test_task_group_arrow_with_setup_group_deeper_setup():
+    with DAG(dag_id="setup_group_teardown_group_2", start_date=pendulum.now()):
+        with TaskGroup("group_1") as g1:
+
+            @setup
+            def setup_1():
+                ...
+
+            @setup
+            def setup_2():
+                ...
+
+            @teardown
+            def teardown_0():
+                ...
+
+            s1 = setup_1()
+            s2 = setup_2()
+            t0 = teardown_0()
+            s2 >> t0
+
+        with TaskGroup("group_2") as g2:
+
+            @teardown
+            def teardown_1():
+                ...
+
+            @teardown
+            def teardown_2():
+                ...
+
+            t1 = teardown_1()
+            t2 = teardown_2()
+
+        @task_decorator
+        def work():
+            ...
+
+        w1 = work()
+        g1 >> w1 >> g2
+        t1.as_teardown(setups=s1)
+        t2.as_teardown(setups=s2)
+    assert set(s1.operator.downstream_task_ids) == {"work", "group_2.teardown_1"}
+    assert set(s2.operator.downstream_task_ids) == {"work", "group_1.teardown_0", "group_2.teardown_2"}
+    assert set(w1.operator.downstream_task_ids) == {"group_2.teardown_1", "group_2.teardown_2"}
+    assert set(t1.operator.downstream_task_ids) == set()
+    assert set(t2.operator.downstream_task_ids) == set()
+
+    def get_nodes(group):
+        d = task_group_to_dict(group)
+        new_d = {}
+        new_d["id"] = d["id"]
+        new_d["children"] = [{"id": x["id"]} for x in d["children"]]
+        return new_d
+
+    assert get_nodes(g1) == {
+        "id": "group_1",
+        "children": [
+            {"id": "group_1.setup_1"},
+            {"id": "group_1.setup_2"},
+            {"id": "group_1.teardown_0"},
+            {"id": "group_1.downstream_join_id"},
+        ],
+    }

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -29,7 +29,7 @@ from airflow.decorators import (
     task_group as task_group_decorator,
     teardown,
 )
-from airflow.exceptions import AirflowException, TaskAlreadyInTaskGroup
+from airflow.exceptions import TaskAlreadyInTaskGroup
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG
 from airflow.models.xcom_arg import XComArg
@@ -1485,75 +1485,6 @@ def test_task_group_arrow_with_setups_teardowns():
         tg1 >> w2
     assert t1.downstream_task_ids == set()
     assert w1.downstream_task_ids == {"tg1.t1", "w2"}
-
-
-def test_tasks_defined_outside_task_group(dag_maker):
-    # Test that classic tasks defined outside a task group are added to the root task group
-    # when the relationships are defined inside the task group
-    with dag_maker() as dag:
-        t1 = make_task("t1")
-        t2 = make_task("t2")
-        t3 = make_task("t3")
-        with TaskGroup(group_id="tg1"):
-            t1 >> t2 >> t3
-    dag.validate()
-    assert set(dag.task_group.children.keys()) == {"t1", "t2", "t3", "tg1"}
-    assert set(dag.task_group.children["tg1"].children.keys()) == set()
-    assert dag.task_group.children["t1"].upstream_task_ids == set()
-    assert dag.task_group.children["t1"].downstream_task_ids == {"t2"}
-    assert dag.task_group.children["t2"].upstream_task_ids == {"t1"}
-    assert dag.task_group.children["t2"].downstream_task_ids == {"t3"}
-    assert dag.task_group.children["t3"].upstream_task_ids == {"t2"}
-    assert dag.task_group.children["t3"].downstream_task_ids == set()
-
-    # Test that decorated tasks defined outside a task group are added to the root task group
-    # when relationships are defined inside the task group
-    with dag_maker() as dag:
-        t1 = make_task("t1", type_="decorated")
-        t2 = make_task("t2", type_="decorated")
-        t3 = make_task("t3", type_="decorated")
-        with TaskGroup(group_id="tg1"):
-            t1 >> t2 >> t3
-    dag.validate()
-    assert set(dag.task_group.children.keys()) == {"tg1", "t1", "t2", "t3"}
-    assert dag.task_group.children["tg1"].children.keys() == set()
-    assert dag.task_group.children["t1"].upstream_task_ids == set()
-    assert dag.task_group.children["t1"].downstream_task_ids == {"t2"}
-    assert dag.task_group.children["t2"].upstream_task_ids == {"t1"}
-    assert dag.task_group.children["t2"].downstream_task_ids == {"t3"}
-    assert dag.task_group.children["t3"].upstream_task_ids == {"t2"}
-    assert dag.task_group.children["t3"].downstream_task_ids == set()
-
-    # Test adding single decorated task defined outside a task group to a task group
-    with dag_maker() as dag:
-        t1 = make_task("t1", type_="decorated")
-        with TaskGroup(group_id="tg1") as tg1:
-            tg1.add_task(t1)
-    dag.validate()
-    assert dag.task_group.children.keys() == {"tg1"}
-    assert dag.task_group.children["tg1"].children.keys() == {"t1"}
-    assert dag.task_group.children["tg1"].children["t1"].upstream_task_ids == set()
-    assert dag.task_group.children["tg1"].children["t1"].downstream_task_ids == set()
-
-    # Test adding single classic task defined outside a task group to a task group
-    with dag_maker() as dag:
-        t1 = make_task("t1")
-        with TaskGroup(group_id="tg1") as tg1:
-            tg1.add_task(t1)
-    dag.validate()
-    assert dag.task_group.children.keys() == {"tg1"}
-    assert dag.task_group.children["tg1"].children.keys() == {"t1"}
-    assert dag.task_group.children["tg1"].children["t1"].upstream_task_ids == set()
-    assert dag.task_group.children["tg1"].children["t1"].downstream_task_ids == set()
-
-    with pytest.raises(
-        AirflowException,
-        match="Using this method on a task group that's not a context manager is not supported.",
-    ):
-        with dag_maker():
-            t1 = make_task("t1")
-            tg1 = TaskGroup(group_id="tg1")
-            tg1.add_task(t1)
 
 
 def test_task_group_arrow_with_setup_group():


### PR DESCRIPTION
Makes it possible to have your setups in a group and your teardowns in a group

<img width="817" alt="image" src="https://github.com/apache/airflow/assets/15932138/1ffab37d-4eab-4ab2-be70-11d18905fc0b">
