### PR TITLE
Add typing to concrete taskflow examples

### DIFF
--- a/docs/shared/template-examples/taskflow-kwargs.rst
+++ b/docs/shared/template-examples/taskflow-kwargs.rst
@@ -17,11 +17,15 @@
 
  .. code-block:: python
 
+    from airflow.models.taskinstance import TaskInstance
+    from airflow.models.dagrun import DagRun
+
+
     @task
     def print_ti_info(**kwargs):
-        ti = kwargs["task_instance"]
+        ti: TaskInstance = kwargs["task_instance"]
         print(f"Run ID: {ti.run_id}")  # Run ID: scheduled__2023-08-09T00:00:00+00:00
         print(f"Duration: {ti.duration}")  # Duration: 0.972019
 
-        dr = kwargs["dag_run"]
+        dr: DagRun = kwargs["dag_run"]
         print(f"DAG Run queued at: {dr.queued_at}")  # 2023-08-10 00:00:01+02:20

--- a/docs/shared/template-examples/taskflow.rst
+++ b/docs/shared/template-examples/taskflow.rst
@@ -17,8 +17,12 @@
 
  .. code-block:: python
 
+    from airflow.models.taskinstance import TaskInstance
+    from airflow.models.dagrun import DagRun
+
+
     @task
-    def print_ti_info(task_instance=None, dag_run=None):
+    def print_ti_info(task_instance: TaskInstance | None = None, dag_run: DagRun | None = None):
         print(f"Run ID: {task_instance.run_id}")  # Run ID: scheduled__2023-08-09T00:00:00+00:00
         print(f"Duration: {task_instance.duration}")  # Duration: 0.972019
         print(f"DAG Run queued at: {dag_run.queued_at}")  # 2023-08-10 00:00:01+02:20


### PR DESCRIPTION
I just saw the PR #33296 in Slack and really liked it - I was struggeling to find concrete examples myself multiple times. Thanks to  @RNHTTR for making this!

When taking a look to the examples I noticed that they were not using any typing. I really much like Python type annotations to check code and preventing typos, allowing mypy also to check DAG code.

This PR is a proposal - other opinions welcome - to add typing to examples.