### PR TITLE
openlineage: defensively check for provided datetimes in listener

### DIFF
--- a/airflow/providers/openlineage/plugins/adapter.py
+++ b/airflow/providers/openlineage/plugins/adapter.py
@@ -127,8 +127,8 @@ class OpenLineageAdapter(LoggingMixin):
         parent_job_name: str | None,
         parent_run_id: str | None,
         code_location: str | None,
-        nominal_start_time: str,
-        nominal_end_time: str,
+        nominal_start_time: str | None,
+        nominal_end_time: str | None,
         owners: list[str],
         task: OperatorLineage | None,
         run_facets: dict[str, BaseFacet] | None = None,  # Custom run facets


### PR DESCRIPTION
This fixes following bug:
```
[2023-08-11, 18:27:35 UTC] {trigger_dagrun.py:209} INFO - Waiting for trigger_target_dag on 2023-08-11T18:23:35.355250+00:00 to become allowed state ['success'] ...
[2023-08-11, 18:28:35 UTC] {trigger_dagrun.py:209} INFO - Waiting for trigger_target_dag on 2023-08-11T18:23:35.355250+00:00 to become allowed state ['success'] ...
[2023-08-11, 18:29:35 UTC] {taskinstance.py:1943} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/airflow/operators/trigger_dagrun.py", line 220, in execute
    raise AirflowException(f"{self.trigger_dag_id} failed with failed states {state}")
airflow.exceptions.AirflowException: trigger_target_dag failed with failed states failed
[2023-08-11, 18:29:35 UTC] {utils.py:401} ERROR - 'NoneType' object has no attribute 'isoformat'
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/airflow/providers/openlineage/utils/utils.py", line 399, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/airflow/providers/openlineage/plugins/listener.py", line 145, in on_failure
    end_time=task_instance.end_date.isoformat(),
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'isoformat'
```

Additionally, add fallback for any similar situation, where it's getting datetime from Airflow object, checking if it's not null first.