### PR TITLE
Update define-extra-link.rst

### DIFF
--- a/docs/apache-airflow/howto/define-extra-link.rst
+++ b/docs/apache-airflow/howto/define-extra-link.rst
@@ -29,6 +29,8 @@ The following code shows how to add extra links to an operator via Plugins:
 
     from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
     from airflow.plugins_manager import AirflowPlugin
+    from airflow.models.taskinstancekey import TaskInstanceKey
+
 
 
     class GoogleLink(BaseOperatorLink):
@@ -81,7 +83,8 @@ tasks using :class:`~airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSToS3Ope
 .. code-block:: python
 
   from airflow.plugins_manager import AirflowPlugin
-  from airflow.models.baseoperator import BaseOperatorLink
+  from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
+  from airflow.models.taskinstancekey import TaskInstanceKey
   from airflow.providers.amazon.aws.transfers.gcs_to_s3 import GCSToS3Operator
 
 
@@ -118,7 +121,9 @@ Console, but if we wanted to change that link we could:
 .. code-block:: python
 
     from airflow.plugins_manager import AirflowPlugin
-    from airflow.models.baseoperator import BaseOperatorLink
+    from airflow.models.baseoperator import BaseOperatorLink, BaseOperator
+    from airflow.models.taskinstancekey import TaskInstanceKey
+
     from airflow.models.xcom import XCom
     from airflow.providers.google.cloud.operators.bigquery import BigQueryOperator
 

--- a/docs/apache-airflow/howto/define-extra-link.rst
+++ b/docs/apache-airflow/howto/define-extra-link.rst
@@ -32,7 +32,6 @@ The following code shows how to add extra links to an operator via Plugins:
     from airflow.models.taskinstancekey import TaskInstanceKey
 
 
-
     class GoogleLink(BaseOperatorLink):
         name = "Google"
 

--- a/docs/apache-airflow/howto/define-extra-link.rst
+++ b/docs/apache-airflow/howto/define-extra-link.rst
@@ -28,8 +28,8 @@ The following code shows how to add extra links to an operator via Plugins:
 .. code-block:: python
 
     from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
-    from airflow.plugins_manager import AirflowPlugin
     from airflow.models.taskinstancekey import TaskInstanceKey
+    from airflow.plugins_manager import AirflowPlugin
 
 
     class GoogleLink(BaseOperatorLink):
@@ -81,9 +81,9 @@ tasks using :class:`~airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSToS3Ope
 
 .. code-block:: python
 
-  from airflow.plugins_manager import AirflowPlugin
   from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
   from airflow.models.taskinstancekey import TaskInstanceKey
+  from airflow.plugins_manager import AirflowPlugin
   from airflow.providers.amazon.aws.transfers.gcs_to_s3 import GCSToS3Operator
 
 
@@ -119,11 +119,10 @@ Console, but if we wanted to change that link we could:
 
 .. code-block:: python
 
-    from airflow.plugins_manager import AirflowPlugin
     from airflow.models.baseoperator import BaseOperatorLink, BaseOperator
     from airflow.models.taskinstancekey import TaskInstanceKey
-
     from airflow.models.xcom import XCom
+    from airflow.plugins_manager import AirflowPlugin
     from airflow.providers.google.cloud.operators.bigquery import BigQueryOperator
 
     # Change from https to http just to display the override


### PR DESCRIPTION
Add necessary imports for type hints in examples.

The examples look like they are intended to be self-contained and should work when cutting and pasting them into a (plugin) python file. Sadly the imports are incomplete.