### PR TITLE
Add marker for a test to run ti with test mode

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -269,6 +269,7 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "backend(name): mark test to run with named backend")
     config.addinivalue_line("markers", "system(name): mark test to run with named system")
     config.addinivalue_line("markers", "long_running: mark test that run for a long time (many minutes)")
+    config.addinivalue_line("markers", "ti_test_mode: mark tests that runs task instance with test_mode=True")
     config.addinivalue_line(
         "markers", "quarantined: mark test that are in quarantine (i.e. flaky, need to be isolated and fixed)"
     )
@@ -942,3 +943,9 @@ def initialize_providers_manager():
     from airflow.providers_manager import ProvidersManager
 
     ProvidersManager().initialize_providers_configuration()
+
+
+@pytest.fixture(autouse=True)
+def set_ti_test_mode(request, monkeypatch):
+    if request.node.get_closest_marker("ti_test_mode"):
+        monkeypatch.setattr("airflow.models.taskinstance.TEST_MODE", True)

--- a/tests/models/test_xcom_arg_map.py
+++ b/tests/models/test_xcom_arg_map.py
@@ -140,6 +140,7 @@ def test_xcom_convert_to_kwargs_fails_task(dag_maker, session):
     ]
 
 
+@pytest.mark.ti_test_mode
 def test_xcom_map_error_fails_task(dag_maker, session):
     with dag_maker(session=session) as dag:
 


### PR DESCRIPTION
There are three layers in the change: First, the test_mode default is changed to take a None instead so we can calculate the value lazily. Second, a global constant is introduced to hold the actual default at runtime, and substitute the value when given None. Finally, a Pytest marker is introduced to set the default to True for selected tests.

We could potentially set the value to True globally, but I'm not sure how this would affect older tests that might be less well structured. With this marker mechanism we can hopefully make the process more gradual without breaking a ton of things.

See also #33178.