### PR TITLE
Raise max runtime for sagemaker jobs _again_

### DIFF
--- a/tests/system/providers/amazon/aws/example_sagemaker.py
+++ b/tests/system/providers/amazon/aws/example_sagemaker.py
@@ -255,7 +255,7 @@ def set_up(env_id, role_arn):
         "ProcessingResources": {
             "ClusterConfig": resource_config,
         },
-        "StoppingCondition": {"MaxRuntimeInSeconds": 300},
+        "StoppingCondition": {"MaxRuntimeInSeconds": 600},
         "AppSpecification": {
             "ImageUri": ecr_repository_uri,
         },
@@ -294,7 +294,7 @@ def set_up(env_id, role_arn):
         "ExperimentConfig": {"ExperimentName": experiment_name},
         "ResourceConfig": resource_config,
         "RoleArn": role_arn,
-        "StoppingCondition": {"MaxRuntimeInSeconds": 300},
+        "StoppingCondition": {"MaxRuntimeInSeconds": 600},
         "TrainingJobName": training_job_name,
     }
     model_trained_weights = (
@@ -357,7 +357,7 @@ def set_up(env_id, role_arn):
             "OutputDataConfig": {"S3OutputPath": f"s3://{bucket_name}/{training_output_s3_key}"},
             "ResourceConfig": resource_config,
             "RoleArn": role_arn,
-            "StoppingCondition": {"MaxRuntimeInSeconds": 300},
+            "StoppingCondition": {"MaxRuntimeInSeconds": 600},
         },
     }
     transform_config = {


### PR DESCRIPTION
raised it in #33942 but apparently not enough.

What we were seeing is that jobs had a limit of 60 seconds but were ending after 350 seconds
now they fail with the limit of 300 seconds too. Maybe we need to set a limit that bigger than that ?
Maybe it's only checked after 300+ seconds have passed ?