### PR TITLE
Fix tests to respond to Python 3.12 handling of utcnow in sentry-sdk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -363,7 +363,7 @@ rabbitmq = [
 ]
 sentry = [
     "blinker>=1.1",
-    "sentry-sdk>=0.8.0",
+    "sentry-sdk>=1.32.0",
 ]
 statsd = [
     "statsd>=3.3.0",

--- a/tests/core/test_sentry.py
+++ b/tests/core/test_sentry.py
@@ -56,7 +56,7 @@ TASK_DATA = {
     "duration": None,
 }
 
-CRUMB_DATE = datetime.datetime(2019, 5, 15)
+CRUMB_DATE = datetime.datetime(2019, 5, 15, tzinfo=datetime.timezone.utc)
 CRUMB = {
     "timestamp": CRUMB_DATE,
     "type": "default",


### PR DESCRIPTION
The sentry-sdk 1.32.0 released on 11th of October fixed handling of utcnow to make it future-compatible with Python 3.12. The breadcrumb timestamp returned was naive and now it is timezone aware with utc specified explicitly as timezone. This broke our tests.

The change in sentry that impacted it is
https://github.com/getsentry/sentry-python/pull/2415

We use the opportunity also to bump sentry sdk minimum version to be 1.32.0 from very old 0.8.0 (from 2019). Sentry is a service, so they generally always want you to use the latest version, and sentry has very little requirements on its own to cause conflicts (for Python 3.8+ it only requires "certifi" without any specific limitations)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
