### PR TITLE
Make core compatible with `pendulum` 3

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -63,6 +63,7 @@ from airflow.utils.docs import get_docs_url
 from airflow.utils.module_loading import import_string, qualname
 from airflow.utils.operator_resources import Resources
 from airflow.utils.task_group import MappedTaskGroup, TaskGroup
+from airflow.utils.timezone import parse_timezone
 from airflow.utils.types import NOTSET, ArgNotSet
 
 if TYPE_CHECKING:
@@ -165,9 +166,9 @@ def encode_timezone(var: Timezone) -> str | int:
     )
 
 
-def decode_timezone(var: str | int) -> Timezone:
+def decode_timezone(var: str | int) -> Timezone | FixedTimezone:
     """Decode a previously serialized Pendulum Timezone."""
-    return pendulum.tz.timezone(var)
+    return parse_timezone(var)
 
 
 def _get_registered_timetable(importable_string: str) -> type[Timetable] | None:
@@ -605,7 +606,7 @@ class BaseSerialization:
             raise TypeError(f"Invalid type {type_!s} in deserialization.")
 
     _deserialize_datetime = pendulum.from_timestamp
-    _deserialize_timezone = pendulum.tz.timezone
+    _deserialize_timezone = parse_timezone
 
     @classmethod
     def _deserialize_timedelta(cls, seconds: int) -> datetime.timedelta:

--- a/airflow/serialization/serializers/datetime.py
+++ b/airflow/serialization/serializers/datetime.py
@@ -24,7 +24,7 @@ from airflow.serialization.serializers.timezone import (
     serialize as serialize_timezone,
 )
 from airflow.utils.module_loading import qualname
-from airflow.utils.timezone import convert_to_utc, is_naive
+from airflow.utils.timezone import convert_to_utc, is_naive, parse_timezone
 
 if TYPE_CHECKING:
     import datetime
@@ -65,23 +65,22 @@ def deserialize(classname: str, version: int, data: dict | str) -> datetime.date
     import datetime
 
     from pendulum import DateTime
-    from pendulum.tz import fixed_timezone, timezone
 
     tz: datetime.tzinfo | None = None
     if isinstance(data, dict) and TIMEZONE in data:
         if version == 1:
             # try to deserialize unsupported timezones
             timezone_mapping = {
-                "EDT": fixed_timezone(-4 * 3600),
-                "CDT": fixed_timezone(-5 * 3600),
-                "MDT": fixed_timezone(-6 * 3600),
-                "PDT": fixed_timezone(-7 * 3600),
-                "CEST": timezone("CET"),
+                "EDT": parse_timezone(-4 * 3600),
+                "CDT": parse_timezone(-5 * 3600),
+                "MDT": parse_timezone(-6 * 3600),
+                "PDT": parse_timezone(-7 * 3600),
+                "CEST": parse_timezone("CET"),
             }
             if data[TIMEZONE] in timezone_mapping:
                 tz = timezone_mapping[data[TIMEZONE]]
             else:
-                tz = timezone(data[TIMEZONE])
+                tz = parse_timezone(data[TIMEZONE])
         else:
             tz = deserialize_timezone(data[TIMEZONE][1], data[TIMEZONE][2], data[TIMEZONE][0])
 

--- a/airflow/serialization/serializers/timezone.py
+++ b/airflow/serialization/serializers/timezone.py
@@ -74,16 +74,13 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
 
 
 def deserialize(classname: str, version: int, data: object) -> Any:
-    from pendulum.tz import fixed_timezone, timezone
+    from airflow.utils.timezone import parse_timezone
 
     if not isinstance(data, (str, int)):
         raise TypeError(f"{data} is not of type int or str but of {type(data)}")
 
     if version > __version__:
         raise TypeError(f"serialized {version} of {classname} > {__version__}")
-
-    if isinstance(data, int):
-        return fixed_timezone(data)
 
     if "zoneinfo.ZoneInfo" in classname:
         try:
@@ -93,7 +90,7 @@ def deserialize(classname: str, version: int, data: object) -> Any:
 
         return ZoneInfo(data)
 
