### PR TITLE
Make AWS SecretsManager tests compatible with `moto>=4.2.1`

### DIFF
--- a/tests/providers/amazon/aws/hooks/test_secrets_manager.py
+++ b/tests/providers/amazon/aws/hooks/test_secrets_manager.py
@@ -33,20 +33,15 @@ class TestSecretsManagerHook:
 
     def test_get_secret_string(self):
         secret_name = "arn:aws:secretsmanager:us-east-2:999999999999:secret:db_cluster-YYYYYYY"
-        secret_value = '{"user": "test"}'
+        secret_value = "test"
         hook = SecretsManagerHook(aws_conn_id="aws_default")
 
         create_param = {
             "Name": secret_name,
-        }
-
-        put_param = {
-            "SecretId": secret_name,
             "SecretString": secret_value,
         }
 
         hook.get_conn().create_secret(**create_param)
-        hook.get_conn().put_secret_value(**put_param)
 
         secret = hook.get_secret(secret_name)
         assert secret == secret_value
@@ -58,15 +53,10 @@ class TestSecretsManagerHook:
 
         create_param = {
             "Name": secret_name,
-        }
-
-        put_param = {
-            "SecretId": secret_name,
             "SecretString": secret_value,
         }
 
         hook.get_conn().create_secret(**create_param)
-        hook.get_conn().put_secret_value(**put_param)
 
         secret = hook.get_secret_as_dict(secret_name)
         assert secret == json.loads(secret_value)
@@ -75,17 +65,9 @@ class TestSecretsManagerHook:
         secret_name = "arn:aws:secretsmanager:us-east-2:999999999999:secret:db_cluster-YYYYYYY"
         secret_value_binary = base64.b64encode(b'{"username": "test"}')
         hook = SecretsManagerHook(aws_conn_id="aws_default")
-        create_param = {
-            "Name": secret_name,
-        }
-
-        put_param = {
-            "SecretId": secret_name,
-            "SecretBinary": secret_value_binary,
-        }
+        create_param = {"Name": secret_name, "SecretBinary": secret_value_binary}
 
         hook.get_conn().create_secret(**create_param)
-        hook.get_conn().put_secret_value(**put_param)
 
         secret = hook.get_secret(secret_name)
         assert secret == base64.b64decode(secret_value_binary)

--- a/tests/providers/amazon/aws/secrets/test_secrets_manager.py
+++ b/tests/providers/amazon/aws/secrets/test_secrets_manager.py
@@ -37,16 +37,11 @@ class TestSecretsManagerBackend:
         secret_id = "airflow/connections/test_postgres"
         create_param = {
             "Name": secret_id,
-        }
-
-        param = {
-            "SecretId": secret_id,
             "SecretString": "postgresql://airflow:airflow@host:5432/airflow",
         }
 
         secrets_manager_backend = SecretsManagerBackend()
         secrets_manager_backend.client.create_secret(**create_param)
-        secrets_manager_backend.client.put_secret_value(**param)
 
         returned_uri = secrets_manager_backend.get_conn_value(conn_id="test_postgres")
         assert "postgresql://airflow:airflow@host:5432/airflow" == returned_uri
