### PR TITLE
Temporarily exclude openlineage from "PyPI" constraints generation

### DIFF
--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -287,6 +287,13 @@ function install_all_providers_from_pypi_with_eager_upgrade() {
     for provider_package in ${ALL_PROVIDERS_PACKAGES}
     do
         echo -n "Checking if ${provider_package} is available in PyPI: "
+        if [[ ${provider_package} == "apache-airflow-providers-openlineage" ]]; then
+            # The openlineage provider has 2.7.0 airflow dependency so it should be excluded for now in
+            # "pypi" dependency calculation
+            # We should remove it right after 2.7.0 is released to PyPI and regenerate the 2.7.0 constraints
+            echo "${COLOR_YELLOW}Skipped until 2.7.0 is released${COLOR_RESET}"
+            continue
+        fi
         res=$(curl --head -s -o /dev/null -w "%{http_code}" "https://pypi.org/project/${provider_package}/")
         if [[ ${res} == "200" ]]; then
             packages_to_install+=( "${provider_package}" )


### PR DESCRIPTION
The openlineage provider has apache-airflow >= 2.7.0 as dependency, and this is a problem for automated constraint generation. Since there is only one version of the provider released, it's the only one that can be installed from PyPI, but until apache-airflow 2.7.0 is released it cannot be installed because of the dependency missing.

This makes calculating of the constraints by PyPI impossible and it loops in continuously trying to find a solution that cannot be found.

In order to unblock constraint generation we need to exclude the provider temporarily and regenerate the constraints again when airflow 2.7.0 gets released (which will generally only bring the open-lineage provider as part of the constraints).

(cherry picked from commit b08188e24bf7e52a0b700e083caa38347a4fa3fc)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
