### PR TITLE
Add LiteralValue wrapper rendered without templating

### DIFF
--- a/airflow/template/templater.py
+++ b/airflow/template/templater.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Collection, Iterable, Sequence
 
 from airflow.utils.helpers import render_template_as_native, render_template_to_string
@@ -30,6 +31,17 @@ if TYPE_CHECKING:
 
     from airflow import DAG
     from airflow.utils.context import Context
+
+
+@dataclass(frozen=True)
+class LiteralValue:
+    """
+    A wrapper for a value that should be rendered as-is, without applying any templating to its contents.
+
+    :param value: The value to be rendered without templating
+    """
+
+    value: Any
 
 
 class Templater(LoggingMixin):
@@ -167,6 +179,8 @@ class Templater(LoggingMixin):
             return {k: self.render_template(v, context, jinja_env, oids) for k, v in value.items()}
         elif isinstance(value, set):
             return {self.render_template(element, context, jinja_env, oids) for element in value}
+        elif isinstance(value, LiteralValue):
+            return value.value
 
         # More complex collections.
         self._render_nested_template_fields(value, context, jinja_env, oids)

--- a/airflow/template/templater.py
+++ b/airflow/template/templater.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 @dataclass(frozen=True)
 class LiteralValue:
     """
-    A wrapper for a value that should be rendered as-is, without applying any templating to its contents.
+    A wrapper for a value that should be rendered as-is, without applying jinja templating to its contents.
 
     :param value: The value to be rendered without templating
     """

--- a/airflow/template/templater.py
+++ b/airflow/template/templater.py
@@ -167,6 +167,8 @@ class Templater(LoggingMixin):
             return self._render(template, context)
         if isinstance(value, ResolveMixin):
             return value.resolve(context)
+        if isinstance(value, LiteralValue):
+            return value.value
 
         # Fast path for common built-in collections.
         if value.__class__ is tuple:
@@ -179,8 +181,6 @@ class Templater(LoggingMixin):
             return {k: self.render_template(v, context, jinja_env, oids) for k, v in value.items()}
         elif isinstance(value, set):
             return {self.render_template(element, context, jinja_env, oids) for element in value}
-        elif isinstance(value, LiteralValue):
-            return value.value
 
         # More complex collections.
         self._render_nested_template_fields(value, context, jinja_env, oids)

--- a/airflow/utils/template.py
+++ b/airflow/utils/template.py
@@ -21,7 +21,7 @@ from typing import Any
 from airflow.template.templater import LiteralValue
 
 
-def literal_value(value: Any) -> LiteralValue:
+def literal(value: Any) -> LiteralValue:
     """
     Wrap a value to ensure it is rendered as-is without applying Jinja templating to its contents.
 

--- a/airflow/utils/template.py
+++ b/airflow/utils/template.py
@@ -23,8 +23,9 @@ from airflow.template.templater import LiteralValue
 
 def literal_value(value: Any) -> LiteralValue:
     """
