### PR TITLE
added default_run_id parameter

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -384,6 +384,12 @@ class DAG(LoggingMixin):
     :param fail_stop: Fails currently running tasks when task in DAG fails.
         **Warning**: A fail stop dag can only have tasks with the default trigger rule ("all_success").
         An exception will be thrown if any task in a fail stop dag has a non default trigger rule.
+    :param default_run_id: A function to determine run_id when it's not specifically given through API.
+        The function should have run_type, logical_date, data_interval, conf parameters to run properly.
+
+        **Example**
+        def my_default_run_id(run_type, logical_date, data_interval, conf):
+            return f"{conf['param1']}_{logical_date.isoformat()}"
     """
 
     _comps = {

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1717,6 +1717,22 @@ class TestDag:
         dr = dag.create_dagrun(run_id="custom_is_set_to_manual", state=State.NONE)
         assert dr.run_type == DagRunType.MANUAL
 
+    def test_create_dagrun_custom_run_id_template_is_generated(self):
+        def run_id_template(run_type, logical_date, data_interval, conf):
+            return f"custom_runid__{logical_date.isoformat()}"
+
+        dag = DAG(dag_id="run_id_is_generated", default_run_id=run_id_template)
+        dr = dag.create_dagrun(execution_date=DEFAULT_DATE, state=State.NONE)
+        assert dr.run_id == f"custom_template__{DEFAULT_DATE.isoformat()}"
+
+        def run_id_template_from_config(run_type, logical_date, data_interval, conf):
+            return f"{conf['param1']}_{logical_date.isoformat()}"
+
+        dag = DAG(dag_id="run_id_is_generated", default_run_id=run_id_template_from_config)
+        conf = {"param1": "test_run"}
+        dr = dag.create_dagrun(execution_date=DEFAULT_DATE, state=State.NONE, conf=conf)
+        assert dr.run_id == f"test_run__{DEFAULT_DATE.isoformat()}"
+
     def test_create_dagrun_job_id_is_set(self):
         job_id = 42
         dag = DAG(dag_id="test_create_dagrun_job_id_is_set")


### PR DESCRIPTION
Adds a parameter to DAG to edit default dag id.
On top of run_type, logical_date, data_interval parameters, can use run config as well.

If NULL / not defined, the standard "manual__{logical_date}" format is used.

Also solves the issue #34064

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
