### PR TITLE
Use `boto3.client` linked to resource meta instead of create new one for waiters

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -680,12 +680,16 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
         return self.get_client_type(region_name=self.region_name, deferrable=True)
 
     @cached_property
-    def conn_client_meta(self) -> ClientMeta:
-        """Get botocore client metadata from Hook connection (cached)."""
+    def _client(self) -> botocore.client.BaseClient:
         conn = self.conn
         if isinstance(conn, botocore.client.BaseClient):
-            return conn.meta
-        return conn.meta.client.meta
+            return conn
+        return conn.meta.client
+
+    @property
+    def conn_client_meta(self) -> ClientMeta:
+        """Get botocore client metadata from Hook connection (cached)."""
+        return self._client.meta
 
     @property
     def conn_region_name(self) -> str:
@@ -862,19 +866,9 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
 
         if deferrable and not client:
             raise ValueError("client must be provided for a deferrable waiter.")
-        client = client or self.conn
+        # Currently, the custom waiter doesn't work with resource_type, only client_type is supported.
+        client = client or self._client
         if self.waiter_path and (waiter_name in self._list_custom_waiters()):
-            # Currently, the custom waiter doesn't work with resource_type, only client_type is supported.
-            if self.resource_type:
-                credentials = self.get_credentials()
-                client = boto3.client(
-                    self.resource_type,
-                    region_name=self.region_name,
-                    aws_access_key_id=credentials.access_key,
-                    aws_secret_access_key=credentials.secret_key,
-                    aws_session_token=credentials.token,
-                )
-
             # Technically if waiter_name is in custom_waiters then self.waiter_path must
             # exist but MyPy doesn't like the fact that self.waiter_path could be None.
             with open(self.waiter_path) as config_file:
@@ -909,7 +903,7 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
         return [*self._list_official_waiters(), *self._list_custom_waiters()]
 
     def _list_official_waiters(self) -> list[str]:
-        return self.conn.waiter_names
+        return self._client.waiter_names
 
     def _list_custom_waiters(self) -> list[str]:
         if not self.waiter_path:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

Instead of create new client which can't refresh credentials and not accessible in `_list_official_waiters` better to get client from resource meta, it should have use same session


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
