### PR TITLE
Limit Redis dependencies to match celery limits

### DIFF
--- a/airflow/providers/redis/provider.yaml
+++ b/airflow/providers/redis/provider.yaml
@@ -39,7 +39,11 @@ versions:
 
 dependencies:
   - apache-airflow>=2.4.0
-  - redis>=3.2.0
+  # We limit redis to <5.0.0 because of incompatibility with celery. Both Celery and Kombu limited it
+  # and deferred fixing it for later, we should bump the limit once they do. Also !=4.5.5 matches celery
+  # limits and prevents installing 4.5.5 which is broken.
+  # https://github.com/celery/celery/pull/8442, https://github.com/celery/kombu/pull/1776
+  - redis>=4.5.2,<5.0.0,!=4.5.5
 
 integrations:
   - integration-name: Redis

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -754,7 +754,7 @@
   "redis": {
     "deps": [
       "apache-airflow>=2.4.0",
-      "redis>=3.2.0"
+      "redis>=4.5.2,<5.0.0,!=4.5.5"
     ],
     "cross-providers-deps": [],
     "excluded-python-versions": []


### PR DESCRIPTION
Redis 5 relased last week breaks celery, celery is limiting it for now and will resolve it later, we should similarly limit redis on our side to limit redis for users who will not upgrade to celery that will be released shortly.

Fixes: #33744

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
