### PR TITLE
Fix typo in docstring of DataplexGetDataQualityScanResultOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/dataplex.py
+++ b/airflow/providers/google/cloud/operators/dataplex.py
@@ -1053,10 +1053,10 @@ class DataplexGetDataQualityScanResultOperator(GoogleCloudBaseOperator):
     :param fail_on_dq_failure: If set to true and not all Data Quality scan rules have been passed,
         an exception is thrown. If set to false and not all Data Quality scan rules have been passed,
         execution will finish with success.
-    :param wait_for_result: Flag indicating whether to wait for the result of a job execution
+    :param wait_for_results: Flag indicating whether to wait for the result of a job execution
         or to return the job in its current state.
     :param result_timeout: Value in seconds for which operator will wait for the Data Quality scan result
-        when the flag `wait_for_result = True`.
+        when the flag `wait_for_results = True`.
         Throws exception if there is no result found after specified amount of seconds.
     :param polling_interval_seconds: time in seconds between polling for job completion.
         The value is considered only when running in deferrable mode. Must be greater than 0.


### PR DESCRIPTION
## Summary:
While reviewing the docstring for `DataplexGetDataQualityScanResultOperator` in `dataplex.py`, I noticed a small typo. This PR aims to correct that.

## Details:
- Fixed a typo in the docstring where `wait_for_result` was mentioned instead of the correct `wait_for_results`.


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
