### PR TITLE
Fix inaccurate test case names in providers 

### DIFF
--- a/tests/providers/dbt/cloud/sensors/test_dbt_cloud.py
+++ b/tests/providers/dbt/cloud/sensors/test_dbt_cloud.py
@@ -174,7 +174,7 @@ class TestDbtCloudJobRunSensor:
             )
 
 
-class TestDbtCloudJobRunSensorAsync:
+class TestDbtCloudJobRunAsyncSensor:
     TASK_ID = "dbt_cloud_run_job"
     CONN_ID = "dbt_cloud_default"
     DBT_RUN_ID = 1234
@@ -186,7 +186,7 @@ class TestDbtCloudJobRunSensorAsync:
     )
 
     @mock.patch("airflow.providers.dbt.cloud.sensors.dbt.DbtCloudHook")
-    def test_dbt_job_run_sensor_async(self, mock_hook):
+    def test_dbt_job_run_async_sensor(self, mock_hook):
         """Assert execute method defer for Dbt cloud job run status sensors"""
 
         with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
@@ -201,7 +201,7 @@ class TestDbtCloudJobRunSensorAsync:
             task.execute({})
         assert isinstance(exc.value.trigger, DbtCloudRunJobTrigger), "Trigger is not a DbtCloudRunJobTrigger"
 
-    def test_dbt_job_run_sensor_async_execute_complete_success(self):
+    def test_dbt_job_run_async_sensor_execute_complete_success(self):
         """Assert execute_complete log success message when trigger fire with target status"""
         with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = DbtCloudJobRunAsyncSensor(
@@ -225,7 +225,7 @@ class TestDbtCloudJobRunSensorAsync:
             ("error", "Job run 1234 has failed."),
         ],
     )
