### PR TITLE
Attempt to stabilise tests for xcom_arg_map

### DIFF
--- a/tests/models/test_xcom_arg_map.py
+++ b/tests/models/test_xcom_arg_map.py
@@ -84,12 +84,12 @@ def test_xcom_map_transform_to_none(dag_maker, session):
     # Run "push".
     decision = dr.task_instance_scheduling_decisions(session=session)
     for ti in decision.schedulable_tis:
-        ti.run()
+        ti.run(session=session)
 
     # Run "pull". This should automatically convert "c" to None.
     decision = dr.task_instance_scheduling_decisions(session=session)
     for ti in decision.schedulable_tis:
-        ti.run()
+        ti.run(session=session)
     assert results == {"a", "b", None}
 
 
@@ -118,19 +118,19 @@ def test_xcom_convert_to_kwargs_fails_task(dag_maker, session):
     # Run "push".
     decision = dr.task_instance_scheduling_decisions(session=session)
     for ti in decision.schedulable_tis:
-        ti.run()
+        ti.run(session=session)
 
     # Prepare to run "pull"...
     decision = dr.task_instance_scheduling_decisions(session=session)
     tis = {(ti.task_id, ti.map_index): ti for ti in decision.schedulable_tis}
 
     # The first two "pull" tis should also succeed.
-    tis[("pull", 0)].run()
-    tis[("pull", 1)].run()
+    tis[("pull", 0)].run(session=session)
+    tis[("pull", 1)].run(session=session)
 
     # But the third one fails because the map() result cannot be used as kwargs.
     with pytest.raises(ValueError) as ctx:
-        tis[("pull", 2)].run()
+        tis[("pull", 2)].run(session=session)
     assert str(ctx.value) == "expand_kwargs() expects a list[dict], not list[None]"
 
     assert [tis[("pull", i)].state for i in range(3)] == [
@@ -163,7 +163,7 @@ def test_xcom_map_error_fails_task(dag_maker, session):
     # The "push" task should not fail.
     decision = dr.task_instance_scheduling_decisions(session=session)
     for ti in decision.schedulable_tis:
-        ti.run()
+        ti.run(session=session)
     assert [ti.state for ti in decision.schedulable_tis] == [TaskInstanceState.SUCCESS]
 
     # Prepare to run "pull"...
@@ -171,12 +171,12 @@ def test_xcom_map_error_fails_task(dag_maker, session):
     tis = {(ti.task_id, ti.map_index): ti for ti in decision.schedulable_tis}
 
     # The first two "pull" tis should also succeed.
-    tis[("pull", 0)].run()
-    tis[("pull", 1)].run()
+    tis[("pull", 0)].run(session=session)
+    tis[("pull", 1)].run(session=session)
 
     # But the third one (for "c") will fail.
     with pytest.raises(ValueError) as ctx:
-        tis[("pull", 2)].run()
+        tis[("pull", 2)].run(session=session)
     assert str(ctx.value) == "nope"
 
     assert [tis[("pull", i)].state for i in range(3)] == [
@@ -216,17 +216,17 @@ def test_xcom_map_raise_to_skip(dag_maker, session):
     # Run "push".
     decision = dr.task_instance_scheduling_decisions(session=session)
     for ti in decision.schedulable_tis:
-        ti.run()
+        ti.run(session=session)
 
     # Run "forward". This should automatically skip "c".
     decision = dr.task_instance_scheduling_decisions(session=session)
     for ti in decision.schedulable_tis:
-        ti.run()
+        ti.run(session=session)
 
     # Now "collect" should only get "a" and "b".
     decision = dr.task_instance_scheduling_decisions(session=session)
     for ti in decision.schedulable_tis:
-        ti.run()
+        ti.run(session=session)
     assert result == ["a", "b"]
 
 


### PR DESCRIPTION
Similarly to #33145 - this is an attempt to stabilise flaky tests for the test_xcom_arg_map.

Even if the mechanism is not entirely clear (provide_session should also close the connection) seems like using pytest-fixture provided session works better than relying on a new session created in run() methods.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
