### PR TITLE
[docs] Adding a example on page "Testing DAGs with dag.test()"

### DIFF
--- a/docs/apache-airflow/core-concepts/executor/debug.rst
+++ b/docs/apache-airflow/core-concepts/executor/debug.rst
@@ -37,6 +37,7 @@ Using TaskFlow API:
 
   dag = taskflow_example()
   
+  
   if __name__ == "__main__":
       dag.test()
 

--- a/docs/apache-airflow/core-concepts/executor/debug.rst
+++ b/docs/apache-airflow/core-concepts/executor/debug.rst
@@ -31,6 +31,15 @@ To set up ``dag.test``, add these two lines to the bottom of your dag file:
   if __name__ == "__main__":
       dag.test()
 
+Using TaskFlow API:
+
+.. code-block:: python
+
+  dag = taskflow_example()
+  
+  if __name__ == "__main__":
+      dag.test()
+
 and that's it! You can add argument such as ``execution_date`` if you want to test argument-specific DAG runs, but otherwise
 you can run or debug DAGs as needed.
 


### PR DESCRIPTION
Hello! I'm suggesting a small addition on test DAG page, it's an example of using the test method on TaskFlow API.

I think it is necessary because you need to instance the dag first on TaskFlow, and I had to search on other websites to learn how to do that.

It's just a minor addition, but I believe it can be helpful to other users.