### PR TITLE
Remove uploading to test pypi for releases

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
@@ -194,33 +194,25 @@ def prepare_pypi_packages(version, version_suffix, repo_root):
         console_print("PyPI packages prepared")
 
 
-def push_packages_to_test_pypi(version):
-    if confirm_action("Do you want to push packages to test PyPI?"):
-        run_command(["twine", "upload", "-r", "pypitest", "dist/*"], dry_run_override=DRY_RUN, check=True)
-        console_print("Packages pushed to test PyPI")
-        console_print(
-            "Verify that the test package looks good by downloading it and installing it into a virtual "
-            "environment. The package download link is available at: "
-            "https://test.pypi.org/project/apache-airflow/#files "
-            "Install it with the appropriate constraint file, adapt python version: "
-            f"pip install -i https://test.pypi.org/simple/ --extra-index-url "
-            f"https://pypi.org/simple/apache-airflow=={version} --constraint "
-            f"https://raw.githubusercontent.com/apache/airflow/"
-            f"constraints-{version}/constraints-3.8.txt"
-        )
-
-
-def push_packages_to_pypi():
+def push_packages_to_pypi(version):
     if confirm_action("Do you want to push packages to production PyPI?"):
-        confirm_action(
-            "I have tested the package I uploaded to test PyPI. "
-            "I installed and ran a DAG with it and there's no issue. Do you agree to the above?",
-            abort=True,
-        )
         run_command(["twine", "upload", "-r", "pypi", "dist/*"], dry_run_override=DRY_RUN, check=True)
         console_print("Packages pushed to production PyPI")
         console_print(
             "Again, confirm that the package is available here: https://pypi.python.org/pypi/apache-airflow"
+        )
+        console_print(
+            "Verify that the package looks good by downloading it and installing it into a virtual "
+            "environment. "
+            "Install it with the appropriate constraint file, adapt python version: "
+            f"pip install apache-airflow=={version} --constraint "
+            f"https://raw.githubusercontent.com/apache/airflow/"
+            f"constraints-{version}/constraints-3.8.txt"
+        )
+        confirm_action(
+            "I have tested the package I uploaded to PyPI. "
+            "I installed and ran a DAG with it and there's no issue. Do you agree to the above?",
+            abort=True,
         )
         console_print(
             """
@@ -377,11 +369,9 @@ def publish_release_candidate(version, previous_version, github_token):
 
     # Prepare the pypi packages
     prepare_pypi_packages(version, version_suffix, airflow_repo_root)
-    # Push the packages to test pypi
-    push_packages_to_test_pypi(version)
 
     # Push the packages to pypi
-    push_packages_to_pypi()
+    push_packages_to_pypi(version)
 
     # Push the release candidate tag to gitHub
     push_release_candidate_tag_to_github(version)

--- a/dev/breeze/src/airflow_breeze/commands/release_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_command.py
@@ -100,28 +100,8 @@ def verify_pypi_package(version):
         run_command(["twine", "check", "*.whl", f"*{version}.tar.gz"], check=True)
 
 
-def upload_to_pypi_test(version):
-    if confirm_action("Upload to PyPI test?"):
-        run_command(
-            ["twine", "upload", "-r", "pypitest", "*.whl", f"*{version}.tar.gz"],
-            dry_run_override=DRY_RUN,
-            check=True,
-        )
-        console_print("Packages pushed to test PyPI")
-        console_print(
-            "Verify that the test package looks good by downloading it and installing it into a virtual "
-            "environment. The package download link is available at: "
-            "https://test.pypi.org/project/apache-airflow/#files"
-        )
-
-
 def upload_to_pypi(version):
     if confirm_action("Upload to PyPI?"):
-        confirm_action(
-            "I have tested the package I uploaded to test PyPI. "
-            "I installed and ran a DAG with it and there's no issue. Do you agree to the above?",
-            abort=True,
-        )
         run_command(
             ["twine", "upload", "-r", "pypi", "*.whl", f"*{version}.tar.gz"],
             dry_run_override=DRY_RUN,
@@ -129,7 +109,9 @@ def upload_to_pypi(version):
         )
         console_print("Packages pushed to production PyPI")
         console_print(
-            "Again, confirm that the package is available here: https://pypi.python.org/pypi/apache-airflow"
+            "Verify that the package looks good by downloading it and installing it into a virtual "
+            "environment. The package download link is available at: "
+            "https://pypi.python.org/pypi/apache-airflow"
         )
 
 
@@ -276,8 +258,6 @@ def airflow_release(release_candidate, previous_release):
         os.chdir(svn_release_version_dir)
     verify_pypi_package(version)
 
-    # Upload to pypi test
-    upload_to_pypi_test(version)
     # Upload to pypi
     upload_to_pypi(version)
 


### PR DESCRIPTION
Test pypi doesn't work for org and our uploads are failing each time. Time to remove it!

