### PR TITLE
Add `init_command` parameter to `MySqlHook`

### DIFF
--- a/airflow/providers/mysql/hooks/mysql.py
+++ b/airflow/providers/mysql/hooks/mysql.py
@@ -58,6 +58,7 @@ class MySqlHook(DbApiHook):
     :param schema: The MySQL database schema to connect to.
     :param connection: The :ref:`MySQL connection id <howto/connection:mysql>` used for MySQL credentials.
     :param local_infile: Boolean flag determining if local_infile should be used
+    :param init_command: Initial command to issue to MySQL server upon connection
     """
 
     conn_name_attr = "mysql_conn_id"
@@ -71,6 +72,7 @@ class MySqlHook(DbApiHook):
         self.schema = kwargs.pop("schema", None)
         self.connection = kwargs.pop("connection", None)
         self.local_infile = kwargs.pop("local_infile", False)
+        self.init_command = kwargs.pop("init_command", None)
 
     def set_autocommit(self, conn: MySQLConnectionTypes, autocommit: bool) -> None:
         """
@@ -144,6 +146,8 @@ class MySqlHook(DbApiHook):
             conn_config["unix_socket"] = conn.extra_dejson["unix_socket"]
         if self.local_infile:
             conn_config["local_infile"] = 1
+        if self.init_command:
+            conn_config["init_command"] = self.init_command
         return conn_config
 
     def _get_conn_config_mysql_connector_python(self, conn: Connection) -> dict:
@@ -157,6 +161,8 @@ class MySqlHook(DbApiHook):
 
         if self.local_infile:
             conn_config["allow_local_infile"] = True
+        if self.init_command:
+            conn_config["init_command"] = self.init_command
         # Ref: https://dev.mysql.com/doc/connector-python/en/connector-python-connectargs.html
         for key, value in conn.extra_dejson.items():
             if key.startswith("ssl_"):

--- a/tests/providers/mysql/hooks/test_mysql.py
+++ b/tests/providers/mysql/hooks/test_mysql.py
@@ -181,6 +181,15 @@ class TestMySqlHookConn:
             read_default_group="enable-cleartext-plugin",
         )
 
+    @mock.patch("MySQLdb.connect")
+    def test_get_conn_init_command(self, mock_connect):
+        self.db_hook.init_command = "SET time_zone = '+00:00';"
+        self.db_hook.get_conn()
+        assert mock_connect.call_count == 1
+        args, kwargs = mock_connect.call_args
+        assert args == ()
+        assert kwargs["init_command"] == "SET time_zone = '+00:00';"
+
 
 class MockMySQLConnectorConnection:
     DEFAULT_AUTOCOMMIT = "default"

--- a/tests/providers/mysql/hooks/test_mysql_connector_python.py
+++ b/tests/providers/mysql/hooks/test_mysql_connector_python.py
@@ -79,3 +79,14 @@ class TestMySqlHookConnMySqlConnectorPython:
         args, kwargs = mock_connect.call_args
         assert args == ()
         assert kwargs["ssl_disabled"] == 1
+
+    @mock.patch("mysql.connector.connect")
+    def test_get_conn_init_command(self, mock_connect):
+        extra_dict = self.connection.extra_dejson
+        self.connection.extra = json.dumps(extra_dict)
+        self.db_hook.init_command = "SET time_zone = '+00:00';"
+        self.db_hook.get_conn()
+        assert mock_connect.call_count == 1
+        args, kwargs = mock_connect.call_args
+        assert args == ()
+        assert kwargs["init_command"] == "SET time_zone = '+00:00';"


### PR DESCRIPTION
This allows the addition of `init_command` as a `MySqlHook` parameter.

`init_command` is a connection argument to set an initial command to issue to the MySQL server upon connection. It is available as both a `mysqlclient` connection attribute (https://mysqlclient.readthedocs.io/user_guide.html?highlight=init_command#functions-and-attributes) and a `mysql-connector-python` connection attribute (https://dev.mysql.com/doc/connector-python/en/connector-python-connectargs.html).

For example, to set the session's `time_zone` to UTC you can set in a `MySqlHook` an `init_command` parameter as shown:
```python
MySqlHook(init_command="SET time_zone = '+00:00';")
```
or in a SQL operator shown using `hook_params` (which should return "+00:00"):
```python
SQLExecuteQueryOperator(
    task_id="check_time_zone",
    conn_id="mysql_default",
    hook_params={"init_command": "SET time_zone = '+00:00';"},
    sql=r"""SELECT @@SESSION.time_zone;""",
    autocommit=True,
    show_return_value_in_logs=True
)
```

closes: #33300 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
