### PR TITLE
Cleanup Docker operator logging

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -424,27 +424,3 @@ class DeserializingResultError(ValueError):
             "Error deserializing result. Note that result deserialization "
             "is not supported across major Python versions. Cause: " + str(self.__cause__)
         )
-
-
-class DockerContainerFailedException(AirflowException):
-    """
-    Raised when a Docker container returns an error.
-
-    :param logs: The log output of the failed Docker container
-    """
-
-    def __init__(self, message: str | None = None, logs: list[str | bytes] | None = None):
-        super().__init__(message)
-        self.logs = logs
-
-
-class DockerContainerFailedSkipException(AirflowSkipException):
-    """
-    Raised when a Docker container returns an error and task should be skipped.
-
-    :param logs: The log output of the failed Docker container
-    """
-
-    def __init__(self, message: str | None = None, logs: list[str | bytes] | None = None):
-        super().__init__(message)
-        self.logs = logs

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -424,3 +424,27 @@ class DeserializingResultError(ValueError):
             "Error deserializing result. Note that result deserialization "
             "is not supported across major Python versions. Cause: " + str(self.__cause__)
         )
+
+
+class DockerContainerFailedException(AirflowException):
+    """
+    Raised when a Docker container returns an error.
+
+    :param logs: The log output of the failed Docker container
+    """
+
+    def __init__(self, message: str | None = None, logs: list[str | bytes] | None = None):
+        super().__init__(message)
+        self.logs = logs
+
+
+class DockerContainerFailedSkipException(AirflowSkipException):
+    """
+    Raised when a Docker container returns an error and task should be skipped.
+
+    :param logs: The log output of the failed Docker container
+    """
+
+    def __init__(self, message: str | None = None, logs: list[str | bytes] | None = None):
+        super().__init__(message)
+        self.logs = logs

