### PR TITLE
allow providing credentials through keyword argument in AzureKeyVaultBackend

### DIFF
--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -72,6 +72,12 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
         If set to None (null), requests for configurations will not be sent to Azure Key Vault
     :param vault_url: The URL of an Azure Key Vault to use
     :param sep: separator used to concatenate secret_prefix and secret_id. Default: "-"
+    :param tenant_id: The tenant id of an Azure Key Vault to use.
+        If not given, it falls back to ``DefaultAzureCredential``
+    :param client_id: The client id of an Azure Key Vault to use.
+        If not given, it falls back to ``DefaultAzureCredential``
+    :param client_secret: The client secret of an Azure Key Vault to use.
+        If not given, it falls back to ``DefaultAzureCredential``
     """
 
     def __init__(

--- a/tests/providers/microsoft/azure/secrets/test_azure_key_vault.py
+++ b/tests/providers/microsoft/azure/secrets/test_azure_key_vault.py
@@ -150,3 +150,30 @@ class TestAzureKeyVaultBackend:
         backend = AzureKeyVaultBackend(**kwargs)
         assert backend.get_config("test_mysql") is None
         mock_get_secret.assert_not_called()
+
+    @mock.patch("airflow.providers.microsoft.azure.secrets.key_vault.DefaultAzureCredential")
+    @mock.patch("airflow.providers.microsoft.azure.secrets.key_vault.ClientSecretCredential")
+    @mock.patch("airflow.providers.microsoft.azure.secrets.key_vault.SecretClient")
+    def test_client_authenticate_with_default_azure_credential(
+        self, mock_client, mock_client_secret_credential, mock_defaul_azure_credential
+    ):
+        backend = AzureKeyVaultBackend(vault_url="https://example-akv-resource-name.vault.azure.net/")
+        backend.client
+        assert not mock_client_secret_credential.called
+        mock_defaul_azure_credential.assert_called_once()
+
+    @mock.patch("airflow.providers.microsoft.azure.secrets.key_vault.DefaultAzureCredential")
+    @mock.patch("airflow.providers.microsoft.azure.secrets.key_vault.ClientSecretCredential")
+    @mock.patch("airflow.providers.microsoft.azure.secrets.key_vault.SecretClient")
+    def test_client_authenticate_with_client_secret_credential(
+        self, mock_client, mock_client_secret_credential, mock_defaul_azure_credential
+    ):
+        backend = AzureKeyVaultBackend(
+            vault_url="https://example-akv-resource-name.vault.azure.net/",
+            tenant_id="tenant_id",
+            client_id="client_id",
+            client_secret="client_secret",
+        )
+        backend.client
+        assert not mock_defaul_azure_credential.called
+        mock_client_secret_credential.assert_called_once()


### PR DESCRIPTION
Currently, only authenticating through `DefaultAzureCredential` is supported. This PR allows users to pass `tenant_id`, `client_id` and `client_secret`

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
