### PR TITLE
Suppress false warning when TI state is QUEUED and TI doesn't have a start_date

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -618,7 +618,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             )
 
             for ti in executable_tis:
-                ti.emit_state_change_metric(TaskInstanceState.QUEUED)
+                # ti.start_date could be None when the scheduler queue a TI
+                # or when the backfill CLI send a TI to the executor
+                # in this case, this line must be skipped because emit_state_change_metric doesn't expect it
+                if ti.start_date is not None:
+                    ti.emit_state_change_metric(TaskInstanceState.QUEUED)
 
         for ti in executable_tis:
             make_transient(ti)

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -620,9 +620,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             for ti in executable_tis:
                 # ti.start_date could be None when the scheduler queue a TI
                 # or when the backfill CLI send a TI to the executor
-                # in this case, this line must be skipped because emit_state_change_metric doesn't expect it
-                if ti.start_date is not None:
-                    ti.emit_state_change_metric(TaskInstanceState.QUEUED)
+                # in this case set it at this line because emit_state_change_metric doesn't expect it
+                if ti.start_date is None:
+                    ti.start_date = timezone.utcnow()
+                ti.emit_state_change_metric(TaskInstanceState.QUEUED)
 
         for ti in executable_tis:
             make_transient(ti)

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1439,9 +1439,14 @@ class TestSchedulerJob:
         res = self.job_runner._executable_task_instances_to_queued(max_tis=32, session=session)
         assert 2 == len(res)
 
-        mock_emit_metric.assert_called_once()
-        assert mock_emit_metric.call_args.args[0].task_id == task1.task_id
-        assert mock_emit_metric.call_args.args[1] == TaskInstanceState.QUEUED
+        assert mock_emit_metric.call_count == 2
+        first_call_args = mock_emit_metric.call_args_list[0]
+        assert first_call_args.args[0].task_id == task1.task_id
+        assert first_call_args.args[1] == TaskInstanceState.QUEUED
+
+        second_call_args = mock_emit_metric.call_args_list[0]
+        assert second_call_args.args[0].task_id == task2.task_id
+        assert second_call_args.args[1] == TaskInstanceState.QUEUED
 
         session.rollback()
         session.close()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1440,13 +1440,13 @@ class TestSchedulerJob:
         assert 2 == len(res)
 
         assert mock_emit_metric.call_count == 2
-        first_call_args = mock_emit_metric.call_args_list[0]
-        assert first_call_args.args[0].task_id == task1.task_id
-        assert first_call_args.args[1] == TaskInstanceState.QUEUED
 
-        second_call_args = mock_emit_metric.call_args_list[1]
-        assert second_call_args.args[0].task_id == task2.task_id
-        assert second_call_args.args[1] == TaskInstanceState.QUEUED
+        for call_args in mock_emit_metric.call_args_list:
+            assert call_args.args[0].start_date is not None
+            assert call_args.args[1] == TaskInstanceState.QUEUED
+
+        task_ids = list(sorted([call_args.args[0].task_id for call_args in mock_emit_metric.call_args_list]))
+        assert task_ids == [task1.task_id, task2.task_id]
 
         session.rollback()
         session.close()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1444,7 +1444,7 @@ class TestSchedulerJob:
         assert first_call_args.args[0].task_id == task1.task_id
         assert first_call_args.args[1] == TaskInstanceState.QUEUED
 
-        second_call_args = mock_emit_metric.call_args_list[0]
+        second_call_args = mock_emit_metric.call_args_list[1]
         assert second_call_args.args[0].task_id == task2.task_id
         assert second_call_args.args[1] == TaskInstanceState.QUEUED
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/34493
conversations in slack: https://apache-airflow.slack.com/archives/CCPRP7943/p1696235301762429

draft PR for the reviewer's second suggestion in the original PR (https://github.com/apache/airflow/pull/34589)

As mentioned in the issue, there may be a risk in changing the behavior of start_date itself, so I took the approach of to not call this function if the start date is None.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
