### PR TITLE
SECURITY_MANAGER_CLASS should be a referrence to class, not a string

### DIFF
--- a/docs/apache-airflow/security/webserver.rst
+++ b/docs/apache-airflow/security/webserver.rst
@@ -169,14 +169,14 @@ Here is an example of what you might have in your webserver_config.py:
 
 .. code-block:: python
 
+    from airflow.www.security import AirflowSecurityManager
     from flask_appbuilder.security.manager import AUTH_OAUTH
     import os
 
     AUTH_TYPE = AUTH_OAUTH
     AUTH_ROLES_SYNC_AT_LOGIN = True  # Checks roles on every login
     AUTH_USER_REGISTRATION = True  # allow users who are not already in the FAB DB to register
-    # Make sure to replace this with the path to your security manager class
-    SECURITY_MANAGER_CLASS = "your_module.your_security_manager_class"
+
     AUTH_ROLES_MAPPING = {
         "Viewer": ["Viewer"],
         "Admin": ["Admin"],
@@ -198,6 +198,14 @@ Here is an example of what you might have in your webserver_config.py:
             },
         },
     ]
+
+
+    class CustomSecurityManager(AirflowSecurityManager):
+        pass
+
+
+    # Make sure to replace this with your own implementation of AirflowSecurityManager class
+    SECURITY_MANAGER_CLASS = CustomSecurityManager
 
 Here is an example of defining a custom security manager.
 This class must be available in Python's path, and could be defined in


### PR DESCRIPTION
See this comment: https://github.com/apache/airflow/issues/33586#issuecomment-1690033003

If SECURITY_MANAGER_CLASS is a string then you will get error like:
```
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/www/extensions/init_appbuilder.py", line 661, in init_appbuilder
    if not issubclass(security_manager_class, AirflowSecurityManager):
TypeError: issubclass() arg 1 must be a class
```

@vincbeck fyi