### PR TITLE
ECSTaskOperator - Change default behavior for max attempts

### DIFF
--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -476,7 +476,7 @@ class EcsRunTaskOperator(EcsBaseOperator):
         number_logs_exception: int = 10,
         wait_for_completion: bool = True,
         waiter_delay: int = 6,
-        waiter_max_attempts: int = 100,
+        waiter_max_attempts: int = sys.maxsize, # Default to letting airflow manage timeout
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         **kwargs,
     ):
@@ -665,7 +665,6 @@ class EcsRunTaskOperator(EcsBaseOperator):
             return
 
         waiter = self.client.get_waiter("tasks_stopped")
-        waiter.config.max_attempts = sys.maxsize  # timeout is managed by airflow
         waiter.wait(
             cluster=self.cluster,
             tasks=[self.arn],

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -348,9 +348,8 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
         self.ecs._wait_for_task_ended()
         client_mock.get_waiter.assert_called_once_with("tasks_stopped")
         client_mock.get_waiter.return_value.wait.assert_called_once_with(
-            cluster="c", tasks=["arn"], WaiterConfig={"Delay": 6, "MaxAttempts": 100}
+            cluster="c", tasks=["arn"], WaiterConfig={"Delay": 6, "MaxAttempts": sys.maxsize}
         )
-        assert sys.maxsize == client_mock.get_waiter.return_value.config.max_attempts
 
     @mock.patch.object(EcsBaseOperator, "client")
     def test_check_success_tasks_raises_failed_to_start(self, client_mock):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Good day! 

I'd like to make a small modification to the **EcsTaskOperator**'s default behavior to ensure that the task does not time out after 10 minutes.

Historically, the **ECSTaskOperator** would by default set its waiters' `max_attemps` limit to `sys.maxsize`. However, this was changed to a default of 10 minutes `(waiter_max_attemps * waiter_delay)  = 100 * 6 = 600s = 10 minutes` (see [PR](https://github.com/apache/airflow/commit/92cab74b280e9e7162120506c46fe275fbe0b577) where behavior changed). 

To amend this, we:
- Changed the default value for the `waiter_max_attempts` for the **ECSTaskOperator** from 100 to `sys.maxsize`
- Removed legacy line which did not affect operator behavior
- Edited tests to reflect changes

Thanks to @vincbeck for the input on the changes. 


<!-- Please keep an empty line above the dashes. -->

