### PR TITLE
Limit Airflow and breeze to < 3.12

### DIFF
--- a/dev/breeze/README.md
+++ b/dev/breeze/README.md
@@ -66,6 +66,6 @@ PLEASE DO NOT MODIFY THE HASH BELOW! IT IS AUTOMATICALLY UPDATED BY PRE-COMMIT.
 
 ---------------------------------------------------------------------------------------------------------
 
-Package config hash: 20d095e80d897b7c19f3eef96e0e6ceef4a7a0c0a9b82def7089ec962da64e1bd2ee20f02532fc2ef64137d86c045c340bc8038695f53d29aa72833cafe8b153
+Package config hash: 1fe676b16075afde8bd7dd88b92b3e587b12927337a0edfcc8f751a7d400b772e300d64084f02e4c76e5bb5f2f349a23729258ec457bcb0b94f180ef19ffb154
 
 ---------------------------------------------------------------------------------------------------------

--- a/dev/breeze/setup.cfg
+++ b/dev/breeze/setup.cfg
@@ -36,6 +36,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 project_urls =
     Documentation=https://github.com/apache/airflow/BREEZE.rst
     Bug Tracker=https://github.com/apache/airflow/issues
@@ -47,7 +48,9 @@ project_urls =
 [options]
 zip_safe = False
 include_package_data = True
-python_requires = ~=3.8
+# Mainly because of distutils deprecation and some packages not being compatible with it, we should
+# Limit airflow to < 3.12 until those dependencies are ready and until we can support Python 3.12
+python_requires = ~=3.8,<3.12
 package_dir=
     =src
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,9 @@ project_urls =
 [options]
 zip_safe = False
 include_package_data = True
-python_requires = ~=3.8
+# Mainly because of distutils deprecation and some packages not being compatible with it, we should
+# Limit airflow to < 3.12 until those dependencies are ready and until we can support Python 3.12
+python_requires = ~=3.8,<3.12
 packages = find:
 setup_requires =
     gitpython


### PR DESCRIPTION
Python 3.12 has a few breaking changes comparing to earlier versions. While 3.7 - 3.11 were largely backwards compatible, Python 3.12 is the first one for a long time that started to break things more aggressively.

For now we know that Airflow will not work with Python 3.12 mainly because of distutils removal (https://peps.python.org/pep-0632/) and not because of Airflow's usage of it but pendulum's before version 3.

While we are working on getting Pendulum 3 support in #34744 and the #34746, there are likely other dependencies that have similar issue.

Until we fix it and add official 3.12 support, we can limit airflow to not be installable on 3.12.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
