### PR TITLE
Convert hard-coded allowlist error code to be argument of HttpSensor

### DIFF
--- a/airflow/providers/http/sensors/http.py
+++ b/airflow/providers/http/sensors/http.py
@@ -103,8 +103,9 @@ class HttpSensor(BaseSensorOperator):
         self.endpoint = endpoint
         self.http_conn_id = http_conn_id
         self.method = method
-        self.response_error_codes_whitelist = ["404"] if response_error_codes_whitelist is None \
-            else response_error_codes_whitelist
+        self.response_error_codes_whitelist = (
+            ["404"] if response_error_codes_whitelist is None else response_error_codes_whitelist
+        )
         self.request_params = request_params or {}
         self.headers = headers or {}
         self.extra_options = extra_options or {}

--- a/airflow/providers/http/sensors/http.py
+++ b/airflow/providers/http/sensors/http.py
@@ -65,7 +65,7 @@ class HttpSensor(BaseSensorOperator):
     :param request_params: The parameters to be added to the GET url
     :param headers: The HTTP headers to be added to the GET request
     :param response_error_codes_whitelist: An whitelist to return False on poke(), not to raise exception.
-        If the ``None`` value comes in, it is assigned ["404"] by default, to backward compatibility.
+        If the ``None`` value comes in, it is assigned ["404"] by default, for backward compatibility.
         When you also want ``404 Not Found`` to raise the error, explicitly deliver the blank list ``[]``.
     :param response_check: A check against the 'requests' response object.
         The callable takes the response object as the first positional argument
@@ -104,7 +104,7 @@ class HttpSensor(BaseSensorOperator):
         self.http_conn_id = http_conn_id
         self.method = method
         self.response_error_codes_whitelist = (
-            ["404"] if response_error_codes_whitelist is None else response_error_codes_whitelist
+            ("404",) if response_error_codes_whitelist is None else tuple(response_error_codes_whitelist)
         )
         self.request_params = request_params or {}
         self.headers = headers or {}
@@ -139,9 +139,8 @@ class HttpSensor(BaseSensorOperator):
                 kwargs = determine_kwargs(self.response_check, [response], context)
                 return self.response_check(response, **kwargs)
         except AirflowException as exc:
-            for code_in_whitelist in self.response_error_codes_whitelist:
-                if str(exc).startswith(code_in_whitelist):
-                    return False
+            if str(exc).startswith(self.response_error_codes_whitelist):
+                return False
 
             raise exc
 

--- a/airflow/providers/http/sensors/http.py
+++ b/airflow/providers/http/sensors/http.py
@@ -33,7 +33,7 @@ class HttpSensor(BaseSensorOperator):
 
     HTTP Error codes other than 404 (like 403) or Connection Refused Error
     would raise an exception and fail the sensor itself directly (no more poking).
-    To avoid failing the task for other codes than 404, the argument ``response_error_codes_whitelist``
+    To avoid failing the task for other codes than 404, the argument ``response_error_codes_allowlist``
     can be passed with the list containing all the allowed error status codes, like ``["404", "503"]``
     To skip error status code check at all, the argument ``extra_option``
     can be passed with the value ``{'check_response': False}``. It will make the ``response_check``
@@ -64,7 +64,7 @@ class HttpSensor(BaseSensorOperator):
     :param endpoint: The relative part of the full url
     :param request_params: The parameters to be added to the GET url
     :param headers: The HTTP headers to be added to the GET request
-    :param response_error_codes_whitelist: An whitelist to return False on poke(), not to raise exception.
+    :param response_error_codes_allowlist: An allowlist to return False on poke(), not to raise exception.
         If the ``None`` value comes in, it is assigned ["404"] by default, for backward compatibility.
         When you also want ``404 Not Found`` to raise the error, explicitly deliver the blank list ``[]``.
     :param response_check: A check against the 'requests' response object.
@@ -90,7 +90,7 @@ class HttpSensor(BaseSensorOperator):
         method: str = "GET",
         request_params: dict[str, Any] | None = None,
         headers: dict[str, Any] | None = None,
-        response_error_codes_whitelist: list[str] | None = None,
+        response_error_codes_allowlist: list[str] | None = None,
         response_check: Callable[..., bool] | None = None,
         extra_options: dict[str, Any] | None = None,
         tcp_keep_alive: bool = True,
@@ -103,8 +103,8 @@ class HttpSensor(BaseSensorOperator):
         self.endpoint = endpoint
         self.http_conn_id = http_conn_id
         self.method = method
