### PR TITLE
Fix FAB-related logging format interpolation

### DIFF
--- a/airflow/auth/managers/fab/security_manager/modules/db.py
+++ b/airflow/auth/managers/fab/security_manager/modules/db.py
@@ -86,7 +86,7 @@ class FabAirflowSecurityManagerOverrideDb:
             if self.count_users() == 0 and self.auth_role_public != self.auth_role_admin:
                 log.warning(const.LOGMSG_WAR_SEC_NO_USER)
         except Exception as e:
-            log.error(const.LOGMSG_ERR_SEC_CREATE_DB.format(e))
+            log.error(const.LOGMSG_ERR_SEC_CREATE_DB, e)
             exit(1)
 
     """
@@ -104,9 +104,9 @@ class FabAirflowSecurityManagerOverrideDb:
             role.name = name
             self.get_session.merge(role)
             self.get_session.commit()
-            log.info(const.LOGMSG_INF_SEC_UPD_ROLE.format(role))
+            log.info(const.LOGMSG_INF_SEC_UPD_ROLE, role)
         except Exception as e:
-            log.error(const.LOGMSG_ERR_SEC_UPD_ROLE.format(e))
+            log.error(const.LOGMSG_ERR_SEC_UPD_ROLE, e)
             self.get_session.rollback()
             return None
         return role
@@ -120,10 +120,10 @@ class FabAirflowSecurityManagerOverrideDb:
                 role.name = name
                 self.get_session.add(role)
                 self.get_session.commit()
-                log.info(const.LOGMSG_INF_SEC_ADD_ROLE.format(name))
+                log.info(const.LOGMSG_INF_SEC_ADD_ROLE, name)
                 return role
             except Exception as e:
-                log.error(const.LOGMSG_ERR_SEC_ADD_ROLE.format(e))
+                log.error(const.LOGMSG_ERR_SEC_ADD_ROLE, e)
                 self.get_session.rollback()
         return role
 
@@ -187,10 +187,10 @@ class FabAirflowSecurityManagerOverrideDb:
                 user.password = generate_password_hash(password)
             self.get_session.add(user)
             self.get_session.commit()
-            log.info(const.LOGMSG_INF_SEC_ADD_USER.format(username))
+            log.info(const.LOGMSG_INF_SEC_ADD_USER, username)
             return user
         except Exception as e:
-            log.error(const.LOGMSG_ERR_SEC_ADD_USER.format(e))
+            log.error(const.LOGMSG_ERR_SEC_ADD_USER, e)
             self.get_session.rollback()
             return False
 
@@ -226,7 +226,7 @@ class FabAirflowSecurityManagerOverrideDb:
             self.get_session.commit()
             return register_user
         except Exception as e:
-            log.error(const.LOGMSG_ERR_SEC_ADD_REGISTER_USER.format(e))
+            log.error(const.LOGMSG_ERR_SEC_ADD_REGISTER_USER, e)
             self.get_session.rollback()
             return None
 
@@ -267,9 +267,9 @@ class FabAirflowSecurityManagerOverrideDb:
         try:
             self.get_session.merge(user)
             self.get_session.commit()
-            log.info(const.LOGMSG_INF_SEC_UPD_USER.format(user))
+            log.info(const.LOGMSG_INF_SEC_UPD_USER, user)
         except Exception as e:
-            log.error(const.LOGMSG_ERR_SEC_UPD_USER.format(e))
+            log.error(const.LOGMSG_ERR_SEC_UPD_USER, e)
             self.get_session.rollback()
             return False
 
@@ -284,7 +284,7 @@ class FabAirflowSecurityManagerOverrideDb:
             self.get_session.commit()
             return True
         except Exception as e:
-            log.error(const.LOGMSG_ERR_SEC_DEL_REGISTER_USER.format(e))
+            log.error(const.LOGMSG_ERR_SEC_DEL_REGISTER_USER, e)
             self.get_session.rollback()
             return False
 
@@ -322,7 +322,7 @@ class FabAirflowSecurityManagerOverrideDb:
                 self.get_session.commit()
                 return action
             except Exception as e:
-                log.error(const.LOGMSG_ERR_SEC_ADD_PERMISSION.format(e))
+                log.error(const.LOGMSG_ERR_SEC_ADD_PERMISSION, e)
                 self.get_session.rollback()
         return action
 
@@ -334,7 +334,7 @@ class FabAirflowSecurityManagerOverrideDb:
         """
         action = self.get_action(name)
         if not action:
