### PR TITLE
Update dags.rst docs to put SubDag deprecation note right after the SubDag…

### DIFF
--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -677,6 +677,11 @@ This is especially useful if your tasks are built dynamically from configuration
 SubDAGs
 -------
 
+.. note::
+
+    SubDAG is deprecated hence TaskGroup is always the preferred choice.
+
+
 Sometimes, you will find that you are regularly adding exactly the same set of tasks to every DAG, or you want to group a lot of tasks into a single, logical unit. This is what SubDAGs are for.
 
 For example, here's a DAG that has a lot of parallel tasks in two sections:
@@ -753,10 +758,6 @@ You can see the core differences between these two constructs.
 +--------------------------------------------------------+--------------------------------------------------------+
 | Simple construct declaration with context manager      |  Complex DAG factory with naming restrictions          |
 +--------------------------------------------------------+--------------------------------------------------------+
-
-.. note::
-
-    SubDAG is deprecated hence TaskGroup is always the preferred choice.
 
 
 


### PR DESCRIPTION
Small doc change to save time for people by letting them know up front that SubDag feature is deprecated and TaskGroup's should be used instead.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

---
