### PR TITLE
Remove `LocalToAzureDataLakeStorageOperator` class

### DIFF
--- a/airflow/providers/microsoft/azure/CHANGELOG.rst
+++ b/airflow/providers/microsoft/azure/CHANGELOG.rst
@@ -50,6 +50,9 @@ Breaking changes
 * Remove AzureFileShareHook.check_for_file method
 * Remove AzureFileShareHook.load_string, AzureFileShareHook.load_stream in favor of AzureFileShareHook.load_data
 
+.. note::
+  ``LocalToAzureDataLakeStorageOperator`` class has been removed in favor of ``LocalFilesystemToADLSOperator``
+
 6.3.0
 .....
 

--- a/airflow/providers/microsoft/azure/transfers/local_to_adls.py
+++ b/airflow/providers/microsoft/azure/transfers/local_to_adls.py
@@ -16,10 +16,9 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any, Sequence
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.microsoft.azure.hooks.data_lake import AzureDataLakeHook
 
@@ -97,22 +96,3 @@ class LocalFilesystemToADLSOperator(BaseOperator):
             blocksize=self.blocksize,
             **self.extra_upload_options,
         )
-
-
-class LocalToAzureDataLakeStorageOperator(LocalFilesystemToADLSOperator):
-    """
-    This class is deprecated.
-
-    Please use
-    :class:`airflow.providers.microsoft.azure.transfers.local_to_adls.LocalFilesystemToADLSOperator`.
-    """
-
-    def __init__(self, *args, **kwargs):
-        warnings.warn(
-            """This class is deprecated.
-            Please use
-            `airflow.providers.microsoft.azure.transfers.local_to_adls.LocalFilesystemToADLSOperator`.""",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
-        super().__init__(*args, **kwargs)


### PR DESCRIPTION
next release of `microsoft.azure` is 7.0.0 so taking the opportunity to remove deprecated code