### PR TITLE
warn level for deprecated set to stacklevel 2

### DIFF
--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -361,7 +361,8 @@ class PodManager(LoggingMixin):
         warnings.warn(
             "Method `follow_container_logs` is deprecated.  Use `fetch_container_logs` instead"
             "with option `follow=True`.",
-            AirflowProviderDeprecationWarning,
+            category=AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         return self.fetch_container_logs(pod=pod, container_name=container_name, follow=True)
 


### PR DESCRIPTION
I added the category to the warning class
closes: https://github.com/apache/airflow/issues/34423
