### PR TITLE
Execlude Chart.yaml from licence check

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -113,6 +113,7 @@ chart/.gitignore
 chart/values.schema.json
 chart/Chart.lock
 chart/values_schema.schema.json
+chart/Chart.yaml
 
 # Generated autocomplete files
 ./dev/breeze/autocomplete/*


### PR DESCRIPTION
As discussed in https://lists.apache.org/thread/wyoz9g7cldym3f6x4cnhvzsy76hgq0h5, helm remove the comments from this file (including the licence), so we can exclude it until finding a solution to add the licence.