### PR TITLE
Fix cleaning zombie RESTARTING tasks

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1579,7 +1579,7 @@ class SchedulerJobRunner(BaseJobRunner[Job], LoggingMixin):
     @provide_session
     def adopt_or_reset_orphaned_tasks(self, session: Session = NEW_SESSION) -> int:
         """
-        Reset any TaskInstance in QUEUED or SCHEDULED state if its SchedulerJob is no longer running.
+        Adopt or reset any TaskInstance in resettable state if its SchedulerJob is no longer running.
 
         :return: the number of TIs reset
         """
@@ -1609,10 +1609,9 @@ class SchedulerJobRunner(BaseJobRunner[Job], LoggingMixin):
                         self.log.info("Marked %d SchedulerJob instances as failed", num_failed)
                         Stats.incr(self.__class__.__name__.lower() + "_end", num_failed)
 
-                    resettable_states = [TaskInstanceState.QUEUED, TaskInstanceState.RUNNING]
                     query = (
                         select(TI)
-                        .where(TI.state.in_(resettable_states))
+                        .where(TI.state.in_(State.resettable_states))
                         # outerjoin is because we didn't use to have queued_by_job
                         # set, so we need to pick up anything pre upgrade. This (and the
                         # "or queued_by_job_id IS NONE") can go as soon as scheduler HA is

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -200,10 +200,10 @@ class State:
     A list of states indicating that a task has been terminated.
     """
 
-    resettable_states = frozenset(
+    adoptable_states = frozenset(
         [TaskInstanceState.QUEUED, TaskInstanceState.RUNNING, TaskInstanceState.RESTARTING]
     )
     """
-    A list of states indicating that a task can be reset or adopted by a scheduler job
-    if it was queued by another scheduler job is not running anymore.
+    A list of states indicating that a task can be adopted or reset by a scheduler job
+    if it was queued by another scheduler job that is not running anymore.
     """

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -199,3 +199,11 @@ class State:
     """
     A list of states indicating that a task has been terminated.
     """
+
+    resettable_states = frozenset(
+        [TaskInstanceState.QUEUED, TaskInstanceState.RUNNING, TaskInstanceState.RESTARTING]
+    )
+    """
+    A list of states indicating that a task can be reset or adopted by a scheduler job
+    if it was queued by another scheduler job is not running anymore.
+    """

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3152,11 +3152,11 @@ class TestSchedulerJob:
         assert 0 == self.job_runner.adopt_or_reset_orphaned_tasks(session=session)
 
     @pytest.mark.parametrize(
-        "resettable_state",
-        State.resettable_states,
+        "adoptable_state",
+        State.adoptable_states,
     )
-    def test_adopt_or_reset_resettable_tasks(self, dag_maker, resettable_state):
-        dag_id = "test_adopt_or_reset_resettable_tasks_" + resettable_state.name
+    def test_adopt_or_reset_resettable_tasks(self, dag_maker, adoptable_state):
+        dag_id = "test_adopt_or_reset_adoptable_tasks_" + adoptable_state.name
         with dag_maker(dag_id=dag_id, schedule="@daily"):
             task_id = dag_id + "_task"
             EmptyOperator(task_id=task_id)
@@ -3167,7 +3167,7 @@ class TestSchedulerJob:
 
         dr1 = dag_maker.create_dagrun(external_trigger=True)
         ti = dr1.get_task_instances(session=session)[0]
-        ti.state = resettable_state
+        ti.state = adoptable_state
         session.merge(ti)
         session.merge(dr1)
         session.commit()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3161,7 +3161,8 @@ class TestSchedulerJob:
             task_id = dag_id + "_task"
             EmptyOperator(task_id=task_id)
 
-        self.scheduler_job = Job()
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, subdir=os.devnull)
         session = settings.Session()
 
         dr1 = dag_maker.create_dagrun(external_trigger=True)
@@ -3171,7 +3172,7 @@ class TestSchedulerJob:
         session.merge(dr1)
         session.commit()
 
-        num_reset_tis = self.scheduler_job.adopt_or_reset_orphaned_tasks(session=session)
+        num_reset_tis = self.job_runner.adopt_or_reset_orphaned_tasks(session=session)
         assert 1 == num_reset_tis
 
     def test_adopt_or_reset_orphaned_tasks_external_triggered_dag(self, dag_maker):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Resolves #33661

Added `RESTARTING` state to the list of task instance states that are handled by scheduler in `adopt_or_reset_orphaned_tasks()`. This way the system can recover from the situation when a task was set to `RESTARTING` state externally (webserver request) but both task process and scheduler were dead when it happened.

This approach is safe because `adopt_or_reset_orphaned_tasks()` only modifies tasks that were queued by a scheduler that is no longer running. In theory it could reset a task which is still running even though its scheduler is dead, but it is identical situation as with `RUNNING` tasks which are also updated by this method.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
