### PR TITLE
Fail dag test if defer without triggerer

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -424,3 +424,11 @@ class DeserializingResultError(ValueError):
             "Error deserializing result. Note that result deserialization "
             "is not supported across major Python versions. Cause: " + str(self.__cause__)
         )
+
+
+class StopDagTest(AirflowException):
+    """
+    Raise when DAG.test should stop immediately.
+
+    :meta private:
+    """

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -424,11 +424,3 @@ class DeserializingResultError(ValueError):
             "Error deserializing result. Note that result deserialization "
             "is not supported across major Python versions. Cause: " + str(self.__cause__)
         )
-
-
-class StopDagTest(AirflowException):
-    """
-    Raise when DAG.test should stop immediately.
-
-    :meta private:
-    """

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2850,6 +2850,8 @@ class DAG(LoggingMixin):
                                 "You can start the triggerer by running `airflow triggerer` in a terminal."
                             )
                 except _StopDagTest:
+                    # Let this exception bubble out and not be swallowed by the
+                    # except block below.
                     raise
                 except Exception:
                     self.log.exception("Task failed; ti=%s", ti)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2838,7 +2838,10 @@ class DAG(LoggingMixin):
                     ret = _run_task(ti, session=session)
                     if ret is TaskReturnCode.DEFERRED:
                         if not _triggerer_is_healthy():
-                            raise StopDagTest("Task has deferred but the triggerer component is not running.")
+                            raise StopDagTest(
+                                "Task has deferred but triggerer component is not running. "
+                                "You can start the triggerer by running `airflow triggerer` in a terminal."
+                            )
                 except StopDagTest:
                     raise
                 except Exception:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -3978,7 +3978,7 @@ def _triggerer_is_healthy():
     return True
 
 
-def _run_task(ti: TaskInstance, session):
+def _run_task(ti: TaskInstance, session) -> TaskReturnCode | None:
     """
     Run a single task instance, and push result to Xcom for downstream tasks.
 
@@ -4001,8 +4001,7 @@ def _run_task(ti: TaskInstance, session):
     except AirflowSkipException:
         log.info("Task Skipped, continuing")
     log.info("*****************************************************")
-    if ret is not None:
-        return ret
+    return ret
 
 
 def _get_or_create_dagrun(

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2839,7 +2839,7 @@ class DAG(LoggingMixin):
                     ret = _run_task(ti, session=session)
                     if ret is TaskReturnCode.DEFERRED:
                         if not _triggerer_is_healthy():
-                            raise StopDagTest("Task has deferred but there triggerer is not running.")
+                            raise StopDagTest("Task has deferred but the triggerer component is not running.")
                 except StopDagTest:
                     raise
                 except Exception:
@@ -3981,6 +3981,7 @@ def _triggerer_is_healthy():
     health = get_airflow_health()
     if health["triggerer"]["status"] != "healthy":
         return False
+    return True
 
 
 def _run_task(ti: TaskInstance, session):

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -3979,7 +3979,7 @@ def _triggerer_is_healthy():
     from airflow.api.common.airflow_health import get_airflow_health
 
     health = get_airflow_health()
-    if health["triggerer"]["status"] is None:
+    if health["triggerer"]["status"] != "healthy":
         return False
 
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2818,7 +2818,6 @@ class DAG(LoggingMixin):
         # Instead of starting a scheduler, we run the minimal loop possible to check
         # for task readiness and dependency management. This is notably faster
         # than creating a BackfillJob and allows us to surface logs to the user
-        wait_counter = 0
         while dr.state == DagRunState.RUNNING:
             session.expire_all()
             schedulable_tis, _ = dr.update_state(session=session)
@@ -2844,11 +2843,6 @@ class DAG(LoggingMixin):
                     raise
                 except Exception:
                     self.log.exception("Task failed; ti=%s", ti)
-            if schedulable_tis:
-                wait_counter = 0
-            else:
-                self.log.info("No schedulable tasks; sleeping; try=%s", (wait_counter := wait_counter + 1))
-                time.sleep(1)
         if conn_file_path or variable_file_path:
             # Remove the local variables we have added to the secrets_backend_list
             secrets_backend_list.pop(0)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -3980,12 +3980,10 @@ class DagContext:
 
 
 def _triggerer_is_healthy():
-    from airflow.api.common.airflow_health import get_airflow_health
+    from airflow.jobs.triggerer_job_runner import TriggererJobRunner
 
-    health = get_airflow_health()
-    if health["triggerer"]["status"] != "healthy":
-        return False
-    return True
+    job = TriggererJobRunner.most_recent_job()
+    return job and job.is_alive()
 
 
 def _run_task(ti: TaskInstance, session) -> TaskReturnCode | None:

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -849,5 +849,5 @@ class TestCliDags:
             task_two = two(task_one)
             op = MyOp(task_id="abc", tfield=str(task_two))
             task_two >> op
-        with pytest.raises(StopDagTest, match="Task has deferred but there triggerer is not running"):
+        with pytest.raises(StopDagTest, match="Task has deferred but triggerer component is not running"):
             dag.test()

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -34,9 +34,10 @@ from airflow.api_connexion.schemas.dag_schema import DAGSchema
 from airflow.cli import cli_parser
 from airflow.cli.commands import dag_command
 from airflow.decorators import task
-from airflow.exceptions import AirflowException, StopDagTest
+from airflow.exceptions import AirflowException
 from airflow.models import DagBag, DagModel, DagRun
 from airflow.models.baseoperator import BaseOperator
+from airflow.models.dag import _StopDagTest
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.triggers.temporal import TimeDeltaTrigger
 from airflow.utils import timezone
@@ -849,5 +850,5 @@ class TestCliDags:
             task_two = two(task_one)
             op = MyOp(task_id="abc", tfield=str(task_two))
             task_two >> op
-        with pytest.raises(StopDagTest, match="Task has deferred but triggerer component is not running"):
+        with pytest.raises(_StopDagTest, match="Task has deferred but triggerer component is not running"):
             dag.test()

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -838,9 +838,10 @@ class TestCliDags:
                     super().__init__(**kwargs)
 
                 def execute(self, context, event=None):
-                    # breakpoint()
-                    print("I AM DEFERRING")
-                    self.defer(trigger=TimeDeltaTrigger(timedelta(seconds=20)), method_name="execute")
+                    if event is None:
+                        print("I AM DEFERRING")
+                        self.defer(trigger=TimeDeltaTrigger(timedelta(seconds=20)), method_name="execute")
+                        return
                     print("RESUMING")
                     return self.tfield + 1
 


### PR DESCRIPTION
If user runs dag.test and task defers and no triggerer is running, we should fail so user does not sit there waiting forever.