### PR TITLE
Add helpers to better handle session in tests

### DIFF
--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -29,7 +29,6 @@ import attr
 import pendulum
 from sqlalchemy.orm.session import Session
 
-from airflow import settings
 from airflow.compat.functools import cache
 from airflow.exceptions import AirflowException, UnmappableOperator
 from airflow.models.abstractoperator import (
@@ -64,6 +63,7 @@ from airflow.typing_compat import Literal
 from airflow.utils.context import Context, context_update_for_unmapped
 from airflow.utils.helpers import is_container, prevent_duplicates
 from airflow.utils.operator_resources import Resources
+from airflow.utils.session import create_dangling_session
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.types import NOTSET
 from airflow.utils.xcom import XCOM_RETURN_KEY
@@ -719,7 +719,7 @@ class MappedOperator(AbstractOperator):
         # could override this. We can't use @provide_session since it closes and
         # expunges everything, which we don't want to do when we are so "deep"
         # in the weeds here. We don't close this session for the same reason.
-        session = settings.Session()
+        session = create_dangling_session()
 
         mapped_kwargs, seen_oids = self._expand_mapped_kwargs(context, session)
         unmapped_task = self.unmap(mapped_kwargs)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -116,7 +116,7 @@ from airflow.utils.net import get_hostname
 from airflow.utils.operator_helpers import context_to_airflow_vars
 from airflow.utils.platform import getuser
 from airflow.utils.retries import run_with_db_retries
-from airflow.utils.session import NEW_SESSION, create_session, provide_session
+from airflow.utils.session import NEW_SESSION, create_dangling_session, create_session, provide_session
 from airflow.utils.sqlalchemy import (
     ExecutorConfigType,
     ExtendedJSON,
@@ -2039,7 +2039,7 @@ class TaskInstance(Base, LoggingMixin):
         """Return TI Context."""
         # Do not use provide_session here -- it expunges everything on exit!
         if not session:
-            session = settings.Session()
+            session = create_dangling_session()
 
         from airflow import macros
         from airflow.models.abstractoperator import NotMapped

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -951,3 +951,8 @@ def close_all_sqlalchemy_sessions():
     close_all_sessions()
     yield
     close_all_sessions()
+
+
+@pytest.fixture(autouse=True)
+def patch_dangling_session_creator(monkeypatch: pytest.MonkeyPatch, session) -> None:
+    monkeypatch.setattr("airflow.utils.session._create_session", lambda: session)


### PR DESCRIPTION
In various places we intentionally create dangling sessions in the worker, but when running a task in tests (which don't use workers) we need to make those not dangling.
