### PR TITLE
Rename `ExternalBranchPythonOperator` to `BranchExternalPythonOperator`

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -790,7 +790,7 @@ class ExternalPythonOperator(_BasePythonVirtualenvOperator):
             return None
 
 
-class ExternalBranchPythonOperator(ExternalPythonOperator, SkipMixin):
+class BranchExternalPythonOperator(ExternalPythonOperator, SkipMixin):
     """
     A workflow can "branch" or follow a path after the execution of this task,
     Extends ExternalPythonOperator, so expects to get Python:

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -40,8 +40,8 @@ from airflow.models.baseoperator import BaseOperator
 from airflow.models.taskinstance import TaskInstance, clear_task_instances, set_current_context
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import (
+    BranchExternalPythonOperator,
     BranchPythonOperator,
-    ExternalBranchPythonOperator,
     ExternalPythonOperator,
     PythonOperator,
     PythonVirtualenvOperator,
@@ -1121,8 +1121,8 @@ class TestExternalPythonOperator(BaseTestPythonVirtualenvOperator):
             task._read_result(path=mock.Mock())
 
 
-class TestExternalBranchPythonOperator(BaseTestPythonVirtualenvOperator):
-    opcls = ExternalBranchPythonOperator
+class TestBranchExternalPythonOperator(BaseTestPythonVirtualenvOperator):
+    opcls = BranchExternalPythonOperator
 
     @pytest.fixture(autouse=True)
     def setup_tests(self):


### PR DESCRIPTION
Followup on https://github.com/apache/airflow/pull/32787

The convention in the project is `Branch*Operator`: `BranchDayOfWeekOperator`, `BranchSQLOperator`, `BranchPythonOperator` etc..

We can do it without deprecating if we are having 2.7.0rc2 cc @ephraimbuddy 