### PR TITLE
Fix UI DAG counts including deleted DAGs

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -835,9 +835,9 @@ class Airflow(AirflowBaseView):
 
             is_paused_count = dict(
                 session.execute(
-                    all_dags.with_only_columns([DagModel.is_paused, func.count()])
-                    .where(DagModel.is_active)
-                    .group_by(DagModel.is_paused)
+                    all_dags.with_only_columns([DagModel.is_paused, func.count()]).group_by(
+                        DagModel.is_paused
+                    )
                 ).all()
             )
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -836,7 +836,7 @@ class Airflow(AirflowBaseView):
             is_paused_count = dict(
                 session.execute(
                     all_dags.with_only_columns([DagModel.is_paused, func.count()])
-                    .where(DagModel.is_active == True)
+                    .where(DagModel.is_active)
                     .group_by(DagModel.is_paused)
                 ).all()
             )

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -835,7 +835,9 @@ class Airflow(AirflowBaseView):
 
             is_paused_count = dict(
                 session.execute(
-                    select(DagModel.is_paused, func.count(DagModel.dag_id)).group_by(DagModel.is_paused)
+                    all_dags.with_only_columns([DagModel.is_paused, func.count()])
+                    .where(DagModel.is_active == True)
+                    .group_by(DagModel.is_paused)
                 ).all()
             )
 


### PR DESCRIPTION
closes: #33698 

- The All, Active, and Paused counts include deleted DAGs.
- This situation arises due to the code's current approach of grouping all entries from the `dag` table, without specifically filtering for records with the `is_active` flag set to `True`. Consequently, this selection leads to inaccurate counts.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
