### PR TITLE
Update taskflow.rst, fix Multiple outputs inference example

### DIFF
--- a/docs/apache-airflow/tutorial/taskflow.rst
+++ b/docs/apache-airflow/tutorial/taskflow.rst
@@ -423,9 +423,10 @@ Multiple outputs inference
 Tasks can also infer multiple outputs by using dict Python typing.
 
 .. code-block:: python
+   from typing import Dict
 
    @task
-   def identity_dict(x: int, y: int) -> dict[str, int]:
+   def identity_dict(x: int, y: int) -> Dict[str, int]:
        return {"x": x, "y": y}
 
 By using the typing ``Dict`` for the function return type, the ``multiple_outputs`` parameter


### PR DESCRIPTION
Change `dict[str, int]` to `Dict[str, int]`
Add `from typing import Dict` for clarity

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->


