### PR TITLE
Consolidate ExternalTaskSensor deferrable and non deferrable logic

### DIFF
--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -260,7 +260,8 @@ class ExternalTaskSensor(BaseSensorOperator):
                     allowed_states=self.allowed_states,
                     skipped_states=self.skipped_states,
                     failed_states=self.failed_states,
-                    task_id=self.task_id
+                    task_id=self.task_id,
+                    poll_interval=self.poll_interval
                 ),
                 method_name="execute_complete"
             )

--- a/airflow/triggers/external_task.py
+++ b/airflow/triggers/external_task.py
@@ -17,23 +17,31 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import typing
+from airflow.models.dag import DagModel
+from airflow.models.dagbag import DagBag
 
 from asgiref.sync import sync_to_async
 from sqlalchemy import func
 
+from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.models import DagRun, TaskInstance
 from airflow.triggers.base import BaseTrigger, TriggerEvent
+from airflow.utils.file import correct_maybe_zipped
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import TaskInstanceState
+from airflow.utils.sqlalchemy import tuple_in_condition
 from airflow.utils.timezone import utcnow
 
 if typing.TYPE_CHECKING:
     from datetime import datetime
 
-    from sqlalchemy.orm import Session
+    from sqlalchemy.orm import Query, Session
 
     from airflow.utils.state import DagRunState
+
+    from logging import Logger
 
 
 class TaskStateTrigger(BaseTrigger):
@@ -56,21 +64,28 @@ class TaskStateTrigger(BaseTrigger):
 
     def __init__(
         self,
-        dag_id: str,
         execution_dates: list[datetime],
         trigger_start_time: datetime,
-        states: list[str] | None = None,
+        external_task_group_id: str | None,
+        external_task_ids: typing.Collection[str] | None,
+        external_dag_id: str | None,
+        allowed_states: typing.Iterable[str] | None = None,
+        skipped_states: typing.Iterable[str] | None = None,
+        failed_states: typing.Iterable[str] | None = None,
         task_id: str | None = None,
         poll_interval: float = 2.0,
     ):
         super().__init__()
-        self.dag_id = dag_id
         self.task_id = task_id
-        self.states = states
         self.execution_dates = execution_dates
+        self.external_task_group_id = external_task_group_id
+        self.external_task_ids = external_task_ids
+        self.external_dag_id = external_dag_id
+        self.allowed_states = allowed_states
+        self.skipped_states = skipped_states
+        self.failed_states = failed_states
         self.poll_interval = poll_interval
         self.trigger_start_time = trigger_start_time
-        self.states = states if states else [TaskInstanceState.SUCCESS.value]
         self._timeout_sec = 60
 
     def serialize(self) -> tuple[str, dict[str, typing.Any]]:
