### PR TITLE
[bugfix] fix AWS Appflow waiter

### DIFF
--- a/airflow/providers/amazon/aws/waiters/appflow.json
+++ b/airflow/providers/amazon/aws/waiters/appflow.json
@@ -10,13 +10,13 @@
                     "expected": "Successful",
                     "matcher": "path",
                     "state": "success",
-                    "argument": "flowExecutions[?executionId=='{{EXECUTION_ID}}'].executionStatus"
+                    "argument": "flowExecutions[?executionId=='{{EXECUTION_ID}}'].executionStatus | [0]"
                 },
                 {
                     "expected": "Error",
                     "matcher": "path",
                     "state": "failure",
-                    "argument": "flowExecutions[?executionId=='{{EXECUTION_ID}}'].executionStatus"
+                    "argument": "flowExecutions[?executionId=='{{EXECUTION_ID}}'].executionStatus | [0]"
                 },
                 {
                     "expected": true,


### PR DESCRIPTION
closes #33461

Turns out the JMESPath selector was returning an array of one element instead of the element itself, so the matcher was not working.