### PR TITLE
Fix failing "ARM cache" job

### DIFF
--- a/scripts/ci/images/ci_stop_arm_instance.sh
+++ b/scripts/ci/images/ci_stop_arm_instance.sh
@@ -24,8 +24,7 @@ function stop_arm_instance() {
     INSTANCE_ID=$(jq < "${INSTANCE_INFO}" ".Instances[0].InstanceId" -r)
     docker buildx rm --force airflow_cache || true
     aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}"
-    cat ${AUTOSSH_LOGFILE}
-
+    cat ${AUTOSSH_LOGFILE} || true
 }
 
 stop_arm_instance


### PR DESCRIPTION
The new version of autossh installed yesterday when our AMI has been refreshed is a little less verbose when printing AUTOSSH_LOG entries. So far it produced entries for starting and running the autossh - which was not intersting if nothing was wrong:

```
2023/08/21 06:33:27 autossh[31898]: starting ssh (count 1)
2023/08/21 06:33:27 autossh[31898]: ssh child pid is 31899
```

The new versio will not produce any output and wont even create a file when nothing wrong happens and this caused our CI to fail at the very last moment - after the ARM instance has been stopped.

This PR won't fail when the autossh log is missing.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