-    Wraps a value intended for use in an operator's template field, ensuring it will be rendered as-is
-    without applying Jinja templating to its contents.
+    Wrap a value to ensure it is rendered as-is without applying Jinja templating to its contents.
+
+    Designed for use in an operator's template field.
 
     :param value: The value to be rendered without templating
     """

--- a/airflow/utils/template.py
+++ b/airflow/utils/template.py
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import Any
+
+from airflow.template.templater import LiteralValue
+
+
+def literal_value(value: Any) -> LiteralValue:
+    """
+    Wraps a value intended for use in an operator's template field, ensuring it will be rendered as-is
+    without applying Jinja templating to its contents.
+
+    :param value: The value to be rendered without templating
+    """
+    return LiteralValue(value)

--- a/docs/apache-airflow/core-concepts/operators.rst
+++ b/docs/apache-airflow/core-concepts/operators.rst
@@ -169,8 +169,7 @@ For example, consider a BashOperator which runs a multi-line bash script, this w
 
 By default, paths provided in this way should be provided relative to the DAG's folder (as this is the default Jinja template search path), but additional paths can be added by setting the ``template_searchpath`` arg on the DAG.
 
-.. versionadded:: 2.8
-    In some cases, you may want to exclude a string from templating and use it directly. Consider the following task:
+In some cases, you may want to exclude a string from templating and use it directly. Consider the following task:
 
 .. code-block:: python
 
@@ -188,6 +187,9 @@ This approach disables the rendering of both macros and files and can be applied
         task_id="fixed_print_script",
         bash_command=literal("cat script.sh"),
     )
+
+.. versionadded:: 2.8
+    :func:`~airflow.util.template.literal` was added.
 
 Alternatively, if you want to prevent Airflow from treating a value as a reference to a file, you can override ``template_ext``:
 

--- a/docs/apache-airflow/core-concepts/operators.rst
+++ b/docs/apache-airflow/core-concepts/operators.rst
@@ -191,14 +191,14 @@ This will fail with ``TemplateNotFound: cat script.sh``, but we can prevent airf
 
 
 It is also possible to exclude a string from templating and use it directly by wrapping it in
-:class:`~airflow.template.templater.LiteralValue`. This approach disables the rendering of both macros and files and
+:func:`~airflow.util.template.literal_value`. This approach disables the rendering of both macros and files and
 can be applied to selected nested fields, while retaining the default templating rules for the remainder of the content.
 
 .. code-block:: python
 
     fixed_print_script = BashOperator(
         task_id="fixed_print_script",
-        bash_command=LiteralValue("cat script.sh"),
+        bash_command=literal_value("cat script.sh"),
     )
 
 .. _concepts:templating-native-objects:

--- a/docs/apache-airflow/core-concepts/operators.rst
+++ b/docs/apache-airflow/core-concepts/operators.rst
@@ -169,7 +169,8 @@ For example, consider a BashOperator which runs a multi-line bash script, this w
 
 By default, paths provided in this way should be provided relative to the DAG's folder (as this is the default Jinja template search path), but additional paths can be added by setting the ``template_searchpath`` arg on the DAG.
 
-In some cases you may want to disable template rendering on specific fields or prevent airflow from trying to read template files for a given suffix. Consider the following task:
+.. versionadded:: 2.8
+    In some cases, you may want to exclude a string from templating and use it directly. Consider the following task:
 
 .. code-block:: python
 
@@ -178,8 +179,17 @@ In some cases you may want to disable template rendering on specific fields or p
         bash_command="cat script.sh",
     )
 
+This will fail with ``TemplateNotFound: cat script.sh``, but we can prevent airflow from treating this value as a reference to a file by wrapping it in :func:`~airflow.util.template.literal`.
+This approach disables the rendering of both macros and files and can be applied to selected nested fields while retaining the default templating rules for the remainder of the content.
 
-This will fail with ``TemplateNotFound: cat script.sh``, but we can prevent airflow from treating this value as a reference to a file by overriding ``template_ext``:
+.. code-block:: python
+
+    fixed_print_script = BashOperator(
+        task_id="fixed_print_script",
+        bash_command=literal("cat script.sh"),
+    )
+
+Alternatively, if you want to prevent Airflow from treating a value as a reference to a file, you can override ``template_ext``:
 
 .. code-block:: python
 
@@ -189,18 +199,6 @@ This will fail with ``TemplateNotFound: cat script.sh``, but we can prevent airf
     )
     fixed_print_script.template_ext = ()
 
-It is also possible to exclude a string from templating and use it directly by wrapping it in
-:func:`~airflow.util.template.literal`. This approach disables the rendering of both macros and files and
-can be applied to selected nested fields, while retaining the default templating rules for the remainder of the content.
-
-.. versionadded:: 2.8
-
-.. code-block:: python
-
-    fixed_print_script = BashOperator(
-        task_id="fixed_print_script",
-        bash_command=literal("cat script.sh"),
-    )
 
 .. _concepts:templating-native-objects:
 

--- a/docs/apache-airflow/core-concepts/operators.rst
+++ b/docs/apache-airflow/core-concepts/operators.rst
@@ -178,10 +178,14 @@ In some cases, you may want to exclude a string from templating and use it direc
         bash_command="cat script.sh",
     )
 
-This will fail with ``TemplateNotFound: cat script.sh``, but we can prevent airflow from treating this value as a reference to a file by wrapping it in :func:`~airflow.util.template.literal`.
+This will fail with ``TemplateNotFound: cat script.sh`` since Airflow would treat the string as a path to a file, not a command.
+We can prevent airflow from treating this value as a reference to a file by wrapping it in :func:`~airflow.util.template.literal`.
 This approach disables the rendering of both macros and files and can be applied to selected nested fields while retaining the default templating rules for the remainder of the content.
 
 .. code-block:: python
+
+    from airflow.utils.template import literal
+
 
     fixed_print_script = BashOperator(
         task_id="fixed_print_script",

--- a/docs/apache-airflow/core-concepts/operators.rst
+++ b/docs/apache-airflow/core-concepts/operators.rst
@@ -189,10 +189,11 @@ This will fail with ``TemplateNotFound: cat script.sh``, but we can prevent airf
     )
     fixed_print_script.template_ext = ()
 
-
 It is also possible to exclude a string from templating and use it directly by wrapping it in
 :func:`~airflow.util.template.literal`. This approach disables the rendering of both macros and files and
 can be applied to selected nested fields, while retaining the default templating rules for the remainder of the content.
+
+.. versionadded:: 2.8
 
 .. code-block:: python
 

--- a/docs/apache-airflow/core-concepts/operators.rst
+++ b/docs/apache-airflow/core-concepts/operators.rst
@@ -158,13 +158,13 @@ See the `Jinja documentation <https://jinja.palletsprojects.com/en/2.11.x/api/#j
 
 Some operators will also consider strings ending in specific suffixes (defined in ``template_ext``) to be references to files when rendering fields. This can be useful for loading scripts or queries directly from files rather than including them into DAG code.
 
-For example, consider a BashOperator which runs a multi-line bash script, this will load the file at ``script.sh`` and use its contents as the value for ``bash_callable``:
+For example, consider a BashOperator which runs a multi-line bash script, this will load the file at ``script.sh`` and use its contents as the value for ``bash_command``:
 
 .. code-block:: python
 
     run_script = BashOperator(
         task_id="run_script",
-        bash_callable="script.sh",
+        bash_command="script.sh",
     )
 
 By default, paths provided in this way should be provided relative to the DAG's folder (as this is the default Jinja template search path), but additional paths can be added by setting the ``template_searchpath`` arg on the DAG.
@@ -175,7 +175,7 @@ In some cases you may want to disable template rendering on specific fields or p
 
     print_script = BashOperator(
         task_id="print_script",
-        bash_callable="cat script.sh",
+        bash_command="cat script.sh",
     )
 
 
@@ -185,9 +185,21 @@ This will fail with ``TemplateNotFound: cat script.sh``, but we can prevent airf
 
     fixed_print_script = BashOperator(
         task_id="fixed_print_script",
-        bash_callable="cat script.sh",
+        bash_command="cat script.sh",
     )
     fixed_print_script.template_ext = ()
+
+
+It is also possible to exclude a string from templating and use it directly by wrapping it in
+:class:`~airflow.template.templater.LiteralValue`. This approach disables the rendering of both macros and files and
+can be applied to selected nested fields, while retaining the default templating rules for the remainder of the content.
+
+.. code-block:: python
+
+    fixed_print_script = BashOperator(
+        task_id="fixed_print_script",
+        bash_command=LiteralValue("cat script.sh"),
+    )
 
 .. _concepts:templating-native-objects:
 

--- a/docs/apache-airflow/core-concepts/operators.rst
+++ b/docs/apache-airflow/core-concepts/operators.rst
@@ -191,14 +191,14 @@ This will fail with ``TemplateNotFound: cat script.sh``, but we can prevent airf
 
 
 It is also possible to exclude a string from templating and use it directly by wrapping it in
-:func:`~airflow.util.template.literal_value`. This approach disables the rendering of both macros and files and
+:func:`~airflow.util.template.literal`. This approach disables the rendering of both macros and files and
 can be applied to selected nested fields, while retaining the default templating rules for the remainder of the content.
 
 .. code-block:: python
 
     fixed_print_script = BashOperator(
         task_id="fixed_print_script",
-        bash_command=literal_value("cat script.sh"),
+        bash_command=literal("cat script.sh"),
     )
 
 .. _concepts:templating-native-objects:

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -43,7 +43,7 @@ from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils.edgemodifier import Label
 from airflow.utils.task_group import TaskGroup
-from airflow.utils.template import literal_value
+from airflow.utils.template import literal
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.types import DagRunType
 from airflow.utils.weight_rule import WeightRule
@@ -278,9 +278,9 @@ class TestBaseOperator:
             ),
             # By default, Jinja2 drops one (single) trailing newline
             ("{{ foo }}\n\n", {"foo": "bar"}, "bar\n"),
-            (literal_value("{{ foo }}"), {"foo": "bar"}, "{{ foo }}"),
-            (literal_value(["{{ foo }}_1", "{{ foo }}_2"]), {"foo": "bar"}, ["{{ foo }}_1", "{{ foo }}_2"]),
-            (literal_value(("{{ foo }}_1", "{{ foo }}_2")), {"foo": "bar"}, ("{{ foo }}_1", "{{ foo }}_2")),
+            (literal("{{ foo }}"), {"foo": "bar"}, "{{ foo }}"),
+            (literal(["{{ foo }}_1", "{{ foo }}_2"]), {"foo": "bar"}, ["{{ foo }}_1", "{{ foo }}_2"]),
+            (literal(("{{ foo }}_1", "{{ foo }}_2")), {"foo": "bar"}, ("{{ foo }}_1", "{{ foo }}_2")),
         ],
     )
     def test_render_template(self, content, context, expected_output):

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -41,6 +41,7 @@ from airflow.models.baseoperator import (
 from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
+from airflow.template.templater import LiteralValue
 from airflow.utils.edgemodifier import Label
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
@@ -277,6 +278,9 @@ class TestBaseOperator:
             ),
             # By default, Jinja2 drops one (single) trailing newline
             ("{{ foo }}\n\n", {"foo": "bar"}, "bar\n"),
+            (LiteralValue("{{ foo }}"), {"foo": "bar"}, "{{ foo }}"),
+            (LiteralValue(["{{ foo }}_1", "{{ foo }}_2"]), {"foo": "bar"}, ["{{ foo }}_1", "{{ foo }}_2"]),
+            (LiteralValue(("{{ foo }}_1", "{{ foo }}_2")), {"foo": "bar"}, ("{{ foo }}_1", "{{ foo }}_2")),
         ],
     )
     def test_render_template(self, content, context, expected_output):

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -41,9 +41,9 @@ from airflow.models.baseoperator import (
 from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
-from airflow.template.templater import LiteralValue
 from airflow.utils.edgemodifier import Label
 from airflow.utils.task_group import TaskGroup
+from airflow.utils.template import literal_value
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.types import DagRunType
 from airflow.utils.weight_rule import WeightRule
@@ -278,9 +278,9 @@ class TestBaseOperator:
             ),
             # By default, Jinja2 drops one (single) trailing newline
             ("{{ foo }}\n\n", {"foo": "bar"}, "bar\n"),
-            (LiteralValue("{{ foo }}"), {"foo": "bar"}, "{{ foo }}"),
-            (LiteralValue(["{{ foo }}_1", "{{ foo }}_2"]), {"foo": "bar"}, ["{{ foo }}_1", "{{ foo }}_2"]),
-            (LiteralValue(("{{ foo }}_1", "{{ foo }}_2")), {"foo": "bar"}, ("{{ foo }}_1", "{{ foo }}_2")),
+            (literal_value("{{ foo }}"), {"foo": "bar"}, "{{ foo }}"),
+            (literal_value(["{{ foo }}_1", "{{ foo }}_2"]), {"foo": "bar"}, ["{{ foo }}_1", "{{ foo }}_2"]),
+            (literal_value(("{{ foo }}_1", "{{ foo }}_2")), {"foo": "bar"}, ("{{ foo }}_1", "{{ foo }}_2")),
         ],
     )
     def test_render_template(self, content, context, expected_output):

--- a/tests/template/test_templater.py
+++ b/tests/template/test_templater.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import jinja2
 
 from airflow.models.dag import DAG
-from airflow.template.templater import Templater
+from airflow.template.templater import LiteralValue, Templater
 from airflow.utils.context import Context
 
 
@@ -60,3 +60,23 @@ class TestTemplater:
         templater.template_ext = [".txt"]
         rendered_content = templater.render_template(templater.message, context)
         assert rendered_content == "Hello world"
+
+    def test_not_render_literal_value(self):
+        templater = Templater()
+        templater.template_ext = []
+        context = Context({"name": "world"})  # type: ignore
+        content = LiteralValue("Hello {{ name }}")
+
+        rendered_content = templater.render_template(content, context)
+
+        assert rendered_content == "Hello {{ name }}"
+
+    def test_not_render_file_literal_value(self):
+        templater = Templater()
+        templater.template_ext = [".txt"]
+        context = Context({})  # type: ignore
+        content = LiteralValue("template_file.txt")
+
+        rendered_content = templater.render_template(content, context)
+
+        assert rendered_content == "template_file.txt"

--- a/tests/template/test_templater.py
+++ b/tests/template/test_templater.py
@@ -64,7 +64,7 @@ class TestTemplater:
     def test_not_render_literal_value(self):
         templater = Templater()
         templater.template_ext = []
-        context = Context({"name": "world"})  # type: ignore
+        context = Context()
         content = LiteralValue("Hello {{ name }}")
 
         rendered_content = templater.render_template(content, context)
@@ -74,7 +74,7 @@ class TestTemplater:
     def test_not_render_file_literal_value(self):
         templater = Templater()
         templater.template_ext = [".txt"]
-        context = Context({})  # type: ignore
+        context = Context()
         content = LiteralValue("template_file.txt")
 
         rendered_content = templater.render_template(content, context)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Closes: #33694

The PR introduces the airflow.template.templater.LiteralValue class, which wraps a single value and makes the Templater immediately return, bypassing Jinja templating for the content.

This class allows you to use strings that include Jinja macros or recognized file extensions as-is, without the need to modify the Operator by altering its template_fields or template_ext.

In cases where a field contains a complex object, it also enables you to selectively disable rendering for a portion of the object. This level of granularity is not achievable by overriding the template_fields.

Additionally, it provides a cleaner approach to avoid rendering files, in contrast to the documented method of leaving a trailing space within the string.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
