### PR TITLE
Use `requires_access_custom_view` for user and roles API endpoints

### DIFF
--- a/airflow/api_connexion/security.py
+++ b/airflow/api_connexion/security.py
@@ -246,5 +246,26 @@ def requires_access_view(access_view: AccessView) -> Callable[[T], T]:
     return requires_access_decorator
 
 
+def requires_access_custom_view(
+    fab_action_name: str,
+    fab_resource_name: str,
+) -> Callable[[T], T]:
+    def requires_access_decorator(func: T):
+        @wraps(func)
+        def decorated(*args, **kwargs):
+            return _requires_access(
+                is_authorized_callback=lambda: get_auth_manager().is_authorized_custom_view(
+                    fab_action_name=fab_action_name, fab_resource_name=fab_resource_name
+                ),
+                func=func,
+                args=args,
+                kwargs=kwargs,
+            )
+
+        return cast(T, decorated)
+
+    return requires_access_decorator
+
+
 def get_readable_dags() -> list[str]:
     return get_airflow_app().appbuilder.sm.get_accessible_dag_ids(g.user)

--- a/airflow/auth/managers/fab/api_endpoints/role_and_permission_endpoint.py
+++ b/airflow/auth/managers/fab/api_endpoints/role_and_permission_endpoint.py
@@ -24,7 +24,6 @@ from flask import request
 from marshmallow import ValidationError
 from sqlalchemy import asc, desc, func, select
 
-from airflow.api_connexion import security
 from airflow.api_connexion.exceptions import AlreadyExists, BadRequest, NotFound
 from airflow.api_connexion.parameters import check_limit, format_parameters
 from airflow.api_connexion.schemas.role_and_permission_schema import (
@@ -34,6 +33,7 @@ from airflow.api_connexion.schemas.role_and_permission_schema import (
     role_collection_schema,
     role_schema,
 )
+from airflow.api_connexion.security import requires_access_custom_view
 from airflow.auth.managers.fab.models import Action, Role
 from airflow.security import permissions
 from airflow.utils.airflow_flask_app import get_airflow_app
@@ -56,7 +56,7 @@ def _check_action_and_resource(sm: AirflowSecurityManagerV2, perms: list[tuple[s
             raise BadRequest(detail=f"The specified resource: {resource!r} was not found")
 
 
-@security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_ROLE)])
+@requires_access_custom_view(permissions.ACTION_CAN_READ, permissions.RESOURCE_ROLE)
 def get_role(*, role_name: str) -> APIResponse:
     """Get role."""
     ab_security_manager = get_airflow_app().appbuilder.sm
@@ -66,7 +66,7 @@ def get_role(*, role_name: str) -> APIResponse:
     return role_schema.dump(role)
 
 
-@security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_ROLE)])
+@requires_access_custom_view(permissions.ACTION_CAN_READ, permissions.RESOURCE_ROLE)
 @format_parameters({"limit": check_limit})
 def get_roles(*, order_by: str = "name", limit: int, offset: int | None = None) -> APIResponse:
     """Get roles."""
@@ -94,7 +94,7 @@ def get_roles(*, order_by: str = "name", limit: int, offset: int | None = None) 
     return role_collection_schema.dump(RoleCollection(roles=roles, total_entries=total_entries))
 
 
-@security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_ACTION)])
+@requires_access_custom_view(permissions.ACTION_CAN_READ, permissions.RESOURCE_ACTION)
 @format_parameters({"limit": check_limit})
 def get_permissions(*, limit: int, offset: int | None = None) -> APIResponse:
     """Get permissions."""
@@ -105,7 +105,7 @@ def get_permissions(*, limit: int, offset: int | None = None) -> APIResponse:
     return action_collection_schema.dump(ActionCollection(actions=actions, total_entries=total_entries))
 
 
-@security.requires_access([(permissions.ACTION_CAN_DELETE, permissions.RESOURCE_ROLE)])
+@requires_access_custom_view(permissions.ACTION_CAN_DELETE, permissions.RESOURCE_ROLE)
 def delete_role(*, role_name: str) -> APIResponse:
     """Delete a role."""
     ab_security_manager = get_airflow_app().appbuilder.sm
@@ -116,7 +116,7 @@ def delete_role(*, role_name: str) -> APIResponse:
     return NoContent, HTTPStatus.NO_CONTENT
 
 
