### PR TITLE
Pass additional arguments from Slack's Operators/Notifiers to Hooks

### DIFF
--- a/airflow/providers/slack/notifications/slack.py
+++ b/airflow/providers/slack/notifications/slack.py
@@ -19,9 +19,10 @@ from __future__ import annotations
 
 import json
 from functools import cached_property
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 from airflow.exceptions import AirflowOptionalProviderFeatureException
+from airflow.providers.slack.hooks.slack import SlackHook
 
 try:
     from airflow.notifications.basenotifier import BaseNotifier
@@ -30,7 +31,8 @@ except ImportError:
         "Failed to import BaseNotifier. This feature is only available in Airflow versions >= 2.6.0"
     )
 
-from airflow.providers.slack.hooks.slack import SlackHook
+if TYPE_CHECKING:
+    from slack_sdk.http_retry import RetryHandler
 
 ICON_URL: str = "https://raw.githubusercontent.com/apache/airflow/2.5.0/airflow/www/static/pin_100.png"
 
@@ -46,6 +48,11 @@ class SlackNotifier(BaseNotifier):
     :param icon_url: The icon to use for the message. Optional
     :param attachments: A list of attachments to send with the message. Optional
     :param blocks: A list of blocks to send with the message. Optional
+    :param timeout: The maximum number of seconds the client will wait to connect
+        and receive a response from Slack. Optional
+    :param base_url: A string representing the Slack API base URL. Optional
+    :param proxy: Proxy to make the Slack API call. Optional
+    :param retry_handlers: List of handlers to customize retry logic in ``slack_sdk.WebClient``. Optional
     """
 
     template_fields = ("text", "channel", "username", "attachments", "blocks")
@@ -60,6 +67,10 @@ class SlackNotifier(BaseNotifier):
         icon_url: str = ICON_URL,
         attachments: Sequence = (),
         blocks: Sequence = (),
+        base_url: str | None = None,
+        proxy: str | None = None,
+        timeout: int | None = None,
+        retry_handlers: list[RetryHandler] | None = None,
     ):
         super().__init__()
         self.slack_conn_id = slack_conn_id
@@ -69,11 +80,21 @@ class SlackNotifier(BaseNotifier):
         self.icon_url = icon_url
         self.attachments = attachments
         self.blocks = blocks
+        self.base_url = base_url
+        self.timeout = timeout
+        self.proxy = proxy
+        self.retry_handlers = retry_handlers
 
     @cached_property
     def hook(self) -> SlackHook:
         """Slack Hook."""
-        return SlackHook(slack_conn_id=self.slack_conn_id)
+        return SlackHook(
+            slack_conn_id=self.slack_conn_id,
+            base_url=self.base_url,
+            timeout=self.timeout,
+            proxy=self.proxy,
+            retry_handlers=self.retry_handlers,
+        )
 
     def notify(self, context):
         """Send a message to a Slack Channel."""

--- a/airflow/providers/slack/notifications/slack_webhook.py
+++ b/airflow/providers/slack/notifications/slack_webhook.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 from functools import cached_property
+from typing import TYPE_CHECKING
 
 from airflow.exceptions import AirflowOptionalProviderFeatureException
 from airflow.providers.slack.hooks.slack_webhook import SlackWebhookHook
@@ -28,6 +29,9 @@ except ImportError:
     raise AirflowOptionalProviderFeatureException(
         "Failed to import BaseNotifier. This feature is only available in Airflow versions >= 2.6.0"
     )
+
+if TYPE_CHECKING:
+    from slack_sdk.http_retry import RetryHandler
 
 
 class SlackWebhookNotifier(BaseNotifier):
@@ -45,9 +49,10 @@ class SlackWebhookNotifier(BaseNotifier):
     :param unfurl_links: Option to indicate whether text url should unfurl. Optional
     :param unfurl_media: Option to indicate whether media url should unfurl. Optional
     :param timeout: The maximum number of seconds the client will wait to connect. Optional
-        and receive a response from Slack. If not set than default WebhookClient value will use.
+        and receive a response from Slack. Optional
     :param proxy: Proxy to make the Slack Incoming Webhook call. Optional
     :param attachments: A list of attachments to send with the message. Optional
+    :param retry_handlers: List of handlers to customize retry logic in ``slack_sdk.WebhookClient``. Optional
     """
 
     template_fields = ("slack_webhook_conn_id", "text", "attachments", "blocks", "proxy", "timeout")
