### PR TITLE
Increase kafka integration test timeout

### DIFF
--- a/tests/integration/providers/apache/kafka/operators/test_consume.py
+++ b/tests/integration/providers/apache/kafka/operators/test_consume.py
@@ -39,14 +39,16 @@ def _batch_tester(messages, test_string=None):
     assert len(messages) == 10
 
     for x in messages:
-        assert x.value() == test_string
+        # Confluent Kafka converts messages to bytes
+        assert x.value().decode(encoding="utf-8") == test_string
 
 
 def _basic_message_tester(message, test=None) -> Any:
     """a function that tests the message received"""
 
     assert test
-    assert message.value() == test
+    # Confluent Kafka converts messages to bytes
+    assert message.value().decode(encoding="utf-8") == test
 
 
 @pytest.mark.integration("kafka")
@@ -91,7 +93,7 @@ class TestConsumeFromTopic:
             apply_function="tests.integration.providers.apache.kafka.operators.test_consume._basic_message_tester",
             apply_function_kwargs={"test": TOPIC},
             task_id="test",
-            poll_timeout=0.0001,
+            poll_timeout=10,
         )
 
         x = operator.execute(context={})
@@ -113,7 +115,7 @@ class TestConsumeFromTopic:
             apply_function=_basic_message_tester,
             apply_function_kwargs={"test": TOPIC},
             task_id="test",
-            poll_timeout=0.0001,
+            poll_timeout=10,
         )
 
         x = operator.execute(context={})
@@ -138,7 +140,7 @@ class TestConsumeFromTopic:
             apply_function=_batch_tester,
             apply_function_kwargs={"test_string": TOPIC},
             task_id="test",
-            poll_timeout=0.0001,
+            poll_timeout=10,
             commit_cadence="end_of_batch",
             max_messages=30,
             max_batch_size=10,


### PR DESCRIPTION
The kafka integrations tests were too low for any
messages to be read in, increased the timeout and
also found a few issues in the tests with message
datatypes (returning bytes instead of strings), fixed 
those in the tests as well.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
