### PR TITLE
Adding startupProbe to airflow services charts

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -693,6 +693,39 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- end }}
 {{- end }}
 
+
+{{- define  "scheduler_startup_check_command" }}
+  {{- if semverCompare ">=2.5.0" .Values.airflowVersion }}
+  - sh
+  - -c
+  - |
+    CONNECTION_CHECK_MAX_COUNT=0 AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR exec /entrypoint \
+    airflow jobs check --job-type SchedulerJob --local
+  {{- else if semverCompare ">=2.1.0" .Values.airflowVersion }}
+  - sh
+  - -c
+  - |
+    CONNECTION_CHECK_MAX_COUNT=0 AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR exec /entrypoint \
+    airflow jobs check --job-type SchedulerJob --hostname $(hostname)
+  {{- else }}
+  - sh
+  - -c
+  - |
+    CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -Wignore -c "
+    import os
+    os.environ['AIRFLOW__CORE__LOGGING_LEVEL'] = 'ERROR'
+    os.environ['AIRFLOW__LOGGING__LOGGING_LEVEL'] = 'ERROR'
+    from airflow.jobs.scheduler_job import SchedulerJob
+    from airflow.utils.db import create_session
+    from airflow.utils.net import get_hostname
+    import sys
+    with create_session() as session:
+        job = session.query(SchedulerJob).filter_by(hostname=get_hostname()).order_by(
+            SchedulerJob.latest_heartbeat.desc()).limit(1).first()
+    sys.exit(0 if job.is_alive() else 1)"
+  {{- end }}
+{{- end }}
+
 {{- define "triggerer_liveness_check_command" }}
   {{- if semverCompare ">=2.5.0" .Values.airflowVersion }}
   - sh

--- a/chart/templates/configmaps/configmap.yaml
+++ b/chart/templates/configmaps/configmap.yaml
@@ -57,16 +57,16 @@ data:
     {{- .Values.dags.gitSync.knownHosts | nindent 4 }}
   {{- end }}
 
-  {{- if or (eq $.Values.executor "LocalKubernetesExecutor") (eq $.Values.executor "KubernetesExecutor") (eq $.Values.executor "CeleryKubernetesExecutor") }}
-  {{- if semverCompare ">=1.10.12" .Values.airflowVersion }}
+{{/*  {{- if or (eq $.Values.executor "LocalKubernetesExecutor") (eq $.Values.executor "KubernetesExecutor") (eq $.Values.executor "CeleryKubernetesExecutor") }}*/}}
+{{/*  {{- if semverCompare ">=1.10.12" .Values.airflowVersion }}*/}}
   pod_template_file.yaml: |-
     {{- if .Values.podTemplate }}
       {{- tpl .Values.podTemplate . | nindent 4 }}
     {{- else }}
       {{- tpl (.Files.Get "files/pod-template-file.kubernetes-helm-yaml") . | nindent 4 }}
     {{- end }}
-  {{- end }}
-  {{- end }}
+{{/*  {{- end }}*/}}
+{{/*  {{- end }}*/}}
 
   {{- if .Values.kerberos.enabled }}
   krb5.conf: |-

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -195,6 +195,17 @@ spec:
                 {{- else }}
                   {{- include "scheduler_liveness_check_command" . | indent 14 }}
                 {{- end }}
+          startupProbe:
+            timeoutSeconds: {{ .Values.scheduler.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.scheduler.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.scheduler.startupProbe.periodSeconds }}
+            exec:
+              command:
+                {{- if .Values.scheduler.startupProbe.command }}
+                  {{- toYaml .Values.scheduler.startupProbe.command  | nindent 16 }}
+                {{- else }}
+                  {{- include "scheduler_startup_check_command" . | indent 14 }}
+                {{- end }}
           {{- if and $local (not $elasticsearch) }}
           # Serve logs if we're in local mode and we don't have elasticsearch enabled.
           ports:

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -227,6 +227,19 @@ spec:
             timeoutSeconds: {{ .Values.webserver.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.webserver.readinessProbe.failureThreshold }}
             periodSeconds: {{ .Values.webserver.readinessProbe.periodSeconds }}
+          startupProbe:
+            httpGet:
+              path: {{ if .Values.config.webserver.base_url }}{{- with urlParse (tpl .Values.config.webserver.base_url .) }}{{ .path }}{{ end }}{{ end }}/health
+              port: {{ .Values.ports.airflowUI }}
+              {{- if .Values.config.webserver.base_url}}
+              httpHeaders:
+                - name: Host
+                  value: {{ regexReplaceAll ":\\d+$" (urlParse (tpl .Values.config.webserver.base_url .)).host  "" }}
+              {{- end }}
+              scheme: {{ .Values.webserver.startupProbe.scheme | default "http" }}
+            timeoutSeconds: {{ .Values.webserver.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.webserver.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.webserver.startupProbe.periodSeconds }}
           envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env:
             {{- include "custom_airflow_environment" . | indent 10 }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1973,7 +1973,7 @@
                         "failureThreshold": {
                             "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Minimum value is 1.",
                             "type": "integer",
-                            "default": 60
+                            "default": 6
                         },
                         "periodSeconds": {
                             "description": "How often (in seconds) to perform the probe. Minimum value is 1.",
@@ -3810,7 +3810,7 @@
                         "failureThreshold": {
                             "description": "Webserver Startup probe failure threshold.",
                             "type": "integer",
-                            "default": 60
+                            "default": 6
                         },
                         "periodSeconds": {
                             "description": "Webserver Startup probe period seconds.",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1960,6 +1960,41 @@
                         }
                     }
                 },
