### PR TITLE
Chart: pass workers.terminationGracePeriodSeconds into KubeExecutor pod template

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -103,6 +103,7 @@ spec:
   securityContext: {{ $securityContext | nindent 4 }}
   nodeSelector: {{- toYaml $nodeSelector | nindent 4 }}
   affinity: {{- toYaml $affinity | nindent 4 }}
+  terminationGracePeriodSeconds: {{ .Values.workers.terminationGracePeriodSeconds }}
   tolerations: {{- toYaml $tolerations | nindent 4 }}
   topologySpreadConstraints: {{- toYaml $topologySpreadConstraints | nindent 4 }}
   serviceAccountName: {{ include "worker.serviceAccountName" . }}

--- a/helm_tests/airflow_aux/test_pod_template_file.py
+++ b/helm_tests/airflow_aux/test_pod_template_file.py
@@ -767,3 +767,16 @@ class TestPodTemplateFile:
         assert lifecycle_hook_params["lifecycle_parsed"] == jmespath.search(
             f"spec.containers[0].lifecycle.{hook_type}", docs[0]
         )
+
+    def test_termination_grace_period_seconds(self):
+        docs = render_chart(
+            values={
+                "workers": {
+                    "terminationGracePeriodSeconds": 123,
+                },
+            },
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert 123 == jmespath.search("spec.terminationGracePeriodSeconds", docs[0])


### PR DESCRIPTION
While the chart allows users to specify a custom TerminationGracePeriodSeconds for the celery workers, this value is not passed into the Kubernetes Executor pod template, and thus pods use the default 30s timeout.

It seems like the `workers:` section of the values is applied to both the Celery worker pods as well as the default KubeExecutor pods so I figured there was no need to define a new value. Thoughts?