### PR TITLE
Fix issues related to access_control={}

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -779,7 +779,7 @@ class DAG(LoggingMixin):
         will be replaced with 'can_read', in {'role2': {'can_dag_read', 'can_dag_edit'}}
         'can_dag_edit' will be replaced with 'can_edit', etc.
         """
-        if not access_control:
+        if access_control is None:
             return None
         new_perm_mapping = {
             permissions.DEPRECATED_ACTION_CAN_DAG_READ: permissions.ACTION_CAN_READ,

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1401,6 +1401,14 @@ class SerializedDAG(DAG, BaseSerialization):
         return dag
 
     @classmethod
+    def _is_excluded(cls, var: Any, attrname: str, op: DAGNode):
+        # {} is explicitly different from None in the case of DAG-level access control
+        # and as a result we need to preserve empty dicts through serialization for this field
+        if attrname == "_access_control" and var is not None:
+            return False
+        return super()._is_excluded(var, attrname, op)
+
+    @classmethod
     def to_dict(cls, var: Any) -> dict:
         """Stringifies DAGs and operators contained by var and returns a dict of var."""
         json_dict = {"__version": cls.SERIALIZER_VERSION, "dag": cls.serialize_dag(var)}

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -603,7 +603,7 @@ class AirflowSecurityManager(SecurityManagerOverride, SecurityManager, LoggingMi
                 if (action_name, dag_resource_name) not in perms:
                     self._merge_perm(action_name, dag_resource_name)
 
-            if dag.access_control:
+            if dag.access_control is not None:
                 self.sync_perm_for_dag(dag_resource_name, dag.access_control)
 
     def update_admin_permission(self) -> None:

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -332,6 +332,7 @@ def get_timetable_based_simple_dag(timetable):
     dag.schedule_interval = timetable.summary
     return dag
 
+
 def serialize_subprocess(queue, dag_folder):
     """Validate pickle in a subprocess."""
     dags = collect_dags(dag_folder)
@@ -430,17 +431,13 @@ class TestStringifiedDAGs:
         assert actual == expected
 
     def test_dag_serialization_preserves_empty_access_roles(self):
-        """Verify that an explicitlty empty access_control dict is preserved through serialization and deserialization."""
+        """Verify that an explicitly empty access_control dict is preserved."""
         dag = collect_dags(["airflow/example_dags"])["simple_dag"]
         dag.access_control = {}
         serialized_dag = SerializedDAG.to_dict(dag)
         SerializedDAG.validate_schema(serialized_dag)
 
-        assert serialized_dag["dag"]["_access_control"] == {
-            "__type": "dict",
-            "__var": {}
-        }
-
+        assert serialized_dag["dag"]["_access_control"] == {"__type": "dict", "__var": {}}
 
     def test_dag_serialization_unregistered_custom_timetable(self):
         """Verify serialization fails without timetable registration."""

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -332,7 +332,6 @@ def get_timetable_based_simple_dag(timetable):
     dag.schedule_interval = timetable.summary
     return dag
 
-
 def serialize_subprocess(queue, dag_folder):
     """Validate pickle in a subprocess."""
     dags = collect_dags(dag_folder)
@@ -429,6 +428,19 @@ class TestStringifiedDAGs:
             for k, v in task.items():
                 print(task["task_id"], k, v)
         assert actual == expected
+
+    def test_dag_serialization_preserves_empty_access_roles(self):
+        """Verify that an explicitlty empty access_control dict is preserved through serialization and deserialization."""
+        dag = collect_dags(["airflow/example_dags"])["simple_dag"]
+        dag.access_control = {}
+        serialized_dag = SerializedDAG.to_dict(dag)
+        SerializedDAG.validate_schema(serialized_dag)
+
+        assert serialized_dag["dag"]["_access_control"] == {
+            "__type": "dict",
+            "__var": {}
+        }
+
 
     def test_dag_serialization_unregistered_custom_timetable(self):
         """Verify serialization fails without timetable registration."""


### PR DESCRIPTION
Follow-up to https://github.com/apache/airflow/pull/33632, which only tested the relevant code in isolation (my bad)

While verifying this behaviour in order to test the new release, I noticed a few things - 

1) The `sync_perm --include-dags` CLI command was ignoring DAGs with empty (but not None) `access_control`
2) Empty access_control blocks were being overwritten with `None` during DAG initialization.
3) Loading a serialized DAG from the DB replaces `access_control={}` with `access_control=None`, which appears to be intentional behaviour originating from this function:

https://github.com/apache/airflow/blob/30ddfc578fa01d616c93beba6523f5e026ce5c55/airflow/serialization/serialized_objects.py#L610-L630

With this in mind, is there a preferred way to explicitly enable the serialization/deserialization of empty dicts in the `_access_control` field? For now I've just overridden the method in the SerializedDAG class, but this feels a bit messy.

Also added a test to replicate this issue.