### PR TITLE
Helm chart should set AIRFLOW_HOME from airflowHome

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -53,13 +53,8 @@ If release name contains chart name it will be used as a full name.
 {{/* Standard Airflow environment variables */}}
 {{- define "standard_airflow_environment" }}
   # Hard Coded Airflow Envs
-  {{- if .Values.enableBuiltInSecretEnvVars.AIRFLOW__CORE__FERNET_KEY }}
-  - name: AIRFLOW__CORE__FERNET_KEY
-    valueFrom:
-      secretKeyRef:
-        name: {{ template "fernet_key_secret" . }}
-        key: fernet-key
-  {{- end }}
+  - name: AIRFLOW_HOME
+    value: {{ .Values.airflowHome }}
   # For Airflow <2.3, backward compatibility; moved to [database] in 2.3
   {{- if .Values.enableBuiltInSecretEnvVars.AIRFLOW__CORE__SQL_ALCHEMY_CONN }}
   - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -53,6 +53,13 @@ If release name contains chart name it will be used as a full name.
 {{/* Standard Airflow environment variables */}}
 {{- define "standard_airflow_environment" }}
   # Hard Coded Airflow Envs
+  {{- if .Values.enableBuiltInSecretEnvVars.AIRFLOW__CORE__FERNET_KEY }}
+  - name: AIRFLOW__CORE__FERNET_KEY
+    valueFrom:
+      secretKeyRef:
+        name: {{ template "fernet_key_secret" . }}
+        key: fernet-key
+  {{- end }}
   - name: AIRFLOW_HOME
     value: {{ .Values.airflowHome }}
   # For Airflow <2.3, backward compatibility; moved to [database] in 2.3

--- a/helm_tests/airflow_aux/test_airflow_common.py
+++ b/helm_tests/airflow_aux/test_airflow_common.py
@@ -331,6 +331,7 @@ class TestAirflowCommon:
         )
         expected_vars = [
             "AIRFLOW__CORE__FERNET_KEY",
+            "AIRFLOW_HOME",
             "AIRFLOW_CONN_AIRFLOW_DB",
             "AIRFLOW__CELERY__BROKER_URL",
         ]
@@ -355,6 +356,7 @@ class TestAirflowCommon:
         )
         expected_vars = [
             "AIRFLOW__CORE__FERNET_KEY",
+            "AIRFLOW_HOME",
             "AIRFLOW__CORE__SQL_ALCHEMY_CONN",
             "AIRFLOW__DATABASE__SQL_ALCHEMY_CONN",
             "AIRFLOW_CONN_AIRFLOW_DB",

--- a/helm_tests/airflow_core/test_env.py
+++ b/helm_tests/airflow_core/test_env.py
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import jmespath
+
+from tests.charts.helm_template_generator import render_chart
+
+
+def test_should_add_airflow_home():
+    exp_path = "/not/even/a/real/path"
+    docs = render_chart(
+        values={"airflowHome": exp_path},
+        show_only=["templates/webserver/webserver-deployment.yaml"],
+    )
+    assert {"name": "AIRFLOW_HOME", "value": exp_path} in jmespath.search(
+        "spec.template.spec.containers[0].env", docs[0]
+    )

--- a/helm_tests/airflow_core/test_env.py
+++ b/helm_tests/airflow_core/test_env.py
@@ -30,3 +30,13 @@ def test_should_add_airflow_home():
     assert {"name": "AIRFLOW_HOME", "value": exp_path} in jmespath.search(
         "spec.template.spec.containers[0].env", docs[0]
     )
+
+
+def test_should_add_airflow_home_notset():
+    docs = render_chart(
+        values={},
+        show_only=["templates/webserver/webserver-deployment.yaml"],
+    )
+    assert {"name": "AIRFLOW_HOME", "value": "/opt/airflow"} in jmespath.search(
+        "spec.template.spec.containers[0].env", docs[0]
+    )


### PR DESCRIPTION
Currently if you change airflowHome from /opt/airflow to something else it doesn't totally work because the official image hardcodes the env var AIRFLOW_HOME.  This should fix that.