### PR TITLE
Fix metadata DB & port in Keda connection when usePgbouncer is false

### DIFF
--- a/chart/templates/secrets/metadata-connection-secret.yaml
+++ b/chart/templates/secrets/metadata-connection-secret.yaml
@@ -25,7 +25,8 @@
 {{- $metadataHost := .Values.data.metadataConnection.host | default $defaultMetadataHost }}
 {{- $pgbouncerHost := (printf "%s-%s.%s" .Release.Name "pgbouncer" .Release.Namespace) }}
 {{- $host := ternary $pgbouncerHost $metadataHost .Values.pgbouncer.enabled }}
-{{- $port := ((ternary .Values.ports.pgbouncer .Values.data.metadataConnection.port .Values.pgbouncer.enabled) | toString) }}
+{{- $metadataPort := .Values.data.metadataConnection.port | toString }}
+{{- $port := ((ternary .Values.ports.pgbouncer $metadataPort .Values.pgbouncer.enabled) | toString) }}
 {{- $database := (ternary (printf "%s-%s" .Release.Name "metadata") .Values.data.metadataConnection.db .Values.pgbouncer.enabled) }}
 {{- $query := ternary (printf "sslmode=%s" .Values.data.metadataConnection.sslmode) "" (eq .Values.data.metadataConnection.protocol "postgresql") }}
 apiVersion: v1
@@ -47,7 +48,7 @@ data:
   {{- end }}
   {{- if and .Values.workers.keda.enabled .Values.pgbouncer.enabled (not .Values.workers.keda.usePgbouncer) }}
   {{- with .Values.data.metadataConnection }}
