### PR TITLE
Google Dataform operators: Update `template_fields`

### DIFF
--- a/airflow/providers/google/cloud/operators/dataform.py
+++ b/airflow/providers/google/cloud/operators/dataform.py
@@ -66,7 +66,7 @@ class DataformCreateCompilationResultOperator(GoogleCloudBaseOperator):
         account from the list granting this role to the originating account (templated).
     """
 
-    template_fields = ("repository_id", "impersonation_chain")
+    template_fields = ("project_id", "region", "repository_id", "compilation_result", "impersonation_chain")
 
     def __init__(
         self,
@@ -132,7 +132,13 @@ class DataformGetCompilationResultOperator(GoogleCloudBaseOperator):
         account from the list granting this role to the originating account (templated).
     """
 
-    template_fields = ("repository_id", "compilation_result_id", "impersonation_chain")
+    template_fields = (
+        "project_id",
+        "region",
+        "repository_id",
+        "compilation_result_id",
+        "impersonation_chain",
+    )
 
     def __init__(
         self,
@@ -202,7 +208,7 @@ class DataformCreateWorkflowInvocationOperator(GoogleCloudBaseOperator):
     :param wait_time: Number of seconds between checks
     """
 
-    template_fields = ("workflow_invocation", "impersonation_chain")
+    template_fields = ("project_id", "region", "repository_id", "workflow_invocation", "impersonation_chain")
     operator_extra_links = (DataformWorkflowInvocationLink(),)
 
     def __init__(
@@ -291,7 +297,13 @@ class DataformGetWorkflowInvocationOperator(GoogleCloudBaseOperator):
         account from the list granting this role to the originating account (templated).
     """
 
-    template_fields = ("repository_id", "workflow_invocation_id", "impersonation_chain")
+    template_fields = (
+        "project_id",
+        "region",
+        "repository_id",
+        "workflow_invocation_id",
+        "impersonation_chain",
+    )
     operator_extra_links = (DataformWorkflowInvocationLink(),)
 
     def __init__(
@@ -358,7 +370,13 @@ class DataformCancelWorkflowInvocationOperator(GoogleCloudBaseOperator):
         account from the list granting this role to the originating account (templated).
     """
 
-    template_fields = ("repository_id", "workflow_invocation_id", "impersonation_chain")
+    template_fields = (
+        "project_id",
+        "region",
+        "repository_id",
+        "workflow_invocation_id",
+        "impersonation_chain",
+    )
     operator_extra_links = (DataformWorkflowInvocationLink(),)
 
     def __init__(
@@ -426,6 +444,7 @@ class DataformCreateRepositoryOperator(GoogleCloudBaseOperator):
     operator_extra_links = (DataformRepositoryLink(),)
     template_fields = (
         "project_id",
+        "region",
         "repository_id",
         "impersonation_chain",
     )
@@ -505,6 +524,7 @@ class DataformDeleteRepositoryOperator(GoogleCloudBaseOperator):
 
     template_fields = (
         "project_id",
+        "region",
         "repository_id",
         "impersonation_chain",
     )
@@ -579,7 +599,9 @@ class DataformCreateWorkspaceOperator(GoogleCloudBaseOperator):
     operator_extra_links = (DataformWorkspaceLink(),)
     template_fields = (
         "project_id",
+        "region",
         "repository_id",
+        "workspace_id",
         "impersonation_chain",
     )
 
@@ -663,6 +685,7 @@ class DataformDeleteWorkspaceOperator(GoogleCloudBaseOperator):
 
     template_fields = (
         "project_id",
+        "region",
         "repository_id",
         "workspace_id",
         "impersonation_chain",
@@ -739,6 +762,7 @@ class DataformWriteFileOperator(GoogleCloudBaseOperator):
 
     template_fields = (
         "project_id",
+        "region",
         "repository_id",
         "workspace_id",
         "impersonation_chain",
@@ -820,6 +844,7 @@ class DataformMakeDirectoryOperator(GoogleCloudBaseOperator):
 
     template_fields = (
         "project_id",
+        "region",
         "repository_id",
         "workspace_id",
         "impersonation_chain",
@@ -900,6 +925,7 @@ class DataformRemoveFileOperator(GoogleCloudBaseOperator):
 
     template_fields = (
         "project_id",
+        "region",
         "repository_id",
         "workspace_id",
         "impersonation_chain",
@@ -978,6 +1004,7 @@ class DataformRemoveDirectoryOperator(GoogleCloudBaseOperator):
 
     template_fields = (
         "project_id",
+        "region",
         "repository_id",
         "workspace_id",
         "impersonation_chain",
@@ -1056,6 +1083,7 @@ class DataformInstallNpmPackagesOperator(GoogleCloudBaseOperator):
 
     template_fields = (
         "project_id",
+        "region",
         "repository_id",
         "workspace_id",
         "impersonation_chain",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The `template_fields` differ between each of the Google Dataform operators.

This change ensures the following fields are templated for all operators (where they exist):
- `project_id`
- `region`
- `repository_id`
- `workspace_id`
- `impersonation_chain`

Also adds `compilation_result` to `template_fields`  for the `DataformCreateCompilationResultOperator`. Lots of configuration is passed via this dictionary so will be a useful addition.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
