### PR TITLE
Fix Cluster Activity Health margin

### DIFF
--- a/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
+++ b/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
@@ -105,6 +105,7 @@ const Health = (props: CenterProps) => {
               title="Triggerer"
               status={data?.triggerer?.status}
               latestHeartbeat={data?.triggerer?.latestTriggererHeartbeat}
+              mb={3}
             />
             <HealthSection
               title="Dag Processor"


### PR DESCRIPTION
One liner adjustment, a margin was missing here.

## before:
![image](https://github.com/apache/airflow/assets/14861206/cd7b4e1f-c8af-471e-ae2c-801486501c21)

## after:
![image](https://github.com/apache/airflow/assets/14861206/60903f88-8d33-4447-9848-440dcf08b63c)
