### PR TITLE
Fix an edge case after refactoring back-reference breeze command

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/add_back_references.py
+++ b/dev/breeze/src/airflow_breeze/utils/add_back_references.py
@@ -111,9 +111,12 @@ def generate_back_references(link: str, base_path: Path):
         for old, new in old_to_new:
             # only if old file exists, add the back reference
             if (versioned_provider_path / old).exists():
-                split_new_path, file_name = new.rsplit("/", 1)
-                dest_dir = versioned_provider_path / split_new_path
-
+                if "/" in new:
+                    split_new_path, file_name = new.rsplit("/", 1)
+                    dest_dir = versioned_provider_path / split_new_path
+                else:
+                    file_name = new
+                    dest_dir = versioned_provider_path
                 # finds relative path of old file with respect to new and handles case of different file
                 # names also
                 relative_path = os.path.relpath(old, new)


### PR DESCRIPTION
The #33626 change missed an edge case where back reference new link was in the top-level folder and crashed with ValueError.

Unfortunately back-reference command is one that we do not run (yet) in CI to verify if it works, because we need a checked-out airflow-site for it, so such errors might go unnoticed. However this error is an indication that we likely should add it to CI - in order to avoid situation when the command is expected to be working at release time.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
