### PR TITLE
docs: remove extraneous '>' in provider section name

### DIFF
--- a/docs/apache-airflow/howto/set-config.rst
+++ b/docs/apache-airflow/howto/set-config.rst
@@ -66,7 +66,7 @@ For example consider the pretend section ``providers.some_provider``:
 
 .. code-block:: ini
 
-    [providers.some_provider>]
+    [providers.some_provider]
     this_param = true
 
 .. code-block:: bash


### PR DESCRIPTION
Removed the extraneous '>' character from the 'providers.some_provider>' section name in the documentation