### PR TITLE
Fix installing older airflow versions in Breeze with openssl fix

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import sys
 import threading
@@ -26,6 +27,7 @@ from typing import Iterable
 
 import click
 
+from airflow_breeze.branch_defaults import DEFAULT_AIRFLOW_CONSTRAINTS_BRANCH
 from airflow_breeze.commands.ci_image_commands import rebuild_or_pull_ci_image_if_needed
 from airflow_breeze.commands.main_command import main
 from airflow_breeze.global_constants import (
@@ -96,12 +98,26 @@ from airflow_breeze.utils.run_utils import (
 from airflow_breeze.utils.shared_options import get_dry_run, get_verbose, set_forced_answer
 from airflow_breeze.utils.visuals import ASCIIART, ASCIIART_STYLE, CHEATSHEET, CHEATSHEET_STYLE
 
-# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-# Make sure that whatever you add here as an option is also
-# Added in the "main" command in breeze.py. The min command above
-# Is used for a shorthand of shell and except the extra
-# Args it should have the same parameters.
-# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+def _determine_constraint_branch_used(airflow_constraints_reference: str, use_airflow_version: str | None):
+    """
+    Determine which constraints reference to use.
+
+    When use-airflow-version is branch or version, we derive the constraints branch from it, unless
+    someone specified the constraints branch explicitly.
+
+    :param airflow_constraints_reference: the constraint reference specified (or default)
+    :param use_airflow_version: which airflow version we are installing
+    :return: the actual constraints reference to use
+    """
+    if (
+        use_airflow_version
+        and airflow_constraints_reference == DEFAULT_AIRFLOW_CONSTRAINTS_BRANCH
+        and re.match(r"[0-9]+\.[0-9]+\.[0-9]+[0-9a-z\.]*|main|v[0-9]_.*", use_airflow_version)
+    ):
+        get_console().print(f"[info]Using constraints {use_airflow_version} - matching airflow version used.")
+        return use_airflow_version
+    return airflow_constraints_reference
 
 
 class TimerThread(threading.Thread):
@@ -114,6 +130,14 @@ class TimerThread(threading.Thread):
         sleep(self.max_time)
         get_console().print(f"[error]The command took longer than {self.max_time} s. Failing!")
         os.killpg(os.getpgid(0), SIGTERM)
+
+
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Make sure that whatever you add here as an option is also
+# Added in the "main" command in breeze.py. The min command above
+# Is used for a shorthand of shell and except the extra
+# Args it should have the same parameters.
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 
 @main.command()
@@ -181,6 +205,9 @@ def shell(
     if max_time:
         TimerThread(max_time=max_time).start()
         set_forced_answer("yes")
+    airflow_constraints_reference = _determine_constraint_branch_used(
+        airflow_constraints_reference, use_airflow_version
+    )
     result = enter_shell(
         python=python,
         github_repository=github_repository,
@@ -292,6 +319,10 @@ def start_airflow(
         skip_asset_compilation = True
     if use_airflow_version is None and not skip_asset_compilation:
         run_compile_www_assets(dev=dev_mode, run_in_background=True)
+    airflow_constraints_reference = _determine_constraint_branch_used(
+        airflow_constraints_reference, use_airflow_version
+    )
+
     result = enter_shell(
         python=python,
         github_repository=github_repository,

--- a/scripts/in_container/check_environment.sh
+++ b/scripts/in_container/check_environment.sh
@@ -123,6 +123,9 @@ function startairflow_if_requested() {
                 airflow connections create-default-connections
             fi
         else
+            echo "${COLOR_YELLOW}Failed to run 'airflow db migrate'.${COLOR_RESET}"
+            echo "${COLOR_BLUE}This could be because you are installing old airflow version${COLOR_RESET}"
+            echo "${COLOR_BLUE}Attempting to run deprecated 'airflow db init' instead.${COLOR_RESET}"
             # For Airflow versions that do not support db migrate, we should run airflow db init and
             # set the removed AIRFLOW__DATABASE__LOAD_DEFAULT_CONNECTIONS
             AIRFLOW__DATABASE__LOAD_DEFAULT_CONNECTIONS=${LOAD_DEFAULT_CONNECTIONS} airflow db init


### PR DESCRIPTION
The dnspython and Flask Application Builder have a weird transitive dependency to openssl. It does not require it - it is an optional dependnency of email validator that uses dnspython and the dnspython uses pyopenssl when installed. This is all fine. But when opendns is used with older FAB < 4.1.4) and NEWER opensl (>=23.0), just creating the FAB applicatio in flask causes an exception than there is a missing parameter in openssl.

Since openssl is NOT declared as required dependency in neither FAB nor dnspython, installing airflow with constraints while having a newer version of pyopenssl does not downgrade pyopenssl it is just mentioned in a conflicting message resulting from conflicts with other packages already installed (such as cryptography).

This caused a problem when installin older airflow version in breeze with --use-airflow-version switch.

Also - during checking this issue, it turned out that we were not
- by default - using the constraints for older version when installing it in breeze (you could do that by explicitly specifying the constraints). This was because when you used anoter way to specify versio (commit hash, tag) it is quite complex to figure out which constraints to use. However we can automatically derive constraints when you specify version, or branch, which are the most common scenarios.

This PR fixes the `--use-airflow-version` case for Airflow 2.4 and below by:

* automatically deriving the right constraints when version or branch are used in `--use-airflow-version`

* adding pyopenssl specifically as dependency when --use-airflow-version switch is used.

* also a small quality of life improvment - when airflow db migrate fails (because old versio of airflow does not support it) - we inform the user that it happened and that we are attempting to run the legacy airflow db init instead.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
