### PR TITLE
Adding connection-backed Kubernetes Secrets to KubernetesPodOperator

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -30,9 +30,9 @@ from contextlib import AbstractContextManager
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Iterable, Sequence
 
-from kubernetes.stream import stream
 from kubernetes.client import CoreV1Api, models as k8s
 from kubernetes.client.rest import ApiException
+from kubernetes.stream import stream
 from slugify import slugify
 from urllib3.exceptions import HTTPError
 
@@ -813,7 +813,7 @@ class KubernetesPodOperator(BaseOperator):
             for event in self.pod_manager.read_pod_events(pod).items:
                 self.log.error("Pod Event: %s - %s", event.reason, event.message)
 
-    def is_istio_enabled(self, pod: V1Pod) -> bool:
+    def is_istio_enabled(self, pod: k8s.V1Pod) -> bool:
         """Checks if istio is enabled for the namespace of the pod by inspecting the namespace labels."""
         if not pod:
             return False
@@ -826,7 +826,7 @@ class KubernetesPodOperator(BaseOperator):
 
         return False
 
-    def kill_istio_sidecar(self, pod: V1Pod) -> None:
+    def kill_istio_sidecar(self, pod: k8s.V1Pod) -> None:
         command = "/bin/sh -c curl -fsI -X POST http://localhost:15020/quitquitquit && exit 0"
         command_to_container = shlex.split(command)
         try:

--- a/airflow/providers/cncf/kubernetes/secret.py
+++ b/airflow/providers/cncf/kubernetes/secret.py
@@ -122,3 +122,21 @@ class Secret(K8SModel):
 
     def __repr__(self):
         return f"Secret({self.deploy_type}, {self.deploy_target}, {self.secret}, {self.key})"
+
+
+class KubernetesConnectionSecret(Secret):
+    """
+    Kubernetes Secret which is backed by an Airflow connection.
+
+    At execution time the secret will be created in Kubernetes based on the
+    contents of the connection in the secrets backend.
+
+    The created secrets will be cleaned up after execution.
+
+    :param conn_id: The ID for the connection which will be used to provision a Kubernetes Secret.
+    """
+
+    def __init__(self, deploy_type, deploy_target, conn_id, key=None, items=None):
+        """Instantiate a secret with a missing secret ID, as this is populated at run-time."""
+        super.__init__(self, deploy_type, deploy_target, None, key=key, items=items)
+        self.conn_id = conn_id

--- a/airflow/providers/cncf/kubernetes/secret.py
+++ b/airflow/providers/cncf/kubernetes/secret.py
@@ -138,5 +138,5 @@ class KubernetesConnectionSecret(Secret):
 
     def __init__(self, deploy_type, deploy_target, conn_id, key=None, items=None):
         """Instantiate a secret with a missing secret ID, as this is populated at run-time."""
-        super.__init__(self, deploy_type, deploy_target, None, key=key, items=items)
+        super().__init__(deploy_type, deploy_target, None, key=key, items=items)
         self.conn_id = conn_id


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/28086

This is very much a first-pass / WIP but I wanted to get some early input on the design decisions.

#### tl;dr

This allows a user to define a connection-backed secret to be consumed by the KubernetesPodOperator. The KPO handles the creation of these secrets at execution time and cleans them up after the fact.

A `KubernetesConnectionSecret` is almost identical to a regular `Secret`, except for the removal of the `secret` param and the addition of the `conn_id` param. A secret name is generated at run-time and added to the secret object, after which it can be used as a regular `Secret`.

#### Example:

```python
from airflow.providers.cncf.kubernetes.secret import KubernetesConnectionSecret
from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
from airflow.models import DAG
from datetime import datetime

# this will mount the password from the `my_conn` connection at `/etc/secret_password`
connection_secret = KubernetesConnectionSecret("volume", "/etc/secret_password", "my_conn", key="password")

with DAG(
    dag_id="kube_pod_with_connection_secrets",
    start_date=datetime(2021, 1, 1),
) as dag:
    k = KubernetesPodOperator(
        namespace="default",
        image="ubuntu:16.04",
        cmds=["bash", "-cx"],
        arguments=["echo", "10"],
        connection_secrets=[connection_secret],
        task_id="task",
    )
```

#### Open Questions:

 - How should we map a connection into the secret object? Currently I'm just writing out all of the fields to a dict.

#### TODO (before merging):

 - [ ] Additional test coverage in kubernetes_tests
 - [ ] Add documentation around this feature
