### PR TITLE
Move the try outside the loop when this is possible in Airflow core

### DIFF
--- a/airflow/api/__init__.py
+++ b/airflow/api/__init__.py
@@ -36,12 +36,12 @@ def load_auth():
         pass
 
     backends = []
-    for backend in auth_backends.split(","):
-        try:
+    try:
+        for backend in auth_backends.split(","):
             auth = import_module(backend.strip())
             log.info("Loaded API auth backend: %s", backend)
             backends.append(auth)
-        except ImportError as err:
-            log.critical("Cannot import %s for API authentication due to: %s", backend, err)
-            raise AirflowException(err)
+    except ImportError as err:
+        log.critical("Cannot import %s for API authentication due to: %s", backend, err)
+        raise AirflowException(err)
     return backends

--- a/airflow/cli/commands/standalone_command.py
+++ b/airflow/cli/commands/standalone_command.py
@@ -94,8 +94,8 @@ class StandaloneCommand:
             command.start()
         # Run output loop
         shown_ready = False
-        while True:
-            try:
+        try:
+            while True:
                 # Print all the current lines onto the screen
                 self.update_output()
                 # Print info banner when all components are ready and the
@@ -111,8 +111,8 @@ class StandaloneCommand:
                     shown_ready = True
                 # Ensure we idle-sleep rather than fast-looping
                 time.sleep(0.1)
-            except KeyboardInterrupt:
-                break
+        except KeyboardInterrupt:
+            pass
         # Stop subcommand threads
         self.print_output("standalone", "Shutting down components")
         for command in self.subcommands.values():

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -24,6 +24,7 @@ LocalExecutor.
 """
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import subprocess
@@ -331,15 +332,13 @@ class LocalExecutor(BaseExecutor):
 
         def sync(self):
             """Sync will get called periodically by the heartbeat method."""
-            try:
+            with contextlib.suppress(Empty):
                 while True:
                     results = self.executor.result_queue.get_nowait()
                     try:
                         self.executor.change_state(*results)
                     finally:
                         self.executor.result_queue.task_done()
-            except Empty:
-                pass
 
         def end(self):
             """

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -331,15 +331,15 @@ class LocalExecutor(BaseExecutor):
 
         def sync(self):
             """Sync will get called periodically by the heartbeat method."""
-            while True:
-                try:
+            try:
+                while True:
                     results = self.executor.result_queue.get_nowait()
                     try:
                         self.executor.change_state(*results)
                     finally:
                         self.executor.result_queue.task_done()
-                except Empty:
-                    break
+            except Empty:
+                pass
 
         def end(self):
             """

--- a/airflow/jobs/triggerer_job_runner.py
+++ b/airflow/jobs/triggerer_job_runner.py
@@ -468,8 +468,8 @@ class TriggerRunner(threading.Thread, LoggingMixin):
         """
         watchdog = asyncio.create_task(self.block_watchdog())
         last_status = time.time()
-        while not self.stop:
-            try:
+        try:
+            while not self.stop:
                 # Run core logic
                 await self.create_triggers()
                 await self.cancel_triggers()
@@ -481,9 +481,9 @@ class TriggerRunner(threading.Thread, LoggingMixin):
                     count = len(self.triggers)
                     self.log.info("%i triggers currently running", count)
                     last_status = time.time()
-            except Exception:
-                self.stop = True
-                raise
+        except Exception:
+            self.stop = True
+            raise
         # Wait for watchdog to complete
         await watchdog
 

--- a/airflow/triggers/external_task.py
+++ b/airflow/triggers/external_task.py
@@ -95,8 +95,8 @@ class TaskStateTrigger(BaseTrigger):
         If dag with specified name was not in the running state after _timeout_sec seconds
         after starting execution process of the trigger, terminate with status 'timeout'.
         """
-        while True:
-            try:
+        try:
+            while True:
                 delta = utcnow() - self.trigger_start_time
                 if delta.total_seconds() < self._timeout_sec:
                     # mypy confuses typing here
@@ -112,9 +112,8 @@ class TaskStateTrigger(BaseTrigger):
                     return
                 self.log.info("Task is still running, sleeping for %s seconds...", self.poll_interval)
                 await asyncio.sleep(self.poll_interval)
-            except Exception:
-                yield TriggerEvent({"status": "failed"})
-                return
+        except Exception:
+            yield TriggerEvent({"status": "failed"})
 
     @sync_to_async
     @provide_session

--- a/airflow/www/extensions/init_security.py
+++ b/airflow/www/extensions/init_security.py
@@ -56,14 +56,14 @@ def init_api_experimental_auth(app):
         pass
 
     app.api_auth = []
-    for backend in auth_backends.split(","):
-        try:
+    try:
+        for backend in auth_backends.split(","):
             auth = import_module(backend.strip())
             auth.init_app(app)
             app.api_auth.append(auth)
-        except ImportError as err:
-            log.critical("Cannot import %s for API authentication due to: %s", backend, err)
-            raise AirflowException(err)
+    except ImportError as err:
+        log.critical("Cannot import %s for API authentication due to: %s", backend, err)
+        raise AirflowException(err)
 
 
 def init_check_user_active(app):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
All the blocks with this pattern
```python
while/for:
    try:
        ...
    except:
        return/break/raise
```
could be refactored to
```python
try:
    while/for:
        ...
except:
    return/pass/raise
```
### Why?
To make the code more readable and fatser:
```python
import timeit

code1 = """
try:
    for i in range(100000):
        if i == 99999:
            raise Exception("test")
except Exception as e:
    pass
"""

code2 = """
for i in range(100000):
    try:
        if i == 99999:
            raise Exception("test")
    except Exception as e:
        pass
"""

time_taken_code1 = timeit.timeit(stmt=code1, number=1000, globals=globals())
time_taken_code2 = timeit.timeit(stmt=code2, number=1000, globals=globals())

print("Time taken by loop in try:", time_taken_code1)
print("Time taken by try in loop:", time_taken_code2)

``` 
and here is the result:
```bash
$ python try_except_loop.py 
Time taken by loop in try: 2.8077976499916986
Time taken by try in loop: 3.2557358630001545

```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
