### PR TITLE
Always use Literal from typing_extensions

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -25,13 +25,14 @@ import os
 import sys
 import textwrap
 from contextlib import contextmanager, redirect_stderr, redirect_stdout, suppress
-from typing import Generator, Union, cast
+from typing import Generator, Protocol, Union, cast
 
 import pendulum
 from pendulum.parsing.exceptions import ParserError
 from sqlalchemy import select
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.session import Session
+from typing_extensions import Literal
 
 from airflow import settings
 from airflow.cli.simple_table import AirflowConsole
@@ -50,7 +51,6 @@ from airflow.models.taskinstance import TaskReturnCode
 from airflow.settings import IS_K8S_EXECUTOR_POD
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import SCHEDULER_QUEUED_DEPS
-from airflow.typing_compat import Literal, Protocol
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import (
     get_dag,

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -131,13 +131,13 @@ if TYPE_CHECKING:
     from pendulum.tz.timezone import Timezone
     from sqlalchemy.orm.query import Query
     from sqlalchemy.orm.session import Session
+    from typing_extensions import Literal
 
     from airflow.datasets import Dataset
     from airflow.decorators import TaskDecoratorCollection
     from airflow.models.dagbag import DagBag
     from airflow.models.operator import Operator
     from airflow.models.slamiss import SlaMiss
-    from airflow.typing_compat import Literal
     from airflow.utils.task_group import TaskGroup
 
 log = logging.getLogger(__name__)

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -72,10 +72,10 @@ if TYPE_CHECKING:
     from datetime import datetime
 
     from sqlalchemy.orm import Query, Session
+    from typing_extensions import Literal
 
     from airflow.models.dag import DAG
     from airflow.models.operator import Operator
-    from airflow.typing_compat import Literal
     from airflow.utils.types import ArgNotSet
 
     CreatedTasks = TypeVar("CreatedTasks", Iterator["dict[str, Any]"], Iterator[TI])

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -25,6 +25,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, ClassVar, Collection, Iterable, Iterator, Mapping, Sequence, Union
 
 import attr
+from typing_extensions import Literal
 
 from airflow import settings
 from airflow.compat.functools import cache
@@ -51,7 +52,6 @@ from airflow.models.expandinput import (
 from airflow.models.pool import Pool
 from airflow.serialization.enums import DagAttributeTypes
 from airflow.ti_deps.deps.mapped_task_expanded import MappedTaskIsExpanded
-from airflow.typing_compat import Literal
 from airflow.utils.context import context_update_for_unmapped
 from airflow.utils.helpers import is_container, prevent_duplicates
 from airflow.utils.types import NOTSET

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -135,6 +135,7 @@ if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
     from sqlalchemy.sql.elements import BooleanClauseList
     from sqlalchemy.sql.expression import ColumnOperators
+    from typing_extensions import Literal
 
     from airflow.models.abstractoperator import TaskStateChangeCallback
     from airflow.models.baseoperator import BaseOperator
@@ -143,7 +144,7 @@ if TYPE_CHECKING:
     from airflow.models.dataset import DatasetEvent
     from airflow.models.operator import Operator
     from airflow.timetables.base import DataInterval
-    from airflow.typing_compat import Literal, TypeGuard
+    from airflow.typing_compat import TypeGuard
     from airflow.utils.task_group import TaskGroup
 
     # This is a workaround because mypy doesn't work with hybrid_property

--- a/airflow/providers/amazon/aws/sensors/sqs.py
+++ b/airflow/providers/amazon/aws/sensors/sqs.py
@@ -19,9 +19,10 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Collection, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Collection, Sequence
 
 from deprecated import deprecated
+from typing_extensions import Literal
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException

--- a/airflow/providers/amazon/aws/transfers/sql_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/sql_to_s3.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 import enum
 from collections import namedtuple
 from tempfile import NamedTemporaryFile
-from typing import TYPE_CHECKING, Iterable, Literal, Mapping, Sequence
+from typing import TYPE_CHECKING, Iterable, Mapping, Sequence
+
+from typing_extensions import Literal
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook

--- a/airflow/providers/amazon/aws/triggers/sqs.py
+++ b/airflow/providers/amazon/aws/triggers/sqs.py
@@ -17,7 +17,9 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, AsyncIterator, Collection, Literal
+from typing import Any, AsyncIterator, Collection
+
+from typing_extensions import Literal
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.base_aws import BaseAwsConnection

--- a/airflow/providers/amazon/aws/utils/sqs.py
+++ b/airflow/providers/amazon/aws/utils/sqs.py
@@ -18,9 +18,10 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Literal
+from typing import Any
 
 from jsonpath_ng import parse
+from typing_extensions import Literal
 
 log = logging.getLogger(__name__)
 

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -71,9 +71,9 @@ from airflow.version import version as airflow_version
 
 if TYPE_CHECKING:
     import jinja2
+    from typing_extensions import Literal
 
     from airflow.providers.cncf.kubernetes.secret import Secret
-    from airflow.typing_compat import Literal
     from airflow.utils.context import Context
 
 alphanum_lower = string.ascii_lowercase + string.digits

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -28,7 +28,7 @@ from collections.abc import Iterable
 from contextlib import closing, suppress
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import TYPE_CHECKING, Generator, cast
+from typing import TYPE_CHECKING, Generator, Protocol, cast
 
 import pendulum
 import tenacity
@@ -38,11 +38,11 @@ from kubernetes.stream import stream as kubernetes_stream
 from pendulum import DateTime
 from pendulum.parsing.exceptions import ParserError
 from tenacity import before_log
+from typing_extensions import Literal
 from urllib3.exceptions import HTTPError as BaseHTTPError
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.cncf.kubernetes.pod_generator import PodDefaults
-from airflow.typing_compat import Literal, Protocol
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.timezone import utcnow
 

--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -30,7 +30,7 @@ from airflow.hooks.base import BaseHook
 if TYPE_CHECKING:
     from types import TracebackType
 
-    from airflow.typing_compat import Literal
+    from typing_extensions import Literal
 
 
 class MongoHook(BaseHook):

--- a/airflow/providers/salesforce/operators/bulk.py
+++ b/airflow/providers/salesforce/operators/bulk.py
@@ -22,7 +22,8 @@ from airflow.models import BaseOperator
 from airflow.providers.salesforce.hooks.salesforce import SalesforceHook
 
 if TYPE_CHECKING:
-    from airflow.typing_compat import Literal
+    from typing_extensions import Literal
+
     from airflow.utils.context import Context
 
 

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -33,11 +33,11 @@ from time import perf_counter
 from typing import TYPE_CHECKING, Any, Callable, MutableMapping, NamedTuple, TypeVar, cast
 
 from packaging.utils import canonicalize_name
+from typing_extensions import Literal
 
 from airflow.exceptions import AirflowOptionalProviderFeatureException
 from airflow.hooks.filesystem import FSHook
 from airflow.hooks.package_index import PackageIndexHook
-from airflow.typing_compat import Literal
 from airflow.utils import yaml
 from airflow.utils.entry_points import entry_points_with_dist
 from airflow.utils.log.logging_mixin import LoggingMixin

--- a/airflow/typing_compat.py
+++ b/airflow/typing_compat.py
@@ -30,11 +30,9 @@ __all__ = [
 import sys
 from typing import Protocol, TypedDict, runtime_checkable
 
-# Literal in 3.8 is limited to one single argument, not e.g. "Literal[1, 2]".
-if sys.version_info >= (3, 9):
-    from typing import Literal
-else:
-    from typing import Literal
+# Literal from typing module has various issues in different Python versions, see:
+# https://typing-extensions.readthedocs.io/en/latest/#Literal
+from typing_extensions import Literal
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec, TypeGuard

--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -23,9 +23,9 @@ from typing import Collection
 
 from croniter import croniter
 from dateutil.relativedelta import relativedelta  # for doctest
+from typing_extensions import Literal
 
 from airflow.exceptions import RemovedInAirflow3Warning
-from airflow.typing_compat import Literal
 from airflow.utils import timezone
 
 cron_presets: dict[str, str] = {

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -24,10 +24,7 @@ from functools import cached_property, lru_cache
 from re import match
 from typing import Any, Dict, List, TypeVar
 
-if sys.version_info >= (3, 9):
-    from typing import Literal
-else:
-    from typing import Literal
+from typing_extensions import Literal
 
 from airflow_breeze.global_constants import (
     ALL_PYTHON_MAJOR_MINOR_VERSIONS,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

During the removing support of Python 3.7 #30963, we incidentally create this block
```python
# Literal in 3.8 is limited to one single argument, not e.g. "Literal[1, 2]".
if sys.version_info >= (3, 9):
    from typing import Literal
else:
    from typing import Literal
```

This PR fix by use everywhere `from typing_extension import Literal` instead of 
- `from typing import Literal`
- `from airflow.typing_compat import Literal`

In additional `Literal` has [other known bugs](https://typing-extensions.readthedocs.io/en/latest/#Literal) which finally resolved in Python 3.10.1+, so personally I thought that better just use `from typing_extension import Literal` rather than out `airflow.typing_compat` resolver

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
