### PR TITLE
Fix edge case with constraints conflicting with setup dependencies

### DIFF
--- a/.github/actions/build-ci-images/action.yml
+++ b/.github/actions/build-ci-images/action.yml
@@ -39,13 +39,12 @@ runs:
       run: >
         breeze release-management generate-constraints --run-in-parallel
         --airflow-constraints-mode constraints-source-providers
-      if: env.UPGRADE_TO_NEWER_DEPENDENCIES != 'false'
     - name: "Generate PyPI constraints"
       shell: bash
       run: >
         breeze release-management generate-constraints --run-in-parallel
         --airflow-constraints-mode constraints
-      if: env.UPGRADE_TO_NEWER_DEPENDENCIES != 'false' and ${{ inputs.build-provider-packages != 'true' }}
+      if: ${{ inputs.build-provider-packages != 'true' }}
     - name: "Print dependency upgrade summary"
       shell: bash
       run: |
@@ -53,7 +52,6 @@ runs:
           echo "Summarizing Python $PYTHON_VERSION"
           cat "files/constraints-${PYTHON_VERSION}/*.md" >> $GITHUB_STEP_SUMMARY || true
         done
-      if: env.UPGRADE_TO_NEWER_DEPENDENCIES != 'false'
     - name: "Upload constraint artifacts"
       uses: actions/upload-artifact@v3
       with:

--- a/.github/actions/build-prod-images/action.yml
+++ b/.github/actions/build-prod-images/action.yml
@@ -61,7 +61,6 @@ runs:
       with:
         name: constraints
         path: ./docker-context-files
-      if: env.UPGRADE_TO_NEWER_DEPENDENCIES != 'false'
     - name: "Build & Push PROD images with source providers ${{ env.IMAGE_TAG }}:${{ env.PYTHON_VERSIONS }}"
       shell: bash
       run: >


### PR DESCRIPTION
There was an edge case with race condition between merging the setup.py change to main and refreshing constraint causing a failure of PROD image building when the new setup.py had conflicting dependencies with the past constraints. This happened on Aug 28 with azure-mgmt-containerinstance which got upgrade to a new 8.0.0 version which was conflicting with previous setup.py:

* azure-mgmt-containerinstance>=1.5.0,<2.0

to

* azure-mgmt-containerinstance>=7.0.0,<9.0.0

The problem was that PROD builds used the constraints from main to build the image, because constraints were not produced in the CI builds for the same job (constraints wer only produced in the PR that had "upgrade to newer depedencies".

The regular PR CI builds have a build-in protection against such edge case - they run with `--upgrade-on-failure` flag that causes the PRs to upgrade their constraints eagerly if they fail on constraints failure.

This PR fixes the edge case by utilising the result of the flag --upgrade-on failure.

After this PR, constraints will always be uploaded by CI jobs, not only when "upgrade to newer dependencies" PR is run. this means that when CI build falls back as result of `--upgrade-on-failure` the newly generated constraints are uploaded as artifacts and used by PROD image build.

As a side-effect, every PR will produce the constraints used by that build as artifact. This is actually pretty good thing for diagnosis of dependency problems.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
