### PR TITLE
Update synapse.py to fix timeout bug

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/synapse.py
+++ b/airflow/providers/microsoft/azure/hooks/synapse.py
@@ -179,9 +179,9 @@ class AzureSynapseHook(BaseHook):
             and job_run_status not in expected_statuses
         ):
             # Check if the job-run duration has exceeded the ``timeout`` configured.
-            if start_time + timeout < time.monotonic():
+            if start_time + timeout > time.monotonic():
                 raise AirflowTaskTimeout(
-                    f"Job {job_id} has not reached a terminal status after {timeout} seconds."
+                    f"Job {job_id} has reached a terminal status after {timeout} seconds."
                 )
 
             # Wait to check the status of the job run based on the ``check_interval`` configured.

--- a/airflow/providers/microsoft/azure/hooks/synapse.py
+++ b/airflow/providers/microsoft/azure/hooks/synapse.py
@@ -181,7 +181,7 @@ class AzureSynapseHook(BaseHook):
             # Check if the job-run duration has exceeded the ``timeout`` configured.
             if start_time + timeout > time.monotonic():
                 raise AirflowTaskTimeout(
-                    f"Job {job_id} has reached a terminal status after {timeout} seconds."
+                    f"Job {job_id} has not reached a terminal status after {timeout} seconds."
                 )
 
             # Wait to check the status of the job run based on the ``check_interval`` configured.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
