### PR TITLE
Purge `[elasticsearch_configs] use_ssl` config param in `ElasticsearchTaskHandler`

### DIFF
--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -106,6 +106,15 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
         # Read more at: https://elasticsearch-py.readthedocs.io/en/v8.8.2/api.html#module-elasticsearch
         if es_kwargs.get("retry_timeout"):
             es_kwargs["retry_on_timeout"] = es_kwargs.pop("retry_timeout")
+        # This parameter was removed in elasticsearch>8, however until Airflow 2.7.1 this parameter
+        # provided by default as False in `[elasticsearch_configs] config` section
+        use_ssl = es_kwargs.pop("use_ssl", None)
+        if use_ssl:  # If user set this config param explicitly to True we could warn
+            warnings.warn(
+                "Passing `[elasticsearch_configs] use_ssl` to ElasticsearchTaskHandler has no effect. "
+                "Please remove it from Airflow Configuration.",
+                UserWarning,
+            )
         host = self.format_url(host)
         super().__init__(base_log_folder, filename_template)
         self.closed = False

--- a/tests/providers/elasticsearch/log/test_es_task_handler.py
+++ b/tests/providers/elasticsearch/log/test_es_task_handler.py
@@ -676,6 +676,42 @@ class TestElasticsearchTaskHandler:
         assert second_log["asctime"] == t2.format("YYYY-MM-DDTHH:mm:ss.SSSZZ")
         assert third_log["asctime"] == t3.format("YYYY-MM-DDTHH:mm:ss.SSSZZ")
 
+    def test_elasticsearch_constructor_use_ssl(self):
+        """Test `[elasticsearch_configs] use_ssl` default parameter prior Airflow 2.7.1"""
+        with mock.patch(
+            "airflow.providers.elasticsearch.log.es_task_handler.elasticsearch.Elasticsearch"
+        ) as mock_es:
+            es_kwargs = {"use_ssl": False, "legit_es8_parameter": "foo"}
+            ElasticsearchTaskHandler(
+                base_log_folder="dummy_folder",
+                end_of_log_mark="end_of_log_mark",
+                write_stdout=False,
+                json_format=False,
+                json_fields="fields",
+                host_field="host",
+                offset_field="offset",
+                es_kwargs=es_kwargs,
+            )
+            mock_es.assert_called_once_with(mock.ANY, legit_es8_parameter="foo")
+
+    def test_elasticsearch_constructor_use_ssl_warn_on_true(self):
+        with mock.patch(
+            "airflow.providers.elasticsearch.log.es_task_handler.elasticsearch.Elasticsearch"
+        ) as mock_es:
+            es_kwargs = {"use_ssl": True, "legit_es8_parameter": "bar"}
+            with pytest.warns(UserWarning, match="Passing `\[elasticsearch_configs\] use_ssl`"):
+                ElasticsearchTaskHandler(
+                    base_log_folder="dummy_folder",
+                    end_of_log_mark="end_of_log_mark",
+                    write_stdout=False,
+                    json_format=False,
+                    json_fields="fields",
+                    host_field="host",
+                    offset_field="offset",
+                    es_kwargs=es_kwargs,
+                )
+            mock_es.assert_called_once_with(mock.ANY, legit_es8_parameter="bar")
+
 
 def test_safe_attrgetter():
     class A:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #34099

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
