### PR TITLE
Differentiate 0 and unset as a default param values

### DIFF
--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -125,7 +125,7 @@
     {% elif form_details.schema and ("integer" in form_details.schema.type or "number" in form_details.schema.type) %}
       <input class="form-control" name="element_{{ form_key }}" id="element_{{ form_key }}"
              valuetype="number" {% if "integer" in form_details.schema.type %} type="number" {% else %} type="decimal" {% endif %}
-        value="{% if form_details.value %}{{ form_details.value }}{% endif %}"
+        value="{% if form_details.value is not none %}{{ form_details.value }}{% endif %}"
         {%- if form_details.schema.minimum %} min="{{ form_details.schema.minimum }}"{% endif %}
         {%- if form_details.schema.maximum %} max="{{ form_details.schema.maximum }}"{% endif %}
         {%- if form_details.schema.type and not "null" in form_details.schema.type %} required=""{% endif %} />


### PR DESCRIPTION
Re: https://github.com/apache/airflow/issues/33923

Pretty self explanatory, since python's zero is falsey, using `{% if form.details.value %}` led to the default value being omitted if it was a zero. This minor change makes a zero default value explicitly zero, and if a user wants to default to null they can use something like:

```python
Param(None, type=["integer", "null"])
```

So given the following DAG:
```python
with DAG(
    "params-dag",
    schedule=None,
    params={
        "integer_param": Param(5, type="integer"),
        "zero_integer_param": Param(0, type="integer"),
        "unset_integer_param": Param(None, type=["integer", "null"]),
    },
) as dag:
```

This was the default form before:
<img width="1875" alt="image" src="https://github.com/apache/airflow/assets/16950874/741e86f1-58db-47e9-99a0-f8c2f1516271">

And this is it after:
<img width="1892" alt="image" src="https://github.com/apache/airflow/assets/16950874/ce4fa7d9-e5c5-4a00-b293-b438b7da2784">

List-type params are a whole different problem, and there's a lot of discussion in the original issue, so lets leave that for another PR? In the current implementation there's no way to explicitly pass an empty list through the form interface so I think that some changes will be definitely be required.
