### PR TITLE
Fix broken breeze by fixing packaging version

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1286,7 +1286,7 @@ ARG PYTHON_BASE_IMAGE
 ARG AIRFLOW_IMAGE_REPOSITORY="https://github.com/apache/airflow"
 
 # By increasing this number we can do force build of all dependencies
-ARG DEPENDENCIES_EPOCH_NUMBER="9"
+ARG DEPENDENCIES_EPOCH_NUMBER="10"
 
 # Make sure noninteractive debian install is used and language variables set
 ENV PYTHON_BASE_IMAGE=${PYTHON_BASE_IMAGE} \

--- a/dev/breeze/README.md
+++ b/dev/breeze/README.md
@@ -52,6 +52,6 @@ PLEASE DO NOT MODIFY THE HASH BELOW! IT IS AUTOMATICALLY UPDATED BY PRE-COMMIT.
 
 ---------------------------------------------------------------------------------------------------------
 
-Package config hash: 9d095d522c9f6fcf0c5834fcdc050bc98231d17fad07ec054c4e437580129d547b693b66b61442757f81fc1a505483da5267cc973dbf86babba7cd2c11697708
+Package config hash: 782a39916ea95eedd0cd81f76c9dbf3bbb5cbdc5c03271621a8dd3805324ee6868fbead2b95ac653d9efea0225db85de46b17c6f0e3b07923c7d18de666d236e
 
 ---------------------------------------------------------------------------------------------------------

--- a/dev/breeze/setup.cfg
+++ b/dev/breeze/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     filelock
     inputimeout
     jinja2
-    packaging
+    packaging==23.1
     pendulum
     pre-commit
     psutil

--- a/scripts/ci/install_breeze.sh
+++ b/scripts/ci/install_breeze.sh
@@ -19,6 +19,6 @@ set -euxo pipefail
 
 cd "$( dirname "${BASH_SOURCE[0]}" )/../../"
 
-python -m pip install pipx
+python -m pip install pipx packaging==23.1
 python -m pipx install --editable ./dev/breeze/ --force
 echo '/home/runner/.local/bin' >> "${GITHUB_PATH}"


### PR DESCRIPTION
The CI is broken in main, and comparing the different runs I noticed that the only difference is the version of `packaging` where there was a new version 7 hours ago (https://github.com/pypa/packaging/releases/tag/23.2).