### PR TITLE
Allow non-str value for path concat

### DIFF
--- a/airflow/io/store/path.py
+++ b/airflow/io/store/path.py
@@ -88,7 +88,7 @@ class ObjectStoragePath(os.PathLike):
         protocol = ""
         key = ""
 
-        path = stringify_path(path)
+        path = str(stringify_path(path))
 
         i = path.find("://")
         if i > 0:
@@ -162,13 +162,16 @@ class ObjectStoragePath(os.PathLike):
 
     def __truediv__(self, other) -> ObjectStoragePath:
         o_protocol, o_bucket, o_key = self.split_path(other)
-        if not isinstance(other, str) and o_bucket and self._bucket != o_bucket:
+        if isinstance(other, ObjectStoragePath) and o_bucket and self._bucket != o_bucket:
             raise ValueError("Cannot combine paths from different buckets / containers")
 
         if o_protocol and self._protocol != o_protocol:
             raise ValueError("Cannot combine paths from different protocols")
 
-        path = f"{stringify_path(self).rstrip(self.sep)}/{stringify_path(other).lstrip(self.sep)}"
+        self_path = str(stringify_path(self))
+        other_path = str(stringify_path(other))
+
+        path = f"{self_path.rstrip(self.sep)}/{other_path.lstrip(self.sep)}"
         return ObjectStoragePath(path, conn_id=self._conn_id)
 
     def _unsupported(self, method_name):

--- a/tests/io/store/test_store.py
+++ b/tests/io/store/test_store.py
@@ -66,6 +66,12 @@ class TestFs:
         assert path2.key == "key/part1/part2/part3"
         assert path2._protocol == "file"
 
+        # check if we can append a non string to the path
+        path3 = ObjectStoragePath(path2 / 2023)
+        assert path3.bucket == "bucket"
+        assert path3.key == "key/part1/part2/part3/2023"
+        assert path3._protocol == "file"
+
     def test_read_write(self):
         o = ObjectStoragePath(f"file:///tmp/{str(uuid.uuid4())}")
 


### PR DESCRIPTION
It was not possible to do path / int which is
a typical thing when using date partitioned files.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
