### PR TITLE
Bugfix/prevent concurrency with cached venv

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -422,57 +422,56 @@ class _BasePythonVirtualenvOperator(PythonOperator, metaclass=ABCMeta):
         memo[id(self.pickling_library)] = self.pickling_library
         return super().__deepcopy__(memo)
 
-    def _execute_python_callable_in_subprocess(self, python_path: Path, tmp_dir: Path):
-        op_kwargs: dict[str, Any] = dict(self.op_kwargs)
-        if self.templates_dict:
-            op_kwargs["templates_dict"] = self.templates_dict
-        input_path = tmp_dir / "script.in"
-        output_path = tmp_dir / "script.out"
-        string_args_path = tmp_dir / "string_args.txt"
-        script_path = tmp_dir / "script.py"
-        termination_log_path = tmp_dir / "termination.log"
+    def _execute_python_callable_in_subprocess(self, python_path: Path):
+        with TemporaryDirectory(prefix="venv-call") as tmp:
+            tmp_dir = Path(tmp)
+            op_kwargs: dict[str, Any] = dict(self.op_kwargs)
+            if self.templates_dict:
+                op_kwargs["templates_dict"] = self.templates_dict
+            input_path = tmp_dir / "script.in"
+            output_path = tmp_dir / "script.out"
+            string_args_path = tmp_dir / "string_args.txt"
+            script_path = tmp_dir / "script.py"
+            termination_log_path = tmp_dir / "termination.log"
 
-        self._write_args(input_path)
-        self._write_string_args(string_args_path)
-        write_python_script(
-            jinja_context={
-                "op_args": self.op_args,
-                "op_kwargs": op_kwargs,
-                "expect_airflow": self.expect_airflow,
-                "pickling_library": self.pickling_library.__name__,
-                "python_callable": self.python_callable.__name__,
-                "python_callable_source": self.get_python_source(),
-            },
-            filename=os.fspath(script_path),
-            render_template_as_native_obj=self.dag.render_template_as_native_obj,
-        )
-        # For cached venv we need to make sure that the termination log does not exist
-        # Before process starts (it could be a left-over from a previous run)
-        if termination_log_path.exists():
-            termination_log_path.unlink()
-        try:
-            execute_in_subprocess(
-                cmd=[
-                    os.fspath(python_path),
-                    os.fspath(script_path),
-                    os.fspath(input_path),
-                    os.fspath(output_path),
-                    os.fspath(string_args_path),
-                    os.fspath(termination_log_path),
-                ]
+            self._write_args(input_path)
+            self._write_string_args(string_args_path)
+            write_python_script(
+                jinja_context={
+                    "op_args": self.op_args,
+                    "op_kwargs": op_kwargs,
+                    "expect_airflow": self.expect_airflow,
+                    "pickling_library": self.pickling_library.__name__,
+                    "python_callable": self.python_callable.__name__,
+                    "python_callable_source": self.get_python_source(),
+                },
+                filename=os.fspath(script_path),
+                render_template_as_native_obj=self.dag.render_template_as_native_obj,
             )
-        except subprocess.CalledProcessError as e:
-            if e.returncode in self.skip_on_exit_code:
-                raise AirflowSkipException(f"Process exited with code {e.returncode}. Skipping.")
-            elif termination_log_path.exists() and termination_log_path.stat().st_size > 0:
-                error_msg = f"Process returned non-zero exit status {e.returncode}.\n"
-                with open(termination_log_path) as file:
-                    error_msg += file.read()
-                raise AirflowException(error_msg) from None
-            else:
-                raise
 
-        return self._read_result(output_path)
+            try:
+                execute_in_subprocess(
+                    cmd=[
+                        os.fspath(python_path),
+                        os.fspath(script_path),
+                        os.fspath(input_path),
+                        os.fspath(output_path),
+                        os.fspath(string_args_path),
+                        os.fspath(termination_log_path),
+                    ]
+                )
+            except subprocess.CalledProcessError as e:
+                if e.returncode in self.skip_on_exit_code:
+                    raise AirflowSkipException(f"Process exited with code {e.returncode}. Skipping.")
+                elif termination_log_path.exists() and termination_log_path.stat().st_size > 0:
+                    error_msg = f"Process returned non-zero exit status {e.returncode}.\n"
+                    with open(termination_log_path) as file:
+                        error_msg += file.read()
+                    raise AirflowException(error_msg) from None
+                else:
+                    raise
+
+            return self._read_result(output_path)
 
     def determine_kwargs(self, context: Mapping[str, Any]) -> Mapping[str, Any]:
         return KeywordParameters.determine(self.python_callable, self.op_args, context).serializing()
@@ -704,13 +703,13 @@ class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
         if self.venv_cache_path:
             venv_path = self._ensure_venv_cache_exists(Path(self.venv_cache_path))
             python_path = venv_path / "bin" / "python"
-            return self._execute_python_callable_in_subprocess(python_path, venv_path)
+            return self._execute_python_callable_in_subprocess(python_path)
 
         with TemporaryDirectory(prefix="venv") as tmp_dir:
             tmp_path = Path(tmp_dir)
             self._prepare_venv(tmp_path)
             python_path = tmp_path / "bin" / "python"
-            result = self._execute_python_callable_in_subprocess(python_path, tmp_path)
+            result = self._execute_python_callable_in_subprocess(python_path)
             return result
 
     def _iter_serializable_context_keys(self):
@@ -848,9 +847,7 @@ class ExternalPythonOperator(_BasePythonVirtualenvOperator):
                 f"Sys version: {sys.version_info}. "
                 f"Virtual environment version: {python_version_as_list_of_strings}"
             )
