### PR TITLE
Deprecate get_hook in OSSKeySensor and use hook instead

### DIFF
--- a/airflow/providers/alibaba/cloud/sensors/oss_key.py
+++ b/airflow/providers/alibaba/cloud/sensors/oss_key.py
@@ -23,7 +23,7 @@ from urllib.parse import urlsplit
 
 from deprecated.classic import deprecated
 
-from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
 from airflow.providers.alibaba.cloud.hooks.oss import OSSHook
 from airflow.sensors.base import BaseSensorOperator
 
@@ -96,7 +96,7 @@ class OSSKeySensor(BaseSensorOperator):
         return self.hook.object_exists(key=self.bucket_key, bucket_name=self.bucket_name)
 
     @property
-    @deprecated(reason="use `hook` property instead.")
+    @deprecated(reason="use `hook` property instead.", category=AirflowProviderDeprecationWarning)
     def get_hook(self) -> OSSHook:
         """Create and return an OSSHook."""
         return self.hook

--- a/airflow/providers/alibaba/cloud/sensors/oss_key.py
+++ b/airflow/providers/alibaba/cloud/sensors/oss_key.py
@@ -21,6 +21,8 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Sequence
 from urllib.parse import urlsplit
 
+from deprecated.classic import deprecated
+
 from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.providers.alibaba.cloud.hooks.oss import OSSHook
 from airflow.sensors.base import BaseSensorOperator
@@ -59,7 +61,6 @@ class OSSKeySensor(BaseSensorOperator):
         self.bucket_key = bucket_key
         self.region = region
         self.oss_conn_id = oss_conn_id
-        self.hook: OSSHook | None = None
 
     def poke(self, context: Context):
         """
@@ -92,13 +93,15 @@ class OSSKeySensor(BaseSensorOperator):
                 raise AirflowException(message)
 
         self.log.info("Poking for key : oss://%s/%s", self.bucket_name, self.bucket_key)
-        return self.get_hook.object_exists(key=self.bucket_key, bucket_name=self.bucket_name)
+        return self.hook.object_exists(key=self.bucket_key, bucket_name=self.bucket_name)
 
-    @cached_property
+    @property
+    @deprecated(reason="use `hook` property instead.")
     def get_hook(self) -> OSSHook:
         """Create and return an OSSHook."""
-        if self.hook:
-            return self.hook
-
-        self.hook = OSSHook(oss_conn_id=self.oss_conn_id, region=self.region)
         return self.hook
+
+    @cached_property
+    def hook(self) -> OSSHook:
+        """Create and return an OSSHook."""
+        return OSSHook(oss_conn_id=self.oss_conn_id, region=self.region)

--- a/tests/providers/alibaba/cloud/sensors/test_oss_key.py
+++ b/tests/providers/alibaba/cloud/sensors/test_oss_key.py
@@ -50,10 +50,10 @@ def oss_key_sensor():
 class TestOSSKeySensor:
     @mock.patch(f"{MODULE_NAME}.OSSHook")
     def test_get_hook(self, mock_service, oss_key_sensor):
-        oss_key_sensor.get_hook()
+        oss_key_sensor.hook
         mock_service.assert_called_once_with(oss_conn_id=MOCK_OSS_CONN_ID, region=MOCK_REGION)
 
-    @mock.patch(f"{MODULE_NAME}.OSSKeySensor.get_hook", new_callable=PropertyMock)
+    @mock.patch(f"{MODULE_NAME}.OSSKeySensor.hook", new_callable=PropertyMock)
     def test_poke_exsiting_key(self, mock_service, oss_key_sensor):
         # Given
         mock_service.return_value.object_exists.return_value = True
@@ -65,7 +65,7 @@ class TestOSSKeySensor:
         assert res is True
         mock_service.return_value.object_exists.assert_called_once_with(key=MOCK_KEY, bucket_name=MOCK_BUCKET)
 
-    @mock.patch(f"{MODULE_NAME}.OSSKeySensor.get_hook", new_callable=PropertyMock)
+    @mock.patch(f"{MODULE_NAME}.OSSKeySensor.hook", new_callable=PropertyMock)
     def test_poke_non_exsiting_key(self, mock_service, oss_key_sensor):
         # Given
         mock_service.return_value.object_exists.return_value = False
@@ -80,7 +80,7 @@ class TestOSSKeySensor:
     @pytest.mark.parametrize(
         "soft_fail, expected_exception", ((False, AirflowException), (True, AirflowSkipException))
     )
-    @mock.patch(f"{MODULE_NAME}.OSSKeySensor.get_hook", new_callable=PropertyMock)
+    @mock.patch(f"{MODULE_NAME}.OSSKeySensor.hook", new_callable=PropertyMock)
     def test_poke_without_bucket_name(
         self, mock_service, oss_key_sensor, soft_fail: bool, expected_exception: AirflowException
     ):


### PR DESCRIPTION
This PR deprecate get_hook property and use hook property instead.