### PR TITLE
AIP-44 Fix serialization issues in Internal API.

### DIFF
--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from flask import Response
 
 from airflow.serialization.serialized_objects import BaseSerialization
+from airflow.utils.session import create_session
 
 if TYPE_CHECKING:
     from airflow.api_connexion.types import APIResponse
@@ -95,10 +96,12 @@ def internal_airflow_api(body: dict[str, Any]) -> APIResponse:
 
     log.debug("Calling method %s.", method_name)
     try:
-        output = handler(**params)
-        output_json = BaseSerialization.serialize(output, use_pydantic_models=True)
-        response = json.dumps(output_json) if output_json is not None else None
-        return Response(response=response, headers={"Content-Type": "application/json"})
+        # Session must be created there as it may be needed by serializer for lazy-loaded fields.
+        with create_session() as session:
+            output = handler(**params, session=session)
+            output_json = BaseSerialization.serialize(output, use_pydantic_models=True)
+            response = json.dumps(output_json) if output_json is not None else None
+            return Response(response=response, headers={"Content-Type": "application/json"})
     except Exception as e:
         log.error("Error (%s) when calling method %s.", e, method_name)
         return Response(response=f"Error executing method: {method_name}.", status=500)

--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -90,8 +90,9 @@ def internal_airflow_api(body: dict[str, Any]) -> APIResponse:
         if body.get("params"):
             params_json = json.loads(str(body.get("params")))
             params = BaseSerialization.deserialize(params_json, use_pydantic_models=True)
-    except Exception as err:
-        log.error("Error (%s) when deserializing parameters: %s", err, params_json)
+    except Exception as e:
+        log.error("Error when deserializing parameters for method: %s.", method_name)
+        log.exception(e)
         return Response(response="Error deserializing parameters.", status=400)
 
     log.debug("Calling method %s.", method_name)
@@ -103,5 +104,6 @@ def internal_airflow_api(body: dict[str, Any]) -> APIResponse:
             response = json.dumps(output_json) if output_json is not None else None
             return Response(response=response, headers={"Content-Type": "application/json"})
     except Exception as e:
-        log.error("Error (%s) when calling method %s.", e, method_name)
+        log.error("Error executing method: %s.", method_name)
+        log.exception(e)
         return Response(response=f"Error executing method: {method_name}.", status=500)

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -493,7 +493,7 @@ class BaseSerialization:
 
             def _pydantic_model_dump(model_cls: type[BaseModel], var: Any) -> dict[str, Any]:
                 try:
-                    return model_cls.model_validate(var).model_dump()  # type: ignore[attr-defined]
+                    return model_cls.model_validate(var).model_dump(mode="json")  # type: ignore[attr-defined]
                 except AttributeError:  # Pydantic 1.x compatibility.
                     return model_cls.from_orm(var).dict()  # type: ignore[attr-defined]
 

--- a/tests/api_internal/endpoints/test_rpc_api_endpoint.py
+++ b/tests/api_internal/endpoints/test_rpc_api_endpoint.py
@@ -123,7 +123,7 @@ class TestRpcApiEndpoint:
 
         assert result_cmp_func(response_data, method_result)
 
-        mock_test_method.assert_called_once_with(**method_params)
+        mock_test_method.assert_called_once_with(**method_params, session=mock.ANY)
 
     def test_method_with_exception(self):
         mock_test_method.side_effect = ValueError("Error!!!")


### PR DESCRIPTION
There are 2 fixes covered with this PR:
 - Pydantic 2 must dump model with "json" mode (as we dump it as JSON to send from/to Internal API). Currently it may throw exception like "datetime is not json-serializable"
- session can't be closed when serializing the object in Internal API - otherwise the lazy-loaded fields throws an exception.

Also addded logging the exception on the Internal API side.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
