### PR TITLE
Fix outdated test name and description in BatchSensor

### DIFF
--- a/tests/providers/amazon/aws/sensors/test_batch.py
+++ b/tests/providers/amazon/aws/sensors/test_batch.py
@@ -32,97 +32,112 @@ from airflow.providers.amazon.aws.triggers.batch import BatchJobTrigger
 TASK_ID = "batch_job_sensor"
 JOB_ID = "8222a1c2-b246-4e19-b1b8-0039bb4407c0"
 AWS_REGION = "eu-west-1"
+ENVIRONMENT_NAME = "environment_name"
+JOB_QUEUE = "job_queue"
+
+
+@pytest.fixture(scope="module")
+def batch_sensor() -> BatchSensor:
+    return BatchSensor(
+        task_id="batch_job_sensor",
+        job_id=JOB_ID,
+    )
+
+
+@pytest.fixture(scope="module")
+def deferrable_batch_sensor() -> BatchSensor:
+    return BatchSensor(task_id="task", job_id=JOB_ID, region_name=AWS_REGION, deferrable=True)
 
 
 class TestBatchSensor:
-    def setup_method(self):
-        self.batch_sensor = BatchSensor(
-            task_id="batch_job_sensor",
-            job_id=JOB_ID,
-        )
-        self.deferrable_batch_sensor = BatchSensor(
-            task_id="task", job_id=JOB_ID, region_name=AWS_REGION, deferrable=True
-        )
-
     @mock.patch.object(BatchClientHook, "get_job_description")
-    def test_poke_on_success_state(self, mock_get_job_description):
+    def test_poke_on_success_state(self, mock_get_job_description, batch_sensor: BatchSensor):
         mock_get_job_description.return_value = {"status": "SUCCEEDED"}
-        assert self.batch_sensor.poke({}) is True
+        assert batch_sensor.poke({}) is True
         mock_get_job_description.assert_called_once_with(JOB_ID)
 
     @mock.patch.object(BatchClientHook, "get_job_description")
-    def test_poke_on_failure_state(self, mock_get_job_description):
+    def test_poke_on_failure_state(self, mock_get_job_description, batch_sensor: BatchSensor):
         mock_get_job_description.return_value = {"status": "FAILED"}
         with pytest.raises(AirflowException, match="Batch sensor failed. AWS Batch job status: FAILED"):
-            self.batch_sensor.poke({})
+            batch_sensor.poke({})
 
         mock_get_job_description.assert_called_once_with(JOB_ID)
 
     @mock.patch.object(BatchClientHook, "get_job_description")
-    def test_poke_on_invalid_state(self, mock_get_job_description):
+    def test_poke_on_invalid_state(self, mock_get_job_description, batch_sensor: BatchSensor):
         mock_get_job_description.return_value = {"status": "INVALID"}
         with pytest.raises(
             AirflowException, match="Batch sensor failed. Unknown AWS Batch job status: INVALID"
         ):
-            self.batch_sensor.poke({})
+            batch_sensor.poke({})
 
         mock_get_job_description.assert_called_once_with(JOB_ID)
 
     @pytest.mark.parametrize("job_status", ["SUBMITTED", "PENDING", "RUNNABLE", "STARTING", "RUNNING"])
     @mock.patch.object(BatchClientHook, "get_job_description")
-    def test_poke_on_intermediate_state(self, mock_get_job_description, job_status):
+    def test_poke_on_intermediate_state(
+        self, mock_get_job_description, job_status, batch_sensor: BatchSensor
+    ):
         print(job_status)
         mock_get_job_description.return_value = {"status": job_status}
-        assert self.batch_sensor.poke({}) is False
+        assert batch_sensor.poke({}) is False
         mock_get_job_description.assert_called_once_with(JOB_ID)
 
-    def test_execute_in_deferrable_mode(self):
+    def test_execute_in_deferrable_mode(self, deferrable_batch_sensor: BatchSensor):
         """
         Asserts that a task is deferred and a BatchSensorTrigger will be fired
         when the BatchSensor is executed in deferrable mode.
         """
 
         with pytest.raises(TaskDeferred) as exc:
-            self.deferrable_batch_sensor.execute({})
+            deferrable_batch_sensor.execute({})
         assert isinstance(exc.value.trigger, BatchJobTrigger), "Trigger is not a BatchJobTrigger"
 
