### PR TITLE
Fix CI's docs filter generation

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -726,7 +726,7 @@ class SelectiveChecks:
             packages.append("docker-stack")
         if providers_affected:
             for provider in providers_affected:
-                packages.append(f"{provider.replace('.', '-')}")
+                packages.append(provider.replace("-", "."))
         return " ".join(packages)
 
     @cached_property

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -693,9 +693,9 @@ def test_expected_output_pull_request_v2_3(
                 "needs-helm-tests": "true",
                 "run-tests": "true",
                 "docs-build": "true",
-                "docs-list-as-string": "apache-airflow helm-chart amazon apache-beam apache-cassandra "
-                "cncf-kubernetes common-sql facebook google hashicorp microsoft-azure "
-                "microsoft-mssql mysql openlineage oracle postgres "
+                "docs-list-as-string": "apache-airflow helm-chart amazon apache.beam apache.cassandra "
+                "cncf.kubernetes common.sql facebook google hashicorp microsoft.azure "
+                "microsoft.mssql mysql openlineage oracle postgres "
                 "presto salesforce samba sftp ssh trino",
                 "run-kubernetes-tests": "true",
                 "upgrade-to-newer-dependencies": "false",

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -975,9 +975,9 @@ def test_upgrade_to_newer_dependencies(
         pytest.param(
             ("docs/apache-airflow-providers-google/docs.rst",),
             {
-                "docs-list-as-string": "amazon apache-beam apache-cassandra "
-                "cncf-kubernetes common-sql facebook google hashicorp "
-                "microsoft-azure microsoft-mssql mysql openlineage oracle "
+                "docs-list-as-string": "amazon apache.beam apache.cassandra "
+                "cncf.kubernetes common.sql facebook google hashicorp "
+                "microsoft.azure microsoft.mssql mysql openlineage oracle "
                 "postgres presto salesforce samba sftp ssh trino",
             },
             id="Google provider docs changed",
@@ -985,9 +985,9 @@ def test_upgrade_to_newer_dependencies(
         pytest.param(
             ("airflow/providers/common/sql/common_sql_python.py",),
             {
-                "docs-list-as-string": "apache-airflow amazon apache-drill apache-druid apache-hive "
-                "apache-impala apache-pinot common-sql databricks elasticsearch "
-                "exasol google jdbc microsoft-mssql mysql odbc openlineage "
+                "docs-list-as-string": "apache-airflow amazon apache.drill apache.druid apache.hive "
+                "apache.impala apache.pinot common.sql databricks elasticsearch "
+                "exasol google jdbc microsoft.mssql mysql odbc openlineage "
                 "oracle postgres presto slack snowflake sqlite trino vertica",
             },
             id="Common SQL provider package python files changed",
@@ -1026,7 +1026,7 @@ def test_upgrade_to_newer_dependencies(
         ),
         pytest.param(
             ("airflow/providers/celery/file.py",),
-            {"docs-list-as-string": "apache-airflow celery cncf-kubernetes"},
+            {"docs-list-as-string": "apache-airflow celery cncf.kubernetes"},
             id="Celery python files changed",
         ),
         pytest.param(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fix list generation for `build-docs` CI step.

```console
Run breeze build-docs apache-airflow amazon apache-flink apache-spark celery cncf-kubernetes google
                                                                                
 Usage:                                                                         
 breeze build-docs                                                              
 [OPTIONS] [all-providers | providers-index | apache-airflow | docker-stack |   
 helm-chart | airbyte | alibaba | amazon | apache.beam | apache.cassandra |     
 apache.drill | apache.druid | apache.flink | apache.hdfs | apache.hive |       
 apache.impala | apache.kafka | apache.kylin | apache.livy | apache.pig |       
 apache.pinot | apache.spark | apache.sqoop | apprise | arangodb | asana |      
 atlassian.jira | celery | cloudant | cncf.kubernetes | common.sql |            
 daskexecutor | databricks | datadog | dbt.cloud | dingding | discord | docker  
 | elasticsearch | exasol | facebook | ftp | github | google | grpc | hashicorp 
 | http | imap | influxdb | jdbc | jenkins | microsoft.azure | microsoft.mssql  
 | microsoft.psrp | microsoft.winrm | mongo | mysql | neo4j | odbc | openfaas | 
 openlineage | opensearch | opsgenie | oracle | pagerduty | papermill | plexus  
 | postgres | presto | redis | salesforce | samba | segment | sendgrid | sftp | 
 singularity | slack | smtp | snowflake | sqlite | ssh | tableau | tabular |    
 telegram | trino | vertica | yandex | zendesk]...                              
                                                                                
                                                                                
 Try running the '--help' flag for more information.                            
                                                                                
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ Invalid value for '[all-providers | providers-index | apache-airflow |       │
│ docker-stack | helm-chart | airbyte | alibaba | amazon | apache.beam |       │
│ apache.cassandra | apache.drill | apache.druid | apache.flink | apache.hdfs  │
│ | apache.hive | apache.impala | apache.kafka | apache.kylin | apache.livy |  │
│ apache.pig | apache.pinot | apache.spark | apache.sqoop | apprise | arangodb │
│ | asana | atlassian.jira | celery | cloudant | cncf.kubernetes | common.sql  │
│ | daskexecutor | databricks | datadog | dbt.cloud | dingding | discord |     │
│ docker | elasticsearch | exasol | facebook | ftp | github | google | grpc |  │
│ hashicorp | http | imap | influxdb | jdbc | jenkins | microsoft.azure |      │
│ microsoft.mssql | microsoft.psrp | microsoft.winrm | mongo | mysql | neo4j | │
│ odbc | openfaas | openlineage | opensearch | opsgenie | oracle | pagerduty | │
│ papermill | plexus | postgres | presto | redis | salesforce | samba |        │
│ segment | sendgrid | sftp | singularity | slack | smtp | snowflake | sqlite  │
│ | ssh | tableau | tabular | telegram | trino | vertica | yandex |            │
│ zendesk]...': 'apache-flink' is not one of 'all-providers',                  │
│ 'providers-index', 'apache-airflow', 'docker-stack', 'helm-chart',           │
│ 'airbyte', 'alibaba', 'amazon', 'apache.beam', 'apache.cassandra',           │
│ 'apache.drill', 'apache.druid', 'apache.flink', 'apache.hdfs',               │
│ 'apache.hive', 'apache.impala', 'apache.kafka', 'apache.kylin',              │
│ 'apache.livy', 'apache.pig', 'apache.pinot', 'apache.spark', 'apache.sqoop', │
│ 'apprise', 'arangodb', 'asana', 'atlassian.jira', 'celery', 'cloudant',      │
│ 'cncf.kubernetes', 'common.sql', 'daskexecutor', 'databricks', 'datadog',    │
│ 'dbt.cloud', 'dingding', 'discord', 'docker', 'elasticsearch', 'exasol',     │
│ 'facebook', 'ftp', 'github', 'google', 'grpc', 'hashicorp', 'http', 'imap',  │
│ 'influxdb', 'jdbc', 'jenkins', 'microsoft.azure', 'microsoft.mssql',         │
│ 'microsoft.psrp', 'microsoft.winrm', 'mongo', 'mysql', 'neo4j', 'odbc',      │
│ 'openfaas', 'openlineage', 'opensearch', 'opsgenie', 'oracle', 'pagerduty',  │
│ 'papermill', 'plexus', 'postgres', 'presto', 'redis', 'salesforce', 'samba', │
│ 'segment', 'sendgrid', 'sftp', 'singularity', 'slack', 'smtp', 'snowflake',  │
│ 'sqlite', 'ssh', 'tableau', 'tabular', 'telegram', 'trino', 'vertica',       │
│ 'yandex', 'zendesk'.                                                         │
╰──────────────────────────────────────────────────────────────────────────────╯
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
