### PR TITLE
Use `airflow.exceptions.AirflowException` in core

### DIFF
--- a/airflow/auth/managers/fab/fab_auth_manager.py
+++ b/airflow/auth/managers/fab/fab_auth_manager.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING
 
-from airflow import AirflowException
 from airflow.auth.managers.base_auth_manager import BaseAuthManager
 from airflow.auth.managers.fab.cli_commands.definition import (
     ROLES_COMMANDS,
@@ -30,6 +29,7 @@ from airflow.auth.managers.fab.cli_commands.definition import (
 from airflow.cli.cli_config import (
     GroupCommand,
 )
+from airflow.exceptions import AirflowException
 
 if TYPE_CHECKING:
     from airflow.auth.managers.fab.models import User

--- a/airflow/auth/managers/fab/security_manager/override.py
+++ b/airflow/auth/managers/fab/security_manager/override.py
@@ -40,9 +40,9 @@ from sqlalchemy import func, inspect, select
 from sqlalchemy.exc import MultipleResultsFound
 from werkzeug.security import generate_password_hash
 
-from airflow import AirflowException
 from airflow.auth.managers.fab.models import Action, Permission, RegisterUser, Resource, Role
 from airflow.auth.managers.fab.models.anonymous_user import AnonymousUser
+from airflow.exceptions import AirflowException
 from airflow.www.security_manager import AirflowSecurityManagerV2
 from airflow.www.session import AirflowDatabaseSessionInterface
 

--- a/airflow/decorators/setup_teardown.py
+++ b/airflow/decorators/setup_teardown.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 import types
 from typing import TYPE_CHECKING, Callable
 
-from airflow import AirflowException
 from airflow.decorators import python_task
 from airflow.decorators.task_group import _TaskGroupFactory
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.setup_teardown import SetupTeardownContext
 

--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -35,9 +35,9 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql.expression import ClauseElement, Executable, tuple_
 
-from airflow import AirflowException
 from airflow.cli.simple_table import AirflowConsole
 from airflow.configuration import conf
+from airflow.exceptions import AirflowException
 from airflow.utils import timezone
 from airflow.utils.db import reflect_tables
 from airflow.utils.helpers import ask_yesno

--- a/airflow/utils/dot_renderer.py
+++ b/airflow/utils/dot_renderer.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any
 
 import graphviz
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.mappedoperator import MappedOperator
 from airflow.utils.dag_edges import dag_edges

--- a/tests/always/test_connection.py
+++ b/tests/always/test_connection.py
@@ -27,7 +27,7 @@ import pytest
 import sqlalchemy
 from cryptography.fernet import Fernet
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.models import Connection, crypto
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook

--- a/tests/auth/managers/fab/test_fab_auth_manager.py
+++ b/tests/auth/managers/fab/test_fab_auth_manager.py
@@ -21,10 +21,10 @@ from unittest.mock import Mock
 
 import pytest
 
-from airflow import AirflowException
 from airflow.auth.managers.fab.fab_auth_manager import FabAuthManager
 from airflow.auth.managers.fab.models import User
 from airflow.auth.managers.fab.security_manager.override import FabAirflowSecurityManagerOverride
+from airflow.exceptions import AirflowException
 from airflow.www.security_appless import ApplessAirflowSecurityManager
 
 

--- a/tests/listeners/test_listeners.py
+++ b/tests/listeners/test_listeners.py
@@ -21,7 +21,7 @@ import os
 
 import pytest
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.jobs.job import Job, run_job
 from airflow.listeners.listener import get_listener_manager
 from airflow.operators.bash import BashOperator

--- a/tests/models/test_connection.py
+++ b/tests/models/test_connection.py
@@ -21,7 +21,7 @@ import re
 
 import pytest
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 
 

--- a/tests/models/test_dagcode.py
+++ b/tests/models/test_dagcode.py
@@ -22,7 +22,8 @@ from unittest.mock import patch
 
 import pytest
 
-from airflow import AirflowException, example_dags as example_dags_module
+import airflow.example_dags as example_dags_module
+from airflow.exceptions import AirflowException
 from airflow.models import DagBag
 from airflow.models.dagcode import DagCode
 

--- a/tests/utils/test_db_cleanup.py
+++ b/tests/utils/test_db_cleanup.py
@@ -31,7 +31,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.declarative import DeclarativeMeta
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import DagModel, DagRun, TaskInstance
 from airflow.operators.python import PythonOperator
 from airflow.utils.db_cleanup import (

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.jobs.base_job_runner import BaseJobRunner
 from airflow.utils import helpers, timezone
 from airflow.utils.helpers import (


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Use `from airflow.exceptions import AirflowException` instead of `from airflow import AirflowException` in core

It was a reason for Circular imports in the past
- https://github.com/apache/airflow/pull/28908
- https://github.com/apache/airflow/pull/33652

In additional we have quite a few Exceptions, and only `AirflowException` could be accessed from `airflow.__init__`

As follow up I have a plan to ban usage `from airflow import AirflowException` by add [TID251](https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid) rule for it

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
