### PR TITLE
Remove add_task from TaskGroup

### DIFF
--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -360,14 +360,6 @@ class AbstractOperator(Templater, DAGNode):
                 yield parent
             parent = parent.task_group
 
-    def add_to_taskgroup(self, task_group: TaskGroup) -> None:
-        """Add the task to the given task group.
-
-        :meta private:
-        """
-        if self.node_id not in task_group.children:
-            task_group.add(self)
-
     def get_closest_mapped_task_group(self) -> MappedTaskGroup | None:
         """Get the mapped task group "closest" to this task in the DAG.
 

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -113,11 +113,6 @@ class DependencyMixin:
         self.__rshift__(other)
         return self
 
-    @abstractmethod
-    def add_to_taskgroup(self, task_group: TaskGroup) -> None:
-        """Add the task to the given task group."""
-        raise NotImplementedError()
-
     @classmethod
     def _iter_references(cls, obj: Any) -> Iterable[tuple[DependencyMixin, str]]:
         from airflow.models.baseoperator import AbstractOperator

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -43,7 +43,6 @@ from airflow.utils.xcom import XCOM_RETURN_KEY
 if TYPE_CHECKING:
     from airflow.models.dag import DAG
     from airflow.models.operator import Operator
-    from airflow.utils.task_group import TaskGroup
 
 # Callable objects contained by MapXComArg. We only accept callables from
 # the user, but deserialize them into strings in a serialized XComArg for
@@ -208,15 +207,6 @@ class XComArg(ResolveMixin, DependencyMixin):
         :meta private:
         """
         raise NotImplementedError()
-
-    def add_to_taskgroup(self, task_group: TaskGroup) -> None:
-        """Add the task to the given task group.
-
-        :meta private:
-        """
-        for op, _ in self.iter_references():
-            if op.node_id not in task_group.children:
-                task_group.add(op)
 
     def __enter__(self):
         if not self.operator.is_setup and not self.operator.is_teardown:

--- a/airflow/utils/edgemodifier.py
+++ b/airflow/utils/edgemodifier.py
@@ -169,15 +169,6 @@ class EdgeModifier(DependencyMixin):
         """
         dag.set_edge_info(upstream_id, downstream_id, {"label": self.label})
 
-    def add_to_taskgroup(self, task_group: TaskGroup) -> None:
-        """No-op, since we're not a task.
-
-        We only add tasks to TaskGroups and not EdgeModifiers, but we need
-        this to satisfy the interface.
-
-        :meta private:
-        """
-
 
 # Factory functions
 def Label(label: str):

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -551,26 +551,6 @@ class TaskGroup(DAGNode):
                         f"Encountered a DAGNode that is not a TaskGroup or an AbstractOperator: {type(child)}"
                     )
 
-    def add_task(self, task: AbstractOperator) -> None:
-        """Add a task to the task group.
-
-        :param task: the task to add
-        """
-        if not TaskGroupContext.active:
-            raise AirflowException(
-                "Using this method on a task group that's not a context manager is not supported."
-            )
-        task.add_to_taskgroup(self)
-
-    def add_to_taskgroup(self, task_group: TaskGroup) -> None:
-        """No-op, since we're not a task.
-
-        We only add tasks to TaskGroups and not TaskGroup, but we need
-        this to satisfy the interface.
-
-        :meta private:
-        """
-
 
 class MappedTaskGroup(TaskGroup):
     """A mapped task group.


### PR DESCRIPTION
This was added during work for AIP-52, taking inspiration from the method on the setupteardowncontext object.  But it causes problems because it's assumed in the task_id label logic that if the group is set to prefix task ids then the task id has been prefixed.  This results in bad graph labeling in UI.  Rather than fix it now, at release time, better to revert.
