### PR TITLE
Fix too strict tests for Salesfore hook

### DIFF
--- a/tests/providers/salesforce/hooks/test_salesforce.py
+++ b/tests/providers/salesforce/hooks/test_salesforce.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import os
+from unittest import mock
 from unittest.mock import Mock, patch
 
 import pandas as pd
@@ -484,7 +485,7 @@ class TestSalesforceHook:
                 session=None,
                 session_id=None,
                 username=None,
-                version="52.0",
+                version=mock.ANY,
             )
 
     @patch("airflow.providers.salesforce.hooks.salesforce.Salesforce")
@@ -513,7 +514,7 @@ class TestSalesforceHook:
                 session=None,
                 session_id=None,
                 username=None,
-                version="52.0",
+                version=mock.ANY,
             )
 
     @patch(


### PR DESCRIPTION
The tests for Salescforce hooh were too strict - they were expecting a specific version and when new salesforce-simple library has been released (1.12.5), the version changed - the tests started to fail.

This PR fixes the tests by accepting any version.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
