### PR TITLE
Use `cached_property` for hook in SparkKubernetesSensor

### DIFF
--- a/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING, Sequence
 
 from kubernetes import client
@@ -69,9 +70,12 @@ class SparkKubernetesSensor(BaseSensorOperator):
         self.namespace = namespace
         self.container_name = container_name
         self.kubernetes_conn_id = kubernetes_conn_id
-        self.hook = KubernetesHook(conn_id=self.kubernetes_conn_id)
         self.api_group = api_group
         self.api_version = api_version
+
+    @cached_property
+    def hook(self) -> KubernetesHook:
+        return KubernetesHook(conn_id=self.kubernetes_conn_id)
 
     def _log_driver(self, application_state: str, response: dict) -> None:
         if not self.attach_log:


### PR DESCRIPTION
Best practice to is make constructors of operators/sensors as simple as possible. Currently this sensor directly builds a KubernetesHook object in its construction. Yes, there are db or external calls when building the hook object itself, but:
1. if this hook changes for any reason, these types calls might sneak in; and
2. doesn't allow for templating of `kubernetes_conn_id` as brought up in [Airflow Slack](https://apache-airflow.slack.com/archives/CCQ7EGB1P/p1693904864661079)