### PR TITLE
Referencing correct hooks for Apache Pinot

### DIFF
--- a/airflow/providers/apache/pinot/hooks/pinot.py
+++ b/airflow/providers/apache/pinot/hooks/pinot.py
@@ -56,6 +56,11 @@ class PinotAdminHook(BaseHook):
                                     "Exception" is in the output message.
     """
 
+    conn_name_attr = "conn_id"
+    default_conn_name = "pinot_admin_default"
+    conn_type = "pinot_admin"
+    hook_name = "Pinot Admin"
+
     def __init__(
         self,
         conn_id: str = "pinot_admin_default",
@@ -258,6 +263,8 @@ class PinotDbApiHook(DbApiHook):
 
     conn_name_attr = "pinot_broker_conn_id"
     default_conn_name = "pinot_broker_default"
+    conn_type = "pinot"
+    hook_name = "Pinot Broker"
     supports_autocommit = False
 
     def get_conn(self) -> Any:

--- a/airflow/providers/apache/pinot/provider.yaml
+++ b/airflow/providers/apache/pinot/provider.yaml
@@ -59,5 +59,7 @@ hooks:
       - airflow.providers.apache.pinot.hooks.pinot
 
 connection-types:
-  - hook-class-name: airflow.providers.apache.pinot.hooks.pinot.PinotHook
+  - hook-class-name: airflow.providers.apache.pinot.hooks.pinot.PinotDbApiHook
     connection-type: pinot
+  - hook-class-name: airflow.providers.apache.pinot.hooks.pinot.PinotAdminHook
+    connection-type: pinot_admin


### PR DESCRIPTION
The `provider.yaml` for `airflow.providers.apache.pinot` provider was referencing a non-existing hook class of `PinotHook`, causing a warning during `providers_manager`'s sanity check. This corrects it to list both hooks of this provider.

closes #33596

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
