### PR TITLE
Remove redirect from README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Apache Airflow is tested with:
 \* Experimental
 
 **Note**: MySQL 5.x versions are unable to or have limitations with
-running multiple schedulers -- please see the [Scheduler docs](https://airflow.apache.org/docs/apache-airflow/stable/scheduler.html).
+running multiple schedulers -- please see the [Scheduler docs](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/scheduler.html).
 MariaDB is not tested/recommended.
 
 **Note**: SQLite is used in Airflow tests. Do not use it in production. We recommend
@@ -117,9 +117,9 @@ is used in the [Community managed DockerHub image](https://hub.docker.com/p/apac
 ## Getting started
 
 Visit the official Airflow website documentation (latest **stable** release) for help with
-[installing Airflow](https://airflow.apache.org/docs/apache-airflow/stable/installation.html),
+[installing Airflow](https://airflow.apache.org/docs/apache-airflow/stable/installation/),
 [getting started](https://airflow.apache.org/docs/apache-airflow/stable/start.html), or walking
-through a more complete [tutorial](https://airflow.apache.org/docs/apache-airflow/stable/tutorial.html).
+through a more complete [tutorial](https://airflow.apache.org/docs/apache-airflow/stable/tutorial/).
 
 > Note: If you're looking for documentation for the main branch (latest development branch): you can find it on [s.apache.org/airflow-docs](https://s.apache.org/airflow-docs/).
 


### PR DESCRIPTION
These links resulted in a redirect before ending up at the right page.