### PR TITLE
Slack: use default_conn_name by default

### DIFF
--- a/airflow/providers/slack/hooks/slack.py
+++ b/airflow/providers/slack/hooks/slack.py
@@ -112,7 +112,7 @@ class SlackHook(BaseHook):
     def __init__(
         self,
         *,
-        slack_conn_id: str,
+        slack_conn_id: str = default_conn_name,
         base_url: str | None = None,
         timeout: int | None = None,
         proxy: str | None = None,

--- a/airflow/providers/slack/notifications/slack.py
+++ b/airflow/providers/slack/notifications/slack.py
@@ -53,7 +53,7 @@ class SlackNotifier(BaseNotifier):
     def __init__(
         self,
         *,
-        slack_conn_id: str = "slack_api_default",
+        slack_conn_id: str = SlackHook.default_conn_name,
         text: str = "This is a default message",
         channel: str = "#general",
         username: str = "Airflow",

--- a/airflow/providers/slack/operators/slack.py
+++ b/airflow/providers/slack/operators/slack.py
@@ -43,7 +43,7 @@ class SlackAPIOperator(BaseOperator):
     def __init__(
         self,
         *,
-        slack_conn_id: str,
+        slack_conn_id: str = SlackHook.default_conn_name,
         method: str | None = None,
         api_params: dict | None = None,
         **kwargs,

--- a/airflow/providers/slack/transfers/sql_to_slack.py
+++ b/airflow/providers/slack/transfers/sql_to_slack.py
@@ -237,7 +237,7 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
         sql_conn_id: str,
         sql_hook_params: dict | None = None,
         parameters: Iterable | Mapping[str, Any] | None = None,
-        slack_conn_id: str,
+        slack_conn_id: str = SlackHook.default_conn_name,
         slack_filename: str,
         slack_channels: str | Sequence[str] | None = None,
         slack_initial_comment: str | None = None,

--- a/docs/apache-airflow-providers-slack/connections/slack.rst
+++ b/docs/apache-airflow-providers-slack/connections/slack.rst
@@ -30,13 +30,10 @@ Authenticating to Slack
 Authenticate to Slack using a `Slack API token
 <https://slack.com/help/articles/215770388-Create-and-regenerate-API-tokens>`_.
 
-Default Connection IDs
+Default Connection ID
 ----------------------
 
-.. warning::
-
-  The SlackHook and community provided operators not intend to use any Slack API Connection by default right now.
-  It might change in the future to ``slack_api_default``.
+  The default Slack API Connection ID is ``slack_api_default``.
 
 Configuring the Connection
 --------------------------

--- a/tests/providers/slack/hooks/test_slack.py
+++ b/tests/providers/slack/hooks/test_slack.py
@@ -483,3 +483,7 @@ class TestSlackHook:
             params = hook._get_conn_params()
             assert "proxy" not in params
             assert "base_url" not in params
+
+    def test_default_conn_name(self):
+        hook = SlackHook()
+        assert hook.slack_conn_id == SlackHook.default_conn_name


### PR DESCRIPTION
It's convenient not to define a connection name if there is only one global or default connection. 
This is what is usually done in [other hooks like](https://github.com/Taragolis/airflow/blob/8e1fadf4372a42170cc66949f02917a3be07b558/airflow/providers/http/hooks/http.py#L62) `HttpHook`.

Related discussion: https://github.com/apache/airflow/pull/33557#discussion_r1334110063

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