@@ -78,10 +93,14 @@ class TaskStateTrigger(BaseTrigger):
         return (
             "airflow.triggers.external_task.TaskStateTrigger",
             {
-                "dag_id": self.dag_id,
                 "task_id": self.task_id,
-                "states": self.states,
                 "execution_dates": self.execution_dates,
+                "external_task_group_id": self.external_task_group_id,
+                "external_task_ids": self.external_task_ids,
+                "external_dag_id": self.external_dag_id,
+                "allowed_states": self.allowed_states,
+                "skipped_states": self.skipped_states,
+                "failed_states": self.failed_states,
                 "poll_interval": self.poll_interval,
                 "trigger_start_time": self.trigger_start_time,
             },
@@ -96,55 +115,230 @@ class TaskStateTrigger(BaseTrigger):
         after starting execution process of the trigger, terminate with status 'timeout'.
         """
         try:
-            while True:
+            while self.get_count(self.external_task_group_id, self.external_task_ids, self.external_dag_id,
+                               self.execution_dates, ["running", "success"]) == 0:
+                self.log.info("Waiting for DAG to start execution...")
+
                 delta = utcnow() - self.trigger_start_time
-                if delta.total_seconds() < self._timeout_sec:
-                    # mypy confuses typing here
-                    if await self.count_running_dags() == 0:  # type: ignore[call-arg]
-                        self.log.info("Waiting for DAG to start execution...")
-                        await asyncio.sleep(self.poll_interval)
-                else:
+                if delta.total_seconds() > self._timeout_sec:
                     yield TriggerEvent({"status": "timeout"})
                     return
-                # mypy confuses typing here
-                if await self.count_tasks() == len(self.execution_dates):  # type: ignore[call-arg]
+                
+                await asyncio.sleep(self.poll_interval)
+
+            while True:
+                if self.check_external_dag(self.execution_dates, self.external_task_group_id, self.external_task_ids,
+                                                self.external_dag_id, self.skipped_states, self.allowed_states,
+                                                self.failed_states, False, self.log):
                     yield TriggerEvent({"status": "success"})
                     return
-                self.log.info("Task is still running, sleeping for %s seconds...", self.poll_interval)
+
                 await asyncio.sleep(self.poll_interval)
         except Exception:
             yield TriggerEvent({"status": "failed"})
 
-    @sync_to_async
+    @staticmethod
     @provide_session
-    def count_running_dags(self, session: Session):
-        """Count how many dag instances in running state in the database."""
-        dags = (
-            session.query(func.count("*"))
-            .filter(
-                TaskInstance.dag_id == self.dag_id,
-                TaskInstance.execution_date.in_(self.execution_dates),
-                TaskInstance.state.in_(["running", "success"]),
-            )
-            .scalar()
-        )
-        return dags
+    def check_external_dag(dttm_filter: typing.List[datetime.datetime], external_task_group_id: str | None, external_task_ids: typing.Collection[str] | None,
+                           external_dag_id: str | None, skipped_states: typing.Iterable[str] | None, allowed_states: typing.Iterable[str] | None,
+                           failed_states: typing.Iterable[str] | None, soft_fail: bool, log: Logger, session: Session) -> bool:
+        # delay check to poke rather than __init__ in case it was supplied as XComArgs
+        if external_task_ids and len(external_task_ids) > len(set(external_task_ids)):
+            raise ValueError("Duplicate task_ids passed in external_task_ids parameter")
 
-    @sync_to_async
-    @provide_session
-    def count_tasks(self, *, session: Session = NEW_SESSION) -> int | None:
-        """Count how many task instances in the database match our criteria."""
-        count = (
-            session.query(func.count("*"))  # .count() is inefficient
-            .filter(
-                TaskInstance.dag_id == self.dag_id,
-                TaskInstance.task_id == self.task_id,
-                TaskInstance.state.in_(self.states),
-                TaskInstance.execution_date.in_(self.execution_dates),
+        serialized_dttm_filter = ",".join(dt.isoformat() for dt in dttm_filter)
+
+        if external_task_ids:
+            log.info(
+                "Poking for tasks %s in dag %s on %s ... ",
+                external_task_ids,
+                external_dag_id,
+                serialized_dttm_filter,
             )
-            .scalar()
+
+        if external_task_group_id:
+            log.info(
+                "Poking for task_group '%s' in dag '%s' on %s ... ",
+                external_task_group_id,
+                external_dag_id,
+                serialized_dttm_filter,
+            )
+
+        if external_dag_id and not external_task_group_id and not external_task_ids:
+            log.info(
+                "Poking for DAG '%s' on %s ... ",
+                external_dag_id,
+                serialized_dttm_filter,
+            )
+
+        # TODO: Decide if we should avoid checking this every time
+        TaskStateTrigger._check_for_existence(external_task_group_id=external_task_group_id,
+                                              external_task_ids=external_task_ids,
+                                              external_dag_id=external_dag_id,
+                                              session=session)
+
+        count_failed = -1
+        if failed_states:
+            count_failed = TaskStateTrigger.get_count(external_task_group_id, external_task_ids, external_dag_id,
+                                                      dttm_filter, failed_states, session)
+
+        # Fail if anything in the list has failed.
+        if count_failed > 0:
+            if external_task_ids:
+                if soft_fail:
+                    raise AirflowSkipException(
+                        f"Some of the external tasks {external_task_ids} "
+                        f"in DAG {external_dag_id} failed. Skipping due to soft_fail."
+                    )
+                raise AirflowException(
+                    f"Some of the external tasks {external_task_ids} "
+                    f"in DAG {external_dag_id} failed."
+                )
+            elif external_task_group_id:
+                if soft_fail:
+                    raise AirflowSkipException(
+                        f"The external task_group '{external_task_group_id}' "
+                        f"in DAG '{external_dag_id}' failed. Skipping due to soft_fail."
+                    )
+                raise AirflowException(
+                    f"The external task_group '{external_task_group_id}' "
+                    f"in DAG '{external_dag_id}' failed."
+                )
+
+            else:
+                if soft_fail:
+                    raise AirflowSkipException(
+                        f"The external DAG {external_dag_id} failed. Skipping due to soft_fail."
+                    )
+                raise AirflowException(f"The external DAG {external_dag_id} failed.")
+
+        count_skipped = -1
+        if skipped_states:
+            count_skipped = TaskStateTrigger.get_count(external_task_group_id, external_task_ids, external_dag_id,
+                                                       dttm_filter, skipped_states, session)
+
+        # Skip if anything in the list has skipped. Note if we are checking multiple tasks and one skips
+        # before another errors, we'll skip first.
+        if count_skipped > 0:
+            if external_task_ids:
+                raise AirflowSkipException(
+                    f"Some of the external tasks {external_task_ids} "
+                    f"in DAG {external_dag_id} reached a state in our states-to-skip-on list. Skipping."
+                )
+            elif external_task_group_id:
+                raise AirflowSkipException(
+                    f"The external task_group '{external_task_group_id}' "
+                    f"in DAG {external_dag_id} reached a state in our states-to-skip-on list. Skipping."
+                )
+            else:
+                raise AirflowSkipException(
+                    f"The external DAG {external_dag_id} reached a state in our states-to-skip-on list. "
+                    "Skipping."
+                )
+
+        # only go green if every single task has reached an allowed state
+        count_allowed = TaskStateTrigger.get_count(external_task_group_id, external_task_ids, external_dag_id,
+                                                   dttm_filter, allowed_states, session)
+        log.info('COUNT ALLOWED ' + str(count_allowed))
+        log.info('external_task_group_id %s external_task_ids %s external_dag_id %s, dtm_filter %s allowed_states %s',
+                 str(external_task_group_id), str(external_task_ids), str(external_dag_id), str(dttm_filter),
+                 str(allowed_states))
+        return count_allowed == len(dttm_filter)
+    
+
+    @staticmethod
+    @provide_session
+    def get_count(external_task_group_id: str | None, external_task_ids: typing.Collection[str] | None,
+                  external_dag_id: str | None, dttm_filter, states: typing.Iterable[TaskInstanceState], session: Session) -> int:
+        """
+        Get the count of records against dttm filter and states.
+
+        :param dttm_filter: date time filter for execution date
+        :param session: airflow session object
+        :param states: task or dag states
+        :return: count of record against the filters
+        """
+        TI = TaskInstance
+        DR = DagRun
+        if not dttm_filter:
+            return 0
+
+        if external_task_ids:
+            count = (
+                TaskStateTrigger._count_query(TI, session, states, dttm_filter, external_dag_id)
+                .filter(TI.task_id.in_(external_task_ids))
+                .scalar()
+            ) / len(external_task_ids)
+        elif external_task_group_id:
+            external_task_group_task_ids = TaskStateTrigger.get_external_task_group_task_ids(session, dttm_filter,
+                                                                                             external_dag_id, external_task_group_id)
+            if not external_task_group_task_ids:
+                count = 0
+            else:
+                count = (
+                    TaskStateTrigger._count_query(TI, session, states, dttm_filter)
+                    .filter(tuple_in_condition((TI.task_id, TI.map_index), external_task_group_task_ids))
+                    .scalar()
+                ) / len(external_task_group_task_ids)
+        else:
+            count = TaskStateTrigger._count_query(DR, session, states, dttm_filter).scalar()
+        return count
+
+    @staticmethod
+    def _count_query(model, session, states: typing.Iterable[TaskInstanceState], dttm_filter, external_dag_id: str | None) -> Query:
+        query = session.query(func.count()).filter(
+            model.dag_id == external_dag_id,
+            model.state.in_(states),
+            model.execution_date.in_(dttm_filter),
         )
-        return typing.cast(int, count)
+        return query
+
+    @staticmethod
+    def get_external_task_group_task_ids(session, dttm_filter, external_dag_id: str | None, external_task_group_id: str | None):
+        refreshed_dag_info = DagBag(read_dags_from_db=True).get_dag(external_dag_id, session)
+        task_group = refreshed_dag_info.task_group_dict.get(external_task_group_id)
+
+        if task_group:
+            group_tasks = session.query(TaskInstance).filter(
+                TaskInstance.dag_id == external_dag_id,
+                TaskInstance.task_id.in_(task.task_id for task in task_group),
+                TaskInstance.execution_date.in_(dttm_filter),
+            )
+
+            return [(t.task_id, t.map_index) for t in group_tasks]
+
+        # returning default task_id as group_id itself, this will avoid any failure in case of
+        # 'check_existence=False' and will fail on timeout
+        return [(external_task_group_id, -1)]
+
+
+    @staticmethod
+    def _check_for_existence(external_task_group_id: str | None, external_task_ids: typing.Collection[str] | None,
+                           external_dag_id: str | None, session: Session) -> None:
+        dag_to_wait = DagModel.get_current(external_dag_id, session)
+
+        if not dag_to_wait:
+            raise AirflowException(f"The external DAG {external_dag_id} does not exist.")
+
+        if not os.path.exists(correct_maybe_zipped(dag_to_wait.fileloc)):
+            raise AirflowException(f"The external DAG {external_dag_id} was deleted.")
+
+        if external_task_ids:
+            refreshed_dag_info = DagBag(dag_to_wait.fileloc).get_dag(external_dag_id)
+            for external_task_id in external_task_ids:
+                if not refreshed_dag_info.has_task(external_task_id):
+                    raise AirflowException(
+                        f"The external task {external_task_id} in "
+                        f"DAG {external_dag_id} does not exist."
+                    )
+
+        if external_task_group_id:
+            refreshed_dag_info = DagBag(dag_to_wait.fileloc).get_dag(external_dag_id)
+            if not refreshed_dag_info.has_task_group(external_task_group_id):
+                raise AirflowException(
+                    f"The external task group '{external_task_group_id}' in "
+                    f"DAG '{external_dag_id}' does not exist."
+                )
 
 
 class DagStateTrigger(BaseTrigger):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE


How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: #34204

The existing `poke` logic for the `ExternalTaskSensor` seems sound. However, the `TaskStateTrigger`'s `run` logic is different and seems to cause some bugs (see linked issue). This change consolidates the logic, such that the `ExternalTaskSensor` will use the same logic in deferrable and non-deferrable modes.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
