### PR TITLE
Shorten time for stale bot on pending-response label

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -40,10 +40,10 @@ jobs:
           exempt-pr-labels: 'pinned,security'
           only-issue-labels: 'pending-response'
           remove-stale-when-updated: true
-          days-before-issue-stale: 30
+          days-before-issue-stale: 14
           days-before-issue-close: 7
           stale-issue-message: >
-            This issue has been automatically marked as stale because it has been open for 30 days
+            This issue has been automatically marked as stale because it has been open for 14 days
             with no response from the author. It will be closed in next 7 days if no further
             activity occurs from the issue author.
           close-issue-message: >


### PR DESCRIPTION
We add the pending-response label when we require additional information from the issue author.
If author does not reply after 30 days we issue the stale message and 7 days later if no response we close the issue.

**Motivation:**
I noticed that 30 days is too long as if author isn't responsive quickly most of the times author does not respond at all.
Thus I suggest to shorten the 30 days wait period to 14 days.