### PR TITLE
Refactor import sqlalchemy as sa

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 import pendulum
 import pluggy
-import sqlalchemy
+import sqlalchemy as sa
 from sqlalchemy import create_engine, exc, text
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.pool import NullPool
@@ -237,9 +237,7 @@ def configure_orm(disable_connection_pool=False, pool_class=None):
         session = Session()
         try:
             result = session.execute(
-                sqlalchemy.text(
-                    "SELECT is_read_committed_snapshot_on FROM sys.databases WHERE name=:database_name"
-                ),
+                sa.text("SELECT is_read_committed_snapshot_on FROM sys.databases WHERE name=:database_name"),
                 params={"database_name": engine.url.database},
             )
             data = result.fetchone()[0]

--- a/tests/always/test_connection.py
+++ b/tests/always/test_connection.py
@@ -24,7 +24,7 @@ from collections import namedtuple
 from unittest import mock
 
 import pytest
-import sqlalchemy
+import sqlalchemy as sa
 from cryptography.fernet import Fernet
 
 from airflow import AirflowException
@@ -678,7 +678,7 @@ class TestConnection:
         conn = BaseHook.get_connection(conn_id="test_uri")
         hook = conn.get_hook()
         engine = hook.get_sqlalchemy_engine()
-        assert isinstance(engine, sqlalchemy.engine.Engine)
+        assert isinstance(engine, sa.engine.Engine)
         assert "postgresql://username:password@ec2.compute.com:5432/the_database" == str(engine.url)
 
     @mock.patch.dict(

--- a/tests/cli/commands/test_celery_command.py
+++ b/tests/cli/commands/test_celery_command.py
@@ -23,7 +23,7 @@ from argparse import Namespace
 from unittest import mock
 
 import pytest
-import sqlalchemy
+import sqlalchemy as sa
 
 import airflow
 from airflow.cli import cli_parser
@@ -58,7 +58,7 @@ class TestWorkerPrecheck:
         """
         Test to validate connection failure scenario on SELECT 1 query
         """
-        mock_session.side_effect = sqlalchemy.exc.OperationalError("m1", "m2", "m3", "m4")
+        mock_session.side_effect = sa.exc.OperationalError("m1", "m2", "m3", "m4")
         assert airflow.settings.validate_session() is False
 
 

--- a/tests/providers/google/cloud/hooks/test_spanner.py
+++ b/tests/providers/google/cloud/hooks/test_spanner.py
@@ -21,7 +21,7 @@ from unittest import mock
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
-import sqlalchemy
+import sqlalchemy as sa
 
 from airflow.providers.google.cloud.hooks.spanner import SpannerHook
 from airflow.providers.google.common.consts import CLIENT_INFO
@@ -446,7 +446,7 @@ class TestGcpSpannerHookDefaultProjectId:
     def test_get_sqlalchemy_engine(self, get_client):
         self.spanner_hook_default_project_id._get_conn_params = MagicMock(return_value=SPANNER_CONN_PARAMS)
         engine = self.spanner_hook_default_project_id.get_sqlalchemy_engine()
-        assert isinstance(engine, sqlalchemy.engine.Engine)
+        assert isinstance(engine, sa.engine.Engine)
         assert engine.name == "spanner+spanner"
 
 
@@ -706,5 +706,5 @@ class TestGcpSpannerHookNoDefaultProjectID:
     def test_get_sqlalchemy_engine(self, get_client):
         self.spanner_hook_no_default_project_id._get_conn_params = MagicMock(return_value=SPANNER_CONN_PARAMS)
         engine = self.spanner_hook_no_default_project_id.get_sqlalchemy_engine()
-        assert isinstance(engine, sqlalchemy.engine.Engine)
+        assert isinstance(engine, sa.engine.Engine)
         assert engine.name == "spanner+spanner"

--- a/tests/providers/sqlite/hooks/test_sqlite.py
+++ b/tests/providers/sqlite/hooks/test_sqlite.py
@@ -21,7 +21,7 @@ from unittest import mock
 from unittest.mock import patch
 
 import pytest
-import sqlalchemy
+import sqlalchemy as sa
 
 from airflow.models import Connection
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
@@ -143,7 +143,7 @@ class TestSqliteHook:
         conn_id = "sqlite_default"
         hook = SqliteHook(sqlite_conn_id=conn_id)
         engine = hook.get_sqlalchemy_engine()
-        assert isinstance(engine, sqlalchemy.engine.Engine)
+        assert isinstance(engine, sa.engine.Engine)
         assert engine.name == "sqlite"
         # Assert filepath of the sqliate DB is correct
         assert engine.url.database == hook.get_connection(conn_id).host


### PR DESCRIPTION
This replaces only `import sqlalchemy` and `import sqlalchemy as sqla` with `import sqlalchemy as sa`.

There are plenty of `from sqlalchemy import …`. What would you like to do with them?