### PR TITLE
Update `list_jobs` function in `DatabricksHook` to token-based pagination 

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -33,7 +33,7 @@ from typing import Any
 
 from requests import exceptions as requests_exceptions
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.databricks.hooks.databricks_base import BaseDatabricksHook
 
 RESTART_CLUSTER_ENDPOINT = ("POST", "api/2.0/clusters/restart")

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -163,13 +163,13 @@ class DatabricksHook(BaseDatabricksHook):
         return response["run_id"]
 
     def list_jobs(
-        self, limit: int = 25, offset: int = 0, expand_tasks: bool = False, job_name: str | None = None
+        self, limit: int = 25, page_token: str | None = None, expand_tasks: bool = False, job_name: str | None = None
     ) -> list[dict[str, Any]]:
         """
         Lists the jobs in the Databricks Job Service.
 
         :param limit: The limit/batch size used to retrieve jobs.
-        :param offset: The offset of the first job to return, relative to the most recently created job.
+        :param page_token: The optional page token pointing at the first first job to return.
         :param expand_tasks: Whether to include task and cluster details in the response.
         :param job_name: Optional name of a job to search.
         :return: A list of jobs.
@@ -181,8 +181,9 @@ class DatabricksHook(BaseDatabricksHook):
             payload: dict[str, Any] = {
                 "limit": limit,
                 "expand_tasks": expand_tasks,
-                "offset": offset,
             }
+            if page_token:
+                payload["page_token"] = page_token
             if job_name:
                 payload["name"] = job_name
             response = self._do_api_call(LIST_JOBS_ENDPOINT, payload)
@@ -193,7 +194,7 @@ class DatabricksHook(BaseDatabricksHook):
                 all_jobs += jobs
             has_more = response.get("has_more", False)
             if has_more:
-                offset += len(jobs)
+                page_token = response.get("next_page_token", "")
 
         return all_jobs
 

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -196,7 +196,7 @@ class DatabricksHook(BaseDatabricksHook):
             page_token = ""
         if offset is None:
             offset = 0
-        
+
         while has_more:
             payload: dict[str, Any] = {
                 "limit": limit,

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -164,7 +164,12 @@ class DatabricksHook(BaseDatabricksHook):
         return response["run_id"]
 
     def list_jobs(
-        self, limit: int = 25, offset: int | None = None, expand_tasks: bool = False, job_name: str | None = None, page_token: str | None = None
+        self,
+        limit: int = 25,
+        offset: int | None = None,
+        expand_tasks: bool = False,
+        job_name: str | None = None,
+        page_token: str | None = None,
     ) -> list[dict[str, Any]]:
         """
         Lists the jobs in the Databricks Job Service.
@@ -199,7 +204,7 @@ class DatabricksHook(BaseDatabricksHook):
             }
             if use_token_pagination:
                 payload["page_token"] = page_token
-            else: # offset pagination
+            else:  # offset pagination
                 payload["offset"] = offset
             if job_name:
                 payload["name"] = job_name

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -28,6 +28,7 @@ or the ``api/2.1/jobs/runs/submit``
 from __future__ import annotations
 
 import json
+import warnings
 from typing import Any
 
 from requests import exceptions as requests_exceptions
@@ -179,7 +180,12 @@ class DatabricksHook(BaseDatabricksHook):
         all_jobs = []
         use_token_pagination = (page_token is not None) or (offset is None)
         if offset is not None:
