### PR TITLE
Add command to build a base image with all airflow versions

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/github.py
+++ b/dev/breeze/src/airflow_breeze/utils/github.py
@@ -71,6 +71,8 @@ ACTIVE_TAG_MATCH = re.compile(r"^(\d+)\.\d+\.\d+$")
 def get_active_airflow_versions(confirm: bool = True) -> list[str]:
     """
     Gets list of active Airflow versions from GitHub.
+
+    :param confirm: if True, will ask the user before proceeding with the versions found
     :return: list of active Airflow versions
     """
     from git import GitCommandError, Repo


### PR DESCRIPTION
First part of https://github.com/apache/airflow/issues/34236.

This allows to build a docker image with all the airflow versions pre-installed in separate virtual environments.

I had to group build commands to not have too many layers in the docker image and run into a 'max depth exeeded' for docker layers. (This seems to appear around 100 layers, here we have 35 now ~ the number of airflow versions)

![image](https://github.com/apache/airflow/assets/14861206/5dcff887-d388-45f4-b272-5a4c7e9cc6bb)
