### PR TITLE
Fix for TaskGroup toggles for duplicated labels

### DIFF
--- a/airflow/www/static/js/dag/details/gantt/Row.tsx
+++ b/airflow/www/static/js/dag/details/gantt/Row.tsx
@@ -53,7 +53,7 @@ const Row = ({
   const instance = task.instances.find((ti) => ti.runId === runId);
   const isSelected = taskId === instance?.taskId;
   const hasQueuedDttm = !!instance?.queuedDttm;
-  const isOpen = openGroupIds.includes(task.label || "");
+  const isOpen = openGroupIds.includes(task.id || "");
 
   // Calculate durations in ms
   const taskDuration = getDuration(instance?.startDate, instance?.endDate);

--- a/airflow/www/static/js/dag/details/graph/utils.ts
+++ b/airflow/www/static/js/dag/details/graph/utils.ts
@@ -79,9 +79,9 @@ export const flattenNodes = ({
         onToggleCollapse: () => {
           let newGroupIds = [];
           if (!node.value.isOpen) {
-            newGroupIds = [...openGroupIds, node.value.label];
+            newGroupIds = [...openGroupIds, node.id];
           } else {
-            newGroupIds = openGroupIds.filter((g) => g !== node.value.label);
+            newGroupIds = openGroupIds.filter((g) => g !== node.id);
           }
           onToggleGroups(newGroupIds);
         },

--- a/airflow/www/static/js/dag/grid/TaskName.test.tsx
+++ b/airflow/www/static/js/dag/grid/TaskName.test.tsx
@@ -29,7 +29,7 @@ import TaskName from "./TaskName";
 describe("Test TaskName", () => {
   test("Displays a normal task name", () => {
     const { getByText } = render(
-      <TaskName label="test" onToggle={() => {}} />,
+      <TaskName label="test" id="test" onToggle={() => {}} />,
       { wrapper: ChakraWrapper }
     );
 
@@ -38,7 +38,13 @@ describe("Test TaskName", () => {
 
   test("Displays a mapped task name", () => {
     const { getByText } = render(
-      <TaskName level={0} label="test" isMapped onToggle={() => {}} />,
+      <TaskName
+        level={0}
+        label="test"
+        id="test"
+        isMapped
+        onToggle={() => {}}
+      />,
       { wrapper: ChakraWrapper }
     );
 
@@ -47,7 +53,7 @@ describe("Test TaskName", () => {
 
   test("Displays a group task name", () => {
     const { getByText, getByTestId } = render(
-      <TaskName level={0} label="test" isGroup onToggle={() => {}} />,
+      <TaskName level={0} label="test" id="test" isGroup onToggle={() => {}} />,
       { wrapper: ChakraWrapper }
     );
 

--- a/airflow/www/static/js/dag/grid/TaskName.tsx
+++ b/airflow/www/static/js/dag/grid/TaskName.tsx
@@ -28,6 +28,7 @@ interface Props {
   isOpen?: boolean;
   level?: number;
   label: string;
+  id: string;
 }
 
 const TaskName = ({
@@ -37,11 +38,13 @@ const TaskName = ({
   isOpen = false,
   level = 0,
   label,
+  id,
 }: Props) => (
   <Flex
     as={isGroup ? "button" : "div"}
     onClick={onToggle}
     aria-label={label}
+    data-testid={id}
     title={label}
     mr={4}
     width="100%"

--- a/airflow/www/static/js/dag/grid/ToggleGroups.tsx
+++ b/airflow/www/static/js/dag/grid/ToggleGroups.tsx
@@ -28,7 +28,7 @@ const getGroupIds = (groups: Task[]) => {
   const checkTasks = (tasks: Task[]) =>
     tasks.forEach((task) => {
       if (task.children) {
-        groupIds.push(task.label!);
+        groupIds.push(task.id!);
         checkTasks(task.children);
       }
     });

--- a/airflow/www/static/js/dag/grid/renderTaskRows.tsx
+++ b/airflow/www/static/js/dag/grid/renderTaskRows.tsx
@@ -122,20 +122,20 @@ const Row = (props: RowProps) => {
   const isGroup = !!task.children;
   const isSelected = selected.taskId === task.id;
 
-  const isOpen = openGroupIds.some((g) => g === task.label);
+  const isOpen = openGroupIds.some((g) => g === task.id);
 
   // assure the function is the same across renders
   const memoizedToggle = useCallback(() => {
-    if (isGroup && task.label) {
+    if (isGroup && task.id) {
       let newGroupIds = [];
       if (!isOpen) {
-        newGroupIds = [...openGroupIds, task.label];
+        newGroupIds = [...openGroupIds, task.id];
       } else {
-        newGroupIds = openGroupIds.filter((g) => g !== task.label);
+        newGroupIds = openGroupIds.filter((g) => g !== task.id);
       }
       onToggleGroups(newGroupIds);
     }
-  }, [isGroup, isOpen, task.label, openGroupIds, onToggleGroups]);
+  }, [isGroup, isOpen, task.id, openGroupIds, onToggleGroups]);
 
   // check if the group's parents are all open, if not, return null
   if (level !== openParentCount) return null;
@@ -168,6 +168,7 @@ const Row = (props: RowProps) => {
               isGroup={isGroup}
               isMapped={task.isMapped && !isParentMapped}
               label={task.label || task.id || ""}
+              id={task.id || ""}
               isOpen={isOpen}
               level={level}
             />

--- a/airflow/www/static/js/utils/graph.ts
+++ b/airflow/www/static/js/utils/graph.ts
@@ -170,7 +170,7 @@ const generateGraph = ({
           sourceId: childIds.indexOf(e.sourceId) > -1 ? node.id : e.sourceId,
           targetId: childIds.indexOf(e.targetId) > -1 ? node.id : e.targetId,
         }));
-      closedGroupIds.push(value.label);
+      closedGroupIds.push(id);
     }
     return {
       id,

--- a/airflow/www/static/js/utils/graph.ts
+++ b/airflow/www/static/js/utils/graph.ts
@@ -117,7 +117,7 @@ const generateGraph = ({
     height?: number;
   } => {
     const { id, value, children } = node;
-    const isOpen = openGroupIds?.includes(value.label);
+    const isOpen = openGroupIds?.includes(id);
     const childCount =
       children?.filter((c: DepNode) => !c.id.includes("join_id")).length || 0;
     const childIds = children?.length ? getNestedChildIds(children) : [];


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

closes: #34066

We have been using `_.label` so far to remember which task groups are opened/closed. Unfortunately, this leads to issues when the same label is used twice, which can happen as described in the linked issue. With this change we switch to use `_.id` instead, which must be unique (otherwise parsing the DAG would lead to `DuplicateTaskIdFound`).

New behavior (compare with issue's gif):
<img src="https://cdn-std.droplr.net/files/acc_1153680/2NYRwT" alt="image" width="50%">

I extended the existing tests for the grid view to check for the new behavior. However, it doesn't look like we have any tests for the new graph view yet. I can give it a shot and create some basic tests (also covering the task group toggle).

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
