### PR TITLE
Remove leftover mesos reference in generic hooks

### DIFF
--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -448,7 +448,6 @@ class ProvidersManager(LoggingMixin, metaclass=Singleton):
         core_dummy_hooks = {
             "generic": "Generic",
             "email": "Email",
-            "mesos_framework-id": "Mesos Framework ID",
         }
         for key, display in core_dummy_hooks.items():
             self._hooks_lazy_dict[key] = HookInfo(


### PR DESCRIPTION
As a follow-up of #33051 where I realized that some "mesos" leftovers are in the code, this is a cleanup-PR, It removes the generic connection in Airflow core that provides a "Mesos Framework ID".

I crawled through the code back into history of Airflow 1.10 to find where it comes from. In Airflow 1.10  there was formerly a mesos executor supported which all had been treated as legacy and was removed when going to Airflow 2.0. Just a generic connection hook was left. Also I could not find any traces somewhere in code or documentation where it is still used. But as no mesos executor exists anymore and even the Spark provider only uses a direct URL as parameters this is really a leftover.
As it is not providing any benefit and preventing that somebody in the future need to crawl into history, I propose to remove it. It is not breaking because if somebody really is still using it, it will fall-back in the UI to "generic" and technically is still usable.