### PR TITLE
fix(providers-google): gcp_conn_id parameter ignored in GKEStartPodOperator hook property

### DIFF
--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -540,6 +540,7 @@ class GKEStartPodOperator(KubernetesPodOperator):
             )
 
         hook = GKEPodHook(
+            gcp_conn_id=self.gcp_conn_id,
             cluster_url=self._cluster_url,
             ssl_ca_cert=self._ssl_ca_cert,
         )

--- a/tests/providers/google/cloud/operators/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/operators/test_kubernetes_engine.py
@@ -320,6 +320,43 @@ class TestGKEPodOperator:
         assert cluster_url == CLUSTER_PRIVATE_URL if use_internal_ip else CLUSTER_URL
         assert ssl_ca_cert == SSL_CA_CERT
 
+    def test_default_gcp_conn_id(self):
+        gke_op = GKEStartPodOperator(
+            project_id=TEST_GCP_PROJECT_ID,
+            location=PROJECT_LOCATION,
+            cluster_name=CLUSTER_NAME,
+            task_id=PROJECT_TASK_ID,
+            name=TASK_NAME,
+            namespace=NAMESPACE,
+            image=IMAGE,
+        )
+        gke_op._cluster_url = CLUSTER_URL
+        gke_op._ssl_ca_cert = SSL_CA_CERT
+        hook = gke_op.hook
+
+        assert hook.gcp_conn_id == "google_cloud_default"
+
+    @mock.patch(
+        "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.get_connection",
+        return_value=Connection(conn_id="test_conn"),
+    )
+    def test_gcp_conn_id(self, get_con_mock):
+        gke_op = GKEStartPodOperator(
+            project_id=TEST_GCP_PROJECT_ID,
+            location=PROJECT_LOCATION,
+            cluster_name=CLUSTER_NAME,
+            task_id=PROJECT_TASK_ID,
+            name=TASK_NAME,
+            namespace=NAMESPACE,
+            image=IMAGE,
+            gcp_conn_id="test_conn",
+        )
+        gke_op._cluster_url = CLUSTER_URL
+        gke_op._ssl_ca_cert = SSL_CA_CERT
+        hook = gke_op.hook
+
+        assert hook.gcp_conn_id == "test_conn"
+
     @pytest.mark.parametrize(
         "compatible_kpo, kwargs, expected_attributes",
         [


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
This fixes an issue introduced in "Add deferrable mode to GKEStartPodOperator" ([#29266](https://github.com/apache/airflow/pull/29266)). `gcp_conn_id` is not passed as parameter during the `GKEPodHook` instanciation in `GKEStartPodOperator.hook`. This results in the `gcp_conn_id` being ignored and replaced by the default value `google_cloud_default` as can be seen in the following logs.

```shell
[2023-09-07, 19:14:32 UTC] {base.py:73} INFO - Using connection ID 'google_cloud_airflow_gke' for task execution.
[2023-09-07, 19:14:32 UTC] {kubernetes_engine.py:288} INFO - Fetching cluster (project_id=<redacted>, location=<redacted>, cluster_name=<redacted>)
[2023-09-07, 19:14:32 UTC] {pod.py:852} INFO - Building pod gke-pod-12asd34v with labels: {'dag_id': '<redacted>', 'task_id': '<redacted>', 'run_id': 'manual__2023-09-07T190347.0421980000-2fafa4fb6', 'kubernetes_pod_operator': 'True', 'try_number': '3'}
[2023-09-07, 19:14:32 UTC] {pod.py:907} ERROR - The conn_id `google_cloud_default` isn't defined
```

This PR also adds unit tests to validate usage of `gcp_conn_id`

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
