### PR TITLE
Fix eager upgrade failures for canary builds

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -174,6 +174,8 @@ def build_timout_handler(build_process_group_id: int, signum, frame):
     os.waitpid(build_process_group_id, 0)
     # give the output a little time to flush so that the helpful error message is not hidden
     time.sleep(5)
+    if os.environ.get("GITHUB_ACTIONS", "false") != "true":
+        get_console().print("::endgroup::")
     get_console().print()
     get_console().print(
         "[error]The build timed out. This is likely because `pip` "

--- a/dev/breeze/src/airflow_breeze/params/build_ci_params.py
+++ b/dev/breeze/src/airflow_breeze/params/build_ci_params.py
@@ -58,12 +58,13 @@ class BuildCiParams(CommonBuildParams):
             )
         if self.upgrade_to_newer_dependencies:
             eager_upgrade_arg = self.eager_upgrade_additional_requirements.strip().replace("\n", "")
-            extra_ci_flags.extend(
-                [
-                    "--build-arg",
-                    f"EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS={eager_upgrade_arg}",
-                ]
-            )
+            if eager_upgrade_arg:
+                extra_ci_flags.extend(
+                    [
+                        "--build-arg",
+                        f"EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS={eager_upgrade_arg}",
+                    ]
+                )
         return extra_ci_flags
 
     @property


### PR DESCRIPTION
The canary builds continued failing after fixing aibotocore
in https://github.com/apache/airflow/pull/33364 when aiobotocore dependency limit dependency limit. This was
because the main build is now using "empty" eager upgrade requirements
which override the embedded aiobotocore and continue trigger
backtracking.

This is not easily visible on CI because the backtracking
error is under a folded CI image build group in CI.

This PR fixes both:

* only overrides eager requirements if they are not empty
* make sure that eager upgrade output is in the unfolded output
  of CI job

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
