### PR TITLE
Limit hive provider check for Python 3.11 temporarily

### DIFF
--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -303,6 +303,12 @@ function install_all_providers_from_pypi_with_eager_upgrade() {
         if [[ ${provider_package} == "apache-airflow-providers-yandex" ]]; then
             continue
         fi
+        # Until we release latest `hive` provider with pure-sasl support, we need to remove it from the
+        # list of providers to install for Python 3.11 because we cannot build sasl it for Python 3.11
+        if [[ ${provider_package} == "apache-airflow-providers-apache-hive" \
+            && ${PYTHON_MAJOR_MINOR_VERSION} == "3.11" ]]; then
+            continue
+        fi
         echo -n "Checking if ${provider_package} is available in PyPI: "
         res=$(curl --head -s -o /dev/null -w "%{http_code}" "https://pypi.org/project/${provider_package}/")
         if [[ ${res} == "200" ]]; then


### PR DESCRIPTION
In order to generate constraints, we need to temporarily limit also hive provider. There is a gap between wnen we added it in airflow setup and when we can generate constraints for the released providers from PyPI - we need to release the provider similarly like we have to do it for yandex.

Therefore - until the upcoming hive provider is released (in 3 days) we need to limit hive from being considered in Python 3.11 consstraint generation for providers from PyPI

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
