### PR TITLE
Allows to choose SSL context for IMAP provider

### DIFF
--- a/airflow/providers/imap/CHANGELOG.rst
+++ b/airflow/providers/imap/CHANGELOG.rst
@@ -35,7 +35,7 @@ by setting "ssl_context" in "imap" configuration of the provider. If it is not e
 it will default to "email", "ssl_context" setting in Airflow.
 
 Setting it to "none" brings back the "none" setting that was used in previous versions of the provider,
-but it is not recommended due to security reasons ad this setting disables validation
+but it is not recommended due to security reasons and this setting disables validation
 of certificates and allows MITM attacks.
 
 3.2.2

--- a/airflow/providers/imap/CHANGELOG.rst
+++ b/airflow/providers/imap/CHANGELOG.rst
@@ -26,6 +26,18 @@
 Changelog
 ---------
 
+In case of IMAP SSL connection, the default context now uses "default" context
+
+The "default" context is Python's ``default_ssl_context`` instead of previously used "none". The
+``default_ssl_context`` provides a balance between security and compatibility but in some cases,
+when certificates are old, self-signed or misconfigured, it might not work. This can be configured
+by setting "ssl_context" in "imap" configuration of the provider. If it is not explicitly set,
+it will default to "email", "ssl_context" setting in Airflow.
+
+Setting it to "none" brings back the "none" setting that was used in previous versions of the provider,
+but it is not recommended due to security reasons ad this setting disables validation
+of certificates and allows MITM attacks.
+
 3.2.2
 .....
 

--- a/airflow/providers/imap/CHANGELOG.rst
+++ b/airflow/providers/imap/CHANGELOG.rst
@@ -26,7 +26,7 @@
 Changelog
 ---------
 
-In case of IMAP SSL connection, the default context now uses "default" context
+In case of IMAP SSL connection, the context now uses the "default" context
 
 The "default" context is Python's ``default_ssl_context`` instead of previously used "none". The
 ``default_ssl_context`` provides a balance between security and compatibility but in some cases,

--- a/airflow/providers/imap/provider.yaml
+++ b/airflow/providers/imap/provider.yaml
@@ -62,3 +62,26 @@ hooks:
 connection-types:
   - hook-class-name: airflow.providers.imap.hooks.imap.ImapHook
     connection-type: imap
+
+config:
+  imap:
+    description: "Options for IMAP provider."
+    options:
+      ssl_context:
+        description: |
+          ssl context to use when using SMTP and IMAP SSL connections. By default, the context is "default"
+          which sets it to ``ssl.create_default_context()`` which provides the right balance between
+          compatibility and security, it however requires that certificates in your operating system are
+          updated and that SMTP/IMAP servers of yours have valid certificates that have corresponding public
+          keys installed on your machines. You can switch it to "none" if you want to disable checking
+          of the certificates, but it is not recommended as it allows MITM (man-in-the-middle) attacks
+          if your infrastructure is not sufficiently secured. It should only be set temporarily while you
+          are fixing your certificate configuration. This can be typically done by upgrading to newer
+          version of the operating system you run Airflow components on,by upgrading/refreshing proper
+          certificates in the OS or by updating certificates for your mail servers.
+          If you do not set this option explicitly, it will use Airflow "email.ssl_context" configuration,
+          but if this configuration is not present, it will use "default" value.
+        type: string
+        version_added: 3.3.0
+        example: "default"
+        default: ~

--- a/docs/apache-airflow-providers-imap/configurations-ref.rst
+++ b/docs/apache-airflow-providers-imap/configurations-ref.rst
@@ -1,0 +1,18 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. include:: ../exts/includes/providers-configurations-ref.rst

--- a/docs/apache-airflow-providers-imap/index.rst
+++ b/docs/apache-airflow-providers-imap/index.rst
@@ -34,6 +34,7 @@
     :maxdepth: 1
     :caption: References
 
+    Configuration <configurations-ref>
     Connection types <connections/imap>
     Python API <_api/airflow/providers/imap/index>
 

--- a/docs/apache-airflow/configurations-ref.rst
+++ b/docs/apache-airflow/configurations-ref.rst
@@ -39,6 +39,7 @@ in the provider's documentation. The pre-installed providers that you may want t
 * :doc:`Configuration Reference for Apache Hive Provider <apache-airflow-providers-apache-hive:configurations-ref>`
 * :doc:`Configuration Reference for CNCF Kubernetes Provider <apache-airflow-providers-cncf-kubernetes:configurations-ref>`
 * :doc:`Configuration Reference for SMTP Provider <apache-airflow-providers-smtp:configurations-ref>`
