### PR TITLE
Chart: Fix `runtimeClassName` for KE

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -90,7 +90,7 @@ spec:
   priorityClassName: {{ .Values.workers.priorityClassName }}
   {{- end }}
   {{- if .Values.workers.runtimeClassName }}
-  priorityClassName: {{ .Values.workers.runtimeClassName }}
+  runtimeClassName: {{ .Values.workers.runtimeClassName }}
   {{- end }}
   {{- if or .Values.registry.secretName .Values.registry.connection }}
   imagePullSecrets:

--- a/helm_tests/airflow_aux/test_pod_template_file.py
+++ b/helm_tests/airflow_aux/test_pod_template_file.py
@@ -792,3 +792,14 @@ class TestPodTemplateFile:
         )
 
         assert 123 == jmespath.search("spec.terminationGracePeriodSeconds", docs[0])
+
+    def test_runtime_class_name_values_are_configurable(self):
+        docs = render_chart(
+            values={
+                "workers": {"runtimeClassName": "nvidia"},
+            },
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert jmespath.search("spec.runtimeClassName", docs[0]) == "nvidia"


### PR DESCRIPTION
There was a bug in #31868 that added `runtimeClassName` support to workers. It was under the wrong key in the pod template file.