### PR TITLE
Add back dag_run to docs

### DIFF
--- a/docs/apache-airflow/public-airflow-interface.rst
+++ b/docs/apache-airflow/public-airflow-interface.rst
@@ -86,6 +86,16 @@ References for the modules used in DAGs are here:
   _api/airflow/models/dagbag/index
   _api/airflow/models/param/index
 
+Properties of a :class:`~airflow.models.dagrun.DagRun` can also be referenced in things like :ref:`Templates <templates-ref>`.
+
+.. toctree::
+  :includehidden:
+  :glob:
+  :maxdepth: 1
+
+  _api/airflow/models/dagrun/index
+
+
 Operators
 ---------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -250,6 +250,7 @@ if PACKAGE_NAME == "apache-airflow":
         "baseoperator.py",
         "connection.py",
         "dag.py",
+        "dagrun.py"
         "dagbag.py",
         "param.py",
         "taskinstance.py",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -250,7 +250,7 @@ if PACKAGE_NAME == "apache-airflow":
         "baseoperator.py",
         "connection.py",
         "dag.py",
-        "dagrun.py"
+        "dagrun.py",
         "dagbag.py",
         "param.py",
         "taskinstance.py",


### PR DESCRIPTION
<!-- Please keep an empty line above the dashes. -->
---
Adds in `dag_runs` so it can be linked to and viewed - such as from the `templates.rst` page.

Should others be here? Like `pool`? 🤷 