### PR TITLE
Allow 'airflow variables export' to print to stdout

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -543,7 +543,11 @@ ARG_DEFAULT = Arg(
 ARG_DESERIALIZE_JSON = Arg(("-j", "--json"), help="Deserialize JSON variable", action="store_true")
 ARG_SERIALIZE_JSON = Arg(("-j", "--json"), help="Serialize JSON variable", action="store_true")
 ARG_VAR_IMPORT = Arg(("file",), help="Import variables from JSON file")
-ARG_VAR_EXPORT = Arg(("file",), help="Export all variables to JSON file")
+ARG_VAR_EXPORT = Arg(
+    ("file",),
+    help="Export all variables to JSON file",
+    type=argparse.FileType("w", encoding="UTF-8"),
+)
 
 # kerberos
 ARG_PRINCIPAL = Arg(("principal",), help="kerberos principal", nargs="?")
@@ -1521,6 +1525,10 @@ VARIABLES_COMMANDS = (
     ActionCommand(
         name="export",
         help="Export all variables",
+        description=(
+            "All variables can be exported in STDOUT using the following command:\n"
+            "airflow variables export -\n"
+        ),
         func=lazy_load_command("airflow.cli.commands.variable_command.variables_export"),
         args=(ARG_VAR_EXPORT, ARG_VERBOSE),
     ),

--- a/airflow/cli/commands/connection_command.py
+++ b/airflow/cli/commands/connection_command.py
@@ -17,7 +17,6 @@
 """Connection sub-commands."""
 from __future__ import annotations
 
-import io
 import json
 import os
 import sys
@@ -30,6 +29,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import exc
 
 from airflow.cli.simple_table import AirflowConsole
+from airflow.cli.utils import is_stdout
 from airflow.compat.functools import cache
 from airflow.configuration import conf
 from airflow.exceptions import AirflowNotFoundException
@@ -138,10 +138,6 @@ def _format_connections(conns: list[Connection], file_format: str, serialization
     return json.dumps(connections_dict)
 
 
-def _is_stdout(fileio: io.TextIOWrapper) -> bool:
-    return fileio.name == "<stdout>"
-
-
 def _valid_uri(uri: str) -> bool:
     """Check if a URI is valid, by checking if scheme (conn_type) provided."""
     return urlsplit(uri).scheme != ""
@@ -171,8 +167,7 @@ def connections_export(args):
     if args.format or args.file_format:
         provided_file_format = f".{(args.format or args.file_format).lower()}"
 
-    file_is_stdout = _is_stdout(args.file)
-    if file_is_stdout:
+    if file_is_stdout := is_stdout(args.file):
         filetype = provided_file_format or default_format
     elif provided_file_format:
         filetype = provided_file_format

--- a/airflow/cli/commands/variable_command.py
+++ b/airflow/cli/commands/variable_command.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from json import JSONDecodeError
 
@@ -77,6 +78,8 @@ def variables_delete(args):
 @providers_configuration_loaded
 def variables_import(args):
     """Imports variables from a given file."""
+    if not os.path.exists(args.file):
+        raise SystemExit("Missing variables file.")
     with open(args.file) as varfile:
         try:
             var_json = json.load(varfile)

--- a/airflow/cli/commands/variable_command.py
+++ b/airflow/cli/commands/variable_command.py
@@ -77,26 +77,23 @@ def variables_delete(args):
 @providers_configuration_loaded
 def variables_import(args):
     """Imports variables from a given file."""
-    with args.file as varfile:
-        data = varfile.read()
-
-    try:
-        var_json = json.loads(data)
-    except JSONDecodeError:
-        raise SystemExit("Invalid variables file.")
-    else:
-        suc_count = fail_count = 0
-        for k, v in var_json.items():
-            try:
-                Variable.set(k, v, serialize_json=not isinstance(v, str))
-            except Exception as e:
-                print(f"Variable import failed: {repr(e)}")
-                fail_count += 1
-            else:
-                suc_count += 1
-        print(f"{suc_count} of {len(var_json)} variables successfully updated.")
-        if fail_count:
-            print(f"{fail_count} variable(s) failed to be updated.")
+    with open(args.file) as varfile:
+        try:
+            var_json = json.load(varfile)
+        except JSONDecodeError:
+            raise SystemExit("Invalid variables file.")
+    suc_count = fail_count = 0
+    for k, v in var_json.items():
+        try:
+            Variable.set(k, v, serialize_json=not isinstance(v, str))
+        except Exception as e:
+            print(f"Variable import failed: {repr(e)}")
+            fail_count += 1
+        else:
+            suc_count += 1
+    print(f"{suc_count} of {len(var_json)} variables successfully updated.")
+    if fail_count:
+        print(f"{fail_count} variable(s) failed to be updated.")
 
 
 @providers_configuration_loaded
@@ -116,7 +113,7 @@ def variables_export(args):
 
     with args.file as varfile:
         json.dump(var_dict, varfile, sort_keys=True, indent=4)
-    if is_stdout(args.file):
-        print("\nVariables successfully exported.", file=sys.stderr)
-    else:
-        print(f"Variables successfully exported to {args.file.name}.")
+        if is_stdout(varfile):
+            print("\nVariables successfully exported.", file=sys.stderr)
+        else:
+            print(f"Variables successfully exported to {varfile.name}.")

--- a/airflow/cli/utils.py
+++ b/airflow/cli/utils.py
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import io
+import sys
+
+
+def is_stdout(fileio: io.TextIOWrapper) -> bool:
+    """Check whether a file IO is stdout.
+
+    The intended use case for this helper is to check whether an argument parsed
+    with argparse.FileType points to stdout (by setting the path to ``-``). This
+    is why there is no equivalent for stderr; argparse does not allow using it.
+    """
+    return fileio.fileno() == sys.stdout.fileno()

--- a/airflow/cli/utils.py
+++ b/airflow/cli/utils.py
@@ -21,11 +21,13 @@ import io
 import sys
 
 
-def is_stdout(fileio: io.TextIOWrapper) -> bool:
+def is_stdout(fileio: io.IOBase) -> bool:
     """Check whether a file IO is stdout.
 
     The intended use case for this helper is to check whether an argument parsed
     with argparse.FileType points to stdout (by setting the path to ``-``). This
     is why there is no equivalent for stderr; argparse does not allow using it.
+
+    .. warning:: *fileio* must be open for this check to be successful.
     """
     return fileio.fileno() == sys.stdout.fileno()


### PR DESCRIPTION
This is a continuation to #31854.

Similar to connections, this change allows the CLI to export the variables to stdout using `airflow variables export -`.

There are a couple of change aside from the content in the original PR:

1. The `is_stdout` function has been extracted and improved.
2. The JSON-dumping code is changed to avoid creating an intermediate string in memory.

Close #31851.