### PR TITLE
Respect 'soft_fail' argument when running BatchSensors

### DIFF
--- a/airflow/providers/amazon/aws/sensors/batch.py
+++ b/airflow/providers/amazon/aws/sensors/batch.py
@@ -83,9 +83,17 @@ class BatchSensor(BaseSensorOperator):
             return False
 
         if state == BatchClientHook.FAILURE_STATE:
-            raise AirflowException(f"Batch sensor failed. AWS Batch job status: {state}")
+            # TODO: remove this if block when min_airflow_version is set to higher than 2.7.1
+            message = f"Batch sensor failed. AWS Batch job status: {state}"
+            if self.soft_fail:
+                raise AirflowSkipException(message)
+            raise AirflowException(message)
 
-        raise AirflowException(f"Batch sensor failed. Unknown AWS Batch job status: {state}")
+        # TODO: remove this if block when min_airflow_version is set to higher than 2.7.1
+        message = f"Batch sensor failed. Unknown AWS Batch job status: {state}"
+        if self.soft_fail:
+            raise AirflowSkipException(message)
+        raise AirflowException(message)
 
     def execute(self, context: Context) -> None:
         if not self.deferrable:
@@ -182,7 +190,11 @@ class BatchComputeEnvironmentSensor(BaseSensorOperator):
         )
 
         if not response["computeEnvironments"]:
-            raise AirflowException(f"AWS Batch compute environment {self.compute_environment} not found")
+            message = f"AWS Batch compute environment {self.compute_environment} not found"
+            # TODO: remove this if block when min_airflow_version is set to higher than 2.7.1
+            if self.soft_fail:
+                raise AirflowSkipException(message)
+            raise AirflowException(message)
 
         status = response["computeEnvironments"][0]["status"]
 
@@ -192,9 +204,11 @@ class BatchComputeEnvironmentSensor(BaseSensorOperator):
         if status in BatchClientHook.COMPUTE_ENVIRONMENT_INTERMEDIATE_STATUS:
             return False
 
-        raise AirflowException(
-            f"AWS Batch compute environment failed. AWS Batch compute environment status: {status}"
-        )
+        # TODO: remove this if block when min_airflow_version is set to higher than 2.7.1
+        message = f"AWS Batch compute environment failed. AWS Batch compute environment status: {status}"
+        if self.soft_fail:
+            raise AirflowSkipException(message)
+        raise AirflowException(message)
 
 
 class BatchJobQueueSensor(BaseSensorOperator):
@@ -250,7 +264,11 @@ class BatchJobQueueSensor(BaseSensorOperator):
             if self.treat_non_existing_as_deleted:
                 return True
             else:
-                raise AirflowException(f"AWS Batch job queue {self.job_queue} not found")
+                # TODO: remove this if block when min_airflow_version is set to higher than 2.7.1
+                message = f"AWS Batch job queue {self.job_queue} not found"
+                if self.soft_fail:
+                    raise AirflowSkipException(message)
+                raise AirflowException(message)
 
         status = response["jobQueues"][0]["status"]
 
@@ -260,4 +278,7 @@ class BatchJobQueueSensor(BaseSensorOperator):
         if status in BatchClientHook.JOB_QUEUE_INTERMEDIATE_STATUS:
             return False
 
-        raise AirflowException(f"AWS Batch job queue failed. AWS Batch job queue status: {status}")
+        message = f"AWS Batch job queue failed. AWS Batch job queue status: {status}"
+        if self.soft_fail:
+            raise AirflowSkipException(message)
+        raise AirflowException(message)

--- a/tests/providers/amazon/aws/sensors/test_batch.py
+++ b/tests/providers/amazon/aws/sensors/test_batch.py
@@ -300,26 +300,11 @@ class TestBatchJobQueueSensor:
     @pytest.mark.parametrize(
         "soft_fail, expected_exception", ((False, AirflowException), (True, AirflowSkipException))
     )
+    @pytest.mark.parametrize("job_queue", ([], [{"status": "UNKNOWN_STATUS"}]))
     @mock.patch.object(BatchClientHook, "client")
-    def test_fail_poke_no_jobqueues_status(
-        self, mock_batch_client, batch_job_queue_sensor: BatchJobQueueSensor, soft_fail, expected_exception
+    def test_fail_poke(
+        self, mock_batch_client, batch_job_queue_sensor: BatchJobQueueSensor, job_queue, soft_fail, expected_exception
     ):
-        job_queue = []
-        mock_batch_client.describe_job_queues.return_value = {"jobQueues": job_queue}
-        batch_job_queue_sensor.treat_non_existing_as_deleted = False
-        batch_job_queue_sensor.soft_fail = soft_fail
-        message = "AWS Batch job queue"
-        with pytest.raises(expected_exception, match=message):
-            batch_job_queue_sensor.poke({})
-
-    @pytest.mark.parametrize(
-        "soft_fail, expected_exception", ((False, AirflowException), (True, AirflowSkipException))
-    )
-    @mock.patch.object(BatchClientHook, "client")
-    def test_fail_poke_invalid_jobqueues_status(
-        self, mock_batch_client, batch_job_queue_sensor: BatchJobQueueSensor, soft_fail, expected_exception
-    ):
-        job_queue = [{"status": "UNKNOWN_STATUS"}]
         mock_batch_client.describe_job_queues.return_value = {"jobQueues": job_queue}
         batch_job_queue_sensor.treat_non_existing_as_deleted = False
         batch_job_queue_sensor.soft_fail = soft_fail

--- a/tests/providers/amazon/aws/sensors/test_batch.py
+++ b/tests/providers/amazon/aws/sensors/test_batch.py
@@ -112,13 +112,22 @@ class TestBatchSensor:
     @pytest.mark.parametrize(
         "state, error_message",
         (
-            (BatchClientHook.FAILURE_STATE, f"Batch sensor failed. AWS Batch job status: {BatchClientHook.FAILURE_STATE}"),
-            ("unknown_state", "Batch sensor failed. Unknown AWS Batch job status: unknown_state")
-        )
+            (
+                BatchClientHook.FAILURE_STATE,
+                f"Batch sensor failed. AWS Batch job status: {BatchClientHook.FAILURE_STATE}",
+            ),
+            ("unknown_state", "Batch sensor failed. Unknown AWS Batch job status: unknown_state"),
+        ),
     )
     @mock.patch.object(BatchClientHook, "get_job_description")
     def test_fail_poke(
-        self, mock_get_job_description, batch_sensor: BatchSensor, status, error_message, soft_fail, expected_exception
+        self,
+        mock_get_job_description,
+        batch_sensor: BatchSensor,
+        state,
+        error_message,
+        soft_fail,
+        expected_exception,
     ):
         mock_get_job_description.return_value = {"status": state}
         batch_sensor.soft_fail = soft_fail
