### PR TITLE
Upgrade watchtower to 3.0.1 (#25019)

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -928,6 +928,21 @@ logging:
       type: boolean
       example: ~
       default: "False"
+    json_serializer:
+      description: |
+        By default, for non-string logged messages all non-json-parsable objects are logged as `null` except
+        `datetime` objects which are ISO formatted. Users can optionally provide their own JSON serializer or
+        opt to use a `repr` serializer which calls `repr(object)` for any non-JSON-serializable objects in the
+        logged message. The `airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize` uses
+        `repr` while `airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize_legacy` uses
+        `null`. If a custom serializer is provide, it must adhear to `Callable[[Any], str]`
+        (`def my_serializer(o: Any) -> str`). Be aware, that if opting in to using the `repr` serializer, you
+        should take extra care that no new, sensitive, data is logged (e.g. credentials). If creating your own
+        json-serializer take special care to fail gracefully, without throwing.
+      type: string
+      version_added: 2.7.1
+      example: airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize
+      default: airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize_legacy
 metrics:
   description: |
     StatsD (https://github.com/etsy/statsd) integration settings.

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -928,21 +928,6 @@ logging:
       type: boolean
       example: ~
       default: "False"
-    json_serializer:
-      description: |
-        By default, for non-string logged messages all non-json-parsable objects are logged as `null` except
-        `datetime` objects which are ISO formatted. Users can optionally provide their own JSON serializer or
-        opt to use a `repr` serializer which calls `repr(object)` for any non-JSON-serializable objects in the
-        logged message. The `airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize` uses
-        `repr` while `airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize_legacy` uses
-        `null`. If a custom serializer is provide, it must adhear to `Callable[[Any], str]`
-        (`def my_serializer(o: Any) -> str`). Be aware, that if opting in to using the `repr` serializer, you
-        should take extra care that no new, sensitive, data is logged (e.g. credentials). If creating your own
-        json-serializer take special care to fail gracefully, without throwing.
-      type: string
-      version_added: 2.7.1
-      example: airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize
-      default: airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize_legacy
 metrics:
   description: |
     StatsD (https://github.com/etsy/statsd) integration settings.

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -722,3 +722,21 @@ config:
         example: my_company.aws.MyCustomSessionFactory
         type: string
         version_added: 3.1.1
+      cloudwatch_task_handler_json_serializer:
+        description: |
+          By default, when logging non-string messages, all non-json objects are logged as `null`.
+          Except `datetime` objects which are ISO formatted. Users can optionally use a `repr` serializer or
+          provide their own JSON serializer for any non-JSON-serializable objects in the logged message.
+
+          * `airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize` uses `repr` (be aware
+            there is the potential of logging sensitive data depending on the `repr` method of logged objects)
+          * `airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize_legacy` uses `null`.
+
+          If a custom serializer is provided, it must adhere to `Callable[[Any], str | None]`, where `None`
+          serializes to `null` (e.g. `def my_serializer(o: Any) -> str | None`). Since this is on the logging
+          path and it's possible there's an exception being handled, special care should be taken to fail
+          gracefully without raising a new exception inside of your serializer.
+        type: string
+        version_added: 8.7.2
+        example: airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize
+        default: airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize_legacy

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -81,11 +81,7 @@ dependencies:
   # NOTE!!! BOTOCORE version is always shifted by 3 MINOR VERSIONS from boto3
   # See https://github.com/boto/boto3/issues/2702
   - botocore>=1.31.0
-  # watchtower 3 has been released end Jan and introduced breaking change across the board that might
-  # change logging behaviour:
-  # https://github.com/kislyuk/watchtower/blob/develop/Changes.rst#changes-for-v300-2022-01-26
-  # TODO: update to watchtower >3
-  - watchtower~=2.0.1
+  - watchtower~=3.0.1
   - jsonpath_ng>=1.5.3
   - redshift_connector>=2.0.888
   - sqlalchemy_redshift>=0.8.6

--- a/docs/apache-airflow-providers-amazon/index.rst
+++ b/docs/apache-airflow-providers-amazon/index.rst
@@ -112,7 +112,7 @@ PIP package                              Version required
 ``boto3``                                ``>=1.28.0``
 ``botocore``                             ``>=1.31.0``
 ``asgiref``
-``watchtower``                           ``~=2.0.1``
+``watchtower``                           ``~=3.0.1``
 ``jsonpath_ng``                          ``>=1.5.3``
 ``redshift_connector``                   ``>=2.0.888``
 ``sqlalchemy_redshift``                  ``>=0.8.6``

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -30,7 +30,7 @@
       "jsonpath_ng>=1.5.3",
       "redshift_connector>=2.0.888",
       "sqlalchemy_redshift>=0.8.6",
-      "watchtower~=2.0.1"
+      "watchtower~=3.0.1"
     ],
     "cross-providers-deps": [
       "apache.hive",

--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -17,10 +17,12 @@
 # under the License.
 from __future__ import annotations
 
+import contextlib
+import logging
 import time
 from datetime import datetime as dt, timedelta
 from unittest import mock
-from unittest.mock import call
+from unittest.mock import ANY, Mock, call
 
 import boto3
 import moto
@@ -170,6 +172,50 @@ class TestCloudwatchTaskHandler:
             log_stream_name=self.remote_log_stream,
             end_time=expected_end_time,
         )
+
+    @pytest.mark.parametrize(
+        "conf_json_serialize, expected_serialized_output",
+        [
+            (None, '{"datetime": "2023-01-01T00:00:00+00:00", "customObject": null}'),
+            (
+                "airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize",
+                '{"datetime": "2023-01-01T00:00:00+00:00", "customObject": "SomeCustomSerialization(...)"}',
+            ),
+        ],
+    )
+    @mock.patch.object(AwsLogsHook, "get_log_events")
+    def test_write_json_logs(self, mock_get_log_events, conf_json_serialize, expected_serialized_output):
+        class ToSerialize:
+            def __init__(self):
+                pass
+
+            def __repr__(self):
+                return "SomeCustomSerialization(...)"
+
+        with contextlib.ExitStack() as stack:
+            if conf_json_serialize:
+                stack.enter_context(conf_vars({("logging", "json_serializer"): conf_json_serialize}))
+
+            handler = self.cloudwatch_task_handler
+            handler.set_context(self.ti)
+            message = logging.LogRecord(
+                name="test_log_record",
+                level=logging.DEBUG,
+                pathname="fake.path",
+                lineno=42,
+                args=None,
+                exc_info=None,
+                msg={
+                    "datetime": datetime(2023, 1, 1),
+                    "customObject": ToSerialize(),
+                },
+            )
+            stack.enter_context(mock.patch("watchtower.threading.Thread"))
+            mock_queue = Mock()
+            stack.enter_context(mock.patch("watchtower.queue.Queue", return_value=mock_queue))
+            handler.handle(message)
+
+            mock_queue.put.assert_called_once_with({"message": expected_serialized_output, "timestamp": ANY})
 
     def test_close_prevents_duplicate_calls(self):
         with mock.patch("watchtower.CloudWatchLogHandler.close") as mock_log_handler_close:

--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -194,7 +194,9 @@ class TestCloudwatchTaskHandler:
 
         with contextlib.ExitStack() as stack:
             if conf_json_serialize:
-                stack.enter_context(conf_vars({("logging", "json_serializer"): conf_json_serialize}))
+                stack.enter_context(
+                    conf_vars({("aws", "cloudwatch_task_handler_json_serializer"): conf_json_serialize})
+                )
 
             handler = self.cloudwatch_task_handler
             handler.set_context(self.ti)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
This PR upgrades `watchtower` from `2.0.1` to `3.0.1`. A new config item is introduced to allow customer to opt-in to the "new" serialization format.

### Watchtower functionality
Watchtower introduced a change whereby they use `repr` for any non-serializable objects in place of what was just `null`.

#### Source
```python
{"datetime": datetime(2023,1,1), "customObject": SomeCustomObject(1, 2, 3)}
```
#### Was
`{"datetime": "2023-01-01T00:00:00+00:00", "customObject": null}`

#### Now
`{"datetime": "2023-01-01T00:00:00+00:00", "customObject": "SomeCustomSerializationProvidedByRepr(...)"}`

### Airflow functionality
The default behavior for `airflow` will be to maintain the `null` serialization, but allow the option to use the new style (or provide your own).

The new config is `logging.json_serializer` which is an import path (string). The import should be a callable taking an object and returning a string.


closes: #25019

@ferruzzi 
