### PR TITLE
Add back link to the ASF blog about severity to the policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -62,7 +62,7 @@ variety of operations that could be considered as vulnerabilities in other produ
 Therefore, some potential security vulnerabilities do not apply to Airflow, or have a different severity
 than some generic scoring systems (for example `CVSS`) calculation suggests. Severity of the issue is
 determined based on the criteria described in the
-[Severity Rating blog post](https://security.apache.org/blog/severityrating/)  by the Apache Software
+[Severity Rating blog post](https://security.apache.org/blog/severityrating/) by the Apache Software
 Foundation Security team.
 
 The [Airflow Security Team](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#security-team) will get back to you after assessing the report.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -54,11 +54,16 @@ movie, HTML, or PDF attachment when you could as easily describe it with plain t
 Before reporting vulnerabilities, please make sure to read and understand the
 [security model](https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html) of Airflow, because
 some of the potential security vulnerabilities that are valid for projects that are publicly accessible
-from the Internet, are not valid for Airflow. Airflow is not designed to be used by untrusted users, and some
-trusted users are trusted enough to do a variety of operations that could be considered as vulnerabilities
-in other products/circumstances. Therefore, some potential security vulnerabilities do not
-apply to Airflow, or have a different severity than some generic scoring systems (for example `CVSS`)
-calculation suggests.
+from the Internet, are not valid for Airflow.
+
+
+Airflow is not designed to be used by untrusted users, and some trusted users are trusted enough to do a
+variety of operations that could be considered as vulnerabilities in other products/circumstances.
+Therefore, some potential security vulnerabilities do not apply to Airflow, or have a different severity
+than some generic scoring systems (for example `CVSS`) calculation suggests. Severity of the issue is
+determined based on the criteria described in the
+[Severity Rating blog post](https://security.apache.org/blog/severityrating/)  by the Apache Software
+Foundation Security team.
 
 The [Airflow Security Team](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#security-team) will get back to you after assessing the report.
 


### PR DESCRIPTION
The security policy should be the place where researchers are looking on how to assign severity to their reports. We had the link to the ASF blog post decribing how we assess the severity but it has been moved out in #32496 somewhat accidentally to the information about the security team. It can stay there (as a reference for the security team members/internal, but it would be great to keep it in our Policy targeted for the researchers.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
