### PR TITLE
Add backward compatibility for elasticsearch<8

### DIFF
--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -25,7 +25,7 @@ from datetime import datetime
 from operator import attrgetter
 from time import time
 from typing import TYPE_CHECKING, Any, Callable, List, Tuple
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 # Using `from elasticsearch import *` would break elasticsearch mocking used in unit test.
 import elasticsearch
@@ -105,7 +105,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
             retry_timeout = es_kwargs.get("retry_timeout")
             if retry_timeout:
                 es_kwargs["retry_on_timeout"] = retry_timeout
-            del es_kwargs["retry_timeout"]
+                del es_kwargs["retry_timeout"]
         host = self.format_url(host)
         super().__init__(base_log_folder, filename_template)
         self.closed = False

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -101,11 +101,8 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
         # For elasticsearch>8,arguments like retry_timeout have changed for elasticsearch to retry_on_timeout
         # in Elasticsearch() compared to previous versions.
         # Read more at: https://elasticsearch-py.readthedocs.io/en/v8.8.2/api.html#module-elasticsearch
-        if es_kwargs:
-            retry_timeout = es_kwargs.get("retry_timeout")
-            if retry_timeout:
-                es_kwargs["retry_on_timeout"] = retry_timeout
-                del es_kwargs["retry_timeout"]
+        if es_kwargs.get("retry_timeout"):
+            es_kwargs["retry_on_timeout"] = es_kwargs.pop("retry_timeout")
         host = self.format_url(host)
         super().__init__(base_log_folder, filename_template)
         self.closed = False
@@ -138,7 +135,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
     @staticmethod
     def format_url(host: str) -> str:
         """
-        Formats the given host string to ensure it starts with 'http' or 'https'.
+        Formats the given host string to ensure it starts with 'http'.
         Checks if the host string represents a valid URL.
 
         :params host: The host string to format and check.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2146,7 +2146,7 @@ config:
   elasticsearch_configs:
     max_retries: 3
     timeout: 30
-    retry_timeout: 'True'
+    retry_on_timeout: 'True'
   kerberos:
     keytab: '{{ .Values.kerberos.keytabPath }}'
     reinit_frequency: '{{ .Values.kerberos.reinitFrequency }}'

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2146,7 +2146,7 @@ config:
   elasticsearch_configs:
     max_retries: 3
     timeout: 30
-    retry_on_timeout: 'True'
+    retry_timeout: 'True'
   kerberos:
     keytab: '{{ .Values.kerberos.keytabPath }}'
     reinit_frequency: '{{ .Values.kerberos.reinitFrequency }}'


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
For elasticsearch>8, arguments like `retry_timeout` has changed for elasticsearch to `retry_on_timeout` in `Elasticsearch()` compared to previous versions. Read more at: [documentation](https://elasticsearch-py.readthedocs.io/en/v8.8.2/api.html#module-elasticsearch) This change was done as part of the following [PR](https://github.com/apache/airflow/pull/33135).

This needs backward compatibility support for elasticsearch<8. It fails with following error otherwise:
```
wait-for-airflow-migrations Unable to load the config, contains a configuration error.
wait-for-airflow-migrations Traceback (most recent call last):
wait-for-airflow-migrations   File "/usr/local/lib/python3.10/logging/config.py", line 565, in configure
wait-for-airflow-migrations     handler = self.configure_handler(handlers[name])
wait-for-airflow-migrations   File "/usr/local/lib/python3.10/logging/config.py", line 746, in configure_handler
wait-for-airflow-migrations     result = factory(**kwargs)
wait-for-airflow-migrations   File "/usr/local/lib/python3.10/site-packages/airflow/providers/elasticsearch/log/es_task_handler.py", line 104, in __init__
wait-for-airflow-migrations     self.client = elasticsearch.Elasticsearch(host, **es_kwargs)  # type: ignore[attr-defined]
wait-for-airflow-migrations TypeError: Elasticsearch.__init__() got an unexpected keyword argument 'retry_timeout'
wait-for-airflow-migrations 
wait-for-airflow-migrations The above exception was the direct cause of the following exception:
wait-for-airflow-migrations 
wait-for-airflow-migrations Traceback (most recent call last):
wait-for-airflow-migrations   File "/usr/local/bin/airflow", line 5, in <module>
wait-for-airflow-migrations     from airflow.__main__ import main
wait-for-airflow-migrations   File "/usr/local/lib/python3.10/site-packages/airflow/__init__.py", line 68, in <module>
wait-for-airflow-migrations     settings.initialize()
wait-for-airflow-migrations   File "/usr/local/lib/python3.10/site-packages/airflow/settings.py", line 524, in initialize
wait-for-airflow-migrations     LOGGING_CLASS_PATH = configure_logging()
wait-for-airflow-migrations   File "/usr/local/lib/python3.10/site-packages/airflow/logging_config.py", line 74, in configure_logging
wait-for-airflow-migrations     raise e
wait-for-airflow-migrations   File "/usr/local/lib/python3.10/site-packages/airflow/logging_config.py", line 69, in configure_logging
wait-for-airflow-migrations     dictConfig(logging_config)
wait-for-airflow-migrations   File "/usr/local/lib/python3.10/logging/config.py", line 811, in dictConfig
wait-for-airflow-migrations     dictConfigClass(config).configure()
wait-for-airflow-migrations   File "/usr/local/lib/python3.10/logging/config.py", line 572, in configure
wait-for-airflow-migrations     raise ValueError('Unable to configure handler '
wait-for-airflow-migrations ValueError: Unable to configure handler 'task'
wait-for-airflow-migrations Exception ignored in atexit callback: <function shutdown at 0x7fd39b485870>
wait-for-airflow-migrations Traceback (most recent call last):
wait-for-airflow-migrations   File "/usr/local/lib/python3.10/logging/__init__.py", line 2183, in shutdown
wait-for-airflow-migrations     h.close()
wait-for-airflow-migrations   File "/usr/local/lib/python3.10/site-packages/airflow/providers/elasticsearch/log/es_task_handler.py", line 366, in close
wait-for-airflow-migrations     if not self.mark_end_on_close or getattr(self, "ctx_task_deferred", None):
wait-for-airflow-migrations AttributeError: 'ElasticsearchTaskHandler' object has no attribute 'mark_end_on_close'
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
