### PR TITLE
Add DOAP file containing machine-readable information for Airflow

### DIFF
--- a/doap_airflow.rdf
+++ b/doap_airflow.rdf
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl"?>
+<rdf:RDF xml:lang="en"
+         xmlns="http://usefulinc.com/ns/doap#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+  <Project rdf:about="https://airflow.apache.org">
+    <created>2023-09-04</created>
+    <license rdf:resource="https://spdx.org/licenses/Apache-2.0" />
+    <name>Apache Airflow</name>
+    <homepage rdf:resource="https://airflow.apache.org" />
+    <asfext:pmc rdf:resource="https://airflow.apache.org" />
+    <shortdesc>Workflow automation platform</shortdesc>
+    <description>The mission of Apache Airflow is the creation and maintenance of software
+related to workflow automation and scheduling that can be used to author and
+manage data pipelines.
+</description>
+    <bug-database rdf:resource="https://github.com/apache/airflow/issues" />
+    <mailing-list rdf:resource="https://lists.apache.org/list.html?dev@airflow.apache.org" />
+    <download-page rdf:resource="https://airflow.apache.org/docs/apache-airflow/stable/installation/index.html" />
+    <programming-language>Python</programming-language>
+    <programming-language>JavaScript</programming-language>
+    <category rdf:resource="https://projects.apache.org/category/big-data" />
+    <repository>
+      <GitRepository>
+        <location rdf:resource="https://github.com/apache/airflow.git"/>
+        <browse rdf:resource="https://github.com/apache/airflow"/>
+      </GitRepository>
+    </repository>
+  </Project>
+</rdf:RDF>


### PR DESCRIPTION
The DOAP file is a standard RDF file that describes project's metadata. The Apache Software Foundation uses DOAP files for projects to keep project listing information at
https://projects.apache.org/projects.html

After merging this file we can point the ASF index to it and also add later some automation - for example about releases.

For now adding just basic information should be enough.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
