### PR TITLE
Refactor: Consolidate import datetime

### DIFF
--- a/airflow/example_dags/example_latest_only.py
+++ b/airflow/example_dags/example_latest_only.py
@@ -18,7 +18,7 @@
 """Example of the LatestOnlyOperator"""
 from __future__ import annotations
 
-import datetime as dt
+import datetime
 
 from airflow import DAG
 from airflow.operators.empty import EmptyOperator
@@ -26,8 +26,8 @@ from airflow.operators.latest_only import LatestOnlyOperator
 
 with DAG(
     dag_id="latest_only",
-    schedule=dt.timedelta(hours=4),
-    start_date=dt.datetime(2021, 1, 1),
+    schedule=datetime.timedelta(hours=4),
+    start_date=datetime.datetime(2021, 1, 1),
     catchup=False,
     tags=["example2", "example3"],
 ) as dag:

--- a/airflow/providers/cncf/kubernetes/pod_launcher_deprecated.py
+++ b/airflow/providers/cncf/kubernetes/pod_launcher_deprecated.py
@@ -21,7 +21,6 @@ import json
 import math
 import time
 import warnings
-from datetime import datetime as dt
 from typing import TYPE_CHECKING
 
 import pendulum
@@ -132,12 +131,11 @@ class PodLauncher(LoggingMixin):
         :return:
         """
         resp = self.run_pod_async(pod)
-        curr_time = dt.now()
+        start_time = time.monotonic()
         if resp.status.start_time is None:
             while self.pod_not_started(pod):
                 self.log.warning("Pod not yet started: %s", pod.metadata.name)
-                delta = dt.now() - curr_time
-                if delta.total_seconds() >= startup_timeout:
+                if time.monotonic() >= start_time + startup_timeout:
                     raise AirflowException("Pod took too long to start")
                 time.sleep(1)
 

--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -17,9 +17,9 @@
 # under the License.
 from __future__ import annotations
 
+import datetime
 import json
 import operator
-from datetime import datetime as dt
 from typing import Iterator
 
 import pendulum
@@ -75,7 +75,7 @@ class DateTimeWithTimezoneField(Field):
             # Check if the datetime string is in the format without timezone, if so convert it to the
             # default timezone
             if len(date_str) == 19:
-                parsed_datetime = dt.strptime(date_str, "%Y-%m-%d %H:%M:%S")
+                parsed_datetime = datetime.datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S")
                 default_timezone = self._get_default_timezone()
                 self.data = default_timezone.convert(parsed_datetime)
             else:


### PR DESCRIPTION
There are several files with `from airflow.utils.timezone import datetime` that at the same time `import datetime as dt`, making the two variables confusing. How about changing that `airflow.utils.timezone.datetime` to a more descriptive name?