-            log.warning(const.LOGMSG_WAR_SEC_DEL_PERMISSION.format(name))
+            log.warning(const.LOGMSG_WAR_SEC_DEL_PERMISSION, name)
             return False
         try:
             perms = (
@@ -343,13 +343,13 @@ class FabAirflowSecurityManagerOverrideDb:
                 .all()
             )
             if perms:
-                log.warning(const.LOGMSG_WAR_SEC_DEL_PERM_PVM.format(action, perms))
+                log.warning(const.LOGMSG_WAR_SEC_DEL_PERM_PVM, action, perms)
                 return False
             self.get_session.delete(action)
             self.get_session.commit()
             return True
         except Exception as e:
-            log.error(const.LOGMSG_ERR_SEC_DEL_PERMISSION.format(e))
+            log.error(const.LOGMSG_ERR_SEC_DEL_PERMISSION, e)
             self.get_session.rollback()
             return False
 
@@ -383,7 +383,7 @@ class FabAirflowSecurityManagerOverrideDb:
                 self.get_session.commit()
                 return resource
             except Exception as e:
-                log.error(const.LOGMSG_ERR_SEC_ADD_VIEWMENU.format(e))
+                log.error(const.LOGMSG_ERR_SEC_ADD_VIEWMENU, e)
                 self.get_session.rollback()
         return resource
 
