### PR TITLE
Fix test connection with codemirror and extra

### DIFF
--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -29,6 +29,9 @@ const configTestConnection = getMetaValue("config_test_connection")
 const restApiEnabled = getMetaValue("rest_api_enabled") === "True";
 const connectionTestUrl = getMetaValue("test_url");
 
+// Define editor var which may get populated if extra field exists on the connection
+let editor;
+
 function decode(str) {
   return new DOMParser().parseFromString(str, "text/html").documentElement
     .textContent;
@@ -330,6 +333,11 @@ $(document).ready(() => {
   $("#test-connection").on("click", (e) => {
     e.preventDefault();
     hideAlert();
+    // save the contents of the CodeMirror editor to the textArea if it is populated
+    // (i.e., connection type has extra field)
+    if (Object.prototype.hasOwnProperty.call(editor, "save")) {
+      editor.save();
+    }
     $.ajax({
       url: connectionTestUrl,
       type: "post",
@@ -356,16 +364,18 @@ $(document).ready(() => {
 
   // Change conn.extra TextArea widget to CodeMirror
   const textArea = document.getElementById("extra");
-  const editor = CodeMirror.fromTextArea(textArea, {
+  editor = CodeMirror.fromTextArea(textArea, {
     mode: { name: "javascript", json: true },
     gutters: ["CodeMirror-lint-markers"],
     lineWrapping: true,
     lint: true,
   });
 
-  // beautify JSON
+  // beautify JSON but only if it is not equal to default value of empty string
   const jsonData = editor.getValue();
-  const data = JSON.parse(jsonData);
-  const formattedData = JSON.stringify(data, null, 2);
-  editor.setValue(formattedData);
+  if (jsonData !== "") {
+    const data = JSON.parse(jsonData);
+    const formattedData = JSON.stringify(data, null, 2);
+    editor.setValue(formattedData);
+  }
 });


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: https://github.com/apache/airflow/issues/32890

This fixes an issue where the addition of CodeMirror on the extra text field in https://github.com/apache/airflow/pull/28583 causes the Test button to no longer send the extra field. This fix was previously attempted in https://github.com/apache/airflow/pull/32893 but was later reverted due to inadvertent issues with other connections in https://github.com/apache/airflow/pull/33032.

The reason for the revert was because non-applicable fields were being shown in connections. Instead of moving the instantiation of CodeMirror on textArea, we can declare a global editor variable that is populated if the extra field exists on the connection. If it does exist and a user wants to test a connection with extras, we will call `editor.save` to save the value to textArea which will make it accessible in `getSerializedFormData`.

## Test Plan

Check other connections and make sure they look okay

<img width="780" alt="image" src="https://github.com/apache/airflow/assets/9200263/85f9ba45-1935-4911-adec-8c454c86b53b">

Create a new connection of type HTTP, set a host, and add an extra json field

<img width="625" alt="image" src="https://github.com/apache/airflow/assets/9200263/9d610228-6d56-4ae6-a532-19b2e7fd8a6e">

Ensure extra is passed through the test

<img width="1426" alt="image" src="https://github.com/apache/airflow/assets/9200263/cb797aba-bf19-4b8f-ad7a-3a30cb02534f">

Ensure the connection is persisted properly:

<img width="1440" alt="image" src="https://github.com/apache/airflow/assets/9200263/ccd4b5bb-6de5-4e2d-8017-999f00bbf232">

<img width="1182" alt="image" src="https://github.com/apache/airflow/assets/9200263/32005e36-3942-4bb5-a889-3c2566943df4">


Please let me know if there's anything else I can test.

cc @pankajkoti @genehynson @eladkal 