### PR TITLE
Raise max runtime for sagemaker jobs in system test

### DIFF
--- a/tests/system/providers/amazon/aws/example_sagemaker.py
+++ b/tests/system/providers/amazon/aws/example_sagemaker.py
@@ -255,7 +255,7 @@ def set_up(env_id, role_arn):
         "ProcessingResources": {
             "ClusterConfig": resource_config,
         },
-        "StoppingCondition": {"MaxRuntimeInSeconds": 60},
+        "StoppingCondition": {"MaxRuntimeInSeconds": 300},
         "AppSpecification": {
             "ImageUri": ecr_repository_uri,
         },
@@ -294,7 +294,7 @@ def set_up(env_id, role_arn):
         "ExperimentConfig": {"ExperimentName": experiment_name},
         "ResourceConfig": resource_config,
         "RoleArn": role_arn,
-        "StoppingCondition": {"MaxRuntimeInSeconds": 60},
+        "StoppingCondition": {"MaxRuntimeInSeconds": 300},
         "TrainingJobName": training_job_name,
     }
     model_trained_weights = (
@@ -357,7 +357,7 @@ def set_up(env_id, role_arn):
             "OutputDataConfig": {"S3OutputPath": f"s3://{bucket_name}/{training_output_s3_key}"},
             "ResourceConfig": resource_config,
             "RoleArn": role_arn,
-            "StoppingCondition": {"MaxRuntimeInSeconds": 60},
+            "StoppingCondition": {"MaxRuntimeInSeconds": 300},
         },
     }
     transform_config = {


### PR DESCRIPTION
We've had several occurrences recently of training jobs being terminated before finishing because of this limit When this happens, the output are not produced, and the test fails. Thus it makes sense to give it a bit more time to complete.