### PR TITLE
Displaying "actual" try number in TaskInstance view

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1422,7 +1422,7 @@ class TaskInstance(Base, LoggingMixin):
         This is designed so that task logs end up in the right file.
         """
         return _get_try_number(task_instance=self)
-    
+
     @try_number.expression
     def try_number(cls):
         return cls._try_number

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1428,7 +1428,7 @@ class TaskInstance(Base, LoggingMixin):
         """
         This is what will be used by SQLAlchemy when filtering on try_number.
 
-        This is required because the override in the get_try_number function causes 
+        This is required because the override in the get_try_number function causes
         try_number values to be off by one when listing tasks in the UI.
 
         :meta private:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1425,6 +1425,14 @@ class TaskInstance(Base, LoggingMixin):
 
     @try_number.expression
     def try_number(cls):
+        """
+        This is what will be used by SQLAlchemy when filtering on try_number.
+
+        This is required because the override in the get_try_number function causes 
+        try_number values to be off by one when listing tasks in the UI.
+
+        :meta private:
+        """
         return cls._try_number
 
     @try_number.setter

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1422,6 +1422,10 @@ class TaskInstance(Base, LoggingMixin):
         This is designed so that task logs end up in the right file.
         """
         return _get_try_number(task_instance=self)
+    
+    @try_number.expression
+    def try_number(cls):
+        return cls._try_number
 
     @try_number.setter
     def try_number(self, value: int) -> None:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -5504,10 +5504,7 @@ class TaskInstanceModelView(AirflowModelView):
         "queued_by_job_id",
     ]
 
-    label_columns = {
-        "dag_run.execution_date": "Logical Date",
-        "prev_attempted_tries": "Try Number"
-    }
+    label_columns = {"dag_run.execution_date": "Logical Date", "prev_attempted_tries": "Try Number"}
 
     search_columns = [
         "state",

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -5475,7 +5475,7 @@ class TaskInstanceModelView(AirflowModelView):
         "priority_weight",
         "queue",
         "queued_dttm",
-        "try_number",
+        "prev_attempted_tries",
         "pool",
         "queued_by_job_id",
         "external_executor_id",
@@ -5506,6 +5506,7 @@ class TaskInstanceModelView(AirflowModelView):
 
     label_columns = {
         "dag_run.execution_date": "Logical Date",
+        "prev_attempted_tries": "Try Number"
     }
 
     search_columns = [


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/34309

Since we do some weird stuff with the `try_number` property, we have to do some weird stuff in order to properly search / display it in the UI 🥴:

1) Overriding `try_number.expression` so that sqlalchemy only sees the actual `try_number` value when searching or filtering.
2) Swapping in the `prev_attempted_tries` property in place of the `try_number` property in order to display the actual `try_number` value. 

This causes the UI to function as expect, only showing + filtering on the actual value from the DB:
<img width="1880" alt="image" src="https://github.com/apache/airflow/assets/16950874/c2e975df-116a-4404-9206-2697bf55475d">

However, this feels pretty hacky and I think that overriding the `hybrid_property` expression in particular might cause some issues down the line. I am going to see how complicated it would be to remove the weird try_number property altogether, moving the `try_number+1` logic to a separate property or selectively incrementing the value where required.

All feedback and suggestions welcome.