### PR TITLE
Fix typo re schedule vs schedule_interval

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -225,7 +225,7 @@ def create_timetable(interval: ScheduleIntervalArg, timezone: Timezone) -> Timet
         return DeltaDataIntervalTimetable(interval)
     if isinstance(interval, str):
         return CronDataIntervalTimetable(interval, timezone)
-    raise ValueError(f"{interval!r} is not a valid schedule_interval.")
+    raise ValueError(f"{interval!r} is not a valid interval.")
 
 
 def get_last_dagrun(dag_id, session, include_externally_triggered=False):


### PR DESCRIPTION
Now, typically, the "schedule interval" expression would be passed via param "schedule" since "schedule_interval" was deprecated.  So we should not use the underscore here (which is a remnant of the old var name) but just use either "interval" or "schedule interval", thus referring either to the concept (and not the param name) or the actual local function argument.
