### PR TITLE
Allow templating webserver ingress hostnames

### DIFF
--- a/chart/templates/webserver/webserver-ingress.yaml
+++ b/chart/templates/webserver/webserver-ingress.yaml
@@ -101,7 +101,7 @@ spec:
       {{- $hostname = .name -}}
       {{- end }}
       {{- if $hostname }}
-      host: {{ $hostname | quote }}
+      host: {{ include "common.tplvalues.render" ( dict "value" $hostname "context" $ ) | quote }}
       {{- end }}
     {{- end }}
   {{- if .Values.ingress.web.ingressClassName }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -140,6 +140,7 @@ ingress:
 
     # The hostnames or hosts configuration for the web Ingress
     hosts: []
+    #   # The hostname for the web Ingress (can be templated)
     # - name: ""
     #   # configs for web Ingress TLS
     #   tls:


### PR DESCRIPTION
I would like to propose allowing template values to webserver ingress hostnames.

Why is it needed?
Let's assume that we're providing airflow service to multiple teams.
By creating webserver ingress hostnames using <code>{{ .Release.Namespace }}</code> or <code>{{ .Release.Name }}</code>,
there is no need to create multiple values ​​files to store different hostnames ​​for each team.

Usage
```yaml
    hosts:
    #   # The hostname for the web Ingress (can be templated)
    - name: '{{ .Release.Namespace }}.airflow.service.com'
```

