### PR TITLE
Add possibility to use `ssl_context` extra for SMTP and IMAP connections

### DIFF
--- a/airflow/providers/imap/CHANGELOG.rst
+++ b/airflow/providers/imap/CHANGELOG.rst
@@ -38,6 +38,8 @@ Setting it to "none" brings back the "none" setting that was used in previous ve
 but it is not recommended due to security reasons and this setting disables validation
 of certificates and allows MITM attacks.
 
+You can also override "ssl_context" per-connection by setting "ssl_context" in the connection extra.
+
 3.2.2
 .....
 

--- a/airflow/providers/imap/hooks/imap.py
+++ b/airflow/providers/imap/hooks/imap.py
@@ -84,7 +84,11 @@ class ImapHook(BaseHook):
         if use_ssl:
             from airflow.configuration import conf
 
-            ssl_context_string = conf.get("imap", "SSL_CONTEXT", fallback=None)
+            extra_ssl_context = conn.extra_dejson.get("ssl_context", None)
+            if extra_ssl_context:
+                ssl_context_string = extra_ssl_context
+            else:
+                ssl_context_string = conf.get("imap", "SSL_CONTEXT", fallback=None)
             if ssl_context_string is None:
                 ssl_context_string = conf.get("email", "SSL_CONTEXT", fallback=None)
             if ssl_context_string is None:

--- a/airflow/providers/smtp/CHANGELOG.rst
+++ b/airflow/providers/smtp/CHANGELOG.rst
@@ -39,6 +39,8 @@ Setting it to "none" brings back the "none" setting that was used in previous ve
 but it is not recommended due to security reasons ad this setting disables validation
 of certificates and allows MITM attacks.
 
+You can also override "ssl_context" per-connection by setting "ssl_context" in the connection extra.
+
 1.2.0
 .....
 

--- a/airflow/providers/smtp/hooks/smtp.py
+++ b/airflow/providers/smtp/hooks/smtp.py
@@ -112,7 +112,11 @@ class SmtpHook(BaseHook):
         if self.use_ssl:
             from airflow.configuration import conf
 
-            ssl_context_string = conf.get("smtp_provider", "SSL_CONTEXT", fallback=None)
+            extra_ssl_context = self.conn.extra_dejson.get("ssl_context", None)
+            if extra_ssl_context:
+                ssl_context_string = extra_ssl_context
+            else:
+                ssl_context_string = conf.get("smtp_provider", "SSL_CONTEXT", fallback=None)
             if ssl_context_string is None:
                 ssl_context_string = conf.get("email", "SSL_CONTEXT", fallback=None)
             if ssl_context_string is None:

--- a/docs/apache-airflow-providers-imap/connections/imap.rst
+++ b/docs/apache-airflow-providers-imap/connections/imap.rst
@@ -55,6 +55,9 @@ Extra (optional)
     Specify the extra parameters (as json dictionary)
 
     * ``use_ssl``: If set to false, then a non-ssl connection is being used. Default is true. Also note that changing the ssl option also influences the default port being used.
+    * ``ssl_context``: Can be "default" or "none". Only valid when "use_ssl" is used. The "default" context provides a balance between security and compatibility, "none" is not recommended
+      as it disables validation of certificates and allow MITM attacks and is only needed in case your certificates are wrongly configured in your system. If not specified, defaults are taken from the
+      "imap", "ssl_context" configuration with the fallback to "email". "ssl_context" configuration. If none of it is specified, "default" is used.
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.

--- a/docs/apache-airflow-providers-smtp/connections/smtp.rst
+++ b/docs/apache-airflow-providers-smtp/connections/smtp.rst
@@ -59,6 +59,9 @@ Extra (optional)
     * ``timeout``: The SMTP connection creation timeout in seconds. Default is 30.
     * ``disable_tls``: By default the SMTP connection is created in TLS mode. Set to false to disable tls mode.
     * ``retry_limit``: How many attempts to connect to the server before raising an exception. Default is 5.
+    * ``ssl_context``: Can be "default" or "none". Only valid when SSL is used. The "default" context provides a balance between security and compatibility, "none" is not recommended
+      as it disables validation of certificates and allow MITM attacks, and is only needed in case your certificates are wrongly configured in your system. If not specified, defaults are taken from the
+      "smtp_provider", "ssl_context" configuration with the fallback to "email". "ssl_context" configuration. If none of it is specified, "default" is used.
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.


### PR DESCRIPTION
The previous changes #33070 and #33108 added configuration parameters to allow "ssl_context" to be configured "per installation of airflow".

The ssl_context extras allow to override the system-wide setting with extras configured per-connection.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
