### PR TITLE
Fix usage of cron-descriptor for custom TimeTables since BC in v1.3.0

### DIFF
--- a/airflow/timetables/_cron.py
+++ b/airflow/timetables/_cron.py
@@ -59,10 +59,10 @@ class CronMixin:
             timezone = Timezone(timezone)
         self._timezone = timezone
 
-        descriptor = ExpressionDescriptor(
-            expression=self._expression, casing_type=CasingTypeEnum.Sentence, use_24hour_time_format=True
-        )
         try:
+            descriptor = ExpressionDescriptor(
+                expression=self._expression, casing_type=CasingTypeEnum.Sentence, use_24hour_time_format=True
+            )
             # checking for more than 5 parameters in Cron and avoiding evaluation for now,
             # as Croniter has inconsistent evaluation with other libraries
             if len(croniter(self._expression).expanded) > 5:


### PR DESCRIPTION
When using a custom TimeTable that doesn't provide a CRON expression summary (e.g. : 'Custom TimeTable Plugin'), and if the web UI has not yet load the TimeTable when deserializing the DAG, accessing the grid view will try to parse the custom description as a CRON expression and then cron-descriptor, that introduce a breaking change in v1.3.0 that now calls 'parse' in the ctor of ExpressionDescriptor raise the FormatException outside of the try block

(working great in Airflow v2.4.2 that uses cron-descriptor v1.2.x)

C.f. : https://github.com/Salamek/cron-descriptor/commit/ec9ea4de2533ebacb0b527cb88973992858910f4

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
