### PR TITLE
Fix Google 10.7.0 changelog

### DIFF
--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -27,6 +27,49 @@
 Changelog
 ---------
 
+10.7.0
+......
+
+Features
+~~~~~~~~
+
+``Add CloudRunHook and operators (#33067)``
+``Add 'CloudBatchHook' and operators (#32606)``
+``Adding Support for Google Cloud's Data Pipelines Run Operator (#32846)``
+``Add parameter sftp_prefetch to SFTPToGCSOperator (#33274)``
+``Add Google Cloud's Data Pipelines Create Operator (#32843)``
+``Add Dataplex Data Quality operators. (#32256)``
+
+Bug Fixes
+~~~~~~~~~
+
+``Fix BigQueryCreateExternalTableOperator when using a foramt different to CSV (#33540)``
+``Fix DataplexDataQualityJobStatusSensor and add unit tests (#33440)``
+``Avoid importing pandas and numpy in runtime and module level (#33483)``
+
+Misc
+~~~~
+
+``Add missing template fields to DataformCreateCompilationResultOperator (#33585)``
+``Consolidate import and usage of pandas (#33480)``
+``Import utc from datetime and normalize its import (#33450)``
+
+
+.. Below changes are excluded from the changelog. Move them to
+   appropriate section above if needed. Do not delete the lines(!):
+   ``Refactor: Use random.choices (#33631)``
+   ``Further improvements for provider verification (#33670)``
+   ``Refactor: Remove useless str() calls (#33629)``
+   ``Refactor: lists and paths in dev (#33626)``
+   ``Do not create lists we don't need (#33519)``
+   ``Replace strftime with f-strings where nicer (#33455)``
+   ``Refactor: Better percentage formatting (#33595)``
+   ``Fix typos (double words and it's/its) (#33623)``
+   ``Fix system test example_cloud_storage_transfer_service_aws (#33429)``
+   ``Enable D205 Support (#33398)``
+   ``Update Error details for Generic Error Code  (#32847)``
+   ``D205 Support - Providers - Final Pass (#33303)``
+
 10.6.0
 ......
 
@@ -35,6 +78,7 @@ Features
 
 * ``openlineage, bigquery: add openlineage method support for BigQueryExecuteQueryOperator (#31293)``
 * ``Add GCS Requester Pays bucket support to GCSToS3Operator (#32760)``
+* ``Add system test and docs for CloudDataTransferServiceGCSToGCSOperator (#32960)``
 * ``Add a new parameter to SQL operators to specify conn id field (#30784)``
 
 Bug Fixes
@@ -44,21 +88,20 @@ Bug Fixes
 * ``Fix system test for MetastoreHivePartitionSensor (#32861)``
 * ``Fix catching 409 error (#33173)``
 * ``make 'sql' a cached property in 'BigQueryInsertJobOperator' (#33218)``
-* ``Handle multiple connections using exceptions (#32365)``
 
 Misc
 ~~~~
 
-* ``Refactor of links in Dataproc. (#31895)``
 * ``refactor(providers.google): use module level __getattr__ for DATAPROC_JOB_LOG_LINK to DATAPROC_JOB_LINK and add deprecation warning (#33189)``
-* ``Get rid of Python2 numeric relics (#33050)``
-* ``openlineage,gcs: use proper name for openlineage methods (#32956)``
-* ``Alias 'DATAPROC_JOB_LOG_LINK' to 'DATAPROC_JOB_LINK' (#33148)``
 
 .. Below changes are excluded from the changelog. Move them to
    appropriate section above if needed. Do not delete the lines(!):
-   * ``Add system test and docs for CloudDataTransferServiceGCSToGCSOperator (#32960)``
+   * ``Get rid of Python2 numeric relics (#33050)``
+   * ``Refactor of links in Dataproc. (#31895)``
+   * ``Handle multiple connections using exceptions (#32365)``
+   * ``openlineage,gcs: use proper name for openlineage methods (#32956)``
    * ``Fix DataflowStartSqlJobOperator system test (#32823)``
+   * ``Alias 'DATAPROC_JOB_LOG_LINK' to 'DATAPROC_JOB_LINK' (#33148)``
    * ``Prepare docs for Aug 2023 1st wave of Providers (#33128)``
    * ``Prepare docs for RC2 providers (google, redis) (#33185)``
 


### PR DESCRIPTION
somehow log was corrupted and missed when I worked on release locally.
The release itself is fine just missing the log.

I will regenerate the log for doc-site as well