@@ -199,9 +208,12 @@ class TestBatchComputeEnvironmentSensor:
     @pytest.mark.parametrize(
         "compute_env, error_message",
         (
+            (
+                [{"status": "unknown_status"}],
+                "AWS Batch compute environment failed. AWS Batch compute environment status:",
+            ),
             ([], "AWS Batch compute environment"),
-            ([{"status": "unknown_status"}], "AWS Batch compute environment failed. AWS Batch compute environment status:")
-        )
+        ),
     )
     @mock.patch.object(BatchClientHook, "client")
     def test_fail_poke(
@@ -213,9 +225,7 @@ class TestBatchComputeEnvironmentSensor:
         soft_fail,
         expected_exception,
     ):
-        compute_env = []
         mock_batch_client.describe_compute_environments.return_value = {"computeEnvironments": compute_env}
-        message = 
         batch_compute_environment_sensor.soft_fail = soft_fail
         with pytest.raises(expected_exception, match=error_message):
             batch_compute_environment_sensor.poke({})
@@ -295,7 +305,12 @@ class TestBatchJobQueueSensor:
     @pytest.mark.parametrize("job_queue", ([], [{"status": "UNKNOWN_STATUS"}]))
     @mock.patch.object(BatchClientHook, "client")
     def test_fail_poke(
-        self, mock_batch_client, batch_job_queue_sensor: BatchJobQueueSensor, job_queue, soft_fail, expected_exception
+        self,
+        mock_batch_client,
+        batch_job_queue_sensor: BatchJobQueueSensor,
+        job_queue,
+        soft_fail,
+        expected_exception,
     ):
         mock_batch_client.describe_job_queues.return_value = {"jobQueues": job_queue}
         batch_job_queue_sensor.treat_non_existing_as_deleted = False

--- a/tests/providers/amazon/aws/sensors/test_batch.py
+++ b/tests/providers/amazon/aws/sensors/test_batch.py
@@ -204,37 +204,28 @@ class TestBatchComputeEnvironmentSensor:
     @pytest.mark.parametrize(
         "soft_fail, expected_exception", ((False, AirflowException), (True, AirflowSkipException))
     )
+    @pytest.mark.parametrize(
+        "compute_env, error_message",
+        (
+            ([], "AWS Batch compute environment"),
+            ([{"status": "unknown_status"}], "AWS Batch compute environment failed. AWS Batch compute environment status:")
+        )
+    )
     @mock.patch.object(BatchClientHook, "client")
-    def test_fail_poke_no_compute_env(
+    def test_fail_poke(
         self,
         mock_batch_client,
         batch_compute_environment_sensor: BatchComputeEnvironmentSensor,
+        compute_env,
+        error_message,
         soft_fail,
         expected_exception,
     ):
         compute_env = []
         mock_batch_client.describe_compute_environments.return_value = {"computeEnvironments": compute_env}
-        message = "AWS Batch compute environment"
+        message = 
         batch_compute_environment_sensor.soft_fail = soft_fail
-        with pytest.raises(expected_exception, match=message):
-            batch_compute_environment_sensor.poke({})
-
-    @pytest.mark.parametrize(
-        "soft_fail, expected_exception", ((False, AirflowException), (True, AirflowSkipException))
-    )
-    @mock.patch.object(BatchClientHook, "client")
-    def test_fail_poke_unknown_status(
-        self,
-        mock_batch_client,
-        batch_compute_environment_sensor: BatchComputeEnvironmentSensor,
-        soft_fail,
-        expected_exception,
-    ):
-        compute_env = [{"status": "unknown_status"}]
-        mock_batch_client.describe_compute_environments.return_value = {"computeEnvironments": compute_env}
-        message = "AWS Batch compute environment failed. AWS Batch compute environment status:"
-        batch_compute_environment_sensor.soft_fail = soft_fail
-        with pytest.raises(expected_exception, match=message):
+        with pytest.raises(expected_exception, match=error_message):
             batch_compute_environment_sensor.poke({})
 
 


### PR DESCRIPTION
This PR intends to solve the issue that the soft_fail argument in BatchJobQueueSensor, BatchComputeEnvironmentSensor, and BatchSensor is not respected.