### PR TITLE
Update documentation to enable test connection

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -368,7 +368,7 @@ paths:
       summary: Test a connection
       description: |
         Test a connection.
-        Testing Connections is disabled by default set test_connection flag to enabled in Airflow configuration (airflow.cfg).
+        Testing Connections is disabled by default. Set the "test_connection" flag to "Enabled" in the "core" section of Airflow configuration (airflow.cfg) to enable testing of collections.
         It can also be controlled by the environment variable AIRFLOW__CORE__TEST_CONNECTION.
 
         *New in version 2.2.0*

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -368,6 +368,8 @@ paths:
       summary: Test a connection
       description: |
         Test a connection.
+         Testing Connections is disabled by default set test_connection flag to enabled in Airflow configuration (airflow.cfg).
+         It can also be controlled by the environment variable AIRFLOW__CORE__TEST_CONNECTION.
 
         *New in version 2.2.0*
       x-openapi-router-controller: airflow.api_connexion.endpoints.connection_endpoint

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -368,7 +368,13 @@ paths:
       summary: Test a connection
       description: |
         Test a connection.
-        Testing Connections is disabled by default. Set the "test_connection" flag to "Enabled" in the "core" section of Airflow configuration (airflow.cfg) to enable testing of collections.
+        For security reasons, the test connection functionality is disabled by default across Airflow UI, API and CLI.
+        For more information on capabilities of users, see the documentation:
+        https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html#capabilities-of-authenticated-ui-users.
+        It is strongly advised to not enable the feature until you make sure that only
+        highly trusted UI/API users have "edit connection" permissions.
+
+        Set the "test_connection" flag to "Enabled" in the "core" section of Airflow configuration (airflow.cfg) to enable testing of collections.
         It can also be controlled by the environment variable AIRFLOW__CORE__TEST_CONNECTION.
 
         *New in version 2.2.0*

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -368,6 +368,7 @@ paths:
       summary: Test a connection
       description: |
         Test a connection.
+
         For security reasons, the test connection functionality is disabled by default across Airflow UI, API and CLI.
         For more information on capabilities of users, see the documentation:
         https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html#capabilities-of-authenticated-ui-users.
@@ -375,7 +376,7 @@ paths:
         highly trusted UI/API users have "edit connection" permissions.
 
         Set the "test_connection" flag to "Enabled" in the "core" section of Airflow configuration (airflow.cfg) to enable testing of collections.
-        It can also be controlled by the environment variable AIRFLOW__CORE__TEST_CONNECTION.
+        It can also be controlled by the environment variable `AIRFLOW__CORE__TEST_CONNECTION`.
 
         *New in version 2.2.0*
       x-openapi-router-controller: airflow.api_connexion.endpoints.connection_endpoint

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -368,8 +368,8 @@ paths:
       summary: Test a connection
       description: |
         Test a connection.
