### PR TITLE
Addd triggers and transfers to provider_info.schema

### DIFF
--- a/airflow/provider_info.schema.json
+++ b/airflow/provider_info.schema.json
@@ -25,6 +25,60 @@
                 "deprecatedVersion": "2.2.0"
             }
         },
+        "transfers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "how-to-guide": {
+                        "description": "Path to how-to-guide for the transfer. The path must start with '/docs/'",
+                        "type": "string"
+                    },
+                    "source-integration-name": {
+                        "type": "string",
+                        "description": "Integration name. It must have a matching item in the 'integration' section of any provider."
+                    },
+                    "target-integration-name": {
+                        "type": "string",
+                        "description": "Target integration name. It must have a matching item in the 'integration' section of any provider."
+                    },
+                    "python-module": {
+                        "type": "string",
+                        "description": "List of python modules containing the transfers."
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "source-integration-name",
+                    "target-integration-name",
+                    "python-module"
+                ]
+            }
+        },
+        "triggers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "integration-name": {
+                        "type": "string",
+                        "description": "Integration name. It must have a matching item in the 'integration' section of any provider."
+                    },
+                    "python-modules": {
+                        "description": "List of Python modules containing the triggers.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "integration-name",
+                    "python-modules"
+                ]
+            }
+        },
         "connection-types": {
             "type": "array",
             "description": "Map of connection types mapped to hook class names.",


### PR DESCRIPTION
They were not added to the schema, even if they are appearing already as they are automatically extracted from provider.yaml

Part of #29918

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
