### PR TITLE
Add a mechanism to warn if executors override existing CLI commands

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -24,6 +24,7 @@
 from __future__ import annotations
 
 import argparse
+import collections
 import logging
 from argparse import Action
 from functools import lru_cache
@@ -41,11 +42,12 @@ from airflow.cli.cli_config import (
     GroupCommand,
     core_commands,
 )
+from airflow.cli.utils import CliConflictError
 from airflow.exceptions import AirflowException
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.utils.helpers import partition
 
-airflow_commands = core_commands
+airflow_commands = core_commands.copy()  # make a copy to prevent bad interactions in tests
 
 log = logging.getLogger(__name__)
 try:
@@ -59,26 +61,20 @@ except Exception:
         "a 3.3.0+ version of the Celery provider. If using a Kubernetes executor, install a "
         "7.4.0+ version of the CNCF provider"
     )
-    # Do no re-raise the exception since we want the CLI to still function for
+    # Do not re-raise the exception since we want the CLI to still function for
     # other commands.
 
 
 ALL_COMMANDS_DICT: dict[str, CLICommand] = {sp.name: sp for sp in airflow_commands}
 
+
 # Check if sub-commands are defined twice, which could be an issue.
 if len(ALL_COMMANDS_DICT) < len(airflow_commands):
-    seen = set()
-    dup = []
-    for command in airflow_commands:
-        if command.name not in seen:
-            seen.add(command.name)
-        else:
-            dup.append(command.name)
-    log.warning(
-        "The following CLI %d command(s) are defined more than once, "
-        "CLI behavior when using those will be unpredictable: %s",
-        len(dup),
-        dup,
+    dup = {k for k, v in collections.Counter([c.name for c in airflow_commands]).items() if v > 1}
+    raise CliConflictError(
+        f"The following CLI {len(dup)} command(s) are defined more than once: {sorted(dup)}\n"
+        f"This can be due to the executor '{ExecutorLoader.get_default_executor_name()}' "
+        f"redefining core airflow CLI commands."
     )
 
 

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -65,6 +65,22 @@ except Exception:
 
 ALL_COMMANDS_DICT: dict[str, CLICommand] = {sp.name: sp for sp in airflow_commands}
 
+# Check if sub-commands are defined twice, which could be an issue.
+if len(ALL_COMMANDS_DICT) < len(airflow_commands):
+    seen = set()
+    dup = []
+    for command in airflow_commands:
+        if command.name not in seen:
+            seen.add(command.name)
+        else:
+            dup.append(command.name)
+    log.warning(
+        "The following CLI %d command(s) are defined more than once, "
+        "CLI behavior when using those will be unpredictable: %s",
+        len(dup),
+        dup,
+    )
+
 
 class AirflowHelpFormatter(RichHelpFormatter):
     """

--- a/airflow/cli/utils.py
+++ b/airflow/cli/utils.py
@@ -21,6 +21,12 @@ import io
 import sys
 
 
+class CliConflictError(Exception):
+    """Error for when CLI commands are defined twice by different sources."""
+
+    pass
+
+
 def is_stdout(fileio: io.IOBase) -> bool:
     """Check whether a file IO is stdout.
 

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -488,6 +488,7 @@ class BaseExecutor(LoggingMixin):
 
         Override this method to expose commands via Airflow CLI to manage this executor. This can
         be commands to setup/teardown the executor, inspect state, etc.
+        Make sure to choose unique names for those commands, to avoid collisions.
         """
         return []
 

--- a/tests/cli/commands/test_celery_command.py
+++ b/tests/cli/commands/test_celery_command.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import importlib
 from argparse import Namespace
 from tempfile import NamedTemporaryFile
 from unittest import mock
@@ -65,11 +66,12 @@ class TestWorkerPrecheck:
 class TestCeleryStopCommand:
     @classmethod
     def setup_class(cls):
-        cls.parser = cli_parser.get_parser()
+        with conf_vars({("core", "executor"): "CeleryExecutor"}):
+            importlib.reload(cli_parser)
+            cls.parser = cli_parser.get_parser()
 
     @mock.patch("airflow.cli.commands.celery_command.setup_locations")
     @mock.patch("airflow.cli.commands.celery_command.psutil.Process")
-    @conf_vars({("core", "executor"): "CeleryExecutor"})
     def test_if_right_pid_is_read(self, mock_process, mock_setup_locations):
         args = self.parser.parse_args(["celery", "stop"])
         pid = "123"
@@ -90,7 +92,6 @@ class TestCeleryStopCommand:
     @mock.patch("airflow.cli.commands.celery_command.read_pid_from_pidfile")
     @mock.patch("airflow.providers.celery.executors.celery_executor.app")
     @mock.patch("airflow.cli.commands.celery_command.setup_locations")
-    @conf_vars({("core", "executor"): "CeleryExecutor"})
     def test_same_pid_file_is_used_in_start_and_stop(
         self, mock_setup_locations, mock_celery_app, mock_read_pid_from_pidfile
     ):
@@ -116,7 +117,6 @@ class TestCeleryStopCommand:
     @mock.patch("airflow.providers.celery.executors.celery_executor.app")
     @mock.patch("airflow.cli.commands.celery_command.psutil.Process")
     @mock.patch("airflow.cli.commands.celery_command.setup_locations")
-    @conf_vars({("core", "executor"): "CeleryExecutor"})
     def test_custom_pid_file_is_used_in_start_and_stop(
         self,
         mock_setup_locations,
@@ -147,12 +147,13 @@ class TestCeleryStopCommand:
 class TestWorkerStart:
     @classmethod
     def setup_class(cls):
-        cls.parser = cli_parser.get_parser()
+        with conf_vars({("core", "executor"): "CeleryExecutor"}):
+            importlib.reload(cli_parser)
+            cls.parser = cli_parser.get_parser()
 
     @mock.patch("airflow.cli.commands.celery_command.setup_locations")
     @mock.patch("airflow.cli.commands.celery_command.Process")
     @mock.patch("airflow.providers.celery.executors.celery_executor.app")
-    @conf_vars({("core", "executor"): "CeleryExecutor"})
     def test_worker_started_with_required_arguments(self, mock_celery_app, mock_popen, mock_locations):
         pid_file = "pid_file"
         mock_locations.return_value = (pid_file, None, None, None)
@@ -208,11 +209,12 @@ class TestWorkerStart:
 class TestWorkerFailure:
     @classmethod
     def setup_class(cls):
-        cls.parser = cli_parser.get_parser()
+        with conf_vars({("core", "executor"): "CeleryExecutor"}):
+            importlib.reload(cli_parser)
+            cls.parser = cli_parser.get_parser()
 
     @mock.patch("airflow.cli.commands.celery_command.Process")
     @mock.patch("airflow.providers.celery.executors.celery_executor.app")
-    @conf_vars({("core", "executor"): "CeleryExecutor"})
     def test_worker_failure_gracefull_shutdown(self, mock_celery_app, mock_popen):
         args = self.parser.parse_args(["celery", "worker"])
         mock_celery_app.run.side_effect = Exception("Mock exception to trigger runtime error")
@@ -226,10 +228,11 @@ class TestWorkerFailure:
 class TestFlowerCommand:
     @classmethod
     def setup_class(cls):
-        cls.parser = cli_parser.get_parser()
+        with conf_vars({("core", "executor"): "CeleryExecutor"}):
+            importlib.reload(cli_parser)
+            cls.parser = cli_parser.get_parser()
 
     @mock.patch("airflow.providers.celery.executors.celery_executor.app")
-    @conf_vars({("core", "executor"): "CeleryExecutor"})
     def test_run_command(self, mock_celery_app):
         args = self.parser.parse_args(
             [
@@ -268,7 +271,6 @@ class TestFlowerCommand:
     @mock.patch("airflow.cli.commands.celery_command.setup_locations")
     @mock.patch("airflow.cli.commands.celery_command.daemon")
     @mock.patch("airflow.providers.celery.executors.celery_executor.app")
-    @conf_vars({("core", "executor"): "CeleryExecutor"})
     def test_run_command_daemon(self, mock_celery_app, mock_daemon, mock_setup_locations, mock_pid_file):
         mock_setup_locations.return_value = (
             mock.MagicMock(name="pidfile"),

--- a/tests/cli/commands/test_kubernetes_command.py
+++ b/tests/cli/commands/test_kubernetes_command.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import importlib
 import os
 import tempfile
 from unittest import mock
@@ -26,12 +27,15 @@ from dateutil.parser import parse
 
 from airflow.cli import cli_parser
 from airflow.cli.commands import kubernetes_command
+from tests.test_utils.config import conf_vars
 
 
 class TestGenerateDagYamlCommand:
     @classmethod
     def setup_class(cls):
-        cls.parser = cli_parser.get_parser()
+        with conf_vars({("core", "executor"): "KubernetesExecutor"}):
+            importlib.reload(cli_parser)
+            cls.parser = cli_parser.get_parser()
 
     def test_generate_dag_yaml(self):
         with tempfile.TemporaryDirectory("airflow_dry_run_test/") as directory:
@@ -61,7 +65,9 @@ class TestCleanUpPodsCommand:
 
     @classmethod
     def setup_class(cls):
-        cls.parser = cli_parser.get_parser()
+        with conf_vars({("core", "executor"): "KubernetesExecutor"}):
+            importlib.reload(cli_parser)
+            cls.parser = cli_parser.get_parser()
 
     @mock.patch("kubernetes.client.CoreV1Api.delete_namespaced_pod")
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.config.load_incluster_config")

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -23,7 +23,9 @@ import pytest
 
 from airflow import models
 from airflow.cli import cli_parser
+from airflow.executors import local_executor
 from airflow.providers.celery.executors import celery_executor, celery_kubernetes_executor
+from airflow.providers.cncf.kubernetes.executors import kubernetes_executor, local_kubernetes_executor
 from tests.test_utils.config import conf_vars
 
 # Create custom executors here because conftest is imported first
@@ -34,17 +36,14 @@ custom_executor_module.CustomCeleryExecutor = type(  # type:  ignore
 custom_executor_module.CustomCeleryKubernetesExecutor = type(  # type: ignore
     "CustomCeleryKubernetesExecutor", (celery_kubernetes_executor.CeleryKubernetesExecutor,), {}
 )
-custom_executor_module.CustomCeleryExecutor = type(  # type:  ignore
-    "CustomLocalExecutor", (celery_executor.CeleryExecutor,), {}
+custom_executor_module.CustomLocalExecutor = type(  # type:  ignore
+    "CustomLocalExecutor", (local_executor.LocalExecutor,), {}
 )
-custom_executor_module.CustomCeleryKubernetesExecutor = type(  # type: ignore
-    "CustomLocalKubernetesExecutor", (celery_kubernetes_executor.CeleryKubernetesExecutor,), {}
+custom_executor_module.CustomLocalKubernetesExecutor = type(  # type: ignore
+    "CustomLocalKubernetesExecutor", (local_kubernetes_executor.LocalKubernetesExecutor,), {}
 )
-custom_executor_module.CustomCeleryExecutor = type(  # type:  ignore
-    "CustomKubernetesExecutor", (celery_executor.CeleryExecutor,), {}
-)
-custom_executor_module.CustomCeleryKubernetesExecutor = type(  # type: ignore
-    "CustomCeleryKubernetesExecutor", (celery_kubernetes_executor.CeleryKubernetesExecutor,), {}
+custom_executor_module.CustomKubernetesExecutor = type(  # type:  ignore
+    "CustomKubernetesExecutor", (kubernetes_executor.KubernetesExecutor,), {}
 )
 sys.modules["custom_executor"] = custom_executor_module
 

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -272,15 +272,16 @@ class TestCli:
         [
             ("CeleryExecutor", ["celery"]),
             ("CeleryKubernetesExecutor", ["celery", "kubernetes"]),
-            ("custom_executor.CustomCeleryExecutor", ["celery"]),
-            ("custom_executor.CustomCeleryKubernetesExecutor", ["celery", "kubernetes"]),
             ("KubernetesExecutor", ["kubernetes"]),
-            ("custom_executor.KubernetesExecutor", ["kubernetes"]),
             ("LocalExecutor", []),
             ("LocalKubernetesExecutor", ["kubernetes"]),
-            ("custom_executor.LocalExecutor", []),
-            ("custom_executor.LocalKubernetesExecutor", ["kubernetes"]),
             ("SequentialExecutor", []),
+            # custom executors are mapped to the regular ones in `conftest.py`
+            ("custom_executor.CustomLocalExecutor", []),
+            ("custom_executor.CustomLocalKubernetesExecutor", ["kubernetes"]),
+            ("custom_executor.CustomCeleryExecutor", ["celery"]),
+            ("custom_executor.CustomCeleryKubernetesExecutor", ["celery", "kubernetes"]),
+            ("custom_executor.CustomKubernetesExecutor", ["kubernetes"]),
         ],
     )
     def test_cli_parser_executors(self, executor, expected_args):
@@ -291,9 +292,9 @@ class TestCli:
             ) as stderr:
                 reload(cli_parser)
                 parser = cli_parser.get_parser()
-                with pytest.raises(SystemExit) as e:
+                with pytest.raises(SystemExit) as e:  # running the help command exits, so we prevent that
                     parser.parse_args([expected_arg, "--help"])
-                assert e.value.code == 0, stderr.getvalue()
+                assert e.value.code == 0, stderr.getvalue()  # return code 0 == no problem
                 stderr = stderr.getvalue()
                 assert "airflow command error" not in stderr
 

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -29,7 +29,6 @@ import timeit
 from collections import Counter
 from importlib import reload
 from pathlib import Path
-from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -136,7 +135,7 @@ class TestCli:
                     f"short option flags {conflict_short_option}"
                 )
 
-    @mock.patch.object(LocalExecutor, "get_cli_commands")
+    @patch.object(LocalExecutor, "get_cli_commands")
     def test_dynamic_conflict_detection(self, cli_commands_mock: MagicMock):
         core_commands.append(
             ActionCommand(


### PR DESCRIPTION
Currently, if an executor redefines and existing command (allowed by #29055), I think it silently overrides the existing one, which can be an issue.
I'm in the process of adding one more way to add commands, so doing this seems like a good idea.

Also fixed a test side-effect, which led to fixing a bunch of tests that were only working because of the order in which they were called.