### PR TITLE
Use PyPI constraints for PROD image in non-main branch

### DIFF
--- a/.github/actions/build-ci-images/action.yml
+++ b/.github/actions/build-ci-images/action.yml
@@ -34,12 +34,18 @@ runs:
     - name: "Build & Push AMD64 CI images ${{ env.IMAGE_TAG }} ${{ env.PYTHON_VERSIONS }}"
       shell: bash
       run: breeze ci-image build --push --tag-as-latest --run-in-parallel --upgrade-on-failure
-    - name: "Show dependencies to be upgraded"
+    - name: "Generate source constraints"
       shell: bash
       run: >
         breeze release-management generate-constraints --run-in-parallel
         --airflow-constraints-mode constraints-source-providers
       if: env.UPGRADE_TO_NEWER_DEPENDENCIES != 'false'
+    - name: "Generate PyPI constraints"
+      shell: bash
+      run: >
+        breeze release-management generate-constraints --run-in-parallel
+        --airflow-constraints-mode constraints
+      if: env.UPGRADE_TO_NEWER_DEPENDENCIES != 'false' and ${{ inputs.build-provider-packages != 'true' }}
     - name: "Print dependency upgrade summary"
       shell: bash
       run: |

--- a/.github/actions/build-prod-images/action.yml
+++ b/.github/actions/build-prod-images/action.yml
@@ -62,7 +62,7 @@ runs:
         name: constraints
         path: ./docker-context-files
       if: env.UPGRADE_TO_NEWER_DEPENDENCIES != 'false'
-    - name: "Build & Push PROD images ${{ env.IMAGE_TAG }}:${{ env.PYTHON_VERSIONS }}"
+    - name: "Build & Push PROD images with source providers ${{ env.IMAGE_TAG }}:${{ env.PYTHON_VERSIONS }}"
       shell: bash
       run: >
         breeze prod-image build --tag-as-latest --run-in-parallel --push
@@ -70,6 +70,16 @@ runs:
         --use-constraints-for-context-packages
       env:
         COMMIT_SHA: ${{ github.sha }}
+      if: ${{ inputs.build-provider-packages == 'true' }}
+    - name: "Build & Push PROD images with PyPi providers ${{ env.IMAGE_TAG }}:${{ env.PYTHON_VERSIONS }}"
+      shell: bash
+      run: >
+        breeze prod-image build --tag-as-latest --run-in-parallel --push
+        --install-packages-from-context --airflow-constraints-mode constraints
+        --use-constraints-for-context-packages
+      env:
+        COMMIT_SHA: ${{ github.sha }}
+      if: ${{ inputs.build-provider-packages != 'true' }}
     - name: "Fix ownership"
       shell: bash
       run: breeze ci fix-ownership


### PR DESCRIPTION
When we are building PROD image in CI for non main branch, we are installing providers from PyPI rather than building them locally from sources. Therefore we should use `PyPI` constraints for such builds not the "source" constraints (they might differ).

This PR adds two steps:

* In the CI build, when we do not build providers we generate PyPI constraints additionally to source constraints
* In the PROD build we use the PyPI constraints in case we do not build providers locally

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
