### PR TITLE
Revert "Fix waiting the base container when reading the logs of other containers (#33092)

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -590,9 +590,7 @@ class KubernetesPodOperator(BaseOperator):
                     container_logs=self.container_logs,
                     follow_logs=True,
                 )
-            if not self.get_logs or (
-                self.container_logs is not True and self.base_container_name not in self.container_logs
-            ):
+            else:
                 self.pod_manager.await_container_completion(
                     pod=self.pod, container_name=self.base_container_name
                 )

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -1242,46 +1242,6 @@ class TestKubernetesPodOperator:
             with pytest.raises(expected_exc):
                 self.run_pod(k)
 
-    @patch(f"{POD_MANAGER_CLASS}.extract_xcom")
-    @patch(f"{POD_MANAGER_CLASS}.await_xcom_sidecar_container_start")
-    @patch(f"{POD_MANAGER_CLASS}.await_container_completion")
-    @patch(f"{POD_MANAGER_CLASS}.fetch_requested_container_logs")
-    @patch(HOOK_CLASS)
-    def test_get_logs_but_not_for_base_container(
-        self,
-        hook_mock,
-        mock_fetch_log,
-        mock_await_container_completion,
-        mock_await_xcom_sidecar,
-        mock_extract_xcom,
-    ):
-        k = KubernetesPodOperator(
-            namespace="default",
-            image="ubuntu:16.04",
-            cmds=["bash", "-cx"],
-            arguments=["echo 10"],
-            labels={"foo": "bar"},
-            name="test",
-            task_id="task",
-            do_xcom_push=True,
-            container_logs=["some_init_container"],
-            get_logs=True,
-        )
-        mock_extract_xcom.return_value = "{}"
-        remote_pod_mock = MagicMock()
-        remote_pod_mock.status.phase = "Succeeded"
-        self.await_pod_mock.return_value = remote_pod_mock
-        pod = self.run_pod(k)
-
-        # check that the base container is not included in the logs
-        mock_fetch_log.assert_called_once_with(
-            pod=pod, container_logs=["some_init_container"], follow_logs=True
-        )
-        # check that KPO waits for the base container to complete before proceeding to extract XCom
-        mock_await_container_completion.assert_called_once_with(pod=pod, container_name="base")
-        # check that we wait for the xcom sidecar to start before extracting XCom
-        mock_await_xcom_sidecar.assert_called_once_with(pod=pod)
-
 
 class TestSuppress:
     def test__suppress(self, caplog):


### PR DESCRIPTION

This reverts commit d31c77510cc9141011c65c513d9f07580c639717.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Revert #33092 to fix failed CI in main


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