-    return timezone(data)
+    return parse_timezone(data)
 
 
 # ported from pendulum.tz.timezone._get_tzinfo_name

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -40,6 +40,7 @@ from airflow.executors import executor_constants
 from airflow.logging_config import configure_logging
 from airflow.utils.orm_event_handlers import setup_event_handlers
 from airflow.utils.state import State
+from airflow.utils.timezone import parse_timezone, utc
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Engine
@@ -54,9 +55,9 @@ try:
     if tz == "system":
         TIMEZONE = pendulum.tz.local_timezone()
     else:
-        TIMEZONE = pendulum.tz.timezone(tz)
+        TIMEZONE = parse_timezone(tz)
 except Exception:
-    TIMEZONE = pendulum.tz.timezone("UTC")
+    TIMEZONE = utc
 
 log.info("Configured default timezone %s", TIMEZONE)
 

--- a/airflow/timetables/_cron.py
+++ b/airflow/timetables/_cron.py
@@ -22,14 +22,14 @@ from typing import TYPE_CHECKING, Any
 
 from cron_descriptor import CasingTypeEnum, ExpressionDescriptor, FormatException, MissingFieldException
 from croniter import CroniterBadCronError, CroniterBadDateError, croniter
-from pendulum.tz.timezone import Timezone
 
 from airflow.exceptions import AirflowTimetableInvalid
 from airflow.utils.dates import cron_presets
-from airflow.utils.timezone import convert_to_utc, make_aware, make_naive
+from airflow.utils.timezone import convert_to_utc, make_aware, make_naive, parse_timezone
 
 if TYPE_CHECKING:
     from pendulum import DateTime
+    from pendulum.tz.timezone import Timezone
 
 
 def _is_schedule_fixed(expression: str) -> bool:
@@ -56,7 +56,7 @@ class CronMixin:
         self._expression = cron_presets.get(cron, cron)
 
         if isinstance(timezone, str):
-            timezone = Timezone(timezone)
+            timezone = parse_timezone(timezone)
         self._timezone = timezone
 
         try:

--- a/airflow/utils/sqlalchemy.py
+++ b/airflow/utils/sqlalchemy.py
@@ -24,7 +24,6 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any, Generator, Iterable, overload
 
-import pendulum
 from dateutil import relativedelta
 from sqlalchemy import TIMESTAMP, PickleType, and_, event, false, nullsfirst, or_, true, tuple_
 from sqlalchemy.dialects import mssql, mysql
@@ -34,7 +33,7 @@ from sqlalchemy.types import JSON, Text, TypeDecorator, UnicodeText
 from airflow import settings
 from airflow.configuration import conf
 from airflow.serialization.enums import Encoding
-from airflow.utils.timezone import make_naive
+from airflow.utils.timezone import make_naive, utc
 
 if TYPE_CHECKING:
     from kubernetes.client.models.v1_pod import V1Pod
@@ -45,8 +44,6 @@ if TYPE_CHECKING:
     from sqlalchemy.types import TypeEngine
 
 log = logging.getLogger(__name__)
-
-utc = pendulum.tz.timezone("UTC")
 
 
 class UtcDateTime(TypeDecorator):

--- a/airflow/utils/timezone.py
+++ b/airflow/utils/timezone.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import datetime as dt
-from functools import lru_cache
 from typing import overload
 
 import pendulum
@@ -27,11 +26,14 @@ from pendulum.datetime import DateTime
 from pendulum.tz import fixed_timezone
 from pendulum.tz.timezone import FixedTimezone, Timezone
 
-# UTC time zone as a FixedTimezone instance (subclass of tzinfo)
-# This type uses for compatibility with type provided by pendulum 2.x
+from airflow.compat.functools import cache
+
+# UTC time zone as a Timezone instance (subclass of tzinfo)
+# This type uses for compatibility between pendulum v2 and v3
 # - in pendulum 2.x ``pendulum.tz.timezone`` returns FixedTimezone
 # - in pendulum 3.x ``pendulum.timezone`` returns Timezone
