### PR TITLE
More complete fix for dev release scripts to filter commit for PR

### DIFF
--- a/dev/airflow-github
+++ b/dev/airflow-github
@@ -83,27 +83,31 @@ def get_issue_type(issue):
 def get_commit_in_main_associated_with_pr(repo: git.Repo, issue: Issue) -> str | None:
     """For a PR, find the associated merged commit & return its SHA"""
     if issue.pull_request:
-        commit = repo.git.log("--reverse", f"--grep=#{issue.number}", "origin/main", "--format=%H")
-        if commit:
-            # We only want the oldest commit that referenced this PR number
-            return commit.splitlines()[0]
+        log_output = repo.git.log(f"--grep=(#{issue.number})$", "origin/main", "--format=%H %s")
+        if log_output:
+            for commit_line in log_output.splitlines():
+                # We only want the commit for the PR where squash-merge added (#PR) at the end of subject
+                if commit_line and commit_line.endswith(f"(#{issue.number})"):
+                    return commit_line.split(" ")[0]
+            return None
         else:
             pr: PullRequest = issue.as_pull_request()
             if pr.is_merged():
-                commit = pr.merge_commit_sha
-                return commit
+                return pr.merge_commit_sha
     return None
 
 
 def is_cherrypicked(repo: git.Repo, issue: Issue, previous_version: str | None = None) -> bool:
     """Check if a given issue is cherry-picked in the current branch or not"""
-    log_args = ["--format=%H", f"--grep=(#{issue.number})$"]
+    log_args = ["--format=%H %s", f"--grep=(#{issue.number})$"]
     if previous_version:
         log_args.append(previous_version + "..")
-    log = repo.git.log(*log_args)
+    log_output = repo.git.log(*log_args)
 
-    if log:
-        return True
+    for commit_line in log_output.splitlines():
+        # We only want the commit for the PR where squash-merge added (#PR) at the end of subject
+        if commit_line and commit_line.endswith(f"(#{issue.number})"):
+            return True
     return False
 
 


### PR DESCRIPTION
This is a more complete fix to #33411. This is also a follow up on earlier implementation of #33261 that addressed checking if PRs are merged. This one applies the same pattern to finding commit but also improves it by checking if the (#NNNNNN) ends the subject
- so even if the PR is in the same form in the message, it will be filtered out.

The previous "--reverse" quick fix in #33411 had potential of problem in case there were releated PRs merged before the original PR (which is quite posssible when you have a series of PRs referring to each other.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
