### PR TITLE
Allow custom columns in cli dags list

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -986,8 +986,11 @@ ARG_CLEAR_ONLY = Arg(
     help="If passed, serialized DAGs will be cleared but not reserialized.",
 )
 
-ARG_DAG_LIST_ADDITIONAL_COLUMNS = Arg(
-    ("--additional-columns",), type=string_list_type, help="Additional columns to include when listing dags"
+ARG_DAG_LIST_COLUMNS = Arg(
+    ("--columns",),
+    type=string_list_type,
+    help="List of columns to render. (default: ['dag_id', 'fileloc', 'owner', 'is_paused'])",
+    default=("dag_id", "fileloc", "owners", "is_paused"),
 )
 
 ALTERNATIVE_CONN_SPECS_ARGS = [
@@ -1036,7 +1039,7 @@ DAGS_COMMANDS = (
         name="list",
         help="List all the DAGs",
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_list_dags"),
-        args=(ARG_SUBDIR, ARG_OUTPUT, ARG_VERBOSE, ARG_DAG_LIST_ADDITIONAL_COLUMNS),
+        args=(ARG_SUBDIR, ARG_OUTPUT, ARG_VERBOSE, ARG_DAG_LIST_COLUMNS),
     ),
     ActionCommand(
         name="list-import-errors",

--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -986,6 +986,10 @@ ARG_CLEAR_ONLY = Arg(
     help="If passed, serialized DAGs will be cleared but not reserialized.",
 )
 
+ARG_DAG_LIST_ADDITIONAL_COLUMNS = Arg(
+    ("--additional-columns",), type=string_list_type, help="Additional columns to include when listing dags"
+)
+
 ALTERNATIVE_CONN_SPECS_ARGS = [
     ARG_CONN_TYPE,
     ARG_CONN_DESCRIPTION,
@@ -1032,7 +1036,7 @@ DAGS_COMMANDS = (
         name="list",
         help="List all the DAGs",
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_list_dags"),
-        args=(ARG_SUBDIR, ARG_OUTPUT, ARG_VERBOSE),
+        args=(ARG_SUBDIR, ARG_OUTPUT, ARG_VERBOSE, ARG_DAG_LIST_ADDITIONAL_COLUMNS),
     ),
     ActionCommand(
         name="list-import-errors",

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -356,7 +356,7 @@ def dag_list_dags(args, session=NEW_SESSION) -> None:
     """Display dags with or without stats at the command line."""
     cols = args.columns if args.columns else []
     invalid_cols = [c for c in cols if c not in dag_schema.fields]
-    valid_cols = [c for c in cols if c in dag_schema.fields.keys()]
+    valid_cols = [c for c in cols if c in dag_schema.fields]
     if invalid_cols:
         from rich import print as rich_print
 

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -361,7 +361,7 @@ def dag_list_dags(args, session=NEW_SESSION) -> None:
         from rich import print as rich_print
 
         rich_print(
-            f"[red][bold]Error:[/bold] Ignoring the following invalid columns: {not_valid_cols}.  "
+            f"[red][bold]Error:[/bold] Ignoring the following invalid columns: {invalid_cols}.  "
             f"List of valid columns: {list(dag_schema.fields.keys())}",
             file=sys.stderr,
         )

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -361,7 +361,7 @@ def dag_list_dags(args, session=NEW_SESSION) -> None:
         from rich import print as rich_print
 
         rich_print(
-            f"[red][bold]Error:[/bold] The following are not valid columns: {not_valid_cols}. Ignoring them "
+            f"[red][bold]Error:[/bold] Ignoring the following invalid columns: {not_valid_cols}.  "
             f"Possible columns: {list(dag_schema.fields.keys())}",
             file=sys.stderr,
         )

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -374,7 +374,7 @@ def dag_list_dags(args, session=NEW_SESSION) -> None:
     def get_dag_detail(dag: DAG) -> dict:
         dag_model = DagModel.get_dagmodel(dag.dag_id, session=session)
         dag_detail = dag_schema.dump(dag_model)
-        return {k: v for k, v in dag_detail.items() if k in cols}
+        return {col: dag_detail[col] for col in cols}
 
     AirflowConsole().print_as(
         data=sorted(dagbag.dags.values(), key=operator.attrgetter("dag_id")),

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -355,7 +355,7 @@ def dag_next_execution(args) -> None:
 def dag_list_dags(args, session=NEW_SESSION) -> None:
     """Display dags with or without stats at the command line."""
     cols = args.columns if args.columns else []
-    not_valid_cols = [c for c in cols if c not in dag_schema.fields.keys()]
+    invalid_cols = [c for c in cols if c not in dag_schema.fields]
     valid_cols = [c for c in cols if c in dag_schema.fields.keys()]
     if not_valid_cols:
         from rich import print as rich_print

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -364,7 +364,7 @@ def dag_list_dags(args, session=NEW_SESSION) -> None:
             file=sys.stderr,
         )
 
-    def get_dag_detail(dag):
+    def get_dag_detail(dag: DAG) -> dict:
         dag_model = DagModel.get_dagmodel(dag.dag_id, session=session)
         dag_detail = dag_schema.dump(dag_model)
         add_cols = args.additional_columns if args.additional_columns else []
@@ -372,7 +372,7 @@ def dag_list_dags(args, session=NEW_SESSION) -> None:
             "dag_id": dag.dag_id,
             "filepath": dag.filepath,
             "owner": dag.owner,
-            "paused": dag_model.is_paused,
+            "paused": dag_detail["is_paused"],
             **{k: v for k, v in dag_detail.items() if k in add_cols},
         }
 

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -357,7 +357,7 @@ def dag_list_dags(args, session=NEW_SESSION) -> None:
     cols = args.columns if args.columns else []
     invalid_cols = [c for c in cols if c not in dag_schema.fields]
     valid_cols = [c for c in cols if c in dag_schema.fields.keys()]
-    if not_valid_cols:
+    if invalid_cols:
         from rich import print as rich_print
 
         rich_print(

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -370,6 +370,7 @@ def dag_list_dags(args) -> None:
             "filepath": x.filepath,
             "owner": x.owner,
             "paused": x.get_is_paused(),
+            "last_parsed_time": x.get_last_parsed_time(),
         },
     )
 

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -362,7 +362,7 @@ def dag_list_dags(args, session=NEW_SESSION) -> None:
 
         rich_print(
             f"[red][bold]Error:[/bold] Ignoring the following invalid columns: {not_valid_cols}.  "
-            f"Possible columns: {list(dag_schema.fields.keys())}",
+            f"List of valid columns: {list(dag_schema.fields.keys())}",
             file=sys.stderr,
         )
     dagbag = DagBag(process_subdir(args.subdir))

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1407,11 +1407,6 @@ class DAG(LoggingMixin):
         """Return a boolean indicating whether this DAG is paused."""
         return session.scalar(select(DagModel.is_paused).where(DagModel.dag_id == self.dag_id))
 
-    @provide_session
-    def get_last_parsed_time(self, session=NEW_SESSION) -> datetime:
-        """Return the last time the DAG was parsed."""
-        return session.scalar(select(DagModel.last_parsed_time).where(DagModel.dag_id == self.dag_id))
-
     @property
     def is_paused(self):
         """Use `airflow.models.DAG.get_is_paused`, this attribute is deprecated."""

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1408,7 +1408,7 @@ class DAG(LoggingMixin):
         return session.scalar(select(DagModel.is_paused).where(DagModel.dag_id == self.dag_id))
 
     @provide_session
-    def get_last_parsed_time(self, session=NEW_SESSION) -> None:
+    def get_last_parsed_time(self, session=NEW_SESSION) -> datetime:
         """Return the last time the DAG was parsed."""
         return session.scalar(select(DagModel.last_parsed_time).where(DagModel.dag_id == self.dag_id))
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1407,6 +1407,11 @@ class DAG(LoggingMixin):
         """Return a boolean indicating whether this DAG is paused."""
         return session.scalar(select(DagModel.is_paused).where(DagModel.dag_id == self.dag_id))
 
+    @provide_session
+    def get_last_parsed_time(self, session=NEW_SESSION) -> None:
+        """Return a datetime indicating the last time the DAG was parsed."""
+        return session.scalar(select(DagModel.last_parsed_time).where(DagModel.dag_id == self.dag_id))
+
     @property
     def is_paused(self):
         """Use `airflow.models.DAG.get_is_paused`, this attribute is deprecated."""

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1409,7 +1409,7 @@ class DAG(LoggingMixin):
 
     @provide_session
     def get_last_parsed_time(self, session=NEW_SESSION) -> None:
-        """Return a datetime indicating the last time the DAG was parsed."""
+        """Return the last time the DAG was parsed."""
         return session.scalar(select(DagModel.last_parsed_time).where(DagModel.dag_id == self.dag_id))
 
     @property

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -531,6 +531,7 @@ class TestCliDags:
         assert "owner" in out
         assert "airflow" in out
         assert "paused" in out
+        assert "last_parsed_time" in out
         assert "airflow/example_dags/example_complex.py" in out
         assert "- dag_id:" in out
 

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -553,7 +553,7 @@ class TestCliDags:
         with contextlib.redirect_stderr(StringIO()) as temp_stderr:
             dag_command.dag_list_dags(args)
             out = temp_stderr.getvalue()
-        assert "The following are not valid columns: ['invalid_col']" in out
+        assert "Ignoring the following invalid columns:: ['invalid_col']" in out
 
     @conf_vars({("core", "load_examples"): "false"})
     def test_cli_list_dags_prints_import_errors(self):

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -542,16 +542,18 @@ class TestCliDags:
             dag_command.dag_list_dags(args)
             out = temp_stdout.getvalue()
             dag_list = json.loads(out)
-        assert "dag_id" in dag_list[0]
-        assert "last_parsed_time" in dag_list[0]
-        assert "is_paused" not in dag_list[0]
+        for key in ["dag_id", "last_parsed_time"]:
+            assert key in dag_list[0]
+        for key in ["fileloc", "owners", "is_paused"]:
+            assert key not in dag_list[0]
 
     @conf_vars({("core", "load_examples"): "true"})
     def test_cli_list_dags_invalid_cols(self):
         args = self.parser.parse_args(["dags", "list", "--output", "json", "--columns", "dag_id,invalid_col"])
-        with pytest.raises(SystemExit) as e:
+        with contextlib.redirect_stderr(StringIO()) as temp_stderr:
             dag_command.dag_list_dags(args)
-        assert "The following are not valid columns: ['invalid_col']" in e.value.args[0]
+            out = temp_stderr.getvalue()
+        assert "The following are not valid columns: ['invalid_col']" in out
 
     @conf_vars({("core", "load_examples"): "false"})
     def test_cli_list_dags_prints_import_errors(self):

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -529,10 +529,8 @@ class TestCliDags:
             dag_command.dag_list_dags(args)
             out = temp_stdout.getvalue()
             dag_list = json.loads(out)
-        assert "dag_id" in dag_list[0]
-        assert "fileloc" in dag_list[0]
-        assert "owners" in dag_list[0]
-        assert "is_paused" in dag_list[0]
+        for key in ["dag_id", "fileloc", "owners", "is_paused"]:
+            assert key in dag_list[0]
         assert any("airflow/example_dags/example_complex.py" in d["fileloc"] for d in dag_list)
 
     @conf_vars({("core", "load_examples"): "true"})

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -531,7 +531,22 @@ class TestCliDags:
         assert "owner" in out
         assert "airflow" in out
         assert "paused" in out
+        assert "airflow/example_dags/example_complex.py" in out
+        assert "- dag_id:" in out
+
+    @conf_vars({("core", "load_examples"): "true"})
+    def test_cli_list_dags_additional_comments(self):
+        args = self.parser.parse_args(
+            ["dags", "list", "--additional-columns", "last_parsed_time,is_subdag", "--output", "yaml"]
+        )
+        with contextlib.redirect_stdout(StringIO()) as temp_stdout:
+            dag_command.dag_list_dags(args)
+            out = temp_stdout.getvalue()
+        assert "owner" in out
+        assert "airflow" in out
+        assert "paused" in out
         assert "last_parsed_time" in out
+        assert "is_subdag" in out
         assert "airflow/example_dags/example_complex.py" in out
         assert "- dag_id:" in out
 

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -553,7 +553,7 @@ class TestCliDags:
         with contextlib.redirect_stderr(StringIO()) as temp_stderr:
             dag_command.dag_list_dags(args)
             out = temp_stderr.getvalue()
-        assert "Ignoring the following invalid columns:: ['invalid_col']" in out
+        assert "Ignoring the following invalid columns: ['invalid_col']" in out
 
     @conf_vars({("core", "load_examples"): "false"})
     def test_cli_list_dags_prints_import_errors(self):


### PR DESCRIPTION
This closes #34765

This adds an additional optional parameter `columns` to the cli command `airflow dags list`.

Examples: 

```bash
root@2cce825aa9b1:/opt/airflow# airflow dags list
dag_id      | is_paused | fileloc             | owners
============+===========+=====================+========
my_dag_name | True      | /files/dags/test.py | airflow
```

```bash
root@2cce825aa9b1:/opt/airflow# airflow dags list --columns dag_id,last_parsed_time
dag_id      | last_parsed_time
============+=================================
my_dag_name | 2023-10-30T03:34:20.148064+00:00
```

Note: Will have a follow up pr to minimize database calls 
