### PR TITLE
Skip trigger timeout check on occasional db deadlocks

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1653,21 +1653,34 @@ class SchedulerJobRunner(BaseJobRunner[Job], LoggingMixin):
     @provide_session
     def check_trigger_timeouts(self, session: Session = NEW_SESSION) -> None:
         """Mark any "deferred" task as failed if the trigger or execution timeout has passed."""
-        num_timed_out_tasks = session.execute(
-            update(TI)
-            .where(
-                TI.state == TaskInstanceState.DEFERRED,
-                TI.trigger_timeout < timezone.utcnow(),
-            )
-            .values(
-                state=TaskInstanceState.SCHEDULED,
-                next_method="__fail__",
-                next_kwargs={"error": "Trigger/execution timeout"},
-                trigger_id=None,
-            )
-        ).rowcount
-        if num_timed_out_tasks:
-            self.log.info("Timed out %i deferred tasks without fired triggers", num_timed_out_tasks)
+        for attempt in run_with_db_retries(logger=self.log):
+            with attempt:
+                self.log.debug(
+                    "Running SchedulerJob.check_trigger_timeouts with retries. Try %d of %d",
+                    attempt.retry_state.attempt_number,
+                    MAX_DB_RETRIES,
+                )
+                self.log.debug("Calling SchedulerJob.check_trigger_timeouts method")
+
+                try:
+                    num_timed_out_tasks = session.execute(
+                        update(TI)
+                        .where(
+                            TI.state == TaskInstanceState.DEFERRED,
+                            TI.trigger_timeout < timezone.utcnow(),
+                        )
+                        .values(
+                            state=TaskInstanceState.SCHEDULED,
+                            next_method="__fail__",
+                            next_kwargs={"error": "Trigger/execution timeout"},
+                            trigger_id=None,
+                        )
+                    ).rowcount
+                    if num_timed_out_tasks:
+                        self.log.info("Timed out %i deferred tasks without fired triggers", num_timed_out_tasks)
+                except OperationalError:
+                    session.rollback()
+                    raise
 
     def _find_zombies(self) -> None:
         """

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1653,34 +1653,29 @@ class SchedulerJobRunner(BaseJobRunner[Job], LoggingMixin):
     @provide_session
     def check_trigger_timeouts(self, session: Session = NEW_SESSION) -> None:
         """Mark any "deferred" task as failed if the trigger or execution timeout has passed."""
-        for attempt in run_with_db_retries(logger=self.log):
-            with attempt:
-                self.log.debug(
-                    "Running SchedulerJob.check_trigger_timeouts with retries. Try %d of %d",
-                    attempt.retry_state.attempt_number,
-                    MAX_DB_RETRIES,
-                )
-                self.log.debug("Calling SchedulerJob.check_trigger_timeouts method")
+        self.log.debug("Calling SchedulerJob.check_trigger_timeouts method")
 
-                try:
-                    num_timed_out_tasks = session.execute(
-                        update(TI)
-                        .where(
-                            TI.state == TaskInstanceState.DEFERRED,
-                            TI.trigger_timeout < timezone.utcnow(),
-                        )
-                        .values(
-                            state=TaskInstanceState.SCHEDULED,
-                            next_method="__fail__",
-                            next_kwargs={"error": "Trigger/execution timeout"},
-                            trigger_id=None,
-                        )
-                    ).rowcount
-                    if num_timed_out_tasks:
-                        self.log.info("Timed out %i deferred tasks without fired triggers", num_timed_out_tasks)
-                except OperationalError:
-                    session.rollback()
-                    raise
+        try:
+            num_timed_out_tasks = session.execute(
+                update(TI)
+                .where(
+                    TI.state == TaskInstanceState.DEFERRED,
+                    TI.trigger_timeout < timezone.utcnow(),
+                )
+                .values(
+                    state=TaskInstanceState.SCHEDULED,
+                    next_method="__fail__",
+                    next_kwargs={"error": "Trigger/execution timeout"},
+                    trigger_id=None,
+                )
+            ).rowcount
+            if num_timed_out_tasks:
+                self.log.info("Timed out %i deferred tasks without fired triggers", num_timed_out_tasks)
+        except OperationalError as e:
+            session.rollback()
+            self.log.warning(
+                f"Failed to check trigger timeouts due to {e}. Will reattempt at next scheduled check"
+            )
 
     def _find_zombies(self) -> None:
         """


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliancex

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/32698

We occasionally hit DB deadlocks during the trigger timeout check process. When this happens, the scheduler crashes. See linked [issue](https://github.com/apache/airflow/issues/32698) for graphs, traceback, etc.. I see two potential options:

1. Retry these transactions
2. Skip the check entirely and allow another replica or the next timeout check to run

At first, I was leaning toward option 1 but after seeing it in code, I worry that the retries will cause even more deadlocks. That is, if a user set AIRFLOW__DATABASE__MAX_DB_RETRIES to a high number (default is 3) and since AIRFLOW__SCHEDULER__TRIGGER_TIMEOUT_CHECK_INTERVAL already defaults to a very low number, 15s, this could increase deadlock likelihood and cause even more stress on the db. 

Therefore, going with 2. Please let me know what you think. This should allow us to avoid crashing the scheduler when deadlocks occur on this (not as critical) transaction.


## Manual Testing

Started breeze with the following configurations set:

```bash
export AIRFLOW__LOGGING__LOGGING_LEVEL=DEBUG
export AIRFLOW__SCHEDULER__TRIGGER_TIMEOUT_CHECK_INTERVAL=5
```

<img width="1355" alt="image" src="https://github.com/apache/airflow/assets/9200263/242270e0-5e54-476e-be30-daed1385e8e8">