### PR TITLE
Simplify DAG trigger UI

### DIFF
--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -259,16 +259,7 @@
     <label for="conf">Configuration JSON (Optional, must be a dict object)</label>
     <textarea class="form-control" name="conf" id="json">{{ conf }}</textarea>
     {%- endif %}
-    <p>
-      To access configuration in your DAG use <code>{{ '{{ dag_run.conf }}' }}</code>.
-      {% if is_dag_run_conf_overrides_params %}
-        As <code>core.dag_run_conf_overrides_params</code> is set to <code>True</code>, so passing any configuration
-        here will override task params which can be accessed via <code>{{ '{{ params }}' }}</code>.
-      {% else %}
-        As <code>core.dag_run_conf_overrides_params</code> is set to <code>False</code>, so passing any configuration
-        here won't override task params.
-      {% endif %}
-    </p>
+    {% if dag.get_is_paused() %}
     <div class="form-group">
       <label class="switch-label">
         <input class="switch-input" name="unpause" id="unpause" type="checkbox" checked>
@@ -276,6 +267,7 @@
         Unpause DAG when triggered
       </label>
     </div>
+    {% endif %}
     <button type="submit" class="btn btn-primary">Trigger</button>
     <a class="btn" href="{{ origin }}">Cancel</a>
   </form>


### PR DESCRIPTION
We don't need to show details on how to access dagrun conf on the trigger page every time - DAG authors can find it in the docs.

Also, don't show the "unpause dag" toggle if the DAG is already unpaused - no matter your choice it'll unpaused.

Before:

![Screenshot 2023-09-22 at 2 53 58 PM](https://github.com/apache/airflow/assets/66968678/6df996e8-d76a-4584-82af-6e48a01a29de)


After - DAG Unpaused:

![Screenshot 2023-09-22 at 2 53 28 PM](https://github.com/apache/airflow/assets/66968678/91e2f456-74d5-4146-93d1-12d404b6d86b)

After - DAG Paused:

![Screenshot 2023-09-22 at 2 53 18 PM](https://github.com/apache/airflow/assets/66968678/3523a933-1392-4610-845d-24eb4ffb9d2f)


