### PR TITLE
Fix www cluster_activity view not loading due to standaloneDagProcessor templating

### DIFF
--- a/airflow/www/templates/airflow/cluster_activity.html
+++ b/airflow/www/templates/airflow/cluster_activity.html
@@ -43,7 +43,7 @@
   <script>
     const stateColors = {{ state_color_mapping|tojson }};
     const autoRefreshInterval = {{ auto_refresh_interval }};
-    const standaloneDagProcessor = {{ standalone_dag_processor }} === 'True' ;
+    const standaloneDagProcessor = {{ standalone_dag_processor|tojson }} === true ;
   </script>
   <script src="{{ url_for_asset('clusterActivity.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR fixes the problem with webserver cluster_activity view not loading.

Airflow version: not yet released

When the airflow/www/templates/airflow/cluster_activity.html is templated the `standalone_dag_processor` is replaced with a capitalized boolean, which is not recognized by js. In the end it tries doing the following comparison `False === 'True'`.

As far as I understand it was introduced here #33611

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
