### PR TITLE
Ensure that max_attempts is always an int

### DIFF
--- a/airflow/providers/amazon/aws/triggers/emr.py
+++ b/airflow/providers/amazon/aws/triggers/emr.py
@@ -73,7 +73,7 @@ class EmrAddStepsTrigger(BaseTrigger):
         async with self.hook.async_conn as client:
             for step_id in self.step_ids:
                 waiter = client.get_waiter("step_complete")
-                for attempt in range(1, 1 + self.max_attempts):
+                for attempt in range(1, 1 + int(self.max_attempts)):
                     try:
                         await waiter.wait(
                             ClusterId=self.job_flow_id,


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/34177.  Ensures that the `self.max_attempts` inside the run() method of `EmrAddStepsTrigger` is always an int, to prevent an exception being raised by trying to add an int and a str.