@@ -404,7 +404,7 @@ class FabAirflowSecurityManagerOverrideDb:
         """
         resource = self.get_resource(name)
         if not resource:
-            log.warning(const.LOGMSG_WAR_SEC_DEL_VIEWMENU.format(name))
+            log.warning(const.LOGMSG_WAR_SEC_DEL_VIEWMENU, name)
             return False
         try:
             perms = (
@@ -413,13 +413,13 @@ class FabAirflowSecurityManagerOverrideDb:
                 .all()
             )
             if perms:
-                log.warning(const.LOGMSG_WAR_SEC_DEL_VIEWMENU_PVM.format(resource, perms))
+                log.warning(const.LOGMSG_WAR_SEC_DEL_VIEWMENU_PVM, resource, perms)
                 return False
             self.get_session.delete(resource)
             self.get_session.commit()
             return True
         except Exception as e:
-            log.error(const.LOGMSG_ERR_SEC_DEL_PERMISSION.format(e))
+            log.error(const.LOGMSG_ERR_SEC_DEL_PERMISSION, e)
             self.get_session.rollback()
             return False
 
@@ -481,10 +481,10 @@ class FabAirflowSecurityManagerOverrideDb:
         try:
             self.get_session.add(perm)
             self.get_session.commit()
-            log.info(const.LOGMSG_INF_SEC_ADD_PERMVIEW.format(perm))
+            log.info(const.LOGMSG_INF_SEC_ADD_PERMVIEW, perm)
             return perm
         except Exception as e:
-            log.error(const.LOGMSG_ERR_SEC_ADD_PERMVIEW.format(e))
+            log.error(const.LOGMSG_ERR_SEC_ADD_PERMVIEW, e)
             self.get_session.rollback()
             return None
 
@@ -507,7 +507,7 @@ class FabAirflowSecurityManagerOverrideDb:
             self.get_session.query(self.role_model).filter(self.role_model.permissions.contains(perm)).first()
         )
         if roles:
-            log.warning(const.LOGMSG_WAR_SEC_DEL_PERMVIEW.format(resource_name, action_name, roles))
+            log.warning(const.LOGMSG_WAR_SEC_DEL_PERMVIEW, resource_name, action_name, roles)
             return
         try:
             # delete permission on resource
@@ -516,9 +516,9 @@ class FabAirflowSecurityManagerOverrideDb:
             # if no more permission on permission view, delete permission
             if not self.get_session.query(self.permission_model).filter_by(action=perm.action).all():
                 self.delete_action(perm.action.name)
-            log.info(const.LOGMSG_INF_SEC_DEL_PERMVIEW.format(action_name, resource_name))
+            log.info(const.LOGMSG_INF_SEC_DEL_PERMVIEW, action_name, resource_name)
         except Exception as e:
-            log.error(const.LOGMSG_ERR_SEC_DEL_PERMVIEW.format(e))
+            log.error(const.LOGMSG_ERR_SEC_DEL_PERMVIEW, e)
             self.get_session.rollback()
 
     def add_permission_to_role(self, role: Role, permission: Permission | None) -> None:
@@ -534,9 +534,9 @@ class FabAirflowSecurityManagerOverrideDb:
                 role.permissions.append(permission)
                 self.get_session.merge(role)
                 self.get_session.commit()
-                log.info(const.LOGMSG_INF_SEC_ADD_PERMROLE.format(permission, role.name))
+                log.info(const.LOGMSG_INF_SEC_ADD_PERMROLE, permission, role.name)
             except Exception as e:
-                log.error(const.LOGMSG_ERR_SEC_ADD_PERMROLE.format(e))
+                log.error(const.LOGMSG_ERR_SEC_ADD_PERMROLE, e)
                 self.get_session.rollback()
 
     def remove_permission_from_role(self, role: Role, permission: Permission) -> None:
@@ -551,7 +551,7 @@ class FabAirflowSecurityManagerOverrideDb:
                 role.permissions.remove(permission)
                 self.get_session.merge(role)
                 self.get_session.commit()
-                log.info(const.LOGMSG_INF_SEC_DEL_PERMROLE.format(permission, role.name))
+                log.info(const.LOGMSG_INF_SEC_DEL_PERMROLE, permission, role.name)
             except Exception as e:
-                log.error(const.LOGMSG_ERR_SEC_DEL_PERMROLE.format(e))
+                log.error(const.LOGMSG_ERR_SEC_DEL_PERMROLE, e)
                 self.get_session.rollback()

--- a/airflow/www/extensions/init_appbuilder.py
+++ b/airflow/www/extensions/init_appbuilder.py
@@ -69,7 +69,7 @@ def dynamic_class_import(class_path):
         return reduce(getattr, tmp[1:], package)
     except Exception as e:
         log.exception(e)
-        log.error(LOGMSG_ERR_FAB_ADDON_IMPORT.format(class_path, e))
+        log.error(LOGMSG_ERR_FAB_ADDON_IMPORT, class_path, e)
 
 
 class AirflowAppBuilder:
@@ -352,10 +352,10 @@ class AirflowAppBuilder:
                     addon_class.register_views()
                     addon_class.post_process()
                     self.addon_managers[addon] = addon_class
-                    log.info(LOGMSG_INF_FAB_ADDON_ADDED.format(str(addon)))
+                    log.info(LOGMSG_INF_FAB_ADDON_ADDED, addon)
                 except Exception as e:
                     log.exception(e)
-                    log.error(LOGMSG_ERR_FAB_ADDON_PROCESS.format(addon, e))
+                    log.error(LOGMSG_ERR_FAB_ADDON_PROCESS, addon, e)
 
     def _check_and_init(self, baseview):
         if hasattr(baseview, "datamodel"):
@@ -443,7 +443,7 @@ class AirflowAppBuilder:
             appbuilder.add_link("google", href="www.google.com", icon = "fa-google-plus")
         """
         baseview = self._check_and_init(baseview)
-        log.info(LOGMSG_INF_FAB_ADD_VIEW.format(baseview.__class__.__name__, name))
+        log.info(LOGMSG_INF_FAB_ADD_VIEW, baseview.__class__.__name__, name)
 
         if not self._view_exists(baseview):
             baseview.appbuilder = self
