### PR TITLE
Docs for triggered_dataset_event

### DIFF
--- a/docs/apache-airflow/authoring-and-scheduling/datasets.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/datasets.rst
@@ -234,3 +234,5 @@ Example:
                 print(dataset_list[dataset][0].source_dag_run.dag_run_id)
 
         print_triggering_dataset_events()
+
+Note that this example is using `(.values() | first | first) <https://jinja.palletsprojects.com/en/3.1.x/templates/#jinja-filters.first>`_ to fetch the first of one Dataset given to the DAG, and the first of one DatasetEvent for that Dataset. An implementation may be quite complex if you have multiple Datasets, potentially with multiple DatasetEvents.

--- a/docs/apache-airflow/authoring-and-scheduling/datasets.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/datasets.rst
@@ -197,3 +197,9 @@ Notes on schedules
 The ``schedule`` parameter to your DAG can take either a list of datasets to consume or a timetable-based option. The two cannot currently be mixed.
 
 When using datasets, in this first release (v2.4) waiting for all datasets in the list to be updated is the only option when multiple datasets are consumed by a DAG. A later release may introduce more fine-grained options allowing for greater flexibility.
+
+Fetching information from a Triggering Dataset Event
+----------------------------------------------------
+
+A triggered DAG can fetch information from the Dataset that triggered it using the ``triggering_dataset_events`` template or parameter.
+See more at :ref:`templates-ref`.

--- a/docs/apache-airflow/templates-ref.rst
+++ b/docs/apache-airflow/templates-ref.rst
@@ -33,25 +33,25 @@ Variables
 The Airflow engine passes a few variables by default that are accessible
 in all templates
 
-=========================================== ====================== ===================================================================
-Variable                                    Type                   Description
-=========================================== ====================== ===================================================================
-``{{ data_interval_start }}``               `pendulum.DateTime`_   Start of the data interval. Added in version 2.2.
-``{{ data_interval_end }}``                 `pendulum.DateTime`_   End of the data interval. Added in version 2.2.
-``{{ ds }}``                                str                    | The DAG run's logical date as ``YYYY-MM-DD``.
-                                                                   | Same as ``{{ dag_run.logical_date | ds }}``.
-``{{ ds_nodash }}``                         str                    Same as ``{{ dag_run.logical_date | ds_nodash }}``.
-``{{ ts }}``                                str                    | Same as ``{{ dag_run.logical_date | ts }}``.
-                                                                   | Example: ``2018-01-01T00:00:00+00:00``.
-``{{ ts_nodash_with_tz }}``                 str                    | Same as ``{{ dag_run.logical_date | ts_nodash_with_tz }}``.
-                                                                   | Example: ``20180101T000000+0000``.
-``{{ ts_nodash }}``                         str                    | Same as ``{{ dag_run.logical_date | ts_nodash }}``.
-                                                                   | Example: ``20180101T000000``.
-``{{ prev_data_interval_start_success }}``  `pendulum.DateTime`_   | Start of the data interval of the prior successful :class:`~airflow.models.dagrun.DagRun`.
-                                            | ``None``             | Added in version 2.2.
-``{{ prev_data_interval_end_success }}``    `pendulum.DateTime`_   | End of the data interval of the prior successful :class:`~airflow.models.dagrun.DagRun`.
-                                            | ``None``             | Added in version 2.2.
-``{{ prev_start_date_success }}``           `pendulum.DateTime`_   Start date from prior successful :class:`~airflow.models.dagrun.DagRun` (if available).
+=========================================== ===================== ===================================================================
+Variable                                    Type                  Description
+=========================================== ===================== ===================================================================
+``{{ data_interval_start }}``               `pendulum.DateTime`_  Start of the data interval. Added in version 2.2.
+``{{ data_interval_end }}``                 `pendulum.DateTime`_  End of the data interval. Added in version 2.2.
+``{{ ds }}``                                str                   | The DAG run's logical date as ``YYYY-MM-DD``.
+                                                                  | Same as ``{{ dag_run.logical_date | ds }}``.
+``{{ ds_nodash }}``                         str                   Same as ``{{ dag_run.logical_date | ds_nodash }}``.
+``{{ ts }}``                                str                   | Same as ``{{ dag_run.logical_date | ts }}``.
+                                                                  | Example: ``2018-01-01T00:00:00+00:00``.
+``{{ ts_nodash_with_tz }}``                 str                   | Same as ``{{ dag_run.logical_date | ts_nodash_with_tz }}``.
+                                                                  | Example: ``20180101T000000+0000``.
+``{{ ts_nodash }}``                         str                   | Same as ``{{ dag_run.logical_date | ts_nodash }}``.
+                                                                  | Example: ``20180101T000000``.
+``{{ prev_data_interval_start_success }}``  `pendulum.DateTime`_  | Start of the data interval of the prior successful :class:`~airflow.models.dagrun.DagRun`.
+                                            | ``None``            | Added in version 2.2.
+``{{ prev_data_interval_end_success }}``    `pendulum.DateTime`_  | End of the data interval of the prior successful :class:`~airflow.models.dagrun.DagRun`.
+                                            | ``None``            | Added in version 2.2.
+``{{ prev_start_date_success }}``           `pendulum.DateTime`_  Start date from prior successful :class:`~airflow.models.dagrun.DagRun` (if available).
                                             | ``None``
 ``{{ dag }}``                               DAG                   The currently running :class:`~airflow.models.dag.DAG`. You can read more about DAGs in :doc:`DAGs <core-concepts/dags>`.
 ``{{ task }}``                              BaseOperator          | The currently running :class:`~airflow.models.baseoperator.BaseOperator`. You can read more about Tasks in :doc:`core-concepts/operators`
