### PR TITLE
Enable D205 Support

### DIFF
--- a/airflow/providers/google/cloud/hooks/datapipeline.py
+++ b/airflow/providers/google/cloud/hooks/datapipeline.py
@@ -32,6 +32,7 @@ DEFAULT_DATAPIPELINE_LOCATION = "us-central1"
 class DataPipelineHook(GoogleBaseHook):
     """
     Hook for Google Data Pipelines.
+
     All the methods in the hook where project_id is used must be called with
     keyword arguments rather than positional.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ extend-select = [
 ]
 extend-ignore = [
     "D203",
-    "D205",
     "D212",
     "D213",
     "D214",


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/10742

D205 asserts that all docstrings must have a one-line summary ending in a period. If there is more than one sentence then there must be a blank line before the rest of the docstring. Meeting these requirements could be as simple as adding a newline, or might require some rephrasing.

All existing code [has been updated](https://github.com/apache/airflow/pulls?q=is%3Apr+author%3Aferruzzi+D205) to meet the standard, this just throws the switch to enable it in out CI.

### Please Note:
Merging this should maybe be accompanied by an announcement in #development since a handful of existing PRs will suddenly start failing Static Checks if they need to adjust their docstrings.