### PR TITLE
Allow passing context to DruidDbApiHook

### DIFF
--- a/airflow/providers/apache/druid/hooks/druid.py
+++ b/airflow/providers/apache/druid/hooks/druid.py
@@ -156,6 +156,10 @@ class DruidDbApiHook(DbApiHook):
 
     This hook is purely for users to query druid broker.
     For ingestion, please use druidHook.
+
+    :param context: Optional query context parameters to pass to the SQL endpoint.
+        Example: ``{"sqlFinalizeOuterSketches": True}``
+        See: https://druid.apache.org/docs/latest/querying/sql-query-context/
     """
 
     conn_name_attr = "druid_broker_conn_id"
@@ -163,6 +167,10 @@ class DruidDbApiHook(DbApiHook):
     conn_type = "druid"
     hook_name = "Druid"
     supports_autocommit = False
+
+    def __init__(self, context: dict | None = None, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.context = context or {}
 
     def get_conn(self) -> connect:
         """Establish a connection to druid broker."""
@@ -174,6 +182,7 @@ class DruidDbApiHook(DbApiHook):
             scheme=conn.extra_dejson.get("schema", "http"),
             user=conn.login,
             password=conn.password,
+            context=self.context,
         )
         self.log.info("Get the connection to druid broker on %s using user %s", conn.host, conn.login)
         return druid_broker_conn


### PR DESCRIPTION
Druid's SQL API endpoint can accept context param to allow use of various query functionality [described in documentation](https://druid.apache.org/docs/latest/querying/sql-query-context/). This change enables passing context when using `DruidDbApiHook`. For our use case we also do Druid query post processing and values in context allow us to identify Druid query origin, in this case - `airflow`.