### PR TITLE
Name params while invoking ClientSecretCredential

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -181,7 +181,7 @@ class WasbHook(BaseHook):
             # use Active Directory auth
             app_id = conn.login
             app_secret = conn.password
-            token_credential = ClientSecretCredential(tenant, app_id, app_secret, **client_secret_auth_config)
+            token_credential = ClientSecretCredential(tenant_id = tenant, client_id = app_id, client_secret = app_secret, **client_secret_auth_config)
             return BlobServiceClient(account_url=account_url, credential=token_credential, **extra)
 
         if self.public_read:

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -181,7 +181,9 @@ class WasbHook(BaseHook):
             # use Active Directory auth
             app_id = conn.login
             app_secret = conn.password
-            token_credential = ClientSecretCredential(tenant_id = tenant, client_id = app_id, client_secret = app_secret, **client_secret_auth_config)
+            token_credential = ClientSecretCredential(
+                tenant_id=tenant, client_id=app_id, client_secret=app_secret, **client_secret_auth_config
+            )
             return BlobServiceClient(account_url=account_url, credential=token_credential, **extra)
 
         if self.public_read:

--- a/tests/providers/microsoft/azure/hooks/test_wasb.py
+++ b/tests/providers/microsoft/azure/hooks/test_wasb.py
@@ -196,9 +196,9 @@ class TestWasbHook:
         mocked_client_secret_credential.return_value = "spam-egg"
         WasbHook(wasb_conn_id=self.ad_conn_id).get_conn()
         mocked_client_secret_credential.assert_called_once_with(
-            "token",
-            "appID",
-            "appsecret",
+            tenant_id="token",
+            client_id="appID",
+            client_secret="appsecret",
             proxies=self.client_secret_auth_config["proxies"],
             connection_verify=self.client_secret_auth_config["connection_verify"],
             authority=self.client_secret_auth_config["authority"],


### PR DESCRIPTION
Name parameters while invoking ``ClientSecretCredential`` function of Azure Identity.