### PR TITLE
Warning when viewing docs for previous versions of Airflow

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ import re
 import sys
 from collections import defaultdict
 from pathlib import Path
+from textwrap import dedent
 from typing import Any
 
 import yaml
@@ -113,6 +114,26 @@ project = PACKAGE_NAME
 version = PACKAGE_VERSION
 # The full version, including alpha/beta/rc tags.
 release = PACKAGE_VERSION
+
+if PACKAGE_NAME == "apache-airflow":
+    if PACKAGE_VERSION == "stable":
+        prolog = dedent(
+            """
+            .. warning::
+            A newer version of Apache Airflow has been released.
+
+            For documentation for the latest version of Apache Airflow, please see the `stable documentation <https://airflow.apache.org/docs/apache-airflow/stable/index.html>`_.
+            """
+        )
+elif PACKAGE_NAME.startswith("apache-airflow-providers-"):
+    if PACKAGE_VERSION != "stable":
+        prolog = dedent(
+            """
+            .. warning::
+            TODO
+
+            """
+        )
 
 rst_epilog = f"""
 .. |version| replace:: {version}


### PR DESCRIPTION
Sometimes when Googling or finding links from some time ago, you might accidentally find yourself viewing outdated versions of documentation. It'd be nice to include a warning block near the top of pages in docs when you're viewing older versions of Airflow with a link to view the current page in the documentation for the stable version of Airflow.

I'd appreciate help from any restructured text wizards to be help get this working :) 