### PR TITLE
Make `cc` and `bcc` templated fields in EmailOperator

### DIFF
--- a/airflow/providers/smtp/operators/smtp.py
+++ b/airflow/providers/smtp/operators/smtp.py
@@ -36,15 +36,15 @@ class EmailOperator(BaseOperator):
     :param html_content: content of the email, html markup
         is allowed. (templated)
     :param files: file names to attach in email (templated)
-    :param cc: list of recipients to be added in CC field
-    :param bcc: list of recipients to be added in BCC field
+    :param cc: list of recipients to be added in CC field (templated)
+    :param bcc: list of recipients to be added in BCC field (templated)
     :param mime_subtype: MIME sub content type
     :param mime_charset: character set parameter added to the Content-Type
         header.
     :param custom_headers: additional headers to add to the MIME message.
     """
 
-    template_fields: Sequence[str] = ("to", "from_email", "subject", "html_content", "files")
+    template_fields: Sequence[str] = ("to", "from_email", "subject", "html_content", "files", "cc", "bcc")
     template_fields_renderers = {"html_content": "html"}
     template_ext: Sequence[str] = (".html",)
     ui_color = "#e6faf9"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Hello,

This is a small PR to enable templating on `cc` and `bcc` parameters in the EmailOperator.

*Use case*:
I'm sending emails to some people based on a SQL query. I'd like to also add people in cc dynamically based on that SQL query.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
