### PR TITLE
Create setup and teardown tasks in AWS system test `example_glue_databrew`

### DIFF
--- a/tests/system/providers/amazon/aws/example_glue_databrew.py
+++ b/tests/system/providers/amazon/aws/example_glue_databrew.py
@@ -16,31 +16,143 @@
 # under the License.
 from __future__ import annotations
 
+import boto3
 import pendulum
 
+from airflow.decorators import task
 from airflow.models.baseoperator import chain
 from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.operators.glue_databrew import (
     GlueDataBrewStartJobOperator,
 )
+from airflow.providers.amazon.aws.operators.s3 import (
+    S3CreateBucketOperator,
+    S3CreateObjectOperator,
+    S3DeleteBucketOperator,
+)
+from airflow.utils.trigger_rule import TriggerRule
 from tests.system.providers.amazon.aws.utils import SystemTestContextBuilder
 
-DAG_ID = "example_databrew"
+DAG_ID = "example_glue_databrew"
 
-sys_test_context_task = SystemTestContextBuilder().build()
+# Externally fetched variables:
+ROLE_ARN_KEY = "ROLE_ARN"
+
+sys_test_context_task = SystemTestContextBuilder().add_variable(ROLE_ARN_KEY).build()
+
+EXAMPLE_JSON = "{}"
+
+
+@task
+def create_dataset(dataset_name: str, bucket_name: str, object_key: str):
+    client = boto3.client("databrew")
+    client.create_dataset(
+        Name=dataset_name,
+        Format="JSON",
+        FormatOptions={
+            "Json": {"MultiLine": False},
+        },
+        Input={
+            "S3InputDefinition": {
+                "Bucket": bucket_name,
+                "Key": object_key,
+            },
+        },
+    )
+
+
+@task
+def create_job(
+    dataset_name: str, job_name: str, bucket_output_name: str, object_output_key: str, role_arn: str
+):
+    client = boto3.client("databrew")
+    client.create_profile_job(
+        DatasetName=dataset_name,
+        Name=job_name,
+        LogSubscription="ENABLE",
+        OutputLocation={
+            "Bucket": bucket_output_name,
+            "Key": object_output_key,
+        },
+        RoleArn=role_arn,
+    )
+
+
+@task(trigger_rule=TriggerRule.ALL_DONE)
+def delete_dataset(dataset_name: str):
+    client = boto3.client("databrew")
+    client.delete_dataset(Name=dataset_name)
+
+
+@task(trigger_rule=TriggerRule.ALL_DONE)
+def delete_job(job_name: str):
+    client = boto3.client("databrew")
+    client.delete_job(Name=job_name)
 
 
 with DAG(DAG_ID, schedule="@once", start_date=pendulum.datetime(2023, 1, 1, tz="UTC"), catchup=False) as dag:
     test_context = sys_test_context_task()
     env_id = test_context["ENV_ID"]
+    role_arn = test_context[ROLE_ARN_KEY]
 
+    bucket_name = f"{env_id}-bucket-databrew"
+    bucket_output_name = f"{env_id}-bucket-output-databrew"
+    file_name = "data.json"
+    dataset_name = f"{env_id}-dataset"
     job_name = f"{env_id}-databrew-job"
 
+    create_bucket = S3CreateBucketOperator(
+        task_id="create_bucket",
+        bucket_name=bucket_name,
+    )
+
+    create_bucket_output = S3CreateBucketOperator(
+        task_id="create_bucket_output",
+        bucket_name=bucket_output_name,
+    )
+
+    upload_file = S3CreateObjectOperator(
+        task_id="upload_file",
+        s3_bucket=bucket_name,
+        s3_key=file_name,
+        data=EXAMPLE_JSON,
+        replace=True,
+    )
+
     # [START howto_operator_glue_databrew_start]
-    start_job = GlueDataBrewStartJobOperator(task_id="startjob", deferrable=True, job_name=job_name, delay=15)
+    start_job = GlueDataBrewStartJobOperator(task_id="startjob", job_name=job_name, delay=15)
     # [END howto_operator_glue_databrew_start]
 
-    chain(test_context, start_job)
+    delete_bucket = S3DeleteBucketOperator(
+        task_id="delete_bucket",
+        trigger_rule=TriggerRule.ALL_DONE,
+        bucket_name=bucket_name,
+        force_delete=True,
+    )
+
+    delete_bucket_output = S3DeleteBucketOperator(
+        task_id="delete_bucket_output",
+        trigger_rule=TriggerRule.ALL_DONE,
+        bucket_name=bucket_output_name,
+        force_delete=True,
+    )
+
+    chain(
+        # TEST SETUP
+        test_context,
+        create_bucket,
+        create_bucket_output,
+        upload_file,
+        create_dataset(dataset_name, bucket_name, file_name),
+        create_job(dataset_name, job_name, bucket_output_name, "output.json", role_arn),
+        # TEST BODY
+        start_job,
+        # TEST TEARDOWN
+        delete_job(job_name),
+        delete_dataset(dataset_name),
+        delete_bucket,
+        delete_bucket_output,
+    )
 
     from tests.system.utils.watcher import watcher
 


### PR DESCRIPTION
In order to use `GlueDataBrewStartJobOperator` operator you need to create resources beforehand. This PR makes the system test `example_glue_databrew` executable.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
