### PR TITLE
Decode response in f-string

### DIFF
--- a/airflow/providers/databricks/hooks/databricks_base.py
+++ b/airflow/providers/databricks/hooks/databricks_base.py
@@ -245,7 +245,8 @@ class BaseDatabricksHook(BaseHook):
         except RetryError:
             raise AirflowException(f"API requests to Databricks failed {self.retry_limit} times. Giving up.")
         except requests_exceptions.HTTPError as e:
-            raise AirflowException(f"Response: {e.response.content}, Status Code: {e.response.status_code}")
+            msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
+            raise AirflowException(msg)
 
         return jsn["access_token"]
 
@@ -279,7 +280,8 @@ class BaseDatabricksHook(BaseHook):
         except RetryError:
             raise AirflowException(f"API requests to Databricks failed {self.retry_limit} times. Giving up.")
         except requests_exceptions.HTTPError as e:
-            raise AirflowException(f"Response: {e.response.content}, Status Code: {e.response.status_code}")
+            msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
+            raise AirflowException(msg)
 
         return jsn["access_token"]
 
@@ -340,7 +342,8 @@ class BaseDatabricksHook(BaseHook):
         except RetryError:
             raise AirflowException(f"API requests to Azure failed {self.retry_limit} times. Giving up.")
         except requests_exceptions.HTTPError as e:
-            raise AirflowException(f"Response: {e.response.content}, Status Code: {e.response.status_code}")
+            msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
+            raise AirflowException(msg)
 
         return jsn["access_token"]
 
@@ -606,11 +609,9 @@ class BaseDatabricksHook(BaseHook):
             raise AirflowException(f"API requests to Databricks failed {self.retry_limit} times. Giving up.")
         except requests_exceptions.HTTPError as e:
             if wrap_http_errors:
-                raise AirflowException(
-                    f"Response: {e.response.content}, Status Code: {e.response.status_code}"
-                )
-            else:
-                raise e
+                msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
+                raise AirflowException(msg)
+            raise
 
     async def _a_do_api_call(self, endpoint_info: tuple[str, str], json: dict[str, Any] | None = None):
         """

--- a/airflow/providers/snowflake/hooks/snowflake_sql_api.py
+++ b/airflow/providers/snowflake/hooks/snowflake_sql_api.py
@@ -162,7 +162,8 @@ class SnowflakeSqlApiHook(SnowflakeHook):
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:  # pragma: no cover
-            raise AirflowException(f"Response: {e.response.content} Status Code: {e.response.status_code}")
+            msg = f"Response: {e.response.content.decode()} Status Code: {e.response.status_code}"
+            raise AirflowException(msg)
         json_response = response.json()
         self.log.info("Snowflake SQL POST API response: %s", json_response)
         if "statementHandles" in json_response:
@@ -226,9 +227,8 @@ class SnowflakeSqlApiHook(SnowflakeHook):
                 response.raise_for_status()
                 self.log.info(response.json())
             except requests.exceptions.HTTPError as e:
-                raise AirflowException(
-                    f"Response: {e.response.content}, Status Code: {e.response.status_code}"
-                )
+                msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
+                raise AirflowException(msg)
 
     def _process_response(self, status_code, resp):
         self.log.info("Snowflake SQL GET statements status API response: %s", resp)

--- a/tests/providers/snowflake/hooks/test_snowflake_sql_api.py
+++ b/tests/providers/snowflake/hooks/test_snowflake_sql_api.py
@@ -27,6 +27,7 @@ import requests
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from responses import RequestsMock
 
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
@@ -216,33 +217,24 @@ class TestSnowflakeSqlApiHook:
             hook.check_query_output(query_ids)
         mock_log_info.assert_called_with(GET_RESPONSE)
 
-    @pytest.mark.parametrize(
-        "query_ids",
-        [
-            (["uuid", "uuid1"]),
-        ],
-    )
-    @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.requests.get")
+    @pytest.mark.parametrize("query_ids", [(["uuid", "uuid1"])])
     @mock.patch(
         "airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook."
         "get_request_url_header_params"
     )
-    def test_check_query_output_exception(self, mock_geturl_header_params, mock_requests, query_ids):
+    def test_check_query_output_exception(self, mock_geturl_header_params, query_ids):
         """
         Test check_query_output by passing query ids as params and mock get_request_url_header_params
         to raise airflow exception and mock with http error
         """
         req_id = uuid.uuid4()
         params = {"requestId": str(req_id), "page": 2, "pageSize": 10}
-        mock_geturl_header_params.return_value = HEADERS, params, "/test/airflow/"
-        mock_resp = requests.models.Response()
-        mock_resp.status_code = 404
-        mock_requests.return_value = mock_resp
+        mock_geturl_header_params.return_value = HEADERS, params, "https://test/airflow/"
         hook = SnowflakeSqlApiHook("mock_conn_id")
-        with mock.patch.object(hook.log, "error"):
-            with pytest.raises(AirflowException) as airflow_exception:
+        with mock.patch.object(hook.log, "error"), RequestsMock() as requests_mock:
+            requests_mock.get(url="https://test/airflow/", json={"foo": "bar"}, status=500)
+            with pytest.raises(AirflowException, match='Response: {"foo": "bar"}, Status Code: 500'):
                 hook.check_query_output(query_ids)
-            assert airflow_exception
 
     @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook._get_conn_params")
     @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook.get_headers")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fix construction exception messages which contains response in bytes, it should make mypy happy, and also fix the `main`

```console
airflow/providers/databricks/hooks/databricks_base.py:248: error: On Python 3
formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this
is desired behavior  [str-bytes-safe]
                raise AirflowException(f"Response: {e.response.content}, S...
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~...
airflow/providers/databricks/hooks/databricks_base.py:282: error: On Python 3
formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this
is desired behavior  [str-bytes-safe]
                raise AirflowException(f"Response: {e.response.content}, S...
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~...
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
