### PR TITLE
Fix updating account url for WasbHook

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import logging
 import os
 from typing import Any, Union
+from urllib.parse import urlparse
 
 from asgiref.sync import sync_to_async
 from azure.core.exceptions import HttpResponseError, ResourceExistsError, ResourceNotFoundError
@@ -152,11 +153,13 @@ class WasbHook(BaseHook):
             # connection_string auth takes priority
             return BlobServiceClient.from_connection_string(connection_string, **extra)
 
-        account_url = (
-            conn.host
-            if conn.host and conn.host.startswith("https://")
-            else f"https://{conn.login}.blob.core.windows.net/"
-        )
+        account_url = conn.host if conn.host else f"https://{conn.login}.blob.core.windows.net/"
+        parsed_url = urlparse(account_url)
+
+        if not parsed_url.netloc and "." not in parsed_url.path:
+            # if there's no netloc and no dots in the path, then user only
+            # provided the host ID, not the full URL or DNS name
+            account_url = f"https://{conn.login}.blob.core.windows.net/"
 
         tenant = self._get_field(extra, "tenant_id")
         if tenant:
@@ -555,11 +558,13 @@ class WasbAsyncHook(WasbHook):
             )
             return self.blob_service_client
 
-        account_url = (
-            conn.host
-            if conn.host and conn.host.startswith("https://")
-            else f"https://{conn.login}.blob.core.windows.net/"
-        )
+        account_url = conn.host if conn.host else f"https://{conn.login}.blob.core.windows.net/"
+        parsed_url = urlparse(account_url)
+
+        if not parsed_url.netloc and "." not in parsed_url.path:
+            # if there's no netloc and no dots in the path, then user only
+            # provided the host ID, not the full URL or DNS name
+            account_url = f"https://{conn.login}.blob.core.windows.net/"
 
         tenant = self._get_field(extra, "tenant_id")
         if tenant:

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -158,7 +158,7 @@ class WasbHook(BaseHook):
 
         if not parsed_url.netloc and "." not in parsed_url.path:
             # if there's no netloc and no dots in the path, then user only
-            # provided the host ID, not the full URL or DNS name
+            # provided the Active Directory ID, not the full URL or DNS name
             account_url = f"https://{conn.login}.blob.core.windows.net/"
 
         tenant = self._get_field(extra, "tenant_id")
@@ -563,7 +563,7 @@ class WasbAsyncHook(WasbHook):
 
         if not parsed_url.netloc and "." not in parsed_url.path:
             # if there's no netloc and no dots in the path, then user only
-            # provided the host ID, not the full URL or DNS name
+            # provided the Active Directory ID, not the full URL or DNS name
             account_url = f"https://{conn.login}.blob.core.windows.net/"
 
         tenant = self._get_field(extra, "tenant_id")


### PR DESCRIPTION
There are different ways users supply the hostname(account url) in Azure, sometimes the host doesn't have a urlparse.scheme but has urlparse.path e.g. name.blob.windows.net and other times, it will just be Azure ID e.g. aldhjf9dads. While working on #32980, I assumed that if there's no scheme, then the hostname is not valid, that's incorrect since DNS can serve as the host.
The fix was to check if we don't have netloc and that urlparse.path does not include a dot and if it does not, use the login/account_name to construct the account_url

Closes: https://github.com/apache/airflow/issues/33203