### PR TITLE
Fix package name in exception message for hdfs provider

### DIFF
--- a/airflow/providers/apache/hdfs/hooks/hdfs.py
+++ b/airflow/providers/apache/hdfs/hooks/hdfs.py
@@ -23,7 +23,7 @@ _EXCEPTION_MESSAGE = """The old HDFS Hooks have been removed in 4.0.0 version of
 Please convert your DAGs to use the WebHdfsHook or downgrade the provider to below 4.*
 if you want to continue using it.
 If you want to use earlier provider you can downgrade to latest released 3.* version
-using `pip install apache-airflow-providers-hdfs==3.2.1` (no constraints)
+using `pip install apache-airflow-providers-apache-hdfs==3.2.1` (no constraints)
 """
 
 
@@ -34,7 +34,7 @@ class HDFSHookException(AirflowException):
     Please convert your DAGs to use the WebHdfsHook or downgrade the provider
     to below 4.* if you want to continue using it. If you want to use earlier
     provider you can downgrade to latest released 3.* version using
-    `pip install apache-airflow-providers-hdfs==3.2.1` (no constraints).
+    `pip install apache-airflow-providers-apache-hdfs==3.2.1` (no constraints).
     """
 
     def __init__(self, *args, **kwargs):
@@ -48,7 +48,7 @@ class HDFSHook(BaseHook):
     Please convert your DAGs to use the WebHdfsHook or downgrade the provider
     to below 4.*. if you want to continue using it. If you want to use earlier
     provider you can downgrade to latest released 3.* version using
-    `pip install apache-airflow-providers-hdfs==3.2.1` (no constraints).
+    `pip install apache-airflow-providers-apache-hdfs==3.2.1` (no constraints).
     """
 
     def __init__(self, *args, **kwargs):

--- a/airflow/providers/apache/hdfs/sensors/hdfs.py
+++ b/airflow/providers/apache/hdfs/sensors/hdfs.py
@@ -22,7 +22,7 @@ _EXCEPTION_MESSAGE = """The old HDFS Sensors have been removed in 4.0.0 version 
 Please convert your DAGs to use the WebHdfsSensor or downgrade the provider to below 4.*
 if you want to continue using it.
 If you want to use earlier provider you can downgrade to latest released 3.* version
-using `pip install apache-airflow-providers-hdfs==3.2.1` (no constraints)
+using `pip install apache-airflow-providers-apache-hdfs==3.2.1` (no constraints)
 """
 
 
@@ -33,7 +33,7 @@ class HdfsSensor(BaseSensorOperator):
     Please convert your DAGs to use the WebHdfsSensor or downgrade the provider
     to below 4.* if you want to continue using it. If you want to use earlier
     provider you can downgrade to latest released 3.* version using
-    `pip install apache-airflow-providers-hdfs==3.2.1` (no constraints).
+    `pip install apache-airflow-providers-apache-hdfs==3.2.1` (no constraints).
     """
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
The package name is wrong in the exception message and a few other places. This should be fixed as it present some security concerns (redirecting users to untrusted third party PyPI packages)