### PR TITLE
Add airflow db migrate command to migrateDatabaseJob

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3933,7 +3933,7 @@
                     "default": [
                         "bash",
                         "-c",
-                        "exec \\\nairflow {{ semverCompare \">=2.0.0\" .Values.airflowVersion | ternary \"db upgrade\" \"upgradedb\" }}"
+                        "exec \\\nairflow {{ semverCompare \">=2.7.0\" .Values.airflowVersion | ternary \"db migrate\" (semverCompare \">=2.0.0\" .Values.airflowVersion | ternary \"db upgrade\" \"upgradedb\") }}"
                     ]
                 },
                 "annotations": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1018,10 +1018,12 @@ migrateDatabaseJob:
   args:
     - "bash"
     - "-c"
-    # The format below is necessary to get `helm lint` happy
-    - |-
+    - >-
       exec \
-      airflow {{ semverCompare ">=2.7.0" .Values.airflowVersion | ternary "db migrate" (semverCompare ">=2.0.0" .Values.airflowVersion | ternary "db upgrade" "upgradedb") }}
+
+      airflow {{ semverCompare ">=2.7.0" .Values.airflowVersion
+      | ternary "db migrate" (semverCompare ">=2.0.0" .Values.airflowVersion
+      | ternary "db upgrade" "upgradedb") }}
 
   # Annotations on the database migration pod
   annotations: {}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1021,7 +1021,7 @@ migrateDatabaseJob:
     # The format below is necessary to get `helm lint` happy
     - |-
       exec \
-      airflow {{ semverCompare ">=2.0.0" .Values.airflowVersion | ternary "db upgrade" "upgradedb" }}
+      airflow {{ semverCompare ">=2.7.0" .Values.airflowVersion | ternary "db migrate" (semverCompare ">=2.0.0" .Values.airflowVersion | ternary "db upgrade" "upgradedb") }}
 
   # Annotations on the database migration pod
   annotations: {}

--- a/helm_tests/airflow_aux/test_migrate_database_job.py
+++ b/helm_tests/airflow_aux/test_migrate_database_job.py
@@ -277,6 +277,7 @@ class TestMigrateDatabaseJob:
         [
             ("1.10.14", "airflow upgradedb"),
             ("2.0.2", "airflow db upgrade"),
+            ("2.7.1", "airflow db migrate"),
         ],
     )
     def test_default_command_and_args_airflow_version(self, airflow_version, expected_arg):


### PR DESCRIPTION
Add airflow db migrate command to migrateDatabaseJob

Why is it needed?
Newer Airflow(>= 2.7.0) versions can contain database migrations so we must run airflow db migrate to migrate our database with the schema changes in the Airflow version we are upgrading to.

Reference
https://airflow.apache.org/docs/apache-airflow/stable/installation/upgrading.html#why-you-need-to-upgrade