### PR TITLE
Schedule default value description

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -307,7 +307,7 @@ class DAG(LoggingMixin):
     :param schedule: Defines the rules according to which DAG runs are scheduled. Can
         accept cron string, timedelta object, Timetable, or list of Dataset objects.
         If this is not provided, the DAG will be set to the default
-        schedule ``timedelta(days=1)``. See also :doc:`/howto/timetable`. 
+        schedule ``timedelta(days=1)``. See also :doc:`/howto/timetable`.
     :param start_date: The timestamp from which the scheduler will
         attempt to backfill
     :param end_date: A date beyond which your DAG won't run, leave to None

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -306,8 +306,8 @@ class DAG(LoggingMixin):
     :param description: The description for the DAG to e.g. be shown on the webserver
     :param schedule: Defines the rules according to which DAG runs are scheduled. Can
         accept cron string, timedelta object, Timetable, or list of Dataset objects. 
-        If no schedule (or schedule_interval) is provided, then schedule will be set 
-        to  `timedelta(days=1)`. See also :doc:`/howto/timetable`. 
+        If this is not provided, the DAG will be set to the default
+        schedule ``timedelta(days=1)``. See also :doc:`/howto/timetable`. 
     :param start_date: The timestamp from which the scheduler will
         attempt to backfill
     :param end_date: A date beyond which your DAG won't run, leave to None

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -305,7 +305,7 @@ class DAG(LoggingMixin):
         characters, dashes, dots and underscores (all ASCII)
     :param description: The description for the DAG to e.g. be shown on the webserver
     :param schedule: Defines the rules according to which DAG runs are scheduled. Can
-        accept cron string, timedelta object, Timetable, or list of Dataset objects. 
+        accept cron string, timedelta object, Timetable, or list of Dataset objects.
         If this is not provided, the DAG will be set to the default
         schedule ``timedelta(days=1)``. See also :doc:`/howto/timetable`. 
     :param start_date: The timestamp from which the scheduler will

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -305,8 +305,9 @@ class DAG(LoggingMixin):
         characters, dashes, dots and underscores (all ASCII)
     :param description: The description for the DAG to e.g. be shown on the webserver
     :param schedule: Defines the rules according to which DAG runs are scheduled. Can
-        accept cron string, timedelta object, Timetable, or list of Dataset objects.
-        See also :doc:`/howto/timetable`. Default value is `timedelta(days=1)`.
+        accept cron string, timedelta object, Timetable, or list of Dataset objects. 
+        If no schedule (or schedule_interval) is provided, then schedule will be set 
+        to  `timedelta(days=1)`. See also :doc:`/howto/timetable`. 
     :param start_date: The timestamp from which the scheduler will
         attempt to backfill
     :param end_date: A date beyond which your DAG won't run, leave to None

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -306,7 +306,7 @@ class DAG(LoggingMixin):
     :param description: The description for the DAG to e.g. be shown on the webserver
     :param schedule: Defines the rules according to which DAG runs are scheduled. Can
         accept cron string, timedelta object, Timetable, or list of Dataset objects.
-        See also :doc:`/howto/timetable`.
+        See also :doc:`/howto/timetable`. Default value is `timedelta(days=1)`.
     :param start_date: The timestamp from which the scheduler will
         attempt to backfill
     :param end_date: A date beyond which your DAG won't run, leave to None


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Adding more clarification around the behavior of the `schedule` parameter in Airflow. If no value is provided for `schedule` and `schedule_interval` then the result is a default value of `timedelta(days=1)`. 