### PR TITLE
[docs] Add breeze command option for WSL2

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -411,6 +411,22 @@ as follows:
 
     breeze --python 3.8 --backend mysql --mysql-version 8
 
+.. note:: Note for Windows WSL2 users
+
+   You may find error messages:
+
+.. code-block:: bash
+
+    Current context is now "..."
+    protocol not available
+    Error 1 returned
+   
+Try adding ``--builder=default`` to your command. For example:
+
+.. code-block:: bash
+
+    breeze --builder=default --python 3.8 --backend mysql --mysql-version 8
+
 The choices you make are persisted in the ``./.build/`` cache directory so that next time when you use the
 ``breeze`` script, it could use the values that were used previously. This way you do not have to specify
 them when you run the script. You can delete the ``.build/`` directory in case you want to restore the

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -420,7 +420,7 @@ as follows:
     Current context is now "..."
     protocol not available
     Error 1 returned
-   
+
 Try adding ``--builder=default`` to your command. For example:
 
 .. code-block:: bash


### PR DESCRIPTION
I'm using Windows WSL2 with Docker Desktop and I encountered this error. I added a command option to breeze command in the docs to bypass the error.

[#33547](https://github.com/apache/airflow/pull/33547)