### PR TITLE
Unify mapped task group lookup logic

### DIFF
--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -365,11 +365,9 @@ class AbstractOperator(Templater, DAGNode):
 
         :meta private:
         """
-        parent = self.task_group
-        while parent is not None:
-            if isinstance(parent, MappedTaskGroup):
-                yield parent
-            parent = parent.task_group
+        if (group := self.task_group) is None:
+            return
+        yield from group.iter_mapped_task_groups()
 
     def get_closest_mapped_task_group(self) -> MappedTaskGroup | None:
         """Get the mapped task group "closest" to this task in the DAG.


### PR DESCRIPTION
Just some minor refactoring.

The lookup logic in operators is identical to the one on task groups (in a function of the same name), so let's reuse the logic instead of having to maintain two loops with only slightly different code.

I thought about getting rid of this function on AbstractOperator altogether, but the `self.task_group is None` case is annoying enough I feel it's still better to keep the extra abstraction layer.