### PR TITLE
Replace fnmatch with pathlib

### DIFF
--- a/airflow/providers/amazon/aws/sensors/s3.py
+++ b/airflow/providers/amazon/aws/sensors/s3.py
@@ -17,11 +17,11 @@
 # under the License.
 from __future__ import annotations
 
-import fnmatch
 import os
 import re
 from datetime import datetime, timedelta
 from functools import cached_property
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Sequence, cast
 
 from deprecated import deprecated
@@ -115,12 +115,12 @@ class S3KeySensor(BaseSensorOperator):
         if self.wildcard_match:
             prefix = re.split(r"[\[\*\?]", key, 1)[0]
             keys = self.hook.get_file_metadata(prefix, bucket_name)
-            key_matches = [k for k in keys if fnmatch.fnmatch(k["Key"], key)]
-            if len(key_matches) == 0:
+            key_matches = [k for k in keys if Path(k["Key"]).match(key)]
+            if not key_matches:
                 return False
 
             # Reduce the set of metadata to size only
-            files = list(map(lambda f: {"Size": f["Size"]}, key_matches))
+            files = [{"Size": f["Size"]} for f in key_matches]
         else:
             obj = self.hook.head_object(key, bucket_name)
             if obj is None:

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -22,7 +22,7 @@ import datetime
 import os
 import stat
 import warnings
-from fnmatch import fnmatch
+from pathlib import Path
 from typing import Any, Callable
 
 import paramiko
@@ -379,11 +379,7 @@ class SFTPHook(SSHHook):
         :param fnmatch_pattern: The pattern that will be matched with `fnmatch`
         :return: string containing the first found file, or an empty string if none matched
         """
-        for file in self.list_directory(path):
-            if fnmatch(file, fnmatch_pattern):
-                return file
-
-        return ""
+        return next((file for file in self.list_directory(path) if Path(file).match(fnmatch_pattern)), "")
 
     def get_files_by_pattern(self, path, fnmatch_pattern) -> list[str]:
         """Get all matching files based on the given fnmatch type pattern.
@@ -392,9 +388,4 @@ class SFTPHook(SSHHook):
         :param fnmatch_pattern: The pattern that will be matched with `fnmatch`
         :return: list of string containing the found files, or an empty list if none matched
         """
-        matched_files = []
-        for file in self.list_directory(path):
-            if fnmatch(file, fnmatch_pattern):
-                matched_files.append(file)
-
-        return matched_files
+        return [file for file in self.list_directory(path) if Path(file).match(fnmatch_pattern)]

--- a/dev/breeze/src/airflow_breeze/utils/publish_docs_helpers.py
+++ b/dev/breeze/src/airflow_breeze/utils/publish_docs_helpers.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import fnmatch
 import json
 import os
 from glob import glob
@@ -107,15 +106,13 @@ def process_package_filters(available_packages: list[str], package_filters: list
     if not package_filters:
         return available_packages
 
-    invalid_filters = [
-        f for f in package_filters if not any(fnmatch.fnmatch(p, f) for p in available_packages)
-    ]
+    invalid_filters = [f for f in package_filters if not any(Path(p).match(f) for p in available_packages)]
     if invalid_filters:
         raise SystemExit(
             f"Some filters did not find any package: {invalid_filters}, Please check if they are correct."
         )
 
-    return [p for p in available_packages if any(fnmatch.fnmatch(p, f) for f in package_filters)]
+    return [p for p in available_packages if any(Path(p).match(f) for f in package_filters)]
 
 
 def pretty_format_path(path: str, start: str) -> str:

--- a/docs/exts/docs_build/package_filter.py
+++ b/docs/exts/docs_build/package_filter.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-import fnmatch
+from pathlib import Path
 
 
 def process_package_filters(available_packages: list[str], package_filters: list[str] | None):
@@ -27,12 +27,10 @@ def process_package_filters(available_packages: list[str], package_filters: list
     if not package_filters:
         return available_packages
 
-    invalid_filters = [
-        f for f in package_filters if not any(fnmatch.fnmatch(p, f) for p in available_packages)
-    ]
+    invalid_filters = [f for f in package_filters if not any(Path(p).match(f) for p in available_packages)]
     if invalid_filters:
         raise SystemExit(
             f"Some filters did not find any package: {invalid_filters}, Please check if they are correct."
         )
 
-    return [p for p in available_packages if any(fnmatch.fnmatch(p, f) for f in package_filters)]
+    return [p for p in available_packages if any(Path(p).match(f) for f in package_filters)]


### PR DESCRIPTION
Migration towards `pathlib.Path` for all filesystem operations is a lot of work, so let's start by getting rid of `fnmatch`. Some parts may get even more compact again once all filename objects are `pathlib.Path`.