### PR TITLE
openlineage: do not try to redact Proxy objects from deprecated config

### DIFF
--- a/tests/providers/openlineage/plugins/test_utils.py
+++ b/tests/providers/openlineage/plugins/test_utils.py
@@ -171,6 +171,9 @@ def test_redact_with_exclusions(monkeypatch):
         def __init__(self):
             self.password = "passwd"
 
+    class Proxy:
+        pass
+
     def default(self, o):
         if isinstance(o, NotMixin):
             return o.__dict__
@@ -179,6 +182,9 @@ def test_redact_with_exclusions(monkeypatch):
     assert redactor.redact(NotMixin()).password == "passwd"
     monkeypatch.setattr(JSONEncoder, "default", default)
     assert redactor.redact(NotMixin()).password == "***"
+
+    assert redactor.redact(Proxy()) == "<<non-redactable: Proxy>>"
+    assert redactor.redact({"a": "a", "b": Proxy()}) == {"a": "a", "b": "<<non-redactable: Proxy>>"}
 
     class Mixined(RedactMixin):
         _skip_redact = ["password"]


### PR DESCRIPTION
When preparing `AirfowRunFacet` we're iterating over `Context`. This access cause warnings: 

```
[2023-08-14, 09:02:53 UTC] {warnings.py:109} WARNING - /usr/local/lib/python3.11/site-packages/airflow/utils/context.py:314: AirflowContextDeprecationWarning: Accessing 'next_ds' from the template is deprecated and will be removed in a future version. Please use '{{ data_interval_end | ds }}' instead.
  warnings.warn(_create_deprecation_warning(k, replacements))
[2023-08-14, 09:02:53 UTC] {secrets_masker.py:277} WARNING - Unable to redact <Proxy at 0x7f07121b14c0 wrapping '2023-08-14' at 0x7f0712137770 with factory functools.partial(<function lazy_mapping_from_context.<locals>._deprecated_proxy_factory at 0x7f071216d260>, 'next_ds', '2023-08-14')>, please report this via <https://github.com/apache/airflow/issues>. Error was: TypeError: ObjectProxy() missing required argument 'wrapped' (pos 1)
```

This PR removes direct access to those objects, and redacting it when `Proxy` is encountered. We can't remove iteration over dict, so in this case we're suppressing this error. In case of `Proxy` we'll skip serializing the object anyway. 