### PR TITLE
Fix AWS RDS hook's DB instance state check

### DIFF
--- a/airflow/providers/amazon/aws/hooks/rds.py
+++ b/airflow/providers/amazon/aws/hooks/rds.py
@@ -240,7 +240,7 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         try:
             response = self.conn.describe_db_instances(DBInstanceIdentifier=db_instance_id)
         except self.conn.exceptions.ClientError as e:
-            if e.response["Error"]["Code"] == "DBInstanceNotFoundFault":
+            if e.response["Error"]["Code"] == "DBInstanceNotFound":
                 raise AirflowNotFoundException(e)
             raise e
         return response["DBInstances"][0]["DBInstanceStatus"].lower()

--- a/airflow/providers/amazon/aws/hooks/rds.py
+++ b/airflow/providers/amazon/aws/hooks/rds.py
@@ -153,8 +153,10 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         """
         try:
             response = self.conn.describe_export_tasks(ExportTaskIdentifier=export_task_id)
-        except self.conn.exceptions.ExportTaskNotFoundFault as e:
-            raise AirflowNotFoundException(e)
+        except self.conn.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] == "ExportTaskNotFoundFault":
+                raise AirflowNotFoundException(e)
+            raise e
         return response["ExportTasks"][0]["Status"].lower()
 
     def wait_for_export_task_state(
@@ -192,8 +194,10 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         """
         try:
             response = self.conn.describe_event_subscriptions(SubscriptionName=subscription_name)
