### PR TITLE
Replace assert by if...raise in www package

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2287,7 +2287,11 @@ class Airflow(AirflowBaseView):
         except AirflowException as ex:
             return redirect_or_json(origin, msg=str(ex), status="error", status_code=500)
 
-        assert isinstance(tis, collections.abc.Iterable)
+        if not isinstance(tis, collections.abc.Iterable):
+            raise AssertionError(
+                f"Expected dag.clear() to return an iterable for dry runs, got {tis} instead."
+            )
+
         details = [str(t) for t in tis]
 
         if not details:


### PR DESCRIPTION
`assert` statement is removed when the compilation is optimized, from [the doc](https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement):
> Assert statements are a convenient way to insert debugging assertions into a program:
assert_stmt ::=  "assert"

> The simple form, assert expression, is equivalent to
 if __debug__:
    if not expression: raise AssertionError
