### PR TITLE
Fix Google cloud tests which are incompatible with `aiohttp==3.8.6`

### DIFF
--- a/tests/providers/google/cloud/hooks/test_cloud_sql.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_sql.py
@@ -1277,7 +1277,7 @@ class TestCloudSQLAsyncHook:
             timer=TimerNoop(),
             traces=[],
             loop=mock.Mock(),
-            session=session,
+            session=None,
         )
         response.status = 200
         mocked_get.return_value = response
@@ -1300,7 +1300,7 @@ class TestCloudSQLAsyncHook:
             timer=TimerNoop(),
             traces=[],
             loop=mock.Mock(),
-            session=session,
+            session=None,
         )
         response.status = 200
         mocked_get.return_value = response

--- a/tests/providers/google/cloud/hooks/test_datafusion.py
+++ b/tests/providers/google/cloud/hooks/test_datafusion.py
@@ -580,7 +580,7 @@ class TestDataFusionHookAsynch:
             timer=TimerNoop(),
             traces=[],
             loop=mock.Mock(),
-            session=session,
+            session=None,
         )
         response.status = 200
         mocked_get.return_value = response
@@ -618,7 +618,7 @@ class TestDataFusionHookAsynch:
             timer=TimerNoop(),
             traces=[],
             loop=mock.Mock(),
-            session=session,
+            session=None,
         )
         response.status = 200
         mocked_get.return_value = response

--- a/tests/providers/google/cloud/hooks/test_mlengine.py
+++ b/tests/providers/google/cloud/hooks/test_mlengine.py
@@ -1060,7 +1060,7 @@ async def test_async_get_job_status_should_execute_successfully(mocked_get):
         timer=TimerNoop(),
         traces=[],
         loop=mock.Mock(),
-        session=session,
+        session=None,
     )
     mocked_get.return_value._headers = {"Content-Type": "application/json;charset=cp1251"}
     mocked_get.return_value._body = b'{"state": "SUCCEEDED"}'
@@ -1083,7 +1083,7 @@ async def test_async_get_job_status_still_running_should_execute_successfully(mo
         timer=TimerNoop(),
         traces=[],
         loop=mock.Mock(),
-        session=session,
+        session=None,
     )
     mocked_get.return_value._headers = {"Content-Type": "application/json;charset=cp1251"}
     mocked_get.return_value._body = b'{"state": "RUNNING"}'


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fix broken main after upgrade to `aiohttp==3.8.6`

```console
FAILED tests/providers/google/cloud/hooks/test_cloud_sql.py::TestCloudSQLAsyncHook::test_async_get_operation_completed_should_execute_successfully - AttributeError: 'function' object has no attribute '_resolve_charset'
FAILED tests/providers/google/cloud/hooks/test_cloud_sql.py::TestCloudSQLAsyncHook::test_async_get_operation_running_should_execute_successfully - AttributeError: 'function' object has no attribute '_resolve_charset'
FAILED tests/providers/google/cloud/hooks/test_datafusion.py::TestDataFusionHookAsynch::test_async_get_pipeline_status_completed_should_execute_successfully[DataFusionPipelineType.BATCH-https://airflow-test-instance-test_project_id-dot-eun1.datafusion.googleusercontent.com/api/v3/namespaces/default/apps/shrubberyPipeline/workflows/DataPipelineWorkflow/runs/123] - AttributeError: 'function' object has no attribute '_resolve_charset'
FAILED tests/providers/google/cloud/hooks/test_datafusion.py::TestDataFusionHookAsynch::test_async_get_pipeline_status_completed_should_execute_successfully[DataFusionPipelineType.STREAM-https://airflow-test-instance-test_project_id-dot-eun1.datafusion.googleusercontent.com/api/v3/namespaces/default/apps/shrubberyPipeline/apsrkss/DataStreamsSparkStreaming/runs/123] - AttributeError: 'function' object has no attribute '_resolve_charset'
FAILED tests/providers/google/cloud/hooks/test_datafusion.py::TestDataFusionHookAsynch::test_async_get_pipeline_status_running_should_execute_successfully[DataFusionPipelineType.BATCH-https://airflow-test-instance-test_project_id-dot-eun1.datafusion.googleusercontent.com/api/v3/namespaces/default/apps/shrubberyPipeline/workflows/DataPipelineWorkflow/runs/123] - AttributeError: 'function' object has no attribute '_resolve_charset'
FAILED tests/providers/google/cloud/hooks/test_datafusion.py::TestDataFusionHookAsynch::test_async_get_pipeline_status_running_should_execute_successfully[DataFusionPipelineType.STREAM-https://airflow-test-instance-test_project_id-dot-eun1.datafusion.googleusercontent.com/api/v3/namespaces/default/apps/shrubberyPipeline/apsrkss/DataStreamsSparkStreaming/runs/123] - AttributeError: 'function' object has no attribute '_resolve_charset'
FAILED tests/providers/google/cloud/hooks/test_mlengine.py::test_async_get_job_status_should_execute_successfully - AttributeError: 'function' object has no attribute '_resolve_charset'
FAILED tests/providers/google/cloud/hooks/test_mlengine.py::test_async_get_job_status_still_running_should_execute_successfully - AttributeError: 'function' object has no attribute '_resolve_charset'
```

That is a bit dumb fix, but locally it resolve issue, as long term we need to think how to migrate such of tests to [`pytest-aiohttp`](https://docs.aiohttp.org/en/stable/testing.html)

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
