### PR TITLE
Refactor: Replace FileNotFound with Path.unlink(missing_ok=True)

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/production_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/production_image_commands.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import contextlib
 import os
 import sys
 from typing import Any
@@ -419,11 +418,10 @@ def clean_docker_context_files():
         get_console().print("[info]Cleaning docker-context-files[/]")
     if get_dry_run():
         return
-    with contextlib.suppress(FileNotFoundError):
-        context_files_to_delete = DOCKER_CONTEXT_DIR.glob("**/*")
-        for file_to_delete in context_files_to_delete:
-            if file_to_delete.name != ".README.md":
-                file_to_delete.unlink()
+    context_files_to_delete = DOCKER_CONTEXT_DIR.rglob("*")
+    for file_to_delete in context_files_to_delete:
+        if file_to_delete.name != ".README.md":
+            file_to_delete.unlink(missing_ok=True)
 
 
 def check_docker_context_files(install_packages_from_context: bool):

--- a/dev/breeze/src/airflow_breeze/utils/kubernetes_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/kubernetes_utils.py
@@ -162,11 +162,7 @@ def _download_tool_if_needed(
             f"[info]Error when running `{tool}`: {e}. "
             f"Removing and downloading {expected_version} version."
         )
-        try:
-            # We can add missing=ok when we go to python 3.8+
-            path.unlink()
-        except FileNotFoundError:
-            pass
+        path.unlink(missing_ok=True)
     get_console().print(f"[info]Downloading from:[/] {url}")
     if get_dry_run():
         return

--- a/dev/breeze/src/airflow_breeze/utils/parallel.py
+++ b/dev/breeze/src/airflow_breeze/utils/parallel.py
@@ -449,10 +449,7 @@ def check_async_run_results(
     finally:
         if not skip_cleanup:
             for output in outputs:
-                try:
-                    os.unlink(output.file_name)
-                except FileNotFoundError:
-                    pass
+                Path(output.file_name).unlink(missing_ok=True)
 
 
 @contextmanager

--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -410,10 +410,7 @@ def _run_compile_internally(command_to_execute: list[str], dev: bool) -> RunComm
         )
     else:
         WWW_ASSET_COMPILE_LOCK.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            WWW_ASSET_COMPILE_LOCK.unlink()
-        except FileNotFoundError:
-            pass
+        WWW_ASSET_COMPILE_LOCK.unlink(missing_ok=True)
         try:
             with SoftFileLock(WWW_ASSET_COMPILE_LOCK, timeout=5):
                 with open(WWW_ASSET_OUT_FILE, "w") as output_file:
@@ -427,10 +424,7 @@ def _run_compile_internally(command_to_execute: list[str], dev: bool) -> RunComm
                         stdout=output_file,
                     )
                 if result.returncode == 0:
-                    try:
-                        WWW_ASSET_OUT_FILE.unlink()
-                    except FileNotFoundError:
-                        pass
+                    WWW_ASSET_OUT_FILE.unlink(missing_ok=True)
                 return result
         except Timeout:
             get_console().print("[error]Another asset compilation is running. Exiting[/]\n")

--- a/scripts/ci/pre_commit/pre_commit_compile_www_assets_dev.py
+++ b/scripts/ci/pre_commit/pre_commit_compile_www_assets_dev.py
@@ -41,10 +41,7 @@ if __name__ == "__main__":
         WWW_HASH_FILE.unlink()
     env = os.environ.copy()
     env["FORCE_COLOR"] = "true"
-    try:
-        WWW_ASSET_OUT_FILE.unlink()
-    except FileNotFoundError:
-        pass
+    WWW_ASSET_OUT_FILE.unlink(missing_ok=True)
     with open(WWW_ASSET_OUT_DEV_MODE_FILE, "w") as f:
         subprocess.run(
             ["yarn", "install", "--frozen-lockfile"],

--- a/scripts/ci/pre_commit/pre_commit_update_common_sql_api_stubs.py
+++ b/scripts/ci/pre_commit/pre_commit_update_common_sql_api_stubs.py
@@ -212,7 +212,7 @@ def compare_stub_files(generated_stub_path: Path, force_override: bool) -> tuple
         module_name, generated_stub_path, patch_generated_files=True
     )
     if generated_pyi_content is None:
-        os.unlink(generated_stub_path)
+        generated_stub_path.unlink()
         if stub_file_target_path.exists():
             console.print(
                 f"[red]The {stub_file_target_path} file is missing in generated files: "
@@ -223,7 +223,7 @@ def compare_stub_files(generated_stub_path: Path, force_override: bool) -> tuple
                     f"[yellow]The file {stub_file_target_path} has been removed "
                     "as changes are force-overridden"
                 )
-                os.unlink(stub_file_target_path)
+                stub_file_target_path.unlink()
             return 1, 0
         else:
             console.print(
@@ -345,7 +345,7 @@ if __name__ == "__main__":
                 console.print(
                     f"[yellow]The file {target_path} has been removed as changes are force-overridden"
                 )
-                os.unlink(target_path)
+                target_path.unlink()
     if not total_removals and not total_additions:
         console.print("\n[green]All OK. The common.sql APIs did not change[/]")
         sys.exit(0)


### PR DESCRIPTION
This removes all `try / unlink / except FileNotFoundError / pass` blocks with `Path.unlink(missing_ok=True)` or better alternatives. In tests, it uses `tmp_path` fixture instead of overwriting (and trying to unlink) files in `/tmp`.