### PR TITLE
Fix flaky sqlite tests with `test_xcom_map_nest` hopefully

### DIFF
--- a/tests/models/test_xcom_arg_map.py
+++ b/tests/models/test_xcom_arg_map.py
@@ -251,12 +251,12 @@ def test_xcom_map_nest(dag_maker, session):
     # Run "push".
     decision = dr.task_instance_scheduling_decisions(session=session)
     for ti in decision.schedulable_tis:
-        ti.run()
+        ti.run(session=session)
 
     # Now "pull" should apply the mapping functions in order.
     decision = dr.task_instance_scheduling_decisions(session=session)
     for ti in decision.schedulable_tis:
-        ti.run()
+        ti.run(session=session)
     assert results == {"aa", "bb", "cc"}
 
 


### PR DESCRIPTION
Recently sqlite started to fail randomly during teardown of `test_xcom_map_nest` or `test_xcom_map_zip_nest`. 
It looks very strange:

```
sqlite3.ProgrammingError: SQLite objects created in a thread can only be
used in that same thread
```

By analysing possible reasons it seems that it was a side effect of the existing `test_xcom_map_nest` that allocated a new session in the run method of task instance rather than pass the sesion that is created and torrn down in the pytest fixture.

The hypothesis is that the session created in the ``test_xcom_map_nest`` were being reclaimed and closed while the `test_xcom_map_zip_nest` test was already starting in a different thread started by Pytest.

The fix is to pass the session object to run method of the taskinstance in the ``test_xcom_map_nest`` test.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
