### PR TITLE
fix: pgbouncer connection with useStandardNaming

### DIFF
--- a/chart/templates/secrets/metadata-connection-secret.yaml
+++ b/chart/templates/secrets/metadata-connection-secret.yaml
@@ -23,7 +23,7 @@
 {{- if not .Values.data.metadataSecretName }}
 {{- $defaultMetadataHost :=  .Values.postgresql.nameOverride | default (printf "%s-%s.%s" .Release.Name "postgresql" .Release.Namespace) }}
 {{- $metadataHost := .Values.data.metadataConnection.host | default $defaultMetadataHost }}
-{{- $pgbouncerHost := (printf "%s-%s.%s" .Release.Name "pgbouncer" .Release.Namespace) }}
+{{- $pgbouncerHost := (printf "%s-%s.%s" ( include "airflow.fullname" . ) "pgbouncer" .Release.Namespace) }}
 {{- $host := ternary $pgbouncerHost $metadataHost .Values.pgbouncer.enabled }}
 {{- $port := ((ternary .Values.ports.pgbouncer .Values.data.metadataConnection.port .Values.pgbouncer.enabled) | toString) }}
 {{- $database := (ternary (printf "%s-%s" .Release.Name "metadata") .Values.data.metadataConnection.db .Values.pgbouncer.enabled) }}

--- a/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -573,6 +573,32 @@ class TestBaseChartTest:
             == base64.b64decode(doc["data"]["connection"]).decode("utf-8")
         )
 
+    def test_postgres_connection_url_pgbouncer(self):
+        # no nameoverride, pgbouncer
+        doc = render_chart(
+            "my-release",
+            show_only=["templates/secrets/metadata-connection-secret.yaml"],
+            values={"pgbouncer": {"enabled": True}},
+        )[0]
+        assert "postgresql://postgres:postgres@my-release-pgbouncer.default:6543/my-release-metadata?sslmode=disable" == base64.b64decode(
+            doc["data"]["connection"]
+        ).decode(
+            "utf-8"
+        )
+
+    def test_postgres_connection_url_pgbouncer_use_standard_naming(self):
+        # no nameoverride, pgbouncer and useStandardNaming
+        doc = render_chart(
+            "my-release",
+            show_only=["templates/secrets/metadata-connection-secret.yaml"],
+            values={"useStandardNaming": True, "pgbouncer": {"enabled": True}},
+        )[0]
+        assert "postgresql://postgres:postgres@my-release-airflow-pgbouncer.default:6543/my-release-metadata?sslmode=disable" == base64.b64decode(
+            doc["data"]["connection"]
+        ).decode(
+            "utf-8"
+        )
+
     def test_postgres_connection_url_name_override(self):
         # nameoverride provided
         doc = render_chart(

--- a/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -580,10 +580,10 @@ class TestBaseChartTest:
             show_only=["templates/secrets/metadata-connection-secret.yaml"],
             values={"pgbouncer": {"enabled": True}},
         )[0]
-        assert "postgresql://postgres:postgres@my-release-pgbouncer.default:6543/my-release-metadata?sslmode=disable" == base64.b64decode(
-            doc["data"]["connection"]
-        ).decode(
-            "utf-8"
+        assert (
+            "postgresql://postgres:postgres@my-release-pgbouncer.default:6543/"
+            "my-release-metadata?sslmode=disable"
+            == base64.b64decode(doc["data"]["connection"]).decode("utf-8")
         )
 
     def test_postgres_connection_url_pgbouncer_use_standard_naming(self):
@@ -593,10 +593,10 @@ class TestBaseChartTest:
             show_only=["templates/secrets/metadata-connection-secret.yaml"],
             values={"useStandardNaming": True, "pgbouncer": {"enabled": True}},
         )[0]
-        assert "postgresql://postgres:postgres@my-release-airflow-pgbouncer.default:6543/my-release-metadata?sslmode=disable" == base64.b64decode(
-            doc["data"]["connection"]
-        ).decode(
-            "utf-8"
+        assert (
+            "postgresql://postgres:postgres@my-release-airflow-pgbouncer.default:6543/"
+            "my-release-metadata?sslmode=disable"
+            == base64.b64decode(doc["data"]["connection"]).decode("utf-8")
         )
 
     def test_postgres_connection_url_name_override(self):


### PR DESCRIPTION
**Issue**

PR #31066 introduced a new option to standardize the naming of the different helm chart resources.
However this didn't include also updating the reference when creating the pgbouncer connection in the
metadata secret. This PR fixes that and makes sure we use the proper hostname for pgbouncer based on
the new option `useStandardNaming`

**How to reproduce**

Helm chart 1.11.0

Deploy airflow helm chart using `useStandardNaming: true` and `pgbouncer.enabled: true`, only when both are enabled the issue is presented, otherwise it works as it should