### PR TITLE
Fixes the Kafka provider's max message limit error (#32926)

### DIFF
--- a/airflow/providers/apache/kafka/operators/consume.py
+++ b/airflow/providers/apache/kafka/operators/consume.py
@@ -161,7 +161,9 @@ class ConsumeFromTopicOperator(BaseOperator):
                 batch_size = self.max_batch_size
 
             msgs = consumer.consume(num_messages=batch_size, timeout=self.poll_timeout)
-            messages_left -= len(msgs)
+            self.log.info("Messages count is %s", len(msgs))
+            if not self.read_to_end:
+                messages_left -= len(msgs)
 
             if not msgs:  # No messages + messages_left is being used.
                 self.log.info("Reached end of log. Exiting.")

--- a/airflow/providers/apache/kafka/operators/consume.py
+++ b/airflow/providers/apache/kafka/operators/consume.py
@@ -161,7 +161,6 @@ class ConsumeFromTopicOperator(BaseOperator):
                 batch_size = self.max_batch_size
 
             msgs = consumer.consume(num_messages=batch_size, timeout=self.poll_timeout)
-            self.log.info("Messages count is %s", len(msgs))
             if not self.read_to_end:
                 messages_left -= len(msgs)
 

--- a/tests/integration/providers/apache/kafka/operators/test_consume.py
+++ b/tests/integration/providers/apache/kafka/operators/test_consume.py
@@ -65,7 +65,7 @@ class TestConsumeFromTopic:
                     extra=json.dumps(
                         {
                             "socket.timeout.ms": 10,
-                            "bootstrap.servers": "localhost:9092",
+                            "bootstrap.servers": "broker:29092",
                             "group.id": f"operator.consumer.test.integration.test_{num}",
                             "enable.auto.commit": False,
                             "auto.offset.reset": "beginning",
@@ -135,7 +135,7 @@ class TestConsumeFromTopic:
         operator = ConsumeFromTopicOperator(
             kafka_config_id=TOPIC,
             topics=[TOPIC],
-            apply_function=_batch_tester,
+            apply_function_batch=_batch_tester,
             apply_function_kwargs={"test_string": TOPIC},
             task_id="test",
             poll_timeout=0.0001,

--- a/tests/providers/apache/kafka/operators/test_consume.py
+++ b/tests/providers/apache/kafka/operators/test_consume.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import logging
 from typing import Any
+from unittest import mock
 
 from airflow.models import Connection
 
@@ -78,4 +79,32 @@ class TestConsumeFromTopic:
         )
 
         # execute the operator (this is essentially a no op as the broker isn't setup)
+        operator.execute(context={})
+
+    @mock.patch("airflow.providers.apache.kafka.hooks.consume.KafkaConsumerHook.get_consumer")
+    def test_operator_consume_max(self, mock_get_consumer):
+        mock_consumer = mock.MagicMock()
+
+        mocked_messages = ["test_messages" for i in range(1001)]
+
+        def mock_consume(num_messages=0, timeout=-1):
+            nonlocal mocked_messages
+            if num_messages < 0:
+                raise Exception("Number of messages needs to be positive")
+            msg_count = min(num_messages, len(mocked_messages))
+            returned_messages = mocked_messages[:msg_count]
+            mocked_messages = mocked_messages[msg_count:]
+            return returned_messages
+
+        mock_consumer.consume = mock_consume
+        mock_get_consumer.return_value = mock_consumer
+
+        operator = ConsumeFromTopicOperator(
+            kafka_config_id="kafka_d",
+            topics=["test"],
+            task_id="test",
+            poll_timeout=0.0001,
+        )
+
+        # execute the operator (this is essentially a no op as we're mocking the consumer)
         operator.execute(context={})


### PR DESCRIPTION
The Kafka provider ConsumeFromTopicOperator throws
an error when max_messages is not set and there exist
more that a 1000 (Default value of max messages) messages

closes: #32926
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
