### PR TITLE
fsspec base Hook for filesystem operations

### DIFF
--- a/airflow/providers/alibaba/cloud/hooks/oss.py
+++ b/airflow/providers/alibaba/cloud/hooks/oss.py
@@ -21,6 +21,7 @@ from functools import wraps
 from inspect import signature
 from typing import TYPE_CHECKING, Callable, TypeVar, cast
 from urllib.parse import urlsplit
+from airflow.providers.common.filesystem.hooks.filesystem import FsApiHook
 
 import oss2
 from oss2.exceptions import ClientError
@@ -76,7 +77,7 @@ def unify_bucket_name_and_key(func: T) -> T:
     return cast(T, wrapper)
 
 
-class OSSHook(BaseHook):
+class OSSHook(BaseHook, FsApiHook):
     """Interact with Alibaba Cloud OSS, using the oss2 library."""
 
     conn_name_attr = "alibabacloud_conn_id"

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -39,6 +39,7 @@ from time import sleep
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 from urllib.parse import urlsplit
 from uuid import uuid4
+from airflow.providers.common.filesystem.hooks.filesystem import FsApiHook
 
 if TYPE_CHECKING:
     try:
@@ -145,7 +146,7 @@ def unify_bucket_name_and_key(func: T) -> T:
     return cast(T, wrapper)
 
 
-class S3Hook(AwsBaseHook):
+class S3Hook(AwsBaseHook, FsApiHook):
     """
     Interact with Amazon Simple Storage Service (S3).
 

--- a/airflow/providers/common/filesystem/hooks/__init__.py
+++ b/airflow/providers/common/filesystem/hooks/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/common/filesystem/hooks/filesystem.py
+++ b/airflow/providers/common/filesystem/hooks/filesystem.py
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from urllib.parse import urlsplit
+
+import fsspec
+
+from airflow.hooks.base import BaseHook
+
+
+class FsApiHook(BaseHook):
+    """
+    Abstract base class for fsspec hooks.
+    """
+
+    # Override to have a default connection id for a particular hook
+    default_fs_conn_name = "default_conn_id"
+
+    def __init__(self, *args, fs_conn_name: str = default_fs_conn_name, **kwargs):
+        self.fs_conn_name = fs_conn_name
+        super().__init__(*args, **kwargs)
+
+    def get_conn(self) -> fsspec.AbstractFileSystem:
+        conn = self.get_connection(self.fs_conn_name)
+        uri = urlsplit(conn.get_uri())
+        extras = conn.extra_dejson.get("fsspec", {})
+
+        fs = fsspec.filesystem(uri.scheme, *extras)
+        if full_path := uri.hostname or "" + uri.path:
+            fs = DirFileSystem(full_path, fs=fs)
+
+        return fs

--- a/airflow/providers/common/filesystem/provider.yaml
+++ b/airflow/providers/common/filesystem/provider.yaml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+---
+package-name: apache-airflow-providers-common-fsspec
+name: Common File System
+description: |
+    `Common file system provider`
+
+suspended: false
+versions:
+  - 1.0.0
+
+dependencies:
+  - apache-airflow>=2.4.0
+  - fsspec>=2023.6.0
+
+integrations:
+  - integration-name: Common file system
+    external-doc-url: https://filesystem-spec.readthedocs.io/en/latest/
+    tags: [software]
+
+hooks:
+  - integration-name: Common file system
+    python-modules:
+      - airflow.providers.common.filesystem.hooks.filesystem

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -33,6 +33,7 @@ from typing import Any
 from requests import exceptions as requests_exceptions
 
 from airflow.exceptions import AirflowException
+from airflow.providers.common.filesystem.hooks.filesystem import FsApiHook
 from airflow.providers.databricks.hooks.databricks_base import BaseDatabricksHook
 
 RESTART_CLUSTER_ENDPOINT = ("POST", "api/2.0/clusters/restart")
@@ -108,7 +109,7 @@ class RunState:
         return RunState(**json.loads(data))
 
 
-class DatabricksHook(BaseDatabricksHook):
+class DatabricksHook(BaseDatabricksHook, FsApiHook):
     """
     Interact with Databricks.
 

--- a/airflow/providers/ftp/hooks/ftp.py
+++ b/airflow/providers/ftp/hooks/ftp.py
@@ -23,9 +23,10 @@ import os.path
 from typing import Any, Callable
 
 from airflow.hooks.base import BaseHook
+from airflow.providers.common.filesystem.hooks.filesystem import FsApiHook
 
 
-class FTPHook(BaseHook):
+class FTPHook(BaseHook, FsApiHook):
     """
     Interact with FTP.
 

--- a/airflow/providers/github/hooks/github.py
+++ b/airflow/providers/github/hooks/github.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from airflow.providers.common.filesystem.hooks.filesystem import FsApiHook
 
 from github import Github as GithubClient
 
@@ -26,7 +27,7 @@ from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 
 
-class GithubHook(BaseHook):
+class GithubHook(BaseHook, FsApiHook):
     """
     Interact with GitHub.
 

--- a/airflow/providers/google/cloud/hooks/gcs.py
+++ b/airflow/providers/google/cloud/hooks/gcs.py
@@ -35,6 +35,7 @@ from typing import IO, Any, Callable, Generator, Sequence, TypeVar, cast, overlo
 from urllib.parse import urlsplit
 
 from aiohttp import ClientSession
+from airflow.providers.common.filesystem.hooks.filesystem import FsApiHook
 from gcloud.aio.storage import Storage
 from google.api_core.exceptions import GoogleAPICallError, NotFound
 from google.api_core.retry import Retry
@@ -142,7 +143,7 @@ def _fallback_object_url_to_object_name_and_bucket_name(
 PROVIDE_BUCKET: str = cast(str, None)
 
 
-class GCSHook(GoogleBaseHook):
+class GCSHook(GoogleBaseHook, FsApiHook):
     """Use the Google Cloud connection to interact with Google Cloud Storage."""
 
     _conn: storage.Client | None = None

--- a/airflow/providers/http/hooks/http.py
+++ b/airflow/providers/http/hooks/http.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 import aiohttp
 import requests
+from airflow.providers.common.filesystem.hooks.filesystem import FsApiHook
 import tenacity
 from aiohttp import ClientResponseError
 from asgiref.sync import sync_to_async
@@ -35,7 +36,7 @@ if TYPE_CHECKING:
     from aiohttp.client_reqrep import ClientResponse
 
 
-class HttpHook(BaseHook):
+class HttpHook(BaseHook, FsApiHook):
     """Interact with HTTP servers.
 
     :param method: the API method to be called


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Related: #8804, #3526 

As explained in the related issue, it can be hard to cover all the `<provider>To<provider>` use cases. It could be nice to have a generic "file transfer" operator which can handle most of the storage provider (local filesystem as well as cloud blob storages). Such kind of storage wrapper already exists as the `fsspec` library which is already an Airflow dependency.

This PR aims at providing a base "class" (it's more like a mixin) to mix with blob storage provider (such as S3, GCS, etc.) to allow easy creation of fsspec.FileSystem from such hooks.

I am not very fluent with the Hook/Connection API, so I am not sure that this PR make sense.

---

