### PR TITLE
Introducing class constant to make worker pod log lines configurable

### DIFF
--- a/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -147,6 +147,7 @@ KUBERNETES_COMMANDS = (
 class KubernetesExecutor(BaseExecutor):
     """Executor for Kubernetes."""
 
+    RUNNING_POD_LOG_LINES = 100
     supports_ad_hoc_ti_run: bool = True
 
     def __init__(self):
@@ -502,7 +503,7 @@ class KubernetesExecutor(BaseExecutor):
                 namespace=namespace,
                 container="base",
                 follow=False,
-                tail_lines=100,
+                tail_lines=self.RUNNING_POD_LOG_LINES,
                 _preload_content=False,
             )
             for line in res:

--- a/tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -228,6 +228,19 @@ class TestAirflowKubernetesScheduler:
         finally:
             kube_executor.end()
 
+    def test_running_pod_log_lines(self):
+        # default behaviour
+        kube_executor = KubernetesExecutor()
+        assert kube_executor.RUNNING_POD_LOG_LINES == 100
+
+        # monkey-patching for second executor
+        kube_executor_2 = KubernetesExecutor()
+        kube_executor_2.RUNNING_POD_LOG_LINES = 200
+
+        # monkey-patching should not affect the class constant
+        assert kube_executor.RUNNING_POD_LOG_LINES == 100
+        assert kube_executor_2.RUNNING_POD_LOG_LINES == 200
+
 
 class TestKubernetesExecutor:
     """


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The number of logs read from the worker pods while using Kubernetes based executors is hard coded and is not configurable. One suggestion on an old PR: https://github.com/apache/airflow/pull/29299 was to introduce a class constant so that it can be monkey patched on requirement.

Related PR https://github.com/apache/airflow/pull/29299

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