-        self.response_error_codes_whitelist = (
-            ("404",) if response_error_codes_whitelist is None else tuple(response_error_codes_whitelist)
+        self.response_error_codes_allowlist = (
+            ("404",) if response_error_codes_allowlist is None else tuple(response_error_codes_allowlist)
         )
         self.request_params = request_params or {}
         self.headers = headers or {}
@@ -139,7 +139,7 @@ class HttpSensor(BaseSensorOperator):
                 kwargs = determine_kwargs(self.response_check, [response], context)
                 return self.response_check(response, **kwargs)
         except AirflowException as exc:
-            if str(exc).startswith(self.response_error_codes_whitelist):
+            if str(exc).startswith(self.response_error_codes_allowlist):
                 return False
 
             raise exc

--- a/airflow/providers/http/sensors/http.py
+++ b/airflow/providers/http/sensors/http.py
@@ -33,7 +33,9 @@ class HttpSensor(BaseSensorOperator):
 
     HTTP Error codes other than 404 (like 403) or Connection Refused Error
     would raise an exception and fail the sensor itself directly (no more poking).
-    To avoid failing the task for other codes than 404, the argument ``extra_option``
+    To avoid failing the task for other codes than 404, the argument ``response_error_codes_whitelist``
+    can be passed with the list containing all the allowed error status codes, like ``["404", "503"]``
+    To skip error status code check at all, the argument ``extra_option``
     can be passed with the value ``{'check_response': False}``. It will make the ``response_check``
     be execute for any http status code.
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -34,6 +34,7 @@ Alibaba
 alibaba
 allAuthenticatedUsers
 allowinsert
+allowlist
 allUsers
 alphanumerics
 Alphasort

--- a/tests/providers/http/sensors/test_http.py
+++ b/tests/providers/http/sensors/test_http.py
@@ -183,6 +183,58 @@ class TestHttpSensor:
             ]
             mock_log.error.assert_has_calls(calls)
 
+    @patch("airflow.providers.http.hooks.http.requests.Session.send")
+    def test_response_error_codes_allowlist(self, mock_session_send, create_task_of_operator):
+        allowed_error_response_gen = iter(
+            [
+                (503, "Service Unavailable"),
+                (503, "Service Unavailable"),
+                (503, "Service Unavailable"),
+                (404, "Not Found"),
+                (499, "Allowed Non-standard Error Code"),
+            ]
+        )
+
+        def mocking_allowed_error_responses(*_, **__):
+            try:
+                error_code, error_reason = next(allowed_error_response_gen)
+            except StopIteration:
+                return mock.DEFAULT
+
+            error_response = requests.Response()
+            error_response.status_code = error_code
+            error_response.reason = error_reason
+
+            return error_response
+
+        def resp_check(_):
+            return True
+
+        final_response = requests.Response()
+        final_response.status_code = 500
+        final_response.reason = "Internal Server Error"
+
+        mock_session_send.side_effect = mocking_allowed_error_responses
+        mock_session_send.return_value = final_response
+
+        task = create_task_of_operator(
+            HttpSensor,
+            dag_id="http_sensor_response_error_codes_allowlist",
+            task_id="http_sensor_response_error_codes_allowlist",
+            response_error_codes_allowlist=["404", "499", "503"],
+            http_conn_id="http_default",
+            endpoint="",
+            request_params={},
+            method="GET",
+            response_check=resp_check,
+            timeout=5,
+            poke_interval=1,
+        )
+        with pytest.raises(AirflowException) as excinfo:
+            task.execute(context={})
+
+        assert str(excinfo.value) == "500:Internal Server Error"
+
 
 class FakeSession:
     def __init__(self):

--- a/tests/providers/http/sensors/test_http.py
+++ b/tests/providers/http/sensors/test_http.py
@@ -230,10 +230,8 @@ class TestHttpSensor:
             timeout=5,
             poke_interval=1,
         )
-        with pytest.raises(AirflowException) as excinfo:
+        with pytest.raises(AirflowException, match="500:Internal Server Error"):
             task.execute(context={})
-
-        assert str(excinfo.value) == "500:Internal Server Error"
 
 
 class FakeSession:


### PR DESCRIPTION
I tried to use `HttpSensor` to roll out our Trino cluster(each with single coordinator) groups periodically with Airflow. In my use case, the `503` error has to be in the allowlist, same as `404 Not Found`.

But, I noticed that `HttpSensor` raise `AirflowException` when the target responds with `503 Service Temporarily Unavailable`.

How about converting hard-coded `404` to list-typed argument `response_error_codes_allowlist`?

There is already the alternative option with `extra_option={'check_response': False}`, but the all or nothing method doesn't seem very fancy for covering all the use cases.