### PR TITLE
Bump MariaDB client libraries to latest LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -180,39 +180,27 @@ COPY <<"EOF" /install_mysql.sh
 set -euo pipefail
 declare -a packages
 
-MYSQL_VERSION="8.0"
-readonly MYSQL_VERSION
-MARIADB_VERSION="10.5"
-readonly MARIADB_VERSION
+MYSQL_LTS_VERSION="8.0"
+MARIADB_LTS_VERSION="10.11"
+readonly MYSQL_LTS_VERSION
+readonly MARIADB_LTS_VERSION
 
 COLOR_BLUE=$'\e[34m'
 readonly COLOR_BLUE
 COLOR_YELLOW=$'\e[1;33m'
 readonly COLOR_YELLOW
+COLOR_RED=$'\e[1;31m'
+readonly COLOR_RED
 COLOR_RESET=$'\e[0m'
 readonly COLOR_RESET
 
 : "${INSTALL_MYSQL_CLIENT:?Should be true or false}"
 
-install_mysql_client() {
-    if [[ "${1}" == "dev" ]]; then
-        packages=("libmysqlclient-dev" "mysql-client")
-    elif [[ "${1}" == "prod" ]]; then
-        packages=("libmysqlclient21" "mysql-client")
-    else
-        echo
-        echo "Specify either prod or dev"
-        echo
-        exit 1
-    fi
+export_key() {
+    local key="${1}"
+    local name="${2:-mysql}"
 
-    echo
-    echo "${COLOR_BLUE}Installing mysql client version ${MYSQL_VERSION}: ${1}${COLOR_RESET}"
-    echo
-
-    local key="467B942D3A79BD29"
-    readonly key
-
+    echo "${COLOR_BLUE}Verify and export GPG public key ${key}${COLOR_RESET}"
     GNUPGHOME="$(mktemp -d)"
     export GNUPGHOME
     set +e
@@ -222,11 +210,37 @@ install_mysql_client() {
         gpg --keyserver "${keyserver}" --recv-keys "${key}" 2>&1 && break
     done
     set -e
-    gpg --export "${key}" > /etc/apt/trusted.gpg.d/mysql.gpg
+    gpg --export "${key}" > "/etc/apt/trusted.gpg.d/${name}.gpg"
     gpgconf --kill all
     rm -rf "${GNUPGHOME}"
     unset GNUPGHOME
-    echo "deb http://repo.mysql.com/apt/debian/ $(lsb_release -cs) mysql-${MYSQL_VERSION}" > /etc/apt/sources.list.d/mysql.list
+}
+
+install_mysql_client() {
+    if [[ "${1}" == "dev" ]]; then
+        packages=("libmysqlclient-dev" "mysql-client")
+    elif [[ "${1}" == "prod" ]]; then
+        # `libmysqlclientXX` where XX is number, and it should be increased every new GA MySQL release, for example
+        # 18 - MySQL 5.6.48
+        # 20 - MySQL 5.7.42
+        # 21 - MySQL 8.0.34
+        # 22 - MySQL 8.1
+        packages=("libmysqlclient21" "mysql-client")
+    else
+        echo
+        echo "${COLOR_RED}Specify either prod or dev${COLOR_RESET}"
+        echo
+        exit 1
+    fi
+
+    export_key "467B942D3A79BD29" "mysql"
+
+    echo
+    echo "${COLOR_BLUE}Installing Oracle MySQL client version ${MYSQL_LTS_VERSION}: ${1}${COLOR_RESET}"
+    echo
+
+    echo "deb http://repo.mysql.com/apt/debian/ $(lsb_release -cs) mysql-${MYSQL_LTS_VERSION}" > \
+        /etc/apt/sources.list.d/mysql.list
     apt-get update
     apt-get install --no-install-recommends -y "${packages[@]}"
     apt-get autoremove -yqq --purge
@@ -234,21 +248,38 @@ install_mysql_client() {
 }
 
 install_mariadb_client() {
+    # List of compatible package Oracle MySQL -> MariaDB:
+    # `mysql-client` -> `mariadb-client` or `mariadb-client-compat` (11+)
+    # `libmysqlclientXX` (where XX is a number) -> `libmariadb3-compat`
+    # `libmysqlclient-dev` -> `libmariadb-dev-compat`
+    #
+    # Different naming against Debian repo which we used before
+    # that some of packages might contains `-compat` suffix, Debian repo -> MariaDB repo:
+    # `libmariadb-dev` -> `libmariadb-dev-compat`
+    # `mariadb-client-core` -> `mariadb-client` or `mariadb-client-compat` (11+)
     if [[ "${1}" == "dev" ]]; then
-        packages=("libmariadb-dev" "mariadb-client-core-${MARIADB_VERSION}")
+        packages=("libmariadb-dev-compat" "mariadb-client")
     elif [[ "${1}" == "prod" ]]; then
-        packages=("mariadb-client-core-${MARIADB_VERSION}")
+        packages=("libmariadb3-compat" "mariadb-client")
     else
         echo
-        echo "Specify either prod or dev"
+        echo "${COLOR_RED}Specify either prod or dev${COLOR_RESET}"
         echo
         exit 1
     fi
 
+    export_key "0xF1656F24C74CD1D8" "mariadb"
+
     echo
-    echo "${COLOR_BLUE}Installing MariaDB client version ${MARIADB_VERSION}: ${1}${COLOR_RESET}"
-    echo "${COLOR_YELLOW}MariaDB client binary compatible with MySQL client.${COLOR_RESET}"
+    echo "${COLOR_BLUE}Installing MariaDB client version ${MARIADB_LTS_VERSION}: ${1}${COLOR_RESET}"
+    echo "${COLOR_YELLOW}MariaDB client protocol-compatible with MySQL client.${COLOR_RESET}"
     echo
+
+    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+    echo "deb [arch=amd64,arm64] https://archive.mariadb.org/mariadb-${MARIADB_LTS_VERSION}/repo/debian/ $(lsb_release -cs) main" > \
+        /etc/apt/sources.list.d/mariadb.list
+    # Make sure that dependencies from MariaDB repo are preferred over Debian dependencies
+    printf "Package: *\nPin: release o=MariaDB\nPin-Priority: 999\n" > /etc/apt/preferences.d/mariadb
     apt-get update
     apt-get install --no-install-recommends -y "${packages[@]}"
     apt-get autoremove -yqq --purge

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -140,39 +140,27 @@ COPY <<"EOF" /install_mysql.sh
 set -euo pipefail
 declare -a packages
 
-MYSQL_VERSION="8.0"
-readonly MYSQL_VERSION
-MARIADB_VERSION="10.5"
-readonly MARIADB_VERSION
+MYSQL_LTS_VERSION="8.0"
+MARIADB_LTS_VERSION="10.11"
+readonly MYSQL_LTS_VERSION
+readonly MARIADB_LTS_VERSION
 
 COLOR_BLUE=$'\e[34m'
 readonly COLOR_BLUE
 COLOR_YELLOW=$'\e[1;33m'
 readonly COLOR_YELLOW
+COLOR_RED=$'\e[1;31m'
+readonly COLOR_RED
 COLOR_RESET=$'\e[0m'
 readonly COLOR_RESET
 
 : "${INSTALL_MYSQL_CLIENT:?Should be true or false}"
 
-install_mysql_client() {
-    if [[ "${1}" == "dev" ]]; then
-        packages=("libmysqlclient-dev" "mysql-client")
-    elif [[ "${1}" == "prod" ]]; then
-        packages=("libmysqlclient21" "mysql-client")
-    else
-        echo
-        echo "Specify either prod or dev"
-        echo
-        exit 1
-    fi
+export_key() {
+    local key="${1}"
+    local name="${2:-mysql}"
 
-    echo
-    echo "${COLOR_BLUE}Installing mysql client version ${MYSQL_VERSION}: ${1}${COLOR_RESET}"
-    echo
-
-    local key="467B942D3A79BD29"
-    readonly key
-
+    echo "${COLOR_BLUE}Verify and export GPG public key ${key}${COLOR_RESET}"
     GNUPGHOME="$(mktemp -d)"
     export GNUPGHOME
     set +e
@@ -182,11 +170,37 @@ install_mysql_client() {
         gpg --keyserver "${keyserver}" --recv-keys "${key}" 2>&1 && break
     done
     set -e
-    gpg --export "${key}" > /etc/apt/trusted.gpg.d/mysql.gpg
+    gpg --export "${key}" > "/etc/apt/trusted.gpg.d/${name}.gpg"
     gpgconf --kill all
     rm -rf "${GNUPGHOME}"
     unset GNUPGHOME
-    echo "deb http://repo.mysql.com/apt/debian/ $(lsb_release -cs) mysql-${MYSQL_VERSION}" > /etc/apt/sources.list.d/mysql.list
+}
+
+install_mysql_client() {
+    if [[ "${1}" == "dev" ]]; then
+        packages=("libmysqlclient-dev" "mysql-client")
+    elif [[ "${1}" == "prod" ]]; then
+        # `libmysqlclientXX` where XX is number, and it should be increased every new GA MySQL release, for example
+        # 18 - MySQL 5.6.48
+        # 20 - MySQL 5.7.42
+        # 21 - MySQL 8.0.34
+        # 22 - MySQL 8.1
+        packages=("libmysqlclient21" "mysql-client")
+    else
+        echo
+        echo "${COLOR_RED}Specify either prod or dev${COLOR_RESET}"
+        echo
+        exit 1
+    fi
+
+    export_key "467B942D3A79BD29" "mysql"
+
+    echo
+    echo "${COLOR_BLUE}Installing Oracle MySQL client version ${MYSQL_LTS_VERSION}: ${1}${COLOR_RESET}"
+    echo
+
+    echo "deb http://repo.mysql.com/apt/debian/ $(lsb_release -cs) mysql-${MYSQL_LTS_VERSION}" > \
+        /etc/apt/sources.list.d/mysql.list
     apt-get update
     apt-get install --no-install-recommends -y "${packages[@]}"
     apt-get autoremove -yqq --purge
@@ -194,21 +208,38 @@ install_mysql_client() {
 }
 
 install_mariadb_client() {
+    # List of compatible package Oracle MySQL -> MariaDB:
+    # `mysql-client` -> `mariadb-client` or `mariadb-client-compat` (11+)
+    # `libmysqlclientXX` (where XX is a number) -> `libmariadb3-compat`
+    # `libmysqlclient-dev` -> `libmariadb-dev-compat`
+    #
+    # Different naming against Debian repo which we used before
+    # that some of packages might contains `-compat` suffix, Debian repo -> MariaDB repo:
+    # `libmariadb-dev` -> `libmariadb-dev-compat`
+    # `mariadb-client-core` -> `mariadb-client` or `mariadb-client-compat` (11+)
     if [[ "${1}" == "dev" ]]; then
-        packages=("libmariadb-dev" "mariadb-client-core-${MARIADB_VERSION}")
+        packages=("libmariadb-dev-compat" "mariadb-client")
     elif [[ "${1}" == "prod" ]]; then
-        packages=("mariadb-client-core-${MARIADB_VERSION}")
+        packages=("libmariadb3-compat" "mariadb-client")
     else
         echo
-        echo "Specify either prod or dev"
+        echo "${COLOR_RED}Specify either prod or dev${COLOR_RESET}"
         echo
         exit 1
     fi
 
+    export_key "0xF1656F24C74CD1D8" "mariadb"
+
     echo
-    echo "${COLOR_BLUE}Installing MariaDB client version ${MARIADB_VERSION}: ${1}${COLOR_RESET}"
-    echo "${COLOR_YELLOW}MariaDB client binary compatible with MySQL client.${COLOR_RESET}"
+    echo "${COLOR_BLUE}Installing MariaDB client version ${MARIADB_LTS_VERSION}: ${1}${COLOR_RESET}"
+    echo "${COLOR_YELLOW}MariaDB client protocol-compatible with MySQL client.${COLOR_RESET}"
     echo
+
+    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+    echo "deb [arch=amd64,arm64] https://archive.mariadb.org/mariadb-${MARIADB_LTS_VERSION}/repo/debian/ $(lsb_release -cs) main" > \
+        /etc/apt/sources.list.d/mariadb.list
+    # Make sure that dependencies from MariaDB repo are preferred over Debian dependencies
+    printf "Package: *\nPin: release o=MariaDB\nPin-Priority: 999\n" > /etc/apt/preferences.d/mariadb
     apt-get update
     apt-get install --no-install-recommends -y "${packages[@]}"
     apt-get autoremove -yqq --purge

--- a/scripts/docker/install_mysql.sh
+++ b/scripts/docker/install_mysql.sh
@@ -19,39 +19,29 @@
 set -euo pipefail
 declare -a packages
 
-MYSQL_VERSION="8.0"
-readonly MYSQL_VERSION
-MARIADB_VERSION="10.5"
-readonly MARIADB_VERSION
+# https://dev.mysql.com/blog-archive/introducing-mysql-innovation-and-long-term-support-lts-versions/
+MYSQL_LTS_VERSION="8.0"
+# https://mariadb.org/about/#maintenance-policy
+MARIADB_LTS_VERSION="10.11"
+readonly MYSQL_LTS_VERSION
+readonly MARIADB_LTS_VERSION
 
 COLOR_BLUE=$'\e[34m'
 readonly COLOR_BLUE
 COLOR_YELLOW=$'\e[1;33m'
 readonly COLOR_YELLOW
+COLOR_RED=$'\e[1;31m'
+readonly COLOR_RED
 COLOR_RESET=$'\e[0m'
 readonly COLOR_RESET
 
 : "${INSTALL_MYSQL_CLIENT:?Should be true or false}"
 
-install_mysql_client() {
-    if [[ "${1}" == "dev" ]]; then
-        packages=("libmysqlclient-dev" "mysql-client")
-    elif [[ "${1}" == "prod" ]]; then
-        packages=("libmysqlclient21" "mysql-client")
-    else
-        echo
-        echo "Specify either prod or dev"
-        echo
-        exit 1
-    fi
+export_key() {
+    local key="${1}"
+    local name="${2:-mysql}"
 
-    echo
-    echo "${COLOR_BLUE}Installing mysql client version ${MYSQL_VERSION}: ${1}${COLOR_RESET}"
-    echo
-
-    local key="467B942D3A79BD29"
-    readonly key
-
+    echo "${COLOR_BLUE}Verify and export GPG public key ${key}${COLOR_RESET}"
     GNUPGHOME="$(mktemp -d)"
     export GNUPGHOME
     set +e
@@ -61,11 +51,37 @@ install_mysql_client() {
         gpg --keyserver "${keyserver}" --recv-keys "${key}" 2>&1 && break
     done
     set -e
-    gpg --export "${key}" > /etc/apt/trusted.gpg.d/mysql.gpg
+    gpg --export "${key}" > "/etc/apt/trusted.gpg.d/${name}.gpg"
     gpgconf --kill all
     rm -rf "${GNUPGHOME}"
     unset GNUPGHOME
-    echo "deb http://repo.mysql.com/apt/debian/ $(lsb_release -cs) mysql-${MYSQL_VERSION}" > /etc/apt/sources.list.d/mysql.list
+}
+
+install_mysql_client() {
+    if [[ "${1}" == "dev" ]]; then
+        packages=("libmysqlclient-dev" "mysql-client")
+    elif [[ "${1}" == "prod" ]]; then
+        # `libmysqlclientXX` where XX is number, and it should be increased every new GA MySQL release, for example
+        # 18 - MySQL 5.6.48
+        # 20 - MySQL 5.7.42
+        # 21 - MySQL 8.0.34
+        # 22 - MySQL 8.1
+        packages=("libmysqlclient21" "mysql-client")
+    else
+        echo
+        echo "${COLOR_RED}Specify either prod or dev${COLOR_RESET}"
+        echo
+        exit 1
+    fi
+
+    export_key "467B942D3A79BD29" "mysql"
+
+    echo
+    echo "${COLOR_BLUE}Installing Oracle MySQL client version ${MYSQL_LTS_VERSION}: ${1}${COLOR_RESET}"
+    echo
+
+    echo "deb http://repo.mysql.com/apt/debian/ $(lsb_release -cs) mysql-${MYSQL_LTS_VERSION}" > \
+        /etc/apt/sources.list.d/mysql.list
     apt-get update
     apt-get install --no-install-recommends -y "${packages[@]}"
     apt-get autoremove -yqq --purge
@@ -73,21 +89,38 @@ install_mysql_client() {
 }
 
 install_mariadb_client() {
+    # List of compatible package Oracle MySQL -> MariaDB:
+    # `mysql-client` -> `mariadb-client` or `mariadb-client-compat` (11+)
+    # `libmysqlclientXX` (where XX is a number) -> `libmariadb3-compat`
+    # `libmysqlclient-dev` -> `libmariadb-dev-compat`
+    #
+    # Different naming against Debian repo which we used before
+    # that some of packages might contains `-compat` suffix, Debian repo -> MariaDB repo:
+    # `libmariadb-dev` -> `libmariadb-dev-compat`
+    # `mariadb-client-core` -> `mariadb-client` or `mariadb-client-compat` (11+)
     if [[ "${1}" == "dev" ]]; then
-        packages=("libmariadb-dev" "mariadb-client-core-${MARIADB_VERSION}")
+        packages=("libmariadb-dev-compat" "mariadb-client")
     elif [[ "${1}" == "prod" ]]; then
-        packages=("mariadb-client-core-${MARIADB_VERSION}")
+        packages=("libmariadb3-compat" "mariadb-client")
     else
         echo
-        echo "Specify either prod or dev"
+        echo "${COLOR_RED}Specify either prod or dev${COLOR_RESET}"
         echo
         exit 1
     fi
 
+    export_key "0xF1656F24C74CD1D8" "mariadb"
+
     echo
-    echo "${COLOR_BLUE}Installing MariaDB client version ${MARIADB_VERSION}: ${1}${COLOR_RESET}"
-    echo "${COLOR_YELLOW}MariaDB client binary compatible with MySQL client.${COLOR_RESET}"
+    echo "${COLOR_BLUE}Installing MariaDB client version ${MARIADB_LTS_VERSION}: ${1}${COLOR_RESET}"
+    echo "${COLOR_YELLOW}MariaDB client protocol-compatible with MySQL client.${COLOR_RESET}"
     echo
+
+    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+    echo "deb [arch=amd64,arm64] https://archive.mariadb.org/mariadb-${MARIADB_LTS_VERSION}/repo/debian/ $(lsb_release -cs) main" > \
+        /etc/apt/sources.list.d/mariadb.list
+    # Make sure that dependencies from MariaDB repo are preferred over Debian dependencies
+    printf "Package: *\nPin: release o=MariaDB\nPin-Priority: 999\n" > /etc/apt/preferences.d/mariadb
     apt-get update
     apt-get install --no-install-recommends -y "${packages[@]}"
     apt-get autoremove -yqq --purge
@@ -96,7 +129,7 @@ install_mariadb_client() {
 
 # Install MySQL client only if it is not disabled.
 # For amd64 (x86_64) install MySQL client from Oracle repositories.
-# For arm64 install MariaDB client from Debian repository, see:
+# For arm64 install MariaDB client from MariaDB repository, see:
 # https://mariadb.com/kb/en/mariadb-clientserver-tcp-protocol/
 if [[ ${INSTALL_MYSQL_CLIENT:="true"} == "true" ]]; then
     if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In the end I decide to only update MariaDB to the latest LTS version 10.11. Compare to Debian Repo:
- Debian Bullseye (11) use previous LTS [10.5](https://packages.debian.org/bullseye/libmariadb-dev) 
- Debian Bookworm (12) use current LTS [10.11](https://packages.debian.org/bookworm/libmariadb-dev) 

**AMD64** (aka x86_64): Still use Oracle MySQL Libraries from current LTS 8.0, technically it is not named as LTS, but who cares?
**ARM64** Use MariaDB latest LTS version, same version also use in Debian 12

I've also tried to replace MySQL to MariaDB **client libraries 1 to 1**, because at that moment we use not the same replacement, anyway even now (main branch and 2.7.1) current combination works fine, at least I have no issues for last 6 months since we have support of MySQL in breeze on ARM 

When you tried to resolve different version of MySQL and/or MariaDB on different distro
![image](https://github.com/apache/airflow/assets/3998685/49091021-ddb4-44ca-9efa-d30aaf8e9b46)

In case if one day we decide to use only MariaDB client libraries even for AMD64 then we need to change _L138_ line:
https://github.com/apache/airflow/blob/5dff482026bfbecd53663d3c54689694bad7fa15/scripts/docker/install_mysql.sh#L134-L140

<details>
  <summary>Previous description</summary>
  
Trying to update mysql-compatible client libraries

MariaDB:
- Use specific version
- Use MariaDB repo (https://archive.mariadb.org/) instead of Debian's
- Explicit install compatible with mysql client libraries

MySQL:
- workaround for find name of `libmysqlclient`, e.g. in MySQL 8.0 repo it has name `libmysqlclient21` in innovation it has name `libmysqlclient22`, and I have no idea is it bumped when 8.2 (next innovation released) 
- workaround for decide which branch we should use `mysql-X.Y` or `mysql-innovation`
- and other kind of pain...pain...pain. IMHO better use compatible client libraries from MariaDB even for X86_64 rather then struggling with oracle APT repo. **(maybe in the future, not now, not in this PR)**

</details>



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
