### PR TITLE
Set snowflake_conn_id on Snowflake Operators to avoid error

### DIFF
--- a/airflow/providers/snowflake/operators/snowflake.py
+++ b/airflow/providers/snowflake/operators/snowflake.py
@@ -213,6 +213,7 @@ class SnowflakeCheckOperator(SQLCheckOperator):
         session_parameters: dict | None = None,
         **kwargs,
     ) -> None:
+        self.snowflake_conn_id = snowflake_conn_id
         if any([warehouse, database, role, schema, authenticator, session_parameters]):
             hook_params = kwargs.pop("hook_params", {})
             kwargs["hook_params"] = {
@@ -282,6 +283,7 @@ class SnowflakeValueCheckOperator(SQLValueCheckOperator):
         session_parameters: dict | None = None,
         **kwargs,
     ) -> None:
+        self.snowflake_conn_id = snowflake_conn_id
         if any([warehouse, database, role, schema, authenticator, session_parameters]):
             hook_params = kwargs.pop("hook_params", {})
             kwargs["hook_params"] = {
@@ -362,6 +364,7 @@ class SnowflakeIntervalCheckOperator(SQLIntervalCheckOperator):
         session_parameters: dict | None = None,
         **kwargs,
     ) -> None:
+        self.snowflake_conn_id = snowflake_conn_id
         if any([warehouse, database, role, schema, authenticator, session_parameters]):
             hook_params = kwargs.pop("hook_params", {})
             kwargs["hook_params"] = {


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/33679

In https://github.com/apache/airflow/pull/30784 we added new template fields, but in the case of the snowflake operators, this attribute was never actually set during initialization (it was just passed to the parent class as `conn_id`). 

As a result, these operators fail with the following exception:
```
AttributeError: 'snowflake_conn_id' is configured as a template field but SnowflakeCheckOperator does not have this attribute.
```

Anyways, this PR just adds the missing attributes.

I replicated the original failure mode in Breeze, and then verified this fix.