--- a/airflow/providers/docker/exceptions.py
+++ b/airflow/providers/docker/exceptions.py
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Exceptions used by Docker provider."""
+from __future__ import annotations
+
+from airflow.exceptions import AirflowException, AirflowSkipException
+
+
+class DockerContainerFailedException(AirflowException):
+    """
+    Raised when a Docker container returns an error.
+
+    :param logs: The log output of the failed Docker container
+    """
+
+    def __init__(self, message: str | None = None, logs: list[str | bytes] | None = None) -> None:
+        super().__init__(message)
+        self.logs = logs
+
+
+class DockerContainerFailedSkipException(AirflowSkipException):
+    """
+    Raised when a Docker container returns an error and task should be skipped.
+
+    :param logs: The log output of the failed Docker container
+    """
+
+    def __init__(self, message: str | None = None, logs: list[str | bytes] | None = None) -> None:
+        super().__init__(message)
+        self.logs = logs

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -407,8 +407,7 @@ class DockerOperator(BaseOperator):
                     f"Docker container returned exit code {self.skip_on_exit_code}. Skipping."
                 )
             elif result["StatusCode"] != 0:
-                joined_log_lines = "\n".join(log_lines)
-                raise AirflowException(f"Docker container failed: {result!r} lines {joined_log_lines}")
+                raise AirflowException(f"Docker container failed: {result!r}")
 
             if self.retrieve_output:
                 return self._attempt_to_retrieve_result()

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -33,11 +33,7 @@ from docker.errors import APIError
 from docker.types import LogConfig, Mount
 from dotenv import dotenv_values
 
-from airflow.exceptions import (
-    AirflowProviderDeprecationWarning,
-    DockerContainerFailedException,
-    DockerContainerFailedSkipException,
-)
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
 from airflow.models import BaseOperator
 from airflow.providers.docker.hooks.docker import DockerHook
 
@@ -46,6 +42,30 @@ if TYPE_CHECKING:
     from docker.types import DeviceRequest
 
     from airflow.utils.context import Context
+
+
+class DockerContainerFailedException(AirflowException):
+    """
+    Raised when a Docker container returns an error.
+
+    :param logs: The log output of the failed Docker container
+    """
+
+    def __init__(self, message: str | None = None, logs: list[str | bytes] | None = None):
+        super().__init__(message)
+        self.logs = logs
+
+
+class DockerContainerFailedSkipException(AirflowSkipException):
+    """
+    Raised when a Docker container returns an error and task should be skipped.
+
+    :param logs: The log output of the failed Docker container
+    """
+
+    def __init__(self, message: str | None = None, logs: list[str | bytes] | None = None):
+        super().__init__(message)
+        self.logs = logs
 
 
 def stringify(line: str | bytes):

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -33,8 +33,12 @@ from docker.errors import APIError
 from docker.types import LogConfig, Mount
 from dotenv import dotenv_values
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
+from airflow.providers.docker.exceptions import (
+    DockerContainerFailedException,
+    DockerContainerFailedSkipException,
+)
 from airflow.providers.docker.hooks.docker import DockerHook
 
 if TYPE_CHECKING:
@@ -42,30 +46,6 @@ if TYPE_CHECKING:
     from docker.types import DeviceRequest
 
     from airflow.utils.context import Context
-
-
-class DockerContainerFailedException(AirflowException):
-    """
-    Raised when a Docker container returns an error.
-
-    :param logs: The log output of the failed Docker container
-    """
-
-    def __init__(self, message: str | None = None, logs: list[str | bytes] | None = None):
-        super().__init__(message)
-        self.logs = logs
-
-
-class DockerContainerFailedSkipException(AirflowSkipException):
-    """
-    Raised when a Docker container returns an error and task should be skipped.
-
-    :param logs: The log output of the failed Docker container
-    """
-
-    def __init__(self, message: str | None = None, logs: list[str | bytes] | None = None):
-        super().__init__(message)
-        self.logs = logs
 
 
 def stringify(line: str | bytes):

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -565,7 +565,7 @@ class TestDockerOperator:
             assert str(raised_exception.value) == expected_message.format(
                 failed_msg=failed_msg,
             )
-            assert raised_exception.logs == f'{log_line[0].strip()}\n{log_line[1].decode("utf-8")}'
+            assert raised_exception.value.logs == f'{log_line[0].strip()}\n{log_line[1].decode("utf-8")}'
 
     def test_auto_remove_container_fails(self):
         self.client_mock.wait.return_value = {"StatusCode": 1}

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -27,7 +27,8 @@ from docker.errors import APIError
 from docker.types import DeviceRequest, LogConfig, Mount
 
 from airflow.exceptions import AirflowException, AirflowSkipException
-from airflow.providers.docker.operators.docker import DockerContainerFailedException, DockerOperator
+from airflow.providers.docker.exceptions import DockerContainerFailedException
+from airflow.providers.docker.operators.docker import DockerOperator
 
 TEST_CONN_ID = "docker_test_connection"
 TEST_DOCKER_URL = "unix://var/run/docker.test.sock"

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -553,7 +553,7 @@ class TestDockerOperator:
     def test_execute_container_fails(self):
         failed_msg = {"StatusCode": 1}
         log_line = ["unicode container log 😁   ", b"byte string container log"]
-        expected_message = "Docker container failed: {failed_msg} lines {expected_log_output}"
+        expected_message = "Docker container failed: {failed_msg}"
         self.client_mock.attach.return_value = log_line
         self.client_mock.wait.return_value = failed_msg
 
@@ -564,7 +564,6 @@ class TestDockerOperator:
 
         assert str(raised_exception.value) == expected_message.format(
             failed_msg=failed_msg,
-            expected_log_output=f'{log_line[0].strip()}\n{log_line[1].decode("utf-8")}',
         )
 
     def test_auto_remove_container_fails(self):

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -562,10 +562,10 @@ class TestDockerOperator:
         with pytest.raises(DockerContainerFailedException) as raised_exception:
             operator.execute(None)
 
-            assert str(raised_exception.value) == expected_message.format(
-                failed_msg=failed_msg,
-            )
-            assert raised_exception.value.logs == f'{log_line[0].strip()}\n{log_line[1].decode("utf-8")}'
+        assert str(raised_exception.value) == expected_message.format(
+            failed_msg=failed_msg,
+        )
+        assert raised_exception.value.logs == [log_line[0].strip(), log_line[1].decode("utf-8")]
 
     def test_auto_remove_container_fails(self):
         self.client_mock.wait.return_value = {"StatusCode": 1}

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -26,8 +26,8 @@ from docker import APIClient
 from docker.errors import APIError
 from docker.types import DeviceRequest, LogConfig, Mount
 
-from airflow.exceptions import AirflowException, AirflowSkipException, DockerContainerFailedException
-from airflow.providers.docker.operators.docker import DockerOperator
+from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.providers.docker.operators.docker import DockerContainerFailedException, DockerOperator
 
 TEST_CONN_ID = "docker_test_connection"
 TEST_DOCKER_URL = "unix://var/run/docker.test.sock"


### PR DESCRIPTION
We are using the DockerOperator and noticed that the logs are a bit confusing when there is an error in a Docker container (return code != 0) because Airflow shows the log output of the Docker container 3 times.

The logs of a failed run with the DockerOperator currently look like this:

```
[2023-08-29T13:12:32.261+0000] {docker.py:160} INFO - << log line from Docker container >>
[2023-08-29T13:12:34.308+0000] {docker.py:474} INFO - << log line from Docker container >>
[2023-08-29T13:12:34.308+0000] {docker.py:474} INFO - << log line from Docker container >>
...
...
...
[2023-08-29T13:39:15.959+0000] {taskinstance.py:1943} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/providers/docker/operators/docker.py", line 476, in execute
    return self._run_image()
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/providers/docker/operators/docker.py", line 338, in _run_image
    return self._run_image_with_mounts(self.mounts + [tmp_mount], add_tmp_variable=True)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/providers/docker/operators/docker.py", line 411, in _run_image_with_mounts
    raise AirflowException(f"Docker container failed: {repr(result)} lines {joined_log_lines}")
airflow.exceptions.AirflowException: Docker container failed: {'StatusCode': 1} lines << log line from Docker container >>
<< log line from Docker container >>
<< log line from Docker container >>
...
...
...
[2023-08-29T13:39:15.991+0000] {taskinstance.py:1400} INFO - Marking task as FAILED. dag_id=<< dag id >>, task_id=<< task id >>, execution_date=20230829T131212, start_date=20230829T131229, end_date=20230829T133915
[2023-08-29T13:39:16.226+0000] {standard_task_runner.py:104} ERROR - Failed to execute job 1948 for task << task id >> (Docker container failed: {'StatusCode': 1} lines << log line from Docker container >>
<< log line from Docker container >>
<< log line from Docker container >>
...
...
...
[2023-08-29T13:39:16.248+0000] {local_task_job_runner.py:228} INFO - Task exited with return code 1
[2023-08-29T13:39:16.463+0000] {taskinstance.py:2784} INFO - 0 downstream tasks scheduled from follow-on schedule check
```

This PR removes the output of the Docker container from the Airflow exception that is thrown. With this change the log output of the Docker container is only shown one single time in Airflow (regardless of the return code).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
