### PR TITLE
Gantt chart: Use earliest/oldest ti dates for chart duration

### DIFF
--- a/airflow/www/static/js/dag/details/gantt/GanttTooltip.tsx
+++ b/airflow/www/static/js/dag/details/gantt/GanttTooltip.tsx
@@ -42,6 +42,9 @@ const GanttTooltip = ({ task, instance }: Props) => {
       <Text>
         Task{isGroup ? " Group" : ""}: {task.label}
       </Text>
+      {!!instance?.tryNumber && instance.tryNumber > 1 && (
+        <Text>Try Number: {instance.tryNumber}</Text>
+      )}
       <br />
       {instance?.queuedDttm && (
         <Text>

--- a/airflow/www/static/js/dag/details/gantt/Row.tsx
+++ b/airflow/www/static/js/dag/details/gantt/Row.tsx
@@ -24,24 +24,31 @@ import { getDuration } from "src/datetime_utils";
 import { SimpleStatus } from "src/dag/StatusBox";
 import { useContainerRef } from "src/context/containerRef";
 import { hoverDelay } from "src/utils";
-import type { DagRun, Task } from "src/types";
+import type { Task } from "src/types";
 import GanttTooltip from "./GanttTooltip";
 
 interface Props {
   ganttWidth?: number;
   openGroupIds: string[];
-  dagRun: DagRun;
   task: Task;
+  ganttStartDate?: string | null;
+  ganttEndDate?: string | null;
 }
 
-const Row = ({ ganttWidth = 500, openGroupIds, task, dagRun }: Props) => {
+const Row = ({
+  ganttWidth = 500,
+  openGroupIds,
+  task,
+  ganttStartDate,
+  ganttEndDate,
+}: Props) => {
   const {
     selected: { runId, taskId },
     onSelect,
   } = useSelection();
   const containerRef = useContainerRef();
 
-  const runDuration = getDuration(dagRun?.startDate, dagRun?.endDate);
+  const runDuration = getDuration(ganttStartDate, ganttEndDate);
 
   const instance = task.instances.find((ti) => ti.runId === runId);
   const isSelected = taskId === instance?.taskId;
@@ -54,7 +61,7 @@ const Row = ({ ganttWidth = 500, openGroupIds, task, dagRun }: Props) => {
     ? getDuration(instance?.queuedDttm, instance?.startDate)
     : 0;
   const taskStartOffset = getDuration(
-    dagRun.startDate,
+    ganttStartDate,
     instance?.queuedDttm || instance?.startDate
   );
 
@@ -127,7 +134,8 @@ const Row = ({ ganttWidth = 500, openGroupIds, task, dagRun }: Props) => {
           <Row
             ganttWidth={ganttWidth}
             openGroupIds={openGroupIds}
-            dagRun={dagRun}
+            ganttStartDate={ganttStartDate}
+            ganttEndDate={ganttEndDate}
             task={c}
             key={`gantt-${c.id}`}
           />


### PR DESCRIPTION
When retrying a task, the end date could become later than the dag run end date. So to make sure we always capture the whole dag run, we should check the task instance queued/start/end when determining the bounds of the gantt chart.

Also, included the try number of the task instance to help explain why a task might not be in order.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
