### PR TITLE
Ensure that tasks wait for running indirect setup

### DIFF
--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -293,6 +293,17 @@ class AbstractOperator(Templater, DAGNode):
                     if t.is_teardown and not t == self:
                         yield t
 
+    def get_upstreams_only_setups(self) -> Iterable[Operator]:
+        """
+        Return relevant upstream setups.
+
+        This method is meant to be used when we are checking task dependencies where we need
+        to wait for all the upstream setups to complete before we can run the task.
+        """
+        for task in self.get_upstreams_only_setups_and_teardowns():
+            if task.is_setup:
+                yield task
+
     def _iter_all_mapped_downstreams(self) -> Iterator[MappedOperator | MappedTaskGroup]:
         """Return mapped nodes that are direct dependencies of the current task.
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -128,11 +128,11 @@ from airflow.utils.types import NOTSET, ArgNotSet, DagRunType, EdgeInfoType
 
 if TYPE_CHECKING:
     from types import ModuleType
+    from typing import Literal
 
     from pendulum.tz.timezone import Timezone
     from sqlalchemy.orm.query import Query
     from sqlalchemy.orm.session import Session
-    from typing_extensions import Literal
 
     from airflow.datasets import Dataset
     from airflow.decorators import TaskDecoratorCollection
@@ -722,7 +722,9 @@ class DAG(LoggingMixin):
             if task.is_setup:
                 for down_task in task.downstream_list:
                     if not down_task.is_teardown and down_task.trigger_rule != TriggerRule.ALL_SUCCESS:
-                        # this is required to ensure consistent clearing behavior when upstream
+                        # todo: we can relax this to allow out-of-scope tasks to have other trigger rules
+                        # this is required to ensure consistent behavior of dag
+                        # when clearing an indirect setup
                         raise ValueError("Setup tasks must be followed with trigger rule ALL_SUCCESS.")
             FailStopDagInvalidTriggerRule.check(dag=self, trigger_rule=task.trigger_rule)
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -123,6 +123,7 @@ from airflow.utils.sqlalchemy import (
     with_row_locks,
 )
 from airflow.utils.state import DagRunState, TaskInstanceState
+from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.types import NOTSET, ArgNotSet, DagRunType, EdgeInfoType
 
 if TYPE_CHECKING:
@@ -718,6 +719,11 @@ class DAG(LoggingMixin):
         :meta private:
         """
         for task in self.tasks:
+            if task.is_setup:
+                for down_task in task.downstream_list:
+                    if not down_task.is_teardown and down_task.trigger_rule != TriggerRule.ALL_SUCCESS:
+                        # this is required to ensure consistent clearing behavior when upstream
+                        raise ValueError("Setup tasks must be followed with trigger rule ALL_SUCCESS.")
             FailStopDagInvalidTriggerRule.check(dag=self, trigger_rule=task.trigger_rule)
 
     def __repr__(self):

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -128,11 +128,11 @@ from airflow.utils.types import NOTSET, ArgNotSet, DagRunType, EdgeInfoType
 
 if TYPE_CHECKING:
     from types import ModuleType
-    from typing import Literal
 
     from pendulum.tz.timezone import Timezone
     from sqlalchemy.orm.query import Query
     from sqlalchemy.orm.session import Session
+    from typing_extensions import Literal
 
     from airflow.datasets import Dataset
     from airflow.decorators import TaskDecoratorCollection

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -144,7 +144,7 @@ class TriggerRuleDep(BaseTIDep):
             except (NotFullyPopulated, NotMapped):
                 return None
             return ti.get_relevant_upstream_map_indexes(
-                upstream=ti.dag.task_dict[upstream_id],
+                upstream=ti.task.dag.task_dict[upstream_id],
                 ti_count=expanded_ti_count,
                 session=session,
             )

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -549,7 +549,9 @@ class TriggerRuleDep(BaseTIDep):
             # a teardown cannot have any indirect setups
             relevant_setups = {t.task_id: t for t in ti.task.get_upstreams_only_setups()}
             if relevant_setups:
-                tasks_dict = relevant_setups  # used by _get_relevant_upstream_map_indexes
+                # set tasks_dict to contain relevant setups
+                # _get_relevant_upstream_map_indexes will use this to look up the task_id
+                tasks_dict = relevant_setups
                 for status, changed in _evaluate_setup_constraint(relevant_setups=relevant_setups):
                     yield status
                     if not status.passed and changed:
