### PR TITLE
Fix 'check-provider-yaml-valid' Precommit hook error message

### DIFF
--- a/scripts/in_container/run_provider_yaml_files_check.py
+++ b/scripts/in_container/run_provider_yaml_files_check.py
@@ -340,7 +340,7 @@ def check_correctness_of_list_of_sensors_operators_hook_trigger_modules(
                 f"Currently configured list of {resource_type} modules in {yaml_file_path}",
                 extra_message="[yellow]Additional check[/]: If there are deprecated modules in the list,"
                 "please add them to DEPRECATED_MODULES in "
-                f"{pathlib.Path(__file__).relative_to(ROOT_DIR)}[/]",
+                f"{pathlib.Path(__file__).relative_to(ROOT_DIR)}",
             )
         except AssertionError as ex:
             nested_error = textwrap.indent(str(ex), "  ")


### PR DESCRIPTION
The following line when added to the error message and printed to the console - 
```
[yellow]Additional check[/]: If there are deprecated modules in the list, please add them to DEPRECATED_MODULES in scripts/in_container/run_provider_yaml_files_check.py[/]
```
Results in the below error because of extra `[/]`:
```
Traceback (most recent call last):
  File "/Applications/PyCharm CE.app/Contents/plugins/python-ce/helpers/pydev/pydevconsole.py", line 364, in runcode
    coro = func()
  File "<input>", line 1, in <module>
  File "/Users/utkarsharma/sandbox/airflow-sandbox/venv_3.10/lib/python3.10/site-packages/rich/console.py", line 1673, in print
    renderables = self._collect_renderables(
  File "/Users/utkarsharma/sandbox/airflow-sandbox/venv_3.10/lib/python3.10/site-packages/rich/console.py", line 1537, in _collect_renderables
    self.render_str(
  File "/Users/utkarsharma/sandbox/airflow-sandbox/venv_3.10/lib/python3.10/site-packages/rich/console.py", line 1429, in render_str
    rich_text = render_markup(
  File "/Users/utkarsharma/sandbox/airflow-sandbox/venv_3.10/lib/python3.10/site-packages/rich/markup.py", line 168, in render
    raise MarkupError(
rich.errors.MarkupError: closing tag '[/]' at position 562 has nothing to close
```
