### PR TITLE
Fix handling selective docs builds for "special" packages

### DIFF
--- a/dev/breeze/src/airflow_breeze/params/doc_build_params.py
+++ b/dev/breeze/src/airflow_breeze/params/doc_build_params.py
@@ -20,20 +20,14 @@ import os
 from dataclasses import dataclass
 
 from airflow_breeze.branch_defaults import AIRFLOW_BRANCH
+from airflow_breeze.utils.general_utils import get_docs_filter_name_from_short_hand
 
 providers_prefix = "apache-airflow-providers-"
 
 
-def get_provider_name_from_short_hand(short_form_providers: tuple[str, ...]):
-    return tuple(
-        providers_prefix + short_form_provider.replace(".", "-")
-        for short_form_provider in short_form_providers
-    )
-
-
 @dataclass
 class DocBuildParams:
-    package_filter: tuple[str]
+    package_filter: tuple[str, ...]
     docs_only: bool
     spellcheck_only: bool
     short_doc_packages: tuple[str, ...]
@@ -53,10 +47,9 @@ class DocBuildParams:
         if AIRFLOW_BRANCH != "main":
             doc_args.append("--disable-provider-checks")
         if self.short_doc_packages:
-            providers = get_provider_name_from_short_hand(self.short_doc_packages)
-            for single_provider in providers:
-                doc_args.extend(["--package-filter", single_provider])
+            for filter_from_short_doc in get_docs_filter_name_from_short_hand(self.short_doc_packages):
+                doc_args.extend(["--package-filter", filter_from_short_doc])
         if self.package_filter:
-            for single_filter in self.package_filter:
-                doc_args.extend(["--package-filter", single_filter])
+            for filter in self.package_filter:
+                doc_args.extend(["--package-filter", filter])
         return doc_args

--- a/dev/breeze/src/airflow_breeze/utils/general_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/general_utils.py
@@ -21,7 +21,7 @@ from airflow_breeze.global_constants import ALL_SPECIAL_DOC_KEYS, get_available_
 providers_prefix = "apache-airflow-providers-"
 
 
-def get_provider_name_from_short_hand(short_form_providers: tuple[str]):
+def get_docs_filter_name_from_short_hand(short_form_providers: tuple[str]):
     providers = []
     for short_form_provider in short_form_providers:
         if specific_doc := ALL_SPECIAL_DOC_KEYS.get(short_form_provider):

--- a/dev/breeze/src/airflow_breeze/utils/publish_docs_helpers.py
+++ b/dev/breeze/src/airflow_breeze/utils/publish_docs_helpers.py
@@ -26,7 +26,7 @@ from typing import Any
 
 import yaml
 
-from airflow_breeze.utils.general_utils import get_provider_name_from_short_hand
+from airflow_breeze.utils.general_utils import get_docs_filter_name_from_short_hand
 
 CONSOLE_WIDTH = 180
 
@@ -111,8 +111,7 @@ def process_package_filters(
     if not package_filters and not packages_short_form:
         return available_packages
 
-    expanded_short_form_packages = get_provider_name_from_short_hand(packages_short_form)
-    package_filters = list(package_filters + expanded_short_form_packages)
+    package_filters = list(package_filters + get_docs_filter_name_from_short_hand(packages_short_form))
 
     invalid_filters = [
         f for f in package_filters if not any(fnmatch.fnmatch(p, f) for p in available_packages)

--- a/dev/breeze/tests/test_general_utils.py
+++ b/dev/breeze/tests/test_general_utils.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import pytest
 
-from airflow_breeze.utils.general_utils import get_provider_name_from_short_hand
+from airflow_breeze.utils.general_utils import get_docs_filter_name_from_short_hand
 
 
 @pytest.mark.parametrize(
@@ -43,4 +43,4 @@ from airflow_breeze.utils.general_utils import get_provider_name_from_short_hand
     ],
 )
 def test_get_provider_name_from_short_hand(short_form_providers, expected):
-    assert get_provider_name_from_short_hand(short_form_providers) == expected
+    assert get_docs_filter_name_from_short_hand(short_form_providers) == expected


### PR DESCRIPTION
The #35069 and #35087 that switched from `--package-filter` to shorthand package names in CI did not handle all the cases - special package names such as "apache-airflow" or "helm-chart" were treated also as providers and the --package-filter constructed was wrong.

This caused a few PRs that got "selective" documentation build (only when they changed provider + some airflow docs) would fail.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
