### PR TITLE
zoneinfo.ZoneInfo is not available on < Python 3.9

### DIFF
--- a/airflow/serialization/serializers/timezone.py
+++ b/airflow/serialization/serializers/timezone.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import datetime
+import sys
 from typing import TYPE_CHECKING, Any, cast
 
 from airflow.utils.module_loading import qualname
@@ -29,9 +30,13 @@ if TYPE_CHECKING:
 serializers = [
     "pendulum.tz.timezone.FixedTimezone",
     "pendulum.tz.timezone.Timezone",
-    "zoneinfo.ZoneInfo",
     "backports.zoneinfo.ZoneInfo",
 ]
+
+PY39 = sys.version_info >= (3, 9)
+
+if PY39:
+    serializers.append("zoneinfo.ZoneInfo")
 
 deserializers = serializers
 

--- a/airflow/serialization/serializers/timezone.py
+++ b/airflow/serialization/serializers/timezone.py
@@ -88,7 +88,7 @@ def deserialize(classname: str, version: int, data: object) -> Any:
     if "zoneinfo.ZoneInfo" in classname:
         try:
             from zoneinfo import ZoneInfo
-        except ImportError
+        except ImportError:
             from backports.zoneinfo import ZoneInfo
 
         return ZoneInfo(data)

--- a/airflow/serialization/serializers/timezone.py
+++ b/airflow/serialization/serializers/timezone.py
@@ -37,7 +37,7 @@ PY39 = sys.version_info >= (3, 9)
 if PY39:
     serializers.append("zoneinfo.ZoneInfo")
 else:
-    serializers.append("backports.zoneinfo.ZoneInfo"),
+    serializers.append("backports.zoneinfo.ZoneInfo")
 
 deserializers = serializers
 

--- a/airflow/serialization/serializers/timezone.py
+++ b/airflow/serialization/serializers/timezone.py
@@ -30,13 +30,14 @@ if TYPE_CHECKING:
 serializers = [
     "pendulum.tz.timezone.FixedTimezone",
     "pendulum.tz.timezone.Timezone",
-    "backports.zoneinfo.ZoneInfo",
 ]
 
 PY39 = sys.version_info >= (3, 9)
 
 if PY39:
     serializers.append("zoneinfo.ZoneInfo")
+else:
+    serializers.append("backports.zoneinfo.ZoneInfo"),
 
 deserializers = serializers
 
@@ -84,17 +85,11 @@ def deserialize(classname: str, version: int, data: object) -> Any:
     if isinstance(data, int):
         return fixed_timezone(data)
 
-    if classname == "zoneinfo.ZoneInfo":
-        from zoneinfo import ZoneInfo
-
-        return ZoneInfo(data)
-
-    if classname == "backports.zoneinfo.ZoneInfo":
-        # python version might have been upgraded, so we need to check
+    if "zoneinfo.ZoneInfo" in classname:
         try:
-            from backports.zoneinfo import ZoneInfo
-        except ImportError:
             from zoneinfo import ZoneInfo
+        except ImportError
+            from backports.zoneinfo import ZoneInfo
 
         return ZoneInfo(data)
 

--- a/setup.py
+++ b/setup.py
@@ -462,7 +462,7 @@ _devel_only_static_checks = [
 
 _devel_only_tests = [
     "aioresponses",
-    "backports.zoneinfo>=0.2.1;python_version<'3.9'",
+    "backports.zoneinfo>=0.2.1",
     "beautifulsoup4>=4.7.1",
     "coverage>=7.2",
     "pytest",

--- a/setup.py
+++ b/setup.py
@@ -462,7 +462,7 @@ _devel_only_static_checks = [
 
 _devel_only_tests = [
     "aioresponses",
-    "backports.zoneinfo>=0.2.1",
+    "backports.zoneinfo>=0.2.1;python_version<'3.9'",
     "beautifulsoup4>=4.7.1",
     "coverage>=7.2",
     "pytest",


### PR DESCRIPTION
Tests were not functioning due to checks if classes could be imported from serializers.

@Taragolis @ferruzzi 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
