### PR TITLE
Remove useless print from dbt operator

### DIFF
--- a/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/airflow/providers/dbt/cloud/operators/dbt.py
@@ -135,7 +135,6 @@ class DbtCloudRunJobOperator(BaseOperator):
             additional_run_config=self.additional_run_config,
         )
         self.run_id = trigger_job_response.json()["data"]["id"]
-        print(self.run_id)
         job_run_url = trigger_job_response.json()["data"]["href"]
         # Push the ``job_run_url`` value to XCom regardless of what happens during execution so that the job
         # run can be monitored via the operator link.


### PR DESCRIPTION
related: #34270

I thought about replacing it by `self.log.info` but it's completely useless, and I think it was added to debug locally and pushed by mistake.