### PR TITLE
Run back-reference breeze command as part of our CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -645,13 +645,13 @@ jobs:
           breeze release-management publish-docs
           --override-versioned
           ${{ needs.build-info.outputs.docs-filter-list-as-string }}
-      - name: "Generate back-reference for providers"
+      - name: "Generate back references for providers"
         run: breeze release-management add-back-references all-providers
-      - name: "Generate back-reference for apache-airflow"
+      - name: "Generate back references for apache-airflow"
         run: breeze release-management add-back-references apache-airflow
-      - name: "Generate back-reference for docker-stack"
+      - name: "Generate back references for docker-stack"
         run: breeze release-management add-back-references docker-stack
-      - name: "Generate back-reference for helm-chart"
+      - name: "Generate back references for helm-chart"
         run: breeze release-management add-back-references helm-chart
       - name: Configure AWS credentials
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -645,6 +645,14 @@ jobs:
           breeze release-management publish-docs
           --override-versioned
           ${{ needs.build-info.outputs.docs-filter-list-as-string }}
+      - name: "Generate back-reference for providers"
+        run: breeze release-management add-back-references all-providers
+      - name: "Generate back-reference for apache-airflow"
+        run: breeze release-management add-back-references apache-airflow
+      - name: "Generate back-reference for docker-stack"
+        run: breeze release-management add-back-references docker-stack
+      - name: "Generate back-reference for helm-chart"
+        run: breeze release-management add-back-references helm-chart
       - name: Configure AWS credentials
         uses: ./.github/actions/configure-aws-credentials
         if: >

--- a/dev/breeze/src/airflow_breeze/utils/add_back_references.py
+++ b/dev/breeze/src/airflow_breeze/utils/add_back_references.py
@@ -23,8 +23,6 @@ from pathlib import Path
 from urllib.error import URLError
 from urllib.request import urlopen
 
-from rich import print
-
 from airflow_breeze.utils.console import get_console
 
 airflow_redirects_link = (
@@ -43,9 +41,9 @@ def download_file(url):
         return True, file_name
     except URLError as e:
         if e.reason == "Not Found":
-            print(f"[blue]The {url} does not exist. Skipping.")
+            get_console().print(f"[blue]The {url} does not exist. Skipping.")
         else:
-            print(f"[yellow]Could not download file {url}: {e}")
+            get_console().print(f"[yellow]Could not download file {url}: {e}")
         return False, "no-file"
 
 
@@ -74,9 +72,9 @@ def crete_redirect_html_if_not_exist(path: Path, content: str):
     if not path.exists():
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content)
-        print(f"[green]Created back reference redirect: {path}")
+        get_console().print(f"[green]Created back reference redirect: {path}")
     else:
-        print(f"Skipping file:{path}, redirects already exist")
+        get_console().print(f"Skipping file:{path}, redirects already exist")
 
 
 def create_back_reference_html(back_ref_url: str, target_path: Path):
@@ -99,14 +97,14 @@ def generate_back_references(link: str, base_path: Path):
     if not is_downloaded:
         old_to_new: list[tuple[str, str]] = []
     else:
-        print(f"Constructs old to new mapping from redirects.txt for {base_path}")
+        get_console().print(f"Constructs old to new mapping from redirects.txt for {base_path}")
         old_to_new = construct_old_to_new_tuple_mapping(file_name)
     old_to_new.append(("index.html", "changelog.html"))
     old_to_new.append(("index.html", "security.html"))
     old_to_new.append(("security.html", "security/security-model.html"))
 
     for versioned_provider_path in (p for p in base_path.iterdir() if p.is_dir()):
-        print(f"Processing {base_path}, version: {versioned_provider_path.name}")
+        get_console().print(f"Processing {base_path}, version: {versioned_provider_path.name}")
 
         for old, new in old_to_new:
             # only if old file exists, add the back reference
@@ -145,5 +143,5 @@ def start_generating_back_references(airflow_site_directory: Path, short_provide
             f"apache-airflow-providers-{package.replace('.','-')}" for package in short_provider_package_ids
         ]
         for p in all_providers:
-            print(f"Processing airflow provider: {p}")
+            get_console().print(f"Processing airflow provider: {p}")
             generate_back_references(get_github_redirects_url(p), docs_archive_path / p)


### PR DESCRIPTION
The `back-reference` command post-processes our docuementation to add redirections for new pages in the old documentation, so that user browsing the page can change version without hittin 404 error.

This command was not run in CI and some refactorings could break it (as it already happened in #33626 - fixed by #33790).

Most other breeze commands are already run in CI, so this one should be no different.

This PR adds back-reference generation as part of our regular documentation building step.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
