### PR TITLE
Added command for installing specific pipx packaging version

### DIFF
--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -282,6 +282,16 @@ Setting up Breeze
 
   $ breeze setup autocomplete
 
+.. note::
+   If you encounter an error like "ModuleNotFoundError: No module named 'airflow_breeze.params'",
+   you may execute the following command to install the specific packaging version:
+
+   .. code-block:: bash
+
+      $ python -m pip install pipx packaging==23.1
+
+   Once the package is installed, execute the breeze command again. 
+
 4. Initialize breeze environment with required python version and backend. This may take a while for first time.
 
 .. code-block:: bash

--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -288,7 +288,7 @@ Setting up Breeze
 
    .. code-block:: bash
 
-      $ python -m pip install pipx packaging==23.1
+      $ python3 -m pip install pipx packaging==23.1
 
    Once the package is installed, execute the breeze command again. 
 


### PR DESCRIPTION
I was setting up Airflow with Breeze when I encountered this error: 
`ModuleNotFoundError: No module named 'airflow_breeze.params'`

Came across this PR (https://github.com/apache/airflow/pull/34701) with the same issue, which also provided the fix. Accordingly, I did try to test with the latest main, but the problem wasn't solved. 
Was able to resolve it when I ran `python3 -m pip install pipx packaging==23.1` (from the commit of the above PR) and then ran the breeze command. 

Did anyone else also face this issue? (I installed pipx via brew.)

If significant, I've edited the `CONTRIBUTORS_QUICK_START.rst` to address this potential error.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
