### PR TITLE
respect soft_fail argument when ExternalTaskSensor runs in deferrable mode

### DIFF
--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -330,6 +330,12 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
     def get_serialized_fields(cls):
         return super().get_serialized_fields() | {"reschedule"}
 
+    def raise_failed_or_skiping_exception(self, failed_message: str, skipping_message: str = "") -> None:
+        """Raise AirflowSkipException if self.soft_fail is set to True. Otherwise raise AirflowException."""
+        if self.soft_fail:
+            raise AirflowSkipException(skipping_message or failed_message)
+        raise AirflowException(failed_message)
+
 
 def poke_mode_only(cls):
     """

--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -330,7 +330,7 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
     def get_serialized_fields(cls):
         return super().get_serialized_fields() | {"reschedule"}
 
-    def raise_failed_or_skiping_exception(self, failed_message: str, skipping_message: str = "") -> None:
+    def raise_failed_or_skiping_exception(self, *, failed_message: str, skipping_message: str = "") -> None:
         """Raise AirflowSkipException if self.soft_fail is set to True. Otherwise raise AirflowException."""
         if self.soft_fail:
             raise AirflowSkipException(skipping_message or failed_message)


### PR DESCRIPTION
We notice that not all the sensors respect [soft_fail](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/sensors/base/index.html#airflow.sensors.base.BaseSensorOperator). This PR is meant to demonstrate how I'd like to address this issue. Will send PRs to fix other sensors when we finalize the way to fix it.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