-    def test_execute_failure_in_deferrable_mode(self):
+    def test_execute_failure_in_deferrable_mode(self, deferrable_batch_sensor: BatchSensor):
         """Tests that an AirflowException is raised in case of error event"""
 
         with pytest.raises(AirflowException):
-            self.deferrable_batch_sensor.execute_complete(context={}, event={"status": "failure"})
+            deferrable_batch_sensor.execute_complete(context={}, event={"status": "failure"})
+
+
+@pytest.fixture(scope="module")
+def batch_compute_environment_sensor() -> BatchComputeEnvironmentSensor:
+    return BatchComputeEnvironmentSensor(
+        task_id="test_batch_compute_environment_sensor",
+        compute_environment=ENVIRONMENT_NAME,
+    )
 
 
 class TestBatchComputeEnvironmentSensor:
-    def setup_method(self):
-        self.environment_name = "environment_name"
-        self.sensor = BatchComputeEnvironmentSensor(
-            task_id="test_batch_compute_environment_sensor",
-            compute_environment=self.environment_name,
-        )
-
     @mock.patch.object(BatchClientHook, "client")
-    def test_poke_no_environment(self, mock_batch_client):
+    def test_poke_no_environment(
+        self, mock_batch_client, batch_compute_environment_sensor: BatchComputeEnvironmentSensor
+    ):
         mock_batch_client.describe_compute_environments.return_value = {"computeEnvironments": []}
         with pytest.raises(AirflowException) as ctx:
-            self.sensor.poke({})
+            batch_compute_environment_sensor.poke({})
         mock_batch_client.describe_compute_environments.assert_called_once_with(
-            computeEnvironments=[self.environment_name],
+            computeEnvironments=[ENVIRONMENT_NAME],
         )
         assert "not found" in str(ctx.value)
 
     @mock.patch.object(BatchClientHook, "client")
-    def test_poke_valid(self, mock_batch_client):
+    def test_poke_valid(
+        self, mock_batch_client, batch_compute_environment_sensor: BatchComputeEnvironmentSensor
+    ):
         mock_batch_client.describe_compute_environments.return_value = {
             "computeEnvironments": [{"status": "VALID"}]
         }
-        assert self.sensor.poke({}) is True
+        assert batch_compute_environment_sensor.poke({}) is True
         mock_batch_client.describe_compute_environments.assert_called_once_with(
-            computeEnvironments=[self.environment_name],
+            computeEnvironments=[ENVIRONMENT_NAME],
         )
 
     @mock.patch.object(BatchClientHook, "client")
-    def test_poke_running(self, mock_batch_client):
+    def test_poke_running(
+        self, mock_batch_client, batch_compute_environment_sensor: BatchComputeEnvironmentSensor
+    ):
         mock_batch_client.describe_compute_environments.return_value = {
             "computeEnvironments": [
                 {
@@ -130,13 +145,15 @@ class TestBatchComputeEnvironmentSensor:
                 }
             ]
         }
-        assert self.sensor.poke({}) is False
+        assert batch_compute_environment_sensor.poke({}) is False
         mock_batch_client.describe_compute_environments.assert_called_once_with(
-            computeEnvironments=[self.environment_name],
+            computeEnvironments=[ENVIRONMENT_NAME],
         )
 
     @mock.patch.object(BatchClientHook, "client")
