### PR TITLE
Add `local_infile` parameter to `S3ToMySqlOperator`

### DIFF
--- a/airflow/providers/mysql/transfers/s3_to_mysql.py
+++ b/airflow/providers/mysql/transfers/s3_to_mysql.py
@@ -40,6 +40,7 @@ class S3ToMySqlOperator(BaseOperator):
             https://dev.mysql.com/doc/refman/8.0/en/load-data.html#load-data-duplicate-key-handling
     :param mysql_extra_options: MySQL options to specify exactly how to load the data.
     :param aws_conn_id: The S3 connection that contains the credentials to the S3 Bucket.
+    :param mysql_conn_id: Reference to :ref:`mysql connection id <howto/connection:mysql>`.
     :param mysql_local_infile: flag to enable local_infile option on the MySQLHook. This
         loads MySQL directly using the LOAD DATA LOCAL INFILE command. Defaults to False.
     """

--- a/airflow/providers/mysql/transfers/s3_to_mysql.py
+++ b/airflow/providers/mysql/transfers/s3_to_mysql.py
@@ -40,7 +40,8 @@ class S3ToMySqlOperator(BaseOperator):
             https://dev.mysql.com/doc/refman/8.0/en/load-data.html#load-data-duplicate-key-handling
     :param mysql_extra_options: MySQL options to specify exactly how to load the data.
     :param aws_conn_id: The S3 connection that contains the credentials to the S3 Bucket.
-    :param mysql_conn_id: Reference to :ref:`mysql connection id <howto/connection:mysql>`.
+    :param mysql_local_infile: flag to enable local_infile option on the MySQLHook. This
+        loads MySQL directly using the LOAD DATA LOCAL INFILE command. Defaults to False.
     """
 
     template_fields: Sequence[str] = (
@@ -59,6 +60,7 @@ class S3ToMySqlOperator(BaseOperator):
         mysql_extra_options: str | None = None,
         aws_conn_id: str = "aws_default",
         mysql_conn_id: str = "mysql_default",
+        mysql_local_infile: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -68,6 +70,7 @@ class S3ToMySqlOperator(BaseOperator):
         self.mysql_extra_options = mysql_extra_options or ""
         self.aws_conn_id = aws_conn_id
         self.mysql_conn_id = mysql_conn_id
+        self.mysql_local_infile = mysql_local_infile
 
     def execute(self, context: Context) -> None:
         """
@@ -81,7 +84,7 @@ class S3ToMySqlOperator(BaseOperator):
         file = s3_hook.download_file(key=self.s3_source_key)
 
         try:
-            mysql = MySqlHook(mysql_conn_id=self.mysql_conn_id)
+            mysql = MySqlHook(mysql_conn_id=self.mysql_conn_id, local_infile=self.mysql_local_infile)
             mysql.bulk_load_custom(
                 table=self.mysql_table,
                 tmp_file=file,

--- a/tests/providers/mysql/transfers/test_s3_to_mysql.py
+++ b/tests/providers/mysql/transfers/test_s3_to_mysql.py
@@ -61,6 +61,7 @@ class TestS3ToMySqlTransfer:
                 FIELDS TERMINATED BY ','
                 IGNORE 1 LINES
             """,
+            "mysql_local_infile": False,
             "task_id": "task_id",
             "dag": None,
         }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
Adding `local_infile` option to MySQL providers `S3ToMySqlOperator` transfer, similar to `bulk_upload` flag on `VerticaToMySqlOperator`.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
