### PR TITLE
Use iterative loop to look for mapped parent

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -122,7 +122,7 @@ from airflow.utils.net import get_hostname
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.strings import to_boolean
-from airflow.utils.task_group import MappedTaskGroup, TaskGroup, task_group_to_dict
+from airflow.utils.task_group import TaskGroup, task_group_to_dict
 from airflow.utils.timezone import td_format, utcnow
 from airflow.version import version
 from airflow.www import auth, utils as wwwutils
@@ -426,14 +426,9 @@ def dag_to_grid(dag: DagModel, dag_runs: Sequence[DagRun], session: Session):
                 **setup_teardown_type,
             }
 
-        def check_group_is_mapped(tg: TaskGroup | None) -> bool:
-            if tg is None:
-                return False
-            return isinstance(tg, MappedTaskGroup) or check_group_is_mapped(tg.parent_group)
-
         # Task Group
         task_group = item
-        group_is_mapped = check_group_is_mapped(task_group)
+        group_is_mapped = next(task_group.iter_mapped_task_groups(), None) is not None
 
         children = [
             task_group_to_grid(child, grouped_tis, is_parent_mapped=group_is_mapped)


### PR DESCRIPTION
Alternative fix to #34587.

This changes the logic in views to look for a parent mapped task group (so to decide whether a task group is mapped) from using a recursive function to an iterative loop. This should help prevent RecursionError when a DAG has deeply-nested task groups. I hope no-one really writes such a DAG in practice, but you never know. Also in cases both solutions work, the loop should generally be faster anyway due to how CPython is implemented.