### PR TITLE
docs: fix partial doc reference error due to missing space

### DIFF
--- a/docs/apache-airflow-providers-microsoft-azure/operators/adls.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/operators/adls.rst
@@ -22,7 +22,7 @@ Azure DataLake Storage Operators
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include::/operators/_partials/prerequisite_tasks.rst
+.. include:: /operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:ADLSDeleteOperator:
 

--- a/docs/apache-airflow-providers-microsoft-azure/transfer/local_to_adls.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/transfer/local_to_adls.rst
@@ -25,7 +25,7 @@ This page shows how to upload data from local filesystem to ADL.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include::/operators/_partials/prerequisite_tasks.rst
+.. include:: /operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:LocalFilesystemToADLSOperator:
 

--- a/docs/apache-airflow-providers-presto/operators/transfer/gcs_to_presto.rst
+++ b/docs/apache-airflow-providers-presto/operators/transfer/gcs_to_presto.rst
@@ -27,12 +27,6 @@ querying data where it lives, including Hive, Cassandra, relational databases or
 A single Presto query can combine data from multiple sources, allowing for analytics across your entire
 organization.
 
-
-Prerequisite Tasks
-^^^^^^^^^^^^^^^^^^
-
-.. include:: /operators/_partials/prerequisite_tasks.rst
-
 .. _howto/operator:GCSToPresto:
 
 Load CSV from GCS to Presto Table

--- a/docs/apache-airflow-providers-presto/operators/transfer/gcs_to_presto.rst
+++ b/docs/apache-airflow-providers-presto/operators/transfer/gcs_to_presto.rst
@@ -31,7 +31,7 @@ organization.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include::/operators/_partials/prerequisite_tasks.rst
+.. include:: /operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GCSToPresto:
 

--- a/docs/apache-airflow-providers-qubole/operators/qubole.rst
+++ b/docs/apache-airflow-providers-qubole/operators/qubole.rst
@@ -25,11 +25,6 @@ Airflow provides operators to execute tasks (commands) on QDS and perform checks
 Also, there are provided sensors that waits for a file, folder or partition to be present in cloud storage and check for its presence via QDS APIs
 
 
-Prerequisite Tasks
-^^^^^^^^^^^^^^^^^^
-
-.. include:: /operators/_partials/prerequisite_tasks.rst
-
 .. _howto/operator:QuboleOperator:
 
 Execute tasks

--- a/docs/apache-airflow-providers-qubole/operators/qubole.rst
+++ b/docs/apache-airflow-providers-qubole/operators/qubole.rst
@@ -28,7 +28,7 @@ Also, there are provided sensors that waits for a file, folder or partition to b
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include::/operators/_partials/prerequisite_tasks.rst
+.. include:: /operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:QuboleOperator:
 

--- a/docs/apache-airflow-providers-qubole/operators/qubole_check.rst
+++ b/docs/apache-airflow-providers-qubole/operators/qubole_check.rst
@@ -23,11 +23,6 @@ Qubole delivers a Self-Service Platform for Big Data Analytics built on Amazon W
 
 Airflow provides operators to execute tasks (commands) on QDS and perform checks against Qubole Commands.
 
-Prerequisite Tasks
-^^^^^^^^^^^^^^^^^^
-
-.. include:: /operators/_partials/prerequisite_tasks.rst
-
 .. _howto/operator:QuboleCheckOperator:
 
 Perform checks

--- a/docs/apache-airflow-providers-qubole/operators/qubole_check.rst
+++ b/docs/apache-airflow-providers-qubole/operators/qubole_check.rst
@@ -26,7 +26,7 @@ Airflow provides operators to execute tasks (commands) on QDS and perform checks
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include::/operators/_partials/prerequisite_tasks.rst
+.. include:: /operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:QuboleCheckOperator:
 

--- a/docs/apache-airflow-providers-trino/operators/transfer/gcs_to_trino.rst
+++ b/docs/apache-airflow-providers-trino/operators/transfer/gcs_to_trino.rst
@@ -27,12 +27,6 @@ querying data where it lives, including Hive, Cassandra, relational databases or
 A single Trino query can combine data from multiple sources, allowing for analytics across your entire
 organization.
 
-
-Prerequisite Tasks
-^^^^^^^^^^^^^^^^^^
-
-.. include:: /operators/_partials/prerequisite_tasks.rst
-
 .. _howto/operator:GCSToPresto:
 
 Load CSV from GCS to Trino Table

--- a/docs/apache-airflow-providers-trino/operators/transfer/gcs_to_trino.rst
+++ b/docs/apache-airflow-providers-trino/operators/transfer/gcs_to_trino.rst
@@ -31,7 +31,7 @@ organization.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include::/operators/_partials/prerequisite_tasks.rst
+.. include:: /operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GCSToPresto:
 


### PR DESCRIPTION
The content of "Prerequisite Tasks" is missing [here](https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure/6.2.4/operators/adls.html). This is due to a missing space when referencing the partial doc. Also fix other places other than the azure one

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