@@ -559,5 +561,7 @@ class TriggerRuleDep(BaseTIDep):
         task = ti.task
         trigger_rule = task.trigger_rule
         upstream_tasks = {t.task_id: t for t in task.upstream_list}
+        # set tasks_dict to contain direct upstream tasks
+        # _get_relevant_upstream_map_indexes will use this to look up the task_id
         tasks_dict = upstream_tasks
         yield from _evaluate_direct_relatives()

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -144,7 +144,7 @@ class TriggerRuleDep(BaseTIDep):
             except (NotFullyPopulated, NotMapped):
                 return None
             return ti.get_relevant_upstream_map_indexes(
-                upstream=ti.dag.task_dict.tasks_dict[upstream_id],
+                upstream=ti.dag.task_dict[upstream_id],
                 ti_count=expanded_ti_count,
                 session=session,
             )

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -191,7 +191,7 @@ class TriggerRuleDep(BaseTIDep):
                 return
             # Otherwise we need to figure out which map indexes are depended on
             # for each upstream by the current task instance.
-            for upstream_id, upstream_task in relevant_tasks.items():
+            for upstream_id in relevant_tasks.keys():
                 map_indexes = _get_relevant_upstream_map_indexes(upstream_id)
                 if map_indexes is None:  # All tis of this upstream are dependencies.
                     yield (TaskInstance.task_id == upstream_id)

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
     from sqlalchemy.sql.expression import ColumnOperators
 
+    from airflow import DAG
     from airflow.models.taskinstance import TaskInstance
     from airflow.ti_deps.dep_context import DepContext
     from airflow.ti_deps.deps.base_ti_dep import TIDepStatus
