### PR TITLE
Add extra fields to plugins endpoint

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3833,6 +3833,24 @@ components:
           type: string
           description: The plugin source
           nullable: true
+        ti_deps:
+          type: array
+          items:
+              type: string
+              nullable: true
+          description: The plugin task instance dependencies
+        listeners:
+          type: array
+          items:
+              type: string
+              nullable: true
+          description: The plugin listeners
+        timetables:
+          type: array
+          items:
+              type: string
+              nullable: true
+          description: The plugin timetables
 
     PluginCollection:
       type: object

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3837,19 +3837,16 @@ components:
           type: array
           items:
               type: string
-              nullable: true
           description: The plugin task instance dependencies
         listeners:
           type: array
           items:
               type: string
-              nullable: true
           description: The plugin listeners
         timetables:
           type: array
           items:
               type: string
-              nullable: true
           description: The plugin timetables
 
     PluginCollection:

--- a/airflow/api_connexion/schemas/plugin_schema.py
+++ b/airflow/api_connexion/schemas/plugin_schema.py
@@ -34,6 +34,9 @@ class PluginSchema(Schema):
     global_operator_extra_links = fields.List(fields.String())
     operator_extra_links = fields.List(fields.String())
     source = fields.String()
+    ti_deps = fields.List(fields.String())
+    listeners = fields.List(fields.String())
+    timetables = fields.List(fields.String())
 
 
 class PluginCollection(NamedTuple):

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -78,14 +78,16 @@ PLUGINS_ATTRIBUTES_TO_DUMP = {
     "hooks",
     "executors",
     "macros",
+    "admin_views",
     "flask_blueprints",
+    "menu_links",
     "appbuilder_views",
     "appbuilder_menu_items",
     "global_operator_extra_links",
     "operator_extra_links",
+    "source",
     "ti_deps",
     "timetables",
-    "source",
     "listeners",
 }
 

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1598,11 +1598,11 @@ export interface components {
       /** @description The plugin source */
       source?: string | null;
       /** @description The plugin task instance dependencies */
-      ti_deps?: (string | null)[];
+      ti_deps?: string[];
       /** @description The plugin listeners */
-      listeners?: (string | null)[];
+      listeners?: string[];
       /** @description The plugin timetables */
-      timetables?: (string | null)[];
+      timetables?: string[];
     };
     /**
      * @description A collection of plugin.

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1597,6 +1597,12 @@ export interface components {
       operator_extra_links?: (string | null)[];
       /** @description The plugin source */
       source?: string | null;
+      /** @description The plugin task instance dependencies */
+      ti_deps?: (string | null)[];
+      /** @description The plugin listeners */
+      listeners?: (string | null)[];
+      /** @description The plugin timetables */
+      timetables?: (string | null)[];
     };
     /**
      * @description A collection of plugin.

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -106,6 +106,7 @@ from airflow.models.dataset import DagScheduleDatasetReference, DatasetDagRunQue
 from airflow.models.operator import needs_expansion
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance, TaskInstanceNote
+from airflow.plugins_manager import PLUGINS_ATTRIBUTES_TO_DUMP
 from airflow.providers_manager import ProvidersManager
 from airflow.security import permissions
 from airflow.ti_deps.dep_context import DepContext
@@ -4521,19 +4522,7 @@ class PluginView(AirflowBaseView):
         permissions.ACTION_CAN_ACCESS_MENU,
     ]
 
-    plugins_attributes_to_dump = [
-        "hooks",
-        "executors",
-        "macros",
-        "admin_views",
-        "flask_blueprints",
-        "menu_links",
-        "appbuilder_views",
-        "appbuilder_menu_items",
-        "global_operator_extra_links",
-        "operator_extra_links",
-        "source",
-    ]
+    plugins_attributes_to_dump = PLUGINS_ATTRIBUTES_TO_DUMP
 
     @expose("/plugin")
     @auth.has_access_website()

--- a/tests/api_connexion/schemas/test_plugin_schema.py
+++ b/tests/api_connexion/schemas/test_plugin_schema.py
@@ -91,6 +91,9 @@ class TestPluginSchema(TestPluginBase):
             "operator_extra_links": [str(MockOperatorLink())],
             "source": None,
             "name": "test_plugin",
+            "ti_deps": [],
+            "listeners": [],
+            "timetables": [],
         }
 
 
@@ -112,6 +115,9 @@ class TestPluginCollectionSchema(TestPluginBase):
                     "operator_extra_links": [str(MockOperatorLink())],
                     "source": None,
                     "name": "test_plugin",
+                    "ti_deps": [],
+                    "listeners": [],
+                    "timetables": [],
                 },
                 {
                     "appbuilder_menu_items": [appbuilder_menu_items],
@@ -124,6 +130,9 @@ class TestPluginCollectionSchema(TestPluginBase):
                     "operator_extra_links": [str(MockOperatorLink())],
                     "source": None,
                     "name": "test_plugin_2",
+                    "ti_deps": [],
+                    "listeners": [],
+                    "timetables": [],
                 },
             ],
             "total_entries": 2,

--- a/tests/cli/commands/test_plugins_command.py
+++ b/tests/cli/commands/test_plugins_command.py
@@ -61,7 +61,9 @@ class TestPluginsCommand:
         assert info == [
             {
                 "name": "test_plugin",
+                "admin_views": [],
                 "macros": ["tests.plugins.test_plugin.plugin_macro"],
+                "menu_links": [],
                 "executors": ["tests.plugins.test_plugin.PluginExecutor"],
                 "flask_blueprints": [
                     "<flask.blueprints.Blueprint: name='test_plugin' import_name='tests.plugins.test_plugin'>"


### PR DESCRIPTION
I added three extra fields, ti_deps, timetables, and listeners which I think are worth having since they will help in visualizing if those are included in a plugin.

I also found out that the UI has admin_views and menu_links which seems to come from airflow 1 but for consistency, I merged the attributes for both UI & webserver to be the same. The REST API does not have these two attributes as I feel they will soon be removed.

