### PR TITLE
Add last_parsed_time to cli command, airflow dags list 

### DIFF
--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -370,6 +370,7 @@ def dag_list_dags(args) -> None:
             "filepath": x.filepath,
             "owner": x.owner,
             "paused": x.get_is_paused(),
+            "last_parsed_time": x.get_last_parsed_time(),
         },
     )
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1376,7 +1376,7 @@ class DAG(LoggingMixin):
         return session.scalar(select(DagModel.is_paused).where(DagModel.dag_id == self.dag_id))
 
     @provide_session
-    def get_last_parsed_time(self, session=NEW_SESSION) -> None:
+    def get_last_parsed_time(self, session=NEW_SESSION) -> datetime:
         """Return the last time the DAG was parsed."""
         return session.scalar(select(DagModel.last_parsed_time).where(DagModel.dag_id == self.dag_id))
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1375,6 +1375,11 @@ class DAG(LoggingMixin):
         """Return a boolean indicating whether this DAG is paused."""
         return session.scalar(select(DagModel.is_paused).where(DagModel.dag_id == self.dag_id))
 
+    @provide_session
+    def get_last_parsed_time(self, session=NEW_SESSION) -> None:
+        """Return a datetime indicating the last time the DAG was parsed."""
+        return session.scalar(select(DagModel.last_parsed_time).where(DagModel.dag_id == self.dag_id))
+
     @property
     def is_paused(self):
         """Use `airflow.models.DAG.get_is_paused`, this attribute is deprecated."""

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1377,7 +1377,7 @@ class DAG(LoggingMixin):
 
     @provide_session
     def get_last_parsed_time(self, session=NEW_SESSION) -> None:
-        """Return a datetime indicating the last time the DAG was parsed."""
+        """Return the last time the DAG was parsed."""
         return session.scalar(select(DagModel.last_parsed_time).where(DagModel.dag_id == self.dag_id))
 
     @property

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -527,6 +527,7 @@ class TestCliDags:
         assert "owner" in out
         assert "airflow" in out
         assert "paused" in out
+        assert "last_parsed_time" in out
         assert "airflow/example_dags/example_complex.py" in out
         assert "- dag_id:" in out
 


### PR DESCRIPTION
This partially solution to #34765

This adds the last_parsed_time to the cli command `airflow dag list`

Before
```
root@956035f65680:/opt/airflow# airflow dags list
dag_id      | filepath | owner   | paused
============+==========+=========+=======
my_dag_name | test.py  | airflow | True
```

After
```
root@956035f65680:/opt/airflow# airflow dags list
dag_id      | filepath | owner   | paused | last_parsed_time
============+==========+=========+========+=================================
my_dag_name | test.py  | airflow | True   | 2023-10-29 05:07:14.613774+00:00
```

Note: Will refactor some parts in a few follow up PRs
1. Add optional way of selecting which columns to add in dag list
2. Batch database calls in the `airflow dags list` 
