### PR TITLE
Use aiohttp.BasicAuth instead of HTTPBasicAuth for aiohttp session in databricks hook

### DIFF
--- a/airflow/providers/databricks/hooks/databricks_base.py
+++ b/airflow/providers/databricks/hooks/databricks_base.py
@@ -262,7 +262,7 @@ class BaseDatabricksHook(BaseHook):
                 with attempt:
                     async with self._session.post(
                         resource,
-                        auth=HTTPBasicAuth(self.databricks_conn.login, self.databricks_conn.password),
+                        auth=aiohttp.BasicAuth(self.databricks_conn.login, self.databricks_conn.password),
                         data="grant_type=client_credentials&scope=all-apis",
                         headers={
                             **self.user_agent_header,


### PR DESCRIPTION
closes: #34450

Databricks hook uses aiohttp client session for async methods, but in the method `_a_get_sp_token`, we use `HTTPBasicAuth` instance to provide basic authentication credentials which is not compatible with aiohttp sessions. This PR fixes the issue by providing the credentials using `aiohttp.BasicAuth` instance as we do in the other methods.