### PR TITLE
Improve precision of the remove_task_decorator function

### DIFF
--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -62,12 +62,18 @@ def remove_task_decorator(python_source: str, task_decorator_name: str) -> str:
 
     :param python_source: The python source code
     :param task_decorator_name: the decorator name
+
+    TODO: Python 3.9+: Rewrite this to use ast.parse and ast.unparse
     """
 
     def _remove_task_decorator(py_source, decorator_name):
-        if decorator_name not in py_source:
+        # if no line starts with @decorator_name, we can early exit
+        for line in py_source.split("\n"):
+            if line.startswith(decorator_name):
+                break
+        else:
             return python_source
-        split = python_source.split(decorator_name)
+        split = python_source.split(decorator_name, 1)
         before_decorator, after_decorator = split[0], split[1]
         if after_decorator[0] == "(":
             after_decorator = _balance_parens(after_decorator)

--- a/tests/utils/test_python_virtualenv.py
+++ b/tests/utils/test_python_virtualenv.py
@@ -128,9 +128,11 @@ class TestPrepareVirtualenv:
         assert res == "def f():\nimport funcsigs"
 
     def test_remove_decorator_including_comment(self):
-        py_source = "@task.virtualenv\ndef f():\n# the @task.virtualenv decorator runs this in an isolated env\nimport funcsigs"
+        py_source = "@task.virtualenv\ndef f():\n# @task.virtualenv\nimport funcsigs"
         res = remove_task_decorator(python_source=py_source, task_decorator_name="@task.virtualenv")
-        assert res == "def f():\n# the @task.virtualenv decorator runs this in an isolated env\nimport funcsigs"
+        assert (
+            res == "def f():\n# the @task.virtualenv decorator runs this in an isolated env\nimport funcsigs"
+        )
 
     def test_remove_decorator_nested(self):
 

--- a/tests/utils/test_python_virtualenv.py
+++ b/tests/utils/test_python_virtualenv.py
@@ -127,6 +127,11 @@ class TestPrepareVirtualenv:
         res = remove_task_decorator(python_source=py_source, task_decorator_name="@task.virtualenv")
         assert res == "def f():\nimport funcsigs"
 
+    def test_remove_decorator_including_comment(self):
+        py_source = "@task.virtualenv\ndef f():\n# the @task.virtualenv decorator runs this in an isolated env\nimport funcsigs"
+        res = remove_task_decorator(python_source=py_source, task_decorator_name="@task.virtualenv")
+        assert res == "def f():\n# the @task.virtualenv decorator runs this in an isolated env\nimport funcsigs"
+
     def test_remove_decorator_nested(self):
 
         py_source = "@foo\n@task.virtualenv\n@bar\ndef f():\nimport funcsigs"


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/34154

The `remove_task_decorator` can incorrectly truncate function bodies if there are specific comments in the function body present, which is a rare edge case but can lead to _really_ misleading behaviour where only a part of the intended code is executed. 

I think that the correct way to do code manipulation like this would be to lean on the `ast` library, but the ability to go from ast back to code was only added in python 3.9 with the `ast.unparse()` function. 

Anyways, this PR is an attempt to improve the accuracy of this method. While I don't think that this is perfect, it at least solves the issue for the cases in the linked issue with the following changes:
 - only early exiting if a line _starts_ with the decorator name
 - splitting the code at most one time

Any suggestions welcome.

If you want to discuss this IRL, come find me at Airflow Summit :) 



