### PR TITLE
fix: BigQuery job error message

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -3099,16 +3099,16 @@ class BigQueryAsyncHook(GoogleBaseAsyncHook):
         with await self.service_file_as_context() as f:
             return Job(job_id=job_id, project=project_id, service_file=f, session=cast(Session, session))
 
-    async def get_job_status(self, job_id: str | None, project_id: str | None = None) -> str:
+    async def get_job_status(self, job_id: str | None, project_id: str | None = None) -> dict[str, str]:
         async with ClientSession() as s:
             job_client = await self.get_job_instance(project_id, job_id, s)
             job = await job_client.get_job()
             status = job.get("status", {})
             if status["state"] == "DONE":
                 if "errorResult" in status:
-                    return "error"
-                return "success"
-            return status["state"].lower()
+                    return {"status": "error", "message": status["errorResult"]["message"]}
+                return {"status": "success", "message": "Job completed"}
+            return {"status": status["state"].lower(), "message": "Job running"}
 
     async def get_job_output(
         self,

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -2142,9 +2142,12 @@ class TestBigQueryAsyncHookMethods(_BigQueryBaseAsyncTestClass):
     @pytest.mark.parametrize(
         "job_status, expected",
         [
-            ({"status": {"state": "DONE"}}, "success"),
-            ({"status": {"state": "DONE", "errorResult": "Timeout"}}, "error"),
-            ({"status": {"state": "running"}}, "running"),
+            ({"status": {"state": "DONE"}}, {"status": "success", "message": "Job completed"}),
+            (
+                {"status": {"state": "DONE", "errorResult": {"message": "Timeout"}}},
+                {"status": "error", "message": "Timeout"},
+            ),
+            ({"status": {"state": "running"}}, {"status": "running", "message": "Job running"}),
         ],
     )
     @pytest.mark.asyncio

--- a/tests/providers/google/cloud/triggers/test_bigquery.py
+++ b/tests/providers/google/cloud/triggers/test_bigquery.py
@@ -165,7 +165,7 @@ class TestBigQueryInsertJobTrigger:
         """
         Tests the BigQueryInsertJobTrigger only fires once the query execution reaches a successful state.
         """
-        mock_job_status.return_value = "success"
+        mock_job_status.return_value = {"status": "success", "message": "Job completed"}
 
         generator = insert_job_trigger.run()
         actual = await generator.asend(None)
@@ -198,13 +198,16 @@ class TestBigQueryInsertJobTrigger:
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
     async def test_bigquery_op_trigger_terminated(self, mock_job_status, caplog, insert_job_trigger):
         """Test that BigQuery Triggers fire the correct event in case of an error."""
-        # Set the status to a value other than success or pending
-
-        mock_job_status.return_value = "error"
+        mock_job_status.return_value = {
+            "status": "error",
+            "message": "The conn_id `bq_default` isn't defined",
+        }
 
         generator = insert_job_trigger.run()
         actual = await generator.asend(None)
-        assert TriggerEvent({"status": "error"}) == actual
+        assert (
+            TriggerEvent({"status": "error", "message": "The conn_id `bq_default` isn't defined"}) == actual
+        )
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
@@ -240,7 +243,7 @@ class TestBigQueryGetDataTrigger:
 
         mock_job_client = AsyncMock(Job)
         mock_job_instance.return_value = mock_job_client
-        mock_job_instance.return_value.get_job.return_value = {"status": {"state": "RUNNING"}}
+        mock_job_instance.return_value.get_job.return_value = {"status": {"state": "running"}}
         caplog.set_level(logging.INFO)
 
         task = asyncio.create_task(get_data_trigger.run().__anext__())
@@ -260,11 +263,16 @@ class TestBigQueryGetDataTrigger:
         """Test that BigQuery Triggers fire the correct event in case of an error."""
         # Set the status to a value other than success or pending
 
-        mock_job_status.return_value = "error"
+        mock_job_status.return_value = {
+            "status": "error",
+            "message": "The conn_id `bq_default` isn't defined",
+        }
 
         generator = get_data_trigger.run()
         actual = await generator.asend(None)
-        assert TriggerEvent({"status": "error"}) == actual
+        assert (
+            TriggerEvent({"status": "error", "message": "The conn_id `bq_default` isn't defined"}) == actual
+        )
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
@@ -285,7 +293,7 @@ class TestBigQueryGetDataTrigger:
         """
         Tests that BigQueryGetDataTrigger only fires once the query execution reaches a successful state.
         """
-        mock_job_status.return_value = "success"
+        mock_job_status.return_value = {"status": "success", "message": "Job completed"}
         mock_job_output.return_value = {
             "kind": "bigquery#tableDataList",
             "etag": "test_etag",
@@ -316,7 +324,7 @@ class TestBigQueryGetDataTrigger:
             TriggerEvent(
                 {
                     "status": "success",
-                    "message": "success",
+                    "message": "Job completed",
                     "records": [[42, "monthy python"], [42, "fishy fish"]],
                 }
             )
@@ -353,11 +361,16 @@ class TestBigQueryCheckTrigger:
         """Test that BigQuery Triggers fire the correct event in case of an error."""
         # Set the status to a value other than success or pending
 
-        mock_job_status.return_value = "error"
+        mock_job_status.return_value = {
+            "status": "error",
+            "message": "The conn_id `bq_default` isn't defined",
+        }
 
         generator = check_trigger.run()
         actual = await generator.asend(None)
-        assert TriggerEvent({"status": "error", "message": "error"}) == actual
+        assert (
+            TriggerEvent({"status": "error", "message": "The conn_id `bq_default` isn't defined"}) == actual
+        )
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
@@ -390,7 +403,7 @@ class TestBigQueryCheckTrigger:
         """
         Test the BigQueryCheckTrigger only fires once the query execution reaches a successful state.
         """
-        mock_job_status.return_value = "success"
+        mock_job_status.return_value = {"status": "success", "message": "Job completed"}
         mock_job_output.return_value = {
             "kind": "bigquery#getQueryResultsResponse",
             "etag": "test_etag",
@@ -410,17 +423,16 @@ class TestBigQueryCheckTrigger:
         generator = check_trigger.run()
         actual = await generator.asend(None)
 
-        assert TriggerEvent({"status": "success", "records": [22]}) == actual
+        assert TriggerEvent({"status": "success", "message": "Job completed", "records": [22]}) == actual
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_output")
     async def test_check_trigger_success_without_data(self, mock_job_output, mock_job_status, check_trigger):
         """
-        Tests that BigQueryCheckTrigger sends TriggerEvent as  { "status": "success", "records": None}
-        when no rows are available in the query result.
+        Tests that BigQueryCheckTrigger sends TriggerEvent when no rows are available in the query result.
         """
-        mock_job_status.return_value = "success"
+        mock_job_status.return_value = {"status": "success", "message": "Job completed"}
         mock_job_output.return_value = {
             "kind": "bigquery#getQueryResultsResponse",
             "etag": "test_etag",
@@ -444,7 +456,7 @@ class TestBigQueryCheckTrigger:
 
         generator = check_trigger.run()
         actual = await generator.asend(None)
-        assert TriggerEvent({"status": "success", "records": None}) == actual
+        assert TriggerEvent({"status": "success", "message": "Job completed", "records": None}) == actual
 
 
 class TestBigQueryIntervalCheckTrigger:
@@ -477,7 +489,7 @@ class TestBigQueryIntervalCheckTrigger:
         """
         Tests the BigQueryIntervalCheckTrigger only fires once the query execution reaches a successful state.
         """
-        mock_job_status.return_value = "success"
+        mock_job_status.return_value = {"status": "success", "message": "Job completed"}
         mock_get_job_output.return_value = ["0"]
 
         generator = interval_check_trigger.run()
@@ -490,7 +502,7 @@ class TestBigQueryIntervalCheckTrigger:
         """
         Tests that the BigQueryIntervalCheckTrigger do not fire while a query is still running.
         """
-        mock_job_status.return_value = "pending"
+        mock_job_status.return_value = {"status": "pending", "message": "Job pending"}
         caplog.set_level(logging.INFO)
 
         task = asyncio.create_task(interval_check_trigger.run().__anext__())
@@ -510,12 +522,20 @@ class TestBigQueryIntervalCheckTrigger:
     async def test_interval_check_trigger_terminated(self, mock_job_status, interval_check_trigger):
         """Tests the BigQueryIntervalCheckTrigger fires the correct event in case of an error."""
         # Set the status to a value other than success or pending
-        mock_job_status.return_value = "error"
+        mock_job_status.return_value = {
+            "status": "error",
+            "message": "The conn_id `bq_default` isn't defined",
+        }
 
         generator = interval_check_trigger.run()
         actual = await generator.asend(None)
 
-        assert TriggerEvent({"status": "error", "message": "error", "data": None}) == actual
+        assert (
+            TriggerEvent(
+                {"status": "error", "message": "The conn_id `bq_default` isn't defined", "data": None}
+            )
+            == actual
+        )
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
@@ -559,7 +579,7 @@ class TestBigQueryValueCheckTrigger:
         """
         Tests BigQueryValueCheckTrigger only fires once the query execution reaches a successful state.
         """
-        mock_job_status.return_value = "success"
+        mock_job_status.return_value = {"status": "success", "message": "Job completed"}
         get_job_output.return_value = {}
         get_records.return_value = [[2], [4]]
 
@@ -576,7 +596,7 @@ class TestBigQueryValueCheckTrigger:
         """
         Tests BigQueryValueCheckTrigger only fires once the query execution reaches a successful state.
         """
-        mock_job_status.return_value = "pending"
+        mock_job_status.return_value = {"status": "pending", "message": "Job pending"}
         caplog.set_level(logging.INFO)
 
         task = asyncio.create_task(value_check_trigger.run().__anext__())
@@ -598,7 +618,7 @@ class TestBigQueryValueCheckTrigger:
         """
         Tests BigQueryValueCheckTrigger only fires once the query execution reaches a successful state.
         """
-        mock_job_status.return_value = "dummy"
+        mock_job_status.return_value = {"status": "error", "message": "dummy"}
 
         generator = value_check_trigger.run()
         actual = await generator.asend(None)


### PR DESCRIPTION
closes: #34162 

As mentioned on the issue, currently if a BigQuery job running in deferrable mode ends unsuccessfully during execution - perhaps by cancellation in the BigQuery UI or if the job runs out of resources - then the only message that is returned to logs is the rather unhelpful

```
[2023-09-08, 11:43:22 UTC] {taskinstance.py:1939} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/opt/airflow/airflow/models/baseoperator.py", line 1613, in resume_execution
    return execute_callable(context)
  File "/opt/airflow/airflow/providers/google/cloud/operators/bigquery.py", line 2881, in execute_complete
    raise AirflowException(event["message"])
KeyError: 'message'
```

This is due to the fact that the async function `get_job_status` only returns the string `error` and the actual error message is left behind.

The change involved here is to return a dictionary object that contains both `status` and a `message` which, when a BQ job is in a `DONE` state but contains an `errorResult`, then the specific error is carried through.

This then results in the following error output when the job is cancelled from the UI.

```
[2023-09-08, 08:21:20 UTC] {taskinstance.py:1939} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/opt/airflow/airflow/models/baseoperator.py", line 1613, in resume_execution
    return execute_callable(context)
  File "/opt/airflow/airflow/providers/google/cloud/operators/bigquery.py", line 2881, in execute_complete
    raise AirflowException(event["message"])
airflow.exceptions.AirflowException: Job execution was cancelled: User requested cancellation
```
