### PR TITLE
Add note for ingress on 31066 news fragment

### DIFF
--- a/chart/newsfragments/31066.significant.rst
+++ b/chart/newsfragments/31066.significant.rst
@@ -2,7 +2,7 @@ Support naming customization on helm chart resources, some resources may be rena
 
 This is a new opt-in switch ``useStandardNaming``, for backwards compatibility, to leverage the standard naming convention, which allows full use of fullnameOverride and nameOverride in all resources.
 
-The following resources will be renamed using default of ``useStandardNaming=false`` when upgrading from to 1.11.0 or a higher version
+The following resources will be renamed using default of ``useStandardNaming=false`` when upgrading to 1.11.0 or a higher version.
 - ConfigMap {release}-airflow-config to {release}-config
 - Secret {release}-airflow-metadata to {release}-metadata
 - Secret {release}-airflow-result-backend to {release}-result-backend

--- a/chart/newsfragments/31066.significant.rst
+++ b/chart/newsfragments/31066.significant.rst
@@ -3,6 +3,7 @@ Support naming customization on helm chart resources, some resources may be rena
 This is a new opt-in switch ``useStandardNaming``, for backwards compatibility, to leverage the standard naming convention, which allows full use of fullnameOverride and nameOverride in all resources.
 
 The following resources will be renamed using default of ``useStandardNaming=false`` when upgrading to 1.11.0 or a higher version.
+
 - ConfigMap {release}-airflow-config to {release}-config
 - Secret {release}-airflow-metadata to {release}-metadata
 - Secret {release}-airflow-result-backend to {release}-result-backend

--- a/chart/newsfragments/31066.significant.rst
+++ b/chart/newsfragments/31066.significant.rst
@@ -2,10 +2,11 @@ Support naming customization on helm chart resources, some resources may be rena
 
 This is a new opt-in switch ``useStandardNaming``, for backwards compatibility, to leverage the standard naming convention, which allows full use of fullnameOverride and nameOverride in all resources.
 
-Only the following resources will be renamed using default of ``useStandardNaming=false``:
+The following resources will be renamed using default of ``useStandardNaming=false`` when upgrading from to 1.11.0 or a higher version
 - ConfigMap {release}-airflow-config to {release}-config
 - Secret {release}-airflow-metadata to {release}-metadata
 - Secret {release}-airflow-result-backend to {release}-result-backend
+- Ingress {release}-airflow-ingress to {release}-ingress
 
 For existing installations, all your resources will be recreated with a new name and helm will delete previous resources.
 


### PR DESCRIPTION
This updates the [31066 news fragment](chart/newsfragments/31066.significant.rst) introduced on https://github.com/apache/airflow/pull/31066 to include the ingress rename as well, and clarify when that happens