-@security.requires_access([(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_ROLE)])
+@requires_access_custom_view(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_ROLE)
 def patch_role(*, role_name: str, update_mask: UpdateMask = None) -> APIResponse:
     """Update a role."""
     appbuilder = get_airflow_app().appbuilder
@@ -150,7 +150,7 @@ def patch_role(*, role_name: str, update_mask: UpdateMask = None) -> APIResponse
     return role_schema.dump(role)
 
 
-@security.requires_access([(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_ROLE)])
+@requires_access_custom_view(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_ROLE)
 def post_role() -> APIResponse:
     """Create a new role."""
     appbuilder = get_airflow_app().appbuilder

--- a/airflow/auth/managers/fab/api_endpoints/user_endpoint.py
+++ b/airflow/auth/managers/fab/api_endpoints/user_endpoint.py
@@ -25,7 +25,6 @@ from marshmallow import ValidationError
 from sqlalchemy import asc, desc, func, select
 from werkzeug.security import generate_password_hash
 
-from airflow.api_connexion import security
 from airflow.api_connexion.exceptions import AlreadyExists, BadRequest, NotFound, Unknown
 from airflow.api_connexion.parameters import check_limit, format_parameters
 from airflow.api_connexion.schemas.user_schema import (
@@ -34,6 +33,7 @@ from airflow.api_connexion.schemas.user_schema import (
     user_collection_schema,
     user_schema,
 )
+from airflow.api_connexion.security import requires_access_custom_view
 from airflow.auth.managers.fab.models import User
 from airflow.security import permissions
 from airflow.utils.airflow_flask_app import get_airflow_app
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from airflow.auth.managers.fab.models import Role
 
 
-@security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_USER)])
+@requires_access_custom_view(permissions.ACTION_CAN_READ, permissions.RESOURCE_USER)
 def get_user(*, username: str) -> APIResponse:
     """Get a user."""
     ab_security_manager = get_airflow_app().appbuilder.sm
@@ -53,7 +53,7 @@ def get_user(*, username: str) -> APIResponse:
     return user_collection_item_schema.dump(user)
 
 
-@security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_USER)])
+@requires_access_custom_view(permissions.ACTION_CAN_READ, permissions.RESOURCE_USER)
 @format_parameters({"limit": check_limit})
 def get_users(*, limit: int, order_by: str = "id", offset: str | None = None) -> APIResponse:
     """Get users."""
@@ -85,7 +85,7 @@ def get_users(*, limit: int, order_by: str = "id", offset: str | None = None) ->
     return user_collection_schema.dump(UserCollection(users=users, total_entries=total_entries))
 
 
-@security.requires_access([(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_USER)])
+@requires_access_custom_view(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_USER)
 def post_user() -> APIResponse:
     """Create a new user."""
     try:
@@ -128,7 +128,7 @@ def post_user() -> APIResponse:
     return user_schema.dump(user)
 
 
-@security.requires_access([(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_USER)])
+@requires_access_custom_view(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_USER)
 def patch_user(*, username: str, update_mask: UpdateMask = None) -> APIResponse:
     """Update a user."""
     try:
@@ -197,7 +197,7 @@ def patch_user(*, username: str, update_mask: UpdateMask = None) -> APIResponse:
     return user_schema.dump(user)
 
 
-@security.requires_access([(permissions.ACTION_CAN_DELETE, permissions.RESOURCE_USER)])
+@requires_access_custom_view(permissions.ACTION_CAN_DELETE, permissions.RESOURCE_USER)
 def delete_user(*, username: str) -> APIResponse:
     """Delete a user."""
     security_manager = get_airflow_app().appbuilder.sm


### PR DESCRIPTION
This PR removes the deprecation warnings you get when you start Airflow:

```
/opt/airflow/airflow/auth/managers/fab/api_endpoints/user_endpoint.py:46 RemovedInAirflow3Warning: The 'requires_access' decorator is deprecated. Please use one of the decorator `requires_access_*`defined in airflow/api_connexion/security.py instead.
```

Instead of using the recently deprecated decorator `@security.requires_access`, it uses the new decorator `requires_access_custom_view` that leverages the auth manager method `is_authorized_custom_view` implemented in #35000. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
