### PR TITLE
Rename `TestS3ListOperator` to `TestS3ListPrefixesOperator`

### DIFF
--- a/tests/providers/amazon/aws/operators/test_s3_list_prefixes.py
+++ b/tests/providers/amazon/aws/operators/test_s3_list_prefixes.py
@@ -28,7 +28,7 @@ PREFIX = "test/"
 MOCK_SUBFOLDERS = ["test/"]
 
 
-class TestS3ListOperator:
+class TestS3ListPrefixesOperator:
     @mock.patch("airflow.providers.amazon.aws.operators.s3.S3Hook")
     def test_execute(self, mock_hook):
 


### PR DESCRIPTION
This test is for `S3ListPrefixesOperator` not for `S3ListOperator`

To avoid confusion with

https://github.com/apache/airflow/blob/c255ac411b93d222bc9a0dbd4139a15687d2c981/tests/providers/amazon/aws/operators/test_s3_list.py#L31