### PR TITLE
Chart: configurable mountPath for DAGs volume

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -472,7 +472,11 @@ server_tls_key_file = /etc/pgbouncer/server.key
 
 {{- define "airflow_dags_mount" -}}
 - name: dags
+  {{- if .Values.dags.mountPath }}
+  mountPath: {{ .Values.dags.mountPath }}
+  {{- else }}
   mountPath: {{ printf "%s/dags" .Values.airflowHome }}
+  {{- end }}
   {{- if .Values.dags.persistence.subPath }}
   subPath: {{ .Values.dags.persistence.subPath }}
   {{- end }}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -455,10 +455,18 @@ server_tls_key_file = /etc/pgbouncer/server.key
 {{- end }}
 
 {{- define "airflow_dags" -}}
-  {{- if .Values.dags.gitSync.enabled }}
-    {{- printf "%s/dags/repo/%s" .Values.airflowHome .Values.dags.gitSync.subPath }}
+  {{- if .Values.dags.mountPath }}
+    {{- if .Values.dags.gitSync.enabled }}
+      {{- printf "%s/repo/%s" .Values.dags.mountPath .Values.dags.gitSync.subPath }}
+    {{- else }}
+      {{- printf "%s" .Values.dags.mountPath }}
+    {{- end }}
   {{- else }}
-    {{- printf "%s/dags" .Values.airflowHome }}
+    {{- if .Values.dags.gitSync.enabled }}
+      {{- printf "%s/dags/repo/%s" .Values.airflowHome .Values.dags.gitSync.subPath }}
+    {{- else }}
+      {{- printf "%s/dags" .Values.airflowHome }}
+    {{- end }}
   {{- end }}
 {{- end }}
 

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -6931,6 +6931,14 @@
             "x-docsSection": "Airflow",
             "additionalProperties": false,
             "properties": {
+                "mountPath": {
+                    "description": "Where dags volume will be mounted. Works for both `persistence` and `gitSync`. If not specified, dags mount path will be set to `$AIRFLOW_HOME/dags`",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null
+                },
                 "persistence": {
                     "description": "Persistence configuration.",
                     "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2351,6 +2351,9 @@ podTemplate: ~
 
 # Git sync
 dags:
+  # Where dags volume will be mounted. Works for both persistence and gitSync.
+  # If not specified, dags mount path will be set to $AIRFLOW_HOME/dags
+  mountPath: ~
   persistence:
     # Annotations for dags PVC
     annotations: {}

--- a/helm_tests/airflow_aux/test_airflow_common.py
+++ b/helm_tests/airflow_aux/test_airflow_common.py
@@ -68,6 +68,22 @@ class TestAirflowCommon:
                     "readOnly": False,
                 },
             ),
+            (
+                {"mountPath": "/opt/airflow/dags/custom", "gitSync": {"enabled": True}},
+                {
+                    "mountPath": "/opt/airflow/dags/custom",
+                    "name": "dags",
+                    "readOnly": True,
+                },
+            ),
+            (
+                {"mountPath": "/opt/airflow/dags/custom", "persistence": {"enabled": True}},
+                {
+                    "mountPath": "/opt/airflow/dags/custom",
+                    "name": "dags",
+                    "readOnly": False,
+                },
+            ),
         ],
     )
     def test_dags_mount(self, dag_values, expected_mount):

--- a/helm_tests/airflow_aux/test_configmap.py
+++ b/helm_tests/airflow_aux/test_configmap.py
@@ -179,8 +179,10 @@ metadata:
                 "/opt/airflow/dags/custom/repo/tests/dags",
             ),
             (
-                {"mountPath": "/opt/airflow/dags/custom",
-                 "gitSync": {"enabled": True, "subPath": "mysubPath"}},
+                {
+                    "mountPath": "/opt/airflow/dags/custom",
+                    "gitSync": {"enabled": True, "subPath": "mysubPath"},
+                },
                 "/opt/airflow/dags/custom/repo/mysubPath",
             ),
             (

--- a/helm_tests/airflow_aux/test_configmap.py
+++ b/helm_tests/airflow_aux/test_configmap.py
@@ -162,3 +162,38 @@ metadata:
 
         cfg = jmespath.search('data."airflow.cfg"', docs[0])
         assert expected in cfg.splitlines()
+
+    @pytest.mark.parametrize(
+        "dag_values, expected_default_dag_folder",
+        [
+            (
+                {"gitSync": {"enabled": True}},
+                "/opt/airflow/dags/repo/tests/dags",
+            ),
+            (
+                {"persistence": {"enabled": True}},
+                "/opt/airflow/dags",
+            ),
+            (
+                {"mountPath": "/opt/airflow/dags/custom", "gitSync": {"enabled": True}},
+                "/opt/airflow/dags/custom/repo/tests/dags",
+            ),
+            (
+                {"mountPath": "/opt/airflow/dags/custom",
+                 "gitSync": {"enabled": True, "subPath": "mysubPath"}},
+                "/opt/airflow/dags/custom/repo/mysubPath",
+            ),
+            (
+                {"mountPath": "/opt/airflow/dags/custom", "persistence": {"enabled": True}},
+                "/opt/airflow/dags/custom",
+            ),
+        ],
+    )
+    def test_expected_default_dag_folder(self, dag_values, expected_default_dag_folder):
+        docs = render_chart(
+            values={"dags": dag_values},
+            show_only=["templates/configmaps/configmap.yaml"],
+        )
+        cfg = jmespath.search('data."airflow.cfg"', docs[0])
+        expected_folder_config = f"dags_folder = {expected_default_dag_folder}"
+        assert expected_folder_config in cfg.splitlines()


### PR DESCRIPTION
This PR adds possibility to configure mountPath for DAGs volume.  Configurable mountPath will make it possible to:

* Add some rarely changing DAGs during image building to your `dags_folder` instead of receiving them from git.
* mount to your DAGs folder custom configmaps (for example, to `/dags_folder/my_custom_configmap`).

closes: #34959
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
