### PR TITLE
Make the `OnFinishAction` enum inherit from str to support passing it to `KubernetesPodOperatpor`

### DIFF
--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -723,7 +723,7 @@ class PodManager(LoggingMixin):
         return res
 
 
-class OnFinishAction(enum.Enum):
+class OnFinishAction(str, enum.Enum):
     """Action to take when the pod finishes."""
 
     KEEP_POD = "keep_pod"


### PR DESCRIPTION
![Screenshot from 2023-08-08 21-46-02](https://github.com/apache/airflow/assets/10202690/e1e0d35c-b5d9-4abb-b1ea-7e280980cd34)
