### PR TITLE
Add decorator for suppress optional internal methods in Amazon Provider

### DIFF
--- a/airflow/providers/amazon/aws/utils/suppress.py
+++ b/airflow/providers/amazon/aws/utils/suppress.py
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Module for suppress errors in Amazon Provider.
+
+.. warning::
+    Only for internal usage, this module might be changed or removed in the future
+    without any further notice.
+
+:meta: private
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import wraps
+from typing import Callable, TypeVar
+
+from airflow.typing_compat import ParamSpec
+
+PS = ParamSpec("PS")
+RT = TypeVar("RT")
+
+log = logging.getLogger(__name__)
+
+
+def return_on_error(return_value: RT):
+    """
+    Helper decorator which suppress any ``Exception`` raised in decorator function.
+
+    Main use-case when functional is optional, however any error on functions/methods might
+    raise any error which are subclass of ``Exception``.
+
+    .. note::
+        Decorator doesn't intend to catch ``BaseException``,
+        e.g. ``GeneratorExit``, ``KeyboardInterrupt``, ``SystemExit`` and others.
+
+    .. warning::
+        Only for internal usage, this decorator might be changed or removed in the future
+        without any further notice.
+
+    :param return_value: Return value if decorated function/method raise any ``Exception``.
+    :meta: private
+    """
+
+    def decorator(func: Callable[PS, RT]) -> Callable[PS, RT]:
+        @wraps(func)
+        def wrapper(*args, **kwargs) -> RT:
+            try:
+                return func(*args, **kwargs)
+            except Exception:
+                log.debug(
+                    "Encountered error during execution function/method %r", func.__name__, exc_info=True
+                )
+                return return_value
+
+        return wrapper
+
+    return decorator

--- a/tests/providers/amazon/aws/utils/test_suppress.py
+++ b/tests/providers/amazon/aws/utils/test_suppress.py
@@ -1,0 +1,80 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from airflow.providers.amazon.aws.utils.suppress import return_on_error
+
+
+def test_suppress_function(caplog):
+    @return_on_error("error")
+    def fn(value: str, exc: Exception | None = None) -> str:
+        if exc:
+            raise exc
+        return value
+
+    caplog.set_level("DEBUG", "airflow.providers.amazon.aws.utils.suppress")
+    caplog.clear()
+
+    assert fn("no-error") == "no-error"
+    assert not caplog.messages
+
+    assert fn("foo", ValueError("boooo")) == "error"
+    assert "Encountered error during execution function/method 'fn'" in caplog.messages
+
+    caplog.clear()
+    with pytest.raises(SystemExit, match="42"):
+        # We do not plan to catch exception which only based on `BaseExceptions`
+        fn("bar", SystemExit(42))
+    assert not caplog.messages
+
+    # We catch even serious exceptions, e.g. we do not provide mandatory argument here
+    assert fn() == "error"
+    assert "Encountered error during execution function/method 'fn'" in caplog.messages
+
+
+def test_suppress_methods():
+    class FakeClass:
+        @return_on_error("Oops!… I Did It Again")
+        def some_method(self, value, exc: Exception | None = None) -> str:
+            if exc:
+                raise exc
+            return value
+
+        @staticmethod
+        @return_on_error(0)
+        def some_staticmethod(value, exc: Exception | None = None) -> int:
+            if exc:
+                raise exc
+            return value
+
+        @classmethod
+        @return_on_error("It's fine")
+        def some_classmethod(cls, value, exc: Exception | None = None) -> str:
+            if exc:
+                raise exc
+            return value
+
+    assert FakeClass().some_method("no-error") == "no-error"
+    assert FakeClass.some_staticmethod(42) == 42
+    assert FakeClass.some_classmethod("really-no-error-here") == "really-no-error-here"
+
+    assert FakeClass().some_method("foo", KeyError("foo")) == "Oops!… I Did It Again"
+    assert FakeClass.some_staticmethod(42, RuntimeError("bar")) == 0
+    assert FakeClass.some_classmethod("bar", OSError("Windows detected!")) == "It's fine"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Initially I've plan only refactor `_generate_dag_key` by use internal `generate_uuid` and found that if some error occurs in the future in `generate_uuid` then it might affects  some users.

As final result I decorate all non-main-functional methods by `return_on_error`, so we don't need to put all function code inside of `try.. except Exception`.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