@@ -74,7 +74,8 @@ Variable                                    Type                   Description
 ``{{ expanded_ti_count }}``                 int | ``None``        | Number of task instances that a mapped task was expanded into. If
                                                                   | the current task is not mapped, this should be ``None``.
                                                                   | Added in version 2.5.
-``{{ triggering_dataset_events }}``         list[DatasetEvent]    | If in a Dataset Scheduled DAG, a list of triggering :class:`~airflow.models.dataset.DatasetEvent`.
+``{{ triggering_dataset_events }}``         dict[str,             | If in a Dataset Scheduled DAG, a map of Dataset URI to a list of triggering :class:`~airflow.models.dataset.DatasetEvent`
+                                            list[DatasetEvent]]   | (there may be more than one, if there are multiple Datasets with different frequencies).
                                                                   | Read more here :doc:`Datasets <authoring-and-scheduling/datasets>`.
                                                                   | Added in version 2.4.
 =========================================== ===================== ===================================================================

--- a/docs/apache-airflow/templates-ref.rst
+++ b/docs/apache-airflow/templates-ref.rst
@@ -33,25 +33,25 @@ Variables
 The Airflow engine passes a few variables by default that are accessible
 in all templates
 
-=========================================== ===================== ===================================================================
-Variable                                    Type                  Description
-=========================================== ===================== ===================================================================
-``{{ data_interval_start }}``               `pendulum.DateTime`_  Start of the data interval. Added in version 2.2.
-``{{ data_interval_end }}``                 `pendulum.DateTime`_  End of the data interval. Added in version 2.2.
-``{{ ds }}``                                str                   | The DAG run's logical date as ``YYYY-MM-DD``.
-                                                                  | Same as ``{{ dag_run.logical_date | ds }}``.
-``{{ ds_nodash }}``                         str                   Same as ``{{ dag_run.logical_date | ds_nodash }}``.
-``{{ ts }}``                                str                   | Same as ``{{ dag_run.logical_date | ts }}``.
-                                                                  | Example: ``2018-01-01T00:00:00+00:00``.
-``{{ ts_nodash_with_tz }}``                 str                   | Same as ``{{ dag_run.logical_date | ts_nodash_with_tz }}``.
-                                                                  | Example: ``20180101T000000+0000``.
-``{{ ts_nodash }}``                         str                   | Same as ``{{ dag_run.logical_date | ts_nodash }}``.
-                                                                  | Example: ``20180101T000000``.
-``{{ prev_data_interval_start_success }}``  `pendulum.DateTime`_  | Start of the data interval of the prior successful :class:`~airflow.models.dagrun.DagRun`.
-                                            | ``None``            | Added in version 2.2.
-``{{ prev_data_interval_end_success }}``    `pendulum.DateTime`_  | End of the data interval of the prior successful :class:`~airflow.models.dagrun.DagRun`.
-                                            | ``None``            | Added in version 2.2.
-``{{ prev_start_date_success }}``           `pendulum.DateTime`_  Start date from prior successful :class:`~airflow.models.dagrun.DagRun` (if available).
+=========================================== ====================== ===================================================================
+Variable                                    Type                   Description
+=========================================== ====================== ===================================================================
+``{{ data_interval_start }}``               `pendulum.DateTime`_   Start of the data interval. Added in version 2.2.
+``{{ data_interval_end }}``                 `pendulum.DateTime`_   End of the data interval. Added in version 2.2.
+``{{ ds }}``                                str                    | The DAG run's logical date as ``YYYY-MM-DD``.
+                                                                   | Same as ``{{ dag_run.logical_date | ds }}``.
+``{{ ds_nodash }}``                         str                    Same as ``{{ dag_run.logical_date | ds_nodash }}``.
+``{{ ts }}``                                str                    | Same as ``{{ dag_run.logical_date | ts }}``.
+                                                                   | Example: ``2018-01-01T00:00:00+00:00``.
+``{{ ts_nodash_with_tz }}``                 str                    | Same as ``{{ dag_run.logical_date | ts_nodash_with_tz }}``.
+                                                                   | Example: ``20180101T000000+0000``.
+``{{ ts_nodash }}``                         str                    | Same as ``{{ dag_run.logical_date | ts_nodash }}``.
+                                                                   | Example: ``20180101T000000``.
+``{{ prev_data_interval_start_success }}``  `pendulum.DateTime`_   | Start of the data interval of the prior successful :class:`~airflow.models.dagrun.DagRun`.
+                                            | ``None``             | Added in version 2.2.
+``{{ prev_data_interval_end_success }}``    `pendulum.DateTime`_   | End of the data interval of the prior successful :class:`~airflow.models.dagrun.DagRun`.
+                                            | ``None``             | Added in version 2.2.
+``{{ prev_start_date_success }}``           `pendulum.DateTime`_   Start date from prior successful :class:`~airflow.models.dagrun.DagRun` (if available).
                                             | ``None``
 ``{{ dag }}``                               DAG                   The currently running :class:`~airflow.models.dag.DAG`. You can read more about DAGs in :doc:`DAGs <core-concepts/dags>`.
 ``{{ task }}``                              BaseOperator          | The currently running :class:`~airflow.models.baseoperator.BaseOperator`. You can read more about Tasks in :doc:`core-concepts/operators`
@@ -74,6 +74,9 @@ Variable                                    Type                  Description
 ``{{ expanded_ti_count }}``                 int | ``None``        | Number of task instances that a mapped task was expanded into. If
                                                                   | the current task is not mapped, this should be ``None``.
                                                                   | Added in version 2.5.
+``{{ triggering_dataset_events }}``         list[DatasetEvent]    | If in a Dataset Scheduled DAG, a list of triggering :class:`~airflow.models.dataset.DatasetEvent`.
+                                                                  | Read more here :doc:`Datasets <authoring-and-scheduling/datasets>`.
+                                                                  | Added in version 2.4.
 =========================================== ===================== ===================================================================
 
 .. note::

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -379,6 +379,8 @@ DataScan
 dataScans
 Dataset
 dataset
+DatasetEvent
+DatasetEvents
 datasetId
 Datasets
 datasets


### PR DESCRIPTION
- add `templates.rst` reference for triggering_dataset_events
- adds a note to check the templates page on the datasets page

Validated with breeze locally :) Still can't get stuff like ```:class:`~airflow.models.dataset.DatasetEvent` ``` to link correctly, but that's outside the scope of this