### PR TITLE
Make cluster_context templated in KubernetesPodOperator

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -173,7 +173,7 @@ class KubernetesPodOperator(BaseOperator):
         They can be exposed as environment vars or files in a volume.
     :param in_cluster: run kubernetes client with in_cluster configuration.
     :param cluster_context: context that points to kubernetes cluster.
-        Ignored when in_cluster is True. If None, current-context is used.
+        Ignored when in_cluster is True. If None, current-context is used. (templated)
     :param reattach_on_restart: if the worker dies while the pod is running, reattach and monitor
         during the next try. If False, always create a new pod for each try.
     :param labels: labels to apply to the Pod. (templated)
@@ -262,6 +262,7 @@ class KubernetesPodOperator(BaseOperator):
         "container_resources",
         "volumes",
         "volume_mounts",
+        "cluster_context",
     )
     template_fields_renderers = {"env_vars": "py"}
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Following [Airflow's best practice guide for Variables](https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html#airflow-variables), I have tried replacing all of my variables' usage in `KubernetesPodOperator`, such as `image`, `config_file` etc.. to use the templated syntax. However, for `cluster_context` this didn't work since it's not templated, as in the example below:
 
```diff
default_args = {
-   'cluster_context': Variable.get('k8s_cluster_name')
+   'cluster_context': '{{ var.value.k8s_cluster_name }}' 
}
```

I'd love to have this small feature incorporated, let me know of anything required beyond this commit