### PR TITLE
Fix WSGI middleware example in the doc by import AUTH_REMOTE_USER from fab

### DIFF
--- a/docs/apache-airflow/security/webserver.rst
+++ b/docs/apache-airflow/security/webserver.rst
@@ -113,7 +113,7 @@ and leverage the REMOTE_USER method:
     from typing import Any, Callable
 
     from flask import current_app
-    from airflow.www.fab_security.manager import AUTH_REMOTE_USER
+    from flask_appbuilder.const import AUTH_REMOTE_USER
 
 
     class CustomMiddleware:


### PR DESCRIPTION
closes: #34720

The module `airflow.www.fab_security.manager` doesn't have `AUTH_REMOTE_USER`:
```
ImportError: cannot import name 'AUTH_REMOTE_USER' from 'airflow.www.fab_security.manager'
```
and we should not import objects from 3rd party packages through Airflow package to avoid circular import.

This PR updates the example in the doc by importing the object from `flask_appbuilder.const`.