### PR TITLE
Add parameter sftp_prefetch to SFTPToGCSOperator

### DIFF
--- a/airflow/providers/google/cloud/transfers/sftp_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/sftp_to_gcs.py
@@ -69,7 +69,7 @@ class SFTPToGCSOperator(BaseOperator):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
-    :param sftp_prefetch: Whether to enable SFTP prefetch, the default is False.
+    :param sftp_prefetch: Whether to enable SFTP prefetching, the default is True.
     """
 
     template_fields: Sequence[str] = (
@@ -91,7 +91,7 @@ class SFTPToGCSOperator(BaseOperator):
         gzip: bool = False,
         move_object: bool = False,
         impersonation_chain: str | Sequence[str] | None = None,
-        sftp_prefetch: bool = False,
+        sftp_prefetch: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -154,7 +154,7 @@ class SFTPToGCSOperator(BaseOperator):
         )
 
         with NamedTemporaryFile("w") as tmp:
-            sftp_hook.get_conn().get(source_path, tmp.name, prefetch=self.sftp_prefetch)
+            sftp_hook.retrieve_file(source_path, tmp.name, prefetch=self.sftp_prefetch)
 
             gcs_hook.upload(
                 bucket_name=self.destination_bucket,

--- a/airflow/providers/google/cloud/transfers/sftp_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/sftp_to_gcs.py
@@ -69,7 +69,7 @@ class SFTPToGCSOperator(BaseOperator):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
-    :param sftp_prefetch: Whether to enable SFTP prefetching, the default is True.
+    :param sftp_prefetch: Whether to enable SFTP prefetch, the default is True.
     """
 
     template_fields: Sequence[str] = (

--- a/airflow/providers/google/cloud/transfers/sftp_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/sftp_to_gcs.py
@@ -69,6 +69,7 @@ class SFTPToGCSOperator(BaseOperator):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
+    :param sftp_prefetch: Whether to enable SFTP prefetch, the default is False.
     """
 
     template_fields: Sequence[str] = (
@@ -90,6 +91,7 @@ class SFTPToGCSOperator(BaseOperator):
         gzip: bool = False,
         move_object: bool = False,
         impersonation_chain: str | Sequence[str] | None = None,
+        sftp_prefetch: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -103,6 +105,7 @@ class SFTPToGCSOperator(BaseOperator):
         self.sftp_conn_id = sftp_conn_id
         self.move_object = move_object
         self.impersonation_chain = impersonation_chain
+        self.sftp_prefetch = sftp_prefetch
 
     def execute(self, context: Context):
         gcs_hook = GCSHook(
@@ -151,7 +154,7 @@ class SFTPToGCSOperator(BaseOperator):
         )
 
         with NamedTemporaryFile("w") as tmp:
-            sftp_hook.retrieve_file(source_path, tmp.name)
+            sftp_hook.get_conn().get(source_path, tmp.name, prefetch=self.sftp_prefetch)
 
             gcs_hook.upload(
                 bucket_name=self.destination_bucket,

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -231,7 +231,7 @@ class SFTPHook(SSHHook):
 
         :param remote_full_path: full path to the remote file
         :param local_full_path: full path to the local file
-        :param prefetch: controls whether prefetching is performed (default: True)
+        :param prefetch: controls whether prefetch is performed (default: True)
         """
         conn = self.get_conn()
         conn.get(remote_full_path, local_full_path, prefetch=prefetch)

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -223,7 +223,7 @@ class SFTPHook(SSHHook):
         conn = self.get_conn()
         conn.rmdir(path)
 
-    def retrieve_file(self, remote_full_path: str, local_full_path: str) -> None:
+    def retrieve_file(self, remote_full_path: str, local_full_path: str, prefetch: bool = True) -> None:
         """Transfer the remote file to a local location.
 
         If local_full_path is a string path, the file will be put
@@ -231,9 +231,10 @@ class SFTPHook(SSHHook):
 
         :param remote_full_path: full path to the remote file
         :param local_full_path: full path to the local file
+        :param prefetch: controls whether prefetching is performed (default: True)
         """
         conn = self.get_conn()
-        conn.get(remote_full_path, local_full_path)
+        conn.get(remote_full_path, local_full_path, prefetch=prefetch)
 
     def store_file(self, remote_full_path: str, local_full_path: str, confirm: bool = True) -> None:
         """Transfer a local file to the remote location.

--- a/airflow/providers/sftp/provider.yaml
+++ b/airflow/providers/sftp/provider.yaml
@@ -54,6 +54,7 @@ versions:
 dependencies:
   - apache-airflow>=2.4.0
   - apache-airflow-providers-ssh>=2.1.0
+  - paramiko>=2.8.0
 
 integrations:
   - integration-name: SSH File Transfer Protocol (SFTP)

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -794,7 +794,8 @@
   "sftp": {
     "deps": [
       "apache-airflow-providers-ssh>=2.1.0",
-      "apache-airflow>=2.4.0"
+      "apache-airflow>=2.4.0",
+      "paramiko>=2.8.0"
     ],
     "cross-providers-deps": [
       "openlineage",

--- a/tests/providers/google/cloud/transfers/test_sftp_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_sftp_to_gcs.py
@@ -64,7 +64,6 @@ class TestSFTPToGCSOperator:
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
-            sftp_prefetch=False,
         )
         task.execute(None)
         gcs_hook.assert_called_once_with(
@@ -72,10 +71,11 @@ class TestSFTPToGCSOperator:
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         sftp_hook.assert_called_once_with(SFTP_CONN_ID)
-        sftp_hook.return_value.get_conn.return_value.get.assert_called_once_with(
-            os.path.join(SOURCE_OBJECT_NO_WILDCARD),
-            mock.ANY,
-            prefetch=False)
+
+        sftp_hook.return_value.retrieve_file.assert_called_once_with(
+            os.path.join(SOURCE_OBJECT_NO_WILDCARD), mock.ANY, prefetch=True
+        )
+
         gcs_hook.return_value.upload.assert_called_once_with(
             bucket_name=TEST_BUCKET,
             object_name=DESTINATION_PATH_FILE,
@@ -99,7 +99,7 @@ class TestSFTPToGCSOperator:
             sftp_conn_id=SFTP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
             gzip=True,
-            sftp_prefetch=True,
+            sftp_prefetch=False,
         )
         task.execute(None)
         gcs_hook.assert_called_once_with(
@@ -108,10 +108,9 @@ class TestSFTPToGCSOperator:
         )
         sftp_hook.assert_called_once_with(SFTP_CONN_ID)
 
-        sftp_hook.return_value.get_conn.return_value.get.assert_called_once_with(
-            os.path.join(SOURCE_OBJECT_NO_WILDCARD),
-            mock.ANY,
-            prefetch=True)
+        sftp_hook.return_value.retrieve_file.assert_called_once_with(
+            os.path.join(SOURCE_OBJECT_NO_WILDCARD), mock.ANY, prefetch=False
+        )
 
         gcs_hook.return_value.upload.assert_called_once_with(
             bucket_name=TEST_BUCKET,
@@ -135,6 +134,7 @@ class TestSFTPToGCSOperator:
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
+            sftp_prefetch=True,
         )
         task.execute(None)
         gcs_hook.assert_called_once_with(
@@ -143,10 +143,9 @@ class TestSFTPToGCSOperator:
         )
         sftp_hook.assert_called_once_with(SFTP_CONN_ID)
 
-        sftp_hook.return_value.get_conn.return_value.get.assert_called_once_with(
-            os.path.join(SOURCE_OBJECT_NO_WILDCARD),
-            mock.ANY,
-            prefetch=False)
+        sftp_hook.return_value.retrieve_file.assert_called_once_with(
+            os.path.join(SOURCE_OBJECT_NO_WILDCARD), mock.ANY, prefetch=True
+        )
 
         gcs_hook.return_value.upload.assert_called_once_with(
             bucket_name=TEST_BUCKET,
@@ -182,11 +181,11 @@ class TestSFTPToGCSOperator:
             "main_dir", prefix="main_dir/test_object", delimiter=".json"
         )
 
-        sftp_hook.return_value.get_conn.return_value.get.assert_has_calls(
-          [
-              mock.call("main_dir/test_object3.json", mock.ANY, prefetch=False),
-              mock.call("main_dir/sub_dir/test_object3.json", mock.ANY, prefetch=False),
-          ]
+        sftp_hook.return_value.retrieve_file.assert_has_calls(
+            [
+                mock.call("main_dir/test_object3.json", mock.ANY, prefetch=True),
+                mock.call("main_dir/sub_dir/test_object3.json", mock.ANY, prefetch=True),
+            ]
         )
 
         gcs_hook.return_value.upload.assert_has_calls(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The current `SFTPHook.retrieve_file(...)` has SFTP prefetch enabled which makes it fail to download SFTP files in some cases. This change allows the user to set prefetch and sets the default to True to keep backwards compatibility.

<!-- Please keep an empty line above the dashes. -->
---