### PR TITLE
Clean local tags in tag_providers for network issues with Github

### DIFF
--- a/dev/README_RELEASE_PROVIDER_PACKAGES.md
+++ b/dev/README_RELEASE_PROVIDER_PACKAGES.md
@@ -311,6 +311,11 @@ twine upload -r pypi ${AIRFLOW_REPO_ROOT}/dist/*
 Assume that your remote for apache repository is called `apache` you should now
 set tags for the providers in the repo.
 
+Sometimes in cases when there is a connectivity issue to Github, it might be possible that local tags get created
+and lead to annoying errors. The default behaviour would be to clean such local tags up.
+
+If you want to disable this behaviour, set the env **CLEAN_LOCAL_TAGS** to false.
+
 ```shell script
 ./dev/provider_packages/tag_providers.sh
 ```
@@ -952,6 +957,11 @@ If you decided to remove some packages from the release make sure to do amend th
 
 Assume that your remote for apache repository is called `apache` you should now
 set tags for the providers in the repo.
+
+Sometimes in cases when there is a connectivity issue to Github, it might be possible that local tags get created
+and lead to annoying errors. The default behaviour would be to clean such local tags up.
+
+If you want to disable this behaviour, set the env **CLEAN_LOCAL_TAGS** to false.
 
 ```shell script
 ./dev/provider_packages/tag_providers.sh

--- a/dev/provider_packages/tag_providers.sh
+++ b/dev/provider_packages/tag_providers.sh
@@ -35,6 +35,18 @@ do
     { git tag "${tag}" -m "Release $(date '+%Y-%m-%d') of providers" && tags+=("$tag") ; } || true
    fi
 done
+
 if [[ -n "${tags:-}" && "${#tags}" -gt 0 ]]; then
-   git push $remote "${tags[@]}"
+   if git push $remote "${tags[@]}"; then
+       echo "Tags pushed successfully"
+   else
+       echo "Failed to push tags, probably a connectivity issue to Github"
+       CLEAN_LOCAL_TAGS="${CLEAN_LOCAL_TAGS:-true}"
+       if [[ "$CLEAN_LOCAL_TAGS" == "true" ]]; then
+           echo "Cleaning up local tags..."
+           git tag -d "${tags[@]}"
+       else
+           echo "Local tags are not cleaned up, unset CLEAN_LOCAL_TAGS or set to true"
+       fi
+   fi
 fi


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

As reported on slack, sometimes due to network connectivity issues with Github, our tag_providers.sh script creates tags locally with errors like:
```
➜  airflow git:(main) ./dev/provider_packages/tag_providers.sh
fatal: tag 'providers-airbyte/3.4.0rc1' already exists
fatal: tag 'providers-alibaba/2.6.0rc1' already exists
fatal: tag 'providers-amazon/8.8.0rc1' already exists
fatal: tag 'providers-apache-beam/5.3.0rc1' already exists
fatal: tag 'providers-apache-cassandra/3.3.0rc1' already exists
fatal: tag 'providers-apache-drill/2.5.0rc1' already exists
fatal: tag 'providers-apache-druid/3.6.0rc1' already exists
fatal: tag 'providers-apache-flink/1.2.0rc1' already exists
fatal: tag 'providers-apache-hdfs/4.2.0rc1' already exists
fatal: tag 'providers-apache-hive/6.2.0rc1' already exists
fatal: tag 'providers-apache-impala/1.2.0rc1' already exists
fatal: tag 'providers-apache-kafka/1.2.0rc1' already exists
fatal: tag 'providers-apache-kylin/3.3.0rc1' already exists
fatal: tag 'providers-apache-livy/3.6.0rc1' already exists
fatal: tag 'providers-apache-pig/4.2.0rc1' already exists
fatal: tag 'providers-apache-pinot/4.2.0rc1' already exists
fatal: tag 'providers-apache-spark/4.2.0rc1' already exists
fatal: tag 'providers-apache-sqoop/4.1.0rc1' already exists
fatal: tag 'providers-apprise/1.1.0rc1' already exists
fatal: tag 'providers-arangodb/2.3.0rc1' already exists
fatal: tag 'providers-asana/2.3.0rc1' already exists
fatal: tag 'providers-atlassian-jira/2.2.0rc1' already exists
fatal: tag 'providers-celery/3.4.0rc1' already exists
fatal: tag 'providers-cloudant/3.3.0rc1' already exists
fatal: tag 'providers-cncf-kubernetes/7.7.0rc1' already exists
fatal: tag 'providers-common-sql/1.8.0rc1' already exists
fatal: tag 'providers-daskexecutor/1.1.0rc1' already exists
fatal: tag 'providers-databricks/4.6.0rc1' already exists
fatal: tag 'providers-datadog/3.4.0rc1' already exists
fatal: tag 'providers-dbt-cloud/3.4.0rc1' already exists
fatal: tag 'providers-dingding/3.3.0rc1' already exists
fatal: tag 'providers-discord/3.4.0rc1' already exists
fatal: tag 'providers-docker/3.8.0rc1' already exists
fatal: tag 'providers-elasticsearch/5.1.0rc1' already exists
fatal: tag 'providers-exasol/4.3.0rc1' already exists
fatal: tag 'providers-facebook/3.3.0rc1' already exists
fatal: tag 'providers-ftp/3.6.0rc1' already exists
fatal: tag 'providers-github/2.4.0rc1' already exists
fatal: tag 'providers-google/10.10.0rc1' already exists
fatal: tag 'providers-grpc/3.3.0rc1' already exists
fatal: tag 'providers-hashicorp/3.5.0rc1' already exists
fatal: tag 'providers-http/4.6.0rc1' already exists
fatal: tag 'providers-imap/3.4.0rc1' already exists
fatal: tag 'providers-influxdb/2.3.0rc1' already exists
fatal: tag 'providers-jdbc/4.1.0rc1' already exists
fatal: tag 'providers-jenkins/3.4.0rc1' already exists
fatal: tag 'providers-microsoft-azure/8.0.0rc1' already exists
fatal: tag 'providers-microsoft-mssql/3.5.0rc1' already exists
fatal: tag 'providers-microsoft-psrp/2.4.0rc1' already exists
fatal: tag 'providers-microsoft-winrm/3.3.0rc1' already exists
fatal: tag 'providers-mongo/3.3.0rc1' already exists
```
in cases when the tag could not be pushed. This is irritating because now the release team has to manually delete these tags. Adding ability to do this using an env variable. The default behaviour here is that the tags will be cleaned locally.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
