### PR TITLE
Fix passing dags.gitSync.sshKeySecret with dags.persistence.enabled=true

### DIFF
--- a/chart/newsfragments/34331.bugfix.rst
+++ b/chart/newsfragments/34331.bugfix.rst
@@ -1,0 +1,1 @@
+Fix missing ``git-sync-ssh-key`` volume in ``scheduler`` pod while using ``dags.persistence.enabled=true`` with ``dags.gitSync.sshKeySecret``.

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -239,9 +239,9 @@ spec:
         {{- else if .Values.dags.gitSync.enabled }}
         - name: dags
           emptyDir: {{- toYaml (default (dict) .Values.dags.gitSync.emptyDirConfig) | nindent 12 }}
-        {{- end }}
-        {{- if and .Values.dags.gitSync.enabled .Values.dags.gitSync.sshKeySecret }}
+        {{- if .Values.dags.gitSync.sshKeySecret }}
           {{- include "git_sync_ssh_key_volume" . | indent 8 }}
+        {{- end }}
         {{- end }}
         {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 8 }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -166,6 +166,7 @@ spec:
             {{- end }}
         {{- end }}
         {{- if and $localOrDagProcessorDisabled .Values.dags.gitSync.enabled }}
+        # unlike other pods, git-sync in scheduler is enabled even if dag.persistence is enabled
           {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 8 }}
         {{- end }}
         {{- if .Values.scheduler.extraInitContainers }}
@@ -244,6 +245,7 @@ spec:
               {{- tpl (toYaml .Values.scheduler.extraVolumeMounts) . | nindent 12 }}
             {{- end }}
         {{- if and $localOrDagProcessorDisabled .Values.dags.gitSync.enabled }}
+        # unlike other pods, git-sync in scheduler is enabled even if dag.persistence is enabled
           {{- include "git_sync_container" . | indent 8 }}
         {{- end }}
         {{- if .Values.scheduler.logGroomerSidecar.enabled }}
@@ -299,9 +301,10 @@ spec:
         {{- else if .Values.dags.gitSync.enabled }}
         - name: dags
           emptyDir: {{- toYaml (default (dict) .Values.dags.gitSync.emptyDirConfig) | nindent 12 }}
-        {{- if .Values.dags.gitSync.sshKeySecret }}
-          {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
+        {{- if .Values.dags.gitSync.sshKeySecret }}
+        # unlike other pods, git-sync in scheduler is enabled even if dag.persistence is enabled
+          {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
         {{- end }}
         {{- if .Values.volumes }}

--- a/helm_tests/other/test_git_sync_dag_processor.py
+++ b/helm_tests/other/test_git_sync_dag_processor.py
@@ -21,12 +21,13 @@ import jmespath
 from tests.charts.helm_template_generator import render_chart
 
 
-class TestGitSyncTriggerer:
-    """Test git sync triggerer."""
+class TestGitSyncDagProcessor:
+    """Test git sync dag processor."""
 
     def test_validate_sshkeysecret_not_added_when_persistence_is_enabled(self):
         docs = render_chart(
             values={
+                "dagProcessor": {"enabled": True},
                 "dags": {
                     "gitSync": {
                         "enabled": True,
@@ -36,9 +37,9 @@ class TestGitSyncTriggerer:
                         "branch": "test-branch",
                     },
                     "persistence": {"enabled": True},
-                }
+                },
             },
-            show_only=["templates/triggerer/triggerer-deployment.yaml"],
+            show_only=["templates/dag-processor/dag-processor-deployment.yaml"],
         )
         assert "git-sync-ssh-key" not in jmespath.search("spec.template.spec.volumes[].name", docs[0])
         assert "git-sync-ssh-key" not in jmespath.search(

--- a/helm_tests/other/test_git_sync_scheduler.py
+++ b/helm_tests/other/test_git_sync_scheduler.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import jmespath
+import pytest
 
 from tests.charts.helm_template_generator import render_chart
 
@@ -132,7 +133,9 @@ class TestGitSyncSchedulerTest:
             "secret": {"secretName": "ssh-secret", "defaultMode": 288},
         } in jmespath.search("spec.template.spec.volumes", docs[0])
 
-    def test_validate_sshkeysecret_not_added_when_persistence_is_enabled(self):
+    @pytest.mark.parametrize("persistence", [True, False])
+    def test_validate_sshkeysecret_added_regardless_of_persistence_value(self, persistence):
+        # Unlike
         docs = render_chart(
             values={
                 "dags": {
@@ -143,12 +146,20 @@ class TestGitSyncSchedulerTest:
                         "knownHosts": None,
                         "branch": "test-branch",
                     },
-                    "persistence": {"enabled": True},
+                    "persistence": {"enabled": persistence},
                 }
             },
             show_only=["templates/scheduler/scheduler-deployment.yaml"],
         )
-        assert "git-sync-ssh-key" not in jmespath.search("spec.template.spec.volumes[].name", docs[0])
+        assert "git-sync-ssh-key" in jmespath.search("spec.template.spec.volumes[].name", docs[0])
+        assert "git-sync-ssh-key" in jmespath.search(
+            "spec.template.spec.containers[].volumeMounts[].name",
+            docs[0],
+        )
+        assert "git-sync-ssh-key" in jmespath.search(
+            "spec.template.spec.initContainers[].volumeMounts[].name",
+            docs[0],
+        )
 
     def test_should_set_username_and_pass_env_variables(self):
         docs = render_chart(

--- a/helm_tests/other/test_git_sync_webserver.py
+++ b/helm_tests/other/test_git_sync_webserver.py
@@ -172,3 +172,11 @@ class TestGitSyncWebserver:
             show_only=["templates/webserver/webserver-deployment.yaml"],
         )
         assert "git-sync-ssh-key" not in jmespath.search("spec.template.spec.volumes[].name", docs[0])
+        assert "git-sync-ssh-key" not in jmespath.search(
+            "spec.template.spec.containers[].volumeMounts[].name",
+            docs[0],
+        )
+        assert "git-sync-ssh-key" not in jmespath.search(
+            "spec.template.spec.initContainers[].volumeMounts[].name",
+            docs[0],
+        )

--- a/helm_tests/other/test_git_sync_worker.py
+++ b/helm_tests/other/test_git_sync_worker.py
@@ -132,3 +132,11 @@ class TestGitSyncWorker:
         )
 
         assert "git-sync-ssh-key" not in jmespath.search("spec.template.spec.volumes[].name", docs[0])
+        assert "git-sync-ssh-key" not in jmespath.search(
+            "spec.template.spec.containers[].volumeMounts[].name",
+            docs[0],
+        )
+        assert "git-sync-ssh-key" not in jmespath.search(
+            "spec.template.spec.initContainers[].volumeMounts[].name",
+            docs[0],
+        )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

* Deploy Airflow using Heml chart 1.10.0 with `dags.gitSync.enabled=True`
* After testing git sync is working as expected, set `dags.persistence.enabled=true` to store dags to persistent volume instead of empty dir.
* Got exception that `git-sync-ssh-key` volume is missing in `scheduler` pod description:
```
  volumes:
    - name: config
      configMap:
        name: airflow-airflow-config
    - name: dags
-     emptyDir: {}
-
-   - name: git-sync-ssh-key
-     secret:
-       secretName: airflow-ssh-secret
-       defaultMode: 288
+     persistentVolumeClaim:
+       claimName: airflow-dags
    - name: logs
      persistentVolumeClaim:
```

```
cannot patch "airflow-scheduler" with kind Deployment: Deployment.apps "airflow-scheduler" is invalid: [spec.template.spec.containers[1].volumeMounts[1].name: Not found: "git-sync-ssh-key", spec.template.spec.initContainers[1].volumeMounts[1].name: Not found: "git-sync-ssh-key"]
helm.go:84: [debug] cannot patch "airflow-scheduler" with kind Deployment: Deployment.apps "airflow-scheduler" is invalid: [spec.template.spec.containers[1].volumeMounts[1].name: Not found: "git-sync-ssh-key", spec.template.spec.initContainers[1].volumeMounts[1].name: Not found: "git-sync-ssh-key"]
```

[helm.log](https://github.com/apache/airflow/files/12595699/helm.log)

This is because of wrong condition in helm chart - `git-sync-ssh-key` `volumeMount` is always present in `git-sync` container inside scheduler pod, but corresponding `volume` is added to pod only if `dags.persistence.enabled=false`. Changed this condition to always add `git-sync-ssh-key` to scheduler volumes if git sync is enabled and ssh-key secret is passed to chart.

This issue was introduced in #22913 - git sync should be disabled on all pods if dag persistence is enabled, **except** scheduler (because scheduler pod is the sync point of dags).

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
