### PR TITLE
Clarify that DAG authors can also run code in DAG File Processor

### DIFF
--- a/docs/apache-airflow/security/security_model.rst
+++ b/docs/apache-airflow/security/security_model.rst
@@ -41,12 +41,12 @@ varying access and capabilities:
    model.
 
 2. **DAG Authors**: They can upload, modify, and delete DAG files. The
-   code in DAG files is executed on workers and in DAG File Processor. Note
-   that in the simple deployment configuration parsing DAGs is executed as
-   subprocess of the Scheduler process, but with Standalone DAG File Processor
-   Deployment managers might separate physically parsing from the Scheduler
+   code in DAG files is executed on workers and in the DAG File Processor. Note
+   that in the simple deployment configuration, parsing DAGs is executed as
+   a subprocess of the Scheduler process, but with Standalone DAG File Processor
+   deployment managers might separate parsing DAGs from the Scheduler process.
    Therefore, DAG authors can create and change code executed on workers
-   and DAG File Processor and potentially access the credentials that the DAG
+   and the DAG File Processor and potentially access the credentials that the DAG
    code uses to access external systems. DAG Authors have full access
    to the metadata database and internal audit logs.
 

--- a/docs/apache-airflow/security/security_model.rst
+++ b/docs/apache-airflow/security/security_model.rst
@@ -41,9 +41,13 @@ varying access and capabilities:
    model.
 
 2. **DAG Authors**: They can upload, modify, and delete DAG files. The
-   code in DAG files is executed on workers. Therefore, DAG authors can create
-   and change code executed on workers and potentially access the credentials
-   that DAG code uses to access external systems. DAG Authors have full access
+   code in DAG files is executed on workers and in DAG File Processor. Note
+   that in the simple deployment configuration parsing DAGs is executed as
+   subprocess of the Scheduler process, but with Standalone DAG File Processor
+   Deployment managers might separate physically parsing from the Scheduler
+   Therefore, DAG authors can create and change code executed on workers
+   and DAG File Processor and potentially access the credentials that the DAG
+   code uses to access external systems. DAG Authors have full access
    to the metadata database and internal audit logs.
 
 3. **Authenticated UI users**: They have access to the UI and API. See below


### PR DESCRIPTION
Small addition to our security model - it was not entirely clear that DAG authors can also execute code in DAG File Processor and that DAG File Processor can be run in standalone mode effectively physically separating machines where scheduler is run and where the code modified by DAG authors gets parsed.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
