### PR TITLE
Fix datetime deserialization by replacing timezone short code by its name in serialized values

### DIFF
--- a/airflow/serialization/serializers/datetime.py
+++ b/airflow/serialization/serializers/datetime.py
@@ -29,8 +29,6 @@ from airflow.utils.timezone import convert_to_utc, is_naive
 if TYPE_CHECKING:
     import datetime
 
-    from pendulum.tz.timezone import Timezone
-
     from airflow.serialization.serde import U
 
 __version__ = 2
@@ -68,17 +66,18 @@ def deserialize(classname: str, version: int, data: dict | str) -> datetime.date
 
     from pendulum import DateTime
     from pendulum.tz import timezone
-    from pytz.reference import USTimeZone
 
-    tz: USTimeZone | Timezone | None = None
+    tz: datetime.tzinfo | None = None
     if isinstance(data, dict) and TIMEZONE in data:
         if version == 1:
+            from pytz.reference import Central, Eastern, Mountain, Pacific
+
             # try to deserialize unsupported US timezones
             mapping_us_timezones = {
-                "EDT": USTimeZone(-5, "Eastern", "EST", "EDT"),
-                "CDT": USTimeZone(-6, "Central", "CST", "CDT"),
-                "MDT": USTimeZone(-7, "Mountain", "MST", "MDT"),
-                "PDT": USTimeZone(-8, "Pacific", "PST", "PDT"),
+                "EDT": Eastern,
+                "CDT": Central,
+                "MDT": Mountain,
+                "PDT": Pacific,
             }
             if data[TIMEZONE] in mapping_us_timezones:
                 tz = mapping_us_timezones[data[TIMEZONE]]

--- a/airflow/serialization/serializers/datetime.py
+++ b/airflow/serialization/serializers/datetime.py
@@ -19,15 +19,21 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from airflow.serialization.serializers.timezone import (
+    deserialize as deserialize_timezone,
+    serialize as serialize_timezone,
+)
 from airflow.utils.module_loading import qualname
 from airflow.utils.timezone import convert_to_utc, is_naive
 
 if TYPE_CHECKING:
     import datetime
 
+    from pendulum.tz.timezone import Timezone
+
     from airflow.serialization.serde import U
 
-__version__ = 1
+__version__ = 2
 
 serializers = ["datetime.date", "datetime.datetime", "datetime.timedelta", "pendulum.datetime.DateTime"]
 deserializers = serializers
@@ -44,7 +50,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
         if is_naive(o):
             o = convert_to_utc(o)
 
-        tz = o.tzinfo.name  # type: ignore
+        tz = serialize_timezone(o.tzinfo)
 
         return {TIMESTAMP: o.timestamp(), TIMEZONE: tz}, qn, __version__, True
 
@@ -62,12 +68,30 @@ def deserialize(classname: str, version: int, data: dict | str) -> datetime.date
 
     from pendulum import DateTime
     from pendulum.tz import timezone
+    from pytz.reference import USTimeZone
+
+    tz: USTimeZone | Timezone | None = None
+    if isinstance(data, dict) and TIMEZONE in data:
+        if version == 1:
+            # try to deserialize unsupported US timezones
+            mapping_us_timezones = {
+                "EDT": USTimeZone(-5, "Eastern", "EST", "EDT"),
+                "CDT": USTimeZone(-6, "Central", "CST", "CDT"),
+                "MDT": USTimeZone(-7, "Mountain", "MST", "MDT"),
+                "PDT": USTimeZone(-8, "Pacific", "PST", "PDT"),
+            }
+            if data[TIMEZONE] in mapping_us_timezones:
+                tz = mapping_us_timezones[data[TIMEZONE]]
+            else:
+                tz = timezone(data[TIMEZONE])
+        else:
+            tz = deserialize_timezone(data[TIMEZONE][1], data[TIMEZONE][2], data[TIMEZONE][0])
 
     if classname == qualname(datetime.datetime) and isinstance(data, dict):
-        return datetime.datetime.fromtimestamp(float(data[TIMESTAMP]), tz=timezone(data[TIMEZONE]))
+        return datetime.datetime.fromtimestamp(float(data[TIMESTAMP]), tz=tz)
 
     if classname == qualname(DateTime) and isinstance(data, dict):
-        return DateTime.fromtimestamp(float(data[TIMESTAMP]), tz=timezone(data[TIMEZONE]))
+        return DateTime.fromtimestamp(float(data[TIMESTAMP]), tz=tz)
 
     if classname == qualname(datetime.timedelta) and isinstance(data, (str, float)):
         return datetime.timedelta(seconds=float(data))

--- a/airflow/serialization/serializers/datetime.py
+++ b/airflow/serialization/serializers/datetime.py
@@ -71,15 +71,15 @@ def deserialize(classname: str, version: int, data: dict | str) -> datetime.date
     if isinstance(data, dict) and TIMEZONE in data:
         if version == 1:
             # try to deserialize unsupported timezones