-    def test_dbt_job_run_sensor_async_execute_complete_failure(self, mock_status, mock_message):
+    def test_dbt_job_run_async_sensor_execute_complete_failure(self, mock_status, mock_message):
         """Assert execute_complete method to raise exception on the cancelled and error status"""
         with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = DbtCloudJobRunAsyncSensor(

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -1893,7 +1893,7 @@ class TestBigQueryValueCheckOperator:
     def test_bigquery_value_check_async(self, mock_hook, create_task_instance_of_operator):
         """
         Asserts that a task is deferred and a BigQueryValueCheckTrigger will be fired
-        when the BigQueryValueCheckOperator(deferable=True) is executed.
+        when the BigQueryValueCheckOperator with deferrable=True is executed.
         """
         ti = create_task_instance_of_operator(
             BigQueryValueCheckOperator,

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -26,11 +26,7 @@ import pandas as pd
 import pytest
 from google.cloud.bigquery import DEFAULT_RETRY
 from google.cloud.exceptions import Conflict
-from openlineage.client.facet import (
-    DataSourceDatasetFacet,
-    ExternalQueryRunFacet,
-    SqlJobFacet,
-)
+from openlineage.client.facet import DataSourceDatasetFacet, ExternalQueryRunFacet, SqlJobFacet
 from openlineage.client.run import Dataset
 from openlineage.common.provider.bigquery import BigQueryErrorRunFacet
 
@@ -1897,7 +1893,7 @@ class TestBigQueryValueCheckOperator:
     def test_bigquery_value_check_async(self, mock_hook, create_task_instance_of_operator):
         """
         Asserts that a task is deferred and a BigQueryValueCheckTrigger will be fired
-        when the BigQueryValueCheckOperatorAsync is executed.
+        when the BigQueryValueCheckOperator(deferable=True) is executed.
         """
         ti = create_task_instance_of_operator(
             BigQueryValueCheckOperator,
@@ -1954,13 +1950,17 @@ class TestBigQueryValueCheckOperator:
         ],
     )
     def test_bigquery_value_check_missing_param(self, kwargs, expected):
-        """Assert the exception if require param not pass to BigQueryValueCheckOperatorAsync operator"""
+        """
+        Assert the exception if require param not pass to BigQueryValueCheckOperator with deferrable=True
+        """
         with pytest.raises(AirflowException) as missing_param:
             BigQueryValueCheckOperator(deferrable=True, **kwargs)
         assert missing_param.value.args[0] == expected
 
     def test_bigquery_value_check_empty(self):
-        """Assert the exception if require param not pass to BigQueryValueCheckOperatorAsync operator"""
+        """
+        Assert the exception if require param not pass to BigQueryValueCheckOperator with deferrable=True
+        """
         expected, expected1 = (
             "missing keyword arguments 'sql', 'pass_value'",
             "missing keyword arguments 'pass_value', 'sql'",

--- a/tests/providers/google/cloud/operators/test_datafusion.py
+++ b/tests/providers/google/cloud/operators/test_datafusion.py
@@ -283,7 +283,7 @@ class TestCloudDataFusionStartPipelineOperator:
         mock_hook.return_value.wait_for_pipeline_state.assert_not_called()
 
 
-class TestCloudDataFusionStartPipelineOperatorAsynch:
+class TestCloudDataFusionStartPipelineOperatorAsync:
     @mock.patch(HOOK_STR)
     def test_asynch_execute_should_execute_successfully(self, mock_hook):
         """

--- a/tests/providers/google/cloud/sensors/test_gcs.py
+++ b/tests/providers/google/cloud/sensors/test_gcs.py
@@ -147,7 +147,7 @@ class TestGoogleCloudStorageObjectSensor:
         with pytest.raises(AirflowException):
             task.execute_complete(context=None, event={"status": "error", "message": "test failure message"})
 
-    def test_gcs_object_existence_sensor_async_execute_complete(self):
+    def test_gcs_object_existence_sensor_execute_complete(self):
         """Asserts that logging occurs as expected when deferrable is set to True"""
         task = GCSObjectExistenceSensor(
             task_id="task-id",
@@ -161,14 +161,14 @@ class TestGoogleCloudStorageObjectSensor:
         mock_log_info.assert_called_with("File %s was found in bucket %s.", TEST_OBJECT, TEST_BUCKET)
 
 
-class TestGoogleCloudStorageObjectSensorAsync:
+class TestGoogleCloudStorageObjectAsyncSensor:
     depcrecation_message = (
         "Class `GCSObjectExistenceAsyncSensor` is deprecated and will be removed in a future release. "
         "Please use `GCSObjectExistenceSensor` and set `deferrable` attribute to `True` instead"
     )
 
     @mock.patch("airflow.providers.google.cloud.sensors.gcs.GCSHook")
-    def test_gcs_object_existence_sensor_async(self, mock_hook):
+    def test_gcs_object_existence_async_sensor(self, mock_hook):
         """
         Asserts that a task is deferred and a GCSBlobTrigger will be fired
         when the GCSObjectExistenceAsyncSensor is executed.
@@ -185,7 +185,7 @@ class TestGoogleCloudStorageObjectSensorAsync:
             task.execute(context)
         assert isinstance(exc.value.trigger, GCSBlobTrigger), "Trigger is not a GCSBlobTrigger"
 
-    def test_gcs_object_existence_sensor_async_execute_failure(self):
+    def test_gcs_object_existence_async_sensor_execute_failure(self):
         """Tests that an AirflowException is raised in case of error event"""
         with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = GCSObjectExistenceAsyncSensor(
@@ -197,7 +197,7 @@ class TestGoogleCloudStorageObjectSensorAsync:
         with pytest.raises(AirflowException):
             task.execute_complete(context=None, event={"status": "error", "message": "test failure message"})
 
-    def test_gcs_object_existence_sensor_async_execute_complete(self):
+    def test_gcs_object_existence_async_sensor_execute_complete(self):
         """Asserts that logging occurs as expected"""
         with pytest.warns(AirflowProviderDeprecationWarning, match=self.depcrecation_message):
             task = GCSObjectExistenceAsyncSensor(
@@ -267,7 +267,7 @@ class TestGoogleCloudStorageObjectUpdatedSensor:
         assert not mock_defer.called
 
 
-class TestGCSObjectUpdateSensorAsync:
+class TestGCSObjectUpdateAsyncSensor:
     OPERATOR = GCSObjectUpdateSensor(
         task_id="gcs-obj-update",
         bucket=TEST_BUCKET,
@@ -277,10 +277,10 @@ class TestGCSObjectUpdateSensorAsync:
     )
 
     @mock.patch("airflow.providers.google.cloud.sensors.gcs.GCSHook")
-    def test_gcs_object_update_sensor_async(self, mock_hook):
+    def test_gcs_object_update_async_sensor(self, mock_hook):
         """
         Asserts that a task is deferred and a GCSBlobTrigger will be fired
-        when the GCSObjectUpdateSensorAsync is executed.
+        when the GCSObjectUpdateAsyncSensor is executed.
         """
         mock_hook.return_value.is_updated_after.return_value = False
         with pytest.raises(TaskDeferred) as exc:
@@ -289,7 +289,7 @@ class TestGCSObjectUpdateSensorAsync:
             exc.value.trigger, GCSCheckBlobUpdateTimeTrigger
         ), "Trigger is not a GCSCheckBlobUpdateTimeTrigger"
 
-    def test_gcs_object_update_sensor_async_execute_failure(self, context):
+    def test_gcs_object_update_async_sensor_execute_failure(self, context):
         """Tests that an AirflowException is raised in case of error event"""
 
         with pytest.raises(AirflowException):
@@ -297,7 +297,7 @@ class TestGCSObjectUpdateSensorAsync:
                 context=context, event={"status": "error", "message": "test failure message"}
             )
 
-    def test_gcs_object_update_sensor_async_execute_complete(self, context):
+    def test_gcs_object_update_async_sensor_execute_complete(self, context):
         """Asserts that logging occurs as expected"""
 
         with mock.patch.object(self.OPERATOR.log, "info") as mock_log_info:
@@ -390,7 +390,7 @@ class TestGoogleCloudStoragePrefixSensor:
         assert not mock_defer.called
 
 
-class TestGCSObjectsWithPrefixExistenceSensorAsync:
+class TestGCSObjectsWithPrefixExistenceAsyncSensor:
     OPERATOR = GCSObjectsWithPrefixExistenceSensor(
         task_id="gcs-obj-prefix",
         bucket=TEST_BUCKET,
@@ -400,17 +400,17 @@ class TestGCSObjectsWithPrefixExistenceSensorAsync:
     )
 
     @mock.patch("airflow.providers.google.cloud.sensors.gcs.GCSHook")
-    def test_gcs_object_with_prefix_existence_sensor_async(self, mock_hook):
+    def test_gcs_object_with_prefix_existence_async_sensor(self, mock_hook):
         """
         Asserts that a task is deferred and a GCSPrefixBlobTrigger will be fired
-        when the GCSObjectsWithPrefixExistenceSensorAsync is executed.
+        when the GCSObjectsWithPrefixExistenceAsyncSensor is executed.
         """
         mock_hook.return_value.list.return_value = False
         with pytest.raises(TaskDeferred) as exc:
             self.OPERATOR.execute(mock.MagicMock())
         assert isinstance(exc.value.trigger, GCSPrefixBlobTrigger), "Trigger is not a GCSPrefixBlobTrigger"
 
-    def test_gcs_object_with_prefix_existence_sensor_async_execute_failure(self, context):
+    def test_gcs_object_with_prefix_existence_async_sensor_execute_failure(self, context):
         """Tests that an AirflowException is raised in case of error event"""
 
         with pytest.raises(AirflowException):
@@ -418,7 +418,7 @@ class TestGCSObjectsWithPrefixExistenceSensorAsync:
                 context=context, event={"status": "error", "message": "test failure message"}
             )
 
-    def test_gcs_object_with_prefix_existence_sensor_async_execute_complete(self, context):
+    def test_gcs_object_with_prefix_existence_async_sensor_execute_complete(self, context):
         """Asserts that logging occurs as expected"""
 
         with mock.patch.object(self.OPERATOR.log, "info") as mock_log_info:
@@ -525,7 +525,7 @@ class TestGCSUploadSessionCompleteSensor:
         assert not self.sensor.is_bucket_updated(set())
 
 
-class TestGCSUploadSessionCompleteSensorAsync:
+class TestGCSUploadSessionCompleteAsyncSensor:
     OPERATOR = GCSUploadSessionCompleteSensor(
         task_id="gcs-obj-session",
         bucket=TEST_BUCKET,
@@ -537,10 +537,10 @@ class TestGCSUploadSessionCompleteSensorAsync:
     )
 
     @mock.patch("airflow.providers.google.cloud.sensors.gcs.GCSHook")
-    def test_gcs_upload_session_complete_sensor_async(self, mock_hook):
+    def test_gcs_upload_session_complete_async_sensor(self, mock_hook):
         """
         Asserts that a task is deferred and a GCSUploadSessionTrigger will be fired
-        when the GCSUploadSessionCompleteSensorAsync is executed.
+        when the GCSUploadSessionCompleteAsyncSensor is executed.
         """
         mock_hook.return_value.is_bucket_updated.return_value = False
         with pytest.raises(TaskDeferred) as exc:
@@ -557,7 +557,7 @@ class TestGCSUploadSessionCompleteSensorAsync:
                 context=context, event={"status": "error", "message": "test failure message"}
             )
 
-    def test_gcs_upload_session_complete_sensor_async_execute_complete(self, context):
+    def test_gcs_upload_session_complete_async_sensor_execute_complete(self, context):
         """Asserts that execute complete is completed as expected"""
 
         assert self.OPERATOR.execute_complete(


### PR DESCRIPTION
...OperatorAsync, ...SensorAsync do not exist. Replace them with ...AsyncOperator, ...AsyncSensor

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
