### PR TITLE
allow optional password replacement

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -38,6 +38,7 @@ from airflow.configuration import AIRFLOW_HOME, WEBSERVER_CONFIG, conf  # NOQA F
 from airflow.exceptions import RemovedInAirflow3Warning
 from airflow.executors import executor_constants
 from airflow.logging_config import configure_logging
+from airflow.utils.net import replace_password_from_url
 from airflow.utils.orm_event_handlers import setup_event_handlers
 from airflow.utils.state import State
 
@@ -194,6 +195,10 @@ def configure_vars():
     global PLUGINS_FOLDER
     global DONOT_MODIFY_HANDLERS
     SQL_ALCHEMY_CONN = conf.get("database", "SQL_ALCHEMY_CONN")
+    sql_alchemy_conn_password = conf.get("database", "SQL_ALCHEMY_CONN_PASSWORD", fallback=None)
+    if sql_alchemy_conn_password:
+        SQL_ALCHEMY_CONN = replace_password_from_url(SQL_ALCHEMY_CONN, sql_alchemy_conn_password)
+
     DAGS_FOLDER = os.path.expanduser(conf.get("core", "DAGS_FOLDER"))
 
     PLUGINS_FOLDER = conf.get("core", "plugins_folder", fallback=os.path.join(AIRFLOW_HOME, "plugins"))

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -33,6 +33,7 @@ from airflow.exceptions import AirflowConfigException, RemovedInAirflow3Warning
 from airflow.logging_config import configure_logging
 from airflow.models import import_all_models
 from airflow.settings import _ENABLE_AIP_44
+from airflow.settings import SQL_ALCHEMY_CONN
 from airflow.utils.json import AirflowJsonProvider
 from airflow.www.extensions.init_appbuilder import init_appbuilder
 from airflow.www.extensions.init_appbuilder_links import init_appbuilder_links
@@ -88,7 +89,7 @@ def create_app(config=None, testing=False):
         flask_app.config.from_pyfile(webserver_config, silent=True)
 
     flask_app.config["TESTING"] = testing
-    flask_app.config["SQLALCHEMY_DATABASE_URI"] = conf.get("database", "SQL_ALCHEMY_CONN")
+    flask_app.config["SQLALCHEMY_DATABASE_URI"] = SQL_ALCHEMY_CONN
 
     instance_name = conf.get(section="webserver", key="instance_name", fallback="Airflow")
     instance_name_has_markup = conf.getboolean(
@@ -102,7 +103,7 @@ def create_app(config=None, testing=False):
     url = make_url(flask_app.config["SQLALCHEMY_DATABASE_URI"])
     if url.drivername == "sqlite" and url.database and not url.database.startswith("/"):
         raise AirflowConfigException(
-            f'Cannot use relative path: `{conf.get("database", "SQL_ALCHEMY_CONN")}` to connect to sqlite. '
+            f'Cannot use relative path: `{SQL_ALCHEMY_CONN}` to connect to sqlite. '
             "Please use absolute path such as `sqlite:////tmp/airflow.db`."
         )
 

--- a/tests/cli/commands/test_info_command.py
+++ b/tests/cli/commands/test_info_command.py
@@ -27,6 +27,8 @@ from rich.console import Console
 
 from airflow.cli import cli_parser
 from airflow.cli.commands import info_command
+from airflow.cli.commands.info_command import anonymize_username, anonymize_password, \
+    anonymize_username_and_password
 from airflow.config_templates import airflow_local_settings
 from airflow.logging_config import configure_logging
 from airflow.version import version as airflow_version
@@ -38,6 +40,49 @@ def capture_show_output(instance):
     with console.capture() as capture:
         instance.info(console)
     return capture.get()
+
+
+class TestAnonymizeUsername:
+    @pytest.mark.parametrize(
+        "before, after",
+        [
+            (
+                "postgres",
+                "p...s",
+            ),
+            (
+                None,
+                None,
+            ),
+        ],
+    )
+    def test_should_anonymize_username(self, before, after):
+        assert after == anonymize_username(before)
+
+
+class TestAnonymizePassword:
+    @pytest.mark.parametrize(
+        "before, after",
+        [
+            (
+                "airflow",
+                "PASSWORD",
+            ),
+            (
+                None,
+                None,
+            ),
+        ],
+    )
+    def test_should_replace_password(self, before, after):
+        assert after == anonymize_password(before)
+
+
+class TestAnonymizeUsernameAndPassword:
+    def test_should_anonymize_username_and_password(self):
+        username, password = anonymize_username_and_password("postgres", "airflow")
+        assert username == "p...s"
+        assert password == "PASSWORD"
 
 
 class TestPiiAnonymizer:
@@ -66,6 +111,10 @@ class TestPiiAnonymizer:
             (
                 "postgresql+psycopg2://postgres/airflow",
                 "postgresql+psycopg2://postgres/airflow",
+            ),
+            (
+                None,
+                None,
             ),
         ],
     )

--- a/tests/utils/test_net.py
+++ b/tests/utils/test_net.py
@@ -24,6 +24,7 @@ import pytest
 
 from airflow.exceptions import AirflowConfigException
 from airflow.utils import net
