### PR TITLE
Fix query bug in next_run_datasets_summary endpoint

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1087,8 +1087,8 @@ class Airflow(AirflowBaseView):
             filter_dag_ids = allowed_dag_ids
 
         dataset_triggered_dag_ids = [
-            dag.dag_id
-            for dag in (
+            dag_id
+            for dag_id in (
                 session.scalars(
                     select(DagModel.dag_id)
                     .where(DagModel.dag_id.in_(filter_dag_ids))

--- a/tests/www/views/test_views_dataset.py
+++ b/tests/www/views/test_views_dataset.py
@@ -440,3 +440,14 @@ class TestGetDatasetsEndpointPagination(TestDatasetEndpoint):
 
         assert response.status_code == 200
         assert len(response.json["datasets"]) == 50
+
+
+class TestGetDatasetNextRunSummary(TestDatasetEndpoint):
+    def test_next_run_dataset_summary(self, dag_maker, admin_client):
+        with dag_maker(dag_id="upstream", schedule=[Dataset(uri="s3://bucket/key/1")], serialized=True):
+            EmptyOperator(task_id="task1")
+
+        response = admin_client.post("/next_run_datasets_summary", data={"dag_ids": ["upstream"]})
+
+        assert response.status_code == 200
+        assert response.json == {"upstream": {"ready": 0, "total": 1, "uri": "s3://bucket/key/1"}}


### PR DESCRIPTION
The query to get the dataset_triggered_dag_ids in the next_run_datasets_summary endpoint errors with `str` object has no attribute dag_id. This issue is from a recent refactor on sqlalchemy queries and the view has no unit test to detect it. I added a fix with a unit test