### PR TITLE
Fix local k8s test venv installation to accomodate for local changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1683,7 +1683,7 @@ jobs:
           KUBERNETES_VERSIONS: ${{needs.build-info.outputs.kubernetes-versions-list-as-string}}
           EXECUTOR: ${{matrix.executor}}
           USE_STANDARD_NAMING: ${{matrix.use-standard-naming}}
-          VERBOSE: false
+          VERBOSE: true
       - name: Upload KinD logs on failure ${{needs.build-info.outputs.kubernetes-combos-list-as-string}}
         uses: actions/upload-artifact@v3
         if: failure() || cancelled()

--- a/scripts/ci/kubernetes/k8s_requirements.txt
+++ b/scripts/ci/kubernetes/k8s_requirements.txt
@@ -1,4 +1,4 @@
-apache-airflow[cncf.kubernetes]
+-e .[kubernetes]
 pytest
 pytest-cov
 pytest-instafail


### PR DESCRIPTION
The #35099 switched installation of the local venv for Airflow to released packages, in order to accomodate for case from #34729 where we locally install a new provider that is preinstalled but has not yet been released.

This however has the side-effect - some k8s tests are using K8S Pod operator to run the tests and if this operator has been changed, the local - modified - version of it is not going to be used for tests.

Another side effect is that in case of a new installation, when the constraint installation does not work (for example constraints in main are conflicting with released airflow), `pip` starts to backtrack - and for conflicting requirements it produces strange results (for example it attempts to install airflow 1.10 and fails due to "slugify" dependency.

The previous version of it had another problem - once installed, it had not changed, so in case someone used breeze to run k8s tests locally and iterated over changes in K8SPod Operator, only the version from the moment the k8s environment was installed was used.

Both cases are now handled better:

* INSTALL_PROVIDERS_FROM_SOURCES is used as env variable to make sure new providers (including preinstalled providers) are found in Airfow sources, not in PyPI
* The "." is used back in order to install Airflow but also the -e (editable) installation is used for it - so that any changes to local version of k8s are used. We are not using constraints for installation.
* Dry run and verbose mode of installing the venv are improved a bit - they show better what's going on (and dry_run does not interact with the installation in unexpected ways - deleting the installed venv without recreating it).

We already handled a change that k8s test environment has been reinstalled after the requirements file changed and caching in CI includes the hash of the requirements file as content - so we do not need to handle reinstallation of the venv or caching in CI. The venv should be appropriately reinstalled as needed.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
