### PR TITLE
Respect soft_fail parameter in Glue*Sensor

### DIFF
--- a/airflow/providers/amazon/aws/sensors/glue.py
+++ b/airflow/providers/amazon/aws/sensors/glue.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING, Sequence
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.providers.amazon.aws.hooks.glue import GlueJobHook
 from airflow.sensors.base import BaseSensorOperator
 
@@ -78,6 +78,9 @@ class GlueJobSensor(BaseSensorOperator):
             elif job_state in self.errored_states:
                 job_error_message = "Exiting Job %s Run State: %s", self.run_id, job_state
                 self.log.info(job_error_message)
+                # TODO: remove this if block when min_airflow_version is set to higher than 2.7.1
+                if self.soft_fail:
+                    raise AirflowSkipException(job_error_message)
                 raise AirflowException(job_error_message)
             else:
                 return False

--- a/airflow/providers/amazon/aws/sensors/glue_catalog_partition.py
+++ b/airflow/providers/amazon/aws/sensors/glue_catalog_partition.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 from deprecated import deprecated
 
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
 from airflow.providers.amazon.aws.hooks.glue_catalog import GlueCatalogHook
 from airflow.providers.amazon.aws.triggers.glue import GlueCatalogPartitionTrigger
 from airflow.sensors.base import BaseSensorOperator
@@ -112,7 +112,11 @@ class GlueCatalogPartitionSensor(BaseSensorOperator):
 
     def execute_complete(self, context: Context, event: dict | None = None) -> None:
         if event is None or event["status"] != "success":
-            raise AirflowException(f"Trigger error: event is {event}")
+            # TODO: remove this if block when min_airflow_version is set to higher than 2.7.1
+            message = f"Trigger error: event is {event}"
+            if self.soft_fail:
+                raise AirflowSkipException(message)
+            raise AirflowException(message)
         self.log.info("Partition exists in the Glue Catalog")
 
     @deprecated(reason="use `hook` property instead.", category=AirflowProviderDeprecationWarning)

--- a/airflow/providers/amazon/aws/sensors/glue_crawler.py
+++ b/airflow/providers/amazon/aws/sensors/glue_crawler.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Sequence
 
 from deprecated import deprecated
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
 from airflow.providers.amazon.aws.hooks.glue_crawler import GlueCrawlerHook
 from airflow.sensors.base import BaseSensorOperator
 
@@ -63,7 +63,11 @@ class GlueCrawlerSensor(BaseSensorOperator):
                 self.log.info("Status: %s", crawler_status)
                 return True
             else:
-                raise AirflowException(f"Status: {crawler_status}")
+                # TODO: remove this if block when min_airflow_version is set to higher than 2.7.1
+                message = f"Status: {crawler_status}"
+                if self.soft_fail:
+                    raise AirflowSkipException(message)
+                raise AirflowException(message)
         else:
             return False
 

--- a/tests/providers/amazon/aws/sensors/test_glue.py
+++ b/tests/providers/amazon/aws/sensors/test_glue.py
@@ -22,7 +22,7 @@ from unittest.mock import ANY
 import pytest
 
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.providers.amazon.aws.hooks.glue import GlueJobHook
 from airflow.providers.amazon.aws.sensors.glue import GlueJobSensor
 
@@ -139,3 +139,26 @@ class TestGlueJobSensor:
                 filter_pattern="?ERROR ?Exception",
                 next_token=ANY,
             )
+
+    @pytest.mark.parametrize(
+        "soft_fail, expected_exception", ((False, AirflowException), (True, AirflowSkipException))
+    )
+    @mock.patch("airflow.providers.amazon.aws.hooks.glue.GlueJobHook.get_job_state")
+    def test_fail_poke(self, get_job_state, soft_fail, expected_exception):
+        job_name = "job_name"
+        job_run_id = "job_run_id"
+        op = GlueJobSensor(
+            task_id="test_glue_job_sensor",
+            job_name=job_name,
+            run_id=job_run_id,
+            poke_interval=1,
+            timeout=5,
+            verbose=True,
+        )
+        op.verbose = False
+        op.soft_fail = soft_fail
+        job_state = "FAILED"
+        get_job_state.return_value = job_state
+        job_error_message = "Exiting Job"
+        with pytest.raises(expected_exception, match=job_error_message):
+            op.poke(context={})

--- a/tests/providers/amazon/aws/sensors/test_glue_catalog_partition.py
+++ b/tests/providers/amazon/aws/sensors/test_glue_catalog_partition.py
@@ -22,7 +22,7 @@ from unittest import mock
 import pytest
 from moto import mock_glue
 
-from airflow.exceptions import AirflowException, TaskDeferred
+from airflow.exceptions import AirflowException, AirflowSkipException, TaskDeferred
 from airflow.providers.amazon.aws.hooks.glue_catalog import GlueCatalogHook
 from airflow.providers.amazon.aws.sensors.glue_catalog_partition import GlueCatalogPartitionSensor
 
@@ -112,3 +112,14 @@ class TestGlueCatalogPartitionSensor:
         event = {"status": "success"}
         op.execute_complete(context={}, event=event)
         assert "Partition exists in the Glue Catalog" in caplog.messages
+
+    @pytest.mark.parametrize(
+        "soft_fail, expected_exception", ((False, AirflowException), (True, AirflowSkipException))
+    )
+    def test_fail_execute_complete(self, soft_fail, expected_exception):
+        op = GlueCatalogPartitionSensor(task_id=self.task_id, table_name="tbl", deferrable=True)
+        op.soft_fail = soft_fail
+        event = {"status": "Failed"}
+        message = f"Trigger error: event is {event}"
+        with pytest.raises(expected_exception, match=message):
+            op.execute_complete(context={}, event=event)


### PR DESCRIPTION
This PR intends to solve the issue that the soft_fail argument in GlueJobSensor, GlueCatalogPartitionSensor, and GlueCrawlerSensor is not respected.