### PR TITLE
Remove Airflow 2.3 compat from `PapermillOperator`

### DIFF
--- a/airflow/providers/papermill/operators/papermill.py
+++ b/airflow/providers/papermill/operators/papermill.py
@@ -33,14 +33,7 @@ if TYPE_CHECKING:
 class NoteBook(File):
     """Jupyter notebook."""
 
-    # For compatibility with Airflow 2.3:
-    # 1. Use predefined set because `File.template_fields` introduced in Airflow 2.4
-    # 2. Use old styled annotations because `cattrs` doesn't work well with PEP 604.
-
-    template_fields: ClassVar[Collection[str]] = {
-        "parameters",
-        *(File.template_fields if hasattr(File, "template_fields") else {"url"}),
-    }
+    template_fields: ClassVar[Collection[str]] = {"parameters", *File.template_fields}
 
     type_hint: str | None = "jupyter_notebook"
     parameters: dict | None = {}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Remove remaining Airflow 2.3 compat part which initially was add in https://github.com/apache/airflow/pull/28979 and partially removed in https://github.com/apache/airflow/pull/33301 

I'm not sure but seems like `from airflow.lineage.entities import File` it is a part of [experimental linage](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/lineage.html) and has nothing to do with [AIP-53](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-53+OpenLineage+in+Airflow).

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
