### PR TITLE
Fix azure-identity 1.15.0 api change

### DIFF
--- a/tests/providers/microsoft/azure/hooks/test_adx.py
+++ b/tests/providers/microsoft/azure/hooks/test_adx.py
@@ -21,6 +21,7 @@ from unittest import mock
 
 import pytest
 from azure.kusto.data import ClientRequestProperties, KustoClient, KustoConnectionStringBuilder
+from packaging.version import Version
 
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
@@ -142,12 +143,24 @@ class TestAzureDataExplorerHook:
         monkeypatch.setenv("AZURE_CLIENT_SECRET", "secret")
 
         assert hook.connection._kcsb.data_source == "https://help.kusto.windows.net"
-        mock1.assert_called_once_with(
-            tenant_id="tenant",
-            client_id="client",
-            client_secret="secret",
-            authority="https://login.microsoftonline.com",
-        )
+        import azure.identity
+
+        azure_identity_version = Version(azure.identity.__version__)
+        if azure_identity_version >= Version("1.15.0"):
+            mock1.assert_called_once_with(
+                tenant_id="tenant",
+                client_id="client",
+                client_secret="secret",
+                authority="https://login.microsoftonline.com",
+                _within_dac=True,
+            )
+        else:
+            mock1.assert_called_once_with(
+                tenant_id="tenant",
+                client_id="client",
+                client_secret="secret",
+                authority="https://login.microsoftonline.com",
+            )
 
     @pytest.mark.parametrize(
         "mocked_connection",


### PR DESCRIPTION
The azure-identity 1.15.0 introduced a change in the API call of the secret credential and started to fail our tests. This PR adds conditional test behaviour depending on the azure-identity version.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
