### PR TITLE
Fix autodetect_docker_context for list of dict case

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -828,7 +828,10 @@ def autodetect_docker_context():
     if result.returncode != 0:
         get_console().print("[warning]Could not detect docker builder. Using default.[/]")
         return "default"
-    context_dicts = (json.loads(line) for line in result.stdout.splitlines() if line.strip())
+    try:
+        context_dicts = json.loads(result.stdout)
+    except json.decoder.JSONDecodeError:
+        context_dicts = (json.loads(line) for line in result.stdout.splitlines() if line.strip())
     known_contexts = {info["Name"]: info for info in context_dicts}
     if not known_contexts:
         get_console().print("[warning]Could not detect docker builder. Using default.[/]")

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -830,6 +830,8 @@ def autodetect_docker_context():
         return "default"
     try:
         context_dicts = json.loads(result.stdout)
+        if isinstance(context_dicts, dict):
+            context_dicts = [context_dicts]
     except json.decoder.JSONDecodeError:
         context_dicts = (json.loads(line) for line in result.stdout.splitlines() if line.strip())
     known_contexts = {info["Name"]: info for info in context_dicts}

--- a/dev/breeze/tests/test_docker_command_utils.py
+++ b/dev/breeze/tests/test_docker_command_utils.py
@@ -228,6 +228,16 @@ def _fake_ctx_output(*names: str) -> str:
             "desktop-linux",
             "[info]Using desktop-linux as context",
         ),
+        (
+            _fake_ctx_output("a", "default", "desktop-linux"),
+            "desktop-linux",
+            "[info]Using desktop-linux as context",
+        ),
+        (
+            '[{"Name": "desktop-linux", "DockerEndpoint": "unix://desktop-linux"}]',
+            "desktop-linux",
+            "[info]Using desktop-linux as context",
+        ),
     ],
 )
 def test_autodetect_docker_context(context_output: str, selected_context: str, console_output: str):


### PR DESCRIPTION
In breeze's autodetect_docker_context() there is one case that missed, when the output of `docker context ls --format=json"` is `[{"Name": "desktop-linux", "DockerEndpoint": "unix://desktop-linux"}]`. This PR aims to handle this case. 
