### PR TITLE
Including env variables for statsd container

### DIFF
--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -97,6 +97,13 @@ spec:
             - "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
           {{- end }}
           resources: {{- toYaml .Values.statsd.resources | nindent 12 }}
+          {{- if .Values.statsd.env }}
+          env:
+            {{- range $i, $config := .Values.statsd.env }}
+            - value: {{ $config.value | quote }}
+              name: {{ $config.name | quote }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: statsd-ingest
               protocol: UDP

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4967,6 +4967,27 @@
                     "default": [
                         "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
                     ]
+                },
+                "env": {
+                    "description": "Add additional env vars to statsd container.",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "value"
+                        ],
+                        "additionalProperties": false
+                    }
                 }
             }
         },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1727,6 +1727,7 @@ statsd:
   overrideMappings: []
 
   podAnnotations: {}
+  env: []
 
 # PgBouncer settings
 pgbouncer:

--- a/helm_tests/other/test_statsd.py
+++ b/helm_tests/other/test_statsd.py
@@ -296,6 +296,21 @@ class TestStatsd:
             == "test_pod_annotation_value"
         )
 
+    def test_should_add_custom_env_variables(self):
+        env1 = {"name": "TEST_ENV_1", "value": "test_env_1"}
+
+        docs = render_chart(
+            values={
+                "statsd": {
+                    "enabled": True,
+                    "env": [env1],
+                },
+            },
+            show_only=["templates/statsd/statsd-deployment.yaml"],
+        )[0]
+
+        assert jmespath.search("spec.template.spec.containers[0].env", docs) == [env1]
+
 
 class TestStatsdServiceAccount:
     """Tests statsd service account."""


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Notices while running some helm tests that all the charts and deployments except statsd support having env variable injection in them through helm values. Attempting to reduce the gap between deployments through this common use case.



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
