### PR TITLE
Fix the dags count filter in webserver home page

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -830,7 +830,9 @@ class Airflow(AirflowBaseView):
 
             is_paused_count = dict(
                 session.execute(
-                    select(DagModel.is_paused, func.count(DagModel.dag_id)).group_by(DagModel.is_paused)
+                    all_dags.with_only_columns([DagModel.is_paused, func.count()]).group_by(
+                        DagModel.is_paused
+                    )
                 ).all()
             )
 


### PR DESCRIPTION
This PR revert a change added by mistake to #33810, this change introduced a bug in the dags count in the webserver home page. (https://github.com/apache/airflow/commit/b470c6bdcc801bcd57c4008a823bd768405d1736#r129957716)