-            mapping_us_timezones = {
+            timezone_mapping = {
                 "EDT": fixed_timezone(-4 * 3600),
                 "CDT": fixed_timezone(-5 * 3600),
                 "MDT": fixed_timezone(-6 * 3600),
                 "PDT": fixed_timezone(-7 * 3600),
                 "CEST": timezone("CET"),
             }
-            if data[TIMEZONE] in mapping_us_timezones:
-                tz = mapping_us_timezones[data[TIMEZONE]]
+            if data[TIMEZONE] in timezone_mapping:
+                tz = timezone_mapping[data[TIMEZONE]]
             else:
                 tz = timezone(data[TIMEZONE])
         else:

--- a/airflow/serialization/serializers/datetime.py
+++ b/airflow/serialization/serializers/datetime.py
@@ -65,19 +65,18 @@ def deserialize(classname: str, version: int, data: dict | str) -> datetime.date
     import datetime
 
     from pendulum import DateTime
-    from pendulum.tz import timezone
+    from pendulum.tz import fixed_timezone, timezone
 
     tz: datetime.tzinfo | None = None
     if isinstance(data, dict) and TIMEZONE in data:
         if version == 1:
-            from pytz.reference import Central, Eastern, Mountain, Pacific
-
-            # try to deserialize unsupported US timezones
+            # try to deserialize unsupported timezones
             mapping_us_timezones = {
-                "EDT": Eastern,
-                "CDT": Central,
-                "MDT": Mountain,
-                "PDT": Pacific,
+                "EDT": fixed_timezone(-4 * 3600),
+                "CDT": fixed_timezone(-5 * 3600),
+                "MDT": fixed_timezone(-6 * 3600),
+                "PDT": fixed_timezone(-7 * 3600),
+                "CEST": timezone("CET"),
             }
             if data[TIMEZONE] in mapping_us_timezones:
                 tz = mapping_us_timezones[data[TIMEZONE]]

--- a/airflow/serialization/serializers/datetime.py
+++ b/airflow/serialization/serializers/datetime.py
@@ -44,7 +44,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
         if is_naive(o):
             o = convert_to_utc(o)
 
-        tz = o.tzname()
+        tz = o.tzinfo.name  # type: ignore
 
         return {TIMESTAMP: o.timestamp(), TIMEZONE: tz}, qn, __version__, True
 

--- a/tests/serialization/serializers/test_serializers.py
+++ b/tests/serialization/serializers/test_serializers.py
@@ -62,6 +62,55 @@ class TestSerializers:
         d = deserialize(s)
         assert i.timestamp() == d.timestamp()
 
+    def test_deserialize_datetime_v1(self):
+
+        s = {
+            "__classname__": "pendulum.datetime.DateTime",
+            "__version__": 1,
+            "__data__": {"timestamp": 1657505443.0, "tz": "UTC"},
+        }
+        d = deserialize(s)
+        assert d.timestamp() == 1657505443.0
+        assert d.tzinfo.name == "UTC"
+
+        s["__data__"]["tz"] = "Europe/Paris"
+        d = deserialize(s)
+        assert d.timestamp() == 1657505443.0
+        assert d.tzinfo.name == "Europe/Paris"
+
+        s["__data__"]["tz"] = "America/New_York"
+        d = deserialize(s)
+        assert d.timestamp() == 1657505443.0
+        assert d.tzinfo.name == "America/New_York"
+
+        s["__data__"]["tz"] = "EDT"
+        d = deserialize(s)
+        assert d.timestamp() == 1657505443.0
+        assert d.tzinfo.name == "-04:00"
+        # assert that it's serializable with the new format
+        assert deserialize(serialize(d)) == d
+
+        s["__data__"]["tz"] = "CDT"
+        d = deserialize(s)
+        assert d.timestamp() == 1657505443.0
+        assert d.tzinfo.name == "-05:00"
+        # assert that it's serializable with the new format
+        assert deserialize(serialize(d)) == d
+
+        s["__data__"]["tz"] = "MDT"
+        d = deserialize(s)
+        assert d.timestamp() == 1657505443.0
+        assert d.tzinfo.name == "-06:00"
+        # assert that it's serializable with the new format
+        assert deserialize(serialize(d)) == d
+
+        s["__data__"]["tz"] = "PDT"
+        d = deserialize(s)
+        assert d.timestamp() == 1657505443.0
+        assert d.tzinfo.name == "-07:00"
+        # assert that it's serializable with the new format
+        assert deserialize(serialize(d)) == d
+
     @pytest.mark.parametrize(
         "expr, expected",
         [("1", "1"), ("52e4", "520000"), ("2e0", "2"), ("12e-2", "0.12"), ("12.34", "12.34")],

--- a/tests/serialization/serializers/test_serializers.py
+++ b/tests/serialization/serializers/test_serializers.py
@@ -31,7 +31,6 @@ from airflow.serialization.serde import DATA, deserialize, serialize
 class TestSerializers:
     def test_datetime(self):
         i = datetime.datetime(2022, 7, 10, 22, 10, 43, microsecond=0, tzinfo=pendulum.tz.UTC)
-
         s = serialize(i)
         d = deserialize(s)
         assert i.timestamp() == d.timestamp()
@@ -50,6 +49,18 @@ class TestSerializers:
         s = serialize(i)
         d = deserialize(s)
         assert i == d
+
+        i = datetime.datetime(
+            2022, 7, 10, 22, 10, 43, microsecond=0, tzinfo=pendulum.timezone("America/New_York")
+        )
+        s = serialize(i)
+        d = deserialize(s)
+        assert i.timestamp() == d.timestamp()
+
+        i = DateTime(2022, 7, 10, tzinfo=pendulum.timezone("America/New_York"))
+        s = serialize(i)
+        d = deserialize(s)
+        assert i.timestamp() == d.timestamp()
 
     @pytest.mark.parametrize(
         "expr, expected",


### PR DESCRIPTION
closes: #34483