### PR TITLE
Consolidate hook management in JenkinsJobTriggerOperator

### DIFF
--- a/airflow/providers/jenkins/operators/jenkins_job_trigger.py
+++ b/airflow/providers/jenkins/operators/jenkins_job_trigger.py
@@ -30,7 +30,7 @@ from deprecated.classic import deprecated
 from jenkins import Jenkins, JenkinsException
 from requests import Request
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.jenkins.hooks.jenkins import JenkinsHook
 
@@ -189,7 +189,7 @@ class JenkinsJobTriggerOperator(BaseOperator):
         """Instantiate the Jenkins hook."""
         return JenkinsHook(self.jenkins_connection_id)
 
-    @deprecated(reason="use `hook` property instead.")
+    @deprecated(reason="use `hook` property instead.", category=AirflowProviderDeprecationWarning)
     def get_hook(self) -> JenkinsHook:
         """Instantiate the Jenkins hook."""
         return self.hook

--- a/airflow/providers/jenkins/operators/jenkins_job_trigger.py
+++ b/airflow/providers/jenkins/operators/jenkins_job_trigger.py
@@ -21,10 +21,12 @@ import ast
 import json
 import socket
 import time
+from functools import cached_property
 from typing import Any, Iterable, Mapping, Sequence, Union
 from urllib.error import HTTPError, URLError
 
 import jenkins
+from deprecated.classic import deprecated
 from jenkins import Jenkins, JenkinsException
 from requests import Request
 
@@ -182,9 +184,15 @@ class JenkinsJobTriggerOperator(BaseOperator):
                 f"{self.max_try_before_job_appears} times"
             )
 
-    def get_hook(self) -> JenkinsHook:
+    @cached_property
+    def hook(self) -> JenkinsHook:
         """Instantiate the Jenkins hook."""
         return JenkinsHook(self.jenkins_connection_id)
+
+    @deprecated(reason="use `hook` property instead.")
+    def get_hook(self) -> JenkinsHook:
+        """Instantiate the Jenkins hook."""
+        return self.hook
 
     def execute(self, context: Mapping[Any, Any]) -> str | None:
         self.log.info(
@@ -193,7 +201,7 @@ class JenkinsJobTriggerOperator(BaseOperator):
             self.jenkins_connection_id,
             self.parameters,
         )
-        jenkins_server = self.get_hook().get_jenkins_server()
+        jenkins_server = self.hook.get_jenkins_server()
         jenkins_response = self.build_job(jenkins_server, self.parameters)
         if jenkins_response:
             build_number = self.poll_job_in_queue(jenkins_response["headers"]["Location"], jenkins_server)