-utc = FixedTimezone(offset=0, name="UTC")
+# Same is valid for pendulum.tz.UTC
+utc = Timezone("UTC")
 
 
 def is_localized(value):
@@ -281,7 +283,7 @@ def td_format(td_object: None | dt.timedelta | float | int) -> str | None:
     return joined
 
 
-@lru_cache(maxsize=None)
+@cache
 def parse_timezone(name: str | int) -> Timezone | FixedTimezone:
     """
     Parse timezone and return one of the pendulum Timezone.

--- a/airflow/utils/timezone.py
+++ b/airflow/utils/timezone.py
@@ -28,12 +28,10 @@ from pendulum.tz.timezone import FixedTimezone, Timezone
 
 from airflow.compat.functools import cache
 
-# UTC time zone as a Timezone instance (subclass of tzinfo)
-# This type uses for compatibility between pendulum v2 and v3
-# - in pendulum 2.x ``pendulum.tz.timezone`` returns FixedTimezone
-# - in pendulum 3.x ``pendulum.timezone`` returns Timezone
-# Same is valid for pendulum.tz.UTC
-utc = Timezone("UTC")
+# UTC time zone as a FixedTimezone instance (subclass of tzinfo)
+# This type uses for compatibility with type provided by pendulum 2.x,
+#  some of the components might not work correctly with `pendulum.tz.timezone.Timezone` in pendulum 2.x
+utc = FixedTimezone(offset=0, name="UTC")
 
 
 def is_localized(value):

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -37,6 +37,7 @@ import pendulum
 import pytest
 import time_machine
 from dateutil.relativedelta import relativedelta
+from pendulum.tz.timezone import Timezone
 from sqlalchemy import inspect
 
 from airflow import settings
@@ -96,7 +97,6 @@ from tests.test_utils.timetables import cron_timetable, delta_timetable
 pytestmark = pytest.mark.db_test
 
 TEST_DATE = datetime_tz(2015, 1, 2, 0, 0)
-
 repo_root = Path(__file__).parents[2]
 
 
@@ -676,8 +676,8 @@ class TestDag:
         """
         Make sure DST transitions are properly observed
         """
-        local_tz = pendulum.timezone("Europe/Zurich")
-        start = local_tz.convert(datetime.datetime(2018, 10, 28, 2, 55), dst_rule=pendulum.PRE_TRANSITION)
+        local_tz = Timezone("Europe/Zurich")
+        start = local_tz.convert(datetime.datetime(2018, 10, 28, 2, 55, fold=0))
         assert start.isoformat() == "2018-10-28T02:55:00+02:00", "Pre-condition: start date is in DST"
 
         utc = timezone.convert_to_utc(start)
@@ -705,8 +705,8 @@ class TestDag:
         """
         Make sure DST transitions are properly observed
         """
-        local_tz = pendulum.timezone("Europe/Zurich")
-        start = local_tz.convert(datetime.datetime(2018, 10, 27, 3), dst_rule=pendulum.PRE_TRANSITION)
+        local_tz = Timezone("Europe/Zurich")
+        start = local_tz.convert(datetime.datetime(2018, 10, 27, 3, fold=0))
 
         utc = timezone.convert_to_utc(start)
 
@@ -734,8 +734,8 @@ class TestDag:
         """
         Make sure DST transitions are properly observed
         """
-        local_tz = pendulum.timezone("Europe/Zurich")
-        start = local_tz.convert(datetime.datetime(2018, 3, 25, 2), dst_rule=pendulum.PRE_TRANSITION)
+        local_tz = Timezone("Europe/Zurich")
+        start = local_tz.convert(datetime.datetime(2018, 3, 25, 2, fold=0))
 
         utc = timezone.convert_to_utc(start)
 

--- a/tests/sensors/test_time_sensor.py
+++ b/tests/sensors/test_time_sensor.py
@@ -23,7 +23,7 @@ from unittest.mock import patch
 import pendulum
 import pytest
 import time_machine
-from pendulum.tz.timezone import Timezone, UTC
+from pendulum.tz.timezone import Timezone
 
 from airflow.exceptions import TaskDeferred
 from airflow.models.dag import DAG
@@ -72,8 +72,7 @@ class TestTimeSensorAsync:
         with DAG("test_target_time_aware", start_date=timezone.datetime(2020, 1, 1, 23, 0)):
             aware_time = time(0, 1).replace(tzinfo=pendulum.local_timezone())
             op = TimeSensorAsync(task_id="test", target_time=aware_time)
-            assert hasattr(op.target_datetime.tzinfo, "offset")
-            assert op.target_datetime.tzinfo.offset == 0
+            assert op.target_datetime.tzinfo == timezone.utc
 
     def test_target_time_naive_dag_timezone(self):
         """
