### PR TITLE
Fix SalesforceHook compatiblity with Pandas 2.x

### DIFF
--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -242,8 +242,8 @@ class SalesforceHook(BaseHook):
         # between 0 and 10 are turned into timestamps
         # if the column cannot be converted,
         # just return the original column untouched
-        import pandas as pd
         import numpy as np
+        import pandas as pd
 
         try:
             column = pd.to_datetime(column)

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -243,6 +243,7 @@ class SalesforceHook(BaseHook):
         # if the column cannot be converted,
         # just return the original column untouched
         import pandas as pd
+        import numpy as np
 
         try:
             column = pd.to_datetime(column)
@@ -259,7 +260,7 @@ class SalesforceHook(BaseHook):
             try:
                 converted.append(value.timestamp())
             except (ValueError, AttributeError):
-                converted.append(pd.np.NaN)
+                converted.append(np.NaN)
 
         return pd.Series(converted, index=column.index)
 

--- a/tests/providers/salesforce/hooks/test_salesforce.py
+++ b/tests/providers/salesforce/hooks/test_salesforce.py
@@ -417,7 +417,7 @@ class TestSalesforceHook:
     )
     @patch(
         "pandas.DataFrame.from_records",
-        return_value=pd.DataFrame({"test": [1, 2, 3], "field_1": ["2019-01-01", "2019-01-02", "2019-01-03"]}),
+        return_value=pd.DataFrame({"test": [1, 2, 3, 4], "field_1": ["2019-01-01", "2019-01-02", "2019-01-03", 'NaT']}),
     )
     def test_object_to_df_with_timestamp_conversion(self, mock_data_frame, mock_describe_object):
         obj_name = "obj_name"
@@ -429,7 +429,7 @@ class TestSalesforceHook:
 
         mock_describe_object.assert_called_once_with(obj_name)
         pd.testing.assert_frame_equal(
-            data_frame, pd.DataFrame({"test": [1, 2, 3], "field_1": [1.546301e09, 1.546387e09, 1.546474e09]})
+            data_frame, pd.DataFrame({"test": [1, 2, 3, 4], "field_1": [1.546301e09, 1.546387e09, 1.546474e09, np.nan]})
         )
 
     @patch("airflow.providers.salesforce.hooks.salesforce.time.time", return_value=1.23)

--- a/tests/providers/salesforce/hooks/test_salesforce.py
+++ b/tests/providers/salesforce/hooks/test_salesforce.py
@@ -417,7 +417,9 @@ class TestSalesforceHook:
     )
     @patch(
         "pandas.DataFrame.from_records",
-        return_value=pd.DataFrame({"test": [1, 2, 3, 4], "field_1": ["2019-01-01", "2019-01-02", "2019-01-03", 'NaT']}),
+        return_value=pd.DataFrame(
+            {"test": [1, 2, 3, 4], "field_1": ["2019-01-01", "2019-01-02", "2019-01-03", "NaT"]}
+        ),
     )
     def test_object_to_df_with_timestamp_conversion(self, mock_data_frame, mock_describe_object):
         obj_name = "obj_name"
@@ -429,7 +431,8 @@ class TestSalesforceHook:
 
         mock_describe_object.assert_called_once_with(obj_name)
         pd.testing.assert_frame_equal(
-            data_frame, pd.DataFrame({"test": [1, 2, 3, 4], "field_1": [1.546301e09, 1.546387e09, 1.546474e09, np.nan]})
+            data_frame,
+            pd.DataFrame({"test": [1, 2, 3, 4], "field_1": [1.546301e09, 1.546387e09, 1.546474e09, np.nan]}),
         )
 
     @patch("airflow.providers.salesforce.hooks.salesforce.time.time", return_value=1.23)


### PR DESCRIPTION
In pandas 2.0.0, `pandas.np` was [removed](https://pandas.pydata.org/pandas-docs/version/2.1.0/whatsnew/v2.0.0.html#removal-of-prior-version-deprecations-changes).

Airflow 2.7.0 switched to pandas 2.x, however the `SalesforceHook` still has a reference to `pandas.np`, and is therefore broken in some cases after 2.7.0, resulting in an `AttributeError` if the `_to_timestamp` method is called.

This PR switches from using `pandas.np` to using the `numpy` library directly in order to fix the issue.