### PR TITLE
Fix DagFileProcessor interfering with dags outside its ``processor_subdir``

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -218,7 +218,6 @@ class DagFileProcessorAgent(LoggingMixin, MultiprocessingStartMethodMixin):
         pickle_dags: bool,
         async_mode: bool,
     ) -> None:
-
         # Make this process start as a new process group - that makes it easy
         # to kill all sub-process of this at the OS-level, rather than having
         # to iterate the child processes
@@ -793,8 +792,14 @@ class DagFileProcessorManager(LoggingMixin):
                 alive_dag_filelocs=dag_filelocs,
                 processor_subdir=self.get_dag_directory(),
             )
-            DagModel.deactivate_deleted_dags(dag_filelocs)
-            DagCode.remove_deleted_code(dag_filelocs)
+            DagModel.deactivate_deleted_dags(
+                dag_filelocs,
+                processor_subdir=self.get_dag_directory(),
+            )
+            DagCode.remove_deleted_code(
+                dag_filelocs,
+                processor_subdir=self.get_dag_directory(),
+            )
 
             return True
         return False
@@ -1133,7 +1138,6 @@ class DagFileProcessorManager(LoggingMixin):
         file_paths_recently_processed = []
         file_paths_to_stop_watching = set()
         for file_path in self._file_paths:
-
             if is_mtime_mode:
                 try:
                     files_with_mtime[file_path] = os.path.getmtime(file_path)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -3555,16 +3555,26 @@ class DagModel(Base):
     def deactivate_deleted_dags(
         cls,
         alive_dag_filelocs: Container[str],
+        processor_subdir: str | None = None,
         session: Session = NEW_SESSION,
     ) -> None:
         """
         Set ``is_active=False`` on the DAGs for which the DAG files have been removed.
 
         :param alive_dag_filelocs: file paths of alive DAGs
+        :param processor_subdir: dag processor subdir
         :param session: ORM Session
         """
         log.debug("Deactivating DAGs (for which DAG files are deleted) from %s table ", cls.__tablename__)
-        dag_models = session.scalars(select(cls).where(cls.fileloc.is_not(None)))
+        dag_models = session.scalars(
+            select(cls).where(
+                cls.fileloc.is_not(None),
+                or_(
+                    cls.processor_subdir.is_(None),
+                    cls.processor_subdir == processor_subdir,
+                ),
+            )
+        )
         for dag_model in dag_models:
             if dag_model.fileloc not in alive_dag_filelocs:
                 dag_model.is_active = False

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -3555,7 +3555,7 @@ class DagModel(Base):
     def deactivate_deleted_dags(
         cls,
         alive_dag_filelocs: Container[str],
-        processor_subdir: str | None = None,
+        processor_subdir: str,
         session: Session = NEW_SESSION,
     ) -> None:
         """
@@ -3575,6 +3575,7 @@ class DagModel(Base):
                 ),
             )
         )
+
         for dag_model in dag_models:
             if dag_model.fileloc not in alive_dag_filelocs:
                 dag_model.is_active = False

--- a/airflow/models/dagcode.py
+++ b/airflow/models/dagcode.py
@@ -128,7 +128,7 @@ class DagCode(Base):
     def remove_deleted_code(
         cls,
         alive_dag_filelocs: Collection[str],
-        processor_subdir: str | None = None,
+        processor_subdir: str,
         session: Session = NEW_SESSION,
     ) -> None:
         """Delete code not included in alive_dag_filelocs.

--- a/airflow/models/dagcode.py
+++ b/airflow/models/dagcode.py
@@ -125,10 +125,16 @@ class DagCode(Base):
 
     @classmethod
     @provide_session
-    def remove_deleted_code(cls, alive_dag_filelocs: Collection[str], session: Session = NEW_SESSION) -> None:
+    def remove_deleted_code(
+        cls,
+        alive_dag_filelocs: Collection[str],
+        processor_subdir: str | None = None,
+        session: Session = NEW_SESSION,
+    ) -> None:
         """Delete code not included in alive_dag_filelocs.
 
         :param alive_dag_filelocs: file paths of alive DAGs
+        :param processor_subdir: dag processor subdir
         :param session: ORM Session
         """
         alive_fileloc_hashes = [cls.dag_fileloc_hash(fileloc) for fileloc in alive_dag_filelocs]
@@ -137,7 +143,11 @@ class DagCode(Base):
 
         session.execute(
             delete(cls)
-            .where(cls.fileloc_hash.notin_(alive_fileloc_hashes), cls.fileloc.notin_(alive_dag_filelocs))
+            .where(
+                cls.fileloc_hash.notin_(alive_fileloc_hashes),
+                cls.fileloc.notin_(alive_dag_filelocs),
+                cls.fileloc.contains(processor_subdir),
+            )
             .execution_options(synchronize_session="fetch")
         )
 

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -242,6 +242,7 @@ class SerializedDagModel(Base):
         """Delete DAGs not included in alive_dag_filelocs.
 
         :param alive_dag_filelocs: file paths of alive DAGs
+        :param processor_subdir: dag processor subdir
         :param session: ORM Session
         """
         alive_fileloc_hashes = [DagCode.dag_fileloc_hash(fileloc) for fileloc in alive_dag_filelocs]

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1303,14 +1303,17 @@ class TestDag:
         dag.fileloc = dag_fileloc
         session = settings.Session()
         with mock.patch("airflow.models.dag.DagCode.bulk_sync_to_db"):
-            dag.sync_to_db(session=session)
+            dag.sync_to_db(session=session, processor_subdir="/usr/local/airflow/dags/")
 
         orm_dag = session.query(DagModel).filter(DagModel.dag_id == dag_id).one()
 
         assert orm_dag.is_active
         assert orm_dag.fileloc == dag_fileloc
 
-        DagModel.deactivate_deleted_dags(list_py_file_paths(settings.DAGS_FOLDER))
+        DagModel.deactivate_deleted_dags(
+            list_py_file_paths(settings.DAGS_FOLDER),
+            processor_subdir="/usr/local/airflow/dags/",
+        )
 
         orm_dag = session.query(DagModel).filter(DagModel.dag_id == dag_id).one()
         assert not orm_dag.is_active


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/33310

`DagFileProcessorManager._refresh_dag_dir` should not interfer with `SerializedDagModel`, `DagModel` or `DagCode` outside of its `dag_directory`.

Cf original issue but this mostly cause other dags to get wrongly deactivated by other standalone DagProcessor. I assume this can also cause some scheduling delay if the deactivation of the dag happens  at the wrong timing.

