### PR TITLE
openlineage: disable running listener if not configured

### DIFF
--- a/airflow/providers/openlineage/plugins/openlineage.py
+++ b/airflow/providers/openlineage/plugins/openlineage.py
@@ -27,6 +27,12 @@ def _is_disabled() -> bool:
     return (
         conf.getboolean("openlineage", "disabled")
         or os.getenv("OPENLINEAGE_DISABLED", "false").lower() == "true"
+        or (
+            conf.get("openlineage", "transport") == ""
+            and conf.get("openlineage", "config_path") == ""
+            and os.getenv("OPENLINEAGE_URL", "") == ""
+            and os.getenv("OPENLINEAGE_CONFIG", "") == ""
+        )
     )
 
 
@@ -39,8 +45,8 @@ class OpenLineageProviderPlugin(AirflowPlugin):
     """
 
     name = "OpenLineageProviderPlugin"
-    macros = [lineage_run_id, lineage_parent_id]
     if not _is_disabled():
         from airflow.providers.openlineage.plugins.listener import OpenLineageListener
 
+        macros = [lineage_run_id, lineage_parent_id]
         listeners = [OpenLineageListener()]

--- a/tests/providers/openlineage/plugins/test_openlineage.py
+++ b/tests/providers/openlineage/plugins/test_openlineage.py
@@ -39,8 +39,28 @@ class TestOpenLineageProviderPlugin:
     @pytest.mark.parametrize(
         "mocks, expected",
         [
-            ([patch.dict(os.environ, {"OPENLINEAGE_DISABLED": "true"}, 0)], 0),
-            ([conf_vars({("openlineage", "disabled"): "False"})], 1),
+            ([patch.dict(os.environ, {"OPENLINEAGE_DISABLED": "true"})], 0),
+            (
+                [
+                    conf_vars(
+                        {("openlineage", "transport"): '{"type": "http", "url": "http://localhost:5000"}'}
+                    ),
+                    patch.dict(os.environ, {"OPENLINEAGE_DISABLED": "true"}),
+                ],
+                0,
+            ),
+            ([patch.dict(os.environ, {"OPENLINEAGE_DISABLED": "false"})], 0),
+            (
+                [
+                    conf_vars(
+                        {
+                            ("openlineage", "disabled"): "False",
+                            ("openlineage", "transport"): '{"type": "http", "url": "http://localhost:5000"}',
+                        }
+                    )
+                ],
+                1,
+            ),
             (
                 [
                     conf_vars({("openlineage", "disabled"): "False"}),
@@ -48,7 +68,16 @@ class TestOpenLineageProviderPlugin:
                 ],
                 0,
             ),
-            ([], 1),
+            ([], 0),
+            ([patch.dict(os.environ, {"OPENLINEAGE_URL": "http://localhost:8080"})], 1),
+            (
+                [
+                    conf_vars(
+                        {("openlineage", "transport"): '{"type": "http", "url": "http://localhost:5000"}'}
+                    )
+                ],
+                1,
+            ),
         ],
     )
     def test_plugin_disablements(self, mocks, expected):
@@ -58,4 +87,5 @@ class TestOpenLineageProviderPlugin:
             from airflow.providers.openlineage.plugins.openlineage import OpenLineageProviderPlugin
 
             plugin = OpenLineageProviderPlugin()
+
             assert len(plugin.listeners) == expected


### PR DESCRIPTION
There's a discussion whether to include OpenLineage provider in default Airflow image. 
https://apache-airflow.slack.com/archives/C03G9H97MM2/p1691163069712479

In this case, we won't have an assumption that user explicitely enabled OpenLineage or works in an environment where OpenLineage is expected to run.  This means logs, generating OpenLineage events and some overhead associated with it would be not an expected behavior from an user. 

This PR disables even launching OpenLineage listener if no option required to run it has been configured, so no unexpected behavior exists. Those changes are only relevant in case of it being included by default - they should not be merged otherwise.

 