### PR TITLE
Fix mapped task not waiting for upstream mapped to complete

### DIFF
--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -337,6 +337,10 @@ class TriggerRuleDep(BaseTIDep):
                 ).all()
                 upstream = sum(count for _, count in task_id_counts)
                 upstream_setup = sum(c for t, c in task_id_counts if upstream_tasks[t].is_setup)
+                if not done >= upstream:
+                    # if we don't have all upstreams done, we can't evaluate the trigger rule
+                    yield self._failing_status("Not all upstream tasks are done.")
+                    return
 
             upstream_done = done >= upstream
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1373,19 +1373,19 @@ class TestTaskInstance:
             #
             # Tests for all_success
             #
-            ["all_success", _UpstreamTIStates(5, 0, 0, 0, 0, 0, 0, 0), True, None, True],
-            ["all_success", _UpstreamTIStates(2, 0, 0, 0, 0, 0, 0, 0), True, None, False],
-            ["all_success", _UpstreamTIStates(2, 0, 1, 0, 0, 0, 0, 0), True, State.UPSTREAM_FAILED, False],
-            ["all_success", _UpstreamTIStates(2, 1, 0, 0, 0, 0, 0, 0), True, State.SKIPPED, False],
+            ["all_success", _UpstreamTIStates(5, 0, 0, 0, 0, 5, 0, 0), True, None, True],
+            ["all_success", _UpstreamTIStates(2, 0, 0, 0, 0, 5, 0, 0), True, None, False],
+            ["all_success", _UpstreamTIStates(2, 0, 1, 0, 0, 5, 0, 0), True, State.UPSTREAM_FAILED, False],
+            ["all_success", _UpstreamTIStates(2, 1, 0, 0, 0, 5, 0, 0), True, State.SKIPPED, False],
             # ti.map_index >= success
-            ["all_success", _UpstreamTIStates(3, 0, 0, 0, 2, 0, 0, 0), True, State.REMOVED, True],
+            ["all_success", _UpstreamTIStates(3, 0, 0, 0, 2, 5, 0, 0), True, State.REMOVED, True],
             #
             # Tests for one_success
             #
             ["one_success", _UpstreamTIStates(5, 0, 0, 0, 0, 5, 0, 0), True, None, True],
-            ["one_success", _UpstreamTIStates(2, 0, 0, 0, 0, 2, 0, 0), True, None, True],
-            ["one_success", _UpstreamTIStates(2, 0, 1, 0, 0, 3, 0, 0), True, None, True],
-            ["one_success", _UpstreamTIStates(2, 1, 0, 0, 0, 3, 0, 0), True, None, True],
+            ["one_success", _UpstreamTIStates(2, 0, 0, 0, 0, 5, 0, 0), True, None, True],
+            ["one_success", _UpstreamTIStates(2, 0, 1, 0, 0, 5, 0, 0), True, None, True],
+            ["one_success", _UpstreamTIStates(2, 1, 0, 0, 0, 5, 0, 0), True, None, True],
             ["one_success", _UpstreamTIStates(0, 5, 0, 0, 0, 5, 0, 0), True, State.SKIPPED, False],
             ["one_success", _UpstreamTIStates(0, 4, 1, 0, 0, 5, 0, 0), True, State.UPSTREAM_FAILED, False],
             ["one_success", _UpstreamTIStates(0, 3, 1, 1, 0, 5, 0, 0), True, State.UPSTREAM_FAILED, False],
@@ -1398,12 +1398,12 @@ class TestTaskInstance:
             #
             ["all_failed", _UpstreamTIStates(5, 0, 0, 0, 0, 5, 0, 0), True, State.SKIPPED, False],
             ["all_failed", _UpstreamTIStates(0, 0, 5, 0, 0, 5, 0, 0), True, None, True],
-            ["all_failed", _UpstreamTIStates(2, 0, 0, 0, 0, 2, 0, 0), True, State.SKIPPED, False],
-            ["all_failed", _UpstreamTIStates(2, 0, 1, 0, 0, 3, 0, 0), True, State.SKIPPED, False],
-            ["all_failed", _UpstreamTIStates(2, 1, 0, 0, 0, 3, 0, 0), True, State.SKIPPED, False],
+            ["all_failed", _UpstreamTIStates(2, 0, 0, 0, 0, 5, 0, 0), True, State.SKIPPED, False],
+            ["all_failed", _UpstreamTIStates(2, 0, 1, 0, 0, 5, 0, 0), True, State.SKIPPED, False],
+            ["all_failed", _UpstreamTIStates(2, 1, 0, 0, 0, 5, 0, 0), True, State.SKIPPED, False],
             [
                 "all_failed",
-                _UpstreamTIStates(2, 1, 0, 0, 1, 4, 0, 0),
+                _UpstreamTIStates(2, 1, 0, 0, 1, 5, 0, 0),
                 True,
                 State.SKIPPED,
                 False,
@@ -1411,9 +1411,9 @@ class TestTaskInstance:
             #
             # Tests for one_failed
             #
-            ["one_failed", _UpstreamTIStates(5, 0, 0, 0, 0, 0, 0, 0), True, None, False],
-            ["one_failed", _UpstreamTIStates(2, 0, 0, 0, 0, 0, 0, 0), True, None, False],
-            ["one_failed", _UpstreamTIStates(2, 0, 1, 0, 0, 0, 0, 0), True, None, True],
+            ["one_failed", _UpstreamTIStates(5, 0, 0, 0, 0, 4, 0, 0), True, None, False],
+            ["one_failed", _UpstreamTIStates(2, 0, 0, 0, 0, 2, 0, 0), True, None, False],
+            ["one_failed", _UpstreamTIStates(2, 0, 1, 0, 0, 5, 0, 0), True, None, True],
             ["one_failed", _UpstreamTIStates(2, 1, 0, 0, 0, 3, 0, 0), True, None, False],
             ["one_failed", _UpstreamTIStates(2, 3, 0, 0, 0, 5, 0, 0), True, State.SKIPPED, False],
             [


### PR DESCRIPTION
Mapped task with an upstream mapped task doesn't wait for the mapped upstream task instances to complete before attempting to run. This results in inconsistent behaviour. For example, if you have an upstream task with 3 mapped task, once any of the task instances finishes, the downstream task will try to run and will depend on the state with which the first finished task in the upstream finished. If the state is failed, then the downstream will be upstream failed. Also, if the state is successful, then the downstream trigger rule will evaluate using this success state of one of the upstream tasks. If eventually, other tasks in the upstream are completed with other states other than success, those are not used in the downstream mapped evaluation.

To fix this, I had to check if all the upstreams were done and only proceed to evaluate the trigger rule if the upstreams were done. This affected tests in tests/models/test_taskinstance.py because to evaluate most, we have to make the UpstreamStates.done to be really be done in tests so the trigger rules can be evaluated

To test the bug, run the below task and notice the inconsistent state of the finished dagrun then run the dag using this commit to see the consistency:

```python

with DAG(
    dag_id="AAAbug",
    start_date=datetime(2023, 7, 4),
    schedule="@daily",
    tags=["setup_teardown"]
) as dag:

    @task
    def my_work(val):
        print(val)

    @task
    def my_setup(val):
        if val == "data2.json":
            raise ValueError("fail!")
        elif val == "data3.json":
            raise AirflowSkipException("skip!")
        print(f"setup: {val}")
        return val

    s = my_setup.expand(val=["data1.json", "data2.json", "data3.json"])
    my_work(s)
```