### PR TITLE
add CLI notification commands to providers

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -1801,6 +1801,12 @@ PROVIDERS_COMMANDS = (
         args=(ARG_OUTPUT, ARG_VERBOSE),
     ),
     ActionCommand(
+        name="notifications",
+        help="Get information about notifications provided",
+        func=lazy_load_command("airflow.cli.commands.provider_command.notifications_list"),
+        args=(ARG_OUTPUT, ARG_VERBOSE),
+    ),
+    ActionCommand(
         name="configs",
         help="Get information about provider configuration",
         func=lazy_load_command("airflow.cli.commands.provider_command.config_list"),

--- a/airflow/cli/commands/provider_command.py
+++ b/airflow/cli/commands/provider_command.py
@@ -103,6 +103,18 @@ def triggers_list(args):
 
 @suppress_logs_and_warning
 @providers_configuration_loaded
+def notifications_list(args):
+    AirflowConsole().print_as(
+        data=ProvidersManager().notification,
+        output=args.output,
+        mapper=lambda x: {
+            "notification_class_name": x,
+        },
+    )
+
+
+@suppress_logs_and_warning
+@providers_configuration_loaded
 def connection_form_widget_list(args):
     """Lists all custom connection form fields at the command line."""
     AirflowConsole().print_as(

--- a/scripts/in_container/verify_providers.py
+++ b/scripts/in_container/verify_providers.py
@@ -742,7 +742,7 @@ def run_provider_discovery():
         subprocess.run(["airflow", "providers", "executors"], check=True)
     if packaging.version.parse(airflow.version.version) >= packaging.version.parse("2.7.0.dev0"):
         # CI also check if our providers are installable and discoverable in airflow older versions
-        # But the notifications command is not available till airflow-2-7-0
+        # But the notifications command is not available till airflow-2-8-0
         console.print("[bright_blue]List all notifications[/]\n")
         subprocess.run(["airflow", "providers", "notification"], check=True)
 

--- a/scripts/in_container/verify_providers.py
+++ b/scripts/in_container/verify_providers.py
@@ -740,7 +740,7 @@ def run_provider_discovery():
         # But the executors command is not available till airflow-2-7-0
         console.print("[bright_blue]List all executors[/]\n")
         subprocess.run(["airflow", "providers", "executors"], check=True)
-    if packaging.version.parse(airflow.version.version) >= packaging.version.parse("2.7.0.dev0"):
+    if packaging.version.parse(airflow.version.version) >= packaging.version.parse("2.8.0.dev0"):
         # CI also check if our providers are installable and discoverable in airflow older versions
         # But the notifications command is not available till airflow-2-8-0
         console.print("[bright_blue]List all notifications[/]\n")

--- a/scripts/in_container/verify_providers.py
+++ b/scripts/in_container/verify_providers.py
@@ -52,6 +52,7 @@ class EntityType(Enum):
     Hooks = "Hooks"
     Secrets = "Secrets"
     Trigger = "Trigger"
+    Notification = "Notification"
 
 
 class EntityTypeSummary(NamedTuple):
@@ -83,6 +84,7 @@ ENTITY_NAMES = {
     EntityType.Hooks: "Hooks",
     EntityType.Secrets: "Secrets",
     EntityType.Trigger: "Trigger",
+    EntityType.Notification: "Notification",
 }
 
 TOTALS: dict[EntityType, int] = {
@@ -92,6 +94,7 @@ TOTALS: dict[EntityType, int] = {
     EntityType.Transfers: 0,
     EntityType.Secrets: 0,
     EntityType.Trigger: 0,
+    EntityType.Notification: 0,
 }
 
 OPERATORS_PATTERN = r".*Operator$"
@@ -101,6 +104,7 @@ SECRETS_PATTERN = r".*Backend$"
 TRANSFERS_PATTERN = r".*To[A-Z0-9].*Operator$"
 WRONG_TRANSFERS_PATTERN = r".*Transfer$|.*TransferOperator$"
 TRIGGER_PATTERN = r".*Trigger$"
+NOTIFICATION_PATTERN = r".*Notification$"
 
 ALL_PATTERNS = {
     OPERATORS_PATTERN,
@@ -110,6 +114,7 @@ ALL_PATTERNS = {
     TRANSFERS_PATTERN,
     WRONG_TRANSFERS_PATTERN,
     TRIGGER_PATTERN,
+    NOTIFICATION_PATTERN,
 }
 
 EXPECTED_SUFFIXES: dict[EntityType, str] = {
@@ -119,6 +124,7 @@ EXPECTED_SUFFIXES: dict[EntityType, str] = {
     EntityType.Secrets: "Backend",
     EntityType.Transfers: "Operator",
     EntityType.Trigger: "Trigger",
+    EntityType.Notification: "Notification",
 }
 
 
@@ -462,6 +468,7 @@ def get_package_class_summary(
     from airflow.secrets import BaseSecretsBackend
     from airflow.sensors.base import BaseSensorOperator
     from airflow.triggers.base import BaseTrigger
+    from airflow.notifications.basenotifier import BaseNotifier
 
     all_verified_entities: dict[EntityType, VerifiedEntities] = {
         EntityType.Operators: find_all_entities(
@@ -521,6 +528,14 @@ def get_package_class_summary(
             ancestor_match=BaseTrigger,
             expected_class_name_pattern=TRIGGER_PATTERN,
             unexpected_class_name_patterns=ALL_PATTERNS - {TRIGGER_PATTERN},
+        ),
+        EntityType.Notification: find_all_entities(
+            imported_classes=imported_classes,
+            base_package=full_package_name,
+            sub_package_pattern_match=r".*\.notifications\..*",
+            ancestor_match=BaseNotifier,
+            expected_class_name_pattern=NOTIFICATION_PATTERN,
+            unexpected_class_name_patterns=ALL_PATTERNS - {NOTIFICATION_PATTERN},
         ),
     }
     for entity in EntityType:
@@ -725,6 +740,11 @@ def run_provider_discovery():
         # But the executors command is not available till airflow-2-7-0
         console.print("[bright_blue]List all executors[/]\n")
         subprocess.run(["airflow", "providers", "executors"], check=True)
+    if packaging.version.parse(airflow.version.version) >= packaging.version.parse("2.7.0.dev0"):
+        # CI also check if our providers are installable and discoverable in airflow older versions
+        # But the notifications command is not available till airflow-2-7-0
+        console.print("[bright_blue]List all notifications[/]\n")
+        subprocess.run(["airflow", "providers", "notification"], check=True)
 
 
 AIRFLOW_LOCAL_SETTINGS_PATH = Path("/opt/airflow") / "airflow_local_settings.py"

--- a/scripts/in_container/verify_providers.py
+++ b/scripts/in_container/verify_providers.py
@@ -740,11 +740,6 @@ def run_provider_discovery():
         # But the executors command is not available till airflow-2-7-0
         console.print("[bright_blue]List all executors[/]\n")
         subprocess.run(["airflow", "providers", "executors"], check=True)
-    if packaging.version.parse(airflow.version.version) >= packaging.version.parse("2.8.0.dev0"):
-        # CI also check if our providers are installable and discoverable in airflow older versions
-        # But the notifications command is not available till airflow-2-8-0
-        console.print("[bright_blue]List all notifications[/]\n")
-        subprocess.run(["airflow", "providers", "notification"], check=True)
 
 
 AIRFLOW_LOCAL_SETTINGS_PATH = Path("/opt/airflow") / "airflow_local_settings.py"

--- a/tests/always/test_providers_manager.py
+++ b/tests/always/test_providers_manager.py
@@ -379,6 +379,11 @@ class TestProviderManager:
         trigger_class_names = list(provider_manager.trigger)
         assert len(trigger_class_names) > 10
 
+    def test_notification(self):
+        provider_manager = ProvidersManager()
+        notification_class_names = list(provider_manager.notification)
+        assert len(notification_class_names) > 5
+
     @patch("airflow.providers_manager.import_string")
     def test_optional_feature_no_warning(self, mock_importlib_import_string):
         with self._caplog.at_level(logging.WARNING):


### PR DESCRIPTION
This PR adds the CLI commands to view notifications implementation by providers for issue [#31443](https://github.com/apache/airflow/issues/31443).


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
