### PR TITLE
Fix 2.7.0 db migration job errors

### DIFF
--- a/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -37,7 +37,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 
 try:
     from airflow.cli.cli_config import (

--- a/airflow/sentry.py
+++ b/airflow/sentry.py
@@ -87,7 +87,7 @@ if conf.getboolean("sentry", "sentry_on", fallback=False):
             # LoggingIntegration is set by default.
             integrations = [sentry_flask]
 
-            executor_class, _ = ExecutorLoader.import_default_executor_cls()
+            executor_class, _ = ExecutorLoader.import_default_executor_cls(validate=False)
 
             if executor_class.supports_sentry:
                 from sentry_sdk.integrations.celery import CeleryIntegration


### PR DESCRIPTION
Related to #33651

Fixes 2 issues when running Airflow 2.7.0 python 3.11 on Kubernetes with CeleryKubernetesExecutor and Sentry.
- A circular import from kubernetes_executor.py
- Do not validate SQL when Sentry is initialising. It's still in the configuration phase.

I've tested this on my Kubernetes cluster and it works.

The only doubt I have is the `validate=False` change. I'm not sure if this is the intended use.