-    def test_poke_invalid(self, mock_batch_client):
+    def test_poke_invalid(
+        self, mock_batch_client, batch_compute_environment_sensor: BatchComputeEnvironmentSensor
+    ):
         mock_batch_client.describe_compute_environments.return_value = {
             "computeEnvironments": [
                 {
@@ -145,50 +162,53 @@ class TestBatchComputeEnvironmentSensor:
             ]
         }
         with pytest.raises(AirflowException) as ctx:
-            self.sensor.poke({})
+            batch_compute_environment_sensor.poke({})
         mock_batch_client.describe_compute_environments.assert_called_once_with(
-            computeEnvironments=[self.environment_name],
+            computeEnvironments=[ENVIRONMENT_NAME],
         )
         assert "AWS Batch compute environment failed" in str(ctx.value)
 
 
-class TestBatchJobQueueSensor:
-    def setup_method(self):
-        self.job_queue = "job_queue"
-        self.sensor = BatchJobQueueSensor(
-            task_id="test_batch_job_queue_sensor",
-            job_queue=self.job_queue,
-        )
+@pytest.fixture(scope="module")
+def batch_job_queue_sensor() -> BatchJobQueueSensor:
+    return BatchJobQueueSensor(
+        task_id="test_batch_job_queue_sensor",
+        job_queue=JOB_QUEUE,
+    )
 
+
+class TestBatchJobQueueSensor:
     @mock.patch.object(BatchClientHook, "client")
-    def test_poke_no_queue(self, mock_batch_client):
+    def test_poke_no_queue(self, mock_batch_client, batch_job_queue_sensor: BatchJobQueueSensor):
         mock_batch_client.describe_job_queues.return_value = {"jobQueues": []}
         with pytest.raises(AirflowException) as ctx:
-            self.sensor.poke({})
+            batch_job_queue_sensor.poke({})
         mock_batch_client.describe_job_queues.assert_called_once_with(
-            jobQueues=[self.job_queue],
+            jobQueues=[JOB_QUEUE],
         )
         assert "not found" in str(ctx.value)
 
     @mock.patch.object(BatchClientHook, "client")
-    def test_poke_no_queue_with_treat_non_existing_as_deleted(self, mock_batch_client):
-        self.sensor.treat_non_existing_as_deleted = True
+    def test_poke_no_queue_with_treat_non_existing_as_deleted(
+        self, mock_batch_client, batch_job_queue_sensor: BatchJobQueueSensor
+    ):
+        batch_job_queue_sensor.treat_non_existing_as_deleted = True
         mock_batch_client.describe_job_queues.return_value = {"jobQueues": []}
-        assert self.sensor.poke({}) is True
+        assert batch_job_queue_sensor.poke({}) is True
         mock_batch_client.describe_job_queues.assert_called_once_with(
-            jobQueues=[self.job_queue],
+            jobQueues=[JOB_QUEUE],
         )
 
     @mock.patch.object(BatchClientHook, "client")
-    def test_poke_valid(self, mock_batch_client):
+    def test_poke_valid(self, mock_batch_client, batch_job_queue_sensor: BatchJobQueueSensor):
         mock_batch_client.describe_job_queues.return_value = {"jobQueues": [{"status": "VALID"}]}
-        assert self.sensor.poke({}) is True
+        assert batch_job_queue_sensor.poke({}) is True
         mock_batch_client.describe_job_queues.assert_called_once_with(
-            jobQueues=[self.job_queue],
+            jobQueues=[JOB_QUEUE],
         )
 
     @mock.patch.object(BatchClientHook, "client")
-    def test_poke_running(self, mock_batch_client):
+    def test_poke_running(self, mock_batch_client, batch_job_queue_sensor: BatchJobQueueSensor):
         mock_batch_client.describe_job_queues.return_value = {
             "jobQueues": [
                 {
@@ -196,13 +216,13 @@ class TestBatchJobQueueSensor:
                 }
             ]
         }
-        assert self.sensor.poke({}) is False
+        assert batch_job_queue_sensor.poke({}) is False
         mock_batch_client.describe_job_queues.assert_called_once_with(
-            jobQueues=[self.job_queue],
+            jobQueues=[JOB_QUEUE],
         )
 
     @mock.patch.object(BatchClientHook, "client")
-    def test_poke_invalid(self, mock_batch_client):
+    def test_poke_invalid(self, mock_batch_client, batch_job_queue_sensor: BatchJobQueueSensor):
         mock_batch_client.describe_job_queues.return_value = {
             "jobQueues": [
                 {
@@ -211,8 +231,8 @@ class TestBatchJobQueueSensor:
             ]
         }
         with pytest.raises(AirflowException) as ctx:
-            self.sensor.poke({})
+            batch_job_queue_sensor.poke({})
         mock_batch_client.describe_job_queues.assert_called_once_with(
-            jobQueues=[self.job_queue],
+            jobQueues=[JOB_QUEUE],
         )
         assert "AWS Batch job queue failed" in str(ctx.value)


### PR DESCRIPTION
During worked on https://github.com/apache/airflow/pull/33405, I noticed that we have `BatchSensorAsync` test cases while this sensor doesn't exist.

This PR contains the following changes.

1. merge `TestBatchSensorAsync` into `TestBatchSensor`
2. replace setup_method with fixture (as suggested [here](https://github.com/apache/airflow/blob/main/TESTING.rst#writing-unit-tests))

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
