### PR TITLE
Inspect container state rather than last_state when deciding whether to skip

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -731,10 +731,10 @@ class KubernetesPodOperator(BaseOperator):
                     (x for x in container_statuses if x.name == self.base_container_name), None
                 )
                 exit_code = (
-                    base_container_status.last_state.terminated.exit_code
+                    base_container_status.state.terminated.exit_code
                     if base_container_status
-                    and base_container_status.last_state
-                    and base_container_status.last_state.terminated
+                    and base_container_status.state
+                    and base_container_status.state.terminated
                     else None
                 )
                 if exit_code in self.skip_on_exit_code:

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -1309,10 +1309,10 @@ class TestKubernetesPodOperator:
 
         base_container = MagicMock()
         base_container.name = k.base_container_name
-        base_container.last_state.terminated.exit_code = actual_exit_code
+        base_container.state.terminated.exit_code = actual_exit_code
         sidecar_container = MagicMock()
         sidecar_container.name = "airflow-xcom-sidecar"
-        sidecar_container.last_state.terminated.exit_code = 0
+        sidecar_container.state.terminated.exit_code = 0
         remote_pod.return_value.status.container_statuses = [base_container, sidecar_container]
         remote_pod.return_value.status.phase = "Succeeded" if actual_exit_code == 0 else "Failed"
 
@@ -1569,10 +1569,10 @@ class TestKubernetesPodOperatorAsync:
 
         base_container = MagicMock()
         base_container.name = k.base_container_name
-        base_container.last_state.terminated.exit_code = actual_exit_code
+        base_container.state.terminated.exit_code = actual_exit_code
         sidecar_container = MagicMock()
         sidecar_container.name = "airflow-xcom-sidecar"
-        sidecar_container.last_state.terminated.exit_code = 0
+        sidecar_container.state.terminated.exit_code = 0
         remote_pod = MagicMock()
         remote_pod.status.phase = pod_status
         remote_pod.status.container_statuses = [base_container, sidecar_container]


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/33697

Looking at the [Kubernetes API Docs for containerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#containerstatus-v1-core), it looks like `lastState` provides the state of the previous run of the container, whereas `state` should provide information on the most recent termination (which is the relevant one in this case)

I also added an integration test under `kubernetes_tests` to verify that this works as expected.
