### PR TITLE
improvement: introduce proejct_id in BigQueryIntervalCheckOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -505,7 +505,7 @@ class BigQueryIntervalCheckOperator(_BigQueryDbHookMixin, SQLIntervalCheckOperat
     :param deferrable: Run operator in the deferrable mode
     :param poll_interval: (Deferrable mode only) polling period in seconds to check for the status of job.
         Defaults to 4 seconds.
-    :param project_ud: a string represents the BigQuery projectId
+    :param project_id: a string represents the BigQuery projectId
     """
 
     template_fields: Sequence[str] = (

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -505,6 +505,7 @@ class BigQueryIntervalCheckOperator(_BigQueryDbHookMixin, SQLIntervalCheckOperat
     :param deferrable: Run operator in the deferrable mode
     :param poll_interval: (Deferrable mode only) polling period in seconds to check for the status of job.
         Defaults to 4 seconds.
+    :param project_ud: a string represents the BigQuery projectId
     """
 
     template_fields: Sequence[str] = (
@@ -532,6 +533,7 @@ class BigQueryIntervalCheckOperator(_BigQueryDbHookMixin, SQLIntervalCheckOperat
         labels: dict | None = None,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         poll_interval: float = 4.0,
+        project_id: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(
@@ -547,6 +549,7 @@ class BigQueryIntervalCheckOperator(_BigQueryDbHookMixin, SQLIntervalCheckOperat
         self.location = location
         self.impersonation_chain = impersonation_chain
         self.labels = labels
+        self.project_id = project_id
         self.deferrable = deferrable
         self.poll_interval = poll_interval
 
@@ -560,7 +563,7 @@ class BigQueryIntervalCheckOperator(_BigQueryDbHookMixin, SQLIntervalCheckOperat
         configuration = {"query": {"query": sql, "useLegacySql": self.use_legacy_sql}}
         return hook.insert_job(
             configuration=configuration,
-            project_id=hook.project_id,
+            project_id=self.project_id or hook.project_id,
             location=self.location,
             job_id=job_id,
             nowait=True,

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -1768,6 +1768,80 @@ class TestBigQueryIntervalCheckOperator:
             exc.value.trigger, BigQueryIntervalCheckTrigger
         ), "Trigger is not a BigQueryIntervalCheckTrigger"
 
+    @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
+    def test_bigquery_interval_check_operator_with_project_id(
+        self, mock_hook, create_task_instance_of_operator
+    ):
+        """
+        Test BigQueryIntervalCheckOperator with a specified project_id.
+        Ensure that the bq_project_id is passed correctly when submitting the job.
+        """
+        job_id = "123456"
+        hash_ = "hash"
+        real_job_id = f"{job_id}_{hash_}"
+
+        project_id = "test-project-id"
+        ti = create_task_instance_of_operator(
+            BigQueryIntervalCheckOperator,
+            dag_id="dag_id",
+            task_id="bq_interval_check_operator_with_project_id",
+            table="test_table",
+            metrics_thresholds={"COUNT(*)": 1.5},
+            location=TEST_DATASET_LOCATION,
+            deferrable=True,
+            project_id=project_id,
+        )
+
+        mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
+
+        with pytest.raises(TaskDeferred):
+            ti.task.execute(MagicMock())
+
+        mock_hook.return_value.insert_job.assert_called_with(
+            configuration=mock.ANY,
+            project_id=project_id,
+            location=TEST_DATASET_LOCATION,
+            job_id=mock.ANY,
+            nowait=True,
+        )
+
+    @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
+    def test_bigquery_interval_check_operator_without_project_id(
+        self, mock_hook, create_task_instance_of_operator
+    ):
+        """
+        Test BigQueryIntervalCheckOperator without a specified project_id.
+        Ensure that the project_id falls back to the hook.project_id as previously implemented.
+        """
+        job_id = "123456"
+        hash_ = "hash"
+        real_job_id = f"{job_id}_{hash_}"
+
+        project_id = "test-project-id"
+        ti = create_task_instance_of_operator(
+            BigQueryIntervalCheckOperator,
+            dag_id="dag_id",
+            task_id="bq_interval_check_operator_without_project_id",
+            table="test_table",
+            metrics_thresholds={"COUNT(*)": 1.5},
+            location=TEST_DATASET_LOCATION,
+            deferrable=True,
+        )
+
+        mock_hook.return_value.project_id = project_id
+        mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
+
+        with pytest.raises(TaskDeferred):
+            ti.task.execute(MagicMock())
+
+        mock_hook.return_value.insert_job.assert_called_with(
+            configuration=mock.ANY,
+            project_id=mock_hook.return_value.project_id,
+            location=TEST_DATASET_LOCATION,
+            job_id=mock.ANY,
+            nowait=True,
+        )
+
 
 class TestBigQueryCheckOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryCheckOperator.execute")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

### Notes

This PR is related to Issue #34513. The changes include

- introduced a new member variable for `project_id` and fall back to default `hook.project_id`
- expanded unit tests to cover this change. unit test passed via invoking `breeze testing tests --test-type "Providers[google]"`

Regarding newfragments change, I am inclining to add something but it seems like `newfragements` folder is empty, could I get some pointers on how to add one more `rst` file entry there ?

Thanks

---

### Testing

```
$ breeze testing tests --test-type "Providers[google]"

Running tests tests/providers/google


Starting the tests with those pytest arguments: --verbosity=0 --strict-markers --durations=100 --maxfail=50 --color=yes --junitxml=/files/test_result-Providers-postgres.xml --timeouts-order moi --setup-timeout=60 --execution-timeout=60 --teardown-timeout=60 --output=/files/warnings-Providers-postgres.txt --disable-warnings -rfEXs --ignore=tests/providers/qubole --ignore=tests/system/providers/qubole --ignore=tests/integration/providers/qubole --with-db-init tests/providers/google

============================= test session starts ==============================
platform linux -- Python 3.8.18, pytest-7.4.2, pluggy-1.3.0
rootdir: /opt/airflow
configfile: pyproject.toml
plugins: mock-3.11.1, time-machine-2.13.0, instafail-0.5.0, requests-mock-1.11.0, httpx-0.21.3, timeouts-1.2.1, anyio-4.0.0, xdist-3.3.1, capture-warnings-0.0.4, cov-4.1.0, rerunfailures-12.0, asyncio-0.21.1
asyncio: mode=strict
setup timeout: 60.0s, execution timeout: 60.0s, teardown timeout: 60.0s
collected 3403 items

tests/providers/google/test_go_module.py ..                              [  0%]
tests/providers/google/ads/hooks/test_ads.py .....                       [  0%]
tests/providers/google/ads/operators/test_ads.py .                       [  0%]
tests/providers/google/ads/transfers/test_ads_to_gcs.py .                [  0%]
tests/providers/google/cloud/_internal_client/test_secret_manager_client.py . [  0%]
.....                                                                    [  0%]
tests/providers/google/cloud/hooks/test_automl.py ................       [  0%]
tests/providers/google/cloud/hooks/test_bigquery.py .................... [  1%]
........................................................................ [  3%]
........................................................................ [  5%]
...................                                                      [  6%]
tests/providers/google/cloud/hooks/test_bigquery_dts.py ........         [  6%]
tests/providers/google/cloud/hooks/test_bigquery_system.py sssss         [  6%]
tests/providers/google/cloud/hooks/test_bigtable.py .................... [  7%]
......                                                                   [  7%]
tests/providers/google/cloud/hooks/test_cloud_batch.py ................  [  7%]
tests/providers/google/cloud/hooks/test_cloud_build.py ................. [  8%]
...                                                                      [  8%]
tests/providers/google/cloud/hooks/test_cloud_composer.py ...........    [  8%]
tests/providers/google/cloud/hooks/test_cloud_memorystore.py ........... [  9%]
.............                                                            [  9%]
tests/providers/google/cloud/hooks/test_cloud_run.py ...........         [  9%]
tests/providers/google/cloud/hooks/test_cloud_sql.py ................... [ 10%]
.......................................................                  [ 12%]
tests/providers/google/cloud/hooks/test_cloud_storage_transfer_service.py . [ 12%]
...............................................                          [ 13%]
tests/providers/google/cloud/hooks/test_cloud_storage_transfer_service_async.py . [ 13%]
...                                                                      [ 13%]
tests/providers/google/cloud/hooks/test_compute.py ..................... [ 14%]
..............                                                           [ 14%]
tests/providers/google/cloud/hooks/test_compute_ssh.py ..............    [ 14%]
tests/providers/google/cloud/hooks/test_datacatalog.py ................. [ 15%]
...................................................                      [ 16%]
tests/providers/google/cloud/hooks/test_dataflow.py .................... [ 17%]
........................................................................ [ 19%]
.................                                                        [ 20%]
tests/providers/google/cloud/hooks/test_dataform.py ..............       [ 20%]
tests/providers/google/cloud/hooks/test_datafusion.py .................. [ 21%]
............................                                             [ 21%]
tests/providers/google/cloud/hooks/test_datapipeline.py ....             [ 22%]
tests/providers/google/cloud/hooks/test_dataplex.py .................    [ 22%]
tests/providers/google/cloud/hooks/test_dataprep.py .................... [ 23%]
.................                                                        [ 23%]
tests/providers/google/cloud/hooks/test_dataproc.py .................... [ 24%]
................................................................         [ 26%]
tests/providers/google/cloud/hooks/test_dataproc_metastore.py .......... [ 26%]
........................                                                 [ 27%]
tests/providers/google/cloud/hooks/test_datastore.py ................... [ 27%]
..                                                                       [ 27%]
tests/providers/google/cloud/hooks/test_dlp.py ......................... [ 28%]
...................................................................      [ 30%]
tests/providers/google/cloud/hooks/test_functions.py ..............      [ 30%]
tests/providers/google/cloud/hooks/test_gcs.py ......................... [ 31%]
...............................................                          [ 32%]
tests/providers/google/cloud/hooks/test_gdm.py ....                      [ 33%]
tests/providers/google/cloud/hooks/test_kms.py ......                    [ 33%]
tests/providers/google/cloud/hooks/test_kms_system.py ss                 [ 33%]
tests/providers/google/cloud/hooks/test_kubernetes_engine.py ........... [ 33%]
............                                                             [ 33%]
tests/providers/google/cloud/hooks/test_life_sciences.py ............    [ 34%]
tests/providers/google/cloud/hooks/test_looker.py ....                   [ 34%]
tests/providers/google/cloud/hooks/test_mlengine.py .................... [ 35%]
....................                                                     [ 35%]
tests/providers/google/cloud/hooks/test_natural_language.py ........     [ 35%]
tests/providers/google/cloud/hooks/test_os_login.py .....                [ 36%]
tests/providers/google/cloud/hooks/test_pubsub.py ...................... [ 36%]
........................                                                 [ 37%]
tests/providers/google/cloud/hooks/test_secret_manager.py ...            [ 37%]
tests/providers/google/cloud/hooks/test_secret_manager_system.py sss     [ 37%]
tests/providers/google/cloud/hooks/test_spanner.py ..................... [ 38%]
................                                                         [ 38%]
tests/providers/google/cloud/hooks/test_speech_to_text.py ...            [ 38%]
tests/providers/google/cloud/hooks/test_stackdriver.py ............      [ 39%]
tests/providers/google/cloud/hooks/test_tasks.py ...............         [ 39%]
tests/providers/google/cloud/hooks/test_text_to_speech.py ...            [ 39%]
tests/providers/google/cloud/hooks/test_translate.py ...                 [ 39%]
tests/providers/google/cloud/hooks/test_video_intelligence.py ....       [ 39%]
tests/providers/google/cloud/hooks/test_vision.py ...................... [ 40%]
........................                                                 [ 41%]
tests/providers/google/cloud/hooks/test_workflows.py .............       [ 41%]
tests/providers/google/cloud/hooks/vertex_ai/test_auto_ml.py .......     [ 41%]
tests/providers/google/cloud/hooks/vertex_ai/test_batch_prediction_job.py . [ 41%]
......                                                                   [ 41%]
tests/providers/google/cloud/hooks/vertex_ai/test_custom_job.py ........ [ 42%]
.............                                                            [ 42%]
tests/providers/google/cloud/hooks/vertex_ai/test_dataset.py ........... [ 42%]
..........                                                               [ 43%]
tests/providers/google/cloud/hooks/vertex_ai/test_endpoint_service.py .. [ 43%]
.............                                                            [ 43%]
tests/providers/google/cloud/hooks/vertex_ai/test_hyperparameter_tuning_job.py . [ 43%]
......                                                                   [ 43%]
tests/providers/google/cloud/hooks/vertex_ai/test_model_service.py ..... [ 43%]
....                                                                     [ 44%]
tests/providers/google/cloud/log/test_gcs_task_handler.py ...........    [ 44%]
tests/providers/google/cloud/log/test_gcs_task_handler_system.py s       [ 44%]
tests/providers/google/cloud/log/test_stackdriver_task_handler.py ...... [ 44%]
.....                                                                    [ 44%]
tests/providers/google/cloud/log/test_stackdriver_task_handler_system.py s [ 44%]
s                                                                        [ 44%]
tests/providers/google/cloud/operators/test_automl.py .............      [ 45%]
tests/providers/google/cloud/operators/test_bigquery.py ................ [ 45%]
........................................................................ [ 47%]
............                                                             [ 48%]
tests/providers/google/cloud/operators/test_bigquery_dts.py ....         [ 48%]
tests/providers/google/cloud/operators/test_bigtable.py ................ [ 48%]
...........................                                              [ 49%]
tests/providers/google/cloud/operators/test_cloud_base.py ..             [ 49%]
tests/providers/google/cloud/operators/test_cloud_batch.py .........     [ 49%]
tests/providers/google/cloud/operators/test_cloud_build.py ............. [ 50%]
.......................                                                  [ 50%]
tests/providers/google/cloud/operators/test_cloud_composer.py .........  [ 51%]
tests/providers/google/cloud/operators/test_cloud_memorystore.py ....... [ 51%]
........                                                                 [ 51%]
tests/providers/google/cloud/operators/test_cloud_run.py ............... [ 52%]
....                                                                     [ 52%]
tests/providers/google/cloud/operators/test_cloud_sql.py ............... [ 52%]
......................                                                   [ 53%]
tests/providers/google/cloud/operators/test_cloud_storage_transfer_service.py . [ 53%]
...................................................                      [ 54%]
tests/providers/google/cloud/operators/test_compute.py ................. [ 55%]
.....................................................                    [ 56%]
tests/providers/google/cloud/operators/test_datacatalog.py ............. [ 57%]
.........                                                                [ 57%]
tests/providers/google/cloud/operators/test_dataflow.py ................ [ 57%]
.....                                                                    [ 58%]
tests/providers/google/cloud/operators/test_dataform.py ..............   [ 58%]
tests/providers/google/cloud/operators/test_datafusion.py .............. [ 58%]
..                                                                       [ 59%]
tests/providers/google/cloud/operators/test_datapipeline.py ..........   [ 59%]
tests/providers/google/cloud/operators/test_dataplex.py ................ [ 59%]
                                                                         [ 59%]
tests/providers/google/cloud/operators/test_dataprep.py ..............   [ 60%]
tests/providers/google/cloud/operators/test_dataprep_system.py s         [ 60%]
tests/providers/google/cloud/operators/test_dataproc.py ................ [ 60%]
...................................................                      [ 62%]
tests/providers/google/cloud/operators/test_dataproc_metastore.py ...... [ 62%]
....                                                                     [ 62%]
tests/providers/google/cloud/operators/test_datastore.py .........       [ 62%]
tests/providers/google/cloud/operators/test_datastore_system.py ss       [ 62%]
tests/providers/google/cloud/operators/test_dlp.py ..................... [ 63%]
.........                                                                [ 63%]
tests/providers/google/cloud/operators/test_functions.py ............... [ 64%]
....................................................                     [ 65%]
tests/providers/google/cloud/operators/test_gcs.py ..............        [ 66%]
tests/providers/google/cloud/operators/test_kubernetes_engine.py ....... [ 66%]
..............................                                           [ 67%]
tests/providers/google/cloud/operators/test_life_sciences.py ..          [ 67%]
tests/providers/google/cloud/operators/test_looker.py ....               [ 67%]
tests/providers/google/cloud/operators/test_mlengine.py ................ [ 67%]
..........................                                               [ 68%]
tests/providers/google/cloud/operators/test_natural_language.py ....     [ 68%]
tests/providers/google/cloud/operators/test_pubsub.py ...........        [ 68%]
tests/providers/google/cloud/operators/test_spanner.py ................. [ 69%]
.....................                                                    [ 70%]
tests/providers/google/cloud/operators/test_speech_to_text.py ...        [ 70%]
tests/providers/google/cloud/operators/test_stackdriver.py ..........    [ 70%]
tests/providers/google/cloud/operators/test_tasks.py .............       [ 70%]
tests/providers/google/cloud/operators/test_text_to_speech.py ......     [ 71%]
tests/providers/google/cloud/operators/test_translate.py .               [ 71%]
tests/providers/google/cloud/operators/test_translate_speech.py ..       [ 71%]
tests/providers/google/cloud/operators/test_vertex_ai.py ............... [ 71%]
...................                                                      [ 72%]
tests/providers/google/cloud/operators/test_vertex_ai_system.py sssssss  [ 72%]
tests/providers/google/cloud/operators/test_video_intelligence.py ...    [ 72%]
tests/providers/google/cloud/operators/test_vision.py .................. [ 72%]
....                                                                     [ 73%]
tests/providers/google/cloud/operators/test_workflows.py .........       [ 73%]
tests/providers/google/cloud/secrets/test_secret_manager.py ............ [ 73%]
................                                                         [ 74%]
tests/providers/google/cloud/secrets/test_secret_manager_system.py ss    [ 74%]
tests/providers/google/cloud/sensors/test_bigquery.py .................. [ 74%]
..                                                                       [ 74%]
tests/providers/google/cloud/sensors/test_bigquery_dts.py ..             [ 74%]
tests/providers/google/cloud/sensors/test_cloud_composer.py ...          [ 74%]
tests/providers/google/cloud/sensors/test_cloud_storage_transfer_service.py . [ 74%]
......                                                                   [ 75%]
tests/providers/google/cloud/sensors/test_dataflow.py ......             [ 75%]
tests/providers/google/cloud/sensors/test_datafusion.py ....             [ 75%]
tests/providers/google/cloud/sensors/test_dataplex.py .....              [ 75%]
tests/providers/google/cloud/sensors/test_dataprep.py .                  [ 75%]
tests/providers/google/cloud/sensors/test_dataproc.py ..........         [ 75%]
tests/providers/google/cloud/sensors/test_dataproc_metastore.py ........ [ 76%]
...............                                                          [ 76%]
tests/providers/google/cloud/sensors/test_gcs.py ....................... [ 77%]
..........                                                               [ 77%]
tests/providers/google/cloud/sensors/test_looker.py .....                [ 77%]
tests/providers/google/cloud/sensors/test_pubsub.py ........             [ 77%]
tests/providers/google/cloud/sensors/test_tasks.py ..                    [ 78%]
tests/providers/google/cloud/sensors/test_workflows.py ...               [ 78%]
tests/providers/google/cloud/transfers/test_adls_to_gcs.py ...           [ 78%]
tests/providers/google/cloud/transfers/test_azure_blob_to_gcs.py ..      [ 78%]
tests/providers/google/cloud/transfers/test_azure_fileshare_to_gcs.py .. [ 78%]
.                                                                        [ 78%]
tests/providers/google/cloud/transfers/test_bigquery_to_bigquery.py ..   [ 78%]
tests/providers/google/cloud/transfers/test_bigquery_to_gcs.py ..        [ 78%]
tests/providers/google/cloud/transfers/test_bigquery_to_mssql.py s       [ 78%]
tests/providers/google/cloud/transfers/test_bigquery_to_mysql.py .       [ 78%]
tests/providers/google/cloud/transfers/test_bigquery_to_postgres.py .    [ 78%]
tests/providers/google/cloud/transfers/test_calendar_to_gcs.py ..        [ 78%]
tests/providers/google/cloud/transfers/test_cassandra_to_gcs.py ..       [ 78%]
tests/providers/google/cloud/transfers/test_facebook_ads_to_gcs.py ..    [ 78%]
tests/providers/google/cloud/transfers/test_facebook_ads_to_gcs_system.py s [ 78%]
                                                                         [ 78%]
tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py ......... [ 79%]
......................                                                   [ 79%]
tests/providers/google/cloud/transfers/test_gcs_to_gcs.py .............. [ 80%]
...............................................                          [ 81%]
tests/providers/google/cloud/transfers/test_gcs_to_local.py ....         [ 81%]
tests/providers/google/cloud/transfers/test_gcs_to_sftp.py ............. [ 81%]
....                                                                     [ 82%]
tests/providers/google/cloud/transfers/test_gdrive_to_gcs.py .           [ 82%]
tests/providers/google/cloud/transfers/test_gdrive_to_local.py .         [ 82%]
tests/providers/google/cloud/transfers/test_local_to_gcs.py ......       [ 82%]
tests/providers/google/cloud/transfers/test_mssql_to_gcs.py ssssssssssss [ 82%]
s                                                                        [ 82%]
tests/providers/google/cloud/transfers/test_mysql_to_gcs.py ssssssssssss [ 83%]
sssssssssss                                                              [ 83%]
tests/providers/google/cloud/transfers/test_oracle_to_gcs.py ....        [ 83%]
tests/providers/google/cloud/transfers/test_postgres_to_gcs.py ......... [ 83%]
.....                                                                    [ 83%]
tests/providers/google/cloud/transfers/test_s3_to_gcs.py ............... [ 84%]
...........................                                              [ 85%]
tests/providers/google/cloud/transfers/test_salesforce_to_gcs.py .       [ 85%]
tests/providers/google/cloud/transfers/test_salesforce_to_gcs_system.py s [ 85%]
                                                                         [ 85%]
tests/providers/google/cloud/transfers/test_sftp_to_gcs.py ......        [ 85%]
tests/providers/google/cloud/transfers/test_sheets_to_gcs.py ..          [ 85%]
tests/providers/google/cloud/transfers/test_sql_to_gcs.py .........      [ 85%]
tests/providers/google/cloud/triggers/test_bigquery.py ................. [ 86%]
.................                                                        [ 86%]
tests/providers/google/cloud/triggers/test_bigquery_dts.py .........     [ 86%]
tests/providers/google/cloud/triggers/test_cloud_batch.py .....          [ 87%]
tests/providers/google/cloud/triggers/test_cloud_build.py .....          [ 87%]
tests/providers/google/cloud/triggers/test_cloud_run.py ....             [ 87%]
tests/providers/google/cloud/triggers/test_cloud_sql.py .....            [ 87%]
tests/providers/google/cloud/triggers/test_cloud_storage_transfer_service.py . [ 87%]
...............                                                          [ 87%]
tests/providers/google/cloud/triggers/test_dataflow.py .........         [ 88%]
tests/providers/google/cloud/triggers/test_datafusion.py .....           [ 88%]
tests/providers/google/cloud/triggers/test_dataplex.py ....              [ 88%]
tests/providers/google/cloud/triggers/test_dataproc.py ............      [ 88%]
tests/providers/google/cloud/triggers/test_gcs.py ...................... [ 89%]
...                                                                      [ 89%]
tests/providers/google/cloud/triggers/test_kubernetes_engine.py ........ [ 89%]
..........                                                               [ 90%]
tests/providers/google/cloud/triggers/test_mlengine.py .....             [ 90%]
tests/providers/google/cloud/triggers/test_pubsub.py .                   [ 90%]
tests/providers/google/cloud/utils/test_credentials_provider.py ........ [ 90%]
............................                                             [ 91%]
tests/providers/google/cloud/utils/test_datafusion.py ...                [ 91%]
tests/providers/google/cloud/utils/test_field_sanitizer.py ............  [ 91%]
tests/providers/google/cloud/utils/test_field_validator.py ............. [ 92%]
..............                                                           [ 92%]
tests/providers/google/cloud/utils/test_helpers.py .                     [ 92%]
tests/providers/google/cloud/utils/test_mlengine_operator_utils.py ..... [ 92%]
..                                                                       [ 92%]
tests/providers/google/cloud/utils/test_mlengine_prediction_summary.py . [ 92%]
......                                                                   [ 93%]
tests/providers/google/common/auth_backend/test_google_openid.py ....... [ 93%]
.                                                                        [ 93%]
tests/providers/google/common/hooks/test_base_google.py ................ [ 93%]
.................ss.........................                             [ 95%]
tests/providers/google/common/hooks/test_discovery_api.py ...            [ 95%]
tests/providers/google/common/utils/test_id_token_credentials.py ......  [ 95%]
tests/providers/google/firebase/hooks/test_firestore.py .........        [ 95%]
tests/providers/google/firebase/operators/test_firestore.py .            [ 95%]
tests/providers/google/leveldb/hooks/test_leveldb.py ........            [ 95%]
tests/providers/google/leveldb/operators/test_leveldb.py .               [ 95%]
tests/providers/google/marketing_platform/hooks/test_analytics.py ...... [ 96%]
....                                                                     [ 96%]
tests/providers/google/marketing_platform/hooks/test_campaign_manager.py . [ 96%]
..........                                                               [ 96%]
tests/providers/google/marketing_platform/hooks/test_display_video.py .. [ 96%]
..........................                                               [ 97%]
tests/providers/google/marketing_platform/hooks/test_search_ads.py ....  [ 97%]
tests/providers/google/marketing_platform/operators/test_analytics.py .. [ 97%]
.....                                                                    [ 97%]
tests/providers/google/marketing_platform/operators/test_campaign_manager.py . [ 97%]
..........                                                               [ 97%]
tests/providers/google/marketing_platform/operators/test_display_video.py . [ 97%]
............                                                             [ 98%]
tests/providers/google/marketing_platform/operators/test_display_video_system.py s [ 98%]
ss                                                                       [ 98%]
tests/providers/google/marketing_platform/operators/test_search_ads.py . [ 98%]
......                                                                   [ 98%]
tests/providers/google/marketing_platform/sensors/test_campaign_manager.py . [ 98%]
                                                                         [ 98%]
tests/providers/google/marketing_platform/sensors/test_display_video.py . [ 98%]
...                                                                      [ 98%]
tests/providers/google/marketing_platform/sensors/test_search_ads.py .   [ 98%]
tests/providers/google/suite/hooks/test_calendar.py ..                   [ 98%]
tests/providers/google/suite/hooks/test_drive.py ................        [ 99%]
tests/providers/google/suite/hooks/test_sheets.py .............          [ 99%]
tests/providers/google/suite/operators/test_sheets.py .                  [ 99%]
tests/providers/google/suite/sensors/test_drive.py .                     [ 99%]
tests/providers/google/suite/transfers/test_gcs_to_gdrive.py .....       [ 99%]
tests/providers/google/suite/transfers/test_gcs_to_sheets.py .           [ 99%]
tests/providers/google/suite/transfers/test_local_to_drive.py .          [ 99%]
tests/providers/google/suite/transfers/test_sql_to_sheets.py .           [100%]

-------- generated xml file: /files/test_result-Providers-postgres.xml ---------
```


```
$ pre-commit run --all-files

Check if all hooks apply to the repository.........................................Passed
Add TOC for Markdown and RST files.................................................Passed
Add license for all SQL files......................................................Passed
Add license for all RST files......................................................Passed
Add license for all CSS/JS/JSX/PUML/TS/TSX files...................................Passed
Add license for all JINJA template files...........................................Passed
Add license for all Shell files....................................................Passed
Add license for all Python files...................................................Passed
Add license for all XML files......................................................Passed
Add license for all Helm template files............................................Passed
Add license for all YAML files except Helm templates...............................Passed
Add license for all Markdown files.................................................Passed
Add license for all other files....................................................Passed
Run black (Python formatter).......................................................Passed
Check and update common.sql API stubs..............................................Passed
Update black versions everywhere...................................................Passed
ruff...............................................................................Passed
Run black on Python code blocks in documentation files.............................Passed
Check that merge conflicts are not being committed.................................Passed
Detect accidentally committed debug statements.....................................Passed
Require literal syntax when initializing builtin types.............................Passed
Detect if private key is added to the repository...................................Passed
Make sure that there is an empty line at the end...................................Passed
Detect if mixed line ending is used (\r vs. \r\n)..................................Passed
Check that executables have shebang................................................Passed
Check XML files with xmllint.......................................................Passed
Remove trailing whitespace at end of line..........................................Passed
Remove encoding header from Python files...........................................Passed
Format JSON files..................................................................Passed
Check if RST files use double backticks for code...................................Passed
Check if there are no deprecate log warn...........................................Passed
Check YAML files with yamllint.....................................................Passed
Run flynt string format converter for Python.......................................Passed
Run codespell to check for common misspellings in files............................Passed
Validate pyproject.toml............................................................Passed
Replace bad characters.............................................................Passed
Lint OpenAPI using spectral........................................................Passed
Lint OpenAPI using openapi-spec-validator..........................................Passed
Lint Dockerfile....................................................................Passed
Check order of dependencies in setup.cfg and setup.py..............................Passed
Check airflow.kubernetes imports are not used......................................Passed
Check cncf.kubernetes imports used for executors only..............................Passed
Checks setup extra packages........................................................Passed
Check compatibility of Providers with Airflow......................................Passed
Check google-re2 is declared as dependency when needed.............................Passed
Update mounts in the local yml file................................................Passed
Update cross-dependencies for providers packages...................................Passed
Update extras in documentation.....................................................Passed
Check order of extras in Dockerfile................................................Passed
Updates supported versions in documentation........................................Passed
Check that the REVISION_HEADS_MAP is up-to-date....................................Passed
Update version to the latest version in the documentation..........................Passed
Check for pydevd debug statements accidentally left................................Passed
Verify example dags do not use hard-coded version numbers..........................Passed
Don't use safe in templates........................................................Passed
No providers imports in core example DAGs..........................................Passed
Do not use DeprecationWarning in providers.........................................Passed
No relative imports................................................................Passed
Don't use urlparse in code.........................................................Passed
Check NEW_SESSION is only used with @provide_session...............................Passed
Check for language that we do not accept as community..............................Passed
Check BaseOperator and partial() arguments.........................................Passed
Check model __init__ and decorator arguments are in sync...........................Passed
Check BaseOperator[Link] core imports..............................................Passed
Check BaseOperator[Link] other imports.............................................Passed
Check @task decorator implements custom_operator_name..............................Passed
Verify usage of Airflow deprecation classes in core................................Passed
Check provide_session and create_session imports...................................Passed
Make sure LoggingMixin is not used alone...........................................Passed
Make sure days_ago is imported from airflow.utils.dates............................Passed
start_date not to be defined in default_args in example_dags.......................Passed
Check if licenses are OK for Apache................................................Passed
Check if aiobotocore is an optional dependency only................................Passed
Checks for Boring Cyborg configuration consistency.................................Passed
Sort INTHEWILD.md alphabetically...................................................Passed
Sort alphabetically and uniquify installed_providers.txt...........................Passed
Sort alphabetically and uniquify spelling_wordlist.txt.............................Passed
Lint Helm Chart....................................................................Passed
Check Shell scripts syntax correctness.............................................Passed
stylelint..........................................................................Passed
Provider init file is missing......................................................Passed
Provider subpackage init files are there...........................................Passed
Validate hook IDs & names and sync with docs.......................................Passed
Update Breeze README.md with config files hash.....................................Passed
Breeze should have small number of top-level dependencies..........................Passed
Check if system tests have required segments of code...............................Passed
Generate PyPI README...............................................................Passed
Run markdownlint...................................................................Passed
Lint JSON Schema files with JSON Schema............................................Passed
Lint NodePort Service with JSON Schema.............................................Passed
Lint Docker compose files with JSON Schema.........................................Passed
Lint chart/values.schema.json file with JSON Schema................................Passed
Vendor k8s definitions into values.schema.json.....................................Passed
Lint chart/values.yaml file with JSON Schema.......................................Passed
Lint config_templates/config.yml file with JSON Schema.............................Passed
Check that workflow files have persist-credentials disabled........................Passed
Check that docstrings do not specify param types...................................Passed
Lint chart/values.schema.json file.................................................Passed
Inline Dockerfile and Dockerfile.ci scripts........................................Passed
Check changelogs for duplicate entries.............................................Passed
Check newsfragments are valid......................................................Passed
Update output of breeze commands in BREEZE.rst.....................................Passed
Check that example dags url include provider versions..............................Passed
Check that system tests is properly added..........................................Passed
Check that all logging methods are lazy............................................Passed
Create missing init.py files in tests..............................................Passed
TS types generation / ESLint / Prettier against UI files...........................Passed
Check that unit tests do not inherit from unittest.TestCase........................Passed
Use re2 module instead of re.......................................................Passed
Check default value of deferrable attribute........................................Passed
Run mypy for dev...................................................................Failed
- hook id: mypy-dev
- exit code: 1

The image ghcr.io/Zhenye-Na/airflow/main/ci/python3.8 is not available.


Please run this to fix it:

breeze ci-image build --python 3.8
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