@@ -63,10 +58,6 @@ class TestSecretsManagerBackend:
         secret_id = "airflow/connections/test_postgres"
         create_param = {
             "Name": secret_id,
-        }
-
-        param = {
-            "SecretId": secret_id,
             "SecretString": json.dumps(
                 {
                     "conn_type": "postgresql",
@@ -82,7 +73,6 @@ class TestSecretsManagerBackend:
             are_secret_values_urlencoded=are_secret_values_urlencoded
         )
         secrets_manager_backend.client.create_secret(**create_param)
-        secrets_manager_backend.client.put_secret_value(**param)
 
         conn = secrets_manager_backend.get_connection(conn_id="test_postgres")
 
@@ -97,10 +87,6 @@ class TestSecretsManagerBackend:
         secret_id = "airflow/connections/test_postgres"
         create_param = {
             "Name": secret_id,
-        }
-
-        param = {
-            "SecretId": secret_id,
             "SecretString": json.dumps(
                 {
                     "conn_type": "postgresql",
@@ -114,7 +100,6 @@ class TestSecretsManagerBackend:
 
         secrets_manager_backend = SecretsManagerBackend(full_url_mode=False)
         secrets_manager_backend.client.create_secret(**create_param)
-        secrets_manager_backend.client.put_secret_value(**param)
 
         conn = secrets_manager_backend.get_connection(conn_id="test_postgres")
         assert conn.extra_dejson["foo"] == "bar"
@@ -124,17 +109,14 @@ class TestSecretsManagerBackend:
         secret_id = "airflow/connections/test_postgres"
         create_param = {
             "Name": secret_id,
-        }
-
-        param = {
-            "SecretId": secret_id,
-            "SecretString": '{"user": "airflow", "pass": "airflow", "host": "host", '
-            '"port": 5432, "schema": "airflow", "engine": "postgresql"}',
+            "SecretString": (
+                '{"user": "airflow", "pass": "airflow", "host": "host", '
+                '"port": 5432, "schema": "airflow", "engine": "postgresql"}'
+            ),
         }
 
         secrets_manager_backend = SecretsManagerBackend(full_url_mode=False)
         secrets_manager_backend.client.create_secret(**create_param)
-        secrets_manager_backend.client.put_secret_value(**param)
 
         conn = secrets_manager_backend.get_connection(conn_id="test_postgres")
         returned_uri = conn.get_uri()
@@ -145,19 +127,16 @@ class TestSecretsManagerBackend:
         secret_id = "airflow/connections/test_postgres"
         create_param = {
             "Name": secret_id,
-        }
-
-        param = {
-            "SecretId": secret_id,
-            "SecretString": '{"usuario": "airflow", "pass": "airflow", "host": "host", '
-            '"port": 5432, "schema": "airflow", "engine": "postgresql"}',
+            "SecretString": (
+                '{"usuario": "airflow", "pass": "airflow", "host": "host", '
+                '"port": 5432, "schema": "airflow", "engine": "postgresql"}'
+            ),
         }
 
         secrets_manager_backend = SecretsManagerBackend(
             full_url_mode=False, extra_conn_words={"user": ["usuario"]}
         )
         secrets_manager_backend.client.create_secret(**create_param)
-        secrets_manager_backend.client.put_secret_value(**param)
 
         conn = secrets_manager_backend.get_connection(conn_id="test_postgres")
         returned_uri = conn.get_uri()
@@ -174,16 +153,11 @@ class TestSecretsManagerBackend:
         secret_id = "airflow/connections/test_postgres"
         create_param = {
             "Name": secret_id,
-        }
-
-        param = {
-            "SecretId": secret_id,
             "SecretString": "postgresql://airflow:airflow@host:5432/airflow",
         }
 
         secrets_manager_backend = SecretsManagerBackend()
         secrets_manager_backend.client.create_secret(**create_param)
-        secrets_manager_backend.client.put_secret_value(**param)
 
         assert secrets_manager_backend.get_conn_value(conn_id=conn_id) is None
         assert secrets_manager_backend.get_connection(conn_id=conn_id) is None
@@ -192,15 +166,10 @@ class TestSecretsManagerBackend:
     def test_get_variable(self):
 
         secret_id = "airflow/variables/hello"
-        create_param = {
-            "Name": secret_id,
-        }
-
-        param = {"SecretId": secret_id, "SecretString": "world"}
+        create_param = {"Name": secret_id, "SecretString": "world"}
 
         secrets_manager_backend = SecretsManagerBackend()
         secrets_manager_backend.client.create_secret(**create_param)
-        secrets_manager_backend.client.put_secret_value(**param)
 
         returned_uri = secrets_manager_backend.get_variable("hello")
         assert "world" == returned_uri
@@ -212,14 +181,10 @@ class TestSecretsManagerBackend:
         SystemsManagerParameterStoreBackend.get_variables should return None
         """
         secret_id = "airflow/variables/hello"
-        create_param = {
-            "Name": secret_id,
-        }
-        param = {"SecretId": secret_id, "SecretString": "world"}
+        create_param = {"Name": secret_id, "SecretString": "world"}
 
         secrets_manager_backend = SecretsManagerBackend()
         secrets_manager_backend.client.create_secret(**create_param)
-        secrets_manager_backend.client.put_secret_value(**param)
 
         assert secrets_manager_backend.get_variable("test_mysql") is None
 
@@ -230,14 +195,10 @@ class TestSecretsManagerBackend:
         SystemsManagerParameterStoreBackend.get_config should return None
         """
         secret_id = "airflow/config/hello"
-        create_param = {
-            "Name": secret_id,
-        }
-        param = {"SecretId": secret_id, "SecretString": "world"}
+        create_param = {"Name": secret_id, "SecretString": "world"}
 
         secrets_manager_backend = SecretsManagerBackend()
         secrets_manager_backend.client.create_secret(**create_param)
-        secrets_manager_backend.client.put_secret_value(**param)
 
         assert secrets_manager_backend.get_config("test") is None
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

I'm not sure what is happen yet but upgrade to latests moto==4.2.2 was break our tests in main, this change make our tests work either with latest `moto` and previous versions

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
