### PR TITLE
Fix typo in multiple files, "overriden" is a misspelling of "overridden"

### DIFF
--- a/helm_tests/airflow_aux/test_cleanup_pods.py
+++ b/helm_tests/airflow_aux/test_cleanup_pods.py
@@ -384,7 +384,7 @@ class TestCleanupServiceAccount:
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
-    def test_overriden_automount_service_account_token(self):
+    def test_overridden_automount_service_account_token(self):
         docs = render_chart(
             values={
                 "cleanup": {"enabled": True, "serviceAccount": {"automountServiceAccountToken": False}},

--- a/helm_tests/airflow_aux/test_configmap.py
+++ b/helm_tests/airflow_aux/test_configmap.py
@@ -152,13 +152,13 @@ metadata:
         cfg = jmespath.search('data."airflow.cfg"', docs[0])
         assert expected in cfg.splitlines()
 
-    def test_overriden_flower_url_prefix(self):
+    def test_overridedn_flower_url_prefix(self):
         docs = render_chart(
-            values={"executor": "CeleryExecutor", "ingress": {"flower": {"path": "/overriden-path"}}},
+            values={"executor": "CeleryExecutor", "ingress": {"flower": {"path": "/overridden-path"}}},
             show_only=["templates/configmaps/configmap.yaml"],
         )
 
-        expected = "flower_url_prefix = /overriden-path"
+        expected = "flower_url_prefix = /overridden-path"
 
         cfg = jmespath.search('data."airflow.cfg"', docs[0])
         assert expected in cfg.splitlines()

--- a/helm_tests/airflow_aux/test_create_user_job.py
+++ b/helm_tests/airflow_aux/test_create_user_job.py
@@ -419,7 +419,7 @@ class TestCreateUserJobServiceAccount:
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
-    def test_overriden_automount_service_account_token(self):
+    def test_overridden_automount_service_account_token(self):
         docs = render_chart(
             values={
                 "createUserJob": {

--- a/helm_tests/airflow_aux/test_migrate_database_job.py
+++ b/helm_tests/airflow_aux/test_migrate_database_job.py
@@ -351,7 +351,7 @@ class TestMigrateDatabaseJobServiceAccount:
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
-    def test_overriden_automount_service_account_token(self):
+    def test_overridden_automount_service_account_token(self):
         docs = render_chart(
             values={
                 "migrateDatabaseJob": {

--- a/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm_tests/airflow_core/test_dag_processor.py
@@ -659,7 +659,7 @@ class TestDagProcessorServiceAccount:
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
-    def test_overriden_automount_service_account_token(self):
+    def test_overridden_automount_service_account_token(self):
         docs = render_chart(
             values={
                 "dagProcessor": {

--- a/helm_tests/airflow_core/test_scheduler.py
+++ b/helm_tests/airflow_core/test_scheduler.py
@@ -873,7 +873,7 @@ class TestSchedulerServiceAccount:
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
-    def test_overriden_automount_service_account_token(self):
+    def test_overridden_automount_service_account_token(self):
         docs = render_chart(
             values={
                 "scheduler": {

--- a/helm_tests/airflow_core/test_triggerer.py
+++ b/helm_tests/airflow_core/test_triggerer.py
@@ -621,7 +621,7 @@ class TestTriggererServiceAccount:
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
-    def test_overriden_automount_service_account_token(self):
+    def test_overridden_automount_service_account_token(self):
         docs = render_chart(
             values={
                 "triggerer": {

--- a/helm_tests/airflow_core/test_worker.py
+++ b/helm_tests/airflow_core/test_worker.py
@@ -831,7 +831,7 @@ class TestWorkerServiceAccount:
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
-    def test_overriden_automount_service_account_token(self):
+    def test_overridden_automount_service_account_token(self):
         docs = render_chart(
             values={
                 "workers": {

--- a/helm_tests/other/test_flower.py
+++ b/helm_tests/other/test_flower.py
@@ -603,7 +603,7 @@ class TestFlowerServiceAccount:
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
-    def test_overriden_automount_service_account_token(self):
+    def test_overridden_automount_service_account_token(self):
         docs = render_chart(
             values={
                 "flower": {

--- a/helm_tests/other/test_pgbouncer.py
+++ b/helm_tests/other/test_pgbouncer.py
@@ -700,7 +700,7 @@ class TestPgBouncerServiceAccount:
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
-    def test_overriden_automount_service_account_token(self):
+    def test_overridden_automount_service_account_token(self):
         docs = render_chart(
             values={
                 "pgbouncer": {

--- a/helm_tests/other/test_redis.py
+++ b/helm_tests/other/test_redis.py
@@ -372,7 +372,7 @@ class TestRedisServiceAccount:
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
-    def test_overriden_automount_service_account_token(self):
+    def test_overridden_automount_service_account_token(self):
         docs = render_chart(
             values={
                 "redis": {

--- a/helm_tests/other/test_statsd.py
+++ b/helm_tests/other/test_statsd.py
@@ -351,7 +351,7 @@ class TestStatsdServiceAccount:
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
-    def test_overriden_automount_service_account_token(self):
+    def test_overridden_automount_service_account_token(self):
         docs = render_chart(
             values={
                 "statsd": {

--- a/helm_tests/webserver/test_webserver.py
+++ b/helm_tests/webserver/test_webserver.py
@@ -1070,7 +1070,7 @@ class TestWebserverServiceAccount:
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
-    def test_overriden_automount_service_account_token(self):
+    def test_overridden_automount_service_account_token(self):
         docs = render_chart(
             values={
                 "webserver": {

--- a/tests/decorators/test_setup_teardown.py
+++ b/tests/decorators/test_setup_teardown.py
@@ -186,7 +186,7 @@ class TestSetupTearDownTask:
         assert teardown_task.on_failure_fail_dagrun is on_failure_fail_dagrun
         assert len(dag.task_group.children) == 1
 
-    def test_setup_task_can_be_overriden(self, dag_maker):
+    def test_setup_task_can_be_overridden(self, dag_maker):
         @setup
         def mytask():
             print("I am a setup task")
@@ -197,7 +197,7 @@ class TestSetupTearDownTask:
         setup_task = dag.task_group.children["mytask2"]
         assert setup_task.is_setup
 
-    def test_teardown_on_failure_fail_dagrun_can_be_overriden(self, dag_maker):
+    def test_teardown_on_failure_fail_dagrun_can_be_overridden(self, dag_maker):
         @teardown
         def mytask():
             print("I am a teardown task")
@@ -209,7 +209,7 @@ class TestSetupTearDownTask:
         assert teardown_task.is_teardown
         assert teardown_task.on_failure_fail_dagrun
 
-    def test_retain_on_failure_fail_dagrun_when_other_attrs_are_overriden(self, dag_maker):
+    def test_retain_on_failure_fail_dagrun_when_other_attrs_are_overridden(self, dag_maker):
         @teardown(on_failure_fail_dagrun=True)
         def mytask():
             print("I am a teardown task")

--- a/tests/decorators/test_task_group.py
+++ b/tests/decorators/test_task_group.py
@@ -77,7 +77,7 @@ def test_tooltip_derived_from_function_docstring():
     assert _.task_group_dict["tg"].tooltip == "Function docstring."
 
 
-def test_tooltip_not_overriden_by_function_docstring():
+def test_tooltip_not_overridden_by_function_docstring():
     """
     Test that the tooltip for TaskGroup is the explicitly set value even if the decorated function has a
     docstring.


### PR DESCRIPTION
Fix typo in multiple files, "overriden" is a misspelling of "overridden"

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
