### PR TITLE
change order of issues for stale bot

### DIFF
--- a/.github/workflows/recheck-old-bug-report.yml
+++ b/.github/workflows/recheck-old-bug-report.yml
@@ -43,6 +43,7 @@ jobs:
           remove-stale-when-updated: false
           remove-issue-stale-when-updated: true
           labels-to-add-when-unstale: 'needs-triage'
+          ascending: true
           stale-issue-message: >
             This issue has been automatically marked as stale because it has been open for 365 days
             without any activity. There has been several Airflow releases since last activity on this issue.


### PR DESCRIPTION
This is temporary change.
The bot doesn't pick up all relevant issues I'd like to see if how it behaves with a few scans with the opposite order