@@ -139,6 +140,8 @@ class TriggerRuleDep(BaseTIDep):
             and at most once for each task (instead of once for each expanded
             task instance of the same task).
             """
+            if TYPE_CHECKING:
+                assert isinstance(ti.task.dag, DAG)
             try:
                 expanded_ti_count = _get_expanded_ti_count()
             except (NotFullyPopulated, NotMapped):

--- a/docs/apache-airflow/howto/setup-and-teardown.rst
+++ b/docs/apache-airflow/howto/setup-and-teardown.rst
@@ -131,7 +131,7 @@ Implicit ALL_SUCCESS constraint
 Any task in the scope of a setup has an implicit "all_success" constraint on its setups.
 This is necessary to ensure that if a task with indirect setups is cleared, it will
 wait for them to complete.  If a setup fails or is skipped, the work tasks which depend
-them will be marked ask failures or skips.  We also require that any task directly
+them will be marked ask failures or skips.  We also require that any non-teardown directly
 downstream of a setup must have trigger rule ALL_SUCCESS.
 
 Controlling dag run state

--- a/docs/apache-airflow/howto/setup-and-teardown.rst
+++ b/docs/apache-airflow/howto/setup-and-teardown.rst
@@ -125,6 +125,14 @@ In that example, we (in our pretend docs land) actually wanted to delete the clu
     create_cluster >> run_query >> other_task
     run_query >> EmptyOperator(task_id="cluster_teardown").as_teardown(setups=create_cluster)
 
+Implicit ALL_SUCCESS constraint
+"""""""""""""""""""""""""""""""
+
+Any task in the scope of a setup has an implicit "all_success" constraint on its setups.
+This is necessary to ensure that if a task with indirect setups is cleared, it will
+wait for them to complete.  If a setup fails or is skipped, the work tasks which depend
+them will be marked ask failures or skips.  We also require that any task directly
+downstream of a setup must have trigger rule ALL_SUCCESS.
 
 Controlling dag run state
 """""""""""""""""""""""""

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1236,18 +1236,36 @@ class TestTaskInstance:
                 2,
                 _UpstreamTIStates(6, 0, 1, 0, 0, 7, 1, 0),
                 True,
-                None,
+                (True, None),  # is_teardown=True, expect_state=None
                 True,
-                id="one setup failed one setup success --> should run",
+                id="is teardown one setup failed one setup success",
+            ),
+            param(
+                "all_done_setup_success",
+                2,
+                _UpstreamTIStates(6, 0, 1, 0, 0, 7, 1, 0),
+                True,
+                (False, "upstream_failed"),  # is_teardown=False, expect_state="upstream_failed"
+                True,
+                id="not teardown one setup failed one setup success",
             ),
             param(
                 "all_done_setup_success",
                 2,
                 _UpstreamTIStates(6, 1, 0, 0, 0, 7, 1, 1),
                 True,
-                None,
+                (True, None),  # is_teardown=True, expect_state=None
                 True,
-                id="one setup success one setup skipped --> should run",
+                id="is teardown one setup success one setup skipped",
+            ),
+            param(
+                "all_done_setup_success",
+                2,
+                _UpstreamTIStates(6, 1, 0, 0, 0, 7, 1, 1),
+                True,
+                (False, "skipped"),  # is_teardown=False, expect_state="skipped"
+                True,
+                id="not teardown one setup success one setup skipped",
             ),
             param(
                 "all_done_setup_success",
@@ -1263,18 +1281,36 @@ class TestTaskInstance:
                 1,
                 _UpstreamTIStates(3, 0, 1, 0, 0, 4, 1, 0),
                 True,
-                None,
+                (True, None),  # is_teardown=True, expect_state=None
                 False,
-                id="not all done, one failed",
+                id="is teardown not all done one failed",
+            ),
+            param(
+                "all_done_setup_success",
+                1,
+                _UpstreamTIStates(3, 0, 1, 0, 0, 4, 1, 0),
+                True,
+                (False, "upstream_failed"),  # is_teardown=False, expect_state="upstream_failed"
+                False,
+                id="not teardown not all done one failed",
             ),
             param(
                 "all_done_setup_success",
                 1,
                 _UpstreamTIStates(3, 1, 0, 0, 0, 4, 1, 0),
                 True,
-                None,
+                (True, None),  # is_teardown=True, expect_state=None
                 False,
-                id="not all done, one skipped",
+                id="not all done one skipped",
+            ),
+            param(
+                "all_done_setup_success",
+                1,
+                _UpstreamTIStates(3, 1, 0, 0, 0, 4, 1, 0),
+                True,
+                (False, "skipped"),  # is_teardown=False, expect_state="skipped'
+                False,
+                id="not all done one skipped",
             ),
         ],
     )
@@ -1289,6 +1325,13 @@ class TestTaskInstance:
         expect_state: State,
         expect_passed: bool,
     ):
+        # this allows us to change the expected state depending on whether the
+        # task is a teardown
+        set_teardown = False
+        if isinstance(expect_state, tuple):
+            set_teardown, expect_state = expect_state
+            assert isinstance(set_teardown, bool)
+
         monkeypatch.setattr(_UpstreamTIStates, "calculate", lambda *_: upstream_states)
 
         # sanity checks
@@ -1299,6 +1342,8 @@ class TestTaskInstance:
 
         with dag_maker() as dag:
             downstream = EmptyOperator(task_id="downstream", trigger_rule=trigger_rule)
+            if set_teardown:
+                downstream.as_teardown()
             for i in range(5):
                 task = EmptyOperator(task_id=f"work_{i}", dag=dag)
                 task.set_downstream(downstream)


### PR DESCRIPTION
*Note*: this doesn't change existing trigger rule but does extract the inner functions into methods. For ease of review i have done this part in the first commit, separate from the introduction of setup constraint.

Alternative to https://github.com/apache/airflow/pull/33570

This is yet another approach to solving this one.  But I feel it's the best one thus far because it does not make any changes to existing trigger rule logic, apart from pulling out some internal functions into methods.

The indirect setup constraint logic is processed prior to trigger rules and is completely separate.

This _should_ play nicely with all mapping scenarios but more testing is required to verify.

There are a couple choices to make here.

One is in the "setup constraint" logic, should we apply it only to indirect setups or to all relevant setups?  I think the only time it makes a difference is when it there is a mixture of skipped and failed upstream setups and how we determine state of the object task.

Currently I only look at indirect setups.

Another thing is, for calculation of state, do we just go based on the state of the first non-succcess?  Or should we wait until everything is done and calculate at that point?  Currently it just takes the first non-success and fails (or skips) fast.  And I think this is consistent with airflow's many-to-one behavior more generally.

Note: for easier review, the first commit is a no-behavior-change refactor that just pulls the inner funcions out into methods.  The second commit is where the setup constraint logic is added.

Here is an example dag that can be used to test the behavior:
[Uploading setup_teardown_bug.txt…]()

The way to use that dag is to first change all the "scenarios" to `["success", "success", "success"]` and then you'll get a clean run.
Then you change the scenario e.g. to `["skip", "fail", "succes"]`.  Then, you clear the task with indirect upstream setup and see what happens.  The first mapped setup will skip, 5 seconds later the next fails, then 5 seconds later there's a success.
