### PR TITLE
Use constraints generated at preview time rather than regenerate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,11 +326,10 @@ jobs:
           DEBUG_RESOURCES: ${{needs.build-info.outputs.debug-resources}}
           BUILD_TIMEOUT_MINUTES: 70
 
-  preview-constraints:
+  generate-constraints:
     permissions:
       contents: read
-    timeout-minutes: 20
-    continue-on-error: true
+    timeout-minutes: 70
     name: >
       Preview constraints
       ${{needs.build-info.outputs.all-python-versions-list-as-string}}
@@ -352,18 +351,24 @@ jobs:
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
       - name: Pull CI images ${{ env.PYTHON_VERSIONS }}:${{ env.IMAGE_TAG }}
-        run: breeze ci-image pull --run-in-parallel --tag-as-latest
+        run: breeze ci-image pull --run-in-parallel --tag-as-latest --wait-for-image
       - name: "Source constraints"
         shell: bash
         run: >
           breeze release-management generate-constraints --run-in-parallel
-          --airflow-constraints-mode constraints-source-providers || true
+          --airflow-constraints-mode constraints-source-providers
+      - name: "No providers constraints"
+        shell: bash
+        timeout-minutes: 25
+        run: >
+          breeze release-management generate-constraints --run-in-parallel
+          --airflow-constraints-mode constraints-no-providers
       - name: "PyPI constraints"
         shell: bash
         timeout-minutes: 25
         run: >
           breeze release-management generate-constraints --run-in-parallel
-          --airflow-constraints-mode constraints || true
+          --airflow-constraints-mode constraints
       - name: "Dependency upgrade summary"
         shell: bash
         run: |
@@ -1695,12 +1700,12 @@ jobs:
         run: breeze ci fix-ownership
         if: always()
 
-  constraints:
+  update-constraints:
     permissions:
       contents: write
       packages: write
     timeout-minutes: 80
-    name: "Constraints"
+    name: "Update constraints"
     runs-on: "${{needs.build-info.outputs.runs-on}}"
     needs:
       - build-info
@@ -1714,6 +1719,8 @@ jobs:
       - tests-integration-postgres
       - tests-integration-mysql
       - push-early-buildx-cache-to-github-registry
+      # Skip when generate constraints fails
+      - generate-constraints
     env:
       RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
       DEBUG_RESOURCES: ${{needs.build-info.outputs.debug-resources}}
@@ -1727,24 +1734,6 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: "Install Breeze"
-        uses: ./.github/actions/breeze
-      - name: Pull CI images ${{ env.PYTHON_VERSIONS }}:${{ env.IMAGE_TAG }}
-        run: breeze ci-image pull --run-in-parallel --tag-as-latest
-        env:
-          PYTHON_VERSIONS: ${{ needs.build-info.outputs.python-versions-list-as-string }}
-      - name: "Generate source constraints"
-        run: |
-          breeze release-management generate-constraints \
-              --run-in-parallel --airflow-constraints-mode constraints-source-providers
-      - name: "Generate no-providers constraints"
-        run: |
-          breeze release-management generate-constraints \
-              --run-in-parallel --airflow-constraints-mode constraints-no-providers
-      - name: "Generate PyPi constraints"
-        run: |
-          breeze release-management generate-constraints \
-              --run-in-parallel --airflow-constraints-mode constraints
       - name: "Set constraints branch name"
         id: constraints-branch
         run: ./scripts/ci/constraints/ci_branch_constraints.sh >> ${GITHUB_OUTPUT}
@@ -1756,6 +1745,14 @@ jobs:
           path: "repo"
           ref: ${{ steps.constraints-branch.outputs.branch }}
           persist-credentials: false
+      - name: "Download constraints from the constraints preview"
+        uses: actions/download-artifact@v3
+        with:
+          name: constraints
+          path: ./files
+      - name: "Diff in constraints for ${{needs.build-info.outputs.python-versions}}"
+        run: ./scripts/ci/constraints/ci_diff_constraints.sh
+      # only commit and push constraints in canary runs (main)
       - name: "Commit changed constraint files for ${{needs.build-info.outputs.python-versions}}"
         run: ./scripts/ci/constraints/ci_commit_constraints.sh
         if: needs.build-info.outputs.canary-run == 'true'
@@ -1766,9 +1763,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ steps.constraints-branch.outputs.branch }}
           directory: "repo"
-      - name: "Fix ownership"
-        run: breeze ci fix-ownership
-        if: always()
 
   # Push BuildX cache to GitHub Registry in Apache repository, if all tests are successful and build
   # is executed as result of direct push to "main" or one of the "vX-Y-test" branches
@@ -1780,7 +1774,7 @@ jobs:
     runs-on: "${{needs.build-info.outputs.runs-on}}"
     needs:
       - build-info
-      - constraints
+      - generate-constraints
       - docs
     if: needs.build-info.outputs.canary-run == 'true'
     strategy:

--- a/scripts/ci/constraints/ci_commit_constraints.sh
+++ b/scripts/ci/constraints/ci_commit_constraints.sh
@@ -15,7 +15,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-cp -v ./files/constraints-*/constraints*.txt repo/
 cd repo || exit 1
 git config --local user.email "dev@airflow.apache.org"
 git config --local user.name "Automated GitHub Actions commit"

--- a/scripts/ci/constraints/ci_diff_constraints.sh
+++ b/scripts/ci/constraints/ci_diff_constraints.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+cp -v ./files/constraints-*/constraints*.txt repo/
+cd repo || exit 1
+git diff --color --exit-code --ignore-matching-lines="^#.*" || echo "No changes in constraints"

--- a/setup.py
+++ b/setup.py
@@ -1042,4 +1042,4 @@ def do_setup() -> None:
 
 
 if __name__ == "__main__":
-    do_setup()  # comment to trigger upgrade to newer dependencies
+    do_setup()  # comment to trigger upgrade to newer dependencies when setup.py is changed


### PR DESCRIPTION
So far, we regenerated the constraints in order to get them updated in constraint branches at the end of the CI build when we knew all the builds succeded. However this was not perfect for two reasons:

* there was a race condition that a dependency had been released between the time images were built and tests completed. While it had no impact on "source" constraints (they reflect what is in the image), it could change the PyPI constraints generated or "no-providers" constraints, because they use "current" set of dependencies in PyPI to generate them.

* generating constraints (for PyPI and "no-providers") takes time because `pip` has to resolve dependencies again - taking into account what is in the PyPI registry, and this can take a long time (minutes or even it can lead to long `pip` backtracking. We generally cancel running builds when new commit is merged in main, so this could lead to such constraint job being canceled by subsequent merge

This PR uses the fact that we have now "preview-constraints" job that uploads constraints as artifacts in CI workflow, and instead of regenerating the constraints, we can download the constraints from uploaded artifact and use it - this is very quick and we can also make a clear dependency between "preview" and "update" constraints jobs - making it clear in case of PIP backtracking that we have problem with constraints, not with the image. This will make it far clearer when we will have problems with constraints and backtracking that this is the real issue we have (allowing such PRs to get merged while constraints backtracking problem is being worked on.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
