### PR TITLE
Introduce a generic export for containerized executor logging

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -46,7 +46,7 @@ from airflow.models.dagrun import DagRun
 from airflow.models.operator import needs_expansion
 from airflow.models.param import ParamsDict
 from airflow.models.taskinstance import TaskReturnCode
-from airflow.settings import IS_K8S_EXECUTOR_POD
+from airflow.settings import IS_EXECUTOR_CONTAINER, IS_K8S_EXECUTOR_POD
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import SCHEDULER_QUEUED_DEPS
 from airflow.typing_compat import Literal
@@ -326,7 +326,7 @@ def _move_task_handlers_to_root(ti: TaskInstance) -> Generator[None, None, None]
     console_handler = next((h for h in root_logger.handlers if h.name == "console"), None)
     with LoggerMutationHelper(root_logger), LoggerMutationHelper(ti.log) as task_helper:
         task_helper.move(root_logger)
-        if IS_K8S_EXECUTOR_POD:
+        if IS_K8S_EXECUTOR_POD or IS_EXECUTOR_CONTAINER:
             if console_handler and console_handler not in root_logger.handlers:
                 root_logger.addHandler(console_handler)
         yield

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -578,6 +578,10 @@ IS_K8S_OR_K8SCELERY_EXECUTOR = conf.get("core", "EXECUTOR") in {
     executor_constants.CELERY_KUBERNETES_EXECUTOR,
     executor_constants.LOCAL_KUBERNETES_EXECUTOR,
 }
+
+# Executors can set this to true to configure logging correctly for
+# containerized executors.
+IS_EXECUTOR_CONTAINER = bool(os.environ.get("AIRFLOW_IS_EXECUTOR_CONTAINER", ""))
 IS_K8S_EXECUTOR_POD = bool(os.environ.get("AIRFLOW_IS_K8S_EXECUTOR_POD", ""))
 """Will be True if running in kubernetes executor pod."""
 

--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -209,9 +209,9 @@ class RedirectStdHandler(StreamHandler):
     @property
     def stream(self):
         """Returns current stream."""
-        from airflow.settings import IS_K8S_EXECUTOR_POD
+        from airflow.settings import IS_EXECUTOR_CONTAINER, IS_K8S_EXECUTOR_POD
 
-        if IS_K8S_EXECUTOR_POD:
+        if IS_K8S_EXECUTOR_POD or IS_EXECUTOR_CONTAINER:
             return self._orig_stream
         if self._use_stderr:
             return sys.stderr

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -733,8 +733,10 @@ class TestLogsfromTaskRunCommand:
                 external_executor_id="ABCD12345",
             )
 
-    @pytest.mark.parametrize("is_k8s", ["true", ""])
-    def test_logging_with_run_task_stdout_k8s_executor_pod(self, is_k8s):
+    @pytest.mark.parametrize(
+        "is_k8s, is_container_exec", [("true", "true"), ("true", ""), ("", "true"), ("", "")]
+    )
+    def test_logging_with_run_task_stdout_k8s_executor_pod(self, is_k8s, is_container_exec):
         """
         When running task --local as k8s executor pod, all logging should make it to stdout.
         Otherwise, all logging after "running TI" is redirected to logs (and the actual log
@@ -748,7 +750,10 @@ class TestLogsfromTaskRunCommand:
         import subprocess
 
         with mock.patch.dict(
-            "os.environ", AIRFLOW_IS_K8S_EXECUTOR_POD=is_k8s, PYTHONPATH=os.fspath(AIRFLOW_SOURCES_ROOT)
+            "os.environ",
+            AIRFLOW_IS_K8S_EXECUTOR_POD=is_k8s,
+            AIRFLOW_IS_EXECUTOR_CONTAINER=is_container_exec,
+            PYTHONPATH=os.fspath(AIRFLOW_SOURCES_ROOT),
         ):
             with subprocess.Popen(
                 args=[sys.executable, "-m", "airflow", *self.task_args, "-S", self.dag_path],
@@ -764,7 +769,7 @@ class TestLogsfromTaskRunCommand:
                 found_start = True
             if found_start:
                 lines.append(line)
-        if is_k8s:
+        if any((is_k8s, is_container_exec)):
             # 10 is arbitrary, but, with enough padding to hopefully not be flakey
             assert len(lines) > 10
             self.assert_log_line("Starting attempt 1 of 1", lines)


### PR DESCRIPTION
### Context
Pulling this change out of #34381 into a separate PR as requested [here](https://github.com/apache/airflow/pull/34381#discussion_r1327980137) by @eladkal
 
### Overview
A new logging environment variable to enable task logs to work correctly in containerized executors. K8s has an approach for this, which is followed closely when making it generic in this change. However, I did not convert K8s executor te this new mechanism to keep the change set minimal and reduce blast radius. A follow-up change can be done for this.

### Testing
- unit test updated and passing as expected
- UAT testing done with the ECS Executor as part of #34381


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
