### PR TITLE
Fix Scheduler and triggerer crashes in daemon mode when statsd metrics are enabled

### DIFF
--- a/airflow/cli/commands/daemon_utils.py
+++ b/airflow/cli/commands/daemon_utils.py
@@ -74,6 +74,9 @@ def run_command_with_daemon_option(
             )
 
             with ctx:
+                # in daemon context stats client needs to be reinitialized.
+                from airflow.stats import Stats
+                Stats.instance = None
                 callback()
     else:
         signal.signal(signal.SIGINT, sigint_handler)

--- a/airflow/cli/commands/daemon_utils.py
+++ b/airflow/cli/commands/daemon_utils.py
@@ -76,6 +76,7 @@ def run_command_with_daemon_option(
             with ctx:
                 # in daemon context stats client needs to be reinitialized.
                 from airflow.stats import Stats
+
                 Stats.instance = None
                 callback()
     else:

--- a/airflow/metrics/base_stats_logger.py
+++ b/airflow/metrics/base_stats_logger.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
 class StatsLogger(Protocol):
     """This class is only used for TypeChecking (for IDEs, mypy, etc)."""
 
+    instance: StatsLogger | NoStatsLogger | None = None
+
     @classmethod
     def incr(
         cls,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: #33897


<!-- Please keep an empty line above the dashes. -->
---

Fix services crashing in daemon mode when statsd is enabled.

