### PR TITLE
Add missing re2 dependency to cncf.kubernetes and celery providers

### DIFF
--- a/airflow/providers/celery/provider.yaml
+++ b/airflow/providers/celery/provider.yaml
@@ -46,6 +46,7 @@ dependencies:
   # Make sure that the limit here is synchronized with [celery] extra in the airflow core
   - celery>=5.2.3,<6
   - flower>=1.0.0
+  - google-re2>=1.0
 
 integrations:
   - integration-name: Celery

--- a/airflow/providers/cncf/kubernetes/provider.yaml
+++ b/airflow/providers/cncf/kubernetes/provider.yaml
@@ -82,6 +82,7 @@ dependencies:
   # (started from current 24.2.2 version) to prevent introducing some problems that could be due to some
   #  major changes in the package.
   - kubernetes_asyncio>=18.20.1,<25
+  - google-re2>=1.0
 
 integrations:
   - integration-name: Kubernetes

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -266,6 +266,7 @@
       "apache-airflow>=2.4.0",
       "asgiref>=3.5.2",
       "cryptography>=2.0.0",
+      "google-re2>=1.0",
       "kubernetes>=21.7.0,<24",
       "kubernetes_asyncio>=18.20.1,<25"
     ],

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -246,7 +246,8 @@
     "deps": [
       "apache-airflow>=2.4.0",
       "celery>=5.2.3,<6",
-      "flower>=1.0.0"
+      "flower>=1.0.0",
+      "google-re2>=1.0"
     ],
     "cross-providers-deps": [
       "cncf.kubernetes"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
re lib was replaced by re2 in Airflow core and Kubernetes (#32303), and the dependency was added only to Airflow setup (#32060). However, when we install the Kubernetes provider with an old version of Airflow, the provider will be broken because the re2 is not installed automatically, and we need to add it explicitly:
```bash
python -m venv airflow_2_4_3

airflow_2_4_3/bin/pip install apache_airflow==2.4.3

airflow_2_4_3/bin/pip install apache-airflow-providers-cncf-kubernetes==7.4.1

airflow_2_4_3/bin/python

Python 3.9.13 (main, Oct 13 2022, 21:15:33) 
[GCC 11.2.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from airflow.providers.cncf.kubernetes.pod import KubernetesPodOperator
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<PATH TO VENV>/airflow/__init__.py", line 52, in <module>
    from airflow import configuration, settings
  File "<PATH TO VENV>/airflow/configuration.py", line 41, in <module>
    import re2
ModuleNotFoundError: No module named 're2'
```
I think we'll have the same problem with celery provider when we want to use the new executor with the old Airflow versions (>=2.4.0, <2.7.0).

This PR add `google-re2` dependency to cncf.kubernetes and celery providers.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
