### PR TITLE
Handle left-over termination logs from previous runs with same cache

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -431,6 +431,7 @@ class _BasePythonVirtualenvOperator(PythonOperator, metaclass=ABCMeta):
         string_args_path = tmp_dir / "string_args.txt"
         script_path = tmp_dir / "script.py"
         termination_log_path = tmp_dir / "termination.log"
+
         self._write_args(input_path)
         self._write_string_args(string_args_path)
         write_python_script(
@@ -445,7 +446,10 @@ class _BasePythonVirtualenvOperator(PythonOperator, metaclass=ABCMeta):
             filename=os.fspath(script_path),
             render_template_as_native_obj=self.dag.render_template_as_native_obj,
         )
-
+        # For cached venv we need to make sure that the termination log does not exist
+        # Before process starts (it could be a left-over from a previous run)
+        if termination_log_path.exists():
+            termination_log_path.unlink()
         try:
             execute_in_subprocess(
                 cmd=[

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -25,6 +25,7 @@ import sys
 import warnings
 from collections import namedtuple
 from datetime import date, datetime, timedelta
+from pathlib import Path
 from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Generator
@@ -997,6 +998,38 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
 
         with TemporaryDirectory(prefix="pytest_venv_1234") as tmp_dir:
             self.run_as_task(f, venv_cache_path=tmp_dir, op_args=[4])
+
+    def test_no_side_effect_of_caching_and_termination_log(self):
+        def termination_log(a):
+            import sys
+            from pathlib import Path
+
+            assert "pytest_venv_1234" in sys.executable
+            venv_cache_dir_name = Path(sys.executable).parent.parent.name
+            raise Exception(f"Should produce termination log. Subdir = {venv_cache_dir_name}")
+
+        def no_termination_log(a):
+            import sys
+
+            assert "pytest_venv_1234" in sys.executable
+            raise SystemExit(1)
+
+        with TemporaryDirectory(prefix="pytest_venv_1234") as tmp_dir:
+            with pytest.raises(AirflowException, match="Should produce termination log") as exc:
+                self.run_as_task(termination_log, venv_cache_path=tmp_dir, op_args=[4])
+            venv_dir_cache = exc.value.args[0].split(" ")[-1]
+            termination_log_path = Path(tmp_dir) / venv_dir_cache / "termination.log"
+            assert termination_log_path.exists()
+            assert "Should produce termination log" in termination_log_path.read_text()
+            clear_db_runs()
+
+            # termination log from previous run should not produce side effects in another task
+            # Using the same cached venv
+
+            assert termination_log_path.exists()
+            with pytest.raises(CalledProcessError):
+                self.run_as_task(no_termination_log, venv_cache_path=tmp_dir, op_args=[4])
+            assert not termination_log_path.exists()
 
     # This tests might take longer than default 60 seconds as it is serializing a lot of
     # context using dill (which is slow apparently).


### PR DESCRIPTION
When PythonVirtualEnv and friends use cached venv, script and termination logs are stored in the venv. While this was fine for scripts because the env is locked and scripts were overwritten every time venv started - it was not the same for termination log.

The termination log remains in venv after venv completes (which is good for diagnostics) however when subsequent task failed without raising regular exception but just by sys.exit(), the termination log from previous task was found and such task would return AirflowException instead of CalledProcessError with the message coming from the previous task.

This PR fixes it by deleting the termination log at the start of PythonVirtualenv task, when such termination log is present in the venv.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
