### PR TITLE
replace ~ with . for marking up sections

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -2449,7 +2449,7 @@ you need to do when you are adding system level (debian) level, Python (pip) dep
 dependencies for the webserver.
 
 Python dependencies
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 For temporary adding and modifying the dependencies, you just (in Breeze shell) run
 ``pip install <dependency>`` or similar - in the same way as you would do it
@@ -2492,7 +2492,7 @@ breeze ci-image build --upgrade-to-newer-dependencies
 
 
 System (debian) dependencies
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------
 
 You can install ``apt-get`` dependencies temporarily by running ``apt-get install <dependency>`` in
 Breeze shell. Those dependencies will disappear when you exit Breeze shell.
@@ -2531,7 +2531,7 @@ breeze ci-image build --upgrade-to-newer-dependencies
 ```
 
 Node (yarn) dependencies
-~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------
 
 If you need to change "node" dependencies in ``airflow/www``, you need to compile them in the
 host with ``breeze compile-www-assets`` command. No need to rebuild the image.

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -2449,7 +2449,7 @@ you need to do when you are adding system level (debian) level, Python (pip) dep
 dependencies for the webserver.
 
 Python dependencies
--------------------
+...................
 
 For temporary adding and modifying the dependencies, you just (in Breeze shell) run
 ``pip install <dependency>`` or similar - in the same way as you would do it
@@ -2492,7 +2492,7 @@ breeze ci-image build --upgrade-to-newer-dependencies
 
 
 System (debian) dependencies
-----------------------------
+............................
 
 You can install ``apt-get`` dependencies temporarily by running ``apt-get install <dependency>`` in
 Breeze shell. Those dependencies will disappear when you exit Breeze shell.
@@ -2531,7 +2531,7 @@ breeze ci-image build --upgrade-to-newer-dependencies
 ```
 
 Node (yarn) dependencies
-------------------------
+........................
 
 If you need to change "node" dependencies in ``airflow/www``, you need to compile them in the
 host with ``breeze compile-www-assets`` command. No need to rebuild the image.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #33368
related: #33368 

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

This PR restores the preview feature for ./BREEZE.rst.
I described the issue here #33368 .
The change replaces the tilde `~` character for marking section with `-`.
