### PR TITLE
Update es read query to not use body

### DIFF
--- a/airflow/providers/elasticsearch/provider.yaml
+++ b/airflow/providers/elasticsearch/provider.yaml
@@ -57,7 +57,7 @@ versions:
 dependencies:
   - apache-airflow>=2.5.0
   - apache-airflow-providers-common-sql>=1.3.1
-  - elasticsearch>8,<9
+  - elasticsearch>=8.10,<9
 
 integrations:
   - integration-name: Elasticsearch

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -371,7 +371,7 @@
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.5.0",
-      "elasticsearch>8,<9"
+      "elasticsearch>=8.10,<9"
     ],
     "cross-providers-deps": [
       "common.sql"

--- a/tests/providers/elasticsearch/log/elasticmock/utilities/__init__.py
+++ b/tests/providers/elasticsearch/log/elasticmock/utilities/__init__.py
@@ -213,12 +213,12 @@ def _escape(value):
 class MissingIndexException(NotFoundError):
     """Exception representing a missing index."""
 
-    def __init__(self, msg, body):
+    def __init__(self, msg, query):
         self.msg = msg
-        self.body = body
+        self.query = query
 
     def __str__(self):
-        return f"IndexMissingException[[{self.msg}] missing] with body {self.body}"
+        return f"IndexMissingException[[{self.msg}] missing] with query {self.query}"
 
 
 class SearchFailedException(NotFoundError):


### PR DESCRIPTION
The argument is deprecated and it's advised to use the params directly.
