### PR TITLE
Bump ruff to v0.0.292

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -180,16 +180,14 @@ repos:
         additional_dependencies: ['pyyaml']
         pass_filenames: false
         require_serial: true
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.292
+    hooks:
+      # Since ruff makes use of multiple cores we _purposefully_ don't run this in docker so it can use the
+      # host CPU to it's fullest
       - id: ruff
         name: ruff
-        language: python
-        require_serial: true
-        pass_filenames: true
-        # Since ruff makes use of multiple cores we _purposefully_ don't run this in docker so it can use the
-        # host CPU to it's fullest
-        entry: ruff --fix --force-exclude
-        additional_dependencies: ['ruff==0.0.282']
-        files: \.pyi?$
+        args: [ --fix ]
         exclude: ^.*/.*_vendor/|^tests/dags/test_imports.py
   - repo: https://github.com/asottile/blacken-docs
     rev: 1.16.0

--- a/dev/airflow-github
+++ b/dev/airflow-github
@@ -25,13 +25,16 @@ from __future__ import annotations
 import re
 import sys
 from collections import Counter, defaultdict
+from typing import TYPE_CHECKING
 
 import git
 import rich_click as click
 from github import Github
-from github.Issue import Issue
-from github.PullRequest import PullRequest
 from packaging import version
+
+if TYPE_CHECKING:
+    from github.Issue import Issue
+    from github.PullRequest import PullRequest
 
 GIT_COMMIT_FIELDS = ["id", "author_name", "author_email", "date", "subject", "body"]
 GIT_LOG_FORMAT = "%x1f".join(["%h", "%an", "%ae", "%ad", "%s", "%b"]) + "%x1e"
@@ -252,7 +255,10 @@ def compare(target_version, github_token, previous_version=None, show_uncherrypi
     # :<18 says left align, pad to 18, :>6 says right align, pad to 6
     # :<50.50 truncates after 50 chars
     # !s forces as string
-    formatstr = "{number:>6} | {typ!s:<5} | {changelog!s:<13} | {status!s} | {title:<83.83} | {merged:<6} | {commit:>7.7} | {url}"
+    formatstr = (
+        "{number:>6} | {typ!s:<5} | {changelog!s:<13} | {status!s} "
+        "| {title:<83.83} | {merged:<6} | {commit:>7.7} | {url}"
+    )
 
     print(
         formatstr.format(
@@ -303,7 +309,8 @@ def compare(target_version, github_token, previous_version=None, show_uncherrypi
         )
 
     print(
-        f"Commits on branch: {num_cherrypicked:d}, {sum(num_uncherrypicked.values()):d} ({dict(num_uncherrypicked)}) yet to be cherry-picked"
+        f"Commits on branch: {num_cherrypicked:d}, {sum(num_uncherrypicked.values()):d} "
+        f"({dict(num_uncherrypicked)}) yet to be cherry-picked"
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,8 @@ extend-select = [
     "D419",
     "TCH001",  # typing-only-first-party-import
     "TCH002",  # typing-only-third-party-import
-    "TID251",
+    "TID251",  # Specific modules or module members that may not be imported or accessed
+    "TID253",  # Ban certain modules from being imported at module level
 ]
 extend-ignore = [
     "D203",
@@ -128,15 +129,16 @@ combine-as-imports = true
 
 # Ignore pydoc style from these
 "*.pyi" = ["D"]
-"tests/*" = ["D"]
 "scripts/*" = ["D"]
-"dev/*" = ["D"]
 "docs/*" = ["D"]
 "provider_packages/*" = ["D"]
-"docker_tests/*" = ["D"]
-"kubernetes_tests/*" = ["D"]
 "*/example_dags/*" = ["D"]
 "chart/*" = ["D"]
+# In addition ignore top level imports, e.g. pandas, numpy in tests and dev
+"dev/*" = ["D", "TID253"]
+"tests/*" = ["D", "TID253"]
+"docker_tests/*" = ["D", "TID253"]
+"kubernetes_tests/*" = ["D", "TID253"]
 
 # All of the modules which have an extra license header (i.e. that we copy from another project) need to
 # ignore E402 -- module level import not at top level
@@ -149,6 +151,14 @@ combine-as-imports = true
 [tool.ruff.flake8-tidy-imports.banned-api]
 "airflow.AirflowException".msg = "Use airflow.exceptions.AirflowException instead."
 "airflow.Dataset".msg = "Use airflow.datasets.Dataset instead."
+
+[tool.ruff.flake8-tidy-imports]
+# Ban certain modules from being imported at module level, instead requiring
+# that they're imported lazily (e.g., within a function definition).
+banned-module-level-imports = ["numpy", "pandas"]
+
+[tool.ruff.flake8-type-checking]
+exempt-modules = ["typing", "typing_extensions"]
 
 [tool.coverage.run]
 branch = true
@@ -175,5 +185,3 @@ exclude_also = [
     "@(typing(_extensions)?\\.)?overload",
     "if TYPE_CHECKING:"
 ]
-[tool.ruff.flake8-type-checking]
-exempt-modules = ["typing", "typing_extensions"]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In addition add ban for top level imports for `numpy` and `pandas`
And replace local pre-commit hook to the official one https://github.com/astral-sh/ruff-pre-commit

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
