### PR TITLE
Increase log reader stream loop sleep duration to 1 second

### DIFF
--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 class TaskLogReader:
     """Task log reader."""
 
-    STREAM_LOOP_SLEEP_SECONDS = 0.5
+    STREAM_LOOP_SLEEP_SECONDS = 1
     """Time to sleep between loops while waiting for more logs"""
 
     def read_log_chunks(


### PR DESCRIPTION
One second is plenty fast.  And it only sleeps if it doesn't find on first try.  Nicer to your ES cluster etc.
