### PR TITLE
Clarify new_state in OpenAPI spec

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -4292,12 +4292,7 @@ components:
           type: boolean
 
         new_state:
-          description: Expected new state.
-          type: string
-          enum:
-            - success
-            - failed
-            - skipped
+          $ref: '#/components/schemas/UpdateTaskState'
 
     UpdateTaskInstance:
       type: object
@@ -4310,12 +4305,7 @@ components:
           default: false
 
         new_state:
-          description: Expected new state.
-          type: string
-          enum:
-            - success
-            - failed
-            - skipped
+          $ref: '#/components/schemas/UpdateTaskState'
 
     SetTaskInstanceNote:
       type: object
@@ -4695,6 +4685,19 @@ components:
         - deferred
         - removed
         - restarting
+
+
+    UpdateTaskState:
+      description: |
+        Expected new state. Only a subset of TaskState are available.
+
+        Other states are managed directly by the scheduler or the workers and cannot be updated manually through the REST API.
+
+      type: string
+      enum:
+        - success
+        - failed
+        - skipped
 
     DagState:
       description: |

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1897,11 +1897,7 @@ export interface components {
       include_future?: boolean;
       /** @description If set to True, also tasks from past DAG Runs are affected. */
       include_past?: boolean;
-      /**
-       * @description Expected new state.
-       * @enum {string}
-       */
-      new_state?: "success" | "failed" | "skipped";
+      new_state?: components["schemas"]["UpdateTaskState"];
     };
     UpdateTaskInstance: {
       /**
@@ -1911,11 +1907,7 @@ export interface components {
        * @default false
        */
       dry_run?: boolean;
-      /**
-       * @description Expected new state.
-       * @enum {string}
-       */
-      new_state?: "success" | "failed" | "skipped";
+      new_state?: components["schemas"]["UpdateTaskState"];
     };
     SetTaskInstanceNote: {
       /** @description The custom note to set for this Task Instance. */
@@ -2181,6 +2173,14 @@ export interface components {
           | "restarting"
         )
       | null;
+    /**
+     * @description Expected new state. Only a subset of TaskState are available.
+     *
+     * Other states are managed directly by the scheduler or the workers and cannot be updated manually through the REST API.
+     *
+     * @enum {string}
+     */
+    UpdateTaskState: "success" | "failed" | "skipped";
     /**
      * @description DAG State.
      *
@@ -4881,6 +4881,9 @@ export type CollectionInfo = CamelCasedPropertiesDeep<
 >;
 export type TaskState = CamelCasedPropertiesDeep<
   components["schemas"]["TaskState"]
+>;
+export type UpdateTaskState = CamelCasedPropertiesDeep<
+  components["schemas"]["UpdateTaskState"]
 >;
 export type DagState = CamelCasedPropertiesDeep<
   components["schemas"]["DagState"]


### PR DESCRIPTION
We had questions about this in the slack, instance here:
https://apache-airflow.slack.com/archives/CSS36QQS1/p1693501503281489

This is just a clarification of the spec as to why only a subset of taststate are available when updating a task and setting a new state.