### PR TITLE
For now limit Pydantic to < 2.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -126,7 +126,10 @@ install_requires =
     pendulum>=2.0
     pluggy>=1.0
     psutil>=4.2.0
-    pydantic>=1.10.0
+    # We limit Pydantic to 2.0.0 until we can upgrade - there are limitation for Pydantic in AWS provider
+    # dependency (aws-sam-translator) - also we need to change orm-mode to from_attributes in definitions
+    # of the ORM models. See for the previous attempt https://github.com/apache/airflow/pull/33220
+    pydantic>=1.10.0,<2.0.0
     pygments>=2.0.1
     pyjwt>=2.0.0
     python-daemon>=3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -126,7 +126,7 @@ install_requires =
     pendulum>=2.0
     pluggy>=1.0
     psutil>=4.2.0
-    # We limit Pydantic to 2.0.0 until we can upgrade - there are limitation for Pydantic in AWS provider
+    # We limit Pydantic to <2.0.0 until we can upgrade - there are limitation for Pydantic in AWS provider
     # dependency (aws-sam-translator) - also we need to change orm-mode to from_attributes in definitions
     # of the ORM models. See for the previous attempt https://github.com/apache/airflow/pull/33220
     pydantic>=1.10.0,<2.0.0


### PR DESCRIPTION
Pydantic 2 adds few warnings/deprecations and until AWS dependencies are updated, we cannot move to it anyway.

Limiting Pydantic to <2 for now should prevent the warnings and heep our dependencies in check.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
