### PR TITLE
Make param validation consistent for DAG validation and triggering

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -84,6 +84,7 @@ from airflow.exceptions import (
     AirflowSkipException,
     DuplicateTaskIdFound,
     FailStopDagInvalidTriggerRule,
+    ParamValidationError,
     RemovedInAirflow3Warning,
     TaskNotFound,
 )
@@ -3276,20 +3277,20 @@ class DAG(LoggingMixin):
 
     def validate_schedule_and_params(self):
         """
-        Validate Param values when the schedule_interval is not None.
+        Validate Param values when the DAG has schedule defined.
 
-        Raise exception if there are any Params in the DAG which neither have a default value nor
-        have the null in schema['type'] list, but the DAG have a schedule_interval which is not None.
+        Raise exception if there are any Params which can not be resolved by their schema definition.
         """
         if not self.timetable.can_be_scheduled:
             return
 
-        for v in self.params.values():
-            # As type can be an array, we would check if `null` is an allowed type or not
-            if not v.has_value and ("type" not in v.schema or "null" not in v.schema["type"]):
-                raise AirflowException(
-                    "DAG Schedule must be None, if there are any required params without default values"
-                )
+        try:
+            self.params.validate()
+        except ParamValidationError as pverr:
+            raise AirflowException(
+                "DAG is not allowed to define a Schedule, "
+                "if there are any required params without default values or default values are not valid."
+            ) from pverr
 
     def iter_invalid_owner_links(self) -> Iterator[tuple[str, str]]:
         """


### PR DESCRIPTION
This PR adjusts the DAG level Params validation to the validation also used during triggering and DAG constructor.

It resolves the problem reported in #34227 that params with a value of `None` are leading to invalid/unparsable DAGs after upgrade to Airflow 2.7.1 as a side effect of #33141 - reason is that the validation previously checked for `has_value` assuming that the schema also defines a required field.

How to test:
* See all tests are green
* Define a DAG with the code below and see that with the fix applied, the DAG is parse-able again and can be used:
```
@dag(
    dag_id="dag-example",
    start_date=datetime(2023, 2, 2, tz="America/New_York"),
    schedule="41 2 * * *",
    params={
        "any_param": None,
    },
):
    ...
```

closes: #34227
related: #31299, #31301