### PR TITLE
fix(TimeSensorAsync): use DAG timezone

### DIFF
--- a/airflow/sensors/time_sensor.py
+++ b/airflow/sensors/time_sensor.py
@@ -67,7 +67,7 @@ class TimeSensorAsync(BaseSensorOperator):
         self.target_time = target_time
 
         aware_time = timezone.coerce_datetime(
-            datetime.datetime.combine(datetime.datetime.today(), self.target_time)
+            datetime.datetime.combine(datetime.datetime.today(), self.target_time, self.dag.timezone)
         )
 
         self.target_datetime = timezone.convert_to_utc(aware_time)


### PR DESCRIPTION
Fixes: #33256

TimeSensorAsync used to convert naive times to UTC regardless of DAG timezone. This fixes that.

Please let me know if this is a significant change and I'll write a newsfragment file.