### PR TITLE
Add repository_id and impersonation_chain to template fields in DataformCreateCompilationResultOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/dataform.py
+++ b/airflow/providers/google/cloud/operators/dataform.py
@@ -65,6 +65,8 @@ class DataformCreateCompilationResultOperator(GoogleCloudBaseOperator):
         account from the list granting this role to the originating account (templated).
     """
 
+    template_fields = ("repository_id", "impersonation_chain")
+
     def __init__(
         self,
         project_id: str,


### PR DESCRIPTION
All other operators template these fields, and `impersonation_chain` is explicity said to be templated in the operator's docstring
