### PR TITLE
Clarify audit log permissions

### DIFF
--- a/docs/apache-airflow/security/audit_logs.rst
+++ b/docs/apache-airflow/security/audit_logs.rst
@@ -28,6 +28,8 @@ They provide a way to track user actions and system events, which can be used to
 In Airflow, audit logs are used to track user actions and system events that occur during the execution of DAGs and tasks.
 They are stored in a database and can be accessed through the Airflow UI.
 
+To be able to see audit logs, a user needs to have the ``Audit Logs.can_read`` permission. Such user will be able to see all audit logs, independently of the DAGs permissions applied.
+
 
 Level of Audit Logs
 --------------------


### PR DESCRIPTION
Clarify how permissions apply to audit logs. We had multiple occurrences where people think that you can only see audit logs related to DAGs that you have read permissions on.  