### PR TITLE
Fix bug in task logs when using AWS CloudWatch. Do not set `start_time`

### DIFF
--- a/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
+++ b/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
@@ -114,9 +114,6 @@ class CloudwatchTaskHandler(FileTaskHandler, LoggingMixin):
         :param task_instance: the task instance to get logs about
         :return: string of all logs from the given log stream
         """
-        start_time = (
-            0 if task_instance.start_date is None else datetime_to_epoch_utc_ms(task_instance.start_date)
-        )
         # If there is an end_date to the task instance, fetch logs until that date + 30 seconds
         # 30 seconds is an arbitrary buffer so that we don't miss any logs that were emitted
         end_time = (
@@ -127,7 +124,6 @@ class CloudwatchTaskHandler(FileTaskHandler, LoggingMixin):
         events = self.hook.get_log_events(
             log_group=self.log_group,
             log_stream_name=stream_name,
-            start_time=start_time,
             end_time=end_time,
         )
         return "\n".join(self._event_to_str(event) for event in events)

--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -162,15 +162,12 @@ class TestCloudwatchTaskHandler:
         ],
     )
     @mock.patch.object(AwsLogsHook, "get_log_events")
-    def test_get_cloudwatch_logs(
-        self, mock_get_log_events, start_date, end_date, expected_start_time, expected_end_time
-    ):
+    def test_get_cloudwatch_logs(self, mock_get_log_events, end_date, expected_end_time):
         self.ti.end_date = end_date
         self.cloudwatch_task_handler.get_cloudwatch_logs(self.remote_log_stream, self.ti)
         mock_get_log_events.assert_called_once_with(
             log_group=self.remote_log_group,
             log_stream_name=self.remote_log_stream,
-            start_time=expected_start_time,
             end_time=expected_end_time,
         )
 

--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -155,29 +155,16 @@ class TestCloudwatchTaskHandler:
         )
 
     @pytest.mark.parametrize(
-        "start_date, end_date, expected_start_time, expected_end_time",
+        "end_date, expected_end_time",
         [
-            (None, None, 0, None),
-            (datetime(2020, 1, 1), None, datetime_to_epoch_utc_ms(datetime(2020, 1, 1)), None),
-            (
-                None,
-                datetime(2020, 1, 2),
-                0,
-                datetime_to_epoch_utc_ms(datetime(2020, 1, 2) + timedelta(seconds=30)),
-            ),
-            (
-                datetime(2020, 1, 1),
-                datetime(2020, 1, 2),
-                datetime_to_epoch_utc_ms(datetime(2020, 1, 1)),
-                datetime_to_epoch_utc_ms(datetime(2020, 1, 2) + timedelta(seconds=30)),
-            ),
+            (None, None),
+            (datetime(2020, 1, 2), datetime_to_epoch_utc_ms(datetime(2020, 1, 2) + timedelta(seconds=30))),
         ],
     )
     @mock.patch.object(AwsLogsHook, "get_log_events")
     def test_get_cloudwatch_logs(
         self, mock_get_log_events, start_date, end_date, expected_start_time, expected_end_time
     ):
-        self.ti.start_date = start_date
         self.ti.end_date = end_date
         self.cloudwatch_task_handler.get_cloudwatch_logs(self.remote_log_stream, self.ti)
         mock_get_log_events.assert_called_once_with(


### PR DESCRIPTION
Resolves #33634.

A bug has been introduced in #33231, when tasks are rerun, the task instance refers to the last one only. As a result, when you rerun a task, logs from the first run are not shown in the UI because `task_instance.start_date` is after the first run. Not setting `start_time`  should solve the issue and should keep the optimization in place because, the optimization is based 100% on `end_time`.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
