### PR TITLE
feat(providers/azure): allow passing fully_qualified_namespace and credential to initialize Azure Service Bus Client

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/asb.py
+++ b/airflow/providers/microsoft/azure/hooks/asb.py
@@ -60,7 +60,9 @@ class BaseAzureServiceBusHook(BaseHook):
             "hidden_fields": ["port", "host", "extra", "login", "password"],
             "relabeling": {"schema": "Connection String"},
             "placeholders": {
-                "fully_qualified_namespace": "<Resource group>.servicebus.windows.net (for Azure AD authenticaltion)",
+                "fully_qualified_namespace": (
+                    "<Resource group>.servicebus.windows.net (for Azure AD authenticaltion)"
+                ),
                 "credential": "credential",
                 "schema": "Endpoint=sb://<Resource group>.servicebus.windows.net/;SharedAccessKeyName=<AccessKeyName>;SharedAccessKey=<SharedAccessKey>",  # noqa
             },
@@ -106,7 +108,8 @@ class AdminClientHook(BaseAzureServiceBusHook):
             if not credential:
                 credential = DefaultAzureCredential()
             client = ServiceBusAdministrationClient(
-                fully_qualified_namespace=fully_qualified_namespace, credential=credential
+                fully_qualified_namespace=fully_qualified_namespace,
+                credential=credential,  # type: ignore[arg-type]
             )
         self.log.info("Create and returns ServiceBusAdministrationClient")
         return client
@@ -189,7 +192,8 @@ class MessageHook(BaseAzureServiceBusHook):
             if not credential:
                 credential = DefaultAzureCredential()
             client = ServiceBusClient(
-                fully_qualified_namespace=fully_qualified_namespace, credential=credential
+                fully_qualified_namespace=fully_qualified_namespace,
+                credential=credential,  # type: ignore[arg-type]
             )
 
         self.log.info("Create and returns ServiceBusClient")

--- a/airflow/providers/microsoft/azure/operators/asb.py
+++ b/airflow/providers/microsoft/azure/operators/asb.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING, Any, Sequence
 
+from azure.core.exceptions import ResourceNotFoundError
+
 from airflow.models import BaseOperator
 from airflow.providers.microsoft.azure.hooks.asb import AdminClientHook, MessageHook
 
@@ -293,7 +295,10 @@ class AzureServiceBusTopicCreateOperator(BaseOperator):
         hook = AdminClientHook(azure_service_bus_conn_id=self.azure_service_bus_conn_id)
 
         with hook.get_conn() as service_mgmt_conn:
-            topic_properties = service_mgmt_conn.get_topic(self.topic_name)
+            try:
+                topic_properties = service_mgmt_conn.get_topic(self.topic_name)
+            except ResourceNotFoundError:
+                topic_properties = None
             if topic_properties and topic_properties.name == self.topic_name:
                 self.log.info("Topic name already exists")
                 return topic_properties.name

--- a/tests/providers/microsoft/azure/hooks/test_asb.py
+++ b/tests/providers/microsoft/azure/hooks/test_asb.py
@@ -46,12 +46,28 @@ class TestAdminClientHook:
             conn_type="azure_service_bus",
             schema=self.connection_string,
         )
+        self.mock_conn_without_schema = Connection(
+            conn_id="azure_service_bus_default",
+            conn_type="azure_service_bus",
+            schema="",
+            extra={"fully_qualified_namespace": "fully_qualified_namespace"},
+        )
 
     @mock.patch("airflow.providers.microsoft.azure.hooks.asb.AdminClientHook.get_connection")
     def test_get_conn(self, mock_connection):
         mock_connection.return_value = self.mock_conn
         hook = AdminClientHook(azure_service_bus_conn_id=self.conn_id)
         assert isinstance(hook.get_conn(), ServiceBusAdministrationClient)
+
+    @mock.patch("airflow.providers.microsoft.azure.hooks.asb.DefaultAzureCredential")
+    @mock.patch("airflow.providers.microsoft.azure.hooks.asb.AdminClientHook.get_connection")
+    def test_get_conn_fallback_to_default_azure_credential_when_schema_is_not_provided(
+        self, mock_connection, mock_default_azure_credential
+    ):
+        mock_connection.return_value = self.mock_conn_without_schema
+        hook = AdminClientHook(azure_service_bus_conn_id=self.conn_id)
+        assert isinstance(hook.get_conn(), ServiceBusAdministrationClient)
+        mock_default_azure_credential.assert_called_once()
 
     @mock.patch("azure.servicebus.management.QueueProperties")
     @mock.patch("airflow.providers.microsoft.azure.hooks.asb.AdminClientHook.get_conn")
@@ -136,6 +152,12 @@ class TestMessageHook:
             conn_type="azure_service_bus",
             schema=self.connection_string,
         )
+        self.mock_conn_without_schema = Connection(
+            conn_id="azure_service_bus_default",
+            conn_type="azure_service_bus",
+            schema="",
+            extra={"fully_qualified_namespace": "fully_qualified_namespace"},
+        )
 
     @mock.patch("airflow.providers.microsoft.azure.hooks.asb.MessageHook.get_connection")
     def test_get_service_bus_message_conn(self, mock_connection):
@@ -146,6 +168,16 @@ class TestMessageHook:
         mock_connection.return_value = self.conn
         hook = MessageHook(azure_service_bus_conn_id=self.conn_id)
         assert isinstance(hook.get_conn(), ServiceBusClient)
+
+    @mock.patch("airflow.providers.microsoft.azure.hooks.asb.DefaultAzureCredential")
+    @mock.patch("airflow.providers.microsoft.azure.hooks.asb.MessageHook.get_connection")
+    def test_get_conn_fallback_to_default_azure_credential_when_schema_is_not_provided(
+        self, mock_connection, mock_default_azure_credential
+    ):
+        mock_connection.return_value = self.mock_conn_without_schema
+        hook = MessageHook(azure_service_bus_conn_id=self.conn_id)
+        assert isinstance(hook.get_conn(), ServiceBusClient)
+        mock_default_azure_credential.assert_called_once()
 
     @pytest.mark.parametrize(
         "mock_message, mock_batch_flag",


### PR DESCRIPTION
* add `fully_qualified_namespace`, `credential` to Azure Service Bus connection
* add `DefaultAzureCredential` support for Azure Service Bus Hooks
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
