### PR TITLE
Make Amazon Chime connection lazy loaded and consistent with docs

### DIFF
--- a/airflow/providers/amazon/aws/hooks/chime.py
+++ b/airflow/providers/amazon/aws/hooks/chime.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import re
+from functools import cached_property
 from typing import Any
 
 from airflow.exceptions import AirflowException
@@ -28,19 +29,19 @@ from airflow.providers.http.hooks.http import HttpHook
 
 
 class ChimeWebhookHook(HttpHook):
-    """Interact with Chime Web Hooks to create notifications.
+    """Interact with Amazon Chime Webhooks to create notifications.
 
     .. warning:: This hook is only designed to work with web hooks and not chat bots.
 
-    :param chime_conn_id: Chime connection ID with Endpoint as "https://hooks.chime.aws" and
-                         the webhook token in the form of ```{webhook.id}?token{webhook.token}```
-
+    :param chime_conn_id: :ref:`Amazon Chime Connection ID <howto/connection:chime>`
+        with Endpoint as `https://hooks.chime.aws` and the webhook token
+        in the form of ``{webhook.id}?token{webhook.token}``
     """
 
     conn_name_attr = "chime_conn_id"
     default_conn_name = "chime_default"
     conn_type = "chime"
-    hook_name = "Chime Web Hook"
+    hook_name = "Amazon Chime Webhook"
 
     def __init__(
         self,
@@ -49,7 +50,11 @@ class ChimeWebhookHook(HttpHook):
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        self.webhook_endpoint = self._get_webhook_endpoint(chime_conn_id)
+        self._chime_conn_id = chime_conn_id
+
+    @cached_property
+    def webhook_endpoint(self):
+        return self._get_webhook_endpoint(self._chime_conn_id)
 
     def _get_webhook_endpoint(self, conn_id: str) -> str:
         """
@@ -104,7 +109,7 @@ class ChimeWebhookHook(HttpHook):
             "hidden_fields": ["login", "port", "extra"],
             "relabeling": {
                 "host": "Chime Webhook Endpoint",
-                "password": "Webhook Token",
+                "password": "Chime Webhook token",
             },
             "placeholders": {
                 "schema": "https",

--- a/tests/providers/amazon/aws/hooks/test_chime.py
+++ b/tests/providers/amazon/aws/hooks/test_chime.py
@@ -66,8 +66,9 @@ class TestChimeWebhookHook:
 
         # When/Then
         expected_message = r"Expected Chime webhook token in the form"
+        hook = ChimeWebhookHook(chime_conn_id="chime-bad-url")
         with pytest.raises(AirflowException, match=expected_message):
-            ChimeWebhookHook(chime_conn_id="chime-bad-url")
+            assert not hook.webhook_endpoint
 
     def test_get_webhook_endpoint_conn_id(self):
         # Given


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Make sure that `ChimeWebhookHook` do not access to Airflow Connection in constructor. It should not affect (improve) anything in community provider. However might prevent unwanted connections in the user specific Operators

Define same name for connection fields which are mentioned [into the documentation](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/chime.html)

And rename connection name, it should not affect users pipelines, because this only uses in two places Connection type dropdown selector and in `airflow providers hook` which are intend to show available connections

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
