### PR TITLE
Remove false warning when TI state is QUEUED and TI doesn't have a start_date

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2165,12 +2165,8 @@ class TaskInstance(Base, LoggingMixin):
         elif new_state == TaskInstanceState.QUEUED:
             metric_name = "scheduled_duration"
             if self.start_date is None:
-                # same comment as above
-                self.log.warning(
-                    "cannot record %s for task %s because previous state change time has not been saved",
-                    metric_name,
-                    self.task_id,
-                )
+                # this could happen when the scheduler queue a TI
+                # or when the backfill CLI send a TI to the executor
                 return
             timing = (timezone.utcnow() - self.start_date).total_seconds()
         else:


### PR DESCRIPTION
closes: #34493

Airflow changes the TI state to queue in two cases:
- https://github.com/apache/airflow/blob/7a5b6a39c948bc51d754898b0478ad319dfab43f/airflow/jobs/backfill_job_runner.py#L533
- https://github.com/apache/airflow/blob/7a5b6a39c948bc51d754898b0478ad319dfab43f/airflow/jobs/scheduler_job_runner.py#L603-L614

and in both cases, TI may not have a start date if it's the first attempt, so the warning raised by `emit_state_change_metric` method is false, and should be suppressed.