### PR TITLE
Rename the "system" tests where we run Airflow in K8S

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1639,7 +1639,7 @@ jobs:
   tests-kubernetes:
     timeout-minutes: 240
     name: "\
-      Helm: ${{matrix.executor}} - ${{matrix.use-standard-naming}} - \
+      K8S System:${{matrix.executor}} - ${{matrix.use-standard-naming}} - \
       ${{needs.build-info.outputs.kubernetes-versions-list-as-string}}"
     runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
     needs: [build-info, wait-for-prod-images]


### PR DESCRIPTION
Not to confuse the tests with Helm tests (where we just process Helm chart and verify if rendered templates look good) the Kubernetes test suite actually create K8S clusters (with Kind), build custom airflow Images and deploy them to those K8S cluster (all using latest sources of airflow, images and charts) and run several end-2-end tests + run Kubernetes Pod Operators with the real K8S clusters.

Therefore "K8S System" name is a bit better than "Helm" and also allows to distinguish them from "Helm Unit" tests.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
