### PR TITLE
REST API: Fix wrong plugin schema

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3782,7 +3782,7 @@ components:
         flask_blueprints:
           type: array
           items:
-            type: object
+            type: string
             nullable: true
           description: The flask blueprints
         appbuilder_views:
@@ -3800,13 +3800,13 @@ components:
         global_operator_extra_links:
           type: array
           items:
-            type: object
+            type: string
             nullable: true
           description: The global operator extra links
         operator_extra_links:
           type: array
           items:
-            type: object
+            type: string
             nullable: true
           description: Operator extra links
         source:

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3776,7 +3776,7 @@ components:
         macros:
           type: array
           items:
-            type: object
+            type: string
             nullable: true
           description: The plugin macros
         flask_blueprints:

--- a/airflow/api_connexion/schemas/plugin_schema.py
+++ b/airflow/api_connexion/schemas/plugin_schema.py
@@ -27,12 +27,12 @@ class PluginSchema(Schema):
     name = fields.String()
     hooks = fields.List(fields.String())
     executors = fields.List(fields.String())
-    macros = fields.List(fields.Dict())
-    flask_blueprints = fields.List(fields.Dict())
+    macros = fields.List(fields.String())
+    flask_blueprints = fields.List(fields.String())
     appbuilder_views = fields.List(fields.Dict())
     appbuilder_menu_items = fields.List(fields.Dict())
-    global_operator_extra_links = fields.List(fields.Dict())
-    operator_extra_links = fields.List(fields.Dict())
+    global_operator_extra_links = fields.List(fields.String())
+    operator_extra_links = fields.List(fields.String())
     source = fields.String()
 
 

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1577,15 +1577,15 @@ export interface components {
       /** @description The plugin macros */
       macros?: ({ [key: string]: unknown } | null)[];
       /** @description The flask blueprints */
-      flask_blueprints?: ({ [key: string]: unknown } | null)[];
+      flask_blueprints?: (string | null)[];
       /** @description The appuilder views */
       appbuilder_views?: ({ [key: string]: unknown } | null)[];
       /** @description The Flask Appbuilder menu items */
       appbuilder_menu_items?: ({ [key: string]: unknown } | null)[];
       /** @description The global operator extra links */
-      global_operator_extra_links?: ({ [key: string]: unknown } | null)[];
+      global_operator_extra_links?: (string | null)[];
       /** @description Operator extra links */
-      operator_extra_links?: ({ [key: string]: unknown } | null)[];
+      operator_extra_links?: (string | null)[];
       /** @description The plugin source */
       source?: string | null;
     };

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1575,7 +1575,7 @@ export interface components {
       /** @description The plugin executors */
       executors?: (string | null)[];
       /** @description The plugin macros */
-      macros?: ({ [key: string]: unknown } | null)[];
+      macros?: (string | null)[];
       /** @description The flask blueprints */
       flask_blueprints?: (string | null)[];
       /** @description The appuilder views */

--- a/tests/api_connexion/schemas/test_plugin_schema.py
+++ b/tests/api_connexion/schemas/test_plugin_schema.py
@@ -16,20 +16,64 @@
 # under the License.
 from __future__ import annotations
 
+from flask import Blueprint
+from flask_appbuilder import BaseView
+
 from airflow.api_connexion.schemas.plugin_schema import (
     PluginCollection,
     plugin_collection_schema,
     plugin_schema,
 )
+from airflow.hooks.base import BaseHook
+from airflow.models.baseoperator import BaseOperatorLink
 from airflow.plugins_manager import AirflowPlugin
+
+
+class PluginHook(BaseHook):
+    ...
+
+
+def plugin_macro():
+    ...
+
+
+class MockOperatorLink(BaseOperatorLink):
+    name = "mock_operator_link"
+
+    def get_link(self, operator, *, ti_key) -> str:
+        return "mock_operator_link"
+
+
+bp = Blueprint("mock_blueprint", __name__, url_prefix="/mock_blueprint")
+
+
+class MockView(BaseView):
+    ...
+
+
+appbuilder_menu_items = {
+    "name": "mock_plugin",
+    "href": "https://example.com",
+}
+
+
+class MockPlugin(AirflowPlugin):
+    name = "mock_plugin"
+    flask_blueprints = [bp]
+    appbuilder_views = [{"view": MockView()}]
+    appbuilder_menu_items = [appbuilder_menu_items]
+    global_operator_extra_links = [MockOperatorLink()]
+    operator_extra_links = [MockOperatorLink()]
+    hooks = [PluginHook]
+    macros = [plugin_macro]
 
 
 class TestPluginBase:
     def setup_method(self) -> None:
-        self.mock_plugin = AirflowPlugin()
+        self.mock_plugin = MockPlugin()
         self.mock_plugin.name = "test_plugin"
 
-        self.mock_plugin_2 = AirflowPlugin()
+        self.mock_plugin_2 = MockPlugin()
         self.mock_plugin_2.name = "test_plugin_2"
 
 
@@ -37,14 +81,14 @@ class TestPluginSchema(TestPluginBase):
     def test_serialize(self):
         deserialized_plugin = plugin_schema.dump(self.mock_plugin)
         assert deserialized_plugin == {
-            "appbuilder_menu_items": [],
-            "appbuilder_views": [],
+            "appbuilder_menu_items": [appbuilder_menu_items],
+            "appbuilder_views": [{"view": self.mock_plugin.appbuilder_views[0]["view"]}],
             "executors": [],
-            "flask_blueprints": [],
-            "global_operator_extra_links": [],
-            "hooks": [],
-            "macros": [],
-            "operator_extra_links": [],
+            "flask_blueprints": [str(bp)],
+            "global_operator_extra_links": [str(MockOperatorLink())],
+            "hooks": [str(PluginHook)],
+            "macros": [str(plugin_macro)],
+            "operator_extra_links": [str(MockOperatorLink())],
             "source": None,
             "name": "test_plugin",
         }
@@ -58,26 +102,26 @@ class TestPluginCollectionSchema(TestPluginBase):
         assert deserialized == {
             "plugins": [
                 {
-                    "appbuilder_menu_items": [],
-                    "appbuilder_views": [],
+                    "appbuilder_menu_items": [appbuilder_menu_items],
+                    "appbuilder_views": [{"view": self.mock_plugin.appbuilder_views[0]["view"]}],
                     "executors": [],
-                    "flask_blueprints": [],
-                    "global_operator_extra_links": [],
-                    "hooks": [],
-                    "macros": [],
-                    "operator_extra_links": [],
+                    "flask_blueprints": [str(bp)],
+                    "global_operator_extra_links": [str(MockOperatorLink())],
+                    "hooks": [str(PluginHook)],
+                    "macros": [str(plugin_macro)],
+                    "operator_extra_links": [str(MockOperatorLink())],
                     "source": None,
                     "name": "test_plugin",
                 },
                 {
-                    "appbuilder_menu_items": [],
-                    "appbuilder_views": [],
+                    "appbuilder_menu_items": [appbuilder_menu_items],
+                    "appbuilder_views": [{"view": self.mock_plugin.appbuilder_views[0]["view"]}],
                     "executors": [],
-                    "flask_blueprints": [],
-                    "global_operator_extra_links": [],
-                    "hooks": [],
-                    "macros": [],
-                    "operator_extra_links": [],
+                    "flask_blueprints": [str(bp)],
+                    "global_operator_extra_links": [str(MockOperatorLink())],
+                    "hooks": [str(PluginHook)],
+                    "macros": [str(plugin_macro)],
+                    "operator_extra_links": [str(MockOperatorLink())],
                     "source": None,
                     "name": "test_plugin_2",
                 },


### PR DESCRIPTION
We serialize some plugin's fields as dictionaries leading to errors when accessing the /plugins endpoint.

Here's the error:
ValueError: dictionary update sequence element #0 has length 1; 2 is required

The fields are lists of strings and this PR addresses it.

