### PR TITLE
Resolve D301 in Apprise Provider

### DIFF
--- a/airflow/providers/apprise/hooks/apprise.py
+++ b/airflow/providers/apprise/hooks/apprise.py
@@ -75,7 +75,7 @@ class AppriseHook(BaseHook):
         interpret_escapes: bool | None = None,
         config: AppriseConfig | None = None,
     ):
-        """
+        r"""
         Send message to plugged-in services.
 
         :param body: Specify the message body
@@ -87,9 +87,9 @@ class AppriseHook(BaseHook):
         :param tag: Specify one or more tags to filter which services to notify
         :param attach: Specify one or more file attachment locations
         :param interpret_escapes: Enable interpretation of backslash escapes. For example, this would convert
-            sequences such as \\n and \\r to their respective ascii new-line and carriage return characters
+            sequences such as \n and \r to their respective ascii new-line and carriage return characters
         :param config: Specify one or more configuration
-        """  # noqa: D301
+        """
         title = title or ""
 
         apprise_obj = apprise.Apprise()

--- a/airflow/providers/apprise/notifications/apprise.py
+++ b/airflow/providers/apprise/notifications/apprise.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
 
 class AppriseNotifier(BaseNotifier):
-    """
+    r"""
     Apprise BaseNotifier.
 
     :param body: Specify the message body
@@ -49,10 +49,10 @@ class AppriseNotifier(BaseNotifier):
     :param tag: Specify one or more tags to filter which services to notify
     :param attach: Specify one or more file attachment locations
     :param interpret_escapes: Enable interpretation of backslash escapes. For example, this would convert
-        sequences such as \\n and \\r to their respected ascii new-line and carriage
+        sequences such as \n and \r to their respected ascii new-line and carriage
     :param config: Specify one or more configuration
     :param apprise_conn_id: connection that has Apprise configs setup
-    """  # noqa: D301
+    """
 
     template_fields = ("body", "title", "tag", "attach")
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