+* :doc:`Configuration Reference for IMAP Provider <apache-airflow-providers-imap:configurations-ref>`
 
 .. note::
     For more information see :doc:`/howto/set-config`.

--- a/tests/providers/imap/hooks/test_imap.py
+++ b/tests/providers/imap/hooks/test_imap.py
@@ -27,6 +27,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.imap.hooks.imap import ImapHook
 from airflow.utils import db
+from tests.test_utils.config import conf_vars
 
 imaplib_string = "airflow.providers.imap.hooks.imap.imaplib"
 open_string = "airflow.providers.imap.hooks.imap.open"
@@ -85,13 +86,77 @@ class TestImapHook:
         )
 
     @patch(imaplib_string)
-    def test_connect_and_disconnect(self, mock_imaplib):
+    @patch("ssl.create_default_context")
+    def test_connect_and_disconnect(self, create_default_context, mock_imaplib):
         mock_conn = _create_fake_imap(mock_imaplib)
 
         with ImapHook():
             pass
 
-        mock_imaplib.IMAP4_SSL.assert_called_once_with("imap_server_address", 1993)
+        assert create_default_context.called
+        mock_imaplib.IMAP4_SSL.assert_called_once_with(
+            "imap_server_address", 1993, ssl_context=create_default_context.return_value
+        )
+        mock_conn.login.assert_called_once_with("imap_user", "imap_password")
+        assert mock_conn.logout.call_count == 1
+
+    @patch(imaplib_string)
+    @patch("ssl.create_default_context")
+    def test_connect_and_disconnect_imap_ssl_context_none(self, create_default_context, mock_imaplib):
+        mock_conn = _create_fake_imap(mock_imaplib)
+
+        with conf_vars({("imap", "ssl_context"): "none"}):
+            with ImapHook():
+                pass
+
+        assert not create_default_context.called
+        mock_imaplib.IMAP4_SSL.assert_called_once_with("imap_server_address", 1993, ssl_context=None)
+        mock_conn.login.assert_called_once_with("imap_user", "imap_password")
+        assert mock_conn.logout.call_count == 1
+
+    @patch(imaplib_string)
+    @patch("ssl.create_default_context")
+    def test_connect_and_disconnect_imap_ssl_context_default(self, create_default_context, mock_imaplib):
+        mock_conn = _create_fake_imap(mock_imaplib)
+
+        with conf_vars({("imap", "ssl_context"): "default"}):
+            with ImapHook():
+                pass
+
+        assert create_default_context.called
+        mock_imaplib.IMAP4_SSL.assert_called_once_with(
+            "imap_server_address", 1993, ssl_context=create_default_context.return_value
+        )
+        mock_conn.login.assert_called_once_with("imap_user", "imap_password")
+        assert mock_conn.logout.call_count == 1
+
+    @patch(imaplib_string)
+    @patch("ssl.create_default_context")
+    def test_connect_and_disconnect_email_ssl_context_none(self, create_default_context, mock_imaplib):
+        mock_conn = _create_fake_imap(mock_imaplib)
+
+        with conf_vars({("email", "ssl_context"): "none"}):
+            with ImapHook():
+                pass
+
+        assert not create_default_context.called
+        mock_imaplib.IMAP4_SSL.assert_called_once_with("imap_server_address", 1993, ssl_context=None)
+        mock_conn.login.assert_called_once_with("imap_user", "imap_password")
+        assert mock_conn.logout.call_count == 1
+
+    @patch(imaplib_string)
+    @patch("ssl.create_default_context")
+    def test_connect_and_disconnect_imap_ssl_context_override(self, create_default_context, mock_imaplib):
+        mock_conn = _create_fake_imap(mock_imaplib)
+
+        with conf_vars({("email", "ssl_context"): "none", ("imap", "ssl_context"): "default"}):
+            with ImapHook():
+                pass
+
+        assert create_default_context.called
+        mock_imaplib.IMAP4_SSL.assert_called_once_with(
+            "imap_server_address", 1993, ssl_context=create_default_context.return_value
+        )
         mock_conn.login.assert_called_once_with("imap_user", "imap_password")
         assert mock_conn.logout.call_count == 1
 


### PR DESCRIPTION
This change add two options to choose from when SSL IMAP connection is created:

* default - for balance between compatibility and security
* none - in case compatibility with existing infrastructure is preferred

The fallback is:

* The Airflow "email", "ssl_context"
* "default"

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