@@ -544,7 +544,7 @@ class AirflowAppBuilder:
         :param baseview: A BaseView type class instantiated.
         """
         baseview = self._check_and_init(baseview)
-        log.info(LOGMSG_INF_FAB_ADD_VIEW.format(baseview.__class__.__name__, ""))
+        log.info(LOGMSG_INF_FAB_ADD_VIEW, baseview.__class__.__name__, "")
 
         if not self._view_exists(baseview):
             baseview.appbuilder = self
@@ -554,7 +554,7 @@ class AirflowAppBuilder:
                 self.register_blueprint(baseview, endpoint=endpoint, static_folder=static_folder)
                 self._add_permission(baseview)
         else:
-            log.warning(LOGMSG_WAR_FAB_VIEW_EXISTS.format(baseview.__class__.__name__))
+            log.warning(LOGMSG_WAR_FAB_VIEW_EXISTS, baseview.__class__.__name__)
         return baseview
 
     def security_cleanup(self):
@@ -620,7 +620,7 @@ class AirflowAppBuilder:
                 self.sm.add_permissions_view(baseview.base_permissions, baseview.class_permission_name)
             except Exception as e:
                 log.exception(e)
-                log.error(LOGMSG_ERR_FAB_ADD_PERMISSION_VIEW.format(str(e)))
+                log.error(LOGMSG_ERR_FAB_ADD_PERMISSION_VIEW, e)
 
     def _add_permissions_menu(self, name, update_perms=False):
         if self.update_perms or update_perms:
@@ -628,7 +628,7 @@ class AirflowAppBuilder:
                 self.sm.add_permissions_menu(name)
             except Exception as e:
                 log.exception(e)
-                log.error(LOGMSG_ERR_FAB_ADD_PERMISSION_MENU.format(str(e)))
+                log.error(LOGMSG_ERR_FAB_ADD_PERMISSION_MENU, e)
 
     def _add_menu_permissions(self, update_perms=False):
         if self.update_perms or update_perms:

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -490,7 +490,7 @@ class BaseSecurityManager:
                 "c0976a03d2f18f680bfff877c9a965db9eedc51bc0be87c",
                 "password",
             )
-            log.info(LOGMSG_WAR_SEC_LOGIN_FAILED.format(username))
+            log.info(LOGMSG_WAR_SEC_LOGIN_FAILED, username)
             return None
         elif check_password_hash(user.password, password):
             self._rotate_session_id()
@@ -498,7 +498,7 @@ class BaseSecurityManager:
             return user
         else:
             self.update_user_auth_stat(user, False)
-            log.info(LOGMSG_WAR_SEC_LOGIN_FAILED.format(username))
+            log.info(LOGMSG_WAR_SEC_LOGIN_FAILED, username)
             return None
 
     def _search_ldap(self, ldap, con, username):
@@ -678,7 +678,7 @@ class BaseSecurityManager:
                 try:
                     con.start_tls_s()
                 except Exception:
-                    log.error(LOGMSG_ERR_SEC_AUTH_LDAP_TLS.format(self.auth_ldap_server))
+                    log.error(LOGMSG_ERR_SEC_AUTH_LDAP_TLS, self.auth_ldap_server)
                     return None
 
             # Define variables, so we can check if they are set in later steps
@@ -706,7 +706,7 @@ class BaseSecurityManager:
 
                 # If search failed, go away
                 if user_dn is None:
-                    log.info(LOGMSG_WAR_SEC_NOLDAP_OBJ.format(username))
+                    log.info(LOGMSG_WAR_SEC_NOLDAP_OBJ, username)
                     return None
 
                 # Bind with user_dn/password (validates credentials)
@@ -715,7 +715,7 @@ class BaseSecurityManager:
                         self.update_user_auth_stat(user, False)
 
                     # Invalid credentials, go away
-                    log.info(LOGMSG_WAR_SEC_LOGIN_FAILED.format(username))
+                    log.info(LOGMSG_WAR_SEC_LOGIN_FAILED, username)
                     return None
 
             # Flow 2 - (Direct Search Bind):
@@ -746,7 +746,7 @@ class BaseSecurityManager:
                         self.update_user_auth_stat(user, False)
 
                     # Invalid credentials, go away
-                    log.info(LOGMSG_WAR_SEC_LOGIN_FAILED.format(bind_username))
+                    log.info(LOGMSG_WAR_SEC_LOGIN_FAILED, bind_username)
                     return None
 
                 # Search for `username` (if AUTH_LDAP_SEARCH is set)
@@ -760,7 +760,7 @@ class BaseSecurityManager:
 
                     # If search failed, go away
                     if user_dn is None:
-                        log.info(LOGMSG_WAR_SEC_NOLDAP_OBJ.format(username))
+                        log.info(LOGMSG_WAR_SEC_NOLDAP_OBJ, username)
                         return None
 
             # Sync the user's roles
@@ -785,7 +785,7 @@ class BaseSecurityManager:
 
                 # If user registration failed, go away
                 if not user:
-                    log.info(LOGMSG_ERR_SEC_ADD_REGISTER_USER.format(username))
+                    log.info(LOGMSG_ERR_SEC_ADD_REGISTER_USER, username)
                     return None
 
             # LOGIN SUCCESS (only if user is now registered)
@@ -801,7 +801,7 @@ class BaseSecurityManager:
             if isinstance(e, dict):
                 msg = getattr(e, "message", None)
             if (msg is not None) and ("desc" in msg):
-                log.error(LOGMSG_ERR_SEC_AUTH_LDAP.format(e.message["desc"]))
+                log.error(LOGMSG_ERR_SEC_AUTH_LDAP, e.message["desc"])
                 return None
             else:
                 log.error(e)
@@ -815,7 +815,7 @@ class BaseSecurityManager:
         """
         user = self.find_user(email=email)
         if user is None or (not user.is_active):