@@ -85,4 +84,4 @@ class TestTimeSensorAsync:
         ):
             op = TimeSensorAsync(task_id="test", target_time=pendulum.time(9, 0))
             assert op.target_datetime.time() == pendulum.time(1, 0)
-            assert op.target_datetime.tzinfo == UTC
+            assert op.target_datetime.tzinfo == timezone.utc

--- a/tests/sensors/test_time_sensor.py
+++ b/tests/sensors/test_time_sensor.py
@@ -23,7 +23,7 @@ from unittest.mock import patch
 import pendulum
 import pytest
 import time_machine
-from pendulum.tz.timezone import UTC
+from pendulum.tz.timezone import Timezone, UTC
 
 from airflow.exceptions import TaskDeferred
 from airflow.models.dag import DAG
@@ -33,7 +33,7 @@ from airflow.utils import timezone
 
 DEFAULT_TIMEZONE = "Asia/Singapore"  # UTC+08:00
 DEFAULT_DATE_WO_TZ = datetime(2015, 1, 1)
-DEFAULT_DATE_WITH_TZ = datetime(2015, 1, 1, tzinfo=pendulum.tz.timezone(DEFAULT_TIMEZONE))
+DEFAULT_DATE_WITH_TZ = datetime(2015, 1, 1, tzinfo=Timezone(DEFAULT_TIMEZONE))
 
 
 class TestTimeSensor:
@@ -47,7 +47,7 @@ class TestTimeSensor:
     )
     @time_machine.travel(timezone.datetime(2020, 1, 1, 23, 0).replace(tzinfo=timezone.utc))
     def test_timezone(self, default_timezone, start_date, expected):
-        with patch("airflow.settings.TIMEZONE", pendulum.timezone(default_timezone)):
+        with patch("airflow.settings.TIMEZONE", Timezone(default_timezone)):
             dag = DAG("test", default_args={"start_date": start_date})
             op = TimeSensor(task_id="test", target_time=time(10, 0), dag=dag)
             assert op.poke(None) == expected

--- a/tests/triggers/test_temporal.py
+++ b/tests/triggers/test_temporal.py
@@ -21,6 +21,7 @@ import datetime
 
 import pendulum
 import pytest
+from pendulum.tz.timezone import Timezone
 
 from airflow.triggers.base import TriggerEvent
 from airflow.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
@@ -64,9 +65,9 @@ def test_timedelta_trigger_serialization():
 @pytest.mark.parametrize(
     "tz",
     [
-        pendulum.tz.timezone("UTC"),
-        pendulum.tz.timezone("Europe/Paris"),
-        pendulum.tz.timezone("America/Toronto"),
+        Timezone("UTC"),
+        Timezone("Europe/Paris"),
+        Timezone("America/Toronto"),
     ],
 )
 @pytest.mark.asyncio

--- a/tests/utils/test_timezone.py
+++ b/tests/utils/test_timezone.py
@@ -21,13 +21,14 @@ import datetime
 
 import pendulum
 import pytest
+from pendulum.tz.timezone import Timezone
 
 from airflow.utils import timezone
-from airflow.utils.timezone import coerce_datetime
+from airflow.utils.timezone import coerce_datetime, parse_timezone
 
