### PR TITLE
`PostgresOperator` should not overwrite `SQLExecuteQueryOperator.template_fields`

### DIFF
--- a/airflow/providers/postgres/operators/postgres.py
+++ b/airflow/providers/postgres/operators/postgres.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Mapping, Sequence
+from typing import Mapping
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
@@ -46,9 +46,7 @@ class PostgresOperator(SQLExecuteQueryOperator):
         Deprecated - use `hook_params={'options': '-c <connection_options>'}` instead.
     """
 
-    template_fields: Sequence[str] = ("sql",)
-    template_fields_renderers = {"sql": "postgresql"}
-    template_ext: Sequence[str] = (".sql",)
+    template_fields_renderers = {**SQLExecuteQueryOperator.template_fields_renderers, "sql": "postgresql"}
     ui_color = "#ededed"
 
     def __init__(

--- a/tests/providers/postgres/operators/test_postgres.py
+++ b/tests/providers/postgres/operators/test_postgres.py
@@ -190,3 +190,19 @@ class TestPostgresOpenLineage:
         assert lineage_on_complete.outputs[0].namespace == "postgres://postgres:5432"
         assert lineage_on_complete.outputs[0].name == "airflow.public.test_airflow"
         assert "schema" in lineage_on_complete.outputs[0].facets
+
+
+def test_parameters_are_templatized(create_task_instance_of_operator):
+    """Test that PostgreSQL operator could template the same fields as SQLExecuteQueryOperator"""
+    ti = create_task_instance_of_operator(
+        PostgresOperator,
+        postgres_conn_id="{{ param.conn_id }}",
+        sql="SELECT * FROM {{ param.table }} WHERE spam = %(spam)s;",
+        parameters={"spam": "{{ param.bar }}"},
+        dag_id="test-postgres-op-parameters-are-templatized",
+        task_id="test-task",
+    )
+    task: PostgresOperator = ti.render_templates({"param": {"conn_id": "pg", "table": "foo", "bar": "egg"}})
+    assert task.conn_id == "pg"
+    assert task.sql == "SELECT * FROM foo WHERE spam = %(spam)s;"
+    assert task.parameters == {"spam": "egg"}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

From discussion: https://github.com/apache/airflow/discussions/34920#discussioncomment-7282638

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
