### PR TITLE
change latest to stable to fix broken documentation links

### DIFF
--- a/airflow/utils/docs.py
+++ b/airflow/utils/docs.py
@@ -28,7 +28,7 @@ def get_docs_url(page: str | None = None) -> str:
 
     if any(suffix in version for suffix in ["dev", "a", "b"]):
         result = (
-            "http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/"
+            "http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/stable/"
         )
     else:
         result = f"https://airflow.apache.org/docs/apache-airflow/{version}/"

--- a/chart/README.md
+++ b/chart/README.md
@@ -54,7 +54,7 @@ cluster using the [Helm](https://helm.sh) package manager.
 
 Full documentation for Helm Chart (latest **stable** release) lives [on the website](https://airflow.apache.org/docs/helm-chart/).
 
-> Note: If you're looking for documentation for main branch (latest development branch): you can find it on [s.apache.org/airflow-docs/](http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/helm-chart/latest/index.html).
+> Note: If you're looking for documentation for main branch (latest development branch): you can find it on [s.apache.org/airflow-docs/](http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/helm-chart/stable/index.html).
 > Source code for documentation is in [../docs/helm-chart](https://github.com/apache/airflow/tree/main/docs/helm-chart)
 >
 

--- a/tests/utils/test_docs.py
+++ b/tests/utils/test_docs.py
@@ -37,7 +37,7 @@ class TestGetDocsUrl:
                 "2.0.0.dev0",
                 "migration.html",
                 "http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/"
-                "apache-airflow/stable/migration.html",
+                "apache-airflow/stable/migrations-ref.html",
             ),
             ("1.10.10", None, "https://airflow.apache.org/docs/apache-airflow/1.10.10/"),
             (

--- a/tests/utils/test_docs.py
+++ b/tests/utils/test_docs.py
@@ -31,13 +31,13 @@ class TestGetDocsUrl:
                 "2.0.0.dev0",
                 None,
                 "http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/"
-                "apache-airflow/latest/",
+                "apache-airflow/stable/",
             ),
             (
                 "2.0.0.dev0",
                 "migration.html",
                 "http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/"
-                "apache-airflow/latest/migration.html",
+                "apache-airflow/stable/migration.html",
             ),
             ("1.10.10", None, "https://airflow.apache.org/docs/apache-airflow/1.10.10/"),
             (

--- a/tests/utils/test_docs.py
+++ b/tests/utils/test_docs.py
@@ -35,7 +35,7 @@ class TestGetDocsUrl:
             ),
             (
                 "2.0.0.dev0",
-                "migration.html",
+                "migrations-ref.html",
                 "http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/"
                 "apache-airflow/stable/migrations-ref.html",
             ),


### PR DESCRIPTION
I found that in the dev version ([v2.8.0.dev0](https://pypi.python.org/pypi/apache-airflow/2.8.0.dev0)) of Airflow, the documentation link in the UI is broken. Specifically, this link http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/ gives a 404 error. As suggested, I have changed "latest" to `stable` wherever I could find it. Please review. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