-        except self.conn.exceptions.SubscriptionNotFoundFault as e:
-            raise AirflowNotFoundException(e)
+        except self.conn.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] == "SubscriptionNotFoundFault":
+                raise AirflowNotFoundException(e)
+            raise e
         return response["EventSubscriptionsList"][0]["Status"].lower()
 
     def wait_for_event_subscription_state(

--- a/airflow/providers/amazon/aws/hooks/rds.py
+++ b/airflow/providers/amazon/aws/hooks/rds.py
@@ -61,10 +61,8 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         """
         try:
             response = self.conn.describe_db_snapshots(DBSnapshotIdentifier=snapshot_id)
-        except self.conn.exceptions.ClientError as e:
-            if e.response["Error"]["Code"] == "DBSnapshotNotFound":
-                raise AirflowNotFoundException(e)
-            raise e
+        except self.conn.exceptions.DBSnapshotNotFoundFault as e:
+            raise AirflowNotFoundException(e)
         return response["DBSnapshots"][0]["Status"].lower()
 
     def wait_for_db_snapshot_state(
@@ -109,10 +107,8 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         """
         try:
             response = self.conn.describe_db_cluster_snapshots(DBClusterSnapshotIdentifier=snapshot_id)
-        except self.conn.exceptions.ClientError as e:
-            if e.response["Error"]["Code"] == "DBClusterSnapshotNotFoundFault":
-                raise AirflowNotFoundException(e)
-            raise e
+        except self.conn.exceptions.DBClusterSnapshotNotFoundFault as e:
+            raise AirflowNotFoundException(e)
         return response["DBClusterSnapshots"][0]["Status"].lower()
 
     def wait_for_db_cluster_snapshot_state(
@@ -157,10 +153,8 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         """
         try:
             response = self.conn.describe_export_tasks(ExportTaskIdentifier=export_task_id)
-        except self.conn.exceptions.ClientError as e:
-            if e.response["Error"]["Code"] == "ExportTaskNotFoundFault":
-                raise AirflowNotFoundException(e)
-            raise e
+        except self.conn.exceptions.ExportTaskNotFoundFault as e:
+            raise AirflowNotFoundException(e)
         return response["ExportTasks"][0]["Status"].lower()
 
     def wait_for_export_task_state(
@@ -198,10 +192,8 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         """
         try:
             response = self.conn.describe_event_subscriptions(SubscriptionName=subscription_name)
-        except self.conn.exceptions.ClientError as e:
-            if e.response["Error"]["Code"] == "SubscriptionNotFoundFault":
-                raise AirflowNotFoundException(e)
-            raise e
+        except self.conn.exceptions.SubscriptionNotFoundFault as e:
+            raise AirflowNotFoundException(e)
         return response["EventSubscriptionsList"][0]["Status"].lower()
 
     def wait_for_event_subscription_state(
@@ -239,10 +231,8 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         """
         try:
             response = self.conn.describe_db_instances(DBInstanceIdentifier=db_instance_id)
-        except self.conn.exceptions.ClientError as e:
-            if e.response["Error"]["Code"] == "DBInstanceNotFound":
-                raise AirflowNotFoundException(e)
-            raise e
+        except self.conn.exceptions.DBInstanceNotFoundFault as e:
+            raise AirflowNotFoundException(e)
         return response["DBInstances"][0]["DBInstanceStatus"].lower()
 
     def wait_for_db_instance_state(
@@ -292,10 +282,8 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         """
         try:
             response = self.conn.describe_db_clusters(DBClusterIdentifier=db_cluster_id)
-        except self.conn.exceptions.ClientError as e:
-            if e.response["Error"]["Code"] == "DBClusterNotFoundFault":
-                raise AirflowNotFoundException(e)
-            raise e
+        except self.conn.exceptions.DBClusterNotFoundFault as e:
+            raise AirflowNotFoundException(e)
         return response["DBClusters"][0]["Status"].lower()
 
     def wait_for_db_cluster_state(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Problem

We observed that when the `RdsDbSensor` is run against a database identifier which doesn't yet exist, the sensor fails and enters a retry sequence rather than emitting `False` and poking again at the next interval: https://github.com/WordPress/openverse/issues/2961

The [docs for `get_db_instance_state`](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/_api/airflow/providers/amazon/aws/hooks/rds/index.html#airflow.providers.amazon.aws.hooks.rds.RdsHook.get_db_instance_state) say that this should raise `AirflowNotFoundException` if the DB instance doesn't exist, and the [`RdsDbSensor`'s `poke` method](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/_modules/airflow/providers/amazon/aws/sensors/rds.html#RdsDbSensor) would seem to comport this with how it's expecting to handle an `AirflowNotFoundException`.

However, when running the hook code locally, the hook instead raises a `DBInstanceNotFoundFault` exception:

```
In [5]: response = hook.conn.describe_db_instances(DBInstanceIdentifier='dev-openverse-fake')
---------------------------------------------------------------------------
DBInstanceNotFoundFault                   Traceback (most recent call last)
Cell In[5], line 1
----> 1 response = hook.conn.describe_db_instances(DBInstanceIdentifier='dev-openverse-fake')

File ~/.local/lib/python3.10/site-packages/botocore/client.py:535, in ClientCreator._create_api_method.<locals>._api_call(self, *args, **kwargs)
    531     raise TypeError(
    532         f"{py_operation_name}() only accepts keyword arguments."
    533     )
    534 # The "self" in this scope is referring to the BaseClient.
--> 535 return self._make_api_call(operation_name, kwargs)

File ~/.local/lib/python3.10/site-packages/botocore/client.py:980, in BaseClient._make_api_call(self, operation_name, api_params)
    978     error_code = parsed_response.get("Error", {}).get("Code")
    979     error_class = self.exceptions.from_code(error_code)
--> 980     raise error_class(parsed_response, operation_name)
    981 else:
    982     return parsed_response

DBInstanceNotFoundFault: An error occurred (DBInstanceNotFound) when calling the DescribeDBInstances operation: DBInstance dev-openverse-fake not found.
```

I tried extracting the error code that is checked here myself:

https://github.com/apache/airflow/blob/0c8e30e43b70e9d033e1686b327eb00aab82479c/airflow/providers/amazon/aws/hooks/rds.py#L229-L246

```
In [7]: try:
   ...:     response = hook.conn.describe_db_instances(DBInstanceIdentifier='dev-openverse-fake')
   ...: except hook.conn.exceptions.ClientError as e:
   ...:     x = e
   ...: 

In [8]: x
Out[8]: botocore.errorfactory.DBInstanceNotFoundFault('An error occurred (DBInstanceNotFound) when calling the DescribeDBInstances operation: DBInstance dev-openverse-fake not found.')

In [10]: x.response
Out[10]: 
{'Error': {'Type': 'Sender',
  'Code': 'DBInstanceNotFound',
  'Message': 'DBInstance dev-openverse-fake not found.'},
 'ResponseMetadata': {'RequestId': '[redacted]',
  'HTTPStatusCode': 404,
  'HTTPHeaders': {'x-amzn-requestid': '[redacted]',
   'strict-transport-security': 'max-age=31536000',
   'content-type': 'text/xml',
   'content-length': '289',
   'date': 'Thu, 05 Oct 2023 03:46:28 GMT'},
  'RetryAttempts': 0}}
```

It looks like the code that _should_ be checked against is actually `DBInstanceNotFound`, even if the _exception_ is `DBInstanceNotFoundFault`. I've made the change here, there are a few other places in this hook where `DB[issue]Fault` is used where perhaps `DB[issue]` should be used instead. But I wanted to get this PR up with a minimal change at least to get folks' thoughts :slightly_smiling_face:



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
