### PR TITLE
Custom fetch all handler for vertica to not miss errors

### DIFF
--- a/airflow/providers/vertica/hooks/vertica.py
+++ b/airflow/providers/vertica/hooks/vertica.py
@@ -17,20 +17,11 @@
 # under the License.
 from __future__ import annotations
 
-from typing import (
-    Any,
-    Callable,
-    Iterable,
-    Mapping,
-    TypeVar,
-    overload
-)
+from typing import Any, Callable, Iterable, Mapping, overload
 
 from vertica_python import connect
 
 from airflow.providers.common.sql.hooks.sql import DbApiHook, fetch_all_handler
-
-T = TypeVar("T")
 
 
 def vertica_fetch_all_handler(cursor) -> list[tuple] | None:
@@ -142,10 +133,10 @@ class VerticaHook(DbApiHook):
         sql: str | Iterable[str],
         autocommit: bool = ...,
         parameters: Iterable | Mapping[str, Any] | None = ...,
-        handler: Callable[[Any], T] = ...,
+        handler: Callable[[Any], Any] = ...,
         split_statements: bool = ...,
         return_last: bool = ...,
-    ) -> T | list[T]:
+    ) -> Any | list[Any]:
         ...
 
     def run(
@@ -153,10 +144,10 @@ class VerticaHook(DbApiHook):
         sql: str | Iterable[str],
         autocommit: bool = False,
         parameters: Iterable | Mapping | None = None,
-        handler: Callable[[Any], T] | None = None,
+        handler: Callable[[Any], Any] | None = None,
         split_statements: bool = False,
         return_last: bool = True,
-    ) -> T | list[T] | None:
+    ) -> Any | list[Any] | None:
         if handler == fetch_all_handler:
-            return DbApiHook.run(self, sql, autocommit, parameters, vertica_fetch_all_handler, split_statements, return_last)
+            handler = vertica_fetch_all_handler
         return DbApiHook.run(self, sql, autocommit, parameters, handler, split_statements, return_last)

--- a/airflow/providers/vertica/hooks/vertica.py
+++ b/airflow/providers/vertica/hooks/vertica.py
@@ -31,9 +31,10 @@ def vertica_fetch_all_handler(cursor) -> list[tuple] | None:
     Returned value will not change after the initial call of fetch_all_handler, all the remaining code is here
     only to make vertica client throws error.
     With Vertica, if you run the following sql (with split_statements set to false):
-        INSERT INTO MyTable (Key, Label) values (1, 'test 1');
-        INSERT INTO MyTable (Key, Label) values (1, 'test 2');
-        INSERT INTO MyTable (Key, Label) values (3, 'test 3');
+
+    INSERT INTO MyTable (Key, Label) values (1, 'test 1');
+    INSERT INTO MyTable (Key, Label) values (1, 'test 2');
+    INSERT INTO MyTable (Key, Label) values (3, 'test 3');
 
     each insert will have its own result set and if you don't try to fetch data of those result sets
     you won't detect error on the second insert.

--- a/airflow/providers/vertica/hooks/vertica.py
+++ b/airflow/providers/vertica/hooks/vertica.py
@@ -19,10 +19,10 @@ from __future__ import annotations
 
 from typing import (
     Any,
-    TypeVar,
     Callable,
     Iterable,
     Mapping,
+    TypeVar,
 )
 
 from vertica_python import connect
@@ -30,6 +30,7 @@ from vertica_python import connect
 from airflow.providers.common.sql.hooks.sql import DbApiHook, fetch_all_handler
 
 T = TypeVar("T")
+
 
 def vertica_fetch_all_handler(cursor) -> list[tuple] | None:
     """Replace the default DbApiHook fetch_all_handler ."""

--- a/airflow/providers/vertica/hooks/vertica.py
+++ b/airflow/providers/vertica/hooks/vertica.py
@@ -129,4 +129,4 @@ class VerticaHook(DbApiHook):
     ) -> Any | list[Any] | None:
         if handler == fetch_all_handler:
             handler = vertica_fetch_all_handler
-        return DbApiHook.run(self, sql, autocommit, parameters, split_statements, return_last)
+        return DbApiHook.run(self, sql, autocommit, parameters, handler, split_statements, return_last)

--- a/airflow/providers/vertica/hooks/vertica.py
+++ b/airflow/providers/vertica/hooks/vertica.py
@@ -23,6 +23,7 @@ from typing import (
     Iterable,
     Mapping,
     TypeVar,
+    overload
 )
 
 from vertica_python import connect
@@ -123,6 +124,30 @@ class VerticaHook(DbApiHook):
         conn = connect(**conn_config)
         return conn
 
+    @overload
+    def run(
+        self,
+        sql: str | Iterable[str],
+        autocommit: bool = ...,
+        parameters: Iterable | Mapping[str, Any] | None = ...,
+        handler: None = ...,
+        split_statements: bool = ...,
+        return_last: bool = ...,
+    ) -> None:
+        ...
+
+    @overload
+    def run(
+        self,
+        sql: str | Iterable[str],
+        autocommit: bool = ...,
+        parameters: Iterable | Mapping[str, Any] | None = ...,
+        handler: Callable[[Any], T] = ...,
+        split_statements: bool = ...,
+        return_last: bool = ...,
+    ) -> T | list[T]:
+        ...
+
     def run(
         self,
         sql: str | Iterable[str],
@@ -133,5 +158,5 @@ class VerticaHook(DbApiHook):
         return_last: bool = True,
     ) -> T | list[T] | None:
         if handler == fetch_all_handler:
-            handler = vertica_fetch_all_handler
+            return DbApiHook.run(self, sql, autocommit, parameters, vertica_fetch_all_handler, split_statements, return_last)
         return DbApiHook.run(self, sql, autocommit, parameters, handler, split_statements, return_last)

--- a/airflow/providers/vertica/hooks/vertica.py
+++ b/airflow/providers/vertica/hooks/vertica.py
@@ -26,7 +26,7 @@ from airflow.providers.common.sql.hooks.sql import DbApiHook, fetch_all_handler
 
 def vertica_fetch_all_handler(cursor) -> list[tuple] | None:
     """Replace the default DbApiHook fetch_all_handler ."""
-    to_return = fetch_all_handler(cursor)
+    result = fetch_all_handler(cursor)
     # loop on all statement result sets to get errors
     if cursor.description is not None:
         while cursor.nextset():
@@ -34,7 +34,7 @@ def vertica_fetch_all_handler(cursor) -> list[tuple] | None:
                 row = cursor.fetchone()
                 while row:
                     row = cursor.fetchone()
-    return to_return
+    return result
 
 
 class VerticaHook(DbApiHook):

--- a/tests/providers/vertica/hooks/test_vertica.py
+++ b/tests/providers/vertica/hooks/test_vertica.py
@@ -127,6 +127,7 @@ class TestVerticaHookConn:
 class TestVerticaHook:
     def setup_method(self):
         self.cur = mock.MagicMock(rowcount=0)
+        self.cur.nextset.side_effect = [None]
         self.conn = mock.MagicMock()
         self.conn.cursor.return_value = self.cur
         conn = self.conn


### PR DESCRIPTION
Change the default fetch all handler for vertica provider in order to catch all errors in multi-statement query ([issue 32993](https://github.com/apache/airflow/issues/32993))
Closes: https://github.com/apache/airflow/issues/32993