### PR TITLE
Remove tasks annotation in `AppflowHook`

### DIFF
--- a/airflow/providers/amazon/aws/hooks/appflow.py
+++ b/airflow/providers/amazon/aws/hooks/appflow.py
@@ -24,7 +24,6 @@ from airflow.providers.amazon.aws.utils.waiter_with_logging import wait
 
 if TYPE_CHECKING:
     from mypy_boto3_appflow.client import AppflowClient
-    from mypy_boto3_appflow.type_defs import TaskOutputTypeDef, TaskTypeDef
 
 
 class AppflowHook(AwsBaseHook):
@@ -93,9 +92,7 @@ class AppflowHook(AwsBaseHook):
         exec_details = last_execs[execution_id]
         self.log.info("Run complete, execution details: %s", exec_details)
 
-    def update_flow_filter(
-        self, flow_name: str, filter_tasks: list[TaskTypeDef], set_trigger_ondemand: bool = False
-    ) -> None:
+    def update_flow_filter(self, flow_name: str, filter_tasks, set_trigger_ondemand: bool = False) -> None:
         """
         Update the flow task filter; all filters will be removed if an empty array is passed to filter_tasks.
 
@@ -106,7 +103,7 @@ class AppflowHook(AwsBaseHook):
         """
         response = self.conn.describe_flow(flowName=flow_name)
         connector_type = response["sourceFlowConfig"]["connectorType"]
-        tasks: list[TaskTypeDef | TaskOutputTypeDef] = []
+        tasks = []
 
         # cleanup old filter tasks
         for task in response["tasks"]:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Type hints + Static Checkers + boto3 = Pain
https://github.com/apache/airflow/pull/33822#issuecomment-1697308505

In latest mypy-boto3-appflow (1.28.29) version tasks have type `list[TaskTypeDef]` and `TaskOutputTypeDef` not exists anymore

![image](https://github.com/apache/airflow/assets/3998685/5f663bde-155d-4ac7-acc3-f93dddd8bac4)

Even if we change it and it pass CI static checks, it still won't pass in 1.28.16 (`breeze ci-image build --python 3.8`), for avoid fighting with mypy, just remove annotations related `mypy_boto3_appflow.type_defs`

P.S.: I'm not sure that we should have annotate something more than specific boto3 clients

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
