### PR TITLE
Fix broken link to the "UPDATING.md" file

### DIFF
--- a/docs/apache-airflow/deprecated-rest-api-ref.rst
+++ b/docs/apache-airflow/deprecated-rest-api-ref.rst
@@ -21,7 +21,7 @@ Deprecated REST API
 .. warning::
 
   This REST API is deprecated since version 2.0. Please consider using the :doc:`stable REST API <stable-rest-api-ref>`.
-  For more information on migration, see `UPDATING.md <https://github.com/apache/airflow/blob/main/UPDATING.md>`_
+  For more information on migration, see `UPDATING.md <https://airflow.apache.org/docs/apache-airflow/stable/howto/upgrading-from-1-10/>`_
 
 Before Airflow 2.0 this REST API was known as the "experimental" API, but now that the :doc:`stable REST API <stable-rest-api-ref>` is available, it has been renamed.
 


### PR DESCRIPTION
The "UPDATING.md" file has been removed in v2.3.0 with commit 5b9bd9954bbc6ed68c217761d581f3af46269af9, and therefore it does not exist on the `main` branch. Instead, link to the file's latest version (_i.e._, v2.2.5).
