### PR TITLE
fix(gcp/op/vertex): typecast ListEndpoints to avoid DAG run blocker

### DIFF
--- a/airflow/providers/google/cloud/operators/vertex_ai/endpoint_service.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/endpoint_service.py
@@ -454,7 +454,15 @@ class ListEndpointsOperator(GoogleCloudBaseOperator):
             metadata=self.metadata,
         )
         VertexAIEndpointListLink.persist(context=context, task_instance=self)
-        return [Endpoint.to_dict(result) for result in results]
+        result_endpoints = []
+        for result in results:
+            result_endpoint = result
+            try:
+                result_endpoint = Endpoint(result)
+                result_endpoints.append(Endpoint.to_dict(result_endpoint))
+            except Exception as e:
+                self.log.info("%s can't be casted as Endpoint and/or converted to dictionary: %s", result, e)
+        return result_endpoints
 
 
 class UndeployModelOperator(GoogleCloudBaseOperator):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Closes #34451 

Try to typecast returned data from `client.list_endpoints` before converting to dictionary via `Endpoint.to_dict()`. The true root cause is difficult to track down but we should have guardrail to avoid failing DAG run due to `TypeError` failure.

The `execute()` function doesn't promise to return anything else so it's possible to return  

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
