### PR TITLE
Enable test connection in UI only if explicitly set to `Enabled`

### DIFF
--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -135,7 +135,7 @@ function handleTestConnection(connectionType, testableConnections) {
     $(testButton).hide();
     return;
   }
-  if (configTestConnection === "disabled") {
+  if (configTestConnection !== "enabled") {
     // If test connection is not enabled in config, disable button and display toolip
     // alerting the user.
     $(testButton)


### PR DESCRIPTION
Following up on PR https://github.com/apache/airflow/pull/32052/ the test connection is disabled in UI, API and CLI. 
The API and CLI strictly check for the config value to be set as `Enabled` 
for the functionality to be enabled, whereas the UI just checks that is it 
not set to `Disabled`. As a result setting values to the config param 
other than `Disabled`, enables the button in the UI. Even though the 
button gets enabled, the API forbids it as there is a strict check in the 
API that the value is set to `Enabled` and only then allows, however,
 it makes sense to also strictly check in the UI that value is set to `Enabled`
before enabling the button.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
