### PR TITLE
Temporarily disable PyPI constrainst generation

### DIFF
--- a/.github/actions/build-ci-images/action.yml
+++ b/.github/actions/build-ci-images/action.yml
@@ -39,12 +39,12 @@ runs:
       run: >
         breeze release-management generate-constraints --run-in-parallel
         --airflow-constraints-mode constraints-source-providers
-    - name: "Generate PyPI constraints"
-      shell: bash
-      run: >
-        breeze release-management generate-constraints --run-in-parallel
-        --airflow-constraints-mode constraints
-      if: ${{ inputs.build-provider-packages != 'true' }}
+#    - name: "Generate PyPI constraints"
+#      shell: bash
+#      run: >
+#        breeze release-management generate-constraints --run-in-parallel
+#        --airflow-constraints-mode constraints
+#      if: ${{ inputs.build-provider-packages != 'true' }}
     - name: "Print dependency upgrade summary"
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1683,8 +1683,8 @@ jobs:
               --airflow-constraints-mode constraints-source-providers
           breeze release-management generate-constraints \
               --run-in-parallel --airflow-constraints-mode constraints-no-providers
-          breeze release-management generate-constraints \
-              --run-in-parallel --airflow-constraints-mode constraints
+#          breeze release-management generate-constraints \
+#              --run-in-parallel --airflow-constraints-mode constraints
         env:
           PYTHON_VERSIONS: ${{ needs.build-info.outputs.python-versions-list-as-string }}
       - name: "Set constraints branch name"


### PR DESCRIPTION
PIP recently started backtracking with constraint generation and in order to fix it, more thorough investigation is needed.

Source constraints generation works fine, only PyPI one is a problem. We are disabling it now to fix it temporarily.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
