### PR TITLE
Remove redundant Python 3.7 compat code in google tests

### DIFF
--- a/tests/providers/google/cloud/triggers/test_cloud_storage_transfer_service.py
+++ b/tests/providers/google/cloud/triggers/test_cloud_storage_transfer_service.py
@@ -16,27 +16,20 @@
 # under the License.
 from __future__ import annotations
 
-import sys
+from unittest import mock
 
+import pytest
 from google.api_core.exceptions import GoogleAPICallError
 from google.cloud.storage_transfer_v1 import TransferOperation
 
 from airflow import AirflowException
-from airflow.triggers.base import TriggerEvent
-
-if sys.version_info < (3, 8):
-    from asynctest import mock
-else:
-    from unittest import mock
-
-import pytest
-
 from airflow.providers.google.cloud.hooks.cloud_storage_transfer_service import (
     CloudDataTransferServiceAsyncHook,
 )
 from airflow.providers.google.cloud.triggers.cloud_storage_transfer_service import (
     CloudStorageTransferServiceCreateJobsTrigger,
 )
+from airflow.triggers.base import TriggerEvent
 
 PROJECT_ID = "test-project"
 JOB_0 = "test-job-0"
@@ -53,7 +46,6 @@ CLASS_PATH = (
 ASYNC_HOOK_CLASS_PATH = (
     "airflow.providers.google.cloud.hooks.cloud_storage_transfer_service.CloudDataTransferServiceAsyncHook"
 )
-PYTHON_VERSION = (sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
 
 
 @pytest.fixture(scope="session")
@@ -116,10 +108,6 @@ class TestCloudStorageTransferServiceCreateJobsTrigger:
 
         assert actual_event == expected_event
 
-    @pytest.mark.skipif(
-        (3, 7, 7) < PYTHON_VERSION < (3, 8, 0),
-        reason="Unresolved issue in asynctest: https://github.com/Martiusweb/asynctest/issues/152",
-    )
     @pytest.mark.parametrize(
         "status",
         [
@@ -157,10 +145,6 @@ class TestCloudStorageTransferServiceCreateJobsTrigger:
         assert actual_event == expected_event
         mock_sleep.assert_called_once_with(POLL_INTERVAL)
 
-    @pytest.mark.skipif(
-        (3, 7, 7) < PYTHON_VERSION < (3, 8, 0),
-        reason="Unresolved issue in asynctest: https://github.com/Martiusweb/asynctest/issues/152",
-    )
     @pytest.mark.parametrize(
         "latest_operations_names, expected_failed_job",
         [
@@ -193,10 +177,6 @@ class TestCloudStorageTransferServiceCreateJobsTrigger:
 
         assert actual_event == expected_event
 
-    @pytest.mark.skipif(
-        (3, 7, 7) < PYTHON_VERSION < (3, 8, 0),
-        reason="Unresolved issue in asynctest: https://github.com/Martiusweb/asynctest/issues/152",
-    )
     @pytest.mark.parametrize(
         "job_statuses, failed_operation, expected_status",
         [


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

`asynctest` was removed in #31664 and not required for asyncio tests for python 3.8+


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
