### PR TITLE
Allow to install MariaDB client libraries instead of MySQL on x86_64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -195,7 +195,7 @@ COLOR_RESET=$'\e[0m'
 readonly COLOR_RESET
 
 : "${INSTALL_MYSQL_CLIENT:?Should be true or false}"
-: "${MYSQL_CLIENT_TYPE:-mysql}"
+: "${INSTALL_MYSQL_CLIENT_TYPE:-mysql}"
 
 export_key() {
     local key="${1}"
@@ -289,16 +289,16 @@ install_mariadb_client() {
 
 if [[ ${INSTALL_MYSQL_CLIENT:="true"} == "true" ]]; then
     if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
-        MYSQL_CLIENT_TYPE="mariadb"
+        INSTALL_MYSQL_CLIENT_TYPE="mariadb"
     fi
 
-    if [[ "${MYSQL_CLIENT_TYPE}" == "mysql" ]]; then
+    if [[ "${INSTALL_MYSQL_CLIENT_TYPE}" == "mysql" ]]; then
         install_mysql_client "${@}"
-    elif [[ "${MYSQL_CLIENT_TYPE}" == "mariadb" ]]; then
+    elif [[ "${INSTALL_MYSQL_CLIENT_TYPE}" == "mariadb" ]]; then
         install_mariadb_client "${@}"
     else
         echo
-        echo "${COLOR_RED}Specify either mysql or mariadb, got ${MYSQL_CLIENT_TYPE}${COLOR_RESET}"
+        echo "${COLOR_RED}Specify either mysql or mariadb, got ${INSTALL_MYSQL_CLIENT_TYPE}${COLOR_RESET}"
         echo
         exit 1
     fi
@@ -1219,7 +1219,7 @@ COPY --from=scripts install_os_dependencies.sh /scripts/docker/
 RUN bash /scripts/docker/install_os_dependencies.sh dev
 
 ARG INSTALL_MYSQL_CLIENT="true"
-ARG MYSQL_CLIENT_TYPE="mysql"
+ARG INSTALL_MYSQL_CLIENT_TYPE="mysql"
 ARG INSTALL_MSSQL_CLIENT="true"
 ARG INSTALL_POSTGRES_CLIENT="true"
 ARG AIRFLOW_REPO=apache/airflow
@@ -1270,7 +1270,7 @@ ARG AIRFLOW_USER_HOME_DIR
 ARG AIRFLOW_UID
 
 ENV INSTALL_MYSQL_CLIENT=${INSTALL_MYSQL_CLIENT} \
-    MYSQL_CLIENT_TYPE=${MYSQL_CLIENT_TYPE} \
+    INSTALL_MYSQL_CLIENT_TYPE=${INSTALL_MYSQL_CLIENT_TYPE} \
     INSTALL_MSSQL_CLIENT=${INSTALL_MSSQL_CLIENT} \
     INSTALL_POSTGRES_CLIENT=${INSTALL_POSTGRES_CLIENT}
 
@@ -1442,7 +1442,7 @@ ARG RUNTIME_APT_COMMAND="echo"
 ARG ADDITIONAL_RUNTIME_APT_COMMAND=""
 ARG ADDITIONAL_RUNTIME_APT_ENV=""
 ARG INSTALL_MYSQL_CLIENT="true"
-ARG MYSQL_CLIENT_TYPE="mysql"
+ARG INSTALL_MYSQL_CLIENT_TYPE="mysql"
 ARG INSTALL_MSSQL_CLIENT="true"
 ARG INSTALL_POSTGRES_CLIENT="true"
 
@@ -1451,7 +1451,7 @@ ENV RUNTIME_APT_DEPS=${RUNTIME_APT_DEPS} \
     RUNTIME_APT_COMMAND=${RUNTIME_APT_COMMAND} \
     ADDITIONAL_RUNTIME_APT_COMMAND=${ADDITIONAL_RUNTIME_APT_COMMAND} \
     INSTALL_MYSQL_CLIENT=${INSTALL_MYSQL_CLIENT} \
-    MYSQL_CLIENT_TYPE=${MYSQL_CLIENT_TYPE} \
+    INSTALL_MYSQL_CLIENT_TYPE=${INSTALL_MYSQL_CLIENT_TYPE} \
     INSTALL_MSSQL_CLIENT=${INSTALL_MSSQL_CLIENT} \
     INSTALL_POSTGRES_CLIENT=${INSTALL_POSTGRES_CLIENT} \
     GUNICORN_CMD_ARGS="--worker-tmp-dir /dev/shm" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -195,6 +195,7 @@ COLOR_RESET=$'\e[0m'
 readonly COLOR_RESET
 
 : "${INSTALL_MYSQL_CLIENT:?Should be true or false}"
+: "${MYSQL_CLIENT_TYPE:-mysql}"
 
 export_key() {
     local key="${1}"
@@ -288,9 +289,18 @@ install_mariadb_client() {
 
 if [[ ${INSTALL_MYSQL_CLIENT:="true"} == "true" ]]; then
     if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
+        MYSQL_CLIENT_TYPE="mariadb"
+    fi
+
+    if [[ "${MYSQL_CLIENT_TYPE}" == "mysql" ]]; then
+        install_mysql_client "${@}"
+    elif [[ "${MYSQL_CLIENT_TYPE}" == "mariadb" ]]; then
         install_mariadb_client "${@}"
     else
-        install_mysql_client "${@}"
+        echo
+        echo "${COLOR_RED}Specify either mysql or mariadb, got ${MYSQL_CLIENT_TYPE}${COLOR_RESET}"
+        echo
+        exit 1
     fi
 fi
 EOF
@@ -1209,6 +1219,7 @@ COPY --from=scripts install_os_dependencies.sh /scripts/docker/
 RUN bash /scripts/docker/install_os_dependencies.sh dev
 
 ARG INSTALL_MYSQL_CLIENT="true"
+ARG MYSQL_CLIENT_TYPE="mysql"
 ARG INSTALL_MSSQL_CLIENT="true"
 ARG INSTALL_POSTGRES_CLIENT="true"
 ARG AIRFLOW_REPO=apache/airflow
@@ -1259,6 +1270,7 @@ ARG AIRFLOW_USER_HOME_DIR
 ARG AIRFLOW_UID
 
 ENV INSTALL_MYSQL_CLIENT=${INSTALL_MYSQL_CLIENT} \
+    MYSQL_CLIENT_TYPE=${MYSQL_CLIENT_TYPE} \
     INSTALL_MSSQL_CLIENT=${INSTALL_MSSQL_CLIENT} \
     INSTALL_POSTGRES_CLIENT=${INSTALL_POSTGRES_CLIENT}
 
@@ -1430,6 +1442,7 @@ ARG RUNTIME_APT_COMMAND="echo"
 ARG ADDITIONAL_RUNTIME_APT_COMMAND=""
 ARG ADDITIONAL_RUNTIME_APT_ENV=""
 ARG INSTALL_MYSQL_CLIENT="true"
+ARG MYSQL_CLIENT_TYPE="mysql"
 ARG INSTALL_MSSQL_CLIENT="true"
 ARG INSTALL_POSTGRES_CLIENT="true"
 
@@ -1438,6 +1451,7 @@ ENV RUNTIME_APT_DEPS=${RUNTIME_APT_DEPS} \
     RUNTIME_APT_COMMAND=${RUNTIME_APT_COMMAND} \
     ADDITIONAL_RUNTIME_APT_COMMAND=${ADDITIONAL_RUNTIME_APT_COMMAND} \
     INSTALL_MYSQL_CLIENT=${INSTALL_MYSQL_CLIENT} \
+    MYSQL_CLIENT_TYPE=${MYSQL_CLIENT_TYPE} \
     INSTALL_MSSQL_CLIENT=${INSTALL_MSSQL_CLIENT} \
     INSTALL_POSTGRES_CLIENT=${INSTALL_POSTGRES_CLIENT} \
     GUNICORN_CMD_ARGS="--worker-tmp-dir /dev/shm" \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -155,7 +155,7 @@ COLOR_RESET=$'\e[0m'
 readonly COLOR_RESET
 
 : "${INSTALL_MYSQL_CLIENT:?Should be true or false}"
-: "${MYSQL_CLIENT_TYPE:-mysql}"
+: "${INSTALL_MYSQL_CLIENT_TYPE:-mysql}"
 
 export_key() {
     local key="${1}"
@@ -249,16 +249,16 @@ install_mariadb_client() {
 
 if [[ ${INSTALL_MYSQL_CLIENT:="true"} == "true" ]]; then
     if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
-        MYSQL_CLIENT_TYPE="mariadb"
+        INSTALL_MYSQL_CLIENT_TYPE="mariadb"
     fi
 
-    if [[ "${MYSQL_CLIENT_TYPE}" == "mysql" ]]; then
+    if [[ "${INSTALL_MYSQL_CLIENT_TYPE}" == "mysql" ]]; then
         install_mysql_client "${@}"
-    elif [[ "${MYSQL_CLIENT_TYPE}" == "mariadb" ]]; then
+    elif [[ "${INSTALL_MYSQL_CLIENT_TYPE}" == "mariadb" ]]; then
         install_mariadb_client "${@}"
     else
         echo
-        echo "${COLOR_RED}Specify either mysql or mariadb, got ${MYSQL_CLIENT_TYPE}${COLOR_RESET}"
+        echo "${COLOR_RED}Specify either mysql or mariadb, got ${INSTALL_MYSQL_CLIENT_TYPE}${COLOR_RESET}"
         echo
         exit 1
     fi
@@ -1341,12 +1341,12 @@ COPY --from=scripts install_mysql.sh install_mssql.sh install_postgres.sh /scrip
 ARG HOME=/root
 ARG AIRFLOW_HOME=/root/airflow
 ARG AIRFLOW_SOURCES=/opt/airflow
-ARG MYSQL_CLIENT_TYPE="mysql"
+ARG INSTALL_MYSQL_CLIENT_TYPE="mysql"
 
 ENV HOME=${HOME} \
     AIRFLOW_HOME=${AIRFLOW_HOME} \
     AIRFLOW_SOURCES=${AIRFLOW_SOURCES} \
-    MYSQL_CLIENT_TYPE=${MYSQL_CLIENT_TYPE}
+    INSTALL_MYSQL_CLIENT_TYPE=${INSTALL_MYSQL_CLIENT_TYPE}
 
 # We run scripts with bash here to make sure we can execute the scripts. Changing to +x might have an
 # unexpected result - the cache for Dockerfiles might get invalidated in case the host system
@@ -1434,7 +1434,7 @@ ENV AIRFLOW_REPO=${AIRFLOW_REPO}\
 # * install airflow in editable mode
 # * install always current version of airflow
     INSTALL_MYSQL_CLIENT="true" \
-    MYSQL_CLIENT_TYPE=${MYSQL_CLIENT_TYPE} \
+    INSTALL_MYSQL_CLIENT_TYPE=${INSTALL_MYSQL_CLIENT_TYPE} \
     INSTALL_MSSQL_CLIENT="true" \
     INSTALL_POSTGRES_CLIENT="true" \
     AIRFLOW_INSTALLATION_METHOD="." \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -155,6 +155,7 @@ COLOR_RESET=$'\e[0m'
 readonly COLOR_RESET
 
 : "${INSTALL_MYSQL_CLIENT:?Should be true or false}"
+: "${MYSQL_CLIENT_TYPE:-mysql}"
 
 export_key() {
     local key="${1}"
@@ -248,9 +249,18 @@ install_mariadb_client() {
 
 if [[ ${INSTALL_MYSQL_CLIENT:="true"} == "true" ]]; then
     if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
+        MYSQL_CLIENT_TYPE="mariadb"
+    fi
+
+    if [[ "${MYSQL_CLIENT_TYPE}" == "mysql" ]]; then
+        install_mysql_client "${@}"
+    elif [[ "${MYSQL_CLIENT_TYPE}" == "mariadb" ]]; then
         install_mariadb_client "${@}"
     else
-        install_mysql_client "${@}"
+        echo
+        echo "${COLOR_RED}Specify either mysql or mariadb, got ${MYSQL_CLIENT_TYPE}${COLOR_RESET}"
+        echo
+        exit 1
     fi
 fi
 EOF
@@ -1331,10 +1341,12 @@ COPY --from=scripts install_mysql.sh install_mssql.sh install_postgres.sh /scrip
 ARG HOME=/root
 ARG AIRFLOW_HOME=/root/airflow
 ARG AIRFLOW_SOURCES=/opt/airflow
+ARG MYSQL_CLIENT_TYPE="mysql"
 
 ENV HOME=${HOME} \
     AIRFLOW_HOME=${AIRFLOW_HOME} \
-    AIRFLOW_SOURCES=${AIRFLOW_SOURCES}
+    AIRFLOW_SOURCES=${AIRFLOW_SOURCES} \
+    MYSQL_CLIENT_TYPE=${MYSQL_CLIENT_TYPE}
 
 # We run scripts with bash here to make sure we can execute the scripts. Changing to +x might have an
 # unexpected result - the cache for Dockerfiles might get invalidated in case the host system
@@ -1422,6 +1434,7 @@ ENV AIRFLOW_REPO=${AIRFLOW_REPO}\
 # * install airflow in editable mode
 # * install always current version of airflow
     INSTALL_MYSQL_CLIENT="true" \
+    MYSQL_CLIENT_TYPE=${MYSQL_CLIENT_TYPE} \
     INSTALL_MSSQL_CLIENT="true" \
     INSTALL_POSTGRES_CLIENT="true" \
     AIRFLOW_INSTALLATION_METHOD="." \

--- a/docs/docker-stack/build-arg-ref.rst
+++ b/docs/docker-stack/build-arg-ref.rst
@@ -171,10 +171,10 @@ for examples of using those arguments.
 |                                          |                                          | The mysql extra is removed from extras   |
 |                                          |                                          | if the client is not installed.          |
 +------------------------------------------+------------------------------------------+------------------------------------------+
-| ``INSTALL_MYSQL_CLIENT_TYPE``            | ``mysql``                                | Type of MySQL client library.            |
-|                                          |                                          | This can be ``mysql`` or ``mariadb``.    |
-|                                          |                                          | Regardless of the parameter will         |
-|                                          |                                          | always be used ``mariadb`` on ARM        |
+| ``INSTALL_MYSQL_CLIENT_TYPE``            | ``mysql``                                | (*Experimental*) Type of MySQL client    |
+|                                          |                                          | library. This can be ``mysql`` or        |
+|                                          |                                          | ``mariadb``. Regardless of the parameter |
+|                                          |                                          | will always be used ``mariadb`` on ARM.  |
 +------------------------------------------+------------------------------------------+------------------------------------------+
 | ``INSTALL_MSSQL_CLIENT``                 | ``true``                                 | Whether MsSQL client should be installed |
 +------------------------------------------+------------------------------------------+------------------------------------------+

--- a/docs/docker-stack/build-arg-ref.rst
+++ b/docs/docker-stack/build-arg-ref.rst
@@ -171,6 +171,11 @@ for examples of using those arguments.
 |                                          |                                          | The mysql extra is removed from extras   |
 |                                          |                                          | if the client is not installed.          |
 +------------------------------------------+------------------------------------------+------------------------------------------+
+| ``MYSQL_CLIENT_TYPE``                    | ``mysql``                                | Type of MySQL client library.            |
+|                                          |                                          | This can be ``mysql`` or ``mariadb``.    |
+|                                          |                                          | Regardless of the parameter will         |
+|                                          |                                          | always be used ``mariadb`` on ARM        |
++------------------------------------------+------------------------------------------+------------------------------------------+
 | ``INSTALL_MSSQL_CLIENT``                 | ``true``                                 | Whether MsSQL client should be installed |
 +------------------------------------------+------------------------------------------+------------------------------------------+
 | ``INSTALL_POSTGRES_CLIENT``              | ``true``                                 | Whether Postgres client should be        |

--- a/docs/docker-stack/build-arg-ref.rst
+++ b/docs/docker-stack/build-arg-ref.rst
@@ -171,7 +171,7 @@ for examples of using those arguments.
 |                                          |                                          | The mysql extra is removed from extras   |
 |                                          |                                          | if the client is not installed.          |
 +------------------------------------------+------------------------------------------+------------------------------------------+
-| ``MYSQL_CLIENT_TYPE``                    | ``mysql``                                | Type of MySQL client library.            |
+| ``INSTALL_MYSQL_CLIENT_TYPE``            | ``mysql``                                | Type of MySQL client library.            |
 |                                          |                                          | This can be ``mysql`` or ``mariadb``.    |
 |                                          |                                          | Regardless of the parameter will         |
 |                                          |                                          | always be used ``mariadb`` on ARM        |

--- a/docs/docker-stack/changelog.rst
+++ b/docs/docker-stack/changelog.rst
@@ -58,6 +58,14 @@ here so that users affected can find the reason for the changes.
 Airflow 2.7
 ~~~~~~~~~~~
 
+* 2.7.3
+
+  * You can specify type of MySQL Client libraries when you build the image via ``INSTALL_MYSQL_CLIENT_TYPE``
+    build arg. ``mysql`` for install MySQL client libraries from `Oracle APT repository <https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/>`_,
+    ``mariadb`` for install MariaDB client libraries from `MariaDB repository <https://mariadb.com/kb/en/mariadb-package-repository-setup-and-usage/#mariadb-repository>`_.
+    The selection of MySQL Client libraries only available on AMD64 (x86_64) for ARM docker image it will always install
+    MariaDB client.
+
 * 2.7.0
 
   * As of now, Python 3.7 is no longer supported by the Python community. Therefore, to use Airflow 2.7.0, you must ensure your Python version is

--- a/docs/docker-stack/changelog.rst
+++ b/docs/docker-stack/changelog.rst
@@ -60,7 +60,7 @@ Airflow 2.7
 
 * 2.7.3
 
-  * You can specify type of MySQL Client libraries when you build the image via ``INSTALL_MYSQL_CLIENT_TYPE``
+  * Add experimental feature for select type of MySQL Client libraries during the build custom image via ``INSTALL_MYSQL_CLIENT_TYPE``
     build arg. ``mysql`` for install MySQL client libraries from `Oracle APT repository <https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/>`_,
     ``mariadb`` for install MariaDB client libraries from `MariaDB repository <https://mariadb.com/kb/en/mariadb-package-repository-setup-and-usage/#mariadb-repository>`_.
     The selection of MySQL Client libraries only available on AMD64 (x86_64) for ARM docker image it will always install

--- a/scripts/docker/install_mysql.sh
+++ b/scripts/docker/install_mysql.sh
@@ -36,6 +36,7 @@ COLOR_RESET=$'\e[0m'
 readonly COLOR_RESET
 
 : "${INSTALL_MYSQL_CLIENT:?Should be true or false}"
+: "${MYSQL_CLIENT_TYPE:-mysql}"
 
 export_key() {
     local key="${1}"
@@ -128,13 +129,23 @@ install_mariadb_client() {
 }
 
 # Install MySQL client only if it is not disabled.
-# For amd64 (x86_64) install MySQL client from Oracle repositories.
-# For arm64 install MariaDB client from MariaDB repository, see:
+# MYSQL_CLIENT_TYPE=mysql : Install MySQL client from Oracle repository.
+# MYSQL_CLIENT_TYPE=mariadb : Install MariaDB client from MariaDB repository.
 # https://mariadb.com/kb/en/mariadb-clientserver-tcp-protocol/
+# For ARM64 MYSQL_CLIENT_TYPE ignored and always install MariaDB.
 if [[ ${INSTALL_MYSQL_CLIENT:="true"} == "true" ]]; then
     if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
+        MYSQL_CLIENT_TYPE="mariadb"
+    fi
+
+    if [[ "${MYSQL_CLIENT_TYPE}" == "mysql" ]]; then
+        install_mysql_client "${@}"
+    elif [[ "${MYSQL_CLIENT_TYPE}" == "mariadb" ]]; then
         install_mariadb_client "${@}"
     else
-        install_mysql_client "${@}"
+        echo
+        echo "${COLOR_RED}Specify either mysql or mariadb, got ${MYSQL_CLIENT_TYPE}${COLOR_RESET}"
+        echo
+        exit 1
     fi
 fi

--- a/scripts/docker/install_mysql.sh
+++ b/scripts/docker/install_mysql.sh
@@ -36,7 +36,7 @@ COLOR_RESET=$'\e[0m'
 readonly COLOR_RESET
 
 : "${INSTALL_MYSQL_CLIENT:?Should be true or false}"
-: "${MYSQL_CLIENT_TYPE:-mysql}"
+: "${INSTALL_MYSQL_CLIENT_TYPE:-mysql}"
 
 export_key() {
     local key="${1}"
@@ -129,22 +129,22 @@ install_mariadb_client() {
 }
 
 # Install MySQL client only if it is not disabled.
-# MYSQL_CLIENT_TYPE=mysql : Install MySQL client from Oracle repository.
-# MYSQL_CLIENT_TYPE=mariadb : Install MariaDB client from MariaDB repository.
+# INSTALL_MYSQL_CLIENT_TYPE=mysql : Install MySQL client from Oracle repository.
+# INSTALL_MYSQL_CLIENT_TYPE=mariadb : Install MariaDB client from MariaDB repository.
 # https://mariadb.com/kb/en/mariadb-clientserver-tcp-protocol/
-# For ARM64 MYSQL_CLIENT_TYPE ignored and always install MariaDB.
+# For ARM64 INSTALL_MYSQL_CLIENT_TYPE ignored and always install MariaDB.
 if [[ ${INSTALL_MYSQL_CLIENT:="true"} == "true" ]]; then
     if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
-        MYSQL_CLIENT_TYPE="mariadb"
+        INSTALL_MYSQL_CLIENT_TYPE="mariadb"
     fi
 
-    if [[ "${MYSQL_CLIENT_TYPE}" == "mysql" ]]; then
+    if [[ "${INSTALL_MYSQL_CLIENT_TYPE}" == "mysql" ]]; then
         install_mysql_client "${@}"
-    elif [[ "${MYSQL_CLIENT_TYPE}" == "mariadb" ]]; then
+    elif [[ "${INSTALL_MYSQL_CLIENT_TYPE}" == "mariadb" ]]; then
         install_mariadb_client "${@}"
     else
         echo
-        echo "${COLOR_RED}Specify either mysql or mariadb, got ${MYSQL_CLIENT_TYPE}${COLOR_RESET}"
+        echo "${COLOR_RED}Specify either mysql or mariadb, got ${INSTALL_MYSQL_CLIENT_TYPE}${COLOR_RESET}"
         echo
         exit 1
     fi


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Add option to install MariaDB client libraries instead of MySQL on x86_64 by utilise [customising Airflow image](https://airflow.apache.org/docs/docker-stack/build.html#customizing-the-image) option.

closes: #32708

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
