### PR TITLE
do not fail operator if we cannot find logs

### DIFF
--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -359,7 +359,12 @@ class BatchOperator(BaseOperator):
             else:
                 self.hook.wait_for_job(self.job_id)
 
-        awslogs = self.hook.get_job_all_awslogs_info(self.job_id)
+        awslogs = []
+        try:
+            awslogs = self.hook.get_job_all_awslogs_info(self.job_id)
+        except AirflowException as ae:
+            self.log.warning("cannot determine where to find aws logs for this batch job: %s", ae)
+
         if awslogs:
             self.log.info("AWS Batch job (%s) CloudWatch Events details found. Links to logs:", self.job_id)
             link_builder = CloudWatchEventsLink()

--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -363,7 +363,7 @@ class BatchOperator(BaseOperator):
         try:
             awslogs = self.hook.get_job_all_awslogs_info(self.job_id)
         except AirflowException as ae:
-            self.log.warning("cannot determine where to find aws logs for this batch job: %s", ae)
+            self.log.warning("Cannot determine where to find the AWS logs for this Batch job: %s", ae)
 
         if awslogs:
             self.log.info("AWS Batch job (%s) CloudWatch Events details found. Links to logs:", self.job_id)


### PR DESCRIPTION
reported by a user on slack, their job succeeds, but the the task fails when trying to compute the link to the logs because their job is not of a "supported type".

This is just a bonus, and there is already code handling the fact that we may have no link to display, so errors shouldn't make the task fail either.