### PR TITLE
Fix version heads map pre_commit rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -412,6 +412,7 @@ repos:
         language: python
         entry: ./scripts/ci/pre_commit/pre_commit_version_heads_map.py
         pass_filenames: false
+        files: ^airflow/migrations/versions|^airflow/__init__.py$
         additional_dependencies: ['packaging','google-re2']
       - id: update-version
         name: Update version to the latest version in the documentation

--- a/scripts/ci/pre_commit/pre_commit_version_heads_map.py
+++ b/scripts/ci/pre_commit/pre_commit_version_heads_map.py
@@ -46,6 +46,9 @@ def revision_heads_map():
     sorted_filenames = sorted(filenames, key=sorting_key)
 
     for filename in sorted_filenames:
+        if not filename.endswith(".py"):
+            print(f"skipping non-migration file: {filename}")
+            continue
         with open(os.path.join(MIGRATION_PATH, filename)) as file:
             content = file.read()
             revision_match = re2.search(pattern, content)


### PR DESCRIPTION
Only run it when the map may have changed (migration or core version change), and also only check migration files (ignore things like pycache).