### PR TITLE
Add deferrable mode to DataplexGetDataQualityScanResultOperator, DataplexRunDataQualityScanOperator

### DIFF
--- a/airflow/providers/google/cloud/hooks/dataplex.py
+++ b/airflow/providers/google/cloud/hooks/dataplex.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 from google.api_core.client_options import ClientOptions
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
-from google.cloud.dataplex_v1 import DataplexServiceClient, DataScanServiceClient
+from google.cloud.dataplex_v1 import DataplexServiceClient, DataScanServiceAsyncClient, DataScanServiceClient
 from google.cloud.dataplex_v1.types import (
     Asset,
     DataScan,
@@ -35,7 +35,7 @@ from google.protobuf.field_mask_pb2 import FieldMask
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.common.consts import CLIENT_INFO
-from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
+from airflow.providers.google.common.hooks.base_google import GoogleBaseAsyncHook, GoogleBaseHook
 
 if TYPE_CHECKING:
     from google.api_core.operation import Operation
@@ -858,4 +858,71 @@ class DataplexHook(GoogleBaseHook):
             timeout=timeout,
             metadata=metadata,
         )
+        return result
+
+
+class DataplexAsyncHook(GoogleBaseAsyncHook):
+    """
+    Asynchronous Hook for Google Cloud Dataplex APIs.
+
+    All the methods in the hook where project_id is used must be called with
+    keyword arguments rather than positional.
+    """
+
+    sync_hook_class = DataplexHook
+
+    def __init__(
+        self,
+        gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
+    ) -> None:
+
+        super().__init__(gcp_conn_id=gcp_conn_id, impersonation_chain=impersonation_chain)
+
+    async def get_dataplex_data_scan_client(self) -> DataScanServiceAsyncClient:
+        """Returns DataScanServiceAsyncClient."""
+        client_options = ClientOptions(api_endpoint="dataplex.googleapis.com:443")
+
+        return DataScanServiceAsyncClient(
+            credentials=(await self.get_sync_hook()).get_credentials(),
+            client_info=CLIENT_INFO,
+            client_options=client_options,
+        )
+
+    @GoogleBaseHook.fallback_to_default_project_id
+    async def get_data_scan_job(
+        self,
+        project_id: str,
+        region: str,
+        data_scan_id: str | None = None,
+        job_id: str | None = None,
+        retry: Retry | _MethodDefault = DEFAULT,
+        timeout: float | None = None,
+        metadata: Sequence[tuple[str, str]] = (),
+    ) -> Any:
+        """
+        Gets a DataScan Job resource.
+
+        :param project_id: Required. The ID of the Google Cloud project that the lake belongs to.
+        :param region: Required. The ID of the Google Cloud region that the lake belongs to.
+        :param data_scan_id: Required. DataScan identifier.
+        :param job_id: Required. The resource name of the DataScanJob:
+            projects/{project_id}/locations/{region}/dataScans/{data_scan_id}/jobs/{data_scan_job_id}
+        :param retry: A retry object used  to retry requests. If `None` is specified, requests
+            will not be retried.
+        :param timeout: The amount of time, in seconds, to wait for the request to complete.
+            Note that if `retry` is specified, the timeout applies to each individual attempt.
+        :param metadata: Additional metadata that is provided to the method.
+        """
+        client = await self.get_dataplex_data_scan_client()
+
+        name = f"projects/{project_id}/locations/{region}/dataScans/{data_scan_id}/jobs/{job_id}"
+        result = await client.get_data_scan_job(
+            request={"name": name, "view": "FULL"},
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+
         return result

--- a/airflow/providers/google/cloud/operators/dataplex.py
+++ b/airflow/providers/google/cloud/operators/dataplex.py
@@ -22,6 +22,7 @@ from time import sleep
 from typing import TYPE_CHECKING, Any, Sequence
 
 from airflow import AirflowException
+from airflow.providers.google.cloud.triggers.dataplex import DataplexDataQualityJobTrigger
 
 if TYPE_CHECKING:
     from google.protobuf.field_mask_pb2 import FieldMask
@@ -34,6 +35,7 @@ from google.api_core.retry import Retry, exponential_sleep_generator
 from google.cloud.dataplex_v1.types import Asset, DataScan, DataScanJob, Lake, Task, Zone
 from googleapiclient.errors import HttpError
 
+from airflow.configuration import conf
 from airflow.providers.google.cloud.hooks.dataplex import AirflowDataQualityScanException, DataplexHook
 from airflow.providers.google.cloud.links.dataplex import (
     DataplexLakeLink,
@@ -895,6 +897,9 @@ class DataplexRunDataQualityScanOperator(GoogleCloudBaseOperator):
     :param result_timeout: Value in seconds for which operator will wait for the Data Quality scan result
         when the flag `asynchronous = False`.
         Throws exception if there is no result found after specified amount of seconds.
+    :param polling_interval_seconds: time in seconds between polling for job completion.
+        The value is considered only when running in deferrable mode. Must be greater than 0.
+    :param deferrable: Run operator in the deferrable mode.
 
     :return: Dataplex Data Quality scan job id.
     """
@@ -915,6 +920,8 @@ class DataplexRunDataQualityScanOperator(GoogleCloudBaseOperator):
         asynchronous: bool = False,
         fail_on_dq_failure: bool = False,
         result_timeout: float = 60.0 * 10,
+        deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
+        polling_interval_seconds: int = 10,
         *args,
         **kwargs,
     ) -> None:
@@ -932,6 +939,8 @@ class DataplexRunDataQualityScanOperator(GoogleCloudBaseOperator):
         self.asynchronous = asynchronous
         self.fail_on_dq_failure = fail_on_dq_failure
         self.result_timeout = result_timeout
+        self.deferrable = deferrable
+        self.polling_interval_seconds = polling_interval_seconds
 
     def execute(self, context: Context) -> str:
         hook = DataplexHook(
@@ -949,6 +958,24 @@ class DataplexRunDataQualityScanOperator(GoogleCloudBaseOperator):
             metadata=self.metadata,
         )
         job_id = result.job.name.split("/")[-1]
+
+        if self.deferrable:
+            if self.asynchronous:
+                raise AirflowException(
+                    "Both asynchronous and deferrable parameters were passed. Please, provide only one."
+                )
+            self.defer(
+                trigger=DataplexDataQualityJobTrigger(
+                    job_id=job_id,
+                    data_scan_id=self.data_scan_id,
+                    project_id=self.project_id,
+                    region=self.region,
+                    gcp_conn_id=self.gcp_conn_id,
+                    impersonation_chain=self.impersonation_chain,
+                    polling_interval_seconds=self.polling_interval_seconds,
+                ),
+                method_name="execute_complete",
+            )
         if not self.asynchronous:
             job = hook.wait_for_data_scan_job(
                 job_id=job_id,
@@ -972,6 +999,31 @@ class DataplexRunDataQualityScanOperator(GoogleCloudBaseOperator):
             else:
                 self.log.info("Data Quality job execution returned status: %s", job.status)
 
+        return job_id
+
+    def execute_complete(self, context, event=None) -> None:
+        """
+        Callback for when the trigger fires - returns immediately.
+
+        Relies on trigger to throw an exception, otherwise it assumes execution was
+        successful.
+        """
+        job_state = event["job_state"]
+        job_id = event["job_id"]
+        if job_state == DataScanJob.State.FAILED:
+            raise AirflowException(f"Job failed:\n{job_id}")
+        if job_state == DataScanJob.State.CANCELLED:
+            raise AirflowException(f"Job was cancelled:\n{job_id}")
+        if job_state == DataScanJob.State.SUCCEEDED:
+            job = event["job"]
+            if not job["data_quality_result"]["passed"]:
+                if self.fail_on_dq_failure:
+                    raise AirflowDataQualityScanException(
+                        f"Data Quality job {job_id} execution failed due to failure of its scanning "
+                        f"rules: {self.data_scan_id}"
+                    )
+            else:
+                self.log.info("Data Quality job executed successfully.")
         return job_id
 
 
@@ -1006,6 +1058,9 @@ class DataplexGetDataQualityScanResultOperator(GoogleCloudBaseOperator):
     :param result_timeout: Value in seconds for which operator will wait for the Data Quality scan result
         when the flag `wait_for_result = True`.
         Throws exception if there is no result found after specified amount of seconds.
+    :param polling_interval_seconds: time in seconds between polling for job completion.
+        The value is considered only when running in deferrable mode. Must be greater than 0.
+    :param deferrable: Run operator in the deferrable mode.
 
     :return: Dict representing DataScanJob.
         When the job completes with a successful status, information about the Data Quality result
@@ -1029,6 +1084,8 @@ class DataplexGetDataQualityScanResultOperator(GoogleCloudBaseOperator):
         fail_on_dq_failure: bool = False,
         wait_for_results: bool = True,
         result_timeout: float = 60.0 * 10,
+        deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
+        polling_interval_seconds: int = 10,
         *args,
         **kwargs,
     ) -> None:
@@ -1046,6 +1103,8 @@ class DataplexGetDataQualityScanResultOperator(GoogleCloudBaseOperator):
         self.fail_on_dq_failure = fail_on_dq_failure
         self.wait_for_results = wait_for_results
         self.result_timeout = result_timeout
+        self.deferrable = deferrable
+        self.polling_interval_seconds = polling_interval_seconds
 
     def execute(self, context: Context) -> dict:
         hook = DataplexHook(
@@ -1070,13 +1129,27 @@ class DataplexGetDataQualityScanResultOperator(GoogleCloudBaseOperator):
             self.job_id = job_id.split("/")[-1]
 
         if self.wait_for_results:
-            job = hook.wait_for_data_scan_job(
-                job_id=self.job_id,
-                data_scan_id=self.data_scan_id,
-                project_id=self.project_id,
-                region=self.region,
-                result_timeout=self.result_timeout,
-            )
+            if self.deferrable:
+                self.defer(
+                    trigger=DataplexDataQualityJobTrigger(
+                        job_id=self.job_id,
+                        data_scan_id=self.data_scan_id,
+                        project_id=self.project_id,
+                        region=self.region,
+                        gcp_conn_id=self.gcp_conn_id,
+                        impersonation_chain=self.impersonation_chain,
+                        polling_interval_seconds=self.polling_interval_seconds,
+                    ),
+                    method_name="execute_complete",
+                )
+            else:
+                job = hook.wait_for_data_scan_job(
+                    job_id=self.job_id,
+                    data_scan_id=self.data_scan_id,
+                    project_id=self.project_id,
+                    region=self.region,
+                    result_timeout=self.result_timeout,
+                )
         else:
             job = hook.get_data_scan_job(
                 project_id=self.project_id,
@@ -1104,6 +1177,34 @@ class DataplexGetDataQualityScanResultOperator(GoogleCloudBaseOperator):
         result["state"] = DataScanJob.State(result["state"]).name
 
         return result
+
+    def execute_complete(self, context, event=None) -> None:
+        """
+        Callback for when the trigger fires - returns immediately.
+
+        Relies on trigger to throw an exception, otherwise it assumes execution was
+        successful.
+        """
+        job_state = event["job_state"]
+        job_id = event["job_id"]
+        job = event["job"]
+        if job_state == DataScanJob.State.FAILED:
+            raise AirflowException(f"Job failed:\n{job_id}")
+        if job_state == DataScanJob.State.CANCELLED:
+            raise AirflowException(f"Job was cancelled:\n{job_id}")
+        if job_state == DataScanJob.State.SUCCEEDED:
+            if not job["data_quality_result"]["passed"]:
+                if self.fail_on_dq_failure:
+                    raise AirflowDataQualityScanException(
+                        f"Data Quality job {self.job_id} execution failed due to failure of its scanning "
+                        f"rules: {self.data_scan_id}"
+                    )
+            else:
+                self.log.info("Data Quality job executed successfully")
+        else:
+            self.log.info("Data Quality job execution returned status: %s", job_state)
+
+        return job
 
 
 class DataplexCreateZoneOperator(GoogleCloudBaseOperator):

--- a/airflow/providers/google/cloud/triggers/dataplex.py
+++ b/airflow/providers/google/cloud/triggers/dataplex.py
@@ -1,0 +1,110 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""This module contains Google Dataplex triggers."""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator, Sequence
+
+from google.cloud.dataplex_v1.types import DataScanJob
+
+from airflow.providers.google.cloud.hooks.dataplex import DataplexAsyncHook
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+
+class DataplexDataQualityJobTrigger(BaseTrigger):
+    """
+    DataplexDataQualityJobTrigger runs on the trigger worker and waits for the job to be `SUCCEEDED` state.
+
+    :param job_id: Optional. The ID of a Dataplex job.
+    :param data_scan_id: Required. DataScan identifier.
+    :param project_id: Google Cloud Project where the job is running.
+    :param region: The ID of the Google Cloud region that the job belongs to.
+    :param gcp_conn_id: Optional, the connection ID used to connect to Google Cloud Platform.
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :param polling_interval_seconds: polling period in seconds to check for the status.
+    """
+
+    def __init__(
+        self,
+        job_id: str | None,
+        data_scan_id: str,
+        project_id: str | None,
+        region: str,
+        gcp_conn_id: str = "google_cloud_default",
+        polling_interval_seconds: int = 10,
+        impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
+    ):
+
+        super().__init__(**kwargs)
+        self.job_id = job_id
+        self.data_scan_id = data_scan_id
+        self.project_id = project_id
+        self.region = region
+        self.gcp_conn_id = gcp_conn_id
+        self.polling_interval_seconds = polling_interval_seconds
+        self.impersonation_chain = impersonation_chain
+
+    def serialize(self):
+        return (
+            "airflow.providers.google.cloud.triggers.dataplex.DataplexDataQualityJobTrigger",
+            {
+                "job_id": self.job_id,
+                "data_scan_id": self.data_scan_id,
+                "project_id": self.project_id,
+                "region": self.region,
+                "gcp_conn_id": self.gcp_conn_id,
+                "impersonation_chain": self.impersonation_chain,
+                "polling_interval_seconds": self.polling_interval_seconds,
+            },
+        )
+
+    async def run(self) -> AsyncIterator[TriggerEvent]:
+        hook = DataplexAsyncHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
+        while True:
+            job = await hook.get_data_scan_job(
+                project_id=self.project_id,
+                region=self.region,
+                job_id=self.job_id,
+                data_scan_id=self.data_scan_id,
+            )
+            state = job.state
+            if state in (DataScanJob.State.FAILED, DataScanJob.State.SUCCEEDED, DataScanJob.State.CANCELLED):
+                break
+            self.log.info(
+                "Current state is: %s, sleeping for %s seconds.",
+                DataScanJob.State(state).name,
+                self.polling_interval_seconds,
+            )
+            await asyncio.sleep(self.polling_interval_seconds)
+        yield TriggerEvent({"job_id": self.job_id, "job_state": state, "job": self._convert_to_dict(job)})
+
+    def _convert_to_dict(self, job: DataScanJob) -> dict:
+        """Returns a representation of a DataScanJob instance as a dict."""
+        return DataScanJob.to_dict(job)

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -905,6 +905,9 @@ triggers:
   - integration-name: Google Data Fusion
     python-modules:
       - airflow.providers.google.cloud.triggers.datafusion
+  - integration-name: Google Dataplex
+    python-modules:
+      - airflow.providers.google.cloud.triggers.dataplex
   - integration-name: Google Dataproc
     python-modules:
       - airflow.providers.google.cloud.triggers.dataproc

--- a/docs/apache-airflow-providers-google/operators/cloud/dataplex.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/dataplex.rst
@@ -217,6 +217,14 @@ To check that running Dataplex Data Quality scan succeeded you can use:
     :start-after: [START howto_dataplex_data_scan_job_state_sensor]
     :end-before: [END howto_dataplex_data_scan_job_state_sensor]
 
+Also for this action you can use operator in the deferrable mode:
+
+.. exampleinclude:: /../../tests/system/providers/google/cloud/dataplex/example_dataplex_dq.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_dataplex_run_data_quality_def_operator]
+    :end-before: [END howto_dataplex_run_data_quality_def_operator]
+
 Get a Data Quality scan job
 ---------------------------
 
@@ -229,6 +237,14 @@ To get a Data Quality scan job you can use:
     :dedent: 4
     :start-after: [START howto_dataplex_get_data_quality_job_operator]
     :end-before: [END howto_dataplex_get_data_quality_job_operator]
+
+Also for this action you can use operator in the deferrable mode:
+
+.. exampleinclude:: /../../tests/system/providers/google/cloud/dataplex/example_dataplex_dq.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_dataplex_get_data_quality_job_def_operator]
+    :end-before: [END howto_dataplex_get_data_quality_job_def_operator]
 
 Create a zone
 -------------

--- a/tests/providers/google/cloud/operators/test_dataplex.py
+++ b/tests/providers/google/cloud/operators/test_dataplex.py
@@ -18,8 +18,10 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
 from google.api_core.gapic_v1.method import DEFAULT
 
+from airflow.exceptions import TaskDeferred
 from airflow.providers.google.cloud.operators.dataplex import (
     DataplexCreateAssetOperator,
     DataplexCreateLakeOperator,
@@ -36,6 +38,8 @@ from airflow.providers.google.cloud.operators.dataplex import (
     DataplexListTasksOperator,
     DataplexRunDataQualityScanOperator,
 )
+from airflow.providers.google.cloud.triggers.dataplex import DataplexDataQualityJobTrigger
+from airflow.providers.google.common.consts import GOOGLE_DEFAULT_DEFERRABLE_METHOD_NAME
 
 HOOK_STR = "airflow.providers.google.cloud.operators.dataplex.DataplexHook"
 TASK_STR = "airflow.providers.google.cloud.operators.dataplex.Task"
@@ -289,13 +293,48 @@ class TestDataplexRunDataQualityScanOperator:
             metadata=(),
         )
 
+    @mock.patch(HOOK_STR)
+    @mock.patch(DATASCANJOB_STR)
+    def test_execute_deferrable(self, mock_data_scan_job, hook_mock):
+        op = DataplexRunDataQualityScanOperator(
+            task_id="execute_data_scan",
+            project_id=PROJECT_ID,
+            region=REGION,
+            data_scan_id=DATA_SCAN_ID,
+            api_version=API_VERSION,
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+            deferrable=True,
+        )
+
+        with pytest.raises(TaskDeferred) as exc:
+            op.execute(mock.MagicMock())
+
+        hook_mock.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            api_version=API_VERSION,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+        hook_mock.return_value.run_data_scan.assert_called_once_with(
+            project_id=PROJECT_ID,
+            region=REGION,
+            data_scan_id=DATA_SCAN_ID,
+            retry=DEFAULT,
+            timeout=None,
+            metadata=(),
+        )
+        hook_mock.return_value.wait_for_data_scan_job.assert_not_called()
+
+        assert isinstance(exc.value.trigger, DataplexDataQualityJobTrigger)
+        assert exc.value.method_name == GOOGLE_DEFAULT_DEFERRABLE_METHOD_NAME
+
 
 class TestDataplexGetDataQualityScanResultOperator:
     @mock.patch(HOOK_STR)
     @mock.patch(DATASCANJOB_STR)
     def test_execute(self, mock_data_scan_job, hook_mock):
         op = DataplexGetDataQualityScanResultOperator(
-            task_id="get_data_scan",
+            task_id="get_data_scan_result",
             project_id=PROJECT_ID,
             region=REGION,
             job_id=JOB_ID,
@@ -321,6 +360,36 @@ class TestDataplexGetDataQualityScanResultOperator:
             timeout=None,
             metadata=(),
         )
