### PR TITLE
Deferrable sensors can implement sensor timeout

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -391,10 +391,12 @@ class TaskDeferred(BaseException):
         self.trigger = trigger
         self.method_name = method_name
         self.kwargs = kwargs
-        self.timeout = timeout
+        self.timeout: timedelta | None
         # Check timeout type at runtime
-        if isinstance(self.timeout, (int, float)):
-            self.timeout = timedelta(seconds=self.timeout)
+        if isinstance(timeout, (int, float)):
+            self.timeout = timedelta(seconds=timeout)
+        else:
+            self.timeout = timeout
         if self.timeout is not None and not hasattr(self.timeout, "total_seconds"):
             raise ValueError("Timeout value must be a timedelta")
 

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -59,13 +59,13 @@ from airflow.models.asset import (
     TaskOutletAssetReference,
 )
 from airflow.models.backfill import Backfill
-from airflow.models.baseoperator import TRIGGER_TIMEOUT_REPR
 from airflow.models.dag import DAG, DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun
 from airflow.models.dagwarning import DagWarning, DagWarningType
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance
+from airflow.models.trigger import TRIGGER_FAIL_REPR, TriggerFailureReason
 from airflow.stats import Stats
 from airflow.ti_deps.dependencies_states import EXECUTION_STATES
 from airflow.timetables.simple import AssetTriggeredTimetable
@@ -2058,8 +2058,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     )
                     .values(
                         state=TaskInstanceState.SCHEDULED,
-                        next_method="__fail__",
-                        next_kwargs={"error": TRIGGER_TIMEOUT_REPR},
+                        next_method=TRIGGER_FAIL_REPR,
+                        next_kwargs={"error": TriggerFailureReason.TRIGGER_TIMEOUT},
                         trigger_id=None,
                     )
                 ).rowcount

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -2058,7 +2058,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     .values(
                         state=TaskInstanceState.SCHEDULED,
                         next_method="__fail__",
-                        next_kwargs={"error": "Trigger/execution timeout"},
+                        next_kwargs={"error": "Trigger timeout"},
                         trigger_id=None,
                     )
                 ).rowcount

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -59,6 +59,7 @@ from airflow.models.asset import (
     TaskOutletAssetReference,
 )
 from airflow.models.backfill import Backfill
+from airflow.models.baseoperator import TRIGGER_TIMEOUT_REPR
 from airflow.models.dag import DAG, DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbag import DagBag
@@ -2058,7 +2059,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     .values(
                         state=TaskInstanceState.SCHEDULED,
                         next_method="__fail__",
-                        next_kwargs={"error": "Trigger timeout"},
+                        next_kwargs={"error": TRIGGER_TIMEOUT_REPR},
                         trigger_id=None,
                     )
                 ).rowcount

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -50,6 +50,7 @@ from airflow.configuration import conf
 from airflow.exceptions import (
     AirflowException,
     TaskDeferralError,
+    TaskDeferralTimeout,
     TaskDeferred,
 )
 from airflow.lineage import apply_lineage, prepare_lineage
