### PR TITLE
Hide Irrelevant Dag Processor from Cluster Activity Page

### DIFF
--- a/airflow/www/jest-setup.js
+++ b/airflow/www/jest-setup.js
@@ -61,4 +61,4 @@ global.defaultDagRunDisplayNumber = 245;
 
 global.moment = moment;
 
-global.standaloneDagProcessor=false;
+global.standaloneDagProcessor=true;

--- a/airflow/www/jest-setup.js
+++ b/airflow/www/jest-setup.js
@@ -60,3 +60,5 @@ global.stateColors = {
 global.defaultDagRunDisplayNumber = 245;
 
 global.moment = moment;
+
+global.standaloneDagProcessor=false;

--- a/airflow/www/jest-setup.js
+++ b/airflow/www/jest-setup.js
@@ -61,4 +61,4 @@ global.defaultDagRunDisplayNumber = 245;
 
 global.moment = moment;
 
-global.standaloneDagProcessor=true;
+global.standaloneDagProcessor = true;

--- a/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
+++ b/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
@@ -113,7 +113,7 @@ const Health = (props: CenterProps) => {
                 latestHeartbeat={
                   data?.dagProcessor?.latestDagProcessorHeartbeat
                 }
-                mb={3}
+                mt={3}
               />
             )}
           </CardBody>

