### PR TITLE
Allow timetable to slightly miss catchup cutoff

### DIFF
--- a/airflow/timetables/trigger.py
+++ b/airflow/timetables/trigger.py
@@ -89,7 +89,7 @@ class CronTriggerTimetable(CronMixin, Timetable):
             else:
                 next_start_time = self._align_to_next(restriction.earliest)
         else:
-            start_time_candidates = [self._align_to_next(DateTime.utcnow())]
+            start_time_candidates = [self._align_to_prev(DateTime.utcnow())]
             if last_automated_data_interval is not None:
                 start_time_candidates.append(self._get_next(last_automated_data_interval.end))
             if restriction.earliest is not None:

--- a/newsfragments/33404.significant.rst
+++ b/newsfragments/33404.significant.rst
@@ -1,0 +1,16 @@
+CronTriggerTimetable is now less aggressive when trying to skip a run
+
+When setting ``catchup=False``, CronTriggerTimetable no longer skips a run if
+the scheduler does not query the timetable immediately after the previous run
+has been triggered.
+
+This should not affect scheduling in most cases, but can change the behaviour if
+a DAG is paused-unpaused to manually skip a run. Previously, the timetable (with
+``catchup=False``) would only start a run after a DAG is unpaused, but with this
+change, the scheduler would try to look at little bit back to schedule the
+previous run that covers a part of the period when the DAG was paused. This
+means you will need to keep a DAG paused longer (namely, for the entire cron
+period to pass) to really skip a run.
+
+Note that this is also the behaviour exhibited by various other cron-based
+scheduling tools, such as anacron.

--- a/tests/timetables/test_trigger_timetable.py
+++ b/tests/timetables/test_trigger_timetable.py
@@ -48,11 +48,11 @@ DELTA_FROM_MIDNIGHT = datetime.timedelta(minutes=30, hours=16)
     [
         pytest.param(
             None,
-            CURRENT_TIME + DELTA_FROM_MIDNIGHT,
+            YESTERDAY + DELTA_FROM_MIDNIGHT,
             id="first-run",
         ),
         pytest.param(
-            PREV_DATA_INTERVAL_EXACT,
+            DataInterval.exact(YESTERDAY + DELTA_FROM_MIDNIGHT),
             CURRENT_TIME + DELTA_FROM_MIDNIGHT,
             id="before-now",
         ),
@@ -89,8 +89,20 @@ def test_daily_cron_trigger_no_catchup_first_starts_at_next_schedule(
         pytest.param(
             pendulum.DateTime(2022, 7, 27, 0, 30, 0, tzinfo=TIMEZONE),
             START_DATE,
-            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 1, 0, 0, tzinfo=TIMEZONE)),
+            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 0, 0, 0, tzinfo=TIMEZONE)),
             id="current_time_not_on_boundary",
+        ),
+        pytest.param(
+            pendulum.DateTime(2022, 7, 27, 1, 0, 0, tzinfo=TIMEZONE),
+            START_DATE,
+            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 1, 0, 0, tzinfo=TIMEZONE)),
+            id="current_time_miss_one_interval_on_boundary",
+        ),
+        pytest.param(
+            pendulum.DateTime(2022, 7, 27, 1, 30, 0, tzinfo=TIMEZONE),
+            START_DATE,
+            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 1, 0, 0, tzinfo=TIMEZONE)),
+            id="current_time_miss_one_interval_not_on_boundary",
         ),
         pytest.param(
             pendulum.DateTime(2022, 7, 27, 0, 30, 0, tzinfo=TIMEZONE),


### PR DESCRIPTION
Previously, with catchup=False, CronTriggerTimetable would aggressively cut off a run if the scheduler doesn't ask to schedule the next run immediately. This causes DAGs to seemingly mysteriously "miss" a run from time to time due to the scheduler inevitably having a very slight hiccup.

This change makes the timetable's non-catchup cutoff logic a little more lax, and only activate when the scheduler misses at least an entire interval. For example, for a daily cron, if the previous run happened on midnight of 2nd Jun (to cover 1st Jun), the timetable would still allow scheduling a run covering 2nd Jun if the scheduler asks for it some time during the 2nd, and would skip the 2nd Jun run entirely only if the scheduler fails to ask for a run on the entirety of the 2nd and only asks after midnight on the 3rd.

As discussed in #27399, I feel this is the more reasonable fix than #32921, even though it slightly changes the behaviour (specifically, the first ever run would start one interval earlier than previously). Quoting from the linked issue:

> > I think a reasonable logic would be to change the catchup=False logic to cover one schedule before the current time instead, so in the above scenario, the timetable would make the next run cover 4am, and only skip the 4am run if the current time is pas 5am.
>
> Sounds good. It's natural to those who are used to Cron and Anacron.
>
> I think we need to document the new behavior. […]

Fix #27339. Close #32921.