### PR TITLE
Restrict `astroid` version < 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -299,7 +299,9 @@ deprecated_api = [
     "requests>=2.26.0",
 ]
 doc = [
-    "astroid>=2.12.3",
+    # sphinx-autoapi fails with astroid 3.0, see: https://github.com/readthedocs/sphinx-autoapi/issues/407
+    # This was fixed in sphinx-autoapi 3.0, however it has requirement sphinx>=6.1, but we stuck on 5.x
+    "astroid>=2.12.3, <3.0",
     "checksumdir",
     # click 8.1.4 and 8.1.5 generate mypy errors due to typing issue in the upstream package:
     # https://github.com/pallets/click/issues/2558


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Our `main` branch CI unable to build docs due to an error, see: https://github.com/readthedocs/sphinx-autoapi/issues/407

```console
  apache-airflow-providers-jenkins                             sphinx.errors.ExtensionError: Handler <function run_autoapi at 0x7fba67749550> for event 'builder-inited' threw an 
  exception (exception: 'Module' object has no attribute 'doc')
  apache-airflow-providers-jenkins                             
  apache-airflow-providers-jenkins                             [91mExtension error (autoapi.extension):[39;49;00m
  apache-airflow-providers-jenkins                             Handler <function run_autoapi at 0x7fba67749550> for event 'builder-inited' threw an exception (exception: 'Module' 
  object has no attribute 'doc')
```



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
