### PR TITLE
Fix wrong import for cloud build example

### DIFF
--- a/tests/system/providers/google/cloud/cloud_build/example_cloud_build.py
+++ b/tests/system/providers/google/cloud/cloud_build/example_cloud_build.py
@@ -31,9 +31,9 @@ import os
 from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
+from urllib.parse import urlsplit
 
 import yaml
-from future.backports.urllib.parse import urlsplit
 
 from airflow import models
 from airflow.models.baseoperator import chain

--- a/tests/system/providers/google/cloud/cloud_build/example_cloud_build_async.py
+++ b/tests/system/providers/google/cloud/cloud_build/example_cloud_build_async.py
@@ -31,9 +31,9 @@ import os
 from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
+from urllib.parse import urlparse
 
 import yaml
-from future.backports.urllib.parse import urlparse
 
 from airflow import models
 from airflow.models.baseoperator import chain


### PR DESCRIPTION
The import of urlparse in cloud build was importing "future" urlparse which is a Python 2 remnant (future library has been used in order to make a bridge between Python 2 and Python 3 and provided Python 3 - compatible implementation of some stdlib calls that could be used in both Puthon 3 and Python 2.

Apparently one of our  of our dependncies stopped pulling future in Python 3.11 so it started to fail our main with Python 3.11 because the future library is missing there.

This PR switches the import to regular urlparse.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
