### PR TITLE
correcting wrong time showing in grid view

### DIFF
--- a/airflow/www/static/js/dag/grid/dagRuns/Bar.tsx
+++ b/airflow/www/static/js/dag/grid/dagRuns/Bar.tsx
@@ -26,13 +26,12 @@ import { Flex, Box, Tooltip, Text, VStack, useTheme } from "@chakra-ui/react";
 import { useContainerRef } from "src/context/containerRef";
 import Time from "src/components/Time";
 import type { SelectionProps } from "src/dag/useSelection";
-import { hoverDelay, getStatusBackgroundColor } from "src/utils";
+import { hoverDelay, getStatusBackgroundColor , getDagRunLabel } from "src/utils";
 import RunTypeIcon from "src/components/RunTypeIcon";
 
+import { useGridData } from "src/api";
 import DagRunTooltip from "./Tooltip";
 import type { RunWithDuration } from ".";
-import { getDagRunLabel } from "src/utils";
-import { useGridData } from "src/api";
 
 const BAR_HEIGHT = 100;
 
@@ -53,7 +52,7 @@ const DagRunBar = ({
   isSelected,
   onSelect,
 }: Props) => {
-  const { runType, runId, duration, state, executionDate } = run;
+  const { runType, runId, duration, state } = run;
   const containerRef = useContainerRef();
   const { colors } = useTheme();
   const hoverBlue = `${colors.blue[100]}50`;
@@ -91,7 +90,7 @@ const DagRunBar = ({
   const {
     data: { ordering },
   } = useGridData();
-  const dagRun = run
+  const dagRun = run;
 
   return (
     <Box
@@ -165,7 +164,10 @@ const DagRunBar = ({
             transform="rotate(-30deg) translateX(28px)"
             mt="-23px !important"
           >
-            <Time dateTime={getDagRunLabel({ dagRun, ordering })} format="MMM DD, HH:mm" />
+            <Time
+              dateTime={getDagRunLabel({ dagRun, ordering })}
+              format="MMM DD, HH:mm"
+            />
           </Text>
           <Box borderLeftWidth={1} opacity={0.7} height="100px" zIndex={0} />
         </VStack>

--- a/airflow/www/static/js/dag/grid/dagRuns/Bar.tsx
+++ b/airflow/www/static/js/dag/grid/dagRuns/Bar.tsx
@@ -26,7 +26,11 @@ import { Flex, Box, Tooltip, Text, VStack, useTheme } from "@chakra-ui/react";
 import { useContainerRef } from "src/context/containerRef";
 import Time from "src/components/Time";
 import type { SelectionProps } from "src/dag/useSelection";
-import { hoverDelay, getStatusBackgroundColor , getDagRunLabel } from "src/utils";
+import {
+  hoverDelay,
+  getStatusBackgroundColor,
+  getDagRunLabel,
+} from "src/utils";
 import RunTypeIcon from "src/components/RunTypeIcon";
 
 import { useGridData } from "src/api";

--- a/airflow/www/static/js/dag/grid/dagRuns/Bar.tsx
+++ b/airflow/www/static/js/dag/grid/dagRuns/Bar.tsx
@@ -31,6 +31,8 @@ import RunTypeIcon from "src/components/RunTypeIcon";
 
 import DagRunTooltip from "./Tooltip";
 import type { RunWithDuration } from ".";
+import { getDagRunLabel } from "src/utils";
+import { useGridData } from "src/api";
 
 const BAR_HEIGHT = 100;
 
@@ -86,6 +88,10 @@ const DagRunBar = ({
     inverseIndex === 4 || (inverseIndex > 4 && (inverseIndex - 4) % 10 === 0);
 
   const color = stateColors[state];
+  const {
+    data: { ordering },
+  } = useGridData();
+  const dagRun = run
 
   return (
     <Box
@@ -159,7 +165,7 @@ const DagRunBar = ({
             transform="rotate(-30deg) translateX(28px)"
             mt="-23px !important"
           >
-            <Time dateTime={executionDate} format="MMM DD, HH:mm" />
+            <Time dateTime={getDagRunLabel({ dagRun, ordering })} format="MMM DD, HH:mm" />
           </Text>
           <Box borderLeftWidth={1} opacity={0.7} height="100px" zIndex={0} />
         </VStack>


### PR DESCRIPTION
related: https://github.com/apache/airflow/issues/32751

corrected inconsistent times in grid view.
I have kept the code of time on area above bars same as the time of tooltip, so that there would be no inconsistency.

Earlier photos( It can be seen in photo that tooltip date is 6 Sep, but date above bar is 5 Sep ):
![normal_hover_time](https://github.com/apache/airflow/assets/120032754/3def7daf-f033-4120-965a-722c3bc76a07) 

![normal_wrong_time](https://github.com/apache/airflow/assets/120032754/31522629-b5f0-4664-9134-d4925c2f809a)


Photo after correction 
![corrected_time](https://github.com/apache/airflow/assets/120032754/5b3e3315-9237-4f6c-bad7-85e473bf6eef)
