### PR TITLE
Don't run isort when creating new alembic migrations

### DIFF
--- a/airflow/alembic.ini
+++ b/airflow/alembic.ini
@@ -83,9 +83,3 @@ formatter = generic
 [formatter_generic]
 format = %(levelname)-5.5s [%(name)s] %(message)s
 datefmt = %H:%M:%S
-
-[post_write_hooks]
-hooks=isort
-
-isort.type=console_scripts
-isort.entrypoint=isort


### PR DESCRIPTION
We can let pre-commit do its thing instead of running specific static-check type things explicity. There are a number of things that could mutate the file before it's ready ultimately.

This is the error we get today, though the migration file is created:

```
  Generating /opt/airflow/airflow/migrations/versions/ff1136b2c21b_add_something.py ...  done
  Running post write hook 'isort' ...
  FAILED
[2023-09-27T00:46:38.441+0000] {messaging.py:70} ERROR - Could not find entrypoint console_scripts.isort
  FAILED: Could not find entrypoint console_scripts.isort
```