+                "startupProbe": {
+                    "description": "Startup probe configuration for scheduler container.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Minimum value is 1 seconds.",
+                            "type": "integer",
+                            "default": 20
+                        },
+                        "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Minimum value is 1.",
+                            "type": "integer",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Minimum value is 1.",
+                            "type": "integer",
+                            "default": 10
+                        },
+                        "command": {
+                            "description": "Command for livenessProbe",
+                            "type": [
+                                "array",
+                                "null"
+                            ],
+                            "items": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    }
+                },
                 "replicas": {
                     "description": "Airflow 2.0 allows users to run multiple schedulers. This feature is only recommended for MySQL 8+ and PostgreSQL",
                     "type": "integer",
@@ -3757,6 +3792,33 @@
                         },
                         "scheme": {
                             "description": "Webserver Readiness probe scheme.",
+                            "type": "string",
+                            "default": "HTTP"
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "description": "Startup probe configuration.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "timeoutSeconds": {
+                            "description": "Webserver Startup probe timeout seconds.",
+                            "type": "integer",
+                            "default": 20
+                        },
+                        "failureThreshold": {
+                            "description": "Webserver Startup probe failure threshold.",
+                            "type": "integer",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "description": "Webserver Startup probe period seconds.",
+                            "type": "integer",
+                            "default": 10
+                        },
+                        "scheme": {
+                            "description": "Webserver Startup probe scheme.",
                             "type": "string",
                             "default": "HTTP"
                         }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -721,6 +721,14 @@ scheduler:
     failureThreshold: 5
     periodSeconds: 60
     command: ~
+
+  # Wait for at most 10 minutes (60*10s) for the scheduler container to startup.
+  # livenessProbe kicks in after the startup
+  startupProbe:
+    failureThreshold: 60
+    periodSeconds: 10
+    timeoutSeconds: 20
+    command: ~
   # Airflow 2.0 allows users to run multiple schedulers,
   # However this feature is only recommended for MySQL 8+ and Postgres
   replicas: 1
@@ -1063,6 +1071,12 @@ webserver:
     initialDelaySeconds: 15
     timeoutSeconds: 5
     failureThreshold: 5
+    periodSeconds: 10
+    scheme: HTTP
+
+  startupProbe:
+    timeoutSeconds: 20
+    failureThreshold: 60
     periodSeconds: 10
     scheme: HTTP
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -722,10 +722,10 @@ scheduler:
     periodSeconds: 60
     command: ~
 
-  # Wait for at most 10 minutes (60*10s) for the scheduler container to startup.
+  # Wait for at most 10 minutes (6*10s) for the scheduler container to startup.
   # livenessProbe kicks in after the startup
   startupProbe:
-    failureThreshold: 60
+    failureThreshold: 6
     periodSeconds: 10
     timeoutSeconds: 20
     command: ~
@@ -1076,7 +1076,7 @@ webserver:
 
   startupProbe:
     timeoutSeconds: 20
-    failureThreshold: 60
+    failureThreshold: 6
     periodSeconds: 10
     scheme: HTTP
 

--- a/helm_tests/airflow_core/test_scheduler.py
+++ b/helm_tests/airflow_core/test_scheduler.py
@@ -357,6 +357,30 @@ class TestScheduler:
             "spec.template.spec.containers[0].livenessProbe.exec.command", docs[0]
         )
 
