### PR TITLE
Fix Cluster Activity historical metrics for ongoing dagrun if end_date is provided

### DIFF
--- a/airflow/www/static/js/cluster-activity/useFilters.tsx
+++ b/airflow/www/static/js/cluster-activity/useFilters.tsx
@@ -49,7 +49,10 @@ export const now = date.toISOString();
 const useFilters = (): FilterHookReturn => {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const endDate = searchParams.get(END_DATE_PARAM) || now;
+  const endDate =
+    searchParams.get(END_DATE_PARAM) ||
+    // @ts-ignore
+    moment(now).add(1, "h").toISOString();
   const startDate =
     searchParams.get(START_DATE_PARAM) ||
     // @ts-ignore

--- a/tests/www/views/test_views_cluster_activity.py
+++ b/tests/www/views/test_views_cluster_activity.py
@@ -49,7 +49,7 @@ def freeze_time_for_dagruns(time_machine):
 
 
 @pytest.fixture
-def make_dag_runs(dag_maker, session):
+def make_dag_runs(dag_maker, session, time_machine):
     with dag_maker(
         dag_id="test_dag_id",
         serialized=True,
@@ -76,29 +76,40 @@ def make_dag_runs(dag_maker, session):
         start_date=dag_maker.dag.next_dagrun_info(date).logical_date,
     )
 
+    run3 = dag_maker.create_dagrun(
+        run_id="run_3",
+        state=DagRunState.RUNNING,
+        run_type=DagRunType.SCHEDULED,
+        execution_date=pendulum.DateTime(2023, 2, 3, 0, 0, 0, tzinfo=pendulum.UTC),
+        start_date=pendulum.DateTime(2023, 2, 3, 0, 0, 0, tzinfo=pendulum.UTC),
+    )
+    run3.end_date = None
+
     for ti in run1.task_instances:
         ti.state = TaskInstanceState.SUCCESS
 
     for ti in run2.task_instances:
         ti.state = TaskInstanceState.FAILED
 
+    time_machine.move_to("2023-07-02T00:00:00+00:00", tick=False)
+
     session.flush()
 
 
 @pytest.mark.usefixtures("freeze_time_for_dagruns", "make_dag_runs")
-def test_historical_metrics_data(admin_client, session):
+def test_historical_metrics_data(admin_client, session, time_machine):
     resp = admin_client.get(
-        "/object/historical_metrics_data?start_date=2023-01-01T00:00&end_date=2023-05-02T00:00",
+        "/object/historical_metrics_data?start_date=2023-01-01T00:00&end_date=2023-08-02T00:00",
         follow_redirects=True,
     )
     assert resp.status_code == 200
     assert resp.json == {
-        "dag_run_states": {"failed": 1, "queued": 0, "running": 0, "success": 1},
-        "dag_run_types": {"backfill": 0, "dataset_triggered": 1, "manual": 0, "scheduled": 1},
+        "dag_run_states": {"failed": 1, "queued": 0, "running": 1, "success": 1},
+        "dag_run_types": {"backfill": 0, "dataset_triggered": 1, "manual": 0, "scheduled": 2},
         "task_instance_states": {
             "deferred": 0,
             "failed": 2,
-            "no_status": 0,
+            "no_status": 2,
             "queued": 0,
             "removed": 0,
             "restarting": 0,
@@ -117,7 +128,7 @@ def test_historical_metrics_data(admin_client, session):
 @pytest.mark.usefixtures("freeze_time_for_dagruns", "make_dag_runs")
 def test_historical_metrics_data_date_filters(admin_client, session):
     resp = admin_client.get(
-        "/object/historical_metrics_data?start_date=2023-02-02T00:00&end_date=2023-05-02T00:00",
+        "/object/historical_metrics_data?start_date=2023-02-02T00:00&end_date=2023-06-02T00:00",
         follow_redirects=True,
     )
     assert resp.status_code == 200


### PR DESCRIPTION
We were selecting DagRuns/Tasks that were either:
- without end_date (to have current runs)
- with an end_date defined that is less than the requested date


Issue, if the end_date is chosen in the past, runs without end_date (ongoing run) will be counted in the metrics, which is wrong.

This handle such cases i.e when `dagrun.end_date is None`:
- If the end_date is in the future then we want data for ongoing runs
- If the end_date is in the past, we don't want data for ongoing runs


## before
An old range such as this one would be updated with data regarding ongoing runs (i.e end_date is None)
![image](https://github.com/apache/airflow/assets/14861206/dd8a9273-183c-4d9a-81ab-488f2b8479cc)

## After
This will not be the case anymore, data will remain stable on old ranges, because ongoing run will be taken out. In this example there is no records on this period.
![image](https://github.com/apache/airflow/assets/14861206/17323f70-9a40-4121-9467-bc572d1ede36)


To still be able to get data from ongoing run in the query we need to provide an `end_date` that is greater than 'now' by default we look ahead 1 hour. 
> Runs are considered out of range if the requested `end_date` <= `now` and that the run still has no end_date because it will settle in the future with an end_date >= now, therefore cannot meet the condition.
