### PR TITLE
Fix LookerHook serialize missing 1 argument error

### DIFF
--- a/airflow/providers/google/cloud/hooks/looker.py
+++ b/airflow/providers/google/cloud/hooks/looker.py
@@ -194,7 +194,7 @@ class LookerHook(BaseHook):
         return methods40.Looker40SDK(
             auth_session.AuthSession(settings, transport, serialize.deserialize40, "4.0"),
             serialize.deserialize40,
-            serialize.serialize,
+            serialize.serialize40,
             transport,
             "4.0",
         )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

There was a ticket open for this back in March (https://github.com/apache/airflow/issues/30169), it was closed out due to inactivity and there was [a comment](https://github.com/apache/airflow/issues/30169#issuecomment-1481547661) that it was related to an upstream issue in `looker_sdk`. I took a look at the issue in `looker_sdk` and it didn't quite seem like the same thing.

After digging in, I believe this is simply a typo in the hook's `get_looker_sdk()` method and the `40` was left off by mistake. Adding the `40` back on here fixes the issues in my local environment. I can't seem to find any reason it would be desirable to use `serialize.serialize` there, and in fact looker_sdk uses `serialize40` here.

You can see [here](https://github.com/looker-open-source/sdk-codegen/blob/f7783890bbe7edaea58f7f849f494f6c9ed69df4/python/looker_sdk/__init__.py#L85) in the `looker_sdk` repo that during init we use `serialize.serialize40`, whereas in `LookerHook` we use `serialize.serialize`.

`serialize.serialize` points [here](https://github.com/looker-open-source/sdk-codegen/blob/f7783890bbe7edaea58f7f849f494f6c9ed69df4/python/looker_sdk/rtl/serialize.py#L78C2-L78C2), where it expects a `converter` to be passed in.

`serialize.serialize40` points [here](https://github.com/looker-open-source/sdk-codegen/blob/f7783890bbe7edaea58f7f849f494f6c9ed69df4/python/looker_sdk/rtl/serialize.py#L117C10-L117C10), where there is a default `converter` set.

This becomes problematic when you want to do something with the sdk from `LookerHook` when calling a method using `post`, like `create_query`.

An example - when we try to do something like this, we get an error due to the missing `converter`:

```python

def example():
  sdk = LookerHook("looker_conn").get_looker_sdk()

  query = sdk.create_query(
    body=models.WriteQuery(
      model="my_model",
      view="my_explore",
      fields=["field1"],
    )
  )

with DAG(...) as dag:
  PythonOperator(task_id="example", python_callable=example)
```

This generates the error: `TypeError: serialize() missing 1 required keyword-only argument: 'converter'`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
