### PR TITLE
Import Dataset from airflow.datasets to avoid circular dependency

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -41,7 +41,7 @@ import attr
 import re2
 import typing_extensions
 
-from airflow import Dataset
+from airflow.datasets import Dataset
 from airflow.exceptions import AirflowException
 from airflow.models.abstractoperator import DEFAULT_RETRIES, DEFAULT_RETRY_DELAY
 from airflow.models.baseoperator import (


### PR DESCRIPTION
related: #34558

I'm not sure if this could fix the reported issue because we don't have the full context, but this PR consolidates the import of Dataset.