### PR TITLE
Create a new method used to resume the task in order to implement specific logic for operators

### DIFF
--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -287,9 +287,7 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
             return super().resume_execution(next_method, next_kwargs, context)
         except (AirflowException, TaskDeferralError) as e:
             if self.soft_fail:
-                raise AirflowSkipException(str(e))
-            raise
-        except Exception:
+                raise AirflowSkipException(str(e)) from e
             raise
 
     def _get_next_poke_interval(

--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -35,6 +35,7 @@ from airflow.exceptions import (
     AirflowSensorTimeout,
     AirflowSkipException,
     AirflowTaskTimeout,
+    TaskDeferralError,
 )
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.models.baseoperator import BaseOperator
@@ -284,7 +285,7 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
     def resume_execution(self, next_method: str, next_kwargs: dict[str, Any] | None, context: Context):
         try:
             return super().resume_execution(next_method, next_kwargs, context)
-        except AirflowException as e:
+        except (AirflowException, TaskDeferralError) as e:
             if self.soft_fail:
                 raise AirflowSkipException(e)
             raise

--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -286,7 +286,7 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
             return super().resume_execution(next_method, next_kwargs, context)
         except AirflowException as e:
             if self.soft_fail:
-                raise AirflowSkipException(e.args[0][1])
+                raise AirflowSkipException(e)
             raise
         except Exception:
             raise

--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -287,7 +287,7 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
             return super().resume_execution(next_method, next_kwargs, context)
         except (AirflowException, TaskDeferralError) as e:
             if self.soft_fail:
-                raise AirflowSkipException(e)
+                raise AirflowSkipException(str(e))
             raise
         except Exception:
             raise

--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -281,6 +281,16 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         self.log.info("Success criteria met. Exiting.")
         return xcom_value
 
+    def resume_execution(self, next_method: str, next_kwargs: dict[str, Any] | None, context: Context):
+        try:
+            return super().resume_execution(next_method, next_kwargs, context)
+        except AirflowException as e:
+            if self.soft_fail:
+                raise AirflowSkipException(e.args[0][1])
+            raise
+        except Exception:
+            raise
+
     def _get_next_poke_interval(
         self,
         started_at: datetime.datetime | float,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: #33405
related: #33196

This PR creates a new method used by the TI to resume the execution, and moves handling the triggers errors to this method. In this way we can simplify handling the trigger result which should not be in TaskInstance, and implement specific  processing for some operators.

With this solution we can easily handle the soft fail for all the sensors (the core operators, where we still need a solution for providers sensors when using an older version of Airflow).


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
