### PR TITLE
openlineage, common.sql: send column lineage from SQL operators.

### DIFF
--- a/tests/integration/providers/openlineage/__init__.py
+++ b/tests/integration/providers/openlineage/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/integration/providers/openlineage/operators/__init__.py
+++ b/tests/integration/providers/openlineage/operators/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/openlineage/utils/test_sqlparser.py
+++ b/tests/providers/openlineage/utils/test_sqlparser.py
@@ -20,7 +20,14 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
-from openlineage.client.facet import SchemaDatasetFacet, SchemaField, SqlJobFacet
+from openlineage.client.facet import (
+    ColumnLineageDatasetFacet,
+    ColumnLineageDatasetFacetFieldsAdditional,
+    ColumnLineageDatasetFacetFieldsAdditionalInputFields,
+    SchemaDatasetFacet,
+    SchemaField,
+    SqlJobFacet,
+)
 from openlineage.client.run import Dataset
 from openlineage.common.sql import DbTableMeta
 
@@ -32,16 +39,6 @@ DB_SCHEMA_NAME = "PUBLIC"
 DB_TABLE_NAME = DbTableMeta("DISCOUNTS")
 
 NAMESPACE = "test_namespace"
-
-SCHEMA_FACET = SchemaDatasetFacet(
-    fields=[
-        SchemaField(name="ID", type="int4"),
-        SchemaField(name="AMOUNT_OFF", type="int4"),
-        SchemaField(name="CUSTOMER_EMAIL", type="varchar"),
-        SchemaField(name="STARTS_ON", type="timestamp"),
-        SchemaField(name="ENDS_ON", type="timestamp"),
-    ]
-)
 
 
 def normalize_name_lower(name: str) -> str:
@@ -56,7 +53,8 @@ class TestSQLParser:
 
         # base check with db, no cross db
         assert SQLParser._get_tables_hierarchy(
-            [DbTableMeta("Db.Schema1.Table1"), DbTableMeta("Db.Schema2.Table2")], normalize_name_lower
+            [DbTableMeta("Db.Schema1.Table1"), DbTableMeta("Db.Schema2.Table2")],
+            normalize_name_lower,
         ) == {None: {"schema1": ["Table1"], "schema2": ["Table2"]}}
 
         # same, with cross db
@@ -148,20 +146,42 @@ class TestSQLParser:
             ]
 
         hook.get_conn.return_value.cursor.return_value.fetchall.side_effect = [
-            rows("TABLE_IN"),
-            rows("TABLE_OUT"),
+            rows("top_delivery_times"),
+            rows("popular_orders_day_of_week"),
         ]
 
+        expected_schema_facet = SchemaDatasetFacet(
+            fields=[
+                SchemaField(name="ID", type="int4"),
+                SchemaField(name="AMOUNT_OFF", type="int4"),
+                SchemaField(name="CUSTOMER_EMAIL", type="varchar"),
+                SchemaField(name="STARTS_ON", type="timestamp"),
+                SchemaField(name="ENDS_ON", type="timestamp"),
+            ]
+        )
+
         expected = (
-            [Dataset(namespace=NAMESPACE, name="PUBLIC.TABLE_IN", facets={"schema": SCHEMA_FACET})],
-            [Dataset(namespace=NAMESPACE, name="PUBLIC.TABLE_OUT", facets={"schema": SCHEMA_FACET})],
+            [
+                Dataset(
+                    namespace=NAMESPACE,
+                    name="PUBLIC.top_delivery_times",
+                    facets={"schema": expected_schema_facet},
+                )
+            ],
+            [
+                Dataset(
+                    namespace=NAMESPACE,
+                    name="PUBLIC.popular_orders_day_of_week",
+                    facets={"schema": expected_schema_facet},
+                )
+            ],
         )
 
         assert expected == parser.parse_table_schemas(
             hook=hook,
             namespace=NAMESPACE,
-            inputs=[DbTableMeta("TABLE_IN")],
-            outputs=[DbTableMeta("TABLE_OUT")],
+            inputs=[DbTableMeta("top_delivery_times")],
+            outputs=[DbTableMeta("popular_orders_day_of_week")],
             database_info=db_info,
         )
 
@@ -173,48 +193,78 @@ class TestSQLParser:
 
         hook = MagicMock()
 
-        def rows(schema, table):
-            return [
-                (schema, table, "ID", 1, "int4"),
-                (schema, table, "AMOUNT_OFF", 2, "int4"),
-                (schema, table, "CUSTOMER_EMAIL", 3, "varchar"),
-                (schema, table, "STARTS_ON", 4, "timestamp"),
-                (schema, table, "ENDS_ON", 5, "timestamp"),
-            ]
+        returned_schema = DB_SCHEMA_NAME if parser_returns_schema else None
+        returned_rows = [
+            [
+                (returned_schema, "top_delivery_times", "order_id", 1, "int4"),
+                (
+                    returned_schema,
+                    "top_delivery_times",
+                    "order_placed_on",
+                    2,
+                    "timestamp",
+                ),
+                (returned_schema, "top_delivery_times", "customer_email", 3, "varchar"),
+            ],
+            [
+                (
+                    returned_schema,
+                    "popular_orders_day_of_week",
+                    "order_day_of_week",
+                    1,
+                    "varchar",
+                ),
+                (
+                    returned_schema,
+                    "popular_orders_day_of_week",
+                    "order_placed_on",
+                    2,
+                    "timestamp",
+                ),
+                (
+                    returned_schema,
+                    "popular_orders_day_of_week",
+                    "orders_placed",
+                    3,
+                    "int4",
+                ),
+            ],
+        ]
 
-        sql = """CREATE TABLE table_out (
-            ID int,
-            AMOUNT_OFF int,
-            CUSTOMER_EMAIL varchar,
-            STARTS_ON timestamp,
-            ENDS_ON timestamp
+        sql = """INSERT INTO popular_orders_day_of_week (order_day_of_week)
+    SELECT EXTRACT(ISODOW FROM order_placed_on) AS order_day_of_week
+      FROM top_delivery_times
             --irrelevant comment
         )
         ;
         """
 
-        hook.get_conn.return_value.cursor.return_value.fetchall.side_effect = [
-            rows(DB_SCHEMA_NAME if parser_returns_schema else None, "TABLE_IN"),
-            rows(DB_SCHEMA_NAME if parser_returns_schema else None, "TABLE_OUT"),
-        ]
+        hook.get_conn.return_value.cursor.return_value.fetchall.side_effect = returned_rows
 
         mock_sql_meta = MagicMock()
         if parser_returns_schema:
-            mock_sql_meta.in_tables = [DbTableMeta("PUBLIC.TABLE_IN")]
-            mock_sql_meta.out_tables = [DbTableMeta("PUBLIC.TABLE_OUT")]
+            mock_sql_meta.in_tables = [DbTableMeta("PUBLIC.top_delivery_times")]
+            mock_sql_meta.out_tables = [DbTableMeta("PUBLIC.popular_orders_day_of_week")]
         else:
-            mock_sql_meta.in_tables = [DbTableMeta("TABLE_IN")]
-            mock_sql_meta.out_tables = [DbTableMeta("TABLE_OUT")]
+            mock_sql_meta.in_tables = [DbTableMeta("top_delivery_times")]
+            mock_sql_meta.out_tables = [DbTableMeta("popular_orders_day_of_week")]
+        mock_column_lineage = MagicMock()
+        mock_column_lineage.descendant.name = "order_day_of_week"
+        mock_lineage = MagicMock()
+        mock_lineage.name = "order_placed_on"
+        mock_lineage.origin.name = "top_delivery_times"
+        mock_lineage.origin.database = None
+        mock_lineage.origin.schema = "PUBLIC" if parser_returns_schema else None
+        mock_column_lineage.lineage = [mock_lineage]
+
+        mock_sql_meta.column_lineage = [mock_column_lineage]
         mock_sql_meta.errors = []
 
         mock_parse.return_value = mock_sql_meta
 
-        formatted_sql = """CREATE TABLE table_out (
-            ID int,
-            AMOUNT_OFF int,
-            CUSTOMER_EMAIL varchar,
-            STARTS_ON timestamp,
-            ENDS_ON timestamp
+        formatted_sql = """INSERT INTO popular_orders_day_of_week (order_day_of_week)
+    SELECT EXTRACT(ISODOW FROM order_placed_on) AS order_day_of_week
+      FROM top_delivery_times
 
 )"""
         expected_schema = "PUBLIC" if parser_returns_schema else "ANOTHER_SCHEMA"
@@ -222,15 +272,46 @@ class TestSQLParser:
             inputs=[
                 Dataset(
                     namespace="myscheme://host:port",
-                    name=f"{expected_schema}.TABLE_IN",
-                    facets={"schema": SCHEMA_FACET},
+                    name=f"{expected_schema}.top_delivery_times",
+                    facets={
+                        "schema": SchemaDatasetFacet(
+                            fields=[
+                                SchemaField(name="order_id", type="int4"),
+                                SchemaField(name="order_placed_on", type="timestamp"),
+                                SchemaField(name="customer_email", type="varchar"),
+                            ]
+                        )
+                    },
                 )
             ],
             outputs=[
                 Dataset(
                     namespace="myscheme://host:port",
-                    name=f"{expected_schema}.TABLE_OUT",
-                    facets={"schema": SCHEMA_FACET},
+                    name=f"{expected_schema}.popular_orders_day_of_week",
+                    facets={
+                        "schema": SchemaDatasetFacet(
+                            fields=[
+                                SchemaField(name="order_day_of_week", type="varchar"),
+                                SchemaField(name="order_placed_on", type="timestamp"),
+                                SchemaField(name="orders_placed", type="int4"),
+                            ]
+                        ),
+                        "columnLineage": ColumnLineageDatasetFacet(
+                            fields={
+                                "order_day_of_week": ColumnLineageDatasetFacetFieldsAdditional(
+                                    inputFields=[
+                                        ColumnLineageDatasetFacetFieldsAdditionalInputFields(
+                                            namespace="myscheme://host:port",
+                                            name=f"{expected_schema}.top_delivery_times",
+                                            field="order_placed_on",
+                                        )
+                                    ],
+                                    transformationDescription="",
+                                    transformationType="",
+                                )
+                            }
+                        ),
+                    },
                 )
             ],
             job_facets={"sql": SqlJobFacet(query=formatted_sql)},


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



This PR enables sending column lineage information retrieved from SQL parser.