### PR TITLE
Consolidate hook management in AzureBatchOperator

### DIFF
--- a/airflow/providers/microsoft/azure/operators/batch.py
+++ b/airflow/providers/microsoft/azure/operators/batch.py
@@ -21,6 +21,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, Sequence
 
 from azure.batch import models as batch_models
+from deprecated.classic import deprecated
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -181,7 +182,12 @@ class AzureBatchOperator(BaseOperator):
     @cached_property
     def hook(self) -> AzureBatchHook:
         """Create and return an AzureBatchHook (cached)."""
-        return self.get_hook()
+        return AzureBatchHook(self.azure_batch_conn_id)
+
+    @deprecated(reason="use `hook` property instead.")
+    def get_hook(self) -> AzureBatchHook:
+        """Create and return an AzureBatchHook."""
+        return self.hook
 
     def _check_inputs(self) -> Any:
         if not self.os_family and not self.vm_publisher:
@@ -314,10 +320,6 @@ class AzureBatchOperator(BaseOperator):
             job_id=self.batch_job_id, terminate_reason="Job killed by user"
         )
         self.log.info("Azure Batch job (%s) terminated: %s", self.batch_job_id, response)
-
-    def get_hook(self) -> AzureBatchHook:
-        """Create and return an AzureBatchHook."""
-        return AzureBatchHook(azure_batch_conn_id=self.azure_batch_conn_id)
 
     def clean_up(self, pool_id: str | None = None, job_id: str | None = None) -> None:
         """

--- a/airflow/providers/microsoft/azure/operators/batch.py
+++ b/airflow/providers/microsoft/azure/operators/batch.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 from azure.batch import models as batch_models
 from deprecated.classic import deprecated
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.microsoft.azure.hooks.batch import AzureBatchHook
 
@@ -184,7 +184,7 @@ class AzureBatchOperator(BaseOperator):
         """Create and return an AzureBatchHook (cached)."""
         return AzureBatchHook(self.azure_batch_conn_id)
 
-    @deprecated(reason="use `hook` property instead.")
+    @deprecated(reason="use `hook` property instead.", category=AirflowProviderDeprecationWarning)
     def get_hook(self) -> AzureBatchHook:
         """Create and return an AzureBatchHook."""
         return self.hook


### PR DESCRIPTION
This PR deprecates get_hook and moves its code to hook cached property.
