### PR TITLE
Parse 'docker context ls --format=json' correctly

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -828,11 +828,8 @@ def autodetect_docker_context():
     if result.returncode != 0:
         get_console().print("[warning]Could not detect docker builder. Using default.[/]")
         return "default"
-    context_json = json.loads(result.stdout)
-    if isinstance(context_json, dict):
-        # In case there is one context it is returned as dict not array of dicts ¯\_(ツ)_/¯
-        context_json = [context_json]
-    known_contexts = {info["Name"]: info for info in context_json}
+    context_dicts = (json.loads(line) for line in result.stdout.splitlines() if line.strip())
+    known_contexts = {info["Name"]: info for info in context_dicts}
     if not known_contexts:
         get_console().print("[warning]Could not detect docker builder. Using default.[/]")
         return "default"

--- a/dev/breeze/tests/test_docker_command_utils.py
+++ b/dev/breeze/tests/test_docker_command_utils.py
@@ -195,39 +195,36 @@ def test_check_docker_compose_version_ok(mock_get_console, mock_run_command):
     )
 
 
-def _fake_ctx(name: str) -> dict[str, str]:
-    return {
-        "Name": name,
-        "DockerEndpoint": f"unix://{name}",
-    }
+def _fake_ctx_output(*names: str) -> str:
+    return "\n".join(json.dumps({"Name": name, "DockerEndpoint": f"unix://{name}"}) for name in names)
 
 
 @pytest.mark.parametrize(
     "context_output, selected_context, console_output",
     [
         (
-            json.dumps([_fake_ctx("default")]),
+            _fake_ctx_output("default"),
             "default",
             "[info]Using default as context",
         ),
-        ("[]", "default", "[warning]Could not detect docker builder"),
+        ("\n", "default", "[warning]Could not detect docker builder"),
         (
-            json.dumps([_fake_ctx("a"), _fake_ctx("b")]),
+            _fake_ctx_output("a", "b"),
             "a",
             "[warning]Could not use any of the preferred docker contexts",
         ),
         (
-            json.dumps([_fake_ctx("a"), _fake_ctx("desktop-linux")]),
+            _fake_ctx_output("a", "desktop-linux"),
             "desktop-linux",
             "[info]Using desktop-linux as context",
         ),
         (
-            json.dumps([_fake_ctx("a"), _fake_ctx("default")]),
+            _fake_ctx_output("a", "default"),
             "default",
             "[info]Using default as context",
         ),
         (
-            json.dumps([_fake_ctx("a"), _fake_ctx("default"), _fake_ctx("desktop-linux")]),
+            _fake_ctx_output("a", "default", "desktop-linux"),
             "desktop-linux",
             "[info]Using desktop-linux as context",
         ),


### PR DESCRIPTION
Apparently the command outputs *multiple lines of JSON objects* when there are more than one context, not one JSON array of objects. Pretty f-ed up if you ask me but it's what it is.

This should fix the JSON error mentioned in https://github.com/apache/airflow/pull/34701#issuecomment-1742532327 (*not* the ModuleNotFoundError)

cc @Lee-W 