-            print("[WARN] You are using the offset parameter in list_jobs which will be deprecated soon")
+            warnings.warn(
+                """You are using the deprecated offset parameter in list_jobs.
+                Please paginate using page_token.""",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
         if page_token is None:
             page_token = ""
         if offset is None:

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -182,7 +182,8 @@ class DatabricksHook(BaseDatabricksHook):
         if offset is not None:
             warnings.warn(
                 """You are using the deprecated offset parameter in list_jobs.
-                Please paginate using page_token.""",
+                It will be hard-limited at the maximum value of 1000 by Databricks API after Oct 9, 2023.
+                Please paginate using page_token instead.""",
                 AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -163,16 +163,16 @@ class DatabricksHook(BaseDatabricksHook):
         return response["run_id"]
 
     def list_jobs(
-        self, limit: int = 25, offset: int | None = None, page_token: str | None = None, expand_tasks: bool = False, job_name: str | None = None
+        self, limit: int = 25, offset: int | None = None, expand_tasks: bool = False, job_name: str | None = None, page_token: str | None = None
     ) -> list[dict[str, Any]]:
         """
         Lists the jobs in the Databricks Job Service.
 
         :param limit: The limit/batch size used to retrieve jobs.
         :param offset: The offset of the first job to return, relative to the most recently created job.
-        :param page_token: The optional page token pointing at the first first job to return.
         :param expand_tasks: Whether to include task and cluster details in the response.
         :param job_name: Optional name of a job to search.
+        :param page_token: The optional page token pointing at the first first job to return.
         :return: A list of jobs.
         """
         has_more = True

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -737,7 +737,7 @@ class TestDatabricksHook:
         mock_requests.get.assert_called_once_with(
             list_jobs_endpoint(HOST),
             json=None,
-            params={"limit": 25, "offset": None, "page_token": None, "expand_tasks": False},
+            params={"limit": 25, "page_token": "", "expand_tasks": False},
             auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=self.hook.user_agent_header,
             timeout=self.hook.timeout_seconds,
@@ -759,11 +759,11 @@ class TestDatabricksHook:
 
         first_call_args = mock_requests.method_calls[0]
         assert first_call_args[1][0] == list_jobs_endpoint(HOST)
-        assert first_call_args[2]["params"] == {"limit": 25, "offset": None, "page_token": None, "expand_tasks": False}
+        assert first_call_args[2]["params"] == {"limit": 25, "page_token": "", "expand_tasks": False}
 
         second_call_args = mock_requests.method_calls[1]
         assert second_call_args[1][0] == list_jobs_endpoint(HOST)
-        assert second_call_args[2]["params"] == {"limit": 25, "offset": None, "page_token": "PAGETOKEN", "expand_tasks": False}
+        assert second_call_args[2]["params"] == {"limit": 25, "page_token": "PAGETOKEN", "expand_tasks": False}
 
         assert len(jobs) == 2
         assert jobs == LIST_JOBS_RESPONSE["jobs"] * 2
@@ -778,7 +778,7 @@ class TestDatabricksHook:
         mock_requests.get.assert_called_once_with(
             list_jobs_endpoint(HOST),
             json=None,
-            params={"limit": 25, "offset": None, "page_token": None, "expand_tasks": False, "name": JOB_NAME},
+            params={"limit": 25, "page_token": "", "expand_tasks": False, "name": JOB_NAME},
             auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=self.hook.user_agent_header,
             timeout=self.hook.timeout_seconds,
@@ -797,7 +797,7 @@ class TestDatabricksHook:
         mock_requests.get.assert_called_once_with(
             list_jobs_endpoint(HOST),
             json=None,
-            params={"limit": 25, "offset": None, "page_token": None, "expand_tasks": False, "name": job_name},
+            params={"limit": 25, "page_token": "", "expand_tasks": False, "name": job_name},
             auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=self.hook.user_agent_header,
             timeout=self.hook.timeout_seconds,
@@ -820,7 +820,7 @@ class TestDatabricksHook:
         mock_requests.get.assert_called_once_with(
             list_jobs_endpoint(HOST),
             json=None,
-            params={"limit": 25, "offset": None, "page_token": None, "expand_tasks": False, "name": JOB_NAME},
+            params={"limit": 25, "page_token": "", "expand_tasks": False, "name": JOB_NAME},
             auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=self.hook.user_agent_header,
             timeout=self.hook.timeout_seconds,

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -749,7 +749,9 @@ class TestDatabricksHook:
     def test_list_jobs_success_multiple_pages(self, mock_requests):
         mock_requests.codes.ok = 200
         mock_requests.get.side_effect = [
-            create_successful_response_mock({**LIST_JOBS_RESPONSE, "has_more": True, "page_token": "PAGETOKEN"}),
+            create_successful_response_mock(
+                {**LIST_JOBS_RESPONSE, "has_more": True, "page_token": "PAGETOKEN"}
+            ),
             create_successful_response_mock(LIST_JOBS_RESPONSE),
         ]
 
@@ -763,7 +765,11 @@ class TestDatabricksHook:
 
         second_call_args = mock_requests.method_calls[1]
         assert second_call_args[1][0] == list_jobs_endpoint(HOST)
-        assert second_call_args[2]["params"] == {"limit": 25, "page_token": "PAGETOKEN", "expand_tasks": False}
+        assert second_call_args[2]["params"] == {
+            "limit": 25,
+            "page_token": "PAGETOKEN",
+            "expand_tasks": False,
+        }
 
         assert len(jobs) == 2
         assert jobs == LIST_JOBS_RESPONSE["jobs"] * 2

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -737,7 +737,7 @@ class TestDatabricksHook:
         mock_requests.get.assert_called_once_with(
             list_jobs_endpoint(HOST),
             json=None,
-            params={"limit": 25, "offset": 0, "expand_tasks": False},
+            params={"limit": 25, "offset": None, "page_token": None, "expand_tasks": False},
             auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=self.hook.user_agent_header,
             timeout=self.hook.timeout_seconds,
@@ -749,7 +749,7 @@ class TestDatabricksHook:
     def test_list_jobs_success_multiple_pages(self, mock_requests):
         mock_requests.codes.ok = 200
         mock_requests.get.side_effect = [
-            create_successful_response_mock({**LIST_JOBS_RESPONSE, "has_more": True}),
+            create_successful_response_mock({**LIST_JOBS_RESPONSE, "has_more": True, "page_token": "PAGETOKEN"}),
             create_successful_response_mock(LIST_JOBS_RESPONSE),
         ]
 
@@ -759,11 +759,11 @@ class TestDatabricksHook:
 
         first_call_args = mock_requests.method_calls[0]
         assert first_call_args[1][0] == list_jobs_endpoint(HOST)
-        assert first_call_args[2]["params"] == {"limit": 25, "offset": 0, "expand_tasks": False}
+        assert first_call_args[2]["params"] == {"limit": 25, "offset": None, "page_token": None, "expand_tasks": False}
 
         second_call_args = mock_requests.method_calls[1]
         assert second_call_args[1][0] == list_jobs_endpoint(HOST)
-        assert second_call_args[2]["params"] == {"limit": 25, "offset": 1, "expand_tasks": False}
+        assert second_call_args[2]["params"] == {"limit": 25, "offset": None, "page_token": "PAGETOKEN", "expand_tasks": False}
 
         assert len(jobs) == 2
         assert jobs == LIST_JOBS_RESPONSE["jobs"] * 2

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -750,7 +750,7 @@ class TestDatabricksHook:
         mock_requests.codes.ok = 200
         mock_requests.get.side_effect = [
             create_successful_response_mock(
-                {**LIST_JOBS_RESPONSE, "has_more": True, "page_token": "PAGETOKEN"}
+                {**LIST_JOBS_RESPONSE, "has_more": True, "next_page_token": "PAGETOKEN"}
             ),
             create_successful_response_mock(LIST_JOBS_RESPONSE),
         ]

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -778,7 +778,7 @@ class TestDatabricksHook:
         mock_requests.get.assert_called_once_with(
             list_jobs_endpoint(HOST),
             json=None,
-            params={"limit": 25, "offset": 0, "expand_tasks": False, "name": JOB_NAME},
+            params={"limit": 25, "offset": None, "page_token": None, "expand_tasks": False, "name": JOB_NAME},
             auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=self.hook.user_agent_header,
             timeout=self.hook.timeout_seconds,
@@ -797,7 +797,7 @@ class TestDatabricksHook:
         mock_requests.get.assert_called_once_with(
             list_jobs_endpoint(HOST),
             json=None,
-            params={"limit": 25, "offset": 0, "expand_tasks": False, "name": job_name},
+            params={"limit": 25, "offset": None, "page_token": None, "expand_tasks": False, "name": job_name},
             auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=self.hook.user_agent_header,
             timeout=self.hook.timeout_seconds,
@@ -820,7 +820,7 @@ class TestDatabricksHook:
         mock_requests.get.assert_called_once_with(
             list_jobs_endpoint(HOST),
             json=None,
-            params={"limit": 25, "offset": 0, "expand_tasks": False, "name": JOB_NAME},
+            params={"limit": 25, "offset": None, "page_token": None, "expand_tasks": False, "name": JOB_NAME},
             auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=self.hook.user_agent_header,
             timeout=self.hook.timeout_seconds,


### PR DESCRIPTION
Update Airflow to switch from default offset-based pagination (deprecated) to using a page token