--- a/tests/providers/jenkins/operators/test_jenkins_job_trigger.py
+++ b/tests/providers/jenkins/operators/test_jenkins_job_trigger.py
@@ -35,7 +35,7 @@ TEST_PARAMETERS = (
 
 class TestJenkinsOperator:
     @pytest.mark.parametrize("parameters", TEST_PARAMETERS)
-    def test_execute(self, parameters):
+    def test_execute(self, parameters, mocker):
         jenkins_mock = Mock(spec=jenkins.Jenkins, auth="secret")
         jenkins_mock.get_build_info.return_value = {
             "result": "SUCCESS",
@@ -46,14 +46,18 @@ class TestJenkinsOperator:
         hook_mock = Mock(spec=JenkinsHook)
         hook_mock.get_jenkins_server.return_value = jenkins_mock
 
-        with patch.object(JenkinsJobTriggerOperator, "get_hook") as get_hook_mocked, patch(
+        with patch.object(
+            JenkinsJobTriggerOperator,
+            "hook",
+            new_callable=mocker.PropertyMock,
+        ) as hook_mocked, patch(
             "airflow.providers.jenkins.operators.jenkins_job_trigger.jenkins_request_with_headers"
         ) as mock_make_request:
             mock_make_request.side_effect = [
                 {"body": "", "headers": {"Location": "http://what-a-strange.url/18"}},
                 {"body": '{"executable":{"number":"1"}}', "headers": {}},
             ]
-            get_hook_mocked.return_value = hook_mock
+            hook_mocked.return_value = hook_mock
             operator = JenkinsJobTriggerOperator(
                 dag=None,
                 jenkins_connection_id="fake_jenkins_connection",
@@ -70,7 +74,7 @@ class TestJenkinsOperator:
             jenkins_mock.get_build_info.assert_called_once_with(name="a_job_on_jenkins", number="1")
 
     @pytest.mark.parametrize("parameters", TEST_PARAMETERS)
-    def test_execute_job_polling_loop(self, parameters):
+    def test_execute_job_polling_loop(self, parameters, mocker):
         jenkins_mock = Mock(spec=jenkins.Jenkins, auth="secret")
         jenkins_mock.get_job_info.return_value = {"nextBuildNumber": "1"}
         jenkins_mock.get_build_info.side_effect = [
@@ -82,14 +86,18 @@ class TestJenkinsOperator:
         hook_mock = Mock(spec=JenkinsHook)
         hook_mock.get_jenkins_server.return_value = jenkins_mock
 
-        with patch.object(JenkinsJobTriggerOperator, "get_hook") as get_hook_mocked, patch(
+        with patch.object(
+            JenkinsJobTriggerOperator,
+            "hook",
+            new_callable=mocker.PropertyMock,
+        ) as hook_mocked, patch(
             "airflow.providers.jenkins.operators.jenkins_job_trigger.jenkins_request_with_headers"
         ) as mock_make_request:
             mock_make_request.side_effect = [
                 {"body": "", "headers": {"Location": "http://what-a-strange.url/18"}},
                 {"body": '{"executable":{"number":"1"}}', "headers": {}},
             ]
-            get_hook_mocked.return_value = hook_mock
+            hook_mocked.return_value = hook_mock
             operator = JenkinsJobTriggerOperator(
                 dag=None,
                 task_id="operator_test",
@@ -104,7 +112,7 @@ class TestJenkinsOperator:
             assert jenkins_mock.get_build_info.call_count == 2
 
     @pytest.mark.parametrize("parameters", TEST_PARAMETERS)
-    def test_execute_job_failure(self, parameters):
+    def test_execute_job_failure(self, parameters, mocker):
         jenkins_mock = Mock(spec=jenkins.Jenkins, auth="secret")
         jenkins_mock.get_job_info.return_value = {"nextBuildNumber": "1"}
         jenkins_mock.get_build_info.return_value = {
@@ -116,14 +124,18 @@ class TestJenkinsOperator:
         hook_mock = Mock(spec=JenkinsHook)
         hook_mock.get_jenkins_server.return_value = jenkins_mock
 
-        with patch.object(JenkinsJobTriggerOperator, "get_hook") as get_hook_mocked, patch(
+        with patch.object(
+            JenkinsJobTriggerOperator,
+            "hook",
+            new_callable=mocker.PropertyMock,
+        ) as hook_mocked, patch(
             "airflow.providers.jenkins.operators.jenkins_job_trigger.jenkins_request_with_headers"
         ) as mock_make_request:
             mock_make_request.side_effect = [
                 {"body": "", "headers": {"Location": "http://what-a-strange.url/18"}},
                 {"body": '{"executable":{"number":"1"}}', "headers": {}},
             ]
-            get_hook_mocked.return_value = hook_mock
+            hook_mocked.return_value = hook_mock
             operator = JenkinsJobTriggerOperator(
                 dag=None,
                 task_id="operator_test",
@@ -158,7 +170,7 @@ class TestJenkinsOperator:
             ),
         ],
     )
-    def test_allowed_jenkins_states(self, state, allowed_jenkins_states):
+    def test_allowed_jenkins_states(self, state, allowed_jenkins_states, mocker):
         jenkins_mock = Mock(spec=jenkins.Jenkins, auth="secret")
         jenkins_mock.get_job_info.return_value = {"nextBuildNumber": "1"}
         jenkins_mock.get_build_info.return_value = {
@@ -170,14 +182,18 @@ class TestJenkinsOperator:
         hook_mock = Mock(spec=JenkinsHook)
         hook_mock.get_jenkins_server.return_value = jenkins_mock
 
-        with patch.object(JenkinsJobTriggerOperator, "get_hook") as get_hook_mocked, patch(
-            "airflow.providers.jenkins.operators.jenkins_job_trigger.jenkins_request_with_headers"
+        with patch.object(
+            JenkinsJobTriggerOperator,
+            "hook",
+            new_callable=mocker.PropertyMock,
+        ) as hook_mocked, patch(
+            "airflow.providers.jenkins.operators.jenkins_job_trigger.jenkins_request_with_headers",
         ) as mock_make_request:
             mock_make_request.side_effect = [
                 {"body": "", "headers": {"Location": "http://what-a-strange.url/18"}},
                 {"body": '{"executable":{"number":"1"}}', "headers": {}},
             ]
-            get_hook_mocked.return_value = hook_mock
+            hook_mocked.return_value = hook_mock
             operator = JenkinsJobTriggerOperator(
                 dag=None,
                 task_id="operator_test",
@@ -218,7 +234,7 @@ class TestJenkinsOperator:
             ),
         ],
     )
-    def test_allowed_jenkins_states_failure(self, state, allowed_jenkins_states):
+    def test_allowed_jenkins_states_failure(self, state, allowed_jenkins_states, mocker):
         jenkins_mock = Mock(spec=jenkins.Jenkins, auth="secret")
         jenkins_mock.get_job_info.return_value = {"nextBuildNumber": "1"}
         jenkins_mock.get_build_info.return_value = {
@@ -230,14 +246,18 @@ class TestJenkinsOperator:
         hook_mock = Mock(spec=JenkinsHook)
         hook_mock.get_jenkins_server.return_value = jenkins_mock
 
-        with patch.object(JenkinsJobTriggerOperator, "get_hook") as get_hook_mocked, patch(
+        with patch.object(
+            JenkinsJobTriggerOperator,
+            "hook",
+            new_callable=mocker.PropertyMock,
+        ) as hook_mocked, patch(
             "airflow.providers.jenkins.operators.jenkins_job_trigger.jenkins_request_with_headers"
         ) as mock_make_request:
             mock_make_request.side_effect = [
                 {"body": "", "headers": {"Location": "http://what-a-strange.url/18"}},
                 {"body": '{"executable":{"number":"1"}}', "headers": {}},
             ]
-            get_hook_mocked.return_value = hook_mock
+            hook_mocked.return_value = hook_mock
             operator = JenkinsJobTriggerOperator(
                 dag=None,
                 task_id="operator_test",


### PR DESCRIPTION
This PR deprecates get_hook method and uses hook cached_property instead.