### PR TITLE
Allowing ability to add custom env into pgbouncer container

### DIFF
--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -101,12 +101,8 @@ spec:
           args: {{ tpl (toYaml .Values.pgbouncer.args) . | nindent 12 }}
           {{- end }}
           resources: {{- toYaml .Values.pgbouncer.resources | nindent 12 }}
-          {{- if .Values.pgbouncer.env }}
-          env:
-            {{- range $i, $config := .Values.pgbouncer.env }}
-            - value: {{ $config.value }}
-              name: {{ $config.name }}
-            {{- end }}
+          {{- with .Values.pgbouncer.env }}
+          env: {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
             - name: pgbouncer

--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -101,6 +101,13 @@ spec:
           args: {{ tpl (toYaml .Values.pgbouncer.args) . | nindent 12 }}
           {{- end }}
           resources: {{- toYaml .Values.pgbouncer.resources | nindent 12 }}
+          {{- if .Values.pgbouncer.env }}
+          env:
+            {{- range $i, $config := .Values.pgbouncer.env }}
+            - value: {{ $config.value }}
+              name: {{ $config.name }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: pgbouncer
               containerPort: {{ .Values.ports.pgbouncer }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -5081,6 +5081,27 @@
             "x-docsSection": "PgBouncer",
             "additionalProperties": false,
             "properties": {
+                "env": {
+                    "description": "Add additional env vars to pgbouncer container.",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "value"
+                        ],
+                        "additionalProperties": false
+                    }
+                },
                 "enabled": {
                     "description": "Enable PgBouncer.",
                     "type": "boolean",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -5082,7 +5082,7 @@
             "additionalProperties": false,
             "properties": {
                 "env": {
-                    "description": "Add additional env vars to pgbouncer container.",
+                    "description": "Add additional env vars to `pgbouncer` container.",
                     "type": "array",
                     "default": [],
                     "items": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1926,6 +1926,9 @@ pgbouncer:
       periodSeconds: 10
       timeoutSeconds: 1
 
+  # Environment variables to add to pgbouncer container
+  env: []
+
 # Configuration for the redis provisioned by the chart
 redis:
   enabled: true

--- a/helm_tests/other/test_pgbouncer.py
+++ b/helm_tests/other/test_pgbouncer.py
@@ -525,6 +525,21 @@ class TestPgbouncerConfig:
         assert "server_round_robin = 1" in ini
         assert "stats_period = 30" in ini
 
+    def test_should_add_custom_env_variables(self):
+        env1 = {"name": "TEST_ENV_1", "value": "test_env_1"}
+
+        docs = render_chart(
+            values={
+                "pgbouncer": {
+                    "enabled": True,
+                    "env": [env1],
+                },
+            },
+            show_only=["templates/pgbouncer/pgbouncer-deployment.yaml"],
+        )[0]
+
+        assert jmespath.search("spec.template.spec.containers[0].env", docs) == [env1]
+
 
 class TestPgbouncerExporter:
     """Tests PgBouncer exporter."""


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Currently, we do not allow adding custom environment variables into the pgbouncer container. It should be allowed when we want to set some custom configs through env.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
