### PR TITLE
Fix xcom view returning bytes as xcom value

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1926,15 +1926,15 @@ class Airflow(AirflowBaseView):
             flash(f"Task [{dag_id}.{task_id}] doesn't seem to exist at the moment", "error")
             return redirect(url_for("Airflow.index"))
 
-        xcom_query = session.execute(
-            select(XCom.key, XCom.value).where(
+        xcom_query = session.scalars(
+            select(XCom).where(
                 XCom.dag_id == dag_id,
                 XCom.task_id == task_id,
                 XCom.execution_date == dttm,
                 XCom.map_index == map_index,
             )
         )
-        attributes = [(k, v) for k, v in xcom_query if not k.startswith("_")]
+        attributes = [(xcom.key, xcom.value) for xcom in xcom_query if not xcom.key.startswith("_")]
 
         title = "XCom"
         return self.render_template(


### PR DESCRIPTION
XCom.value is a LargeBinary column type and making a select/query directly on a LargeBinary column results in SQLALchemy returning byte data. This commit fixes this issue that resulted in xcom value displayed as byte data in the UI

