### PR TITLE
Add debug log saying whats being run to `EventScheduler`

### DIFF
--- a/airflow/utils/event_scheduler.py
+++ b/airflow/utils/event_scheduler.py
@@ -20,8 +20,10 @@ from __future__ import annotations
 from sched import scheduler
 from typing import Callable
 
+from airflow.utils.log.logging_mixin import LoggingMixin
 
-class EventScheduler(scheduler):
+
+class EventScheduler(scheduler, LoggingMixin):
     """General purpose event scheduler."""
 
     def call_regular_interval(
@@ -34,6 +36,7 @@ class EventScheduler(scheduler):
         """Call a function at (roughly) a given interval."""
 
         def repeat(*args, **kwargs):
+            self.log.debug("Calling %s", action)
             action(*args, **kwargs)
             # This is not perfect. If we want a timer every 60s, but action
             # takes 10s to run, this will run it every 70s.


### PR DESCRIPTION
It can be difficult to debug issues in things the EventScheduler runs, especially if they don't log anything meaningful themselves.

A simple "Hey, I'm going to run x" debug level log is very useful.