@@ -63,6 +68,7 @@ class SlackWebhookNotifier(BaseNotifier):
         proxy: str | None = None,
         timeout: int | None = None,
         attachments: list | None = None,
+        retry_handlers: list[RetryHandler] | None = None,
     ):
         super().__init__()
         self.slack_webhook_conn_id = slack_webhook_conn_id
@@ -73,12 +79,16 @@ class SlackWebhookNotifier(BaseNotifier):
         self.unfurl_media = unfurl_media
         self.timeout = timeout
         self.proxy = proxy
+        self.retry_handlers = retry_handlers
 
     @cached_property
     def hook(self) -> SlackWebhookHook:
         """Slack Incoming Webhook Hook."""
         return SlackWebhookHook(
-            slack_webhook_conn_id=self.slack_webhook_conn_id, proxy=self.proxy, timeout=self.timeout
+            slack_webhook_conn_id=self.slack_webhook_conn_id,
+            proxy=self.proxy,
+            timeout=self.timeout,
+            retry_handlers=self.retry_handlers,
         )
 
     def notify(self, context):

--- a/airflow/providers/slack/operators/slack.py
+++ b/airflow/providers/slack/operators/slack.py
@@ -20,11 +20,14 @@ from __future__ import annotations
 import json
 import warnings
 from functools import cached_property
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.slack.hooks.slack import SlackHook
+
+if TYPE_CHECKING:
+    from slack_sdk.http_retry import RetryHandler
 
 
 class SlackAPIOperator(BaseOperator):
