### PR TITLE
fix: Delete warning in get_uri

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -229,12 +229,6 @@ class Connection(Base, LoggingMixin):
 
     def get_uri(self) -> str:
         """Return connection in URI format."""
-        if self.conn_type and "_" in self.conn_type:
-            self.log.warning(
-                "Connection schemes (type: %s) shall not contain '_' according to RFC3986.",
-                self.conn_type,
-            )
-
         if self.conn_type:
             uri = f"{self.conn_type.lower().replace('_', '-')}://"
         else:


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/34419

Calling `get_uri` with a uri that contains `_` generated a warning. This PR removes the aforementioned warning in `get_uri`.