### PR TITLE
Consolidate the permissions name in SlaMissModelView

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4016,6 +4016,11 @@ class SlaMissModelView(AirflowModelView):
     class_permission_name = permissions.RESOURCE_SLA_MISS
     method_permission_name = {
         "list": "read",
+        "action_muldelete": "delete",
+        "action_mulnotificationsent": "edit",
+        "action_mulnotificationsentfalse": "edit",
+        "action_mulemailsent": "edit",
+        "action_mulemailsentfalse": "edit",
     }
 
     base_permissions = [


### PR DESCRIPTION
In all the other views, we use the permission `delete` for muldelete action and edit for all the set actions, but in SlaMiss, we use these permissions:
![image](https://github.com/apache/airflow/assets/21311487/a055b69f-4d5d-4f4f-8709-404fb4058da2)