-  kedaConnection: {{ urlJoin (dict "scheme" .protocol "userinfo" (printf "%s:%s" (.user | urlquery) (.pass | urlquery) ) "host" (printf "%s:%s" $metadataHost $port) "path" (printf "/%s" $database) "query" $query) | b64enc | quote }}
+  kedaConnection: {{ urlJoin (dict "scheme" .protocol "userinfo" (printf "%s:%s" (.user | urlquery) (.pass | urlquery) ) "host" (printf "%s:%s" $metadataHost $metadataPort) "path" (printf "/%s" $database) "query" $query) | b64enc | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/secrets/metadata-connection-secret.yaml
+++ b/chart/templates/secrets/metadata-connection-secret.yaml
@@ -27,7 +27,8 @@
 {{- $host := ternary $pgbouncerHost $metadataHost .Values.pgbouncer.enabled }}
 {{- $metadataPort := .Values.data.metadataConnection.port | toString }}
 {{- $port := ((ternary .Values.ports.pgbouncer $metadataPort .Values.pgbouncer.enabled) | toString) }}
-{{- $database := (ternary (printf "%s-%s" .Release.Name "metadata") .Values.data.metadataConnection.db .Values.pgbouncer.enabled) }}
+{{- $meadataDatabase := .Values.data.metadataConnection.db }}
+{{- $database := (ternary (printf "%s-%s" .Release.Name "metadata") $meadataDatabase .Values.pgbouncer.enabled) }}
 {{- $query := ternary (printf "sslmode=%s" .Values.data.metadataConnection.sslmode) "" (eq .Values.data.metadataConnection.protocol "postgresql") }}
 apiVersion: v1
 kind: Secret
@@ -48,7 +49,7 @@ data:
   {{- end }}
   {{- if and .Values.workers.keda.enabled .Values.pgbouncer.enabled (not .Values.workers.keda.usePgbouncer) }}
   {{- with .Values.data.metadataConnection }}
-  kedaConnection: {{ urlJoin (dict "scheme" .protocol "userinfo" (printf "%s:%s" (.user | urlquery) (.pass | urlquery) ) "host" (printf "%s:%s" $metadataHost $metadataPort) "path" (printf "/%s" $database) "query" $query) | b64enc | quote }}
+  kedaConnection: {{ urlJoin (dict "scheme" .protocol "userinfo" (printf "%s:%s" (.user | urlquery) (.pass | urlquery) ) "host" (printf "%s:%s" $metadataHost $metadataPort) "path" (printf "/%s" $meadataDatabase) "query" $query) | b64enc | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/secrets/metadata-connection-secret.yaml
+++ b/chart/templates/secrets/metadata-connection-secret.yaml
@@ -27,8 +27,8 @@
 {{- $host := ternary $pgbouncerHost $metadataHost .Values.pgbouncer.enabled }}
 {{- $metadataPort := .Values.data.metadataConnection.port | toString }}
 {{- $port := ((ternary .Values.ports.pgbouncer $metadataPort .Values.pgbouncer.enabled) | toString) }}
-{{- $meadataDatabase := .Values.data.metadataConnection.db }}
-{{- $database := (ternary (printf "%s-%s" .Release.Name "metadata") $meadataDatabase .Values.pgbouncer.enabled) }}
+{{- $metadataDatabase := .Values.data.metadataConnection.db }}
+{{- $database := (ternary (printf "%s-%s" .Release.Name "metadata") $metadataDatabase .Values.pgbouncer.enabled) }}
 {{- $query := ternary (printf "sslmode=%s" .Values.data.metadataConnection.sslmode) "" (eq .Values.data.metadataConnection.protocol "postgresql") }}
 apiVersion: v1
 kind: Secret
@@ -49,7 +49,7 @@ data:
   {{- end }}
   {{- if and .Values.workers.keda.enabled .Values.pgbouncer.enabled (not .Values.workers.keda.usePgbouncer) }}
   {{- with .Values.data.metadataConnection }}
-  kedaConnection: {{ urlJoin (dict "scheme" .protocol "userinfo" (printf "%s:%s" (.user | urlquery) (.pass | urlquery) ) "host" (printf "%s:%s" $metadataHost $metadataPort) "path" (printf "/%s" $meadataDatabase) "query" $query) | b64enc | quote }}
+  kedaConnection: {{ urlJoin (dict "scheme" .protocol "userinfo" (printf "%s:%s" (.user | urlquery) (.pass | urlquery) ) "host" (printf "%s:%s" $metadataHost $metadataPort) "path" (printf "/%s" $metadataDatabase) "query" $query) | b64enc | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/helm_tests/other/test_keda.py
+++ b/helm_tests/other/test_keda.py
@@ -260,12 +260,16 @@ class TestKeda:
         assert "KEDA_DB_CONN" in worker_container_env_vars
 
         secret_data = jmespath.search("data", metadata_connection_secret)
+        connection_secret = base64.b64decode(secret_data["connection"]).decode()
+        keda_connection_secret = base64.b64decode(secret_data["kedaConnection"]).decode()
         assert "connection" in secret_data.keys()
-        assert "@release-name-pgbouncer" in base64.b64decode(secret_data["connection"]).decode()
-        assert ":6543" in base64.b64decode(secret_data["connection"]).decode()
+        assert "@release-name-pgbouncer" in connection_secret
+        assert ":6543" in connection_secret
+        assert "/release-name-metadata" in connection_secret
         assert "kedaConnection" in secret_data.keys()
-        assert "@release-name-postgresql" in base64.b64decode(secret_data["kedaConnection"]).decode()
-        assert ":5432" in base64.b64decode(secret_data["kedaConnection"]).decode()
+        assert "@release-name-postgresql" in keda_connection_secret
+        assert ":5432" in keda_connection_secret
+        assert "/postgres" in keda_connection_secret
 
         autoscaler_connection_env_var = jmespath.search(
             "spec.triggers[0].metadata.connectionFromEnv", keda_autoscaler

--- a/helm_tests/other/test_keda.py
+++ b/helm_tests/other/test_keda.py
@@ -262,8 +262,10 @@ class TestKeda:
         secret_data = jmespath.search("data", metadata_connection_secret)
         assert "connection" in secret_data.keys()
         assert "@release-name-pgbouncer" in base64.b64decode(secret_data["connection"]).decode()
+        assert ":6543" in base64.b64decode(secret_data["connection"]).decode()
         assert "kedaConnection" in secret_data.keys()
         assert "@release-name-postgresql" in base64.b64decode(secret_data["kedaConnection"]).decode()
+        assert ":5432" in base64.b64decode(secret_data["kedaConnection"]).decode()
 
         autoscaler_connection_env_var = jmespath.search(
             "spec.triggers[0].metadata.connectionFromEnv", keda_autoscaler


### PR DESCRIPTION
closes: #34740

When `usePgbouncer` and KEDA is activated, KEDA connection should use the metadata port instead of pgbouncer port.