@@ -973,7 +974,7 @@ class BaseOperator(TaskSDKBaseOperator, AbstractOperator, metaclass=BaseOperator
         trigger: BaseTrigger,
         method_name: str,
         kwargs: dict[str, Any] | None = None,
-        timeout: timedelta | None = None,
+        timeout: timedelta | int | float | None = None,
     ) -> NoReturn:
         """
         Mark this Operator "deferred", suspending its execution until the provided trigger fires an event.
@@ -995,7 +996,10 @@ class BaseOperator(TaskSDKBaseOperator, AbstractOperator, metaclass=BaseOperator
             traceback = next_kwargs.get("traceback")
             if traceback is not None:
                 self.log.error("Trigger failed:\n%s", "\n".join(traceback))
-            raise TaskDeferralError(next_kwargs.get("error", "Unknown"))
+            if (error := next_kwargs.get("error", "Unknown")) == "Trigger timeout":
+                raise TaskDeferralTimeout(error)
+            else:
+                raise TaskDeferralError(error)
         # Grab the callable off the Operator/Task and add in any kwargs
         execute_callable = getattr(self, next_method)
         if next_kwargs:

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -124,6 +124,13 @@ T = TypeVar("T", bound=FunctionType)
 
 logger = logging.getLogger("airflow.models.baseoperator.BaseOperator")
 
+TRIGGER_TIMEOUT_REPR = "__trigger_timeout__"
+"""
+String to represent that this trigger timed out.
+
+:meta private:
+"""
+
 
 def parse_retries(retries: Any) -> int | None:
     if retries is None:
@@ -996,7 +1003,7 @@ class BaseOperator(TaskSDKBaseOperator, AbstractOperator, metaclass=BaseOperator
             traceback = next_kwargs.get("traceback")
             if traceback is not None:
                 self.log.error("Trigger failed:\n%s", "\n".join(traceback))
-            if (error := next_kwargs.get("error", "Unknown")) == "Trigger timeout":
+            if (error := next_kwargs.get("error", "Unknown")) == TRIGGER_TIMEOUT_REPR:
                 raise TaskDeferralTimeout(error)
             else:
                 raise TaskDeferralError(error)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1538,6 +1538,7 @@ def _defer_task(
 ) -> TaskInstance:
     from airflow.models.trigger import Trigger
 
+    timeout: timedelta | None
     if exception is not None:
         trigger_row = Trigger.from_object(exception.trigger)
         next_method = exception.method_name

--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -175,7 +175,7 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         super().__init__(**kwargs)
         self.poke_interval = self._coerce_poke_interval(poke_interval).total_seconds()
         self.soft_fail = soft_fail
-        self.timeout = self._coerce_timeout(timeout).total_seconds()
+        self.timeout: int | float = self._coerce_timeout(timeout).total_seconds()
         self.mode = mode
         self.exponential_backoff = exponential_backoff
         self.max_wait = self._coerce_max_wait(max_wait)

--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -38,6 +38,7 @@ from airflow.exceptions import (
     AirflowSkipException,
     AirflowTaskTimeout,
     TaskDeferralError,
+    TaskDeferralTimeout,
 )
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.models.baseoperator import BaseOperator
@@ -338,6 +339,8 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
     def resume_execution(self, next_method: str, next_kwargs: dict[str, Any] | None, context: Context):
         try:
             return super().resume_execution(next_method, next_kwargs, context)
+        except TaskDeferralTimeout as e:
+            raise AirflowSensorTimeout(*e.args) from e
         except (AirflowException, TaskDeferralError) as e:
             if self.soft_fail:
                 raise AirflowSkipException(str(e)) from e

--- a/providers/src/airflow/providers/standard/sensors/time_delta.py
+++ b/providers/src/airflow/providers/standard/sensors/time_delta.py
@@ -91,7 +91,11 @@ class TimeDeltaSensorAsync(TimeDeltaSensor):
                 raise AirflowSkipException("Skipping due to soft_fail is set to True.") from e
             raise
 
-        self.defer(trigger=trigger, method_name="execute_complete")
+        self.defer(
+            trigger=trigger,
+            method_name="execute_complete",
+            timeout=self.timeout,
+        )
 
     def execute_complete(self, context: Context, event: Any = None) -> None:
         """Handle the event when the trigger fires and return immediately."""

--- a/providers/src/airflow/providers/standard/sensors/time_delta.py
+++ b/providers/src/airflow/providers/standard/sensors/time_delta.py
@@ -21,6 +21,8 @@ from datetime import timedelta
 from time import sleep
 from typing import TYPE_CHECKING, Any, NoReturn
 
+from packaging.version import Version
+
 from airflow.configuration import conf
 from airflow.exceptions import AirflowSkipException
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
@@ -33,8 +35,6 @@ if TYPE_CHECKING:
 
 
 def _get_airflow_version():
-    from packaging.version import Version
-
     from airflow import __version__ as airflow_version
 
     return Version(Version(airflow_version).base_version)

--- a/providers/src/airflow/providers/standard/sensors/time_delta.py
+++ b/providers/src/airflow/providers/standard/sensors/time_delta.py
@@ -23,7 +23,6 @@ from typing import TYPE_CHECKING, Any, NoReturn
 
 from packaging.version import Version
 
-from airflow import __version__ as airflow_version
 from airflow.configuration import conf
 from airflow.exceptions import AirflowSkipException
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
@@ -34,14 +33,11 @@ from airflow.utils import timezone
 if TYPE_CHECKING:
     from airflow.utils.context import Context
 
-AIRFLOW_V_2_11_PLUS = Version(Version(airflow_version).base_version) >= Version("2.11.0")
-"""
-Whether airflow version is 2.11 or greater.
 
