### PR TITLE
Add volumeClaimTemplate for worker in Helm chart

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -398,5 +398,16 @@ spec:
         resources:
           requests:
             storage: {{ .Values.workers.persistence.size }}
+    {{- range .Values.workers.volumeClaimTemplates }}
+    - metadata:
+        name: {{ .metadata.name }}
+      spec:
+        storageClassName: {{ .spec.storageClassName }}
+        accessModes:
+          - {{ .spec.accessModes | quote }}
+        resources:
+          requests:
+            storage: {{ .spec.resources.requests.storage }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -398,16 +398,8 @@ spec:
         resources:
           requests:
             storage: {{ .Values.workers.persistence.size }}
-    {{- range .Values.workers.volumeClaimTemplates }}
-    - metadata:
-        name: {{ .metadata.name }}
-      spec:
-        storageClassName: {{ .spec.storageClassName }}
-        accessModes:
-          - {{ .spec.accessModes | quote }}
-        resources:
-          requests:
-            storage: {{ .spec.resources.requests.storage }}
+    {{- with .Values.workers.volumeClaimTemplates }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2020,6 +2020,40 @@
                         ],
                         "additionalProperties": false
                     }
+                },
+                "volumeClaimTemplates": {
+                    "description": "Specify additional volume claim template for workers.",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimTemplate"
+                    },
+                    "examples": [
+                        {
+                            "name": "data-volume-1",
+                            "storageClassName": "storage-class-1",
+                            "accessModes": [
+                                "ReadWriteOnce"
+                            ],
+                            "resources": {
+                                "requests": {
+                                    "storage": "10Gi"
+                                }
+                            }
+                        },
+                        {
+                            "name": "data-volume-2",
+                            "storageClassName": "storage-class-2",
+                            "accessModes": [
+                                "ReadWriteOnce"
+                            ],
+                            "resources": {
+                                "requests": {
+                                    "storage": "20Gi"
+                                }
+                            }
+                        }
+                    ]
                 }
             }
         },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -729,6 +729,31 @@ workers:
 
   env: []
 
+  volumeClaimTemplates: []
+  # Additional volumeClaimTemplates needed.
+  # Comment out the above and uncomment the section below to enable it.
+  # Add more as needed
+  # Make sure to mount it under extraVolumeMounts.
+  # volumeClaimTemplates:
+  #   - metadata:
+  #       name: data-volume-1
+  #     spec:
+  #       storageClassName: "storage-class-1"
+  #       accessModes:
+  #         - "ReadWriteOnce"
+  #       resources:
+  #         requests:
+  #           storage: "10Gi"
+  #   - metadata:
+  #       name: data-volume-2
+  #     spec:
+  #       storageClassName: "storage-class-2"
+  #       accessModes:
+  #         - "ReadWriteOnce"
+  #       resources:
+  #         requests:
+  #           storage: "20Gi"
+
 # Airflow scheduler settings
 scheduler:
   #  hostAliases for the scheduler pod

--- a/helm_tests/airflow_core/test_worker.py
+++ b/helm_tests/airflow_core/test_worker.py
@@ -707,12 +707,8 @@ class TestWorker:
         assert "storage-class-2" == jmespath.search(
             "spec.volumeClaimTemplates[2].spec.storageClassName", docs[0]
         )
-        assert ["ReadWriteOnce"] == jmespath.search(
-            "spec.volumeClaimTemplates[1].spec.accessModes[0]", docs[0]
-        )
-        assert ["ReadWriteOnce"] == jmespath.search(
-            "spec.volumeClaimTemplates[2].spec.accessModes[0]", docs[0]
-        )
+        assert ["ReadWriteOnce"] == jmespath.search("spec.volumeClaimTemplates[1].spec.accessModes", docs[0])
+        assert ["ReadWriteOnce"] == jmespath.search("spec.volumeClaimTemplates[2].spec.accessModes", docs[0])
         assert "10Gi" == jmespath.search(
             "spec.volumeClaimTemplates[1].spec.resources.requests.storage", docs[0]
         )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

Problem: The current Helm chart doesn't support additional persistence volume for worker statefulset.

Resolution: Adding in new feature to add extra volumeClaimTemplates for additional persistent volume needed by statefulset.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
