### PR TITLE
Cleanup dependencies of cache image pushing and ARM image build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1725,7 +1725,6 @@ jobs:
       - tests-postgres
       - tests-integration-postgres
       - tests-integration-mysql
-      - push-early-buildx-cache-to-github-registry
       # Skip when generate constraints fails
       - generate-constraints
     env:
@@ -1779,8 +1778,7 @@ jobs:
     runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
     needs:
       - build-info
-      - generate-constraints
-      - docs
+      - update-constraints
     if: needs.build-info.outputs.canary-run == 'true'
     strategy:
       fail-fast: false
@@ -1865,6 +1863,10 @@ jobs:
         run: breeze ci fix-ownership
         if: always()
 
+  # This is only a check if ARM images are successfully building when committer runs PR from
+  # Apache repository. This is needed in case you want to fix failing cache job in "canary" run
+  # There is no point in running this one in "canary" run, because the above step is doing the
+  # same build anyway.
   build-ci-arm-images:
     timeout-minutes: 50
     name: >
@@ -1873,8 +1875,8 @@ jobs:
     runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
     needs:
       - build-info
-      - wait-for-ci-images
-      - wait-for-prod-images
+      - generate-constraints
+      - docs
       - static-checks
       - tests-sqlite
       - tests-mysql
@@ -1888,7 +1890,6 @@ jobs:
       # Force more parallelism for build even on small instances
       PARALLELISM: 6
     if: >
-      needs.build-info.outputs.upgrade-to-newer-dependencies != 'false' &&
       needs.build-info.outputs.in-workflow-build == 'true' &&
       needs.build-info.outputs.canary-run != 'true'
     steps:


### PR DESCRIPTION
The cache image pushing should only happen after all tests succeeded and constraints got pushed.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
