### PR TITLE
Remove unnecessary `or` function in template files

### DIFF
--- a/chart/templates/cleanup/cleanup-cronjob.yaml
+++ b/chart/templates/cleanup/cleanup-cronjob.yaml
@@ -92,7 +92,7 @@ spec:
             - name: airflow-cleanup-pods
               image: {{ template "airflow_image" . }}
               imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
-              securityContext: {{ or $containerSecurityContext .Values.cleanup.securityContexts.container .Values.securityContexts.containers | nindent 16 }}
+              securityContext: {{ $containerSecurityContext | nindent 16 }}
               {{- if .Values.cleanup.command }}
               command: {{ tpl (toYaml .Values.cleanup.command) . | nindent 16 }}
               {{- end }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -172,7 +172,7 @@ spec:
         - name: webserver
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
-          securityContext: {{ or $containerSecurityContext .Values.webserver.securityContexts.container .Values.securityContexts.container | nindent 12 }}
+          securityContext: {{ $containerSecurityContext | nindent 12 }}
           {{- if $containerLifecycleHooks  }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
https://github.com/apache/airflow/blob/35699acbf447ce190107665d0145f1bf63df5a92/chart/templates/_helpers.yaml#L919-L935

Since <code>containerSecurityContext</code> helper function is called before <code>or</code> function, there is no need to call <code>or</code> function.