+from airflow.utils.net import replace_items_from_url, replace_password_from_url
 from tests.test_utils.config import conf_vars
 
 
@@ -56,3 +57,116 @@ class TestGetHostname:
             ),
         ):
             net.get_hostname()
+
+
+def replace_username_and_password(username, password) -> (str, str):
+    return "USERNAME", "PASSWORD"
+
+
+def replace_with_none(username, password) -> (str, str):
+    return None, None
+
+
+def replace_username(username, password) -> (str, str):
+    return "USERNAME", password
+
+
+def replace_password(username, password) -> (str, str):
+    return username, "PASSWORD"
+
+
+def no_replacement(username, password) -> (str, str):
+    return username, password
+
+
+class TestReplaceItemsFromUrl:
+    @pytest.mark.parametrize(
+        "before, after, function",
+        [
+            (
+                "postgresql+psycopg2://postgres:airflow@postgres/airflow",
+                "postgresql+psycopg2://USERNAME:PASSWORD@postgres/airflow",
+                replace_username_and_password,
+            ),
+            (
+                "postgresql+psycopg2://postgres:airflow@postgres/airflow",
+                "postgresql+psycopg2://USERNAME:airflow@postgres/airflow",
+                replace_username,
+            ),
+            (
+                "postgresql+psycopg2://postgres:airflow@postgres/airflow",
+                "postgresql+psycopg2://postgres:PASSWORD@postgres/airflow",
+                replace_password,
+            ),
+            (
+                "postgresql+psycopg2://postgres:airflow@postgres/airflow",
+                "postgresql+psycopg2://postgres:airflow@postgres/airflow",
+                no_replacement,
+            ),
+            (
+                "postgresql+psycopg2://postgres@postgres/airflow",
+                "postgresql+psycopg2://USERNAME:PASSWORD@postgres/airflow",
+                replace_username_and_password,
+            ),
+            (
+                "postgresql+psycopg2://:airflow@postgres/airflow",
+                "postgresql+psycopg2://USERNAME:PASSWORD@postgres/airflow",
+                replace_username_and_password,
+            ),
+            (
+                "postgresql+psycopg2://postgres/airflow",
+                "postgresql+psycopg2://USERNAME:PASSWORD@postgres/airflow",
+                replace_username_and_password
+            ),
+            (
+                None,
+                None,
+                replace_username_and_password
+            ),
+            (
+                "postgresql+psycopg2://postgres:airflow@postgres/airflow",
+                "postgresql+psycopg2://postgres/airflow",
+                replace_with_none,
+            ),
+            (
+                # test output of no username, password, or host - seems like an invalid case
+                "postgresql+psycopg2://postgres:airflow@/airflow",
+                # this looks like an invalid url
+                "postgresql+psycopg2:/airflow",
+                replace_with_none,
+            ),
+        ],
+    )
+    def test_should_replace_items_from_url(self, before, after, function):
+
+        assert after == replace_items_from_url(before, function)
+
+
+class TestReplacePasswordFromUrl:
+    @pytest.mark.parametrize(
+        "before, after",
+        [
+            (
+                "postgresql+psycopg2://postgres:airflow@postgres/airflow",
+                "postgresql+psycopg2://postgres:PASSWORD@postgres/airflow",
+            ),
+            (
+                "postgresql+psycopg2://postgres@postgres/airflow",
+                "postgresql+psycopg2://postgres:PASSWORD@postgres/airflow",
+            ),
+            (
+                "postgresql+psycopg2://:airflow@postgres/airflow",
+                "postgresql+psycopg2://:PASSWORD@postgres/airflow",
+            ),
+            (
+                "postgresql+psycopg2://postgres/airflow",
+                "postgresql+psycopg2://:PASSWORD@postgres/airflow",
+            ),
+            (
+                None,
+                None,
+            ),
+        ],
+    )
+    def test_should_replace_password_from_url(self, before, after):
+        assert after == replace_password_from_url(before, "PASSWORD")


### PR DESCRIPTION
This is new functionality that is optional.  In our k8s deployments, the postgres and redis password secrets are initialized in an init container.  After this, the corresponding url secrets need to have the passwords.  Replacing the postgres and redis url secrets so they have the password is not simple.  Therefore, this change will have airflow look for BROKER_URL_PASSWORD.  If it is set, the BROKER_URL will have the password replaced.  Similarly, if SQL_ALCHEMY_CONN_PASSWORD is set, the SQL_ALCHEMY_CONN url will have the password replaced.

Implementation note:  I found code in airflow/cli/commands/info_command.py that is used to replace the password in url's with the word "PASSWORD".  This is done to anonymize the url for logging.  I moved that code into a function so it can be reused.  I put the function in airflow/utils/net.py.  Let me know if a different place makes sense or if it should be in its own file.

Commit message:

For BROKER_URL and SQL_ALCHEMY_CONN, allow optional BROKER_URL_PASSWORD and SQL_ALCHEMY_CONN_PASSWORD.  If set, replace the password in BROKER_URL/SQL_ALCHEMY_CONN with password values.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
