### PR TITLE
Add deferred tasks to Pools Slots in the cluster_activity view

### DIFF
--- a/airflow/www/static/js/cluster-activity/index.test.tsx
+++ b/airflow/www/static/js/cluster-activity/index.test.tsx
@@ -87,6 +87,7 @@ const mockPoolsData = {
       queued_slots: 0,
       running_slots: 0,
       scheduled_slots: 0,
+      deferred_slots: 0,
       slots: 128,
     },
   ],

--- a/airflow/www/static/js/cluster-activity/live-metrics/Pools.tsx
+++ b/airflow/www/static/js/cluster-activity/live-metrics/Pools.tsx
@@ -34,13 +34,14 @@ import LoadingWrapper from "src/components/LoadingWrapper";
 
 const formatData = (
   data?: API.PoolCollection
-): Array<[string, number, number, number, number]> =>
+): Array<[string, number, number, number, number, number]> =>
   data?.pools?.map((pool) => [
     pool.name || "",
     pool.openSlots || 0,
     pool.queuedSlots || 0,
     pool.runningSlots || 0,
     pool.scheduledSlots || 0,
+    pool.deferredSlots || 0,
   ]) || [];
 
 const Pools = (props: BoxProps) => {
@@ -49,7 +50,7 @@ const Pools = (props: BoxProps) => {
   const option: ReactEChartsProps["option"] = {
     dataset: {
       source: [
-        ["pool", "open", "queued", "running", "scheduled"],
+        ["pool", "open", "queued", "running", "scheduled", "deferred"],
         ...formatData(data),
       ],
     },
@@ -60,7 +61,7 @@ const Pools = (props: BoxProps) => {
       },
     },
     legend: {
-      data: ["open", "queued", "running", "scheduled"],
+      data: ["open", "queued", "running", "scheduled", "deferred"],
     },
     grid: {
       left: "0%",
@@ -106,6 +107,14 @@ const Pools = (props: BoxProps) => {
         barMaxWidth: 10,
         itemStyle: {
           color: stateColors.scheduled,
+        },
+      },
+      {
+        type: "bar",
+        stack: "total",
+        barMaxWidth: 10,
+        itemStyle: {
+          color: stateColors.deferred,
         },
       },
     ],


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR adds deferred tasks information to the www cluster_activity view Pool Slots block. At the moment they are not captured there. It can be helpful since Pools may include deferred tasks.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
