### PR TITLE
Use requires_access to check read permission on dag instead of checking it explicitly

### DIFF
--- a/airflow/api_connexion/endpoints/dag_warning_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_warning_endpoint.py
@@ -22,7 +22,6 @@ from flask import g
 from sqlalchemy import select
 
 from airflow.api_connexion import security
-from airflow.api_connexion.exceptions import PermissionDenied
 from airflow.api_connexion.parameters import apply_sorting, check_limit, format_parameters
 from airflow.api_connexion.schemas.dag_warning_schema import (
     DagWarningCollection,
@@ -40,7 +39,12 @@ if TYPE_CHECKING:
     from airflow.api_connexion.types import APIResponse
 
 
-@security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_WARNING)])
+@security.requires_access(
+    [
+        (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+        (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_WARNING),
+    ]
+)
 @format_parameters({"limit": check_limit})
 @provide_session
 def get_dag_warnings(
@@ -60,8 +64,6 @@ def get_dag_warnings(
     allowed_filter_attrs = ["dag_id", "warning_type", "message", "timestamp"]
     query = select(DagWarningModel)
     if dag_id:
-        if not get_airflow_app().appbuilder.sm.can_read_dag(dag_id, g.user):
-            raise PermissionDenied(detail=f"User not allowed to access this DAG: {dag_id}")
         query = query.where(DagWarningModel.dag_id == dag_id)
     else:
         readable_dags = get_airflow_app().appbuilder.sm.get_accessible_dag_ids(g.user)


### PR DESCRIPTION
This PR moves checking the read access on DAG resource to `requires_access` when `dag_id` parameter is not None, it's not a bug fix, both versions of code do the exact same thing. 