### PR TITLE
Bind engine before attempting to drop archive tables

### DIFF
--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -194,6 +194,7 @@ def _do_delete(*, query, orm_model, skip_archive, session):
     session.execute(delete)
     session.commit()
     if skip_archive:
+        metadata.bind = session.get_bind()
         target_table.drop()
     session.commit()
     print("Finished Performing Delete")


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/33606

It looks like we weren't properly binding the engine to the table object before attempting to drop it, and as a result SQLalchemy was throwing exceptions. The only tests which actually run the db cleanup had set `skip_archive=False` so this went through undetected.

Anyways, added a test to replicate the issue and then fixed it.