### PR TITLE
Fixing static checks for FabAirflowSecurityManagerOverride

### DIFF
--- a/airflow/auth/managers/fab/security_manager/modules/db.py
+++ b/airflow/auth/managers/fab/security_manager/modules/db.py
@@ -34,16 +34,16 @@ log = logging.getLogger(__name__)
 
 class FabAirflowSecurityManagerOverrideDb:
     """
+    FabAirflowSecurityManagerOverride is split into multiple classes to avoid having one massive class.
+
     This class contains all methods in
     airflow.auth.managers.fab.security_manager.override.FabAirflowSecurityManagerOverride related to the
     database.
 
-    FabAirflowSecurityManagerOverride is split into multiple classes to avoid having one massive class.
-
     :param appbuilder: The appbuilder.
     """
 
-    """ Models """
+    # Models
     role_model = Role
     permission_model = Permission
     action_model = Action

--- a/airflow/auth/managers/fab/security_manager/modules/oauth.py
+++ b/airflow/auth/managers/fab/security_manager/modules/oauth.py
@@ -29,11 +29,11 @@ log = logging.getLogger(__name__)
 
 class FabAirflowSecurityManagerOverrideOauth:
     """
+    FabAirflowSecurityManagerOverride is split into multiple classes to avoid having one massive class.
+
     This class contains all methods in
     airflow.auth.managers.fab.security_manager.override.FabAirflowSecurityManagerOverride related to the
     oauth authentication.
-
-    FabAirflowSecurityManagerOverride is split into multiple classes to avoid having one massive class.
     """
 
     def get_oauth_user_info(self, provider, resp):


### PR DESCRIPTION
Fixing static checks. FabAirflowSecurityManagerOverrideDb and FabAirflowSecurityManagerOverrideOauth were failing pydocstyle rule D205

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
