### PR TITLE
Fix redis broker URL with useStandardNaming

### DIFF
--- a/chart/templates/secrets/redis-secrets.yaml
+++ b/chart/templates/secrets/redis-secrets.yaml
@@ -76,7 +76,7 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.redis.enabled }}
-  connection: {{ urlJoin (dict "scheme" "redis" "userinfo" (printf ":%s" ((default $random_redis_password .Values.redis.password) | urlquery)) "host" (printf "%s-redis:6379" .Release.Name ) "path" "/0") | b64enc | quote }}
+  connection: {{ urlJoin (dict "scheme" "redis" "userinfo" (printf ":%s" ((default $random_redis_password .Values.redis.password) | urlquery)) "host" (printf "%s-redis:6379" (include "airflow.fullname" .) ) "path" "/0") | b64enc | quote }}
   {{- else }}
   connection: {{ (printf "%s" .Values.data.brokerUrl) | b64enc | quote }}
   {{- end }}

--- a/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -645,6 +645,28 @@ class TestBaseChartTest:
 
         assert obj["preemptionPolicy"] == "PreemptLowerPriority"
 
+    def test_redis_broker_connection_url(self):
+        # no nameoverride, redis
+        doc = render_chart(
+            "my-release",
+            show_only=["templates/secrets/redis-secrets.yaml"],
+            values={"redis": {"enabled": True, "password": "test1234"}},
+        )[1]
+        assert "redis://:test1234@my-release-redis:6379/0" == base64.b64decode(
+            doc["data"]["connection"]
+        ).decode("utf-8")
+
+    def test_redis_broker_connection_url_use_standard_naming(self):
+        # no nameoverride, redis and useStandardNaming
+        doc = render_chart(
+            "my-release",
+            show_only=["templates/secrets/redis-secrets.yaml"],
+            values={"useStandardNaming": True, "redis": {"enabled": True, "password": "test1234"}},
+        )[1]
+        assert "redis://:test1234@my-release-airflow-redis:6379/0" == base64.b64decode(
+            doc["data"]["connection"]
+        ).decode("utf-8")
+
     @staticmethod
     def default_trigger_obj(version):
         if version == "default":


### PR DESCRIPTION
PR https://github.com/apache/airflow/pull/31066 introduced a new option to standardize the naming of the different helm chart resources. However this didn't include the hostname used in the redis connection URL.

How to reproduce

Helm chart 1.11.0

Deploy airflow helm chart using `useStandardNaming: true`, `redis.enabled: true`, and the default `CeleryExecutor`. Worker pods fail as they can't connect to redis.
