### PR TITLE
D205 Support - Helm files

### DIFF
--- a/helm_tests/airflow_aux/test_airflow_common.py
+++ b/helm_tests/airflow_aux/test_airflow_common.py
@@ -24,11 +24,9 @@ from tests.charts.helm_template_generator import render_chart
 
 class TestAirflowCommon:
     """
-    This class holds tests that apply to more than 1 Airflow component so
-    we don't have to repeat tests everywhere.
+    Tests that apply to more than 1 Airflow component so we don't have to repeat tests everywhere.
 
-    The one general exception will be the KubernetesExecutor PodTemplateFile,
-    as it requires extra test setup.
+    The one general exception will be the KubernetesExecutor PodTemplateFile, as it requires extra test setup.
     """
 
     @pytest.mark.parametrize(
@@ -126,8 +124,9 @@ class TestAirflowCommon:
 
     def test_annotations(self):
         """
-        Test Annotations are correctly applied on all pods created Scheduler, Webserver & Worker
-        deployments.
+        Test Annotations are correctly applied.
+
+        Verifies all pods created Scheduler, Webserver & Worker deployments.
         """
         release_name = "test-basic"
         k8s_objects = render_chart(

--- a/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -408,8 +408,9 @@ class TestBaseChartTest:
 
     def test_annotations_on_airflow_pods_in_deployment(self):
         """
-        Test Annotations are correctly applied on all pods created Scheduler, Webserver & Worker
-        deployments.
+        Test Annotations are correctly applied.
+
+        Verifies all pods created Scheduler, Webserver & Worker deployments.
         """
         release_name = "test-basic"
         k8s_objects = render_chart(
@@ -441,10 +442,7 @@ class TestBaseChartTest:
 
     def test_chart_is_consistent_with_official_airflow_image(self):
         def get_k8s_objs_with_image(obj: list[Any] | dict[str, Any]) -> list[dict[str, Any]]:
-            """
-            Recursive helper to retrieve all the k8s objects that have an "image" key
-            inside k8s obj or list of k8s obj.
-            """
+            """Retrieve all the k8s objects that have an "image" key inside k8s obj or list of k8s obj."""
             out = []
             if isinstance(obj, list):
                 for item in obj:

--- a/helm_tests/airflow_core/test_scheduler.py
+++ b/helm_tests/airflow_core/test_scheduler.py
@@ -40,10 +40,7 @@ class TestScheduler:
         ],
     )
     def test_scheduler_kind(self, executor, persistence, kind):
-        """
-        Test scheduler kind is StatefulSet only when using a local executor &
-        worker persistence is enabled.
-        """
+        """Test scheduler kind is StatefulSet only with a local executor & worker persistence is enabled."""
         docs = render_chart(
             values={
                 "executor": executor,
@@ -676,6 +673,7 @@ class TestScheduler:
     ):
         """
         DAG Processor can move gitsync and DAGs mount from the scheduler to the DAG Processor only.
+
         The only exception is when we have a Local executor.
         In these cases, the scheduler does the worker role and needs access to DAGs anyway.
         """

--- a/helm_tests/airflow_core/test_triggerer.py
+++ b/helm_tests/airflow_core/test_triggerer.py
@@ -44,8 +44,9 @@ class TestTriggerer:
 
     def test_can_be_disabled(self):
         """
-        Triggerer should be able to be disabled if the users desires
-        (e.g. Python 3.6 or doesn't want to use async tasks).
+        Triggerer should be able to be disabled if the users desires.
+
+        For example, user may be disabled when using Python 3.6 or doesn't want to use async tasks.
         """
         docs = render_chart(
             values={"triggerer": {"enabled": False}},

--- a/helm_tests/other/test_git_sync_webserver.py
+++ b/helm_tests/other/test_git_sync_webserver.py
@@ -82,10 +82,7 @@ class TestGitSyncWebserver:
         ],
     )
     def test_git_sync_with_different_airflow_versions(self, airflow_version, exclude_webserver):
-        """
-        If Airflow >= 2.0.0 - git sync related containers, volume mounts & volumes
-        are not created.
-        """
+        """If Airflow >= 2.0.0 - git sync related containers, volume mounts & volumes are not created."""
         docs = render_chart(
             values={
                 "airflowVersion": airflow_version,

--- a/helm_tests/other/test_keda.py
+++ b/helm_tests/other/test_keda.py
@@ -41,9 +41,7 @@ class TestKeda:
         ],
     )
     def test_keda_enabled(self, executor, is_created):
-        """ScaledObject should only be created when set to enabled and
-        executor is Celery or CeleryKubernetes.
-        """
+        """ScaledObject should only be created when enabled and executor is Celery or CeleryKubernetes."""
         docs = render_chart(
             values={
                 "workers": {"keda": {"enabled": True}, "persistence": {"enabled": False}},
@@ -128,6 +126,7 @@ class TestKeda:
     def test_keda_query_kubernetes_queue(self, executor, queue, should_filter):
         """
         Verify keda sql query ignores kubernetes queue when CKE is used.
+
         Sometimes a user might want to use a different queue name for k8s executor tasks,
         and we also verify here that we use the configured queue name in that case.
         """


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/10742

D205 asserts that all docstrings must have a one-line summary ending in a period.  If there is more than one sentence then there must be a blank line before the rest of the docstring.  Meeting these requirements could be as simple as adding a newline, or might require some rephrasing.

There are almost a thousand violations in the repo so we're going to have to take this in bites.

### PLEASE NOTE

There should be zero logic changes in this PR, only changes to docstrings and whitespace.  If you see otherwise, please call it out.

### Included in this chunk

All files in the `helm_tests` module.

### To test

If you comment out [this line](https://github.com/apache/airflow/blob/main/pyproject.toml#L68) and run pre-commit in main you will get around 96 errors.  After these changes, only 82 remain and none of the above files should be on the list.  After uncommenting that line and rerunning pre-commits, there should be zero regressions. 