+    def test_startupprobe_values_are_configurable(self):
+        docs = render_chart(
+            values={
+                "scheduler": {
+                    "startupProbe": {
+                        "timeoutSeconds": 111,
+                        "failureThreshold": 222,
+                        "periodSeconds": 333,
+                        "command": ["sh", "-c", "echo", "wow such test"],
+                    }
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        assert 111 == jmespath.search("spec.template.spec.containers[0].startupProbe.timeoutSeconds", docs[0])
+        assert 222 == jmespath.search(
+            "spec.template.spec.containers[0].startupProbe.failureThreshold", docs[0]
+        )
+        assert 333 == jmespath.search("spec.template.spec.containers[0].startupProbe.periodSeconds", docs[0])
+        assert ["sh", "-c", "echo", "wow such test"] == jmespath.search(
+            "spec.template.spec.containers[0].startupProbe.exec.command", docs[0]
+        )
+
     @pytest.mark.parametrize(
         "airflow_version, probe_command",
         [
@@ -373,6 +397,24 @@ class TestScheduler:
         assert (
             probe_command
             in jmespath.search("spec.template.spec.containers[0].livenessProbe.exec.command", docs[0])[-1]
+        )
+
+    @pytest.mark.parametrize(
+        "airflow_version, probe_command",
+        [
+            ("1.9.0", "from airflow.jobs.scheduler_job import SchedulerJob"),
+            ("2.1.0", "airflow jobs check --job-type SchedulerJob --hostname $(hostname)"),
+            ("2.5.0", "airflow jobs check --job-type SchedulerJob --local"),
+        ],
+    )
+    def test_startupprobe_command_depends_on_airflow_version(self, airflow_version, probe_command):
+        docs = render_chart(
+            values={"airflowVersion": f"{airflow_version}"},
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+        assert (
+            probe_command
+            in jmespath.search("spec.template.spec.containers[0].startupProbe.exec.command", docs[0])[-1]
         )
 
     @pytest.mark.parametrize(

--- a/helm_tests/webserver/test_webserver.py
+++ b/helm_tests/webserver/test_webserver.py
@@ -25,7 +25,7 @@ from tests.charts.helm_template_generator import render_chart
 class TestWebserverDeployment:
     """Tests webserver deployment."""
 
-    def test_should_add_host_header_to_liveness_and_readiness_probes(self):
+    def test_should_add_host_header_to_liveness_and_readiness_and_startup_probes(self):
         docs = render_chart(
             values={
                 "config": {
@@ -41,8 +41,11 @@ class TestWebserverDeployment:
         assert {"name": "Host", "value": "example.com"} in jmespath.search(
             "spec.template.spec.containers[0].readinessProbe.httpGet.httpHeaders", docs[0]
         )
+        assert {"name": "Host", "value": "example.com"} in jmespath.search(
+            "spec.template.spec.containers[0].startupProbe.httpGet.httpHeaders", docs[0]
+        )
 
-    def test_should_add_path_to_liveness_and_readiness_probes(self):
+    def test_should_add_path_to_liveness_and_readiness_and_startup_probes(self):
         docs = render_chart(
             values={
                 "config": {
@@ -58,6 +61,10 @@ class TestWebserverDeployment:
         )
         assert (
             jmespath.search("spec.template.spec.containers[0].readinessProbe.httpGet.path", docs[0])
+            == "/mypath/path/health"
+        )
+        assert (
+            jmespath.search("spec.template.spec.containers[0].startupProbe.httpGet.path", docs[0])
             == "/mypath/path/health"
         )
 
@@ -91,6 +98,10 @@ class TestWebserverDeployment:
             jmespath.search("spec.template.spec.containers[0].readinessProbe.httpGet.httpHeaders", docs[0])
             is None
         )
+        assert (
+            jmespath.search("spec.template.spec.containers[0].startupProbe.httpGet.httpHeaders", docs[0])
+            is None
+        )
 
     def test_should_use_templated_base_url_for_probes(self):
         docs = render_chart(
@@ -111,15 +122,20 @@ class TestWebserverDeployment:
         assert {"name": "Host", "value": "release-name.com"} in jmespath.search(
             "readinessProbe.httpGet.httpHeaders", container
         )
+        assert {"name": "Host", "value": "release-name.com"} in jmespath.search(
+            "startupProbe.httpGet.httpHeaders", container
+        )
         assert "/mypath/release-name/path/health" == jmespath.search("livenessProbe.httpGet.path", container)
         assert "/mypath/release-name/path/health" == jmespath.search("readinessProbe.httpGet.path", container)
+        assert "/mypath/release-name/path/health" == jmespath.search("startupProbe.httpGet.path", container)
 
-    def test_should_add_scheme_to_liveness_and_readiness_probes(self):
+    def test_should_add_scheme_to_liveness_and_readiness_and_startup_probes(self):
         docs = render_chart(
             values={
                 "webserver": {
                     "livenessProbe": {"scheme": "HTTPS"},
                     "readinessProbe": {"scheme": "HTTPS"},
+                    "startupProbe": {"scheme": "HTTPS"},
                 }
             },
             show_only=["templates/webserver/webserver-deployment.yaml"],
@@ -130,6 +146,9 @@ class TestWebserverDeployment:
         )
         assert "HTTPS" in jmespath.search(
             "spec.template.spec.containers[0].readinessProbe.httpGet.scheme", docs[0]
+        )
+        assert "HTTPS" in jmespath.search(
+            "spec.template.spec.containers[0].startupProbe.httpGet.scheme", docs[0]
         )
 
     def test_should_add_volume_and_volume_mount_when_exist_webserver_config(self):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

We have an internal feature where we perform a copy of venv from airflow services to cloud storages which can sometimes take a few minutes. Copying of a venv is a metadata heavy load: https://learn.microsoft.com/en-us/troubleshoot/azure/azure-storage/files-troubleshoot-performance?tabs=linux#cause-2-metadata-or-namespace-heavy-workload.

Introducing a startupProbe onto the airflow services would be useful for slow starting container and most of all it doesn't have side effects. startupProbe has been added for scheduler and the webserver following the same flow as their respective liveness and readiness probes. A gracious value of 10 mins has been set for startup. This is based on personal experiments where our deployments took 5 - 6 mins for startup roughly, 10 mins allows some head room. Although, these properties are configurable and would be beneficial for users to use them.

closes: #33099 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
