### PR TITLE
Produce proper exit status in case image has been built with timeout

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -206,6 +206,20 @@ def kill_process_group(build_process_group_id: int):
         pass
 
 
+def get_exitcode(status: int) -> int:
+    # In Python 3.9+ we will be able to use
+    # os.waitstatus_to_exitcode(status) - see https://github.com/python/cpython/issues/84275
+    # but until then we need to do this ugly conversion
+    if os.WIFSIGNALED(status):
+        return -os.WTERMSIG(status)
+    elif os.WIFEXITED(status):
+        return os.WEXITSTATUS(status)
+    elif os.WIFSTOPPED(status):
+        return -os.WSTOPSIG(status)
+    else:
+        return 1
+
+
 @ci_image.command(name="build")
 @option_python
 @option_run_in_parallel
@@ -277,8 +291,13 @@ def build(
             atexit.register(kill_process_group, pid)
             signal.signal(signal.SIGALRM, handler)
             signal.alarm(build_timeout_minutes * 60)
-            os.waitpid(pid, 0)
-            return
+            child_pid, status = os.waitpid(pid, 0)
+            exit_code = get_exitcode(status)
+            if exit_code:
+                get_console().print(f"[error]Exiting with exit code {exit_code}")
+            else:
+                get_console().print(f"[success]Exiting with exit code {exit_code}")
+            sys.exit(exit_code)
         else:
             # turn us into a process group leader
             os.setpgid(0, 0)


### PR DESCRIPTION
When we build the image with timeout, we fork the process and set alarm
and create a new process group in order to be sure that all the parallel
build processes can be killed easily with sending termination signal to
process group on timeout. In order to wait for the forked process
to complete we used waitpid, but we did not handle the status code
properly, so if the build failed, we returned with 0 exit code.

This had the side effect that "Build CI image" did not fail, instead
the next step (generating source providers failed instead and it was
not obvious that the CI image build failing was the root cause.

This PR properly retrieves the wait status and converts it to
exit code - since we are still supporting Python 3.8 this is still
done using a bit nasty set of if statements - only in Python 3.9 we
have `os.waitstatus_to_exitcode` method to do it for us, but we cannot
use the method yet.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
