### PR TITLE
Refactor: path.rglob("…") does not need "**"

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -312,7 +312,7 @@ AVAILABLE_INTEGRATIONS = [
     "statsd",
     "trino",
 ]
-ALL_PROVIDER_YAML_FILES = Path(AIRFLOW_SOURCES_ROOT).glob("airflow/providers/**/provider.yaml")
+ALL_PROVIDER_YAML_FILES = Path(AIRFLOW_SOURCES_ROOT, "airflow", "providers").rglob("provider.yaml")
 
 with Path(AIRFLOW_SOURCES_ROOT, "generated", "provider_dependencies.json").open() as f:
     PROVIDER_DEPENDENCIES = json.load(f)

--- a/dev/breeze/src/airflow_breeze/utils/suspended_providers.py
+++ b/dev/breeze/src/airflow_breeze/utils/suspended_providers.py
@@ -27,7 +27,7 @@ def get_suspended_providers_folders() -> list[str]:
     skipped when running tests (without any prefix - for example apache/beam, yandex, google etc.).
     """
     suspended_providers = []
-    for provider_path in AIRFLOW_PROVIDERS_ROOT.glob("**/provider.yaml"):
+    for provider_path in AIRFLOW_PROVIDERS_ROOT.rglob("provider.yaml"):
         provider_yaml = yaml.safe_load(provider_path.read_text())
         if provider_yaml.get("suspended"):
             suspended_providers.append(
@@ -43,7 +43,7 @@ def get_suspended_provider_ids() -> list[str]:
     Yields the ids of suspended providers.
     """
     suspended_provider_ids = []
-    for provider_path in AIRFLOW_PROVIDERS_ROOT.glob("**/provider.yaml"):
+    for provider_path in AIRFLOW_PROVIDERS_ROOT.rglob("provider.yaml"):
         provider_yaml = yaml.safe_load(provider_path.read_text())
         if provider_yaml.get("suspended"):
             suspended_provider_ids.append(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -269,7 +269,7 @@ if PACKAGE_NAME == "apache-airflow":
 
 elif PACKAGE_NAME != "docker-stack":
     exclude_patterns.extend(
-        _get_rst_filepath_from_path(f) for f in pathlib.Path(PACKAGE_DIR).glob("**/example_dags")
+        _get_rst_filepath_from_path(f) for f in pathlib.Path(PACKAGE_DIR).rglob("example_dags")
     )
 
 # Add any paths that contain templates here, relative to this directory.

--- a/scripts/ci/pre_commit/pre_commit_update_common_sql_api_stubs.py
+++ b/scripts/ci/pre_commit/pre_commit_update_common_sql_api_stubs.py
@@ -319,7 +319,7 @@ if __name__ == "__main__":
     shutil.rmtree(OUT_DIR, ignore_errors=True)
 
     subprocess.run(
-        ["stubgen", *[os.fspath(path) for path in COMMON_SQL_ROOT.rglob("**/*.py")]],
+        ["stubgen", *[os.fspath(path) for path in COMMON_SQL_ROOT.rglob("*.py")]],
         cwd=AIRFLOW_SOURCES_ROOT_PATH,
     )
     total_removals, total_additions = 0, 0
@@ -327,9 +327,9 @@ if __name__ == "__main__":
     if _force_override:
         console.print("\n[yellow]The committed stub APIs are force-updated\n")
     # reformat the generated stubs first
-    for stub_path in OUT_DIR.rglob("**/*.pyi"):
+    for stub_path in OUT_DIR.rglob("*.pyi"):
         write_pyi_file(stub_path, stub_path.read_text(encoding="utf-8"))
-    for stub_path in OUT_DIR.rglob("**/*.pyi"):
+    for stub_path in OUT_DIR.rglob("*.pyi"):
         _new_removals, _new_additions = compare_stub_files(stub_path, force_override=_force_override)
         total_removals += _new_removals
         total_additions += _new_additions

--- a/scripts/in_container/run_provider_yaml_files_check.py
+++ b/scripts/in_container/run_provider_yaml_files_check.py
@@ -582,7 +582,7 @@ def check_doc_files(yaml_files: dict[str, dict]) -> tuple[int, int]:
         console.print()
     expected_logo_urls = {
         f"/{f.relative_to(DOCS_DIR).as_posix()}"
-        for f in DOCS_DIR.glob("integration-logos/**/*")
+        for f in (DOCS_DIR / "integration-logos").rglob("*")
         if f.is_file() and not f"/{f.relative_to(DOCS_DIR).as_posix()}".startswith(tuple(suspended_logos))
     }
 
@@ -684,7 +684,7 @@ if __name__ == "__main__":
     ProvidersManager().initialize_providers_configuration()
     architecture = Architecture.get_current()
     console.print(f"Verifying packages on {architecture} architecture. Platform: {platform.machine()}.")
-    provider_files_pattern = pathlib.Path(ROOT_DIR).glob("airflow/providers/**/provider.yaml")
+    provider_files_pattern = pathlib.Path(ROOT_DIR, "airflow", "providers").rglob("provider.yaml")
     all_provider_files = sorted(str(path) for path in provider_files_pattern)
     if len(sys.argv) > 1:
         paths = [os.fspath(ROOT_DIR / f) for f in sorted(sys.argv[1:])]

--- a/tests/always/test_example_dags.py
+++ b/tests/always/test_example_dags.py
@@ -38,7 +38,7 @@ def get_suspended_providers_folders() -> list[str]:
     skipped when running tests (without any prefix - for example apache/beam, yandex, google etc.).
     """
     suspended_providers = []
-    for provider_path in AIRFLOW_PROVIDERS_ROOT.glob("**/provider.yaml"):
+    for provider_path in AIRFLOW_PROVIDERS_ROOT.rglob("provider.yaml"):
         provider_yaml = yaml.safe_load(provider_path.read_text())
         if provider_yaml.get("suspended"):
             suspended_providers.append(


### PR DESCRIPTION
Replace `path.glob("**/…")` with `path.rglob("…")`. If the `**` placeholder is deeper, then extend `path`.