### PR TITLE
Error handling for when Azure container log cannot be read in properly.

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/container_instance.py
+++ b/airflow/providers/microsoft/azure/hooks/container_instance.py
@@ -177,6 +177,8 @@ class AzureContainerInstanceHook(AzureBaseHook):
         :return: A list of log messages
         """
         logs = self.connection.containers.list_logs(resource_group, name, name, tail=tail)
+        if logs.content == None:
+            return None
         return logs.content.splitlines(True)
 
     def delete(self, resource_group: str, name: str) -> None:

--- a/airflow/providers/microsoft/azure/hooks/container_instance.py
+++ b/airflow/providers/microsoft/azure/hooks/container_instance.py
@@ -177,7 +177,7 @@ class AzureContainerInstanceHook(AzureBaseHook):
         :return: A list of log messages
         """
         logs = self.connection.containers.list_logs(resource_group, name, name, tail=tail)
-        if logs.content == None:
+        if logs.content is None:
             return None
         return logs.content.splitlines(True)
 

--- a/airflow/providers/microsoft/azure/hooks/container_instance.py
+++ b/airflow/providers/microsoft/azure/hooks/container_instance.py
@@ -178,7 +178,7 @@ class AzureContainerInstanceHook(AzureBaseHook):
         """
         logs = self.connection.containers.list_logs(resource_group, name, name, tail=tail)
         if logs.content is None:
-            return None
+            return [None]
         return logs.content.splitlines(True)
 
     def delete(self, resource_group: str, name: str) -> None:

--- a/airflow/providers/microsoft/azure/operators/container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/container_instances.py
@@ -319,7 +319,7 @@ class AzureContainerInstancesOperator(BaseOperator):
                 if state in ["Running", "Terminated", "Succeeded"]:
                     try:
                         logs = self._ci_hook.get_logs(resource_group, name)
-                        if logs is None:
+                        if len(logs) > 0 and logs[0] is None:
                             self.log.error("Container log is broken, marking as failed.")
                             return 1
                         last_line_logged = self._log_last(logs, last_line_logged)

--- a/airflow/providers/microsoft/azure/operators/container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/container_instances.py
@@ -324,6 +324,9 @@ class AzureContainerInstancesOperator(BaseOperator):
                         self.log.exception(
                             "Exception while getting logs from container instance, retrying..."
                         )
+                    except AttributeError:
+                        self.log.error("Container log is broken, marking as failed.")
+                        return 1
 
                 if state == "Terminated":
                     self.log.info("Container exited with detail_status %s", detail_status)

--- a/airflow/providers/microsoft/azure/operators/container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/container_instances.py
@@ -319,7 +319,7 @@ class AzureContainerInstancesOperator(BaseOperator):
                 if state in ["Running", "Terminated", "Succeeded"]:
                     try:
                         logs = self._ci_hook.get_logs(resource_group, name)
-                        if len(logs) > 0 and logs[0] is None:
+                        if logs and logs[0] is None:
                             self.log.error("Container log is broken, marking as failed.")
                             return 1
                         last_line_logged = self._log_last(logs, last_line_logged)

--- a/airflow/providers/microsoft/azure/operators/container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/container_instances.py
@@ -319,14 +319,14 @@ class AzureContainerInstancesOperator(BaseOperator):
                 if state in ["Running", "Terminated", "Succeeded"]:
                     try:
                         logs = self._ci_hook.get_logs(resource_group, name)
+                        if logs == None:
+                            self.log.exception("Container log is broken, marking as failed.")
+                            return 1
                         last_line_logged = self._log_last(logs, last_line_logged)
                     except CloudError:
                         self.log.exception(
                             "Exception while getting logs from container instance, retrying..."
                         )
-                    except AttributeError:
-                        self.log.exception("Container log is broken, marking as failed.")
-                        return 1
 
                 if state == "Terminated":
                     self.log.info("Container exited with detail_status %s", detail_status)

--- a/airflow/providers/microsoft/azure/operators/container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/container_instances.py
@@ -325,7 +325,7 @@ class AzureContainerInstancesOperator(BaseOperator):
                             "Exception while getting logs from container instance, retrying..."
                         )
                     except AttributeError:
-                        self.log.error("Container log is broken, marking as failed.")
+                        self.log.exception("Container log is broken, marking as failed.")
                         return 1
 
                 if state == "Terminated":

--- a/airflow/providers/microsoft/azure/operators/container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/container_instances.py
@@ -319,7 +319,7 @@ class AzureContainerInstancesOperator(BaseOperator):
                 if state in ["Running", "Terminated", "Succeeded"]:
                     try:
                         logs = self._ci_hook.get_logs(resource_group, name)
-                        if logs == None:
+                        if logs is None:
                             self.log.exception("Container log is broken, marking as failed.")
                             return 1
                         last_line_logged = self._log_last(logs, last_line_logged)

--- a/airflow/providers/microsoft/azure/operators/container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/container_instances.py
@@ -320,7 +320,7 @@ class AzureContainerInstancesOperator(BaseOperator):
                     try:
                         logs = self._ci_hook.get_logs(resource_group, name)
                         if logs is None:
-                            self.log.exception("Container log is broken, marking as failed.")
+                            self.log.error("Container log is broken, marking as failed.")
                             return 1
                         last_line_logged = self._log_last(logs, last_line_logged)
                     except CloudError:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
Added simple error handling for when the Azure container log cannot be read in properly, leading to an attribute error when get_logs() uses .splitlines(). Desired behaviour is to stop the run.
Closes #34516 

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
