### PR TITLE
Draft attempt to migrate to Sphinx 7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -299,18 +299,14 @@ doc = [
     # click 8.1.4 and 8.1.5 generate mypy errors due to typing issue in the upstream package:
     # https://github.com/pallets/click/issues/2558
     "click>=8.0,!=8.1.4,!=8.1.5",
-    # Docutils 0.17.0 converts generated <div class="section"> into <section> and breaks our doc formatting
-    # By adding a lot of whitespace separation. This limit can be lifted when we update our doc to handle
-    # <section> tags for sections
-    "docutils<0.17.0",
     "eralchemy2",
-    "sphinx-airflow-theme",
+    "sphinx-airflow-theme>=0.1.1b1",
     "sphinx-argparse>=0.1.13",
     "sphinx-autoapi>=2.0.0",
     "sphinx-copybutton",
     "sphinx-jinja>=2.0",
-    "sphinx-rtd-theme>=0.1.6",
-    "sphinx>=5.2.0",
+    "sphinx-rtd-theme==1.3.0rc1",
+    "sphinx>=7.0.0",
     "sphinxcontrib-httpdomain>=1.7.0",
     "sphinxcontrib-redoc>=1.6.0",
     "sphinxcontrib-spelling>=7.3",


### PR DESCRIPTION
The rtd theme we use sphinx-rtd-theme removed the limits that blocked us from using Sphinx 7 as tracked in the issue:

* https://github.com/readthedocs/sphinx_rtd_theme/pull/1464

This is the first attempt to update Sphinx to newer version and build our documentation.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