-todo: remove backcompat when min airflow version greater than 2.11
+def _get_airflow_version():
+    from airflow import __version__ as airflow_version
 
-:meta private:
-"""
+    return Version(Version(airflow_version).base_version)
 
 
 class TimeDeltaSensor(BaseSensorOperator):
@@ -105,7 +101,7 @@ class TimeDeltaSensorAsync(TimeDeltaSensor):
 
         # todo: remove backcompat when min airflow version greater than 2.11
         timeout: int | float | timedelta
-        if AIRFLOW_V_2_11_PLUS:
+        if _get_airflow_version() >= Version("2.11.0"):
             timeout = self.timeout
         else:
             timeout = timedelta(seconds=self.timeout)

--- a/providers/src/airflow/providers/standard/sensors/time_delta.py
+++ b/providers/src/airflow/providers/standard/sensors/time_delta.py
@@ -21,8 +21,6 @@ from datetime import timedelta
 from time import sleep
 from typing import TYPE_CHECKING, Any, NoReturn
 
-from packaging.version import Version
-
 from airflow.configuration import conf
 from airflow.exceptions import AirflowSkipException
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
@@ -35,6 +33,8 @@ if TYPE_CHECKING:
 
 
 def _get_airflow_version():
+    from packaging.version import Version
+
     from airflow import __version__ as airflow_version
 
     return Version(Version(airflow_version).base_version)

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -29,7 +29,7 @@ import jinja2
 import pytest
 
 from airflow.decorators import task as task_decorator
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, TaskDeferralTimeout
 from airflow.lineage.entities import File
 from airflow.models.baseoperator import (
     BaseOperator,
@@ -581,6 +581,15 @@ class TestBaseOperator:
         # the other case (that when we have set_context it goes to the file is harder to achieve without
         # leaking a lot of state)
         assert caplog.messages == ["test"]
+
+    def test_resume_execution(self):
+        op = BaseOperator(task_id="hi")
+        with pytest.raises(TaskDeferralTimeout):
+            op.resume_execution(
+                next_method="__fail__",
+                next_kwargs={"error": "Trigger timeout"},
+                context={},
+            )
 
 
 def test_deepcopy():

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -32,7 +32,6 @@ from airflow.decorators import task as task_decorator
 from airflow.exceptions import AirflowException, TaskDeferralTimeout
 from airflow.lineage.entities import File
 from airflow.models.baseoperator import (
-    TRIGGER_TIMEOUT_REPR,
     BaseOperator,
     chain,
     chain_linear,
@@ -41,6 +40,7 @@ from airflow.models.baseoperator import (
 from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
+from airflow.models.trigger import TriggerFailureReason
 from airflow.providers.common.sql.operators import sql
 from airflow.utils.edgemodifier import Label
 from airflow.utils.task_group import TaskGroup
@@ -588,7 +588,7 @@ class TestBaseOperator:
         with pytest.raises(TaskDeferralTimeout):
             op.resume_execution(
                 next_method="__fail__",
-                next_kwargs={"error": TRIGGER_TIMEOUT_REPR},
+                next_kwargs={"error": TriggerFailureReason.TRIGGER_TIMEOUT},
                 context={},
             )
 

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -32,6 +32,7 @@ from airflow.decorators import task as task_decorator
 from airflow.exceptions import AirflowException, TaskDeferralTimeout
 from airflow.lineage.entities import File
 from airflow.models.baseoperator import (
+    TRIGGER_TIMEOUT_REPR,
     BaseOperator,
     chain,
     chain_linear,
@@ -587,7 +588,7 @@ class TestBaseOperator:
         with pytest.raises(TaskDeferralTimeout):
             op.resume_execution(
                 next_method="__fail__",
-                next_kwargs={"error": "Trigger timeout"},
+                next_kwargs={"error": TRIGGER_TIMEOUT_REPR},
                 context={},
             )
 

--- a/tests/sensors/test_base.py
+++ b/tests/sensors/test_base.py
@@ -1061,6 +1061,15 @@ class TestBaseSensor:
             task = sensor.prepare_for_execution()
             assert task.mode == mode
 
+    def test_resume_execution(self):
+        op = BaseSensorOperator(task_id="hi")
+        with pytest.raises(AirflowSensorTimeout):
+            op.resume_execution(
+                next_method="__fail__",
+                next_kwargs={"error": "Trigger timeout"},
+                context={},
+            )
+
 
 @poke_mode_only
 class DummyPokeOnlySensor(BaseSensorOperator):

--- a/tests/sensors/test_base.py
+++ b/tests/sensors/test_base.py
@@ -45,7 +45,7 @@ from airflow.executors.executor_constants import (
 from airflow.executors.local_executor import LocalExecutor
 from airflow.executors.sequential_executor import SequentialExecutor
 from airflow.models import TaskInstance, TaskReschedule
-from airflow.models.baseoperator import TRIGGER_TIMEOUT_REPR
+from airflow.models.trigger import TriggerFailureReason
 from airflow.models.xcom import XCom
 from airflow.operators.empty import EmptyOperator
 from airflow.providers.celery.executors.celery_executor import CeleryExecutor
@@ -1067,7 +1067,7 @@ class TestBaseSensor:
         with pytest.raises(AirflowSensorTimeout):
             op.resume_execution(
                 next_method="__fail__",
-                next_kwargs={"error": TRIGGER_TIMEOUT_REPR},
+                next_kwargs={"error": TriggerFailureReason.TRIGGER_TIMEOUT},
                 context={},
             )
 

--- a/tests/sensors/test_base.py
+++ b/tests/sensors/test_base.py
@@ -45,6 +45,7 @@ from airflow.executors.executor_constants import (
 from airflow.executors.local_executor import LocalExecutor
 from airflow.executors.sequential_executor import SequentialExecutor
 from airflow.models import TaskInstance, TaskReschedule
+from airflow.models.baseoperator import TRIGGER_TIMEOUT_REPR
 from airflow.models.xcom import XCom
 from airflow.operators.empty import EmptyOperator
 from airflow.providers.celery.executors.celery_executor import CeleryExecutor
@@ -1066,7 +1067,7 @@ class TestBaseSensor:
         with pytest.raises(AirflowSensorTimeout):
             op.resume_execution(
                 next_method="__fail__",
-                next_kwargs={"error": "Trigger timeout"},
+                next_kwargs={"error": TRIGGER_TIMEOUT_REPR},
                 context={},
             )
 


### PR DESCRIPTION
The goal here is to allow behavioral parity w.r.t. sensor timeouts between deferrable and non-deferrable sensor operators.

With non-deferrable sensors, if there's a sensor timeout, the task fails without retry.  But currently, with deferrable sensors, that does not happen.

Since there's already a "timeout" capability on triggers, we can use this for sensor timeout.  Essentially all that was missing was the ability to distinguish between trigger timeouts and other trigger errors.  With this capability, base sensor can distinguish between the two, and reraise deferral timeouts as sensor timeouts.

So, here we add a new exception type, TaskDeferralTimeout, which base sensor reraises as AirflowSensorTimeout. Then, to take advantage of this feature, a sensor need only ensure that its timeout is passed when deferring. For convenience, we update the task deferred exception signature to take int and float in addition to timedelta, since that's how `timeout` attr is defined on base sensor.  But we do not change the exception attribute type.

In order to keep this PR focused, this PR only updates one sensor to use the timeout functionality, namely, time delta sensor.  Other sensors will have to be done as followups.


-------

Old description below ⬇️ 

Alternative to https://github.com/apache/airflow/pull/32990

resolves https://github.com/apache/airflow/issues/32638

This is a less invasive approach.  Essentially, what we do here is, update `BaseOperator.resume_execution` so that when trigger times out then it raises special exception `AirflowDeferralTimeout`.

Then, `BaseSensorOperator.resume_execution`, we reraise `AirflowDeferralTimeout` as a `AirflowSensorTimeout`.

So, if a sensor resumes from a timed-out deferral, then it's interpreted as a sensor timeout.

All that is required is for a sensor to add a timeout to the deferral.

Example logs:

```
...
[2023-08-25, 07:00:54 UTC] {taskinstance.py:1357} INFO - Resuming after deferral
[2023-08-25, 07:00:54 UTC] {taskinstance.py:1380} INFO - Executing <Task(TimeDeltaSensorAsync): delta_sensor> on 2023-08-25 07:00:32.864128+00:00
[2023-08-25, 07:00:54 UTC] {standard_task_runner.py:57} INFO - Started process 50543 to run task
[2023-08-25, 07:00:54 UTC] {standard_task_runner.py:84} INFO - Running: ['airflow', 'tasks', 'run', 'simple2', 'delta_sensor', 'manual__2023-08-25T07:00:32.864128+00:00', '--job-id', '129', '--raw', '--subdir', '/Users/dstandish/code/airflow/airflow/example_dags/async_timeout.py', '--cfg-path', '/var/folders/9c/tknx7xx10qx92983y1r5djb40000gn/T/tmp72slvjz_']
[2023-08-25, 07:00:54 UTC] {standard_task_runner.py:85} INFO - Job 129: Subtask delta_sensor
[2023-08-25, 07:00:54 UTC] {task_command.py:415} INFO - Running <TaskInstance: simple2.delta_sensor manual__2023-08-25T07:00:32.864128+00:00 [running]> on host daniels-mbp.lan
[2023-08-25, 07:00:54 UTC] {taskinstance.py:1933} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/Users/dstandish/code/airflow/airflow/sensors/base.py", line 288, in resume_execution
    return super().resume_execution(next_method, next_kwargs, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dstandish/code/airflow/airflow/models/baseoperator.py", line 1605, in resume_execution
    raise AirflowDeferralTimeout(error)
airflow.exceptions.AirflowDeferralTimeout: Trigger timeout
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/Users/dstandish/code/airflow/airflow/sensors/base.py", line 290, in resume_execution
    raise AirflowSensorTimeout(*e.args) from e
airflow.exceptions.AirflowSensorTimeout: Trigger timeout
[2023-08-25, 07:00:54 UTC] {taskinstance.py:1398} INFO - Immediate failure requested. Marking task as FAILED. dag_id=simple2, task_id=delta_sensor, execution_date=20230825T070032, start_date=20230825T070034, end_date=20230825T070054
[2023-08-25, 07:00:54 UTC] {standard_task_runner.py:104} ERROR - Failed to execute job 129 for task delta_sensor (Trigger timeout; 50543)
[2023-08-25, 07:00:54 UTC] {local_task_job_runner.py:228} INFO - Task exited with return code 1
[2023-08-25, 07:00:54 UTC] {taskinstance.py:2774} INFO - 0 downstream tasks scheduled from follow-on schedule check
[2023-08-25, 07:00:55 UTC] {triggerer_job_runner.py:611} ERROR - Trigger cancelled due to timeout
[2023-08-25, 07:00:55 UTC] {triggerer_job_runner.py:612} ERROR - Trigger cancelled; message=
```