### PR TITLE
Fix getting correct commit from multiple referenced PR

### DIFF
--- a/dev/airflow-github
+++ b/dev/airflow-github
@@ -83,9 +83,10 @@ def get_issue_type(issue):
 def get_commit_in_main_associated_with_pr(repo: git.Repo, issue: Issue) -> str | None:
     """For a PR, find the associated merged commit & return its SHA"""
     if issue.pull_request:
-        commit = repo.git.log(f"--grep=#{issue.number}", "origin/main", "--format=%H")
+        commit = repo.git.log("--reverse", f"--grep=#{issue.number}", "origin/main", "--format=%H")
         if commit:
-            return commit
+            # We only want the oldest commit that referenced this PR number
+            return commit.splitlines()[0]
         else:
             pr: PullRequest = issue.as_pull_request()
             if pr.is_merged():


### PR DESCRIPTION
When a PR is referenced by other PRs, our dev tool for getting the correct commit lists the latest commit when looking for the commit sha but we should get the oldest.

If you run:
`git log --grep "#33145" --format=%H` returns two commits:
```
3dd0c999f1159a2fefbf32d9f10208a274a79a62
d1d6fc994d46aaed9c801162595cae91a1ffc19c
```
The correct commit for the PR is `d1d6fc994d46aaed9c801162595cae91a1ffc19c` but the first one is returned.

This PR uses --reverse to get the oldest commit where the PR number #33145 was mentioned which equals the PR. 