-        with TemporaryDirectory(prefix="tmd") as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            return self._execute_python_callable_in_subprocess(python_path, tmp_path)
+        return self._execute_python_callable_in_subprocess(python_path)
 
     def _get_python_version_from_environment(self) -> list[str]:
         try:

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -25,7 +25,6 @@ import sys
 import warnings
 from collections import namedtuple
 from datetime import date, datetime, timedelta
-from pathlib import Path
 from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Generator
@@ -998,38 +997,6 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
 
         with TemporaryDirectory(prefix="pytest_venv_1234") as tmp_dir:
             self.run_as_task(f, venv_cache_path=tmp_dir, op_args=[4])
-
-    def test_no_side_effect_of_caching_and_termination_log(self):
-        def termination_log(a):
-            import sys
-            from pathlib import Path
-
-            assert "pytest_venv_1234" in sys.executable
-            venv_cache_dir_name = Path(sys.executable).parent.parent.name
-            raise Exception(f"Should produce termination log. Subdir = {venv_cache_dir_name}")
-
-        def no_termination_log(a):
-            import sys
-
-            assert "pytest_venv_1234" in sys.executable
-            raise SystemExit(1)
-
-        with TemporaryDirectory(prefix="pytest_venv_1234") as tmp_dir:
-            with pytest.raises(AirflowException, match="Should produce termination log") as exc:
-                self.run_as_task(termination_log, venv_cache_path=tmp_dir, op_args=[4])
-            venv_dir_cache = exc.value.args[0].split(" ")[-1]
-            termination_log_path = Path(tmp_dir) / venv_dir_cache / "termination.log"
-            assert termination_log_path.exists()
-            assert "Should produce termination log" in termination_log_path.read_text()
-            clear_db_runs()
-
-            # termination log from previous run should not produce side effects in another task
-            # Using the same cached venv
-
-            assert termination_log_path.exists()
-            with pytest.raises(CalledProcessError):
-                self.run_as_task(no_termination_log, venv_cache_path=tmp_dir, op_args=[4])
-            assert not termination_log_path.exists()
 
     # This tests might take longer than default 60 seconds as it is serializing a lot of
     # context using dill (which is slow apparently).


### PR DESCRIPTION
This PR reverts PR #35252 as the fix made in this PR just fixed one side effect.

Unfortunately when initially the PR #33355 was created I did not see that all temporary scripts and in/out serialized values are written into the tmp folder of the venv and thus pollute the venv. As the vench in the cached case might be used by multiple task slots in parallel, temporary files in a cached venc really generate a concurrency issue - more than just a termination log.

This PR:
- Revers the efforts of @potiuk in #35252 - Sorry as termination log is now not kept but in a separate tmp folder I needed to remove the newly contributed pytest :-(
- Instead each execution of external python/venv is not generating a dedicated temp folder for call data
- The generation and use of the tmp path is pushed into the execution to reduce redundant code.

If there is a general demand to keep the termination log after a failed run, we need to find a mechanism on top of the tempfolder so that it is not deleted as cleanup.

Note, the DIFF is much smaller if you ignore the whitespace.