### PR TITLE
Allow templating flower ingress hostnames

### DIFF
--- a/chart/templates/flower/flower-ingress.yaml
+++ b/chart/templates/flower/flower-ingress.yaml
@@ -84,7 +84,7 @@ spec:
       {{- $hostname = .name -}}
       {{- end }}
       {{- if $hostname }}
-      host: {{ $hostname | quote }}
+      host: {{ include "common.tplvalues.render" ( dict "value" $hostname "context" $ ) | quote }}
       {{- end }}
     {{- end }}
   {{- if .Values.ingress.flower.ingressClassName }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -183,6 +183,7 @@ ingress:
 
     # The hostnames or hosts configuration for the flower Ingress
     hosts: []
+    #   # The hostname for the flower Ingress (can be templated)
     # - name: ""
     #   tls:
     #     # Enable TLS termination for the flower Ingress


### PR DESCRIPTION
I would like to propose allowing template values to flower ingress hostnames.

Why is it needed?
Let's assume that we're providing airflow service to multiple teams.
By creating flower ingress hostnames using <code>{{ .Release.Namespace }}</code> or <code>{{ .Release.Name }}</code>,
there is no need to create multiple values ​​files to store different hostnames ​​for each team.

Usage
```yaml
    hosts:
    #   # The hostname for the flower Ingress (can be templated)
    - name: '{{ .Release.Namespace }}.airflow.service.com'
```

