### PR TITLE
Fix is_parent_mapped value by checking if any of the parent tg is mapped

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -425,9 +425,14 @@ def dag_to_grid(dag: DagModel, dag_runs: Sequence[DagRun], session: Session):
                 **setup_teardown_type,
             }
 
+        def check_group_is_mapped(tg: TaskGroup | None) -> bool:
+            if tg is None:
+                return False
+            return isinstance(tg, MappedTaskGroup) or check_group_is_mapped(tg.parent_group)
+
         # Task Group
         task_group = item
-        group_is_mapped = isinstance(task_group, MappedTaskGroup)
+        group_is_mapped = check_group_is_mapped(task_group)
 
         children = [
             task_group_to_grid(child, grouped_tis, is_parent_mapped=group_is_mapped)


### PR DESCRIPTION
closes: #34535

Currently we check only if the direct task group parent is mapped to consider that the task instance is mapped on the UI, however, when any of the parents of the task group is mapped (for example a nested tg in a mapped tg), the task will be mapped.

This PR fixes the issue by check if any of the parents is mapped task group.