### PR TITLE
Resolve pydantic deprecation warnings re `update_forward_refs`

### DIFF
--- a/airflow/serialization/pydantic/dag_run.py
+++ b/airflow/serialization/pydantic/dag_run.py
@@ -123,4 +123,4 @@ class DagRunPydantic(BaseModelPydantic):
         )
 
 
-DagRunPydantic.update_forward_refs()
+DagRunPydantic.model_rebuild()

--- a/airflow/serialization/pydantic/taskinstance.py
+++ b/airflow/serialization/pydantic/taskinstance.py
@@ -346,4 +346,4 @@ class TaskInstancePydantic(BaseModelPydantic):
         return _get_previous_ti(task_instance=self, state=state, session=session)
 
 
-TaskInstancePydantic.update_forward_refs()
+TaskInstancePydantic.model_rebuild()


### PR DESCRIPTION
Resolves warnings such as these:

airflow/serialization/pydantic/dag_run.py:126 PydanticDeprecatedSince20: The `update_forward_refs` method is deprecated; use `model_rebuild` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.4/migration/