+
+    @mock.patch(HOOK_STR)
+    @mock.patch(DATASCANJOB_STR)
+    def test_execute_deferrable(self, mock_data_scan_job, hook_mock):
+        op = DataplexGetDataQualityScanResultOperator(
+            task_id="get_data_scan_result",
+            project_id=PROJECT_ID,
+            region=REGION,
+            job_id=JOB_ID,
+            data_scan_id=DATA_SCAN_ID,
+            api_version=API_VERSION,
+            wait_for_results=True,
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+            deferrable=True,
+        )
+
+        with pytest.raises(TaskDeferred) as exc:
+            op.execute(mock.MagicMock())
+
+        hook_mock.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            api_version=API_VERSION,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+
+        hook_mock.return_value.wait_for_data_scan_job.assert_not_called()
+
+        assert isinstance(exc.value.trigger, DataplexDataQualityJobTrigger)
+        assert exc.value.method_name == GOOGLE_DEFAULT_DEFERRABLE_METHOD_NAME
 
 
 class TestDataplexCreateAssetOperator:

--- a/tests/providers/google/cloud/triggers/test_dataplex.py
+++ b/tests/providers/google/cloud/triggers/test_dataplex.py
@@ -1,0 +1,135 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest import mock
+
+import pytest
+from google.cloud.dataplex_v1.types import DataScanJob
+
+from airflow.providers.google.cloud.triggers.dataplex import DataplexDataQualityJobTrigger
+from airflow.triggers.base import TriggerEvent
+
+TEST_PROJECT_ID = "project-id"
+TEST_REGION = "region"
+TEST_POLL_INTERVAL = 5
+TEST_GCP_CONN_ID = "test_conn"
+TEST_JOB_ID = "test_job_id"
+TEST_DATA_SCAN_ID = "test_data_scan_id"
+HOOK_STR = "airflow.providers.google.cloud.hooks.dataplex.DataplexAsyncHook.{}"
+TRIGGER_STR = "airflow.providers.google.cloud.triggers.dataplex.DataplexDataQualityJobTrigger.{}"
+
+
+@pytest.fixture
+def trigger():
+    return DataplexDataQualityJobTrigger(
+        job_id=TEST_JOB_ID,
+        data_scan_id=TEST_DATA_SCAN_ID,
+        project_id=TEST_PROJECT_ID,
+        region=TEST_REGION,
+        gcp_conn_id=TEST_GCP_CONN_ID,
+        impersonation_chain=None,
+        polling_interval_seconds=TEST_POLL_INTERVAL,
+    )
+
+
+@pytest.fixture()
+def async_get_data_scan_job():
+    def func(**kwargs):
+        m = mock.MagicMock()
+        m.configure_mock(**kwargs)
+        f = asyncio.Future()
+        f.set_result(m)
+        return f
+
+    return func
+
+
+class TestDataplexDataQualityJobTrigger:
+    def test_async_dataplex_job_trigger_serialization_should_execute_successfully(self, trigger):
+        classpath, kwargs = trigger.serialize()
+        assert classpath == "airflow.providers.google.cloud.triggers.dataplex.DataplexDataQualityJobTrigger"
+        assert kwargs == {
+            "job_id": TEST_JOB_ID,
+            "data_scan_id": TEST_DATA_SCAN_ID,
+            "project_id": TEST_PROJECT_ID,
+            "region": TEST_REGION,
+            "gcp_conn_id": TEST_GCP_CONN_ID,
+            "impersonation_chain": None,
+            "polling_interval_seconds": TEST_POLL_INTERVAL,
+        }
+
+    @pytest.mark.asyncio
+    @mock.patch(TRIGGER_STR.format("_convert_to_dict"))
+    @mock.patch(HOOK_STR.format("get_data_scan_job"))
+    async def test_async_dataplex_job_triggers_on_success_should_execute_successfully(
+        self, mock_hook, mock_convert_to_dict, trigger, async_get_data_scan_job
+    ):
+        mock_hook.return_value = async_get_data_scan_job(
+            state=DataScanJob.State.SUCCEEDED,
+        )
+        mock_convert_to_dict.return_value = {}
+
+        generator = trigger.run()
+        actual_event = await generator.asend(None)
+
+        expected_event = TriggerEvent(
+            {
+                "job_id": TEST_JOB_ID,
+                "job_state": DataScanJob.State.SUCCEEDED,
+                "job": {},
+            }
+        )
+        assert expected_event == actual_event
+
+    @pytest.mark.asyncio
+    @mock.patch(TRIGGER_STR.format("_convert_to_dict"))
+    @mock.patch(HOOK_STR.format("get_data_scan_job"))
+    async def test_async_dataplex_job_trigger_run_returns_error_event(
+        self, mock_hook, mock_convert_to_dict, trigger, async_get_data_scan_job
+    ):
+        mock_hook.return_value = async_get_data_scan_job(
+            state=DataScanJob.State.FAILED,
+        )
+        mock_convert_to_dict.return_value = {}
+
+        actual_event = await (trigger.run()).asend(None)
+        await asyncio.sleep(0.5)
+
+        expected_event = TriggerEvent(
+            {"job_id": TEST_JOB_ID, "job_state": DataScanJob.State.FAILED, "job": {}}
+        )
+        assert expected_event == actual_event
+
+    @pytest.mark.asyncio
+    @mock.patch(HOOK_STR.format("get_data_scan_job"))
+    async def test_async_dataplex_job_run_loop_is_still_running(
+        self, mock_hook, trigger, caplog, async_get_data_scan_job
+    ):
+        mock_hook.return_value = async_get_data_scan_job(
+            state=DataScanJob.State.RUNNING,
+        )
+
+        caplog.set_level(logging.INFO)
+
+        task = asyncio.create_task(trigger.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        assert not task.done()
+        assert f"Current state is: {DataScanJob.State.RUNNING}, sleeping for {TEST_POLL_INTERVAL} seconds."

--- a/tests/system/providers/google/cloud/dataplex/example_dataplex_dq.py
+++ b/tests/system/providers/google/cloud/dataplex/example_dataplex_dq.py
@@ -261,6 +261,31 @@ with models.DAG(
         data_scan_id=DATA_SCAN_ID,
     )
     # [END howto_dataplex_get_data_quality_job_operator]
+    # [START howto_dataplex_run_data_quality_def_operator]
+    run_data_scan_def = DataplexRunDataQualityScanOperator(
+        task_id="run_data_scan_def",
+        project_id=PROJECT_ID,
+        region=REGION,
+        data_scan_id=DATA_SCAN_ID,
+        deferrable=True,
+    )
+    # [END howto_dataplex_run_data_quality_def_operator]
+    run_data_scan_async_2 = DataplexRunDataQualityScanOperator(
+        task_id="run_data_scan_async_2",
+        project_id=PROJECT_ID,
+        region=REGION,
+        data_scan_id=DATA_SCAN_ID,
+        asynchronous=True,
+    )
+    # [START howto_dataplex_get_data_quality_job_def_operator]
+    get_data_scan_job_result_def = DataplexGetDataQualityScanResultOperator(
+        task_id="get_data_scan_job_result_def",
+        project_id=PROJECT_ID,
+        region=REGION,
+        data_scan_id=DATA_SCAN_ID,
+        deferrable=True,
+    )
+    # [END howto_dataplex_get_data_quality_job_def_operator]
     # [START howto_dataplex_delete_asset_operator]
     delete_asset = DataplexDeleteAssetOperator(
         task_id="delete_asset",
@@ -323,6 +348,9 @@ with models.DAG(
         run_data_scan_async,
         get_data_scan_job_status,
         get_data_scan_job_result_2,
+        run_data_scan_def,
+        run_data_scan_async_2,
+        get_data_scan_job_result_def,
         # TEST TEARDOWN
         delete_asset,
         delete_zone,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Add deferrable mode to DataplexGetDataQualityScanResultOperator, DataplexRunDataQualityScanOperator
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
