### PR TITLE
Fix _SECRET and _CMD broker configuration

### DIFF
--- a/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/airflow/providers/celery/executors/celery_executor_utils.py
@@ -43,11 +43,11 @@ import airflow.settings as settings
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
 from airflow.executors.base_executor import BaseExecutor
-from airflow.providers.celery.executors.default_celery import DEFAULT_CELERY_CONFIG
 from airflow.stats import Stats
 from airflow.utils.dag_parsing_context import _airflow_parsing_context_manager
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.net import get_hostname
+from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 from airflow.utils.timeout import timeout
 
 log = logging.getLogger(__name__)
@@ -65,23 +65,36 @@ OPERATION_TIMEOUT = conf.getfloat("celery", "operation_timeout")
 # Make it constant for unit test.
 CELERY_FETCH_ERR_MSG_HEADER = "Error fetching Celery task state"
 
-if conf.has_option("celery", "celery_config_options"):
-    celery_configuration = conf.getimport("celery", "celery_config_options")
+celery_configuration = None
 
-else:
-    celery_configuration = DEFAULT_CELERY_CONFIG
 
-celery_app_name = conf.get("celery", "CELERY_APP_NAME")
-if celery_app_name == "airflow.executors.celery_executor":
-    warnings.warn(
-        "The celery.CELERY_APP_NAME configuration uses deprecated package name: "
-        "'airflow.executors.celery_executor'. "
-        "Change it to `airflow.providers.celery.executors.celery_executor`, and "
-        "update the `-app` flag in your Celery Health Checks "
-        "to use `airflow.providers.celery.executors.celery_executor.app`.",
-        RemovedInAirflow3Warning,
-    )
-app = Celery(celery_app_name, config_source=celery_configuration)
+@providers_configuration_loaded
+def _get_celery_app() -> Celery:
+    """Init providers before importing the configuration, so the _SECRET and _CMD options work."""
+    global celery_configuration
+
+    if conf.has_option("celery", "celery_config_options"):
+        celery_configuration = conf.getimport("celery", "celery_config_options")
+    else:
+        from airflow.providers.celery.executors.default_celery import DEFAULT_CELERY_CONFIG
+
+        celery_configuration = DEFAULT_CELERY_CONFIG
+
+    celery_app_name = conf.get("celery", "CELERY_APP_NAME")
+    if celery_app_name == "airflow.executors.celery_executor":
+        warnings.warn(
+            "The celery.CELERY_APP_NAME configuration uses deprecated package name: "
+            "'airflow.executors.celery_executor'. "
+            "Change it to `airflow.providers.celery.executors.celery_executor`, and "
+            "update the `-app` flag in your Celery Health Checks "
+            "to use `airflow.providers.celery.executors.celery_executor.app`.",
+            RemovedInAirflow3Warning,
+        )
+
+    return Celery(celery_app_name, config_source=celery_configuration)
+
+
+app = _get_celery_app()
 
 
 @celery_import_modules.connect


### PR DESCRIPTION
Fixes _SECRET and _CMD broker configurations not working after 2.7 release

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #34612

Someone wiser than me may be able to come up with an effective test, but because the fix involves import time side effects I couldn't think of an additional unit/integration test that covers this edge case but can confirm that loading the providers before attempting to configure the celery settings via `conf` resolves the bug where _SECRET and _CMD cannot be used to configure the broker after 2.7 moved Celery into the providers package.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
