### PR TITLE
Refactor: Lazy loops, string operations, better sorting

### DIFF
--- a/airflow/api_connexion/endpoints/pool_endpoint.py
+++ b/airflow/api_connexion/endpoints/pool_endpoint.py
@@ -124,7 +124,7 @@ def patch_pool(
 
     else:
         required_fields = {"name", "slots"}
-        fields_diff = required_fields - set(get_json_request_dict().keys())
+        fields_diff = required_fields - set(get_json_request_dict())
         if fields_diff:
             raise BadRequest(detail=f"Missing required property(ies): {sorted(fields_diff)}")
 
@@ -139,7 +139,7 @@ def patch_pool(
 def post_pool(*, session: Session = NEW_SESSION) -> APIResponse:
     """Create a pool."""
     required_fields = {"name", "slots"}  # Pool would require both fields in the post request
-    fields_diff = required_fields - set(get_json_request_dict().keys())
+    fields_diff = required_fields - set(get_json_request_dict())
     if fields_diff:
         raise BadRequest(detail=f"Missing required property(ies): {sorted(fields_diff)}")
 

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -116,10 +116,7 @@ def get_parser(dag_parser: bool = False) -> argparse.ArgumentParser:
     subparsers.required = True
 
     command_dict = DAG_CLI_DICT if dag_parser else ALL_COMMANDS_DICT
-    subparser_list = command_dict.keys()
-    sub_name: str
-    for sub_name in sorted(subparser_list):
-        sub: CLICommand = command_dict[sub_name]
+    for _, sub in sorted(command_dict.items()):
         _add_command(subparsers, sub)
     return parser
 

--- a/airflow/cli/commands/provider_command.py
+++ b/airflow/cli/commands/provider_command.py
@@ -106,7 +106,7 @@ def triggers_list(args):
 def connection_form_widget_list(args):
     """Lists all custom connection form fields at the command line."""
     AirflowConsole().print_as(
-        data=list(sorted(ProvidersManager().connection_form_widgets.items())),
+        data=sorted(ProvidersManager().connection_form_widgets.items()),
         output=args.output,
         mapper=lambda x: {
             "connection_parameter_name": x[0],

--- a/airflow/cli/commands/provider_command.py
+++ b/airflow/cli/commands/provider_command.py
@@ -122,7 +122,7 @@ def connection_form_widget_list(args):
 def connection_field_behaviours(args):
     """Lists field behaviours."""
     AirflowConsole().print_as(
-        data=list(ProvidersManager().field_behaviours.keys()),
+        data=list(ProvidersManager().field_behaviours),
         output=args.output,
         mapper=lambda x: {
             "field_behaviours": x,

--- a/airflow/cli/commands/role_command.py
+++ b/airflow/cli/commands/role_command.py
@@ -121,8 +121,8 @@ def __roles_add_or_remove_permissions(args):
                 exit(1)
 
         permission_count = 0
-        for (role_name, resource_name, action_name) in list(
-            itertools.product(args.role, args.resource, args.action or [None])
+        for (role_name, resource_name, action_name) in itertools.product(
+            args.role, args.resource, args.action or [None]
         ):
             res_key = (role_name, resource_name)
             if is_add and action_name not in perm_map[res_key]:

--- a/airflow/cli/simple_table.py
+++ b/airflow/cli/simple_table.py
@@ -64,7 +64,7 @@ class AirflowConsole(Console):
             return
 
         table = SimpleTable(show_header=self.show_header)
-        for col in data[0].keys():
+        for col in data[0]:
             table.add_column(col)
 
         for row in data:
@@ -77,7 +77,7 @@ class AirflowConsole(Console):
             self.print("No data found")
             return
         rows = [d.values() for d in data]
-        output = tabulate(rows, tablefmt="plain", headers=list(data[0].keys()))
+        output = tabulate(rows, tablefmt="plain", headers=list(data[0]))
         print(output)
 
     def _normalize_data(self, value: Any, output: str) -> list | str | dict | None:
@@ -109,7 +109,7 @@ class AirflowConsole(Console):
         renderer = output_to_renderer.get(output)
         if not renderer:
             raise ValueError(
-                f"Unknown formatter: {output}. Allowed options: {list(output_to_renderer.keys())}"
+                f"Unknown formatter: {output}. Allowed options: {list(output_to_renderer)}"
             )
 
         if mapper:

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -1530,7 +1530,7 @@ class AirflowConfigParser(ConfigParser):
                 continue
             if not display_sensitive and env_var != self._env_var_name("core", "unit_test_mode"):
                 # Don't hide cmd/secret values here
-                if not env_var.lower().endswith("cmd") and not env_var.lower().endswith("secret"):
+                if not env_var.lower().endswith(("cmd", "secret")):
                     if (section, key) in self.sensitive_config_values:
                         opt = "< hidden >"
             elif raw:

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -473,13 +473,7 @@ class AirflowConfigParser(ConfigParser):
 
         :return: list of section names
         """
-        my_own_sections = self.sections()
-
-        all_sections_from_defaults = list(self.configuration_description.keys())
-        for section in my_own_sections:
-            if section not in all_sections_from_defaults:
-                all_sections_from_defaults.append(section)
-        return all_sections_from_defaults
+        return list(dict.fromkeys(self.configuration_description) | dict.fromkeys(self.sections()))
 
     def get_options_including_defaults(self, section: str) -> list[str]:
         """
@@ -489,13 +483,8 @@ class AirflowConfigParser(ConfigParser):
         :return: list of option names for the section given
         """
         my_own_options = self.options(section) if self.has_section(section) else []
-        all_options_from_defaults = list(
-            self.configuration_description.get(section, {}).get("options", {}).keys()
-        )
-        for option in my_own_options:
-            if option not in all_options_from_defaults:
-                all_options_from_defaults.append(option)
-        return all_options_from_defaults
+        all_options_from_defaults = list(self.configuration_description.get(section, {}).get("options", {}))
+        return list(dict.fromkeys(all_options_from_defaults) | dict.fromkeys(my_own_options))
 
     def optionxform(self, optionstr: str) -> str:
         """
@@ -1336,7 +1325,7 @@ class AirflowConfigParser(ConfigParser):
             _section.update(OrderedDict(self.items(section)))
 
         section_prefix = self._env_var_name(section, "")
-        for env_var in sorted(os.environ.keys()):
+        for env_var in sorted(os.environ):
             if env_var.startswith(section_prefix):
                 key = env_var.replace(section_prefix, "")
                 if key.endswith("_CMD"):

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -1001,7 +1001,7 @@ class DagFileProcessorManager(LoggingMixin):
                 processor.terminate()
                 self._file_stats.pop(file_path)
 
-        to_remove = set(self._file_stats.keys()) - set(self._file_paths)
+        to_remove = set(self._file_stats) - set(self._file_paths)
         for key in to_remove:
             # Remove the stats for any dag files that don't exist anymore
             del self._file_stats[key]
@@ -1076,7 +1076,7 @@ class DagFileProcessorManager(LoggingMixin):
         while self._parallelism - len(self._processors) > 0 and self._file_path_queue:
             file_path = self._file_path_queue.popleft()
             # Stop creating duplicate processor i.e. processor with the same filepath
-            if file_path in self._processors.keys():
+            if file_path in self._processors:
                 continue
 
             callback_to_execute_for_file = self._callback_to_execute[file_path]
@@ -1115,7 +1115,7 @@ class DagFileProcessorManager(LoggingMixin):
         self._parsing_start_time = time.perf_counter()
         # If the file path is already being processed, or if a file was
         # processed recently, wait until the next batch
-        file_paths_in_progress = self._processors.keys()
+        file_paths_in_progress = set(self._processors)
         now = timezone.utcnow()
 
         # Sort the file paths by the parsing order mode
@@ -1173,7 +1173,7 @@ class DagFileProcessorManager(LoggingMixin):
             file_path for file_path, stat in self._file_stats.items() if stat.run_count == self._max_runs
         ]
 
-        file_paths_to_exclude = set(file_paths_in_progress).union(
+        file_paths_to_exclude = file_paths_in_progress.union(
             file_paths_recently_processed,
             files_paths_at_run_limit,
         )

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -652,9 +652,7 @@ class DagFileProcessor(LoggingMixin):
             task_pools = {task.pool for task in dag.tasks}
             nonexistent_pools = task_pools - pools
             if nonexistent_pools:
-                return (
-                    f"Dag '{dag.dag_id}' references non-existent pools: {list(sorted(nonexistent_pools))!r}"
-                )
+                return f"Dag '{dag.dag_id}' references non-existent pools: {sorted(nonexistent_pools)!r}"
 
         pools = {p.pool for p in Pool.get_pools(session)}
         for dag in dagbag.dags.values():

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -678,7 +678,7 @@ class DagFileProcessor(LoggingMixin):
         self._validate_task_pools(dagbag=dagbag)
 
         stored_warnings = set(
-            session.query(DagWarning).filter(DagWarning.dag_id.in_(dagbag.dags.keys())).all()
+            session.query(DagWarning).filter(DagWarning.dag_id.in_(dagbag.dags)).all()
         )
 
         for warning_to_delete in stored_warnings - self.dag_warnings:

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -240,7 +240,7 @@ class DecoratedOperator(BaseOperator):
         if not self.multiple_outputs or return_value is None:
             return return_value
         if isinstance(return_value, dict):
-            for key in return_value.keys():
+            for key in return_value:
                 if not isinstance(key, str):
                     raise AirflowException(
                         "Returned dictionary keys must be strings when using "

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -344,7 +344,7 @@ class BaseExecutor(LoggingMixin):
             cleared_events = self.event_buffer
             self.event_buffer = {}
         else:
-            for ti_key in list(self.event_buffer.keys()):
+            for ti_key in list(self.event_buffer):
                 if ti_key.dag_id in dag_ids:
                     cleared_events[ti_key] = self.event_buffer.pop(ti_key)
 

--- a/airflow/jobs/backfill_job_runner.py
+++ b/airflow/jobs/backfill_job_runner.py
@@ -180,7 +180,7 @@ class BackfillJobRunner(BaseJobRunner[Job], LoggingMixin):
         refreshed_tis = []
         TI = TaskInstance
 
-        ti_primary_key_to_ti_key = {ti_key.primary: ti_key for ti_key in ti_status.running.keys()}
+        ti_primary_key_to_ti_key = {ti_key.primary: ti_key for ti_key in ti_status.running}
 
         filter_for_tis = TI.filter_for_tis(list(ti_status.running.values()))
         if filter_for_tis is not None:

--- a/airflow/jobs/triggerer_job_runner.py
+++ b/airflow/jobs/triggerer_job_runner.py
@@ -642,7 +642,7 @@ class TriggerRunner(threading.Thread, LoggingMixin):
         # line's execution, but we consider that safe, since there's a strict
         # add -> remove -> never again lifecycle this function is already
         # handling.
-        running_trigger_ids = set(self.triggers.keys())
+        running_trigger_ids = set(self.triggers)
         known_trigger_ids = (
             running_trigger_ids.union(x[0] for x in self.events)
             .union(self.to_cancel)

--- a/airflow/kubernetes/pre_7_4_0_compatibility/pod_generator.py
+++ b/airflow/kubernetes/pre_7_4_0_compatibility/pod_generator.py
@@ -626,7 +626,7 @@ def merge_objects(base_obj, client_obj):
         base_obj_cp.update(client_obj_cp)
         return base_obj_cp
 
-    for base_key in base_obj.to_dict().keys():
+    for base_key in base_obj.to_dict():
         base_val = getattr(base_obj, base_key, None)
         if not getattr(client_obj, base_key, None) and base_val:
             if not isinstance(client_obj_cp, dict):

--- a/airflow/metrics/otel_logger.py
+++ b/airflow/metrics/otel_logger.py
@@ -309,12 +309,9 @@ class MetricsMap:
         :param attributes:  Counter attributes, used to generate a unique key to store the counter.
         """
         key = _generate_key_name(name, attributes)
-        if key in self.map.keys():
-            return self.map[key]
-        else:
-            new_counter = self._create_counter(name)
-            self.map[key] = new_counter
-            return new_counter
+        if key not in self.map:
+            self.map[key] = self._create_counter(name)
+        return self.map[key]
 
     def del_counter(self, name: str, attributes: Attributes = None) -> None:
         """
@@ -324,7 +321,7 @@ class MetricsMap:
         :param attributes: Counter attributes which were used to generate a unique key to store the counter.
         """
         key = _generate_key_name(name, attributes)
-        if key in self.map.keys():
+        if key in self.map:
             del self.map[key]
 
     def set_gauge_value(self, name: str, value: float | None, delta: bool, tags: Attributes):

--- a/airflow/models/base.py
+++ b/airflow/models/base.py
@@ -69,7 +69,7 @@ def get_id_collation_args():
         # We cannot use session/dialect as at this point we are trying to determine the right connection
         # parameters, so we use the connection
         conn = conf.get("database", "sql_alchemy_conn", fallback="")
-        if conn.startswith("mysql") or conn.startswith("mariadb"):
+        if conn.startswith(("mysql", "mariadb")):
             return {"collation": "utf8mb3_bin"}
         return {}
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -740,7 +740,7 @@ class DAG(LoggingMixin):
         for c in self._comps:
             # task_ids returns a list and lists can't be hashed
             if c == "task_ids":
-                val = tuple(self.task_dict.keys())
+                val = tuple(self.task_dict)
             else:
                 val = getattr(self, c, None)
             try:
@@ -1256,7 +1256,7 @@ class DAG(LoggingMixin):
 
     @property
     def task_ids(self) -> list[str]:
-        return list(self.task_dict.keys())
+        return list(self.task_dict)
 
     @property
     def teardowns(self) -> list[Operator]:
@@ -2899,7 +2899,7 @@ class DAG(LoggingMixin):
         log.info("Sync %s DAGs", len(dags))
         dag_by_ids = {dag.dag_id: dag for dag in dags}
 
-        dag_ids = set(dag_by_ids.keys())
+        dag_ids = set(dag_by_ids)
         query = (
             select(DagModel)
             .options(joinedload(DagModel.tags, innerjoin=False))
@@ -3237,7 +3237,7 @@ class DAG(LoggingMixin):
                 "auto_register",
                 "fail_stop",
             }
-            cls.__serialized_fields = frozenset(vars(DAG(dag_id="test")).keys()) - exclusion_list
+            cls.__serialized_fields = frozenset(vars(DAG(dag_id="test"))) - exclusion_list
         return cls.__serialized_fields
 
     def get_edge_info(self, upstream_task_id: str, downstream_task_id: str) -> EdgeInfoType:
@@ -3596,7 +3596,7 @@ class DagModel(Base):
                 .having(func.count() == func.sum(case((DDRQ.target_dag_id.is_not(None), 1), else_=0)))
             )
         }
-        dataset_triggered_dag_ids = set(dataset_triggered_dag_info.keys())
+        dataset_triggered_dag_ids = set(dataset_triggered_dag_info)
         if dataset_triggered_dag_ids:
             exclusion_list = {
                 x

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -169,7 +169,7 @@ class DagBag(LoggingMixin):
 
         :return: a list of DAG IDs in this bag
         """
-        return list(self.dags.keys())
+        return list(self.dags)
 
     @provide_session
     def get_dag(self, dag_id, session: Session = None):

--- a/airflow/models/expandinput.py
+++ b/airflow/models/expandinput.py
@@ -168,7 +168,7 @@ class DictOfListsExpandInput(NamedTuple):
 
         def _find_index_for_this_field(index: int) -> int:
             # Need to use the original user input to retain argument order.
-            for mapped_key in reversed(list(self.value)):
+            for mapped_key in reversed(self.value):
                 mapped_length = all_lengths[mapped_key]
                 if mapped_length < 1:
                     raise RuntimeError(f"cannot expand field mapped to length {mapped_length!r}")

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -433,7 +433,7 @@ def initialize_extra_operators_links_plugins():
 
     for plugin in plugins:
         global_operator_extra_links.extend(plugin.global_operator_extra_links)
-        operator_extra_links.extend(list(plugin.operator_extra_links))
+        operator_extra_links.extend(plugin.operator_extra_links)
 
         registered_operator_link_classes.update(
             {qualname(link.__class__): link.__class__ for link in plugin.operator_extra_links}

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -494,10 +494,9 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
         responsible with catching and handling those.
         """
         stack = inspect.stack()
-        # Find the index of the most recent frame which called the provided function name.
-        target_frame_index = [frame.function for frame in stack].index(target_function_name)
-        # Pull that frame off the stack.
-        target_frame = stack[target_frame_index][0]
+        # Find the index of the most recent frame which called the provided function name
+        # and pull that frame off the stack.
+        target_frame = next(frame for frame in stack if frame.function == target_function_name)[0]
         # Get the local variables for that frame.
         frame_variables = target_frame.f_locals["self"]
         # Get the class object for that frame.

--- a/airflow/providers/amazon/aws/hooks/redshift_data.py
+++ b/airflow/providers/amazon/aws/hooks/redshift_data.py
@@ -195,7 +195,7 @@ class RedshiftDataHook(AwsGenericHook["RedshiftDataAPIServiceClient"]):
             # we only select a single column (that is a string),
             # so safe to assume that there is only a single col in the record
             pk_columns += [y["stringValue"] for x in response["Records"] for y in x]
-            if "NextToken" not in response.keys():
+            if "NextToken" not in response:
                 break
             else:
                 token = response["NextToken"]

--- a/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -122,9 +122,9 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
         bucket, prefix = self.hook.parse_s3_url(s3url=os.path.join(self.remote_base, worker_log_rel_path))
         keys = self.hook.list_keys(bucket_name=bucket, prefix=prefix)
         if keys:
-            keys = [f"s3://{bucket}/{key}" for key in keys]
-            messages.extend(["Found logs in s3:", *[f"  * {x}" for x in sorted(keys)]])
-            for key in sorted(keys):
+            keys = sorted(f"s3://{bucket}/{key}" for key in keys)
+            messages.extend(["Found logs in s3:", *[f"  * {x}" for x in keys]])
+            for key in keys:
                 logs.append(self.s3_read(key, return_error=True))
         else:
             messages.append(f"No logs found on s3 for ti={ti}")

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -217,11 +217,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
 
         conn_d: dict[str, Any] = {}
         for conn_field, possible_words in possible_words_for_conn_fields.items():
-            try:
-                conn_d[conn_field] = [v for k, v in secret.items() if k in possible_words][0]
-            except IndexError:
-                conn_d[conn_field] = None
-
+            conn_d[conn_field] = next((v for k, v in secret.items() if k in possible_words), None)
         return conn_d
 
     def _remove_escaping_in_secret_dict(self, secret: dict[str, Any]) -> dict[str, Any]:

--- a/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
@@ -137,7 +137,7 @@ class RedshiftToS3Operator(BaseOperator):
 
         if self.redshift_data_api_kwargs:
             for arg in ["sql", "parameters"]:
-                if arg in self.redshift_data_api_kwargs.keys():
+                if arg in self.redshift_data_api_kwargs:
                     raise AirflowException(f"Cannot include param '{arg}' in Redshift Data API kwargs")
 
     def _build_unload_query(

--- a/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -116,7 +116,7 @@ class S3ToRedshiftOperator(BaseOperator):
 
         if self.redshift_data_api_kwargs:
             for arg in ["sql", "parameters"]:
-                if arg in self.redshift_data_api_kwargs.keys():
+                if arg in self.redshift_data_api_kwargs:
                     raise AirflowException(f"Cannot include param '{arg}' in Redshift Data API kwargs")
 
     def _build_copy_query(

--- a/airflow/providers/amazon/aws/transfers/sql_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/sql_to_s3.py
@@ -194,7 +194,7 @@ class SqlToS3Operator(BaseOperator):
             yield "", df
         else:
             grouped_df = df.groupby(**self.groupby_kwargs)
-            for group_label in grouped_df.groups.keys():
+            for group_label in grouped_df.groups:
                 yield group_label, grouped_df.get_group(group_label).reset_index(drop=True)
 
     def _get_hook(self) -> DbApiHook:

--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -707,15 +707,15 @@ class HiveMetastoreHook(BaseHook):
             return None
 
         # Assuming all specs have the same keys.
-        if partition_key not in part_specs[0].keys():
+        if partition_key not in part_specs[0]:
             raise AirflowException(f"Provided partition_key {partition_key} is not in part_specs.")
         is_subset = None
         if filter_map:
-            is_subset = set(filter_map.keys()).issubset(set(part_specs[0].keys()))
+            is_subset = set(filter_map).issubset(set(part_specs[0]))
         if filter_map and not is_subset:
             raise AirflowException(
-                f"Keys in provided filter_map {', '.join(filter_map.keys())} "
-                f"are not subset of part_spec keys: {', '.join(part_specs[0].keys())}"
+                f"Keys in provided filter_map {', '.join(filter_map)} "
+                f"are not subset of part_spec keys: {', '.join(part_specs[0])}"
             )
 
         candidates = [
@@ -765,7 +765,7 @@ class HiveMetastoreHook(BaseHook):
             elif field not in key_name_set:
                 raise AirflowException("Provided field is not a partition key.")
 
-            if filter_map and not set(filter_map.keys()).issubset(key_name_set):
+            if filter_map and not set(filter_map).issubset(key_name_set):
                 raise AirflowException("Provided filter_map contains keys that are not partition key.")
 
             part_names = client.get_partition_names(

--- a/airflow/providers/apache/hive/transfers/s3_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/s3_to_hive.py
@@ -241,7 +241,7 @@ class S3ToHiveOperator(BaseOperator):
     def _match_headers(self, header_list):
         if not header_list:
             raise AirflowException("Unable to retrieve header row from file")
-        field_names = self.field_dict.keys()
+        field_names = list(self.field_dict)
         if len(field_names) != len(header_list):
             self.log.warning(
                 "Headers count mismatch File headers:\n %s\nField names: \n %s\n", header_list, field_names

--- a/airflow/providers/apache/spark/hooks/spark_sql.py
+++ b/airflow/providers/apache/spark/hooks/spark_sql.py
@@ -134,7 +134,7 @@ class SparkSqlHook(BaseHook):
             connection_cmd += ["--num-executors", str(self._num_executors)]
         if self._sql:
             sql = self._sql.strip()
-            if sql.endswith(".sql") or sql.endswith(".hql"):
+            if sql.endswith((".sql", ".hql")):
                 connection_cmd += ["-f", sql]
             else:
                 connection_cmd += ["-e", sql]

--- a/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -371,7 +371,7 @@ class KubernetesExecutor(BaseExecutor):
         from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils import ResourceVersion
 
         resource_instance = ResourceVersion()
-        for ns in resource_instance.resource_version.keys():
+        for ns in resource_instance.resource_version:
             resource_instance.resource_version[ns] = (
                 last_resource_version[ns] or resource_instance.resource_version[ns]
             )

--- a/airflow/providers/cncf/kubernetes/pod_generator.py
+++ b/airflow/providers/cncf/kubernetes/pod_generator.py
@@ -606,7 +606,7 @@ def merge_objects(base_obj, client_obj):
         base_obj_cp.update(client_obj_cp)
         return base_obj_cp
 
-    for base_key in base_obj.to_dict().keys():
+    for base_key in base_obj.to_dict():
         base_val = getattr(base_obj, base_key, None)
         if not getattr(client_obj, base_key, None) and base_val:
             if not isinstance(client_obj_cp, dict):

--- a/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -246,7 +246,7 @@ class KubernetesPodTrigger(BaseTrigger):
         if pod_containers is None:
             return ContainerState.UNDEFINED
 
-        container = [c for c in pod_containers if c.name == self.base_container_name][0]
+        container = next(c for c in pod_containers if c.name == self.base_container_name)
 
         for state in (ContainerState.RUNNING, ContainerState.WAITING, ContainerState.TERMINATED):
             state_obj = getattr(container.state, state)

--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -935,7 +935,7 @@ class SQLIntervalCheckOperator(BaseSQLOperator):
         self.ignore_zero = ignore_zero
         self.table = table
         self.metrics_thresholds = metrics_thresholds
-        self.metrics_sorted = sorted(metrics_thresholds.keys())
+        self.metrics_sorted = sorted(metrics_thresholds)
         self.date_filter_column = date_filter_column
         self.days_back = -abs(days_back)
         sqlexp = ", ".join(self.metrics_sorted)

--- a/airflow/providers/daskexecutor/executors/dask_executor.py
+++ b/airflow/providers/daskexecutor/executors/dask_executor.py
@@ -135,7 +135,7 @@ class DaskExecutor(BaseExecutor):
             assert self.client
             assert self.futures
 
-        self.client.cancel(list(self.futures.keys()))
+        self.client.cancel(list(self.futures))
         for future in as_completed(self.futures.copy()):
             self._process_future(future)
 

--- a/airflow/providers/databricks/utils/databricks.py
+++ b/airflow/providers/databricks/utils/databricks.py
@@ -48,7 +48,7 @@ def normalise_json_content(content, json_path: str = "json") -> str | bool | lis
     elif isinstance(content, (list, tuple)):
         return [normalise(e, f"{json_path}[{i}]") for i, e in enumerate(content)]
     elif isinstance(content, dict):
-        return {k: normalise(v, f"{json_path}[{k}]") for k, v in list(content.items())}
+        return {k: normalise(v, f"{json_path}[{k}]") for k, v in content.items()}
     else:
         param_type = type(content)
         msg = f"Type {param_type} used for parameter {json_path} is not a number or a string"

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -659,7 +659,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             ],
             "googleSheetsOptions": ["skipLeadingRows"],
         }
-        if source_format in src_fmt_to_param_mapping.keys():
+        if source_format in src_fmt_to_param_mapping:
             valid_configs = src_fmt_to_configs_mapping[src_fmt_to_param_mapping[source_format]]
             src_fmt_configs = _validate_src_fmt_configs(
                 source_format, src_fmt_configs, valid_configs, backward_compatibility_configs
@@ -723,7 +723,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :param fields: The fields of ``table`` to change, spelled as the Table
             properties (e.g. "friendly_name").
         """
-        fields = fields or list(table_resource.keys())
+        fields = fields or list(table_resource)
         table_resource = self._resolve_table_reference(
             table_resource=table_resource, project_id=project_id, dataset_id=dataset_id, table_id=table_id
         )
@@ -833,7 +833,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
 
         self.update_table(
             table_resource=table_resource,
-            fields=list(table_resource.keys()),
+            fields=list(table_resource),
             project_id=project_id,
             dataset_id=dataset_id,
             table_id=table_id,
@@ -3265,7 +3265,7 @@ class BigQueryAsyncHook(GoogleBaseAsyncHook):
             "relative_diff": lambda cur, ref: abs(cur - ref) / ref,
         }
 
-        metrics_sorted = sorted(metrics_thresholds.keys())
+        metrics_sorted = sorted(metrics_thresholds)
 
         current = dict(zip(metrics_sorted, row1))
         reference = dict(zip(metrics_sorted, row2))

--- a/airflow/providers/google/cloud/hooks/cloud_sql.py
+++ b/airflow/providers/google/cloud/hooks/cloud_sql.py
@@ -523,7 +523,7 @@ class CloudSqlProxyRunner(LoggingMixin):
         self.log.info("Downloading cloud_sql_proxy from %s to %s", download_url, proxy_path_tmp)
         # httpx has a breaking API change (follow_redirects vs allow_redirects)
         # and this should work with both versions (cf. issue #20088)
-        if "follow_redirects" in signature(httpx.get).parameters.keys():
+        if "follow_redirects" in signature(httpx.get).parameters:
             response = httpx.get(download_url, follow_redirects=True)
         else:
             response = httpx.get(download_url, allow_redirects=True)  # type: ignore[call-arg]

--- a/airflow/providers/google/cloud/hooks/gcs.py
+++ b/airflow/providers/google/cloud/hooks/gcs.py
@@ -1321,8 +1321,8 @@ class GCSHook(GoogleBaseHook):
         source_names_index = {a.name[source_object_prefix_len:]: a for a in source_blobs}
         destination_names_index = {a.name[destination_object_prefix_len:]: a for a in destination_blobs}
         # Create sets with names without parent object name
-        source_names = set(source_names_index.keys())
-        destination_names = set(destination_names_index.keys())
+        source_names = set(source_names_index)
+        destination_names = set(destination_names_index)
         # Determine objects to copy and delete
         to_copy = source_names - destination_names
         to_delete = destination_names - source_names

--- a/airflow/providers/google/cloud/hooks/gdm.py
+++ b/airflow/providers/google/cloud/hooks/gdm.py
@@ -96,7 +96,7 @@ class GoogleDeploymentManagerHook(GoogleBaseHook):
             project=project_id, deployment=deployment, deletePolicy=delete_policy
         )
         resp = request.execute()
-        if "error" in resp.keys():
+        if "error" in resp:
             raise AirflowException(
                 "Errors deleting deployment: ", ", ".join(err["message"] for err in resp["error"]["errors"])
             )

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -2362,7 +2362,7 @@ class BigQueryUpdateDatasetOperator(GoogleCloudBaseOperator):
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
         )
-        fields = self.fields or list(self.dataset_resource.keys())
+        fields = self.fields or list(self.dataset_resource)
 
         dataset = bq_hook.update_dataset(
             dataset_resource=self.dataset_resource,

--- a/airflow/providers/google/cloud/operators/bigtable.py
+++ b/airflow/providers/google/cloud/operators/bigtable.py
@@ -390,7 +390,7 @@ class BigtableCreateTableOperator(GoogleCloudBaseOperator, BigtableValidationMix
 
     def _compare_column_families(self, hook, instance) -> bool:
         table_column_families = hook.get_column_families_for_table(instance, self.table_id)
-        if set(table_column_families.keys()) != set(self.column_families.keys()):
+        if set(table_column_families) != set(self.column_families):
             self.log.error("Table '%s' has different set of Column Families", self.table_id)
             self.log.error("Expected: %s", self.column_families.keys())
             self.log.error("Actual: %s", table_column_families.keys())

--- a/airflow/providers/google/cloud/operators/cloud_build.py
+++ b/airflow/providers/google/cloud/operators/cloud_build.py
@@ -201,7 +201,7 @@ class CloudBuildCreateBuildOperator(GoogleCloudBaseOperator):
         if not isinstance(self.build_raw, str):
             return
         with open(self.build_raw) as file:
-            if any(self.build_raw.endswith(ext) for ext in [".yaml", ".yml"]):
+            if self.build_raw.endswith((".yaml", ".yml")):
                 self.build = yaml.safe_load(file.read())
             if self.build_raw.endswith(".json"):
                 self.build = json.loads(file.read())

--- a/airflow/providers/google/cloud/operators/datafusion.py
+++ b/airflow/providers/google/cloud/operators/datafusion.py
@@ -44,7 +44,7 @@ class DataFusionPipelineLinkHelper:
     @staticmethod
     def get_project_id(instance):
         instance = instance["name"]
-        project_id = [x for x in instance.split("/") if x.startswith("airflow")][0]
+        project_id = next(x for x in instance.split("/") if x.startswith("airflow"))
         return project_id
 
 

--- a/airflow/providers/google/cloud/operators/functions.py
+++ b/airflow/providers/google/cloud/operators/functions.py
@@ -212,7 +212,7 @@ class CloudFunctionDeployFunctionOperator(GoogleCloudBaseOperator):
         )
 
     def _set_airflow_version_label(self) -> None:
-        if "labels" not in self.body.keys():
+        if "labels" not in self.body:
             self.body["labels"] = {}
         self.body["labels"].update({"airflow-version": "v" + version.replace(".", "-").replace("+", "-")})
 

--- a/airflow/providers/google/cloud/sensors/bigtable.py
+++ b/airflow/providers/google/cloud/sensors/bigtable.py
@@ -107,7 +107,7 @@ class BigtableTableReplicationCompletedSensor(BaseSensorOperator, BigtableValida
         ready_state = ClusterState(enums.Table.ReplicationState.READY)
 
         is_table_replicated = True
-        for cluster_id in cluster_states.keys():
+        for cluster_id in cluster_states:
             if cluster_states[cluster_id] != ready_state:
                 self.log.info("Table '%s' is not yet replicated on cluster '%s'.", self.table_id, cluster_id)
                 is_table_replicated = False

--- a/airflow/providers/google/cloud/transfers/facebook_ads_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/facebook_ads_to_gcs.py
@@ -132,7 +132,7 @@ class FacebookAdsReportToGcsOperator(BaseOperator):
             )
         elif isinstance(bulk_report, dict):
             converted_rows_with_action = self._generate_rows_with_action(True)
-            for account_id in bulk_report.keys():
+            for account_id in bulk_report:
                 rows = bulk_report.get(account_id, [])
                 if rows:
                     converted_rows_with_action = self._prepare_rows_for_upload(
@@ -206,7 +206,7 @@ class FacebookAdsReportToGcsOperator(BaseOperator):
 
     def _flush_rows(self, converted_rows: list[Any] | None, object_name: str):
         if converted_rows:
-            headers = converted_rows[0].keys()
+            headers = list(converted_rows[0])
             with tempfile.NamedTemporaryFile("w", suffix=".csv") as csvfile:
                 writer = csv.DictWriter(csvfile, fieldnames=headers)
                 writer.writeheader()

--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -531,7 +531,7 @@ class GCSToBigQueryOperator(BaseOperator):
             ],
             "googleSheetsOptions": ["skipLeadingRows"],
         }
-        if self.source_format in src_fmt_to_param_mapping.keys():
+        if self.source_format in src_fmt_to_param_mapping:
             valid_configs = src_fmt_to_configs_mapping[src_fmt_to_param_mapping[self.source_format]]
             self.src_fmt_configs = self._validate_src_fmt_configs(
                 self.source_format, self.src_fmt_configs, valid_configs, backward_compatibility_configs

--- a/airflow/providers/google/cloud/utils/field_validator.py
+++ b/airflow/providers/google/cloud/utils/field_validator.py
@@ -257,8 +257,8 @@ class GcpBodyFieldValidator(LoggingMixin):
             self._validate_field(
                 validation_spec=child_validation_spec, dictionary_to_validate=value, parent=full_field_path
             )
-        all_dict_keys = [spec["name"] for spec in children_validation_specs]
-        for field_name in value.keys():
+        all_dict_keys = {spec["name"] for spec in children_validation_specs}
+        for field_name in value:
             if field_name not in all_dict_keys:
                 self.log.warning(
                     "The field '%s' is in the body, but is not specified in the "
@@ -428,22 +428,20 @@ class GcpBodyFieldValidator(LoggingMixin):
             raise GcpFieldValidationException(
                 f"There was an error when validating: body '{body_to_validate}': '{e}'"
             )
-        all_field_names = [
+        all_field_names = {
             spec["name"]
             for spec in self._validation_specs
             if spec.get("type") != "union" and spec.get("api_version") != self._api_version
-        ]
+        }
         all_union_fields = [spec for spec in self._validation_specs if spec.get("type") == "union"]
         for union_field in all_union_fields:
-            all_field_names.extend(
-                [
-                    nested_union_spec["name"]
-                    for nested_union_spec in union_field["fields"]
-                    if nested_union_spec.get("type") != "union"
-                    and nested_union_spec.get("api_version") != self._api_version
-                ]
+            all_field_names.update(
+                nested_union_spec["name"]
+                for nested_union_spec in union_field["fields"]
+                if nested_union_spec.get("type") != "union"
+                and nested_union_spec.get("api_version") != self._api_version
             )
-        for field_name in body_to_validate.keys():
+        for field_name in body_to_validate:
             if field_name not in all_field_names:
                 self.log.warning(
                     "The field '%s' is in the body, but is not specified in the "

--- a/airflow/providers/microsoft/mssql/hooks/mssql.py
+++ b/airflow/providers/microsoft/mssql/hooks/mssql.py
@@ -78,7 +78,7 @@ class MsSqlHook(DbApiHook):
         r[0] = self.sqlalchemy_scheme
         # remove query string 'sqlalchemy_scheme' like parameters:
         qs = parse_qs(r[3], keep_blank_values=True)
-        for k in list(qs.keys()):
+        for k in list(qs):
             if k.lower() == "sqlalchemy_scheme":
                 qs.pop(k, None)
         r[3] = urlencode(qs, doseq=True)

--- a/airflow/providers/sendgrid/utils/emailer.py
+++ b/airflow/providers/sendgrid/utils/emailer.py
@@ -94,8 +94,8 @@ def send_email(
     # Add custom_args to personalization if present
     pers_custom_args = kwargs.get("personalization_custom_args")
     if isinstance(pers_custom_args, dict):
-        for key in pers_custom_args.keys():
-            personalization.add_custom_arg(CustomArg(key, pers_custom_args[key]))
+        for key, val in pers_custom_args.items():
+            personalization.add_custom_arg(CustomArg(key, val))
 
     mail.add_personalization(personalization)
     mail.add_content(Content("text/html", html_content))

--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -49,7 +49,7 @@ def get_connection_parameter_names() -> set[str]:
     """Returns :class:`airflow.models.connection.Connection` constructor parameters."""
     from airflow.models.connection import Connection
 
-    return {k for k in signature(Connection.__init__).parameters.keys() if k != "self"}
+    return {k for k in signature(Connection.__init__).parameters if k != "self"}
 
 
 def _parse_env_file(file_path: str) -> tuple[dict[str, list[str]], list[FileSyntaxError]]:
@@ -193,7 +193,7 @@ def _create_connection(conn_id: str, value: Any):
         return Connection(conn_id=conn_id, uri=value)
     if isinstance(value, dict):
         connection_parameter_names = get_connection_parameter_names() | {"extra_dejson"}
-        current_keys = set(value.keys())
+        current_keys = set(value)
         if not current_keys.issubset(connection_parameter_names):
             illegal_keys = current_keys - connection_parameter_names
             illegal_keys_list = ", ".join(illegal_keys)

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -305,9 +305,8 @@ def _stringify(classname: str, version: int, value: T | None) -> str:
         # deserialized values can be != str
         s += ",".join(str(deserialize(value, full=False)))
     elif isinstance(value, dict):
-        for k, v in value.items():
-            s += f"{k}={deserialize(v, full=False)},"
-        s = s[:-1] + ")"
+        s += ",".join(f"{k}={deserialize(v, full=False)}" for k, v in value.items())
+    s += ")"
 
     return s
 

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -840,7 +840,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         # Store all template_fields as they are if there are JSON Serializable
         # If not, store them as strings
         # And raise an exception if the field is not templateable
-        forbidden_fields = set(inspect.signature(BaseOperator.__init__).parameters.keys())
+        forbidden_fields = set(inspect.signature(BaseOperator.__init__).parameters)
         if op.template_fields:
             for template_field in op.template_fields:
                 if template_field in forbidden_fields:

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1173,7 +1173,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
             #       }
             #   )
 
-            _operator_link_class_path, data = list(_operator_links_source.items())[0]
+            _operator_link_class_path, data = next(iter(_operator_links_source.items()))
             if _operator_link_class_path in get_operator_extra_links():
                 single_op_link_class = import_string(_operator_link_class_path)
             elif _operator_link_class_path in plugins_manager.registered_operator_link_classes:

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -469,7 +469,7 @@ def import_local_settings():
         if hasattr(airflow_local_settings, "__all__"):
             names = list(airflow_local_settings.__all__)
         else:
-            names = list(filter(lambda n: not n.startswith("__"), airflow_local_settings.__dict__.keys()))
+            names = list(filter(lambda n: not n.startswith("__"), airflow_local_settings.__dict__))
 
         if "policy" in names and "task_policy" not in names:
             warnings.warn(

--- a/airflow/template/templater.py
+++ b/airflow/template/templater.py
@@ -69,7 +69,7 @@ class Templater(LoggingMixin):
                 content = getattr(self, field, None)
                 if content is None:
                     continue
-                elif isinstance(content, str) and any(content.endswith(ext) for ext in self.template_ext):
+                elif isinstance(content, str) and content.endswith(tuple(self.template_ext)):
                     env = self.get_template_env()
                     try:
                         setattr(self, field, env.loader.get_source(env, content)[0])  # type: ignore
@@ -78,7 +78,7 @@ class Templater(LoggingMixin):
                 elif isinstance(content, list):
                     env = self.get_template_env()
                     for i, item in enumerate(content):
-                        if isinstance(item, str) and any(item.endswith(ext) for ext in self.template_ext):
+                        if isinstance(item, str) and item.endswith(tuple(self.template_ext)):
                             try:
                                 content[i] = env.loader.get_source(env, item)[0]  # type: ignore
                             except Exception:
@@ -149,7 +149,7 @@ class Templater(LoggingMixin):
             jinja_env = self.get_template_env()
 
         if isinstance(value, str):
-            if any(value.endswith(ext) for ext in self.template_ext):  # A filepath.
+            if value.endswith(tuple(self.template_ext)):  # A filepath.
                 template = jinja_env.get_template(value)
             else:
                 template = jinja_env.from_string(value)

--- a/airflow/utils/dag_cycle_tester.py
+++ b/airflow/utils/dag_cycle_tester.py
@@ -67,7 +67,7 @@ def check_cycle(dag: DAG) -> None:
                 return adjacent_task
         return None
 
-    for dag_task_id in dag.task_dict.keys():
+    for dag_task_id in dag.task_dict:
         if visited[dag_task_id] == CYCLE_DONE:
             continue
         path_stack.append(dag_task_id)

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -22,7 +22,6 @@ import io
 import logging
 import os
 import zipfile
-from collections import OrderedDict
 from pathlib import Path
 from typing import Generator, NamedTuple, Pattern, Protocol, overload
 
@@ -230,7 +229,7 @@ def _find_path_from_directory(
                 ]
                 # evaluation order of patterns is important with negation
                 # so that later patterns can override earlier patterns
-                patterns = list(OrderedDict.fromkeys(patterns).keys())
+                patterns = list(dict.fromkeys(patterns))
 
         dirs[:] = [subdir for subdir in dirs if not ignore_rule_type.match(Path(root) / subdir, patterns)]
 

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -491,12 +491,11 @@ class FileTaskHandler(logging.Handler):
     @staticmethod
     def _read_from_local(worker_log_path: Path) -> tuple[list[str], list[str]]:
         messages = []
-        logs = []
-        files = list(worker_log_path.parent.glob(worker_log_path.name + "*"))
+        files = sorted(worker_log_path.parent.glob(worker_log_path.name + "*"))
         if files:
-            messages.extend(["Found local files:", *[f"  * {x}" for x in sorted(files)]])
-        for file in sorted(files):
-            logs.append(Path(file).read_text())
+            messages.append("Found local files:")
+            messages.extend(f"  * {x}" for x in files)
+        logs = [Path(file).read_text() for file in files]
         return messages, logs
 
     def _read_from_logs_server(self, ti, worker_log_rel_path) -> tuple[list[str], list[str]]:

--- a/airflow/utils/log/trigger_handler.py
+++ b/airflow/utils/log/trigger_handler.py
@@ -115,7 +115,7 @@ class TriggererHandlerWrapper(logging.Handler):
             h.flush()
 
     def close(self):
-        for trigger_id in list(self.handlers.keys()):
+        for trigger_id in list(self.handlers):
             h = self.handlers[trigger_id]
             h.close()
             del self.handlers[trigger_id]

--- a/airflow/utils/operator_helpers.py
+++ b/airflow/utils/operator_helpers.py
@@ -157,7 +157,7 @@ class KeywordParameters:
         signature = inspect.signature(func)
         has_wildcard_kwargs = any(p.kind == p.VAR_KEYWORD for p in signature.parameters.values())
 
-        for name in itertools.islice(signature.parameters.keys(), len(args)):
+        for name in itertools.islice(signature.parameters, len(args)):
             # Check if args conflict with names in kwargs.
             if name in kwargs:
                 raise ValueError(f"The key {name!r} in args is a part of kwargs and therefore reserved.")

--- a/airflow/utils/process_utils.py
+++ b/airflow/utils/process_utils.py
@@ -284,7 +284,7 @@ def patch_environ(new_env_variables: dict[str, str]) -> Generator[None, None, No
     After leaving the context, it restores its original state.
     :param new_env_variables: Environment variables to set
     """
-    current_env_state = {key: os.environ.get(key) for key in new_env_variables.keys()}
+    current_env_state = {key: os.environ.get(key) for key in new_env_variables}
     os.environ.update(new_env_variables)
     try:
         yield

--- a/airflow/www/extensions/init_appbuilder.py
+++ b/airflow/www/extensions/init_appbuilder.py
@@ -250,7 +250,7 @@ class AirflowAppBuilder:
             # instantiate the views and add session
             self._check_and_init(baseview)
             # Register the views has blueprints
-            if baseview.__class__.__name__ not in self.get_app.blueprints.keys():
+            if baseview.__class__.__name__ not in self.get_app.blueprints:
                 self.register_blueprint(baseview)
             # Add missing permissions where needed
         self.add_permissions()

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3251,8 +3251,7 @@ class Airflow(AirflowBaseView):
                 y=scale_time_units(cumulative_y[task_id], cum_y_unit),
             )
 
-        dates = sorted({ti.execution_date for ti in task_instances})
-        max_date = max(ti.execution_date for ti in task_instances) if dates else None
+        max_date = max((ti.execution_date for ti in task_instances), default=None)
 
         session.commit()
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1391,7 +1391,7 @@ class Airflow(AirflowBaseView):
             "dag_owner_links",
             "is_paused",
         ]
-        attrs_to_avoid.extend(wwwutils.get_attr_renderer().keys())
+        attrs_to_avoid.extend(wwwutils.get_attr_renderer())
         dag_model_attrs: list[tuple[str, Any]] = [
             (attr_name, attr)
             for attr_name, attr in (
@@ -4677,7 +4677,7 @@ class ConnectionModelView(AirflowModelView):
                     # value isn't an empty string.
                     if value != "":
                         extra[field_name] = value
-        if extra.keys():
+        if extra:
             sensitive_unchanged_keys = set()
             for key, value in extra.items():
                 if value == SENSITIVE_FIELD_PLACEHOLDER:

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -1130,7 +1130,7 @@ def generate_issue_content_providers(
         pr_list: list[PullRequest.PullRequest | Issue.Issue]
 
     if not packages:
-        packages = list(DEPENDENCIES.keys())
+        packages = list(DEPENDENCIES)
     with ci_group("Generates GitHub issue content with people who can test it"):
         if excluded_pr_list:
             excluded_prs = [int(pr) for pr in excluded_pr_list.split(",")]
@@ -1270,7 +1270,7 @@ def generate_providers_metadata(refresh_constraints: bool, python: str | None):
         python = DEFAULT_PYTHON_MAJOR_MINOR_VERSION
     get_all_constraint_files(refresh_constraints=refresh_constraints, python_version=python)
     constraints = load_constraints(python_version=python)
-    for package_id in DEPENDENCIES.keys():
+    for package_id in DEPENDENCIES:
         with ci_group(f"Generating metadata for {package_id}"):
             metadata = generate_providers_metadata_for_package(package_id, constraints)
             if metadata:

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -1033,8 +1033,11 @@ def release_prod_images(
 def is_package_in_dist(dist_files: list[str], package: str) -> bool:
     """Check if package has been prepared in dist folder."""
     for file in dist_files:
-        if file.startswith(f'apache_airflow_providers_{package.replace(".", "_")}') or file.startswith(
-            f'apache-airflow-providers-{package.replace(".", "-")}'
+        if file.startswith(
+            (
+                f'apache_airflow_providers_{package.replace(".", "_")}',
+                f'apache-airflow-providers-{package.replace(".", "-")}',
+            )
         ):
             return True
     return False

--- a/dev/breeze/src/airflow_breeze/commands/sbom_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/sbom_commands.py
@@ -243,7 +243,7 @@ def update_sbom_information(
 )
 @click.option(
     "--provider-id",
-    type=BetterChoice(list(PROVIDER_DEPENDENCIES.keys())),
+    type=BetterChoice(list(PROVIDER_DEPENDENCIES)),
     required=True,
     help="Provider to generate the requirements for",
 )

--- a/dev/breeze/src/airflow_breeze/commands/setup_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/setup_commands.py
@@ -410,7 +410,7 @@ def get_command_hash_dict(hash_file_content: str) -> dict[str, str]:
     results = {}
     for line in hash_file_content.splitlines():
         strip_line = line.strip()
-        if strip_line.strip() == "" or strip_line.startswith("#"):
+        if not strip_line or strip_line.startswith("#"):
             continue
         command = ":".join(strip_line.split(":")[:-1])
         the_hash = strip_line.split(":")[-1]

--- a/dev/breeze/src/airflow_breeze/commands/setup_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/setup_commands.py
@@ -280,7 +280,7 @@ def get_command_hash_export() -> str:
         hashes.append(f"main:{dict_hash(the_context_dict['command']['params'])}")
         commands_dict = the_context_dict["command"]["commands"]
         options = rich_click.rich_click.OPTION_GROUPS
-        for command in sorted(commands_dict.keys()):
+        for command in sorted(commands_dict):
             current_command_dict = commands_dict[command]
             current_command_hash_dict = {
                 "command": current_command_dict,
@@ -288,7 +288,7 @@ def get_command_hash_export() -> str:
             }
             if "commands" in current_command_dict:
                 subcommands = current_command_dict["commands"]
-                for subcommand in sorted(subcommands.keys()):
+                for subcommand in sorted(subcommands):
                     subcommand_click_dict = subcommands[subcommand]
                     try:
                         subcommand_rich_click_dict = options[f"breeze {command} {subcommand}"]
@@ -441,7 +441,7 @@ def regenerate_help_images_for_all_commands(commands: tuple[str, ...], check_onl
     commands_list = list(commands)
     if force:
         console.print("[info]Force regeneration all breeze command images")
-        commands_list.extend(get_command_hash_dict(new_hash_text_dump).keys())
+        commands_list.extend(get_command_hash_dict(new_hash_text_dump))
         regenerate_all_commands = True
     elif commands_list:
         console.print(f"[info]Regenerating breeze command images for specified commands:{commands_list}")
@@ -588,13 +588,13 @@ def check_that_all_params_are_in_groups(commands: tuple[str, ...]) -> int:
     if commands:
         commands_list = list(commands)
     else:
-        commands_list = commands_dict.keys()
+        commands_list = list(commands_dict)
     errors_detected = False
     for command in commands_list:
         current_command_dict = commands_dict[command]
         if "commands" in current_command_dict:
             subcommands = current_command_dict["commands"]
-            for subcommand in sorted(subcommands.keys()):
+            for subcommand in sorted(subcommands):
                 if errors_detected_in_params(command, subcommand, subcommands[subcommand]):
                     errors_detected = True
         else:

--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -587,7 +587,6 @@ def helm_tests(
         env_variables["HELM_TEST_PACKAGE"] = helm_test_package
     perform_environment_checks()
     cleanup_python_generated_files()
-    cmd = [*DOCKER_COMPOSE_COMMAND, "run", "--service-ports", "--rm", "airflow"]
-    cmd.extend(list(extra_pytest_args))
+    cmd = [*DOCKER_COMPOSE_COMMAND, "run", "--service-ports", "--rm", "airflow", *extra_pytest_args]
     result = run_command(cmd, env=env_variables, check=False, output_outside_the_group=True)
     sys.exit(result.returncode)

--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -146,7 +146,7 @@ ALL_HISTORICAL_PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
 
 def get_available_documentation_packages(short_version=False) -> list[str]:
-    provider_names: list[str] = list(json.loads(PROVIDER_DEPENDENCIES_JSON_FILE_PATH.read_text()).keys())
+    provider_names: list[str] = list(json.loads(PROVIDER_DEPENDENCIES_JSON_FILE_PATH.read_text()))
     doc_provider_names = [provider_name.replace(".", "-") for provider_name in provider_names]
     available_packages = [f"apache-airflow-providers-{doc_provider}" for doc_provider in doc_provider_names]
     available_packages.extend(["apache-airflow", "docker-stack", "helm-chart"])

--- a/dev/breeze/src/airflow_breeze/utils/parallel.py
+++ b/dev/breeze/src/airflow_breeze/utils/parallel.py
@@ -237,7 +237,7 @@ def get_multi_tuple_array(title: str, tuples: list[tuple[NamedTuple, ...]]) -> T
     first_tuple = tuples[0]
     keys: list[str] = []
     for named_tuple in first_tuple:
-        keys.extend(named_tuple._asdict().keys())
+        keys.extend(named_tuple._asdict())
     for key in keys:
         table.add_column(header=key, header_style="info")
     for t in tuples:

--- a/dev/breeze/src/airflow_breeze/utils/provider_dependencies.py
+++ b/dev/breeze/src/airflow_breeze/utils/provider_dependencies.py
@@ -65,7 +65,7 @@ def generate_providers_metadata_for_package(
     last_airflow_version = "2.0.0"
     package_name = "apache-airflow-providers-" + provider_id.replace(".", "-")
     for provider_version in reversed(provider_yaml_dict["versions"]):
-        for airflow_version in constraints.keys():
+        for airflow_version in constraints:
             if constraints[airflow_version].get(package_name) == provider_version:
                 last_airflow_version = airflow_version
         date_released = get_tag_date(

--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -361,10 +361,7 @@ def commit_sha():
 
 def filter_out_none(**kwargs) -> dict:
     """Filters out all None values from parameters passed."""
-    for key in list(kwargs):
-        if kwargs[key] is None:
-            kwargs.pop(key)
-    return kwargs
+    return {key: val for key, val in kwargs.items() if val is not None}
 
 
 def check_if_image_exists(image: str) -> bool:

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -722,15 +722,13 @@ class SelectiveChecks:
         ):
             return _ALL_DOCS_LIST
         packages = []
-        if any(
-            [file.startswith("airflow/") or file.startswith("docs/apache-airflow/") for file in self._files]
-        ):
+        if any(file.startswith(("airflow/", "docs/apache-airflow/")) for file in self._files):
             packages.append("apache-airflow")
-        if any([file.startswith("docs/apache-airflow-providers/") for file in self._files]):
+        if any(file.startswith("docs/apache-airflow-providers/") for file in self._files):
             packages.append("apache-airflow-providers")
-        if any([file.startswith("chart/") or file.startswith("docs/helm-chart") for file in self._files]):
+        if any(file.startswith(("chart/", "docs/helm-chart")) for file in self._files):
             packages.append("helm-chart")
-        if any([file.startswith("docs/docker-stack/") for file in self._files]):
+        if any(file.startswith("docs/docker-stack/") for file in self._files):
             packages.append("docker-stack")
         if providers_affected:
             for provider in providers_affected:

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -620,7 +620,7 @@ class SelectiveChecks:
             get_console().print(
                 "[warning]There are no core/other files. Only tests relevant to the changed files are run.[/]"
             )
-        sorted_candidate_test_types = list(sorted(candidate_test_types))
+        sorted_candidate_test_types = sorted(candidate_test_types)
         get_console().print("[warning]Selected test type candidates to run:[/]")
         get_console().print(sorted_candidate_test_types)
         return sorted_candidate_test_types

--- a/dev/chart/build_changelog_annotations.py
+++ b/dev/chart/build_changelog_annotations.py
@@ -96,7 +96,7 @@ with open("chart/RELEASE_NOTES.rst") as f:
                 break
             in_first_release = True
             continue
-        if line.startswith('"""') or line.startswith("----") or line.startswith("^^^^"):
+        if line.startswith(('"""', "----", "^^^^")):
             continue
 
         # Make sure we get past "significant features" before we actually start keeping track

--- a/dev/check_files.py
+++ b/dev/check_files.py
@@ -141,7 +141,7 @@ def check_release(files: list[str], version: str):
 
 
 def expand_name_variations(files):
-    return list(sorted(base + suffix for base, suffix in product(files, ["", ".asc", ".sha512"])))
+    return sorted(base + suffix for base, suffix in product(files, ["", ".asc", ".sha512"]))
 
 
 def check_upgrade_check(files: list[str], version: str):

--- a/dev/perf/dags/elastic_dag.py
+++ b/dev/perf/dags/elastic_dag.py
@@ -106,7 +106,7 @@ def chain_as_grid(*tasks: BashOperator):
     """
     if len(tasks) > 100 * 99 / 2:
         raise ValueError("Cannot generate grid DAGs with lateral size larger than 100 tasks.")
-    grid_size = min(n for n in range(100) if n * (n + 1) / 2 >= len(tasks))
+    grid_size = next(n for n in range(100) if n * (n + 1) / 2 >= len(tasks))
 
     def index(i, j):
         """

--- a/dev/prepare_bulk_issues.py
+++ b/dev/prepare_bulk_issues.py
@@ -201,7 +201,7 @@ def prepare_bulk_issues(
             if index == 0:
                 continue
             issues[row[0]].append(row)
-    names = sorted(issues.keys())[start_from:]
+    names = sorted(issues)[start_from:]
     total_issues = len(names)
     processed_issues = 0
     if dry_run:

--- a/dev/prepare_release_issue.py
+++ b/dev/prepare_release_issue.py
@@ -212,7 +212,7 @@ def print_issue_content(
     if is_helm_chart:
         link = f"https://dist.apache.org/repos/dist/dev/airflow/{current_release}"
         link_text = f"Apache Airflow Helm Chart {current_release.split('/')[-1]}"
-    pr_list = list(pull_requests.keys())
+    pr_list = list(pull_requests)
     pr_list.sort()
     user_logins: dict[int, str] = {pr: "@" + " @".join(users[pr]) for pr in users}
     all_users: set[str] = set()

--- a/dev/send_email.py
+++ b/dev/send_email.py
@@ -304,7 +304,7 @@ def result(
 @cli.command("announce")
 @click.option(
     "--receiver_email",
-    default=",".join(list(MAILING_LIST.values())),
+    default=",".join(MAILING_LIST.values()),
     prompt="The receiver email (To:)",
     help="Receiver's email address. If more than 1, separate them by comma",
 )

--- a/dev/stats/get_important_pr_candidates.py
+++ b/dev/stats/get_important_pr_candidates.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import heapq
 import logging
 import math
 import pickle
@@ -384,7 +385,7 @@ def main(
                 break
 
     console.print(f"Top {top_number} out of {issue_num} PRs:")
-    for pr_scored in sorted(scores.items(), key=lambda s: s[1], reverse=True)[:top_number]:
+    for pr_scored in heapq.nlargest(top_number, scores.items(), key=lambda s: s[1]):
         console.print(f"[green] * PR #{pr_scored[0]}: {pr_scored[1][1]}. Score: [magenta]{pr_scored[1][0]}")
 
     if save:

--- a/dev/validate_version_added_fields_in_config.py
+++ b/dev/validate_version_added_fields_in_config.py
@@ -48,7 +48,7 @@ CONFIG_TEMPLATE_FORMAT_UPDATE = "2.6.0"
 def fetch_pypi_versions() -> list[str]:
     r = requests.get("https://pypi.org/pypi/apache-airflow/json")
     r.raise_for_status()
-    all_version = r.json()["releases"].keys()
+    all_version = r.json()["releases"]
     released_versions = [d for d in all_version if not (("rc" in d) or ("b" in d))]
     return released_versions
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -563,7 +563,7 @@ elif PACKAGE_NAME == "helm-chart":
         ordered_sections.append({"name": name, "params": sections.pop(name)})
 
     if sections:
-        raise ValueError(f"Found section(s) which were not in `section_order`: {list(sections.keys())}")
+        raise ValueError(f"Found section(s) which were not in `section_order`: {list(sections)}")
 
     jinja_contexts = {
         "params_ctx": {"sections": ordered_sections},

--- a/docs/exts/redirects.py
+++ b/docs/exts/redirects.py
@@ -34,7 +34,7 @@ def generate_redirects(app):
         log.info("Could not found the redirect file: %s", redirect_file_path)
         return
 
-    in_suffix = next(iter(app.config.source_suffix.keys()))
+    in_suffix = next(iter(app.config.source_suffix))
 
     if not isinstance(app.builder, builders.StandaloneHTMLBuilder):
         return

--- a/helm_tests/airflow_aux/test_chart_quality.py
+++ b/helm_tests/airflow_aux/test_chart_quality.py
@@ -35,7 +35,7 @@ class TestChartQuality:
         # Add extra restrictions just for the tests to make sure
         # we don't forget to update the schema if we add a new property
         schema["additionalProperties"] = False
-        schema["minProperties"] = len(schema["properties"].keys())
+        schema["minProperties"] = len(schema["properties"])
 
         # shouldn't raise
         validate(instance=values, schema=schema)

--- a/helm_tests/other/test_keda.py
+++ b/helm_tests/other/test_keda.py
@@ -189,9 +189,9 @@ class TestKeda:
         assert "KEDA_DB_CONN" not in worker_container_env_vars
 
         secret_data = jmespath.search("data", metadata_connection_secret)
-        assert "connection" in secret_data.keys()
+        assert "connection" in secret_data
         assert "@release-name-postgresql" in base64.b64decode(secret_data["connection"]).decode()
-        assert "kedaConnection" not in secret_data.keys()
+        assert "kedaConnection" not in secret_data
 
         autoscaler_connection_env_var = jmespath.search(
             "spec.triggers[0].metadata.connectionFromEnv", keda_autoscaler
@@ -225,9 +225,9 @@ class TestKeda:
         assert "KEDA_DB_CONN" not in worker_container_env_vars
 
         secret_data = jmespath.search("data", metadata_connection_secret)
-        assert "connection" in secret_data.keys()
+        assert "connection" in secret_data
         assert "@release-name-pgbouncer" in base64.b64decode(secret_data["connection"]).decode()
-        assert "kedaConnection" not in secret_data.keys()
+        assert "kedaConnection" not in secret_data
 
         autoscaler_connection_env_var = jmespath.search(
             "spec.triggers[0].metadata.connectionFromEnv", keda_autoscaler
@@ -261,9 +261,9 @@ class TestKeda:
         assert "KEDA_DB_CONN" in worker_container_env_vars
 
         secret_data = jmespath.search("data", metadata_connection_secret)
-        assert "connection" in secret_data.keys()
+        assert "connection" in secret_data
         assert "@release-name-pgbouncer" in base64.b64decode(secret_data["connection"]).decode()
-        assert "kedaConnection" in secret_data.keys()
+        assert "kedaConnection" in secret_data
         assert "@release-name-postgresql" in base64.b64decode(secret_data["kedaConnection"]).decode()
 
         autoscaler_connection_env_var = jmespath.search(

--- a/helm_tests/other/test_redis.py
+++ b/helm_tests/other/test_redis.py
@@ -73,14 +73,14 @@ class TestRedis:
             redis_password_in_password_secret = self.get_redis_password_in_password_secret(k8s_obj_by_key)
             assert re.search(expected_password_match, redis_password_in_password_secret)
         else:
-            assert REDIS_OBJECTS["SECRET_PASSWORD"] not in k8s_obj_by_key.keys()
+            assert REDIS_OBJECTS["SECRET_PASSWORD"] not in k8s_obj_by_key
 
         if expected_broker_url_match is not None:
             # assert redis broker url in secret
             broker_url_in_broker_url_secret = self.get_broker_url_in_broker_url_secret(k8s_obj_by_key)
             assert re.search(expected_broker_url_match, broker_url_in_broker_url_secret)
         else:
-            assert REDIS_OBJECTS["SECRET_BROKER_URL"] not in k8s_obj_by_key.keys()
+            assert REDIS_OBJECTS["SECRET_BROKER_URL"] not in k8s_obj_by_key
 
     def assert_broker_url_env(
         self, k8s_obj_by_key, expected_broker_url_secret_name=REDIS_OBJECTS["SECRET_BROKER_URL"][1]
@@ -106,7 +106,7 @@ class TestRedis:
         )
         k8s_obj_by_key = prepare_k8s_lookup_dict(k8s_objects)
 
-        created_redis_objects = SET_POSSIBLE_REDIS_OBJECT_KEYS & set(k8s_obj_by_key.keys())
+        created_redis_objects = SET_POSSIBLE_REDIS_OBJECT_KEYS & set(k8s_obj_by_key)
         assert created_redis_objects == SET_POSSIBLE_REDIS_OBJECT_KEYS
 
         self.assert_password_and_broker_url_secrets(
@@ -129,7 +129,7 @@ class TestRedis:
         )
         k8s_obj_by_key = prepare_k8s_lookup_dict(k8s_objects)
 
-        created_redis_objects = SET_POSSIBLE_REDIS_OBJECT_KEYS & set(k8s_obj_by_key.keys())
+        created_redis_objects = SET_POSSIBLE_REDIS_OBJECT_KEYS & set(k8s_obj_by_key)
         assert created_redis_objects == SET_POSSIBLE_REDIS_OBJECT_KEYS
 
         self.assert_password_and_broker_url_secrets(
@@ -173,7 +173,7 @@ class TestRedis:
         )
         k8s_obj_by_key = prepare_k8s_lookup_dict(k8s_objects)
 
-        created_redis_objects = SET_POSSIBLE_REDIS_OBJECT_KEYS & set(k8s_obj_by_key.keys())
+        created_redis_objects = SET_POSSIBLE_REDIS_OBJECT_KEYS & set(k8s_obj_by_key)
         assert created_redis_objects == SET_POSSIBLE_REDIS_OBJECT_KEYS - {
             REDIS_OBJECTS["SECRET_PASSWORD"],
             REDIS_OBJECTS["SECRET_BROKER_URL"],
@@ -200,7 +200,7 @@ class TestRedis:
         )
         k8s_obj_by_key = prepare_k8s_lookup_dict(k8s_objects)
 
-        created_redis_objects = SET_POSSIBLE_REDIS_OBJECT_KEYS & set(k8s_obj_by_key.keys())
+        created_redis_objects = SET_POSSIBLE_REDIS_OBJECT_KEYS & set(k8s_obj_by_key)
         assert created_redis_objects == {REDIS_OBJECTS["SECRET_BROKER_URL"]}
 
         self.assert_password_and_broker_url_secrets(
@@ -225,7 +225,7 @@ class TestRedis:
         )
         k8s_obj_by_key = prepare_k8s_lookup_dict(k8s_objects)
 
-        created_redis_objects = SET_POSSIBLE_REDIS_OBJECT_KEYS & set(k8s_obj_by_key.keys())
+        created_redis_objects = SET_POSSIBLE_REDIS_OBJECT_KEYS & set(k8s_obj_by_key)
         assert created_redis_objects == set()
 
         self.assert_password_and_broker_url_secrets(

--- a/helm_tests/security/test_extra_configmaps_secrets.py
+++ b/helm_tests/security/test_extra_configmaps_secrets.py
@@ -54,7 +54,7 @@ class TestExtraConfigMapsSecrets:
             ("ConfigMap", f"{RELEASE_NAME}-airflow-variables"),
             ("ConfigMap", f"{RELEASE_NAME}-other-variables"),
         ]
-        assert set(k8s_objects_by_key.keys()) == set(all_expected_keys)
+        assert set(k8s_objects_by_key) == set(all_expected_keys)
 
         all_expected_data = [
             {"AIRFLOW_VAR_HELLO_MESSAGE": "Hi!", "AIRFLOW_VAR_KUBERNETES_NAMESPACE": "default"},
@@ -101,7 +101,7 @@ class TestExtraConfigMapsSecrets:
             ("Secret", f"{RELEASE_NAME}-other-secrets"),
             ("Secret", f"{RELEASE_NAME}-other-secrets-with-type"),
         ]
-        assert set(k8s_objects_by_key.keys()) == set(all_expected_keys)
+        assert set(k8s_objects_by_key) == set(all_expected_keys)
 
         all_expected_data = [
             {"AIRFLOW_CON_AWS": b64encode(b"aws_connection_string").decode("utf-8")},

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -927,7 +927,7 @@ class TestKubernetesPodOperatorSystem:
                 "  creation_timestamp: null",
                 "  deletion_grace_period_seconds: null",
             ]
-            actual = [x.getMessage() for x in caplog.records if x.msg == "Starting pod:\n%s"][0].splitlines()
+            actual = next(x.getMessage() for x in caplog.records if x.msg == "Starting pod:\n%s").splitlines()
             assert actual[: len(expected_lines)] == expected_lines
 
         actual_pod = self.api_client.sanitize_for_serialization(k.pod)

--- a/scripts/ci/pre_commit/pre_commit_check_order_setup.py
+++ b/scripts/ci/pre_commit/pre_commit_check_order_setup.py
@@ -111,7 +111,7 @@ def check_variable_order(var_name: str) -> None:
     var = getattr(setup, var_name)
 
     if isinstance(var, dict):
-        _check_list_sorted(list(var.keys()), f"Order of dependencies in: {var_name}")
+        _check_list_sorted(list(var), f"Order of dependencies in: {var_name}")
     else:
         _check_list_sorted(var, f"Order of dependencies in: {var_name}")
 

--- a/scripts/ci/pre_commit/pre_commit_check_pre_commit_hooks.py
+++ b/scripts/ci/pre_commit/pre_commit_check_pre_commit_hooks.py
@@ -127,10 +127,7 @@ def render_template(
 
 def update_static_checks_array(hooks: dict[str, list[str]], image_hooks: list[str]):
     rows = []
-    hook_ids = list(hooks.keys())
-    hook_ids.sort()
-    for hook_id in hook_ids:
-        hook_description = hooks[hook_id]
+    for hook_id, hook_description in sorted(hooks.items()):
         formatted_hook_description = (
             hook_description[0] if len(hook_description) == 1 else "* " + "\n* ".join(hook_description)
         )

--- a/scripts/ci/pre_commit/pre_commit_check_pre_commit_hooks.py
+++ b/scripts/ci/pre_commit/pre_commit_check_pre_commit_hooks.py
@@ -152,7 +152,7 @@ def main():
         for error in errors:
             console.print(f"* [red]{error}[/]")
         sys.exit(1)
-    ids = list(hooks.keys())
+    ids = list(hooks)
     ids.append("all")
     ids.sort()
     prepare_pre_commit_ids_py_file(ids)

--- a/scripts/ci/pre_commit/pre_commit_check_setup_extra_packages_ref.py
+++ b/scripts/ci/pre_commit/pre_commit_check_setup_extra_packages_ref.py
@@ -57,8 +57,8 @@ def get_file_content(*path_elements: str) -> str:
 def get_extras_from_setup() -> set[str]:
     """Returns a set of regular (non-deprecated) extras from setup."""
     return (
-        set(EXTRAS_DEPENDENCIES.keys())
-        - set(EXTRAS_DEPRECATED_ALIASES.keys())
+        set(EXTRAS_DEPENDENCIES)
+        - set(EXTRAS_DEPRECATED_ALIASES)
         - set(EXTRAS_DEPRECATED_ALIASES_IGNORED_FROM_REF_DOCS)
     )
 
@@ -165,7 +165,7 @@ def check_deprecated_extras(console: Console) -> bool:
     deprecated_extras_table.add_column("DEPRECATED_IN_DOCS", justify="right", style="cyan")
     deprecated_extras_table.add_column("TARGET_IN_DOCS", justify="center", style="magenta")
 
-    for extra in deprecated_setup_extras.keys():
+    for extra in deprecated_setup_extras:
         if extra not in deprecated_docs_extras:
             deprecated_extras_table.add_row(extra, deprecated_setup_extras[extra], "", "")
         elif deprecated_docs_extras[extra] != deprecated_setup_extras[extra]:
@@ -173,7 +173,7 @@ def check_deprecated_extras(console: Console) -> bool:
                 extra, deprecated_setup_extras[extra], extra, deprecated_docs_extras[extra]
             )
 
-    for extra in deprecated_docs_extras.keys():
+    for extra in deprecated_docs_extras:
         if extra not in deprecated_setup_extras:
             deprecated_extras_table.add_row("", "", extra, deprecated_docs_extras[extra])
 

--- a/scripts/ci/pre_commit/pre_commit_insert_extras.py
+++ b/scripts/ci/pre_commit/pre_commit_insert_extras.py
@@ -57,8 +57,8 @@ if __name__ == "__main__":
     global_constants_file_path = (
         AIRFLOW_SOURCES_DIR / "dev" / "breeze" / "src" / "airflow_breeze" / "global_constants.py"
     )
-    extras_list = wrap(", ".join(EXTRAS_DEPENDENCIES.keys()), 100)
+    extras_list = wrap(", ".join(EXTRAS_DEPENDENCIES), 100)
     extras_list = [line + "\n" for line in extras_list]
-    extras_code = [f"    {extra}\n" for extra in EXTRAS_DEPENDENCIES.keys()]
+    extras_code = [f"    {extra}\n" for extra in EXTRAS_DEPENDENCIES]
     insert_documentation(install_file_path, extras_list, INSTALL_HEADER, INSTALL_FOOTER)
     insert_documentation(contributing_file_path, extras_list, RST_HEADER, RST_FOOTER)

--- a/scripts/ci/pre_commit/pre_commit_json_schema.py
+++ b/scripts/ci/pre_commit/pre_commit_json_schema.py
@@ -100,7 +100,7 @@ def load_file(file_path: str):
     if file_path.lower().endswith(".json"):
         with open(file_path) as input_file:
             return json.load(input_file)
-    elif file_path.lower().endswith(".yaml") or file_path.lower().endswith(".yml"):
+    elif file_path.lower().endswith((".yaml", ".yml")):
         with open(file_path) as input_file:
             return yaml.safe_load(input_file)
     raise _ValidatorError("Unknown file format. Supported extension: '.yaml', '.json'")

--- a/scripts/ci/pre_commit/pre_commit_update_common_sql_api_stubs.py
+++ b/scripts/ci/pre_commit/pre_commit_update_common_sql_api_stubs.py
@@ -70,23 +70,16 @@ def summarize_changes(results: list[str]) -> tuple[int, int]:
     removals, additions = 0, 0
     for line in results:
         if (
-            line.startswith("+")
-            or line.startswith("[green]+")
+            line.startswith(("+", "[green]+"))
             and not (
                 # Skip additions of comments in counting removals
-                line.startswith("+#")
-                or line.startswith("[green]+#")
+                line.startswith(("+#", "[green]+#"))
             )
         ):
             additions += 1
-        if (
-            line.startswith("-")
-            or line.startswith("[red]-")
-            and not (
+        if line.startswith(("-", "[red]-")) and not (
                 # Skip removals of comments in counting removals
-                line.startswith("-#")
-                or line.startswith("[red]-#")
-            )
+                line.startswith(("-#", "[red]-#"))
         ):
             removals += 1
     return removals, additions

--- a/scripts/ci/pre_commit/pre_commit_update_example_dags_paths.py
+++ b/scripts/ci/pre_commit/pre_commit_update_example_dags_paths.py
@@ -52,8 +52,7 @@ def get_provider_and_version(url_path: str) -> tuple[str, str]:
                 provider_info = yaml.safe_load(f)
             version = provider_info["versions"][0]
             provider = "-".join(candidate_folders)
-            while provider.endswith("-"):
-                provider = provider[:-1]
+            provider = provider.rstrip("-")
             return provider, version
         except FileNotFoundError:
             candidate_folders = candidate_folders[:-1]

--- a/scripts/ci/pre_commit/pre_commit_update_providers_dependencies.py
+++ b/scripts/ci/pre_commit/pre_commit_update_providers_dependencies.py
@@ -126,7 +126,7 @@ def get_provider_id_from_import(import_name: str, file_path: Path) -> str | None
     provider_id = get_provider_id_from_relative_import_or_file(relative_provider_import)
     if provider_id is None:
         relative_path_from_import = relative_provider_import.replace(".", os.sep)
-        if any(relative_path_from_import.startswith(suspended_path) for suspended_path in suspended_paths):
+        if relative_path_from_import.startswith(tuple(suspended_paths)):
             return None
         warnings.append(f"We could not determine provider id from import {import_name} in {file_path}")
     return provider_id
@@ -154,7 +154,7 @@ def get_provider_id_from_file_name(file_path: Path) -> str | None:
                 return None
     provider_id = get_provider_id_from_relative_import_or_file(str(relative_path))
     if provider_id is None and file_path.name not in ["__init__.py", "get_provider_info.py"]:
-        if any(relative_path.as_posix().startswith(suspended_path) for suspended_path in suspended_paths):
+        if relative_path.as_posix().startswith(tuple(suspended_paths)):
             return None
         else:
             warnings.append(f"We had a problem to classify the file {file_path} to a provider")

--- a/scripts/ci/pre_commit/pre_commit_update_providers_dependencies.py
+++ b/scripts/ci/pre_commit/pre_commit_update_providers_dependencies.py
@@ -195,7 +195,7 @@ if __name__ == "__main__":
             console.print(f"[red] {error}")
         console.print(f"[bright_blue]Total: {len(errors)} errors.")
     unique_sorted_dependencies: dict[str, dict[str, list[str]]] = defaultdict(dict)
-    for key in sorted(ALL_DEPENDENCIES.keys()):
+    for key in sorted(ALL_DEPENDENCIES):
         unique_sorted_dependencies[key]["deps"] = sorted(ALL_DEPENDENCIES[key]["deps"])
         unique_sorted_dependencies[key]["cross-providers-deps"] = sorted(
             set(ALL_DEPENDENCIES[key]["cross-providers-deps"])

--- a/scripts/ci/pre_commit/pre_commit_version_heads_map.py
+++ b/scripts/ci/pre_commit/pre_commit_version_heads_map.py
@@ -44,7 +44,7 @@ def read_revision_heads_map():
 
     revision_heads_map = ast.literal_eval(revision_heads_map_ast.value)
 
-    return revision_heads_map.keys()
+    return list(revision_heads_map)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/runners/sync_authors.py
+++ b/scripts/ci/runners/sync_authors.py
@@ -42,15 +42,9 @@ WORKFLOW = ".github/workflows/ci.yml"
 req = requests.get(AUTHORS)
 author_list = toml.loads(req.text)
 
-author_set = set()
-for membership in author_list:
-    author_set.update([author for author in author_list[membership]])
+author_set = set().union(*author_list.values())
 
-authors = ""
-for author in sorted(author_set):
-    authors += f'            "{author}",\n'
-
-authors = authors[:-2]
+authors = ",\n".join(f'            "{author}"' for author in author_set)
 
 with open(WORKFLOW) as handle:
     new_ci = re.sub(

--- a/scripts/in_container/run_migration_reference.py
+++ b/scripts/in_container/run_migration_reference.py
@@ -184,9 +184,6 @@ def ensure_filenames_are_sorted(revisions):
 
 
 if __name__ == "__main__":
-    revisions = list(reversed(list(get_revisions())))
-    ensure_airflow_version(revisions=revisions)
-    revisions = list(reversed(list(get_revisions())))
-    ensure_filenames_are_sorted(revisions)
-    revisions = list(get_revisions())
-    update_docs(revisions)
+    ensure_airflow_version(revisions=reversed(get_revisions()))
+    ensure_filenames_are_sorted(revisions=reversed(get_revisions()))
+    update_docs(revisions=get_revisions())

--- a/scripts/in_container/run_provider_yaml_files_check.py
+++ b/scripts/in_container/run_provider_yaml_files_check.py
@@ -419,19 +419,18 @@ def check_doc_files(yaml_files: dict[str, dict]):
         for f in expected_doc_files
         if f.name != "index.rst"
         and "_partials" not in f.parts
-        and not any(f.relative_to(DOCS_DIR).as_posix().startswith(s) for s in suspended_providers)
+        and not f.relative_to(DOCS_DIR).as_posix().startswith(tuple(suspended_providers))
     } | {
         f"/docs/{f.relative_to(DOCS_DIR).as_posix()}"
         for f in DOCS_DIR.glob("apache-airflow-providers-*/operators.rst")
-        if not any(f.relative_to(DOCS_DIR).as_posix().startswith(s) for s in suspended_providers)
+        if not f.relative_to(DOCS_DIR).as_posix().startswith(tuple(suspended_providers))
     }
     console.print("[yellow]Suspended logos:[/]")
     console.print(suspended_logos)
     expected_logo_urls = {
         f"/{f.relative_to(DOCS_DIR).as_posix()}"
         for f in DOCS_DIR.glob("integration-logos/**/*")
-        if f.is_file()
-        and not any(f"/{f.relative_to(DOCS_DIR).as_posix()}".startswith(s) for s in suspended_logos)
+        if f.is_file() and not f"/{f.relative_to(DOCS_DIR).as_posix()}".startswith(tuple(suspended_logos))
     }
 
     try:

--- a/scripts/in_container/update_quarantined_test_status.py
+++ b/scripts/in_container/update_quarantined_test_status.py
@@ -63,7 +63,7 @@ status_map: dict[str, bool] = {
     ":x:": False,
 }
 
-reverse_status_map: dict[bool, str] = {status_map[key]: key for key in status_map.keys()}
+reverse_status_map: dict[bool, str] = {val: key for key, val in status_map.items()}
 
 
 def get_url(result: TestResult) -> str:
@@ -160,7 +160,7 @@ def get_history_status(history: TestHistory):
 def get_table(history_map: dict[str, TestHistory]) -> str:
     headers = ["Test", "Last run", f"Last {num_runs} runs", "Status", "Comment"]
     the_table: list[list[str]] = []
-    for ordered_key in sorted(history_map.keys()):
+    for ordered_key in sorted(history_map):
         history = history_map[ordered_key]
         the_table.append(
             [

--- a/scripts/in_container/verify_providers.py
+++ b/scripts/in_container/verify_providers.py
@@ -181,7 +181,7 @@ def import_all_classes(
 
     for path, prefix in walkable_paths_and_prefixes.items():
         for modinfo in pkgutil.walk_packages(path=[path], prefix=prefix, onerror=onerror):
-            if not any(modinfo.name.startswith(provider_prefix) for provider_prefix in provider_prefixes):
+            if not modinfo.name.startswith(tuple(provider_prefixes)):
                 if print_skips:
                     console.print(f"Skipping module: {modinfo.name}")
                 continue

--- a/scripts/in_container/verify_providers.py
+++ b/scripts/in_container/verify_providers.py
@@ -326,8 +326,7 @@ def get_details_about_classes(
     :param wrong_entities: wrong entities found for that type
     :param full_package_name: full package name
     """
-    all_entities = list(entities)
-    all_entities.sort()
+    all_entities = sorted(entities)
     TOTALS[entity_type] += len(all_entities)
     return EntityTypeSummary(
         entities=all_entities,

--- a/setup.py
+++ b/setup.py
@@ -704,7 +704,7 @@ def is_package_excluded(package: str, exclusion_list: list[str]) -> bool:
     :param exclusion_list: list of excluded packages
     :return: true if package should be excluded
     """
-    return any(package.startswith(excluded_package) for excluded_package in exclusion_list)
+    return package.startswith(tuple(exclusion_list))
 
 
 def remove_provider_limits(package: str) -> str:

--- a/setup.py
+++ b/setup.py
@@ -202,7 +202,7 @@ class ListExtras(Command):
 
     def run(self) -> None:
         """List extras."""
-        print("\n".join(wrap(", ".join(EXTRAS_DEPENDENCIES.keys()), 100)))
+        print("\n".join(wrap(", ".join(EXTRAS_DEPENDENCIES), 100)))
 
 
 def git_version() -> str:
@@ -630,7 +630,7 @@ add_extras_for_all_deprecated_aliases()
 
 # This is list of all providers. It's a shortcut for anyone who would like to easily get list of
 # All providers. It is used by pre-commits.
-ALL_PROVIDERS = list(PROVIDER_DEPENDENCIES.keys())
+ALL_PROVIDERS = list(PROVIDER_DEPENDENCIES)
 
 ALL_DB_PROVIDERS = [
     "apache.cassandra",
@@ -748,7 +748,7 @@ def sort_extras_dependencies() -> dict[str, list[str]]:
     external packages will be first, then if providers are added they are added at the end of the lists.
     """
     sorted_dependencies: dict[str, list[str]] = {}
-    sorted_extra_ids = sorted(EXTRAS_DEPENDENCIES.keys())
+    sorted_extra_ids = sorted(EXTRAS_DEPENDENCIES)
     for extra_id in sorted_extra_ids:
         sorted_dependencies[extra_id] = sorted(EXTRAS_DEPENDENCIES[extra_id])
     return sorted_dependencies

--- a/tests/always/test_example_dags.py
+++ b/tests/always/test_example_dags.py
@@ -61,16 +61,15 @@ def example_not_suspended_dags():
     for example_dir in example_dirs:
         candidates = glob(f"{AIRFLOW_SOURCES_ROOT.as_posix()}/{example_dir}", recursive=True)
         for candidate in candidates:
-            if any(candidate.startswith(s) for s in suspended_providers_folders):
-                continue
-            yield candidate
+            if not candidate.startswith(tuple(suspended_providers_folders)):
+                yield candidate
 
 
 def example_dags_except_db_exception():
     return [
         dag_file
         for dag_file in example_not_suspended_dags()
-        if not any(dag_file.endswith(e) for e in NO_DB_QUERY_EXCEPTION)
+        if not dag_file.endswith(tuple(NO_DB_QUERY_EXCEPTION))
     ]
 
 

--- a/tests/always/test_project_structure.py
+++ b/tests/always/test_project_structure.py
@@ -150,7 +150,7 @@ class ProjectStructureTest:
             if not isinstance(current_node, ast.ClassDef):
                 continue
             name = current_node.name
-            if not any(name.endswith(suffix) for suffix in self.CLASS_SUFFIXES):
+            if not name.endswith(tuple(self.CLASS_SUFFIXES)):
                 continue
             results[f"{module}.{name}"] = current_node
         return results
@@ -463,6 +463,6 @@ class TestOperatorsHooks:
             )
         )
 
-        invalid_files = [f for f in files if any(f.endswith(suffix) for suffix in illegal_suffixes)]
+        invalid_files = [f for f in files if f.endswith(tuple(illegal_suffixes))]
 
         assert [] == invalid_files

--- a/tests/always/test_project_structure.py
+++ b/tests/always/test_project_structure.py
@@ -186,7 +186,7 @@ class ExampleCoverageTest(ProjectStructureTest):
         """
         classes = self.list_of_classes()
         assert 0 != len(classes), "Failed to retrieve operators, override class_paths if needed"
-        classes = set(classes.keys())
+        classes = set(classes)
         for example in self.example_paths():
             classes -= get_imports_from_file(example)
 

--- a/tests/always/test_providers_manager.py
+++ b/tests/always/test_providers_manager.py
@@ -50,7 +50,7 @@ class TestProviderManager:
     def test_providers_are_loaded(self):
         with self._caplog.at_level(logging.WARNING):
             provider_manager = ProvidersManager()
-            provider_list = list(provider_manager.providers.keys())
+            provider_list = list(provider_manager.providers)
             # No need to sort the list - it should be sorted alphabetically !
             for provider in provider_list:
                 package_name = provider_manager.providers[provider].data["package-name"]
@@ -189,7 +189,7 @@ class TestProviderManager:
         with pytest.warns(expected_warning=None) as warning_records:
             with self._caplog.at_level(logging.WARNING):
                 provider_manager = ProvidersManager()
-                connections_list = list(provider_manager.hooks.keys())
+                connections_list = list(provider_manager.hooks)
                 assert len(connections_list) > 60
         if len(self._caplog.records) != 0:
             for record in self._caplog.records:
@@ -214,7 +214,7 @@ class TestProviderManager:
 
     def test_connection_form_widgets(self):
         provider_manager = ProvidersManager()
-        connections_form_widgets = list(provider_manager.connection_form_widgets.keys())
+        connections_form_widgets = list(provider_manager.connection_form_widgets)
         assert len(connections_form_widgets) > 29
 
     @pytest.mark.parametrize(
@@ -304,7 +304,7 @@ class TestProviderManager:
             widgets={f: BooleanField(lazy_gettext("Dummy param")) for f in expected_field_names_order},
         )
         actual_field_names_order = tuple(
-            key for key in provider_manager.connection_form_widgets.keys() if key.startswith(field_prefix)
+            key for key in provider_manager.connection_form_widgets if key.startswith(field_prefix)
         )
         assert actual_field_names_order == expected_field_names_order, "Not keeping original fields order"
 
@@ -345,13 +345,13 @@ class TestProviderManager:
             },
         )
         actual_field_names_order = tuple(
-            key for key in provider_manager.connection_form_widgets.keys() if key.startswith(field_prefix)
+            key for key in provider_manager.connection_form_widgets if key.startswith(field_prefix)
         )
         assert actual_field_names_order == expected_field_names_order, "Not keeping original fields order"
 
     def test_field_behaviours(self):
         provider_manager = ProvidersManager()
-        connections_with_field_behaviours = list(provider_manager.field_behaviours.keys())
+        connections_with_field_behaviours = list(provider_manager.field_behaviours)
         assert len(connections_with_field_behaviours) > 16
 
     def test_extra_links(self):

--- a/tests/always/test_secrets_local_filesystem.py
+++ b/tests/always/test_secrets_local_filesystem.py
@@ -283,7 +283,7 @@ class TestLoadConnection:
             connections_by_conn_id = local_filesystem.load_connections_dict("a.yaml")
             for conn_id, connection in connections_by_conn_id.items():
                 expected_attrs = expected_attrs_dict[conn_id]
-                actual_attrs = {k: getattr(connection, k) for k in expected_attrs.keys()}
+                actual_attrs = {k: getattr(connection, k) for k in expected_attrs}
                 assert actual_attrs == expected_attrs
 
     @pytest.mark.parametrize(

--- a/tests/cli/commands/test_config_command.py
+++ b/tests/cli/commands/test_config_command.py
@@ -194,9 +194,7 @@ class TestCliConfigList:
             )
         output = temp_stdout.getvalue()
         lines = output.split("\n")
-        assert all(
-            line.startswith("#") or line.strip() == "" or line.startswith("[") for line in lines if line
-        )
+        assert all(not line.strip() or line.startswith(("#", "[")) for line in lines if line)
 
 
 class TestCliConfigGetValue:

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -503,10 +503,8 @@ class TestCliDags:
             dag_command.dag_details(args)
             out = temp_stdout.getvalue()
 
-        dag_detail_fields = DAGSchema().fields.keys()
-
         # Check if DAG Details field are present
-        for field in dag_detail_fields:
+        for field in DAGSchema().fields:
             assert field in out
 
         # Check if identifying values are present

--- a/tests/dag_processing/test_job_runner.py
+++ b/tests/dag_processing/test_job_runner.py
@@ -403,7 +403,7 @@ class TestDagProcessorJobRunner:
     ):
         """Test files are sorted by modified time"""
         paths_with_mtime = {"file_3.py": 3.0, "file_2.py": 2.0, "file_4.py": 5.0, "file_1.py": 4.0}
-        dag_files = list(paths_with_mtime.keys())
+        dag_files = list(paths_with_mtime)
         mock_getmtime.side_effect = list(paths_with_mtime.values())
         mock_find_path.return_value = dag_files
 
@@ -1252,7 +1252,7 @@ class TestDagProcessorJobRunner:
         assert manager.processor._file_path_queue == collections.deque(
             [dag2_req1.full_filepath, dag1_req1.full_filepath]
         )
-        assert set(manager.processor._callback_to_execute.keys()) == {
+        assert set(manager.processor._callback_to_execute) == {
             dag1_req1.full_filepath,
             dag2_req1.full_filepath,
         }

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -462,7 +462,7 @@ class TestAirflowTaskDecorator(BasePythonTest):
         bigger_number.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
         ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        ti_add_num = [ti for ti in dr.get_task_instances() if ti.task_id == "add_num"][0]
+        ti_add_num = next(ti for ti in dr.get_task_instances() if ti.task_id == "add_num")
         assert ti_add_num.xcom_pull(key=ret.key) == (test_number + 2) * 2
 
     def test_dag_task(self):

--- a/tests/integration/executors/test_celery_executor.py
+++ b/tests/integration/executors/test_celery_executor.py
@@ -146,7 +146,7 @@ class TestCeleryExecutor:
 
                 executor._process_tasks(task_tuples_to_send)
 
-                assert list(executor.tasks.keys()) == [
+                assert list(executor.tasks) == [
                     ("success", "fake_simple_ti", execute_date, 0),
                     ("fail", "fake_simple_ti", execute_date, 0),
                 ]

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3118,7 +3118,7 @@ class TestSchedulerJob:
         }
         for root, _, files in os.walk(TEST_DAG_FOLDER):
             for file_name in files:
-                if file_name.endswith(".py") or file_name.endswith(".zip"):
+                if file_name.endswith((".py", ".zip")):
                     if file_name not in ignored_files:
                         expected_files.add(f"{root}/{file_name}")
         for file_path in list_py_file_paths(TEST_DAG_FOLDER, include_examples=False):
@@ -3131,7 +3131,7 @@ class TestSchedulerJob:
         example_dag_folder = airflow.example_dags.__path__[0]
         for root, _, files in os.walk(example_dag_folder):
             for file_name in files:
-                if file_name.endswith(".py") or file_name.endswith(".zip"):
+                if file_name.endswith((".py", ".zip")):
                     if file_name not in ["__init__.py"] and file_name not in ignored_files:
                         expected_files.add(os.path.join(root, file_name))
         detected_files.clear()

--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -237,7 +237,7 @@ def test_trigger_lifecycle(session):
         # Wait for up to 3 seconds for it to appear in the TriggerRunner's storage
         for _ in range(30):
             if job_runner.trigger_runner.triggers:
-                assert list(job_runner.trigger_runner.triggers.keys()) == [1]
+                assert list(job_runner.trigger_runner.triggers) == [1]
                 break
             time.sleep(0.1)
         else:

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -1706,7 +1706,7 @@ def test_calls_to_verify_integrity_with_mapped_task_zero_length_at_runtime(dag_m
         (1, State.NONE),
         (2, State.NONE),
     ]
-    ti1 = [i for i in tis if i.map_index == 0][0]
+    ti1 = next(i for i in tis if i.map_index == 0)
     # Now "clear" and "reduce" the length to empty list
     dag.clear()
     Variable.set(key="arg1", value=[])

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -1381,7 +1381,7 @@ class TestShortCircuitWithTeardown:
             op1.skip = MagicMock()
             dagrun = dag_maker.create_dagrun()
             tis = dagrun.get_task_instances()
-            ti: TaskInstance = [x for x in tis if x.task_id == "op1"][0]
+            ti: TaskInstance = next(x for x in tis if x.task_id == "op1")
             ti._run_raw_task()
             expected_tasks = {dag.task_dict[x] for x in expected}
         if should_skip:
@@ -1412,7 +1412,7 @@ class TestShortCircuitWithTeardown:
             op1.skip = MagicMock()
             dagrun = dag_maker.create_dagrun()
             tis = dagrun.get_task_instances()
-            ti: TaskInstance = [x for x in tis if x.task_id == "op1"][0]
+            ti: TaskInstance = next(x for x in tis if x.task_id == "op1")
             ti._run_raw_task()
             # we can't use assert_called_with because it's a set and therefore not ordered
             actual_skipped = set(op1.skip.call_args.kwargs["tasks"])
@@ -1439,7 +1439,7 @@ class TestShortCircuitWithTeardown:
             op1.skip = MagicMock()
             dagrun = dag_maker.create_dagrun()
             tis = dagrun.get_task_instances()
-            ti: TaskInstance = [x for x in tis if x.task_id == "op1"][0]
+            ti: TaskInstance = next(x for x in tis if x.task_id == "op1")
             ti._run_raw_task()
             # we can't use assert_called_with because it's a set and therefore not ordered
             actual_kwargs = op1.skip.call_args.kwargs
@@ -1474,7 +1474,7 @@ class TestShortCircuitWithTeardown:
             op1.skip = MagicMock()
             dagrun = dag_maker.create_dagrun()
             tis = dagrun.get_task_instances()
-            ti: TaskInstance = [x for x in tis if x.task_id == "op1"][0]
+            ti: TaskInstance = next(x for x in tis if x.task_id == "op1")
             ti._run_raw_task()
             # we can't use assert_called_with because it's a set and therefore not ordered
             actual_kwargs = op1.skip.call_args.kwargs

--- a/tests/providers/amazon/aws/hooks/test_batch_waiters.py
+++ b/tests/providers/amazon/aws/hooks/test_batch_waiters.py
@@ -85,7 +85,7 @@ class TestBatchWaiters:
         assert config["version"] == 2
         assert isinstance(config["waiters"], dict)
 
-        waiters = sorted(config["waiters"].keys())
+        waiters = sorted(config["waiters"])
         assert waiters == ["JobComplete", "JobExists", "JobRunning"]
 
     def test_list_waiters(self):
@@ -93,7 +93,7 @@ class TestBatchWaiters:
         config = self.batch_waiters.waiter_config
 
         assert isinstance(config["waiters"], dict)
-        waiters = sorted(config["waiters"].keys())
+        waiters = sorted(config["waiters"])
         assert waiters == ["JobComplete", "JobExists", "JobRunning"]
         assert waiters == self.batch_waiters.list_waiters()
 

--- a/tests/providers/amazon/aws/hooks/test_batch_waiters.py
+++ b/tests/providers/amazon/aws/hooks/test_batch_waiters.py
@@ -85,7 +85,7 @@ class TestBatchWaiters:
         assert config["version"] == 2
         assert isinstance(config["waiters"], dict)
 
-        waiters = list(sorted(config["waiters"].keys()))
+        waiters = sorted(config["waiters"].keys())
         assert waiters == ["JobComplete", "JobExists", "JobRunning"]
 
     def test_list_waiters(self):
@@ -93,7 +93,7 @@ class TestBatchWaiters:
         config = self.batch_waiters.waiter_config
 
         assert isinstance(config["waiters"], dict)
-        waiters = list(sorted(config["waiters"].keys()))
+        waiters = sorted(config["waiters"].keys())
         assert waiters == ["JobComplete", "JobExists", "JobRunning"]
         assert waiters == self.batch_waiters.list_waiters()
 

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -1072,7 +1072,7 @@ class TestAwsS3Hook:
         url = presigned_url.split("?")[1]
         params = {x[0]: x[1] for x in [x.split("=") for x in url[0:].split("&")]}
 
-        assert {"AWSAccessKeyId", "Signature", "Expires"}.issubset(set(params.keys()))
+        assert {"AWSAccessKeyId", "Signature", "Expires"}.issubset(set(params))
 
     def test_should_throw_error_if_extra_args_is_not_dict(self):
         with pytest.raises(TypeError, match="extra_args expected dict, got .*"):

--- a/tests/providers/amazon/aws/hooks/test_sagemaker.py
+++ b/tests/providers/amazon/aws/hooks/test_sagemaker.py
@@ -721,8 +721,8 @@ class TestSageMakerHook:
         # check conversion to the weird format for passing parameters (list of tuples)
         assert len(args_passed["PipelineParameters"]) == 2
         for transformed_param in args_passed["PipelineParameters"]:
-            assert "Name" in transformed_param.keys()
-            assert "Value" in transformed_param.keys()
+            assert "Name" in transformed_param
+            assert "Value" in transformed_param
             # Name contains the key
             assert transformed_param["Name"] in params_dict.keys()
             # Value contains the value associated with the key in Name

--- a/tests/providers/amazon/aws/utils/eks_test_utils.py
+++ b/tests/providers/amazon/aws/utils/eks_test_utils.py
@@ -202,7 +202,7 @@ def convert_keys(original: dict) -> dict:
     :param original: Dict which needs the keys converted.
     :value original: Dict
     """
-    if "nodegroup_name" in original.keys():
+    if "nodegroup_name" in original:
         conversion_map = {
             "cluster_name": "clusterName",
             "cluster_role_arn": "roleArn",
@@ -211,7 +211,7 @@ def convert_keys(original: dict) -> dict:
             "nodegroup_name": "nodegroupName",
             "nodegroup_role_arn": "nodeRole",
         }
-    elif "fargate_profile_name" in original.keys():
+    elif "fargate_profile_name" in original:
         conversion_map = {
             "cluster_name": "clusterName",
             "fargate_profile_name": "fargateProfileName",

--- a/tests/providers/amazon/aws/waiters/test_custom_waiters.py
+++ b/tests/providers/amazon/aws/waiters/test_custom_waiters.py
@@ -80,7 +80,7 @@ class TestCustomEKSServiceWaiters:
         with open(hook.waiter_path) as config_file:
             expected_waiters = json.load(config_file)["waiters"]
 
-        for waiter in list(expected_waiters.keys()):
+        for waiter in expected_waiters:
             assert waiter in hook.list_waiters()
             assert waiter in hook._list_custom_waiters()
 

--- a/tests/providers/asana/hooks/test_asana.py
+++ b/tests/providers/asana/hooks/test_asana.py
@@ -245,7 +245,7 @@ class TestAsanaHook:
 
         Note: remove this test when removing ensure_prefixes (after min airflow version >= 2.5.0
         """
-        assert list(AsanaHook.get_ui_field_behaviour()["placeholders"].keys()) == [
+        assert list(AsanaHook.get_ui_field_behaviour()["placeholders"]) == [
             "password",
             "extra__asana__workspace",
             "extra__asana__project",

--- a/tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -635,7 +635,7 @@ class TestKubernetesExecutor:
         executor.kube_config.multi_namespace_mode_namespace_list = multi_namespace_mode_namespace_list
         executor.start()
         try:
-            assert list(executor.kube_scheduler.kube_watchers.keys()) == watchers_keys
+            assert list(executor.kube_scheduler.kube_watchers) == watchers_keys
             assert all(
                 isinstance(v, KubernetesJobWatcher) for v in executor.kube_scheduler.kube_watchers.values()
             )

--- a/tests/providers/common/sql/operators/test_sql.py
+++ b/tests/providers/common/sql/operators/test_sql.py
@@ -476,7 +476,7 @@ class TestTableCheckOperator:
         records = [("row_count_check", 1), ("column_sum_check", "y")]
         operator = self._construct_operator(monkeypatch, self.checks, records)
         operator.execute(context=MagicMock())
-        assert [operator.checks[check]["success"] is True for check in operator.checks.keys()]
+        assert [operator.checks[check]["success"] is True for check in operator.checks]
 
     def test_fail_all_checks_check(self, monkeypatch):
         records = [("row_count_check", 0), ("column_sum_check", "n")]

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -1075,7 +1075,7 @@ class TestTableOperations(_BigQueryBaseTestClass):
             "view": view_patched,
             "requirePartitionFilter": require_partition_filter_patched,
         }
-        fields = list(body.keys())
+        fields = list(body)
         body["tableReference"] = TABLE_REFERENCE_REPR
 
         mock_table.from_api_repr.assert_called_once_with(body)
@@ -1966,7 +1966,7 @@ class TestBigQueryWithKMS(_BigQueryBaseTestClass):
             "requirePartitionFilter": require_partition_filter_patched,
         }
 
-        fields = list(body.keys())
+        fields = list(body)
 
         self.hook.update_table(
             table_resource=body,

--- a/tests/providers/google/cloud/log/test_stackdriver_task_handler.py
+++ b/tests/providers/google/cloud/log/test_stackdriver_task_handler.py
@@ -369,7 +369,7 @@ labels.try_number="3"'''
         assert "https" == parsed_url.scheme
         assert "console.cloud.google.com" == parsed_url.netloc
         assert "/logs/viewer" == parsed_url.path
-        assert {"project", "interval", "resource", "advancedFilter"} == set(parsed_qs.keys())
+        assert {"project", "interval", "resource", "advancedFilter"} == set(parsed_qs)
         assert "global" in parsed_qs["resource"]
 
         filter_params = parsed_qs["advancedFilter"][0].split("\n")

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -462,7 +462,7 @@ class TestBigQueryUpdateDatasetOperator:
             dataset_resource=dataset_resource,
             dataset_id=TEST_DATASET,
             project_id=TEST_GCP_PROJECT_ID,
-            fields=list(dataset_resource.keys()),
+            fields=list(dataset_resource),
         )
 
 

--- a/tests/providers/google/cloud/operators/test_pubsub.py
+++ b/tests/providers/google/cloud/operators/test_pubsub.py
@@ -291,7 +291,7 @@ class TestPubSubPullOperator:
             assert pulled_messages == generated_messages
 
             assert isinstance(context, dict)
-            for key in context.keys():
+            for key in context:
                 assert isinstance(key, str)
 
             return messages_callback_return_value

--- a/tests/providers/google/cloud/sensors/test_pubsub.py
+++ b/tests/providers/google/cloud/sensors/test_pubsub.py
@@ -131,7 +131,7 @@ class TestPubSubPullSensor:
             assert pulled_messages == generated_messages
 
             assert isinstance(context, dict)
-            for key in context.keys():
+            for key in context:
                 assert isinstance(key, str)
 
             return messages_callback_return_value

--- a/tests/providers/microsoft/azure/hooks/test_adx.py
+++ b/tests/providers/microsoft/azure/hooks/test_adx.py
@@ -200,7 +200,7 @@ class TestAzureDataExplorerHook:
 
         Note: remove this test and the _ensure_prefixes decorator after min airflow version >= 2.5.0
         """
-        assert list(AzureDataExplorerHook.get_ui_field_behaviour()["placeholders"].keys()) == [
+        assert list(AzureDataExplorerHook.get_ui_field_behaviour()["placeholders"]) == [
             "login",
             "password",
             "extra__azure_data_explorer__auth_method",

--- a/tests/providers/microsoft/azure/hooks/test_azure_container_volume.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_container_volume.py
@@ -72,7 +72,7 @@ class TestAzureContainerVolumeHook:
 
         Note: remove this test and the _ensure_prefixes decorator after min airflow version >= 2.5.0
         """
-        assert list(AzureContainerVolumeHook.get_ui_field_behaviour()["placeholders"].keys()) == [
+        assert list(AzureContainerVolumeHook.get_ui_field_behaviour()["placeholders"]) == [
             "login",
             "password",
             "extra__azure_container_volume__connection_string",

--- a/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
@@ -261,7 +261,7 @@ class TestAzureCosmosDbHook:
 
         Note: remove this test and the _ensure_prefixes decorator after min airflow version >= 2.5.0
         """
-        assert list(AzureCosmosDBHook.get_ui_field_behaviour()["placeholders"].keys()) == [
+        assert list(AzureCosmosDBHook.get_ui_field_behaviour()["placeholders"]) == [
             "login",
             "password",
             "extra__azure_cosmos__database_name",

--- a/tests/providers/microsoft/azure/hooks/test_azure_data_lake.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_data_lake.py
@@ -144,7 +144,7 @@ class TestAzureDataLakeHook:
 
         Note: remove this test and the _ensure_prefixes decorator after min airflow version >= 2.5.0
         """
-        assert list(AzureDataLakeHook.get_ui_field_behaviour()["placeholders"].keys()) == [
+        assert list(AzureDataLakeHook.get_ui_field_behaviour()["placeholders"]) == [
             "login",
             "password",
             "extra__azure_data_lake__tenant",

--- a/tests/providers/microsoft/azure/hooks/test_azure_fileshare.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_fileshare.py
@@ -252,7 +252,7 @@ class TestAzureFileshareHook:
 
         Note: remove this test when removing ensure_prefixes (after min airflow version >= 2.5.0
         """
-        assert list(AzureFileShareHook.get_ui_field_behaviour()["placeholders"].keys()) == [
+        assert list(AzureFileShareHook.get_ui_field_behaviour()["placeholders"]) == [
             "login",
             "password",
             "extra__azure_fileshare__sas_token",

--- a/tests/providers/microsoft/azure/hooks/test_wasb.py
+++ b/tests/providers/microsoft/azure/hooks/test_wasb.py
@@ -662,7 +662,7 @@ class TestWasbHook:
         Check that ensure_prefixes decorator working properly
         Note: remove this test when removing ensure_prefixes (after min airflow version >= 2.5.0
         """
-        assert list(WasbHook.get_ui_field_behaviour()["placeholders"].keys()) == [
+        assert list(WasbHook.get_ui_field_behaviour()["placeholders"]) == [
             "login",
             "password",
             "host",

--- a/tests/providers/microsoft/azure/operators/test_azure_container_instances.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_container_instances.py
@@ -35,13 +35,13 @@ def make_mock_cg(container_state, events=None):
     """
     events = events or []
     instance_view_dict = {"current_state": container_state, "events": events}
-    instance_view = namedtuple("InstanceView", instance_view_dict.keys())(*instance_view_dict.values())
+    instance_view = namedtuple("InstanceView", instance_view_dict)(*instance_view_dict.values())
 
     container_dict = {"instance_view": instance_view}
-    container = namedtuple("Container", container_dict.keys())(*container_dict.values())
+    container = namedtuple("Container", container_dict)(*container_dict.values())
 
     container_g_dict = {"containers": [container]}
-    container_g = namedtuple("ContainerGroup", container_g_dict.keys())(*container_g_dict.values())
+    container_g = namedtuple("ContainerGroup", container_g_dict)(*container_g_dict.values())
     return container_g
 
 
@@ -53,13 +53,13 @@ def make_mock_cg_with_missing_events(container_state):
     This can happen, when the container group is provisioned, but not started.
     """
     instance_view_dict = {"current_state": container_state, "events": None}
-    instance_view = namedtuple("InstanceView", instance_view_dict.keys())(*instance_view_dict.values())
+    instance_view = namedtuple("InstanceView", instance_view_dict)(*instance_view_dict.values())
 
     container_dict = {"instance_view": instance_view}
-    container = namedtuple("Container", container_dict.keys())(*container_dict.values())
+    container = namedtuple("Container", container_dict)(*container_dict.values())
 
     container_g_dict = {"containers": [container]}
-    container_g = namedtuple("ContainerGroup", container_g_dict.keys())(*container_g_dict.values())
+    container_g = namedtuple("ContainerGroup", container_g_dict)(*container_g_dict.values())
     return container_g
 
 

--- a/tests/providers/slack/hooks/test_slack.py
+++ b/tests/providers/slack/hooks/test_slack.py
@@ -466,7 +466,7 @@ class TestSlackHook:
 
         Note: remove this test when removing ensure_prefixes (after min airflow version >= 2.5.0
         """
-        assert list(SlackHook.get_ui_field_behaviour()["placeholders"].keys()) == [
+        assert list(SlackHook.get_ui_field_behaviour()["placeholders"]) == [
             "password",
             "extra__slack__timeout",
             "extra__slack__base_url",

--- a/tests/providers/slack/hooks/test_slack_webhook.py
+++ b/tests/providers/slack/hooks/test_slack_webhook.py
@@ -593,7 +593,7 @@ class TestSlackWebhookHook:
 
         Note: remove this test when removing ensure_prefixes (after min airflow version >= 2.5.0
         """
-        assert list(SlackWebhookHook.get_ui_field_behaviour()["placeholders"].keys()) == [
+        assert list(SlackWebhookHook.get_ui_field_behaviour()["placeholders"]) == [
             "schema",
             "host",
             "password",

--- a/tests/providers/snowflake/hooks/test_snowflake.py
+++ b/tests/providers/snowflake/hooks/test_snowflake.py
@@ -607,7 +607,7 @@ class TestPytestSnowflakeHook:
 
         Note: remove this test when removing ensure_prefixes (after min airflow version >= 2.5.0
         """
-        assert list(SnowflakeHook.get_ui_field_behaviour()["placeholders"].keys()) == [
+        assert list(SnowflakeHook.get_ui_field_behaviour()["placeholders"]) == [
             "extra",
             "schema",
             "login",

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -454,7 +454,7 @@ class TestStringifiedDAGs:
             items should not matter but assertEqual would fail if the order of
             items changes in the dag dictionary
             """
-            dag_dict["dag"]["tasks"] = sorted(dag_dict["dag"]["tasks"], key=lambda x: sorted(x.keys()))
+            dag_dict["dag"]["tasks"] = sorted(dag_dict["dag"]["tasks"], key=sorted)
             dag_dict["dag"]["_access_control"]["__var"]["test_role"]["__var"] = sorted(
                 dag_dict["dag"]["_access_control"]["__var"]["test_role"]["__var"]
             )
@@ -487,7 +487,7 @@ class TestStringifiedDAGs:
             stringified_dags[dag.dag_id] = dag
 
         dags = collect_dags("airflow/example_dags")
-        assert set(stringified_dags.keys()) == set(dags.keys())
+        assert set(stringified_dags) == set(dags)
 
         # Verify deserialized DAGs.
         for dag_id in stringified_dags:
@@ -1160,7 +1160,7 @@ class TestStringifiedDAGs:
         keys_for_backwards_compat: set = {
             "_concurrency",
         }
-        dag_params: set = set(dag_schema.keys()) - ignored_keys - keys_for_backwards_compat
+        dag_params: set = set(dag_schema) - ignored_keys - keys_for_backwards_compat
         assert set(DAG.get_serialized_fields()) == dag_params
 
     def test_operator_subclass_changing_base_defaults(self):

--- a/tests/system/providers/amazon/aws/example_ec2.py
+++ b/tests/system/providers/amazon/aws/example_ec2.py
@@ -57,8 +57,8 @@ def get_latest_ami_id():
         Owners=["amazon"],
     )
     # Sort on CreationDate
-    sorted_images = sorted(images["Images"], key=itemgetter("CreationDate"), reverse=True)
-    return sorted_images[0]["ImageId"]
+    latest_image = max(images["Images"], key=itemgetter("CreationDate"))
+    return latest_image["ImageId"]
 
 
 @task

--- a/tests/system/providers/amazon/aws/utils/ec2.py
+++ b/tests/system/providers/amazon/aws/utils/ec2.py
@@ -40,7 +40,7 @@ def _get_next_available_cidr(vpc_id: str) -> str:
     if len({block.prefixlen for block in existing_cidr_blocks}) > 1:
         raise ValueError(error_msg_template.format("Subnets do not all use the same CIDR block size."))
 
-    last_used_block = sorted(existing_cidr_blocks)[-1]
+    last_used_block = max(existing_cidr_blocks)
     *_, last_reserved_ip = last_used_block
     return f"{last_reserved_ip + 1}/{last_used_block.prefixlen}"
 

--- a/tests/test_utils/mock_plugins.py
+++ b/tests/test_utils/mock_plugins.py
@@ -54,7 +54,7 @@ def mock_plugin_manager(plugins=None, **kwargs):
     Use this context if you want your test to not have side effects in airflow.plugins_manager, and
     other tests do not affect the results of this test.
     """
-    illegal_arguments = set(kwargs.keys()) - set(PLUGINS_MANAGER_NULLABLE_ATTRIBUTES) - {"import_errors"}
+    illegal_arguments = set(kwargs) - set(PLUGINS_MANAGER_NULLABLE_ATTRIBUTES) - {"import_errors"}
     if illegal_arguments:
         raise TypeError(
             f"TypeError: mock_plugin_manager got an unexpected keyword arguments: {illegal_arguments}"

--- a/tests/test_utils/providers.py
+++ b/tests/test_utils/providers.py
@@ -53,6 +53,6 @@ def get_provider_min_airflow_version(provider_name):
 
     p = ProvidersManager()
     deps = p.providers[provider_name].data["dependencies"]
-    airflow_dep = [x for x in deps if x.startswith("apache-airflow")][0]
+    airflow_dep = next(x for x in deps if x.startswith("apache-airflow"))
     min_airflow_version = tuple(map(int, airflow_dep.split(">=")[1].split(".")))
     return min_airflow_version

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -190,7 +190,7 @@ def test_build_task_group_context_manager():
 
     assert dag.task_group.group_id is None
     assert dag.task_group.is_root
-    assert set(dag.task_group.children.keys()) == {"task1", "group234", "task5"}
+    assert set(dag.task_group.children) == {"task1", "group234", "task5"}
     assert group34.group_id == "group234.group34"
 
     assert task_group_to_dict(dag.task_group) == EXPECTED_JSON
@@ -698,8 +698,8 @@ def test_build_task_group_deco_context_manager():
         sec_1.set_downstream(task_end())
 
     # Testing TaskGroup created using taskgroup decorator
-    assert set(dag.task_group.children.keys()) == {"task_start", "task_end", "section_1"}
-    assert set(dag.task_group.children["section_1"].children.keys()) == {
+    assert set(dag.task_group.children) == {"task_start", "task_end", "section_1"}
+    assert set(dag.task_group.children["section_1"].children) == {
         "section_1.task_1",
         "section_1.task_2",
         "section_1.section_2",
@@ -815,8 +815,8 @@ def test_build_task_group_with_operators():
         sec_1.set_downstream(t_end)
 
     # Testing Tasks in DAG
-    assert set(dag.task_group.children.keys()) == {"section_1", "task_start", "task_end"}
-    assert set(dag.task_group.children["section_1"].children.keys()) == {
+    assert set(dag.task_group.children) == {"section_1", "task_start", "task_end"}
+    assert set(dag.task_group.children["section_1"].children) == {
         "section_1.task_2",
         "section_1.task_3",
         "section_1.task_1",

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -133,7 +133,7 @@ class TestUtils:
     def test_params_none_and_zero(self):
         query_str = utils.get_params(a=0, b=None, c="true")
         # The order won't be consistent, but that doesn't affect behaviour of a browser
-        pairs = list(sorted(query_str.split("&")))
+        pairs = sorted(query_str.split("&"))
         assert ["a=0", "c=true"] == pairs
 
     def test_params_all(self):
@@ -429,7 +429,7 @@ def test_dag_run_custom_sqla_interface_delete_no_collateral_damage(dag_maker, se
     assert len(set(x.run_id for x in dag_runs)) == 3
     run_id_for_single_delete = "scheduled__2023-01-01T00:00:00+00:00"
     # we have 3 runs with this same run_id
-    assert len(list(x for x in dag_runs if x.run_id == run_id_for_single_delete)) == 3
+    assert sum(1 for x in dag_runs if x.run_id == run_id_for_single_delete) == 3
     # each is a different dag
 
     # if we delete one, it shouldn't delete the others

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -433,7 +433,7 @@ def test_dag_run_custom_sqla_interface_delete_no_collateral_damage(dag_maker, se
     # each is a different dag
 
     # if we delete one, it shouldn't delete the others
-    one_run = [x for x in dag_runs if x.run_id == run_id_for_single_delete][0]
+    one_run = next(x for x in dag_runs if x.run_id == run_id_for_single_delete)
     assert interface.delete(item=one_run) is True
     session.commit()
     dag_runs = session.query(DagRun).all()

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -336,7 +336,7 @@ def client_all_dags_dagruns(acl_app, user_all_dags_dagruns):
 def test_dag_stats_success(client_all_dags_dagruns):
     resp = client_all_dags_dagruns.post("dag_stats", follow_redirects=True)
     check_content_in_response("example_bash_operator", resp)
-    assert set(list(resp.json.items())[0][1][0].keys()) == {"state", "count"}
+    assert set(next(iter(resp.json.items()))[1][0].keys()) == {"state", "count"}
 
 
 def test_task_stats_failure(dag_test_client):

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -336,7 +336,7 @@ def client_all_dags_dagruns(acl_app, user_all_dags_dagruns):
 def test_dag_stats_success(client_all_dags_dagruns):
     resp = client_all_dags_dagruns.post("dag_stats", follow_redirects=True)
     check_content_in_response("example_bash_operator", resp)
-    assert set(next(iter(resp.json.items()))[1][0].keys()) == {"state", "count"}
+    assert set(next(iter(resp.json.items()))[1][0]) == {"state", "count"}
 
 
 def test_task_stats_failure(dag_test_client):

--- a/tests/www/views/test_views_base.py
+++ b/tests/www/views/test_views_base.py
@@ -251,7 +251,7 @@ def test_views_get(request, url, client, content):
 
 
 def _check_task_stats_json(resp):
-    return set(list(resp.json.items())[0][1][0].keys()) == {"state", "count"}
+    return set(list(resp.json.items())[0][1][0]) == {"state", "count"}
 
 
 @pytest.mark.parametrize(

--- a/tests/www/views/test_views_home.py
+++ b/tests/www/views/test_views_home.py
@@ -154,7 +154,7 @@ def working_dags(tmpdir):
     dag_contents_template = "from airflow import DAG\ndag = DAG('{}', tags=['{}'])"
 
     with create_session() as session:
-        for dag_id, tag in list(zip(TEST_FILTER_DAG_IDS, TEST_TAGS)):
+        for dag_id, tag in zip(TEST_FILTER_DAG_IDS, TEST_TAGS):
             filename = os.path.join(tmpdir, f"{dag_id}.py")
             with open(filename, "w") as f:
                 f.writelines(dag_contents_template.format(dag_id, tag))
@@ -169,7 +169,7 @@ def working_dags_with_read_perm(tmpdir):
         "access_control={{'role_single_dag':{{'can_read'}}}}) "
     )
     with create_session() as session:
-        for dag_id, tag in list(zip(TEST_FILTER_DAG_IDS, TEST_TAGS)):
+        for dag_id, tag in zip(TEST_FILTER_DAG_IDS, TEST_TAGS):
             filename = os.path.join(tmpdir, f"{dag_id}.py")
             if dag_id == "filter_test_1":
                 with open(filename, "w") as f:
@@ -188,7 +188,7 @@ def working_dags_with_edit_perm(tmpdir):
         "access_control={{'role_single_dag':{{'can_edit'}}}}) "
     )
     with create_session() as session:
-        for dag_id, tag in list(zip(TEST_FILTER_DAG_IDS, TEST_TAGS)):
+        for dag_id, tag in zip(TEST_FILTER_DAG_IDS, TEST_TAGS):
             filename = os.path.join(tmpdir, f"{dag_id}.py")
             if dag_id == "filter_test_1":
                 with open(filename, "w") as f:

--- a/tests/www/views/test_views_trigger_dag.py
+++ b/tests/www/views/test_views_trigger_dag.py
@@ -194,7 +194,7 @@ def test_trigger_dag_params_conf(admin_client, request_conf, expected_conf):
     else:
         test_request_conf = json.dumps(request_conf, indent=4)
         resp = admin_client.get(f"dags/{test_dag_id}/trigger?conf={test_request_conf}&doc_md={doc_md}")
-    for key in expected_conf.keys():
+    for key in expected_conf:
         check_content_in_response(key, resp)
         check_content_in_response(str(expected_conf[key]), resp)
 


### PR DESCRIPTION
Another refactor round in four commits:

1. Replace creating entire lists in order to get the first element with a faster lazy construct
2. Optimize usage of `sorted()`
3. Drop unneeded usage of `list()`
4. Simplify string manipulation: `.startswith()` and `.endswith()` accept tuples of arguments


No change in functionality of the code.
