### PR TITLE
Make `aws.session_factory` part of Amazon provider configuration documentation

### DIFF
--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -711,3 +711,16 @@ additional-extras:
   - name: cncf.kubernetes
     dependencies:
       - apache-airflow-providers-cncf-kubernetes>=7.2.0
+
+config:
+  aws:
+    description: This section applies settings for Amazon Web Services (AWS) integration.
+    options:
+      session_factory:
+        description: |
+          Full import path to the class which implements custom session factory for ``boto3.session.Session``,
+          for more detail please have a look at :ref:`howto/connection:aws:session-factory`.
+        default: ~
+        example: my_company.aws.MyCustomSessionFactory
+        type: string
+        version_added: ~

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -718,8 +718,9 @@ config:
     options:
       session_factory:
         description: |
-          Full import path to the class which implements a custom session factory for ``boto3.session.Session``.
-          For more details please have a look at :ref:`howto/connection:aws:session-factory`.
+          Full import path to the class which implements a custom session factory for
+          ``boto3.session.Session``. For more details please have a look at
+          :ref:`howto/connection:aws:session-factory`.
         default: ~
         example: my_company.aws.MyCustomSessionFactory
         type: string

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -724,4 +724,4 @@ config:
         default: ~
         example: my_company.aws.MyCustomSessionFactory
         type: string
-        version_added: ~
+        version_added: 3.1.1

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -714,12 +714,12 @@ additional-extras:
 
 config:
   aws:
-    description: This section applies settings for Amazon Web Services (AWS) integration.
+    description: This section contains settings for Amazon Web Services (AWS) integration.
     options:
       session_factory:
         description: |
-          Full import path to the class which implements custom session factory for ``boto3.session.Session``,
-          for more detail please have a look at :ref:`howto/connection:aws:session-factory`.
+          Full import path to the class which implements a custom session factory for ``boto3.session.Session``.
+          For more details please have a look at :ref:`howto/connection:aws:session-factory`.
         default: ~
         example: my_company.aws.MyCustomSessionFactory
         type: string

--- a/docs/apache-airflow-providers-amazon/configurations-ref.rst
+++ b/docs/apache-airflow-providers-amazon/configurations-ref.rst
@@ -1,0 +1,18 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. include:: ../exts/includes/providers-configurations-ref.rst

--- a/docs/apache-airflow-providers-amazon/index.rst
+++ b/docs/apache-airflow-providers-amazon/index.rst
@@ -40,6 +40,7 @@
     Deferrable Operators <deferrable>
     Secrets backends <secrets-backends/index>
     Logging for Tasks <logging/index>
+    Configuration <configurations-ref>
 
 .. toctree::
     :hidden:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

Add `[aws] session_factory` part of AWS Documentation. This configuration option added in https://github.com/apache/airflow/pull/21778 and 3.1.1 version of provider.

This PR doesn't add it in [global configuration reference](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#configuration-reference), better add after documentation to Amazon Provider updated, so we do not have missing link in documentation


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