-CET = pendulum.tz.timezone("Europe/Paris")
-EAT = pendulum.tz.timezone("Africa/Nairobi")  # Africa/Nairobi
-ICT = pendulum.tz.timezone("Asia/Bangkok")  # Asia/Bangkok
+CET = Timezone("Europe/Paris")
+EAT = Timezone("Africa/Nairobi")
+ICT = Timezone("Asia/Bangkok")
 UTC = timezone.utc
 
 
@@ -117,3 +118,34 @@ class TestTimezone:
 )
 def test_coerce_datetime(input_datetime, output_datetime):
     assert output_datetime == coerce_datetime(input_datetime)
+
+
+@pytest.mark.parametrize(
+    "tz_name",
+    [
+        pytest.param("Europe/Paris", id="CET"),
+        pytest.param("Africa/Nairobi", id="EAT"),
+        pytest.param("Asia/Bangkok", id="ICT"),
+    ],
+)
+def test_parse_timezone_iana(tz_name):
+    tz = parse_timezone(tz_name)
+    assert tz.name == tz_name
+    assert parse_timezone(tz_name) is tz
+
+
+@pytest.mark.parametrize(
+    "tz_name, expected_offset, expected_name",
+    [
+        pytest.param("UTC", 0, "UTC", id="UTC"),
+        pytest.param("utc", 0, "UTC", id="utc-lower-case"),
+        pytest.param(0, 0, "+00:00", id="zero-offset"),
+        pytest.param(-3600, -3600, "-01:00", id="1-hour-behind"),
+        pytest.param(19800, 19800, "+05:30", id="5.5-hours-ahead"),
+    ],
+)
+def test_parse_timezone_offset(tz_name, expected_offset, expected_name):
+    tz = parse_timezone(tz_name)
+    assert tz.offset == expected_offset
+    assert tz.name == expected_name
+    assert parse_timezone(tz_name) is tz

--- a/tests/utils/test_timezone.py
+++ b/tests/utils/test_timezone.py
@@ -134,11 +134,17 @@ def test_parse_timezone_iana(tz_name):
     assert parse_timezone(tz_name) is tz
 
 
+@pytest.mark.parametrize("tz_name", ["utc", "UTC", "uTc"])
+def test_parse_timezone_utc(tz_name):
+    tz = parse_timezone(tz_name)
+    assert tz.name == "UTC"
+    assert parse_timezone(tz_name) is tz
+    assert tz is timezone.utc, "Expected that UTC timezone is same object as `airflow.utils.timezone.utc`"
+
+
 @pytest.mark.parametrize(
     "tz_name, expected_offset, expected_name",
     [
-        pytest.param("UTC", 0, "UTC", id="UTC"),
-        pytest.param("utc", 0, "UTC", id="utc-lower-case"),
         pytest.param(0, 0, "+00:00", id="zero-offset"),
         pytest.param(-3600, -3600, "-01:00", id="1-hour-behind"),
         pytest.param(19800, 19800, "+05:30", id="5.5-hours-ahead"),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In pendulum 3 (beta) there is no access to `pendulum.tz.timezone` anymore otherwise we should call `pendulum.timezone` for convert string/integer to pendulum timezones

```python
>>> import pendulum
>>> pendulum.__version__
'2.1.2'

>>> pendulum.tz.timezone("UTC")
Timezone('UTC')
>>> pendulum.tz.timezone("Europe/London")
Timezone('Europe/London')
>>> pendulum.tz.timezone(3600)
Timezone('+01:00')

>>> pendulum.timezone("UTC")
Timezone('UTC')
>>> pendulum.timezone("Europe/London")
Timezone('Europe/London')
>>> pendulum.timezone(3600)
Timezone('+01:00')
```

```python
>>> import pendulum
>>> pendulum.__version__
'3.0.0b1'

>>> pendulum.tz.timezone("UTC")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'module' object is not callable
>>> pendulum.tz.timezone("Europe/London")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'module' object is not callable

>>> pendulum.timezone("UTC")
Timezone('UTC')
>>> pendulum.timezone("Europe/London")
Timezone('Europe/London')
>>> pendulum.timezone(3600)
FixedTimezone(3600, name="+01:00")
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
