### PR TITLE
Use set for `template_fields` of `EcsDeregisterTaskDefinitionOperator`

### DIFF
--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -259,7 +259,7 @@ class EcsDeregisterTaskDefinitionOperator(EcsBaseOperator):
         of the task definition to deregister. If you use a family name, you must specify a revision.
     """
 
-    template_fields: Sequence[str] = "task_definition"
+    template_fields: Sequence[str] = ("task_definition",)
 
     def __init__(
         self,


### PR DESCRIPTION
This will handle the following warning:

```airflow/providers/amazon/aws/operators/ecs.py:57: [W0513(warning), ] The `template_fields` value for EcsDeregisterTaskDefinitionOperator is a string but should be a list or tuple of string. Wrapping it in a list for execution. Please update EcsDeregisterTaskDefinitionOperator accordingly.```