### PR TITLE
Fix venv detection for Python virtualenv operator

### DIFF
--- a/airflow/example_dags/example_python_operator.py
+++ b/airflow/example_dags/example_python_operator.py
@@ -22,7 +22,6 @@ virtual environment.
 from __future__ import annotations
 
 import logging
-import shutil
 import sys
 import tempfile
 import time
@@ -32,7 +31,7 @@ import pendulum
 
 from airflow import DAG
 from airflow.decorators import task
-from airflow.operators.python import ExternalPythonOperator, PythonVirtualenvOperator
+from airflow.operators.python import ExternalPythonOperator, PythonVirtualenvOperator, is_venv_installed
 
 log = logging.getLogger(__name__)
 
@@ -86,7 +85,7 @@ with DAG(
         run_this >> log_the_sql >> sleeping_task
     # [END howto_operator_python_kwargs]
 
-    if not shutil.which("virtualenv"):
+    if not is_venv_installed():
         log.warning("The virtalenv_python example task requires virtualenv, please install it.")
     else:
         # [START howto_operator_python_venv]

--- a/airflow/example_dags/tutorial_taskflow_api_virtualenv.py
+++ b/airflow/example_dags/tutorial_taskflow_api_virtualenv.py
@@ -18,14 +18,14 @@
 from __future__ import annotations
 
 import logging
-import shutil
 from datetime import datetime
 
 from airflow.decorators import dag, task
+from airflow.operators.python import is_venv_installed
 
 log = logging.getLogger(__name__)
 
-if not shutil.which("virtualenv"):
+if not is_venv_installed():
     log.warning("The tutorial_taskflow_api_virtualenv example DAG requires virtualenv, please install it.")
 else:
 

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -22,6 +22,7 @@ import inspect
 import logging
 import os
 import pickle
+import shutil
 import subprocess
 import sys
 import types
@@ -52,6 +53,17 @@ from airflow.utils.python_virtualenv import prepare_virtualenv, write_python_scr
 
 if TYPE_CHECKING:
     from pendulum.datetime import DateTime
+
+
+def is_venv_installed() -> bool:
+    """
+    Checks if the virtualenv package is installed via checking if it is on the path or installed as package.
+
+    :return: True if it is. Whichever way of checking it works, is fine.
+    """
+    if shutil.which("virtualenv") or importlib.util.find_spec("virtualenv"):
+        return True
+    return False
 
 
 def task(python_callable: Callable | None = None, multiple_outputs: bool | None = None, **kwargs):
@@ -540,7 +552,7 @@ class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
                 "major versions for PythonVirtualenvOperator. Please use string_args."
                 f"Sys version: {sys.version_info}. Venv version: {python_version}"
             )
-        if importlib.util.find_spec("virtualenv") is None:
+        if not is_venv_installed():
             raise AirflowException("PythonVirtualenvOperator requires virtualenv, please install it.")
         if not requirements:
             self.requirements: list[str] | str = []

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -847,9 +847,11 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
         kwargs["python_version"] = python_version
         return kwargs
 
+    @mock.patch("shutil.which")
     @mock.patch("airflow.operators.python.importlib")
-    def test_virtuenv_not_installed(self, importlib):
-        importlib.util.find_spec.return_value = None
+    def test_virtuenv_not_installed(self, importlib_mock, which_mock):
+        which_mock.return_value = None
+        importlib_mock.util.find_spec.return_value = None
         with pytest.raises(AirflowException, match="requires virtualenv"):
 
             def f():


### PR DESCRIPTION
This is a follow-up after #32939. It seems that findspec does not cover all the cases and the previous check is also faster.

Adding check for the binary first and then falling back to spec finding will make it faster and work in the cases where the findspec does not work (for local development cases).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