-            log.info(LOGMSG_WAR_SEC_LOGIN_FAILED.format(email))
+            log.info(LOGMSG_WAR_SEC_LOGIN_FAILED, email)
             return None
         else:
             self._rotate_session_id()
@@ -845,7 +845,7 @@ class BaseSecurityManager:
         # If user does not exist on the DB and not auto user registration,
         # or user is inactive, go away.
         elif user is None or (not user.is_active):
-            log.info(LOGMSG_WAR_SEC_LOGIN_FAILED.format(username))
+            log.info(LOGMSG_WAR_SEC_LOGIN_FAILED, username)
             return None
 
         self._rotate_session_id()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Due to changes in `flask_appbuilder>=4.3.4` (https://github.com/dpgaspar/Flask-AppBuilder/pull/2071) our logging messages turned into

```console
[2023-09-06T06:59:50.725+0000] {/opt/airflow/airflow/auth/managers/fab/security_manager/modules/db.py:537} INFO - Added Permission %s to role %s
[2023-09-06T06:59:50.737+0000] {/opt/airflow/airflow/auth/managers/fab/security_manager/modules/db.py:484} INFO - Created Permission View: %s
[2023-09-06T06:59:50.740+0000] {/opt/airflow/airflow/auth/managers/fab/security_manager/modules/db.py:537} INFO - Added Permission %s to role %s
[2023-09-06T06:59:50.744+0000] {/opt/airflow/airflow/auth/managers/fab/security_manager/modules/db.py:484} INFO - Created Permission View: %s
[2023-09-06T06:59:50.746+0000] {/opt/airflow/airflow/auth/managers/fab/security_manager/modules/db.py:537} INFO - Added Permission %s to role %s
```
Which do not produce any valuable information


After this fix:
```console
[2023-09-06T17:20:05.744+0000] {/opt/airflow/airflow/auth/managers/fab/security_manager/modules/db.py:537} INFO - Added Permission menu access on Resources to role Admin
[2023-09-06T17:20:05.756+0000] {/opt/airflow/airflow/auth/managers/fab/security_manager/modules/db.py:484} INFO - Created Permission View: can read on Permission Views
[2023-09-06T17:20:05.759+0000] {/opt/airflow/airflow/auth/managers/fab/security_manager/modules/db.py:537} INFO - Added Permission can read on Permission Views to role Admin
[2023-09-06T17:20:05.766+0000] {/opt/airflow/airflow/auth/managers/fab/security_manager/modules/db.py:484} INFO - Created Permission View: menu access on Permission Pairs
[2023-09-06T17:20:05.769+0000] {/opt/airflow/airflow/auth/managers/fab/security_manager/modules/db.py:537} INFO - Added Permission menu access on Permission Pairs to role Admin
```

**update**: we bump FAB to `4.3.6` in https://github.com/apache/airflow/pull/33931

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