@@ -34,7 +37,11 @@ class SlackAPIOperator(BaseOperator):
         which its password is Slack API token.
     :param method: The Slack API Method to Call (https://api.slack.com/methods). Optional
     :param api_params: API Method call parameters (https://api.slack.com/methods). Optional
-    :param client_args: Slack Hook parameters. Optional. Check airflow.providers.slack.hooks.SlackHook
+    :param timeout: The maximum number of seconds the client will wait to connect
+        and receive a response from Slack. Optional
+    :param base_url: A string representing the Slack API base URL. Optional
+    :param proxy: Proxy to make the Slack API call. Optional
+    :param retry_handlers: List of handlers to customize retry logic in ``slack_sdk.WebClient``. Optional
     """
 
     def __init__(
@@ -43,17 +50,31 @@ class SlackAPIOperator(BaseOperator):
         slack_conn_id: str = SlackHook.default_conn_name,
         method: str | None = None,
         api_params: dict | None = None,
+        base_url: str | None = None,
+        proxy: str | None = None,
+        timeout: int | None = None,
+        retry_handlers: list[RetryHandler] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.slack_conn_id = slack_conn_id
         self.method = method
         self.api_params = api_params
+        self.base_url = base_url
+        self.timeout = timeout
+        self.proxy = proxy
+        self.retry_handlers = retry_handlers
 
     @cached_property
     def hook(self) -> SlackHook:
         """Slack Hook."""
-        return SlackHook(slack_conn_id=self.slack_conn_id)
+        return SlackHook(
+            slack_conn_id=self.slack_conn_id,
+            base_url=self.base_url,
+            timeout=self.timeout,
+            proxy=self.proxy,
+            retry_handlers=self.retry_handlers,
+        )
 
     def construct_api_call_params(self) -> Any:
         """API call parameters used by the execute function.

--- a/airflow/providers/slack/transfers/sql_to_slack.py
+++ b/airflow/providers/slack/transfers/sql_to_slack.py
@@ -30,6 +30,7 @@ from airflow.providers.slack.utils import parse_filename
 
 if TYPE_CHECKING:
     import pandas as pd
+    from slack_sdk.http_retry import RetryHandler
 
     from airflow.providers.common.sql.hooks.sql import DbApiHook
     from airflow.utils.context import Context
@@ -44,6 +45,10 @@ class BaseSqlToSlackOperator(BaseOperator):
     :param sql_hook_params: Extra config params to be passed to the underlying hook.
         Should match the desired hook constructor params.
     :param parameters: The parameters to pass to the SQL query.
+    :param slack_proxy: Proxy to make the Slack Incoming Webhook / API calls. Optional
+    :param slack_timeout: The maximum number of seconds the client will wait to connect
+        and receive a response from Slack. Optional
+    :param slack_retry_handlers: List of handlers to customize retry logic. Optional
     """
 
     def __init__(
@@ -53,6 +58,9 @@ class BaseSqlToSlackOperator(BaseOperator):
         sql_conn_id: str,
         sql_hook_params: dict | None = None,
         parameters: Iterable | Mapping[str, Any] | None = None,
+        slack_proxy: str | None = None,
+        slack_timeout: int | None = None,
+        slack_retry_handlers: list[RetryHandler] | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -60,6 +68,9 @@ class BaseSqlToSlackOperator(BaseOperator):
         self.sql_hook_params = sql_hook_params
         self.sql = sql
         self.parameters = parameters
+        self.slack_proxy = slack_proxy
+        self.slack_timeout = slack_timeout
+        self.slack_retry_handlers = slack_retry_handlers
 
     def _get_hook(self) -> DbApiHook:
         self.log.debug("Get connection for %s", self.sql_conn_id)
@@ -146,7 +157,12 @@ class SqlToSlackOperator(BaseSqlToSlackOperator):
         slack_hook.send(text=self.slack_message, channel=self.slack_channel)
 
     def _get_slack_hook(self) -> SlackWebhookHook:
-        return SlackWebhookHook(slack_webhook_conn_id=self.slack_conn_id)
+        return SlackWebhookHook(
+            slack_webhook_conn_id=self.slack_conn_id,
+            proxy=self.slack_proxy,
+            timeout=self.slack_timeout,
+            retry_handlers=self.slack_retry_handlers,
+        )
 
     def render_template_fields(self, context, jinja_env=None) -> None:
         # If this is the first render of the template fields, exclude slack_message from rendering since
@@ -197,7 +213,9 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
          If omitting this parameter, then file will send to workspace.
     :param slack_initial_comment: The message text introducing the file in specified ``slack_channels``.
     :param slack_title: Title of file.
+    :param slack_base_url: A string representing the Slack API base URL. Optional
     :param df_kwargs: Keyword arguments forwarded to ``pandas.DataFrame.to_{format}()`` method.
+
 
     Example:
      .. code-block:: python
@@ -241,6 +259,7 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
         slack_channels: str | Sequence[str] | None = None,
         slack_initial_comment: str | None = None,
         slack_title: str | None = None,
+        slack_base_url: str | None = None,
         df_kwargs: dict | None = None,
         **kwargs,
     ):
@@ -252,6 +271,7 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
         self.slack_channels = slack_channels
         self.slack_initial_comment = slack_initial_comment
         self.slack_title = slack_title
+        self.slack_base_url = slack_base_url
         self.df_kwargs = df_kwargs or {}
 
     def execute(self, context: Context) -> None:
@@ -261,7 +281,13 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
             supported_file_formats=self.SUPPORTED_FILE_FORMATS,
         )
 
-        slack_hook = SlackHook(slack_conn_id=self.slack_conn_id)
+        slack_hook = SlackHook(
+            slack_conn_id=self.slack_conn_id,
+            base_url=self.slack_base_url,
+            timeout=self.slack_timeout,
+            proxy=self.slack_proxy,
+            retry_handlers=self.slack_retry_handlers,
+        )
         with NamedTemporaryFile(mode="w+", suffix=f"_{self.slack_filename}") as fp:
             # tempfile.NamedTemporaryFile used only for create and remove temporary file,
             # pandas will open file in correct mode itself depend on file type.

--- a/tests/providers/slack/notifications/test_slack.py
+++ b/tests/providers/slack/notifications/test_slack.py
@@ -19,17 +19,42 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
+
 from airflow.operators.empty import EmptyOperator
 from airflow.providers.slack.notifications.slack import SlackNotifier, send_slack_notification
+
+DEFAULT_HOOKS_PARAMETERS = {"base_url": None, "timeout": None, "proxy": None, "retry_handlers": None}
 
 
 class TestSlackNotifier:
     @mock.patch("airflow.providers.slack.notifications.slack.SlackHook")
-    def test_slack_notifier(self, mock_slack_hook, dag_maker):
+    @pytest.mark.parametrize(
+        "extra_kwargs, hook_extra_kwargs",
+        [
+            pytest.param({}, DEFAULT_HOOKS_PARAMETERS, id="default-hook-parameters"),
+            pytest.param(
+                {
+                    "base_url": "https://foo.bar",
+                    "timeout": 42,
+                    "proxy": "http://spam.egg",
+                    "retry_handlers": [],
+                },
+                {
+                    "base_url": "https://foo.bar",
+                    "timeout": 42,
+                    "proxy": "http://spam.egg",
+                    "retry_handlers": [],
+                },
+                id="with-extra-hook-parameters",
+            ),
+        ],
+    )
+    def test_slack_notifier(self, mock_slack_hook, dag_maker, extra_kwargs, hook_extra_kwargs):
         with dag_maker("test_slack_notifier") as dag:
             EmptyOperator(task_id="task1")
 
-        notifier = send_slack_notification(text="test")
+        notifier = send_slack_notification(slack_conn_id="test_conn_id", text="test", **extra_kwargs)
         notifier({"dag": dag})
         mock_slack_hook.return_value.call.assert_called_once_with(
             "chat.postMessage",
@@ -43,6 +68,7 @@ class TestSlackNotifier:
                 "blocks": "[]",
             },
         )
+        mock_slack_hook.assert_called_once_with(slack_conn_id="test_conn_id", **hook_extra_kwargs)
 
     @mock.patch("airflow.providers.slack.notifications.slack.SlackHook")
     def test_slack_notifier_with_notifier_class(self, mock_slack_hook, dag_maker):

--- a/tests/providers/slack/notifications/test_slack_webhook.py
+++ b/tests/providers/slack/notifications/test_slack_webhook.py
@@ -19,11 +19,15 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
+
 from airflow.operators.empty import EmptyOperator
 from airflow.providers.slack.notifications.slack_webhook import (
     SlackWebhookNotifier,
     send_slack_webhook_notification,
 )
+
+DEFAULT_HOOKS_PARAMETERS = {"timeout": None, "proxy": None, "retry_handlers": None}
 
 
 class TestSlackNotifier:
@@ -31,9 +35,26 @@ class TestSlackNotifier:
         assert send_slack_webhook_notification is SlackWebhookNotifier
 
     @mock.patch("airflow.providers.slack.notifications.slack_webhook.SlackWebhookHook")
-    def test_slack_webhook_notifier(self, mock_slack_hook):
+    @pytest.mark.parametrize(
+        "slack_op_kwargs, hook_extra_kwargs",
+        [
+            pytest.param({}, DEFAULT_HOOKS_PARAMETERS, id="default-hook-parameters"),
+            pytest.param(
+                {"timeout": 42, "proxy": "http://spam.egg", "retry_handlers": []},
+                {"timeout": 42, "proxy": "http://spam.egg", "retry_handlers": []},
+                id="with-extra-hook-parameters",
+            ),
+        ],
+    )
+    def test_slack_webhook_notifier(self, mock_slack_hook, slack_op_kwargs, hook_extra_kwargs):
         notifier = send_slack_webhook_notification(
-            text="foo-bar", blocks="spam-egg", attachments="baz-qux", unfurl_links=True, unfurl_media=False
+            slack_webhook_conn_id="test_conn_id",
+            text="foo-bar",
+            blocks="spam-egg",
+            attachments="baz-qux",
+            unfurl_links=True,
+            unfurl_media=False,
+            **slack_op_kwargs,
         )
         notifier.notify({})
         mock_slack_hook.return_value.send.assert_called_once_with(
@@ -43,6 +64,7 @@ class TestSlackNotifier:
             unfurl_media=False,
             attachments="baz-qux",
         )
+        mock_slack_hook.assert_called_once_with(slack_webhook_conn_id="test_conn_id", **hook_extra_kwargs)
 
     @mock.patch("airflow.providers.slack.notifications.slack_webhook.SlackWebhookHook")
     def test_slack_webhook_templated(self, mock_slack_hook, dag_maker):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Pass additional parameters from Slack's Operators/Notifiers to Hooks if for some reason required to overwrite connection parameters.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
