### PR TITLE
Use arrow with no circle for setup / teardown

### DIFF
--- a/airflow/www/static/js/dag/details/graph/Node.tsx
+++ b/airflow/www/static/js/dag/details/graph/Node.tsx
@@ -142,10 +142,10 @@ export const BaseNode = ({
                 {taskName}
               </Text>
               {setupTeardownType === "setup" && (
-                <ImArrowUpRight2 size={18} color={colors.gray[800]} />
+                <ImArrowUpRight2 size={15} color={colors.gray[800]} />
               )}
               {setupTeardownType === "teardown" && (
-                <ImArrowDownRight2 size={18} color={colors.gray[800]} />
+                <ImArrowDownRight2 size={15} color={colors.gray[800]} />
               )}
             </Flex>
             {!!instance && instance.state && (

--- a/airflow/www/static/js/dag/details/graph/Node.tsx
+++ b/airflow/www/static/js/dag/details/graph/Node.tsx
@@ -28,10 +28,7 @@ import { getGroupAndMapSummary, hoverDelay } from "src/utils";
 import Tooltip from "src/components/Tooltip";
 import InstanceTooltip from "src/dag/InstanceTooltip";
 import { useContainerRef } from "src/context/containerRef";
-import {
-  MdOutlineArrowCircleUp,
-  MdOutlineArrowCircleDown,
-} from "react-icons/md";
+import { MdArrowUpward, MdArrowDownward } from "react-icons/md";
 
 export interface CustomNodeProps {
   label: string;
@@ -145,10 +142,10 @@ export const BaseNode = ({
                 {taskName}
               </Text>
               {setupTeardownType === "setup" && (
-                <MdOutlineArrowCircleUp size={18} color={colors.gray[800]} />
+                <MdArrowUpward size={18} color={colors.gray[800]} />
               )}
               {setupTeardownType === "teardown" && (
-                <MdOutlineArrowCircleDown size={18} color={colors.gray[800]} />
+                <MdArrowDownward size={18} color={colors.gray[800]} />
               )}
             </Flex>
             {!!instance && instance.state && (

--- a/airflow/www/static/js/dag/details/graph/Node.tsx
+++ b/airflow/www/static/js/dag/details/graph/Node.tsx
@@ -28,7 +28,7 @@ import { getGroupAndMapSummary, hoverDelay } from "src/utils";
 import Tooltip from "src/components/Tooltip";
 import InstanceTooltip from "src/dag/InstanceTooltip";
 import { useContainerRef } from "src/context/containerRef";
-import { MdArrowUpward, MdArrowDownward } from "react-icons/md";
+import { ImArrowUpRight2, ImArrowDownRight2 } from "react-icons/im";
 
 export interface CustomNodeProps {
   label: string;
@@ -142,10 +142,10 @@ export const BaseNode = ({
                 {taskName}
               </Text>
               {setupTeardownType === "setup" && (
-                <MdArrowUpward size={18} color={colors.gray[800]} />
+                <ImArrowUpRight2 size={18} color={colors.gray[800]} />
               )}
               {setupTeardownType === "teardown" && (
-                <MdArrowDownward size={18} color={colors.gray[800]} />
+                <ImArrowDownRight2 size={18} color={colors.gray[800]} />
               )}
             </Flex>
             {!!instance && instance.state && (


### PR DESCRIPTION
Just seems easier to see.

<img width="745" alt="image" src="https://github.com/apache/airflow/assets/15932138/94e4e54a-2299-41ea-82ea-6de200eaa33e">

vs

<img width="817" alt="image" src="https://github.com/apache/airflow/assets/15932138/1ffab37d-4eab-4ab2-be70-11d18905fc0b">