### PR TITLE
Get rid of flakiness in CLI gunicorn tests

### DIFF
--- a/tests/cli/commands/_common_cli_classes.py
+++ b/tests/cli/commands/_common_cli_classes.py
@@ -20,10 +20,11 @@ from __future__ import annotations
 import os
 import re
 import time
+from contextlib import suppress
 
 import psutil
 import pytest
-from psutil import Error
+from psutil import Error, NoSuchProcess
 from rich.console import Console
 
 from airflow.cli import cli_parser
@@ -55,16 +56,19 @@ class _ComonCLIGunicornTestClass:
         if airflow_internal_api_pids or gunicorn_pids:
             console.print("[blue]Some processes are still running")
             for pid in gunicorn_pids + airflow_internal_api_pids:
-                console.print(psutil.Process(pid).as_dict(attrs=["pid", "name", "cmdline"]))
+                with suppress(NoSuchProcess):
+                    console.print(psutil.Process(pid).as_dict(attrs=["pid", "name", "cmdline"]))
             console.print("[blue]Here list of processes ends")
             if airflow_internal_api_pids:
                 console.print(f"[yellow]Forcefully killing {self.main_process_regexp} processes")
                 for pid in airflow_internal_api_pids:
-                    psutil.Process(pid).kill()
+                    with suppress(NoSuchProcess):
+                        psutil.Process(pid).kill()
             if gunicorn_pids:
                 console.print("[yellow]Forcefully killing all gunicorn processes")
                 for pid in gunicorn_pids:
-                    psutil.Process(pid).kill()
+                    with suppress(NoSuchProcess):
+                        psutil.Process(pid).kill()
             if not ignore_running:
                 raise AssertionError(
                     "Background processes are running that prevent the test from passing successfully."


### PR DESCRIPTION
The cli background tests had failed randomly from time to time with "NoSuchProcess" exception. For example in:
https://github.com/apache/airflow/actions/runs/6194862351/job/16819105464

The root cause of it was a race condition - when the process exited after we retrived the list of processes but before we attempted to kill it, creating of Process object failed with NoSuchProcess.

This PR catches such exceptions individually and let the iteration process continue with killing other processes.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
