### PR TITLE
Add support for anonymous access to s3 buckets for objectstorage

### DIFF
--- a/airflow/providers/amazon/aws/fs/s3.py
+++ b/airflow/providers/amazon/aws/fs/s3.py
@@ -85,7 +85,15 @@ def get_fs(conn_id: str | None) -> AbstractFileSystem:
     if proxy_uri := s3_service_config.get(S3_PROXY_URI, None):
         config_kwargs["proxies"] = {"http": proxy_uri, "https": proxy_uri}
 
-    fs = S3FileSystem(session=session, config_kwargs=config_kwargs, endpoint_url=endpoint_url)
+    anon = False
+    if (
+        aws.conn_config.aws_access_key_id is None
+        and aws.conn_config.aws_secret_access_key is None
+        and aws.conn_config.aws_session_token is None
+    ):
+        anon = True
+
+    fs = S3FileSystem(session=session, config_kwargs=config_kwargs, endpoint_url=endpoint_url, anon=anon)
 
     for event_name, event_function in register_events.items():
         fs.s3.meta.events.register_last(event_name, event_function, unique_id=1925)

--- a/airflow/providers/amazon/aws/fs/s3.py
+++ b/airflow/providers/amazon/aws/fs/s3.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import asyncio
 import logging
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Dict
@@ -86,11 +87,7 @@ def get_fs(conn_id: str | None) -> AbstractFileSystem:
         config_kwargs["proxies"] = {"http": proxy_uri, "https": proxy_uri}
 
     anon = False
-    if (
-        aws.conn_config.aws_access_key_id is None
-        and aws.conn_config.aws_secret_access_key is None
-        and aws.conn_config.aws_session_token is None
-    ):
+    if asyncio.run(session.get_credentials()) is None:
         anon = True
 
     fs = S3FileSystem(session=session, config_kwargs=config_kwargs, endpoint_url=endpoint_url, anon=anon)

--- a/airflow/providers/amazon/aws/fs/s3.py
+++ b/airflow/providers/amazon/aws/fs/s3.py
@@ -88,6 +88,7 @@ def get_fs(conn_id: str | None) -> AbstractFileSystem:
 
     anon = False
     if asyncio.run(session.get_credentials()) is None:
+        log.info("No credentials found, using anonymous access")
         anon = True
 
     fs = S3FileSystem(session=session, config_kwargs=config_kwargs, endpoint_url=endpoint_url, anon=anon)

--- a/tests/providers/amazon/aws/fs/test_fs.py
+++ b/tests/providers/amazon/aws/fs/test_fs.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 import responses
 from botocore.awsrequest import AWSRequest
@@ -38,6 +40,14 @@ class TestFilesystem:
         fs = get_fs(conn_id=TEST_CONN)
 
         assert "s3" in fs.protocol
+
+    @patch("s3fs.S3FileSystem", autospec=True)
+    def test_get_s3fs_anonymous(self, s3fs):
+        from airflow.providers.amazon.aws.fs.s3 import get_fs
+
+        get_fs(conn_id=TEST_CONN)
+
+        assert s3fs.call_args.kwargs["anon"] is True
 
     @responses.activate
     def test_signer(self):

--- a/tests/providers/amazon/aws/fs/test_fs.py
+++ b/tests/providers/amazon/aws/fs/test_fs.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import os
 from unittest.mock import patch
 
 import pytest
@@ -42,10 +43,15 @@ class TestFilesystem:
         assert "s3" in fs.protocol
 
     @patch("s3fs.S3FileSystem", autospec=True)
-    def test_get_s3fs_anonymous(self, s3fs):
+    def test_get_s3fs_anonymous(self, s3fs, monkeypatch):
         from airflow.providers.amazon.aws.fs.s3 import get_fs
 
-        get_fs(conn_id=TEST_CONN)
+        # remove all AWS_* env vars
+        for env_name in os.environ:
+            if env_name.startswith("AWS"):
+                monkeypatch.delenv(env_name, raising=False)
+
+        get_fs(conn_id=None)
 
         assert s3fs.call_args.kwargs["anon"] is True
 


### PR DESCRIPTION
@eladkal probably nice to have in #35240


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
