### PR TITLE
Chart: Only create pod template file when using KE

### DIFF
--- a/chart/templates/configmaps/configmap.yaml
+++ b/chart/templates/configmaps/configmap.yaml
@@ -57,16 +57,16 @@ data:
     {{- .Values.dags.gitSync.knownHosts | nindent 4 }}
   {{- end }}
 
-{{/*  {{- if or (eq $.Values.executor "LocalKubernetesExecutor") (eq $.Values.executor "KubernetesExecutor") (eq $.Values.executor "CeleryKubernetesExecutor") }}*/}}
-{{/*  {{- if semverCompare ">=1.10.12" .Values.airflowVersion }}*/}}
+{{- if or (eq $.Values.executor "LocalKubernetesExecutor") (eq $.Values.executor "KubernetesExecutor") (eq $.Values.executor "CeleryKubernetesExecutor") }}
+{{- if semverCompare ">=1.10.12" .Values.airflowVersion }}
   pod_template_file.yaml: |-
     {{- if .Values.podTemplate }}
       {{- tpl .Values.podTemplate . | nindent 4 }}
     {{- else }}
       {{- tpl (.Files.Get "files/pod-template-file.kubernetes-helm-yaml") . | nindent 4 }}
     {{- end }}
-{{/*  {{- end }}*/}}
-{{/*  {{- end }}*/}}
+{{- end }}
+{{- end }}
 
   {{- if .Values.kerberos.enabled }}
   krb5.conf: |-

--- a/helm_tests/airflow_aux/test_configmap.py
+++ b/helm_tests/airflow_aux/test_configmap.py
@@ -97,6 +97,31 @@ class TestConfigmap:
 
         assert jmespath.search('data."krb5.conf"', docs[0]) == "krb5\ncontent"
 
+    @pytest.mark.parametrize(
+        "executor, af_version, should_be_created",
+        [
+            ("KubernetesExecutor", "1.10.11", False),
+            ("KubernetesExecutor", "1.10.12", True),
+            ("KubernetesExecutor", "2.0.0", True),
+            ("CeleryExecutor", "1.10.11", False),
+            ("CeleryExecutor", "2.0.0", False),
+        ],
+    )
+    def test_pod_template_created(self, executor, af_version, should_be_created):
+        docs = render_chart(
+            values={
+                "executor": executor,
+                "airflowVersion": af_version,
+            },
+            show_only=["templates/configmaps/configmap.yaml"],
+        )
+
+        keys = jmespath.search("data", docs[0]).keys()
+        if should_be_created:
+            assert "pod_template_file.yaml" in keys
+        else:
+            assert "pod_template_file.yaml" not in keys
+
     def test_pod_template_is_templated(self):
         docs = render_chart(
             values={


### PR DESCRIPTION
We don't need to create the pod template file if we aren't using KE. This was accidentally broken in #33107.