### PR TITLE
Fixing typo in airflow kerberos

### DIFF
--- a/airflow/security/kerberos.py
+++ b/airflow/security/kerberos.py
@@ -99,7 +99,7 @@ def renew_from_kt(principal: str | None, keytab: str, exit_on_fail: bool = True)
         subp.wait()
         if subp.returncode != 0:
             log.error(
-                "Couldn't reinit from keytab! `kinit' exited with %s.\n%s\n%s",
+                "Couldn't reinit from keytab! `kinit` exited with %s.\n%s\n%s",
                 subp.returncode,
                 "\n".join(subp.stdout.readlines() if subp.stdout else []),
                 "\n".join(subp.stderr.readlines() if subp.stderr else []),
@@ -176,7 +176,7 @@ def detect_conf_var() -> bool:
 
 def run(principal: str | None, keytab: str):
     """
-    Run the kerbros renewer.
+    Run the kerberos renewer.
 
     :param principal: principal name
     :param keytab: keytab file

--- a/tests/security/test_kerberos.py
+++ b/tests/security/test_kerberos.py
@@ -176,7 +176,7 @@ class TestKerberos:
         assert [lr[2] for lr in log_records] == [
             "Re-initialising kerberos from keytab: "
             "kinit -f -a -r 3600m -k -t keytab -c /tmp/airflow_krb5_ccache test-principal",
-            "Couldn't reinit from keytab! `kinit' exited with 1.\nSTDOUT\nSTDERR",
+            "Couldn't reinit from keytab! `kinit` exited with 1.\nSTDOUT\nSTDERR",
         ]
 
         assert mock_subprocess.mock_calls == [


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Came across a small typo while utilising airflow kerberos. Fixing it

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