-         Testing Connections is disabled by default set test_connection flag to enabled in Airflow configuration (airflow.cfg).
-         It can also be controlled by the environment variable AIRFLOW__CORE__TEST_CONNECTION.
+        Testing Connections is disabled by default set test_connection flag to enabled in Airflow configuration (airflow.cfg).
+        It can also be controlled by the environment variable AIRFLOW__CORE__TEST_CONNECTION.
 
         *New in version 2.2.0*
       x-openapi-router-controller: airflow.api_connexion.endpoints.connection_endpoint

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -2567,8 +2567,9 @@ export interface operations {
   };
   /**
    * Test a connection.
-   * Testing Connections is disabled by default set test_connection flag to enabled in Airflow configuration (airflow.cfg).
-   * It can also be controlled by the environment variable AIRFLOW__CORE__TEST_CONNECTION.
+   *  Testing Connections is disabled by default set test_connection flag to enabled in Airflow configuration (airflow.cfg).
+   *  It can also be controlled by the environment variable AIRFLOW__CORE__TEST_CONNECTION.
+   *
    * *New in version 2.2.0*
    */
   test_connection: {

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -44,6 +44,15 @@ export interface paths {
     /**
      * Test a connection.
      *
+     * For security reasons, the test connection functionality is disabled by default across Airflow UI, API and CLI.
+     * For more information on capabilities of users, see the documentation:
+     * https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html#capabilities-of-authenticated-ui-users.
+     * It is strongly advised to not enable the feature until you make sure that only
+     * highly trusted UI/API users have "edit connection" permissions.
+     *
+     * Set the "test_connection" flag to "Enabled" in the "core" section of Airflow configuration (airflow.cfg) to enable testing of collections.
+     * It can also be controlled by the environment variable `AIRFLOW__CORE__TEST_CONNECTION`.
+     *
      * *New in version 2.2.0*
      */
     post: operations["test_connection"];
@@ -2567,6 +2576,15 @@ export interface operations {
   };
   /**
    * Test a connection.
+   *
+   * For security reasons, the test connection functionality is disabled by default across Airflow UI, API and CLI.
+   * For more information on capabilities of users, see the documentation:
+   * https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html#capabilities-of-authenticated-ui-users.
+   * It is strongly advised to not enable the feature until you make sure that only
+   * highly trusted UI/API users have "edit connection" permissions.
+   *
+   * Set the "test_connection" flag to "Enabled" in the "core" section of Airflow configuration (airflow.cfg) to enable testing of collections.
+   * It can also be controlled by the environment variable `AIRFLOW__CORE__TEST_CONNECTION`.
    *
    * *New in version 2.2.0*
    */

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -2567,8 +2567,6 @@ export interface operations {
   };
   /**
    * Test a connection.
-   *  Testing Connections is disabled by default set test_connection flag to enabled in Airflow configuration (airflow.cfg).
-   *  It can also be controlled by the environment variable AIRFLOW__CORE__TEST_CONNECTION.
    *
    * *New in version 2.2.0*
    */

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -2567,7 +2567,8 @@ export interface operations {
   };
   /**
    * Test a connection.
-   *
+   * Testing Connections is disabled by default set test_connection flag to enabled in Airflow configuration (airflow.cfg).
+   * It can also be controlled by the environment variable AIRFLOW__CORE__TEST_CONNECTION.
    * *New in version 2.2.0*
    */
   test_connection: {

--- a/docs/apache-airflow/howto/connection.rst
+++ b/docs/apache-airflow/howto/connection.rst
@@ -205,7 +205,7 @@ AIRFLOW__CORE__TEST_CONNECTION.
 
 The following values are accepted for this config param:
 
-* Disabled: Disables the test connection functionality and disables(greys out) the Test Connection button in the UI.This is also the default value set in the Airflow configuration.
+* Disabled: Disables the test connection functionality and disables the Test Connection button in the UI.This is also the default value set in the Airflow configuration.
 * Enabled: Enables the test connection functionality and activates the Test Connection button in the UI.
 * Hidden: Disables the test connection functionality and hides the Test Connection button in UI.
 

--- a/docs/apache-airflow/howto/connection.rst
+++ b/docs/apache-airflow/howto/connection.rst
@@ -201,15 +201,15 @@ The availability of the
 functionality can be controlled by the test_connection flag in
 the core section of the Airflow configuration (airflow.cfg).
 It can also be controlled by the environment variable
-AIRFLOW__CORE__TEST_CONNECTION.
+``AIRFLOW__CORE__TEST_CONNECTION``.
 
 The following values are accepted for this config param:
 
-* Disabled: Disables the test connection functionality and disables the Test Connection button in the UI.This is also the default value set in the Airflow configuration.
+* Disabled: Disables the test connection functionality and disables the Test Connection button in the UI. This is also the default value set in the Airflow configuration.
 * Enabled: Enables the test connection functionality and activates the Test Connection button in the UI.
 * Hidden: Disables the test connection functionality and hides the Test Connection button in UI.
 
-After enabling Test Connection, it can be used from
+After enabling Test Connection, it can be used from the
 :ref:`create <creating_connection_ui>` or :ref:`edit <editing_connection_ui>` connection page in the UI, through calling
 :doc:`Connections REST API </stable-rest-api-ref/>`, or running the ``airflow connections test`` :ref:`CLI command <cli>`.
 

--- a/docs/apache-airflow/howto/connection.rst
+++ b/docs/apache-airflow/howto/connection.rst
@@ -190,8 +190,20 @@ Passwords cannot be manipulated or read without the key. For information on conf
 
 Testing Connections
 ^^^^^^^^^^^^^^^^^^^
+Testing Connections is disabled
+by default across Airflow UI, API and CLI. The availability of the
+functionality can be controlled by the test_connection flag in
+the core section of the Airflow configuration (airflow.cfg).
+It can also be controlled by the environment variable
+AIRFLOW__CORE__TEST_CONNECTION.
 
-Airflow Web UI, REST API, and CLI allow you to test connections. The test connection feature can be used from
+The following values are accepted for this config param:
+
+* Disabled: Disables the test connection functionality and disables(greys out) the Test Connection button in the UI.This is also the default value set in the Airflow configuration.
+* Enabled: Enables the test connection functionality and activates the Test Connection button in the UI.
+* Hidden: Disables the test connection functionality and hides the Test Connection button in UI.
+
+After enabling Test Connection, it can be used from
 :ref:`create <creating_connection_ui>` or :ref:`edit <editing_connection_ui>` connection page in the UI, through calling
 :doc:`Connections REST API </stable-rest-api-ref/>`, or running the ``airflow connections test`` :ref:`CLI command <cli>`.
 

--- a/docs/apache-airflow/howto/connection.rst
+++ b/docs/apache-airflow/howto/connection.rst
@@ -190,8 +190,14 @@ Passwords cannot be manipulated or read without the key. For information on conf
 
 Testing Connections
 ^^^^^^^^^^^^^^^^^^^
-Testing Connections is disabled
-by default across Airflow UI, API and CLI. The availability of the
+For security reasons, the test connection functionality is disabled by default across Airflow UI, API and CLI.
+
+For more information on capabilities of users, see the documentation:
+https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html#capabilities-of-authenticated-ui-users.
+It is strongly advised to not enable the feature until you make sure that only
+highly trusted UI/API users have "edit connection" permissions.
+
+The availability of the
 functionality can be controlled by the test_connection flag in
 the core section of the Airflow configuration (airflow.cfg).
 It can also be controlled by the environment variable


### PR DESCRIPTION
with [PR](https://github.com/apache/airflow/pull/32052) now testing connections is disabled by default, few docs were not updated with that information this PR is to update docs 

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