--- a/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
+++ b/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
@@ -104,7 +104,6 @@ const Health = (props: CenterProps) => {
               title="Triggerer"
               status={data?.triggerer?.status}
               latestHeartbeat={data?.triggerer?.latestTriggererHeartbeat}
-              mb={3}
             />
             {!!standaloneDagProcessor && (
               <HealthSection

--- a/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
+++ b/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
@@ -81,7 +81,15 @@ const HealthSection = ({
 
 const Health = (props: CenterProps) => {
   const { data, isError } = useHealth();
-
+  let dagProcessorComponent=null;
+  if (standaloneDagProcessor.toString().toLowerCase()==="true") {
+    dagProcessorComponent = 
+      <HealthSection
+        title="Dag Processor"
+        status={data?.dagProcessor?.status}
+        latestHeartbeat={data?.dagProcessor?.latestDagProcessorHeartbeat}
+      />
+  }
   return (
     <Center {...props}>
       <LoadingWrapper hasData={!!data} isError={isError}>
@@ -107,11 +115,7 @@ const Health = (props: CenterProps) => {
               latestHeartbeat={data?.triggerer?.latestTriggererHeartbeat}
               mb={3}
             />
-            <HealthSection
-              title="Dag Processor"
-              status={data?.dagProcessor?.status}
-              latestHeartbeat={data?.dagProcessor?.latestDagProcessorHeartbeat}
-            />
+            {dagProcessorComponent}
           </CardBody>
         </Card>
       </LoadingWrapper>

--- a/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
+++ b/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
@@ -107,7 +107,7 @@ const Health = (props: CenterProps) => {
               mb={3}
             />
             { 
-            standaloneDagProcessor === true &&
+            !!standaloneDagProcessor &&
             <HealthSection
               title="Dag Processor"
               status={data?.dagProcessor?.status}

--- a/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
+++ b/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
@@ -80,17 +80,7 @@ const HealthSection = ({
 );
 
 const Health = (props: CenterProps) => {
-  const { data, isError } = useHealth();
-  let dagProcessorHealthComponent = null;
-  if (standaloneDagProcessor != undefined && standaloneDagProcessor.toString().toLowerCase() === "true") {
-    dagProcessorHealthComponent = (
-      <HealthSection
-        title="Dag Processor"
-        status={data?.dagProcessor?.status}
-        latestHeartbeat={data?.dagProcessor?.latestDagProcessorHeartbeat}
-      />
-    );
-  }
+  const { data, isError } = useHealth();  
   return (
     <Center {...props}>
       <LoadingWrapper hasData={!!data} isError={isError}>
@@ -116,7 +106,16 @@ const Health = (props: CenterProps) => {
               latestHeartbeat={data?.triggerer?.latestTriggererHeartbeat}
               mb={3}
             />
-            {dagProcessorHealthComponent}
+            { 
+            standaloneDagProcessor != undefined && 
+            standaloneDagProcessor.toString().toLowerCase() === "true" &&
+            <HealthSection
+              title="Dag Processor"
+              status={data?.dagProcessor?.status}
+              latestHeartbeat={data?.dagProcessor?.latestDagProcessorHeartbeat}
+              mb={3}
+            />
+            }
           </CardBody>
         </Card>
       </LoadingWrapper>

--- a/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
+++ b/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
@@ -82,7 +82,7 @@ const HealthSection = ({
 const Health = (props: CenterProps) => {
   const { data, isError } = useHealth();
   let dagProcessorHealthComponent = null;
-  if (standaloneDagProcessor.toString().toLowerCase() === "true") {
+  if (standaloneDagProcessor != undefined && standaloneDagProcessor.toString().toLowerCase() === "true") {
     dagProcessorHealthComponent = (
       <HealthSection
         title="Dag Processor"

--- a/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
+++ b/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
@@ -107,7 +107,7 @@ const Health = (props: CenterProps) => {
               mb={3}
             />
             { 
-            standaloneDagProcessor != undefined && 
+            standaloneDagProcessor !== undefined && 
             standaloneDagProcessor.toString().toLowerCase() === "true" &&
             <HealthSection
               title="Dag Processor"

--- a/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
+++ b/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
@@ -80,7 +80,7 @@ const HealthSection = ({
 );
 
 const Health = (props: CenterProps) => {
-  const { data, isError } = useHealth();  
+  const { data, isError } = useHealth();
   return (
     <Center {...props}>
       <LoadingWrapper hasData={!!data} isError={isError}>
@@ -106,15 +106,16 @@ const Health = (props: CenterProps) => {
               latestHeartbeat={data?.triggerer?.latestTriggererHeartbeat}
               mb={3}
             />
-            { 
-            !!standaloneDagProcessor &&
-            <HealthSection
-              title="Dag Processor"
-              status={data?.dagProcessor?.status}
-              latestHeartbeat={data?.dagProcessor?.latestDagProcessorHeartbeat}
-              mb={3}
-            />
-            }
+            {!!standaloneDagProcessor && (
+              <HealthSection
+                title="Dag Processor"
+                status={data?.dagProcessor?.status}
+                latestHeartbeat={
+                  data?.dagProcessor?.latestDagProcessorHeartbeat
+                }
+                mb={3}
+              />
+            )}
           </CardBody>
         </Card>
       </LoadingWrapper>

--- a/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
+++ b/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
@@ -107,8 +107,7 @@ const Health = (props: CenterProps) => {
               mb={3}
             />
             { 
-            standaloneDagProcessor !== undefined && 
-            standaloneDagProcessor.toString().toLowerCase() === "true" &&
+            standaloneDagProcessor === true &&
             <HealthSection
               title="Dag Processor"
               status={data?.dagProcessor?.status}

--- a/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
+++ b/airflow/www/static/js/cluster-activity/live-metrics/Health.tsx
@@ -81,14 +81,15 @@ const HealthSection = ({
 
 const Health = (props: CenterProps) => {
   const { data, isError } = useHealth();
-  let dagProcessorComponent=null;
-  if (standaloneDagProcessor.toString().toLowerCase()==="true") {
-    dagProcessorComponent = 
+  let dagProcessorHealthComponent = null;
+  if (standaloneDagProcessor.toString().toLowerCase() === "true") {
+    dagProcessorHealthComponent = (
       <HealthSection
         title="Dag Processor"
         status={data?.dagProcessor?.status}
         latestHeartbeat={data?.dagProcessor?.latestDagProcessorHeartbeat}
       />
+    );
   }
   return (
     <Center {...props}>
@@ -115,7 +116,7 @@ const Health = (props: CenterProps) => {
               latestHeartbeat={data?.triggerer?.latestTriggererHeartbeat}
               mb={3}
             />
-            {dagProcessorComponent}
+            {dagProcessorHealthComponent}
           </CardBody>
         </Card>
       </LoadingWrapper>

--- a/airflow/www/static/js/index.d.ts
+++ b/airflow/www/static/js/index.d.ts
@@ -22,6 +22,7 @@ import type { DepEdge, DepNode } from "./types";
 // define global variables that come from FAB
 declare global {
   const autoRefreshInterval: number | undefined;
+  const standaloneDagProcessor: string;
   const stateColors: {
     [key: string]: string;
   };

--- a/airflow/www/static/js/index.d.ts
+++ b/airflow/www/static/js/index.d.ts
@@ -22,7 +22,7 @@ import type { DepEdge, DepNode } from "./types";
 // define global variables that come from FAB
 declare global {
   const autoRefreshInterval: number | undefined;
-  const standaloneDagProcessor: string | undefined;
+  const standaloneDagProcessor: boolean | false;
   const stateColors: {
     [key: string]: string;
   };

--- a/airflow/www/static/js/index.d.ts
+++ b/airflow/www/static/js/index.d.ts
@@ -22,7 +22,7 @@ import type { DepEdge, DepNode } from "./types";
 // define global variables that come from FAB
 declare global {
   const autoRefreshInterval: number | undefined;
-  const standaloneDagProcessor: string;
+  const standaloneDagProcessor: string | undefined;
   const stateColors: {
     [key: string]: string;
   };

--- a/airflow/www/static/js/index.d.ts
+++ b/airflow/www/static/js/index.d.ts
@@ -22,7 +22,7 @@ import type { DepEdge, DepNode } from "./types";
 // define global variables that come from FAB
 declare global {
   const autoRefreshInterval: number | undefined;
-  const standaloneDagProcessor: boolean | false;
+  const standaloneDagProcessor: boolean | undefined;
   const stateColors: {
     [key: string]: string;
   };

--- a/airflow/www/templates/airflow/cluster_activity.html
+++ b/airflow/www/templates/airflow/cluster_activity.html
@@ -43,7 +43,7 @@
   <script>
     const stateColors = {{ state_color_mapping|tojson }};
     const autoRefreshInterval = {{ auto_refresh_interval }};
-    const standaloneDagProcessor = {{ standalone_dag_processor }} ;
+    const standaloneDagProcessor = {{ standalone_dag_processor }} === 'True' ;
   </script>
   <script src="{{ url_for_asset('clusterActivity.js') }}"></script>
 {% endblock %}

--- a/airflow/www/templates/airflow/cluster_activity.html
+++ b/airflow/www/templates/airflow/cluster_activity.html
@@ -43,6 +43,7 @@
   <script>
     const stateColors = {{ state_color_mapping|tojson }};
     const autoRefreshInterval = {{ auto_refresh_interval }};
+    const standaloneDagProcessor = {{ standalone_dag_processor }} ;
   </script>
   <script src="{{ url_for_asset('clusterActivity.js') }}"></script>
 {% endblock %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1051,7 +1051,7 @@ class Airflow(AirflowBaseView):
         """Cluster Activity view."""
         state_color_mapping = State.state_color.copy()
         state_color_mapping["no_status"] = state_color_mapping.pop(None)
-        standalone_dag_processor = str(conf.getboolean("scheduler", "standalone_dag_processor")).lower()
+        standalone_dag_processor = conf.getboolean("scheduler", "standalone_dag_processor")
         return self.render_template(
             "airflow/cluster_activity.html",
             auto_refresh_interval=conf.getint("webserver", "auto_refresh_interval"),

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1051,12 +1051,12 @@ class Airflow(AirflowBaseView):
         """Cluster Activity view."""
         state_color_mapping = State.state_color.copy()
         state_color_mapping["no_status"] = state_color_mapping.pop(None)
-        standalone_dag_processor = conf.getboolean("scheduler", "standalone_dag_processor")
+        standalone_dag_processor = str(conf.getboolean("scheduler", "standalone_dag_processor")).lower()
         return self.render_template(
             "airflow/cluster_activity.html",
             auto_refresh_interval=conf.getint("webserver", "auto_refresh_interval"),
             state_color_mapping=state_color_mapping,
-            standalone_dag_processor=str(standalone_dag_processor).lower()
+            standalone_dag_processor=standalone_dag_processor,
         )
 
     @expose("/next_run_datasets_summary", methods=["POST"])

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1051,10 +1051,12 @@ class Airflow(AirflowBaseView):
         """Cluster Activity view."""
         state_color_mapping = State.state_color.copy()
         state_color_mapping["no_status"] = state_color_mapping.pop(None)
+        standalone_dag_processor = conf.getboolean("scheduler", "standalone_dag_processor")
         return self.render_template(
             "airflow/cluster_activity.html",
             auto_refresh_interval=conf.getint("webserver", "auto_refresh_interval"),
             state_color_mapping=state_color_mapping,
+            standalone_dag_processor=str(standalone_dag_processor).lower()
         )
 
     @expose("/next_run_datasets_summary", methods=["POST"])


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #33497

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

<!-- Please keep an empty line above the dashes. -->
Users should not see the Dag Processor health on the Cluster Activity page if `standalone_dag_processor=False`. 

closes: https://github.com/apache/airflow/issues/33497