### PR TITLE
Add a few examples showing --airflow-extras use with breeze

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -572,13 +572,28 @@ When you are starting airflow from local sources, www asset compilation is autom
 
     breeze --python 3.8 --backend mysql start-airflow
 
-
-You can also use it to start any released version of Airflow from ``PyPI`` with the
-``--use-airflow-version`` flag.
+You can also use it to start different executor.
 
 .. code-block:: bash
 
-    breeze start-airflow --python 3.8 --backend mysql --use-airflow-version 2.2.5
+    breeze start-airflow --executor CeleryExecutor
+
+You can also use it to start any released version of Airflow from ``PyPI`` with the
+``--use-airflow-version`` flag - useful for testing and looking at issues raised for specific version.
+
+.. code-block:: bash
+
+    breeze start-airflow --python 3.8 --backend mysql --use-airflow-version 2.7.0
+
+When you are installing version from PyPI, it's also possible to specify extras that should be used
+when installing Airflow - you can provide several extras separated by coma - for example to install
+providers together with Airflow that you are installing. For example when you are using celery executor
+in Airflow 2.7.0+ you need to add ``celery`` extra.
+
+.. code-block:: bash
+
+    breeze start-airflow --use-airflow-version 2.7.0 --executor CeleryExecutor --airflow-extras celery
+
 
 These are all available flags of ``start-airflow`` command:
 

--- a/TESTING.rst
+++ b/TESTING.rst
@@ -1908,12 +1908,6 @@ to test them.
 The DAGs can be run in the main version of Airflow but they also work
 with older versions.
 
-To run the tests for Airflow 1.10.* series, you need to run Breeze with
-``--use-airflow-pypi-version=<VERSION>`` to re-install a different version of Airflow.
-
-You should also consider running it with ``restart`` command when you change the installed version.
-This will clean-up the database so that you start with a clean DB and not DB installed in a previous version.
-So typically you'd run it like ``breeze --use-airflow-pypi-version=1.10.9 restart``.
 
 Tracking SQL statements
 =======================

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -683,8 +683,18 @@ There is also an easy way of installation with Breeze if you have the latest sou
 Running the following command will use tmux inside breeze, create `admin` user and run Webserver & Scheduler:
 
 ```shell script
-breeze start-airflow --use-airflow-version <VERSION>rc<X> --python 3.8 --backend postgres
+breeze start-airflow --use-airflow-version 2.7.0rc1 --python 3.8 --backend postgres
 ```
+
+You can also choose different executors and extras to install when you are installing airflow this way. For
+example in order to run Airflow with CeleryExecutor and install celery, google and amazon provider (as of
+Airflow 2.7.0, you need to have celery provider installed to run Airflow with CeleryExecutor) you can run:
+
+```shell script
+breeze start-airflow --use-airflow-version 2.7.0rc1 --python 3.8 --backend postgres \
+  --executor CeleryExecutor --airflow-extras "celery,google,amazon"
+```
+
 
 Once you install and run Airflow, you should perform any verification you see as necessary to check
 that the Airflow works as you expected.


### PR DESCRIPTION
Using start-airflow with released version of Airflow in PyPI only install airflow with preinstalled providers by default. This for example causes failure when you want to install 2.7.0rc1 and use celery executor when running "start-airflow". It's easy to make it work by adding `--airflow-extras celery` but it was not too obvious.

This PR adds a few examples in relevant places of BREEZE, release and TESTING documentation to surface that you can add extras and that "celery" extra should be used with Celery Executor when you run `--use-airflow-version` for 2.7.0+.

Also removes some old `wrong` references to non-existing `--use-airflow-from-pypi` flag used for Airflow 1.10 (?)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
