### PR TITLE
Remove unused parameter `cluster_role_arn` from `EksPodOperator`'s docstring

### DIFF
--- a/airflow/providers/amazon/aws/operators/eks.py
+++ b/airflow/providers/amazon/aws/operators/eks.py
@@ -973,8 +973,6 @@ class EksPodOperator(KubernetesPodOperator):
         :ref:`howto/operator:EksPodOperator`
 
     :param cluster_name: The name of the Amazon EKS Cluster to execute the task on. (templated)
-    :param cluster_role_arn: The Amazon Resource Name (ARN) of the IAM role that provides permissions
-         for the Kubernetes control plane to make calls to AWS API operations on your behalf. (templated)
     :param in_cluster: If True, look for config inside the cluster; if False look for a local file path.
     :param namespace: The namespace in which to execute the pod. (templated)
     :param pod_name: The unique name to give the pod. (templated)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Seems like this parameter never supported by this operator and added accidentally or just missing implementation, hard to say.

Originally posted by **Roee Zilkha** in [slack](https://apache-airflow.slack.com/archives/CCRR5EBA7/p1694498832416849)
```
Hi all , i am trying to run a task inside an eks pod , but the cluster_arn property doesn’t seem to be supported , anyone experienced this?
airflow.exceptions.AirflowException: Invalid arguments were passed to EksPodOperator (task_id: pod_wait). Invalid arguments were: **kwargs: {‘cluster_role_arn’: ‘poc-test’}
we’re using the latest. version of airflow
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
