### PR TITLE
Extend hooks arguments into `AwsBaseWaiterTrigger`

### DIFF
--- a/airflow/providers/amazon/aws/triggers/base.py
+++ b/airflow/providers/amazon/aws/triggers/base.py
@@ -57,8 +57,10 @@ class AwsBaseWaiterTrigger(BaseTrigger):
     :param aws_conn_id: The Airflow connection used for AWS credentials. To be used to build the hook.
     :param region_name: The AWS region where the resources to watch are. To be used to build the hook.
     :param verify: Whether or not to verify SSL certificates. To be used to build the hook.
+        See: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
     :param botocore_config: Configuration dictionary (key-values) for botocore client.
-        To be used to build the hook.
+        To be used to build the hook. For available key-values see:
+        https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
     """
 
     def __init__(

--- a/airflow/providers/amazon/aws/triggers/base.py
+++ b/airflow/providers/amazon/aws/triggers/base.py
@@ -81,6 +81,7 @@ class AwsBaseWaiterTrigger(BaseTrigger):
         verify: bool | str | None = None,
         botocore_config: dict | None = None,
     ):
+        super().__init__()
         # parameters that should be hardcoded in the child's implem
         self.serialized_fields = serialized_fields
 

--- a/tests/providers/amazon/aws/triggers/test_base.py
+++ b/tests/providers/amazon/aws/triggers/test_base.py
@@ -91,6 +91,17 @@ class TestAwsBaseWaiterTrigger:
 
         assert param_name not in args
 
+    def test_region_name_not_serialized_if_empty_string(self):
+        """
+        Compatibility with previous behaviour when empty string region name not serialised.
+
+        It would evaluate as None, however empty string it is not valid region name in boto3.
+        """
+        self.trigger.region_name = ""
+        _, args = self.trigger.serialize()
+
+        assert "region_name" not in args
+
     def test_serialize_extra_fields(self):
         self.trigger.serialized_fields = {"foo": "bar", "foz": "baz"}
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Follow-up: #34784

Optionally serialise `verify` and `botocore_config` parameters in `AwsBaseWaiterTrigger`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
