### PR TITLE
Resolve `botocore.UNSIGNED` and `unsigned` in Amazon Provider

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -53,6 +53,7 @@ from airflow.exceptions import (
     AirflowProviderDeprecationWarning,
 )
 from airflow.hooks.base import BaseHook
+from airflow.providers.amazon.aws.utils.boto import build_botocore_config
 from airflow.providers.amazon.aws.utils.connection_wrapper import AwsConnectionWrapper
 from airflow.providers.amazon.aws.utils.identifiers import generate_uuid
 from airflow.providers.amazon.aws.utils.suppress import return_on_error
@@ -472,7 +473,7 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
 
         self._region_name = region_name
         if isinstance(config, dict):
-            config = Config(**config)
+            config = build_botocore_config(**config)
         self._config = config
         self._verify = verify
 

--- a/airflow/providers/amazon/aws/utils/boto.py
+++ b/airflow/providers/amazon/aws/utils/boto.py
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+This module contains different `boto3` / `botocore` helpers for internal use within the Amazon provider.
+
+.. warning::
+    Only for internal usage, this module and all classes might be changed, renamed or removed in the future
+    without any further notice.
+
+:meta private:
+"""
+from __future__ import annotations
+
+from botocore import UNSIGNED
+from botocore.config import Config
+
+
+def serialize_botocore_config_params(**params):
+    """
+    Helper function for convert internal botocore types to Python builtin types.
+
+    :meta private:
+    """
+    if signature_version := params.get("signature_version"):
+        if signature_version is UNSIGNED:
+            params["signature_version"] = "unsigned"
+    return params
+
+
+def deserialize_botocore_config_params(**params):
+    """
+    Helper function for convert Python builtin types into botocore types.
+
+    :meta private:
+    """
+    if signature_version := params.get("signature_version"):
+        if isinstance(signature_version, str) and signature_version.lower() == "unsigned":
+            params["signature_version"] = UNSIGNED
+    return params
+
+
+def build_botocore_config(**params) -> Config:
+    """
+    Build ``botocore.config.Config`` from the parameters.
+
+    In additional convert Python builtin types into botocore types.
+
+    :meta private:
+    """
+    return Config(**deserialize_botocore_config_params(**params))

--- a/airflow/providers/amazon/aws/utils/suppress.py
+++ b/airflow/providers/amazon/aws/utils/suppress.py
@@ -22,7 +22,7 @@ Module for suppress errors in Amazon Provider.
     Only for internal usage, this module might be changed or removed in the future
     without any further notice.
 
-:meta: private
+:meta private:
 """
 
 from __future__ import annotations

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -978,7 +978,7 @@ class TestAwsBaseHook:
         [
             pytest.param(None, id="empty-botocore-config"),
             pytest.param(Config(s3={"us_east_1_regional_endpoint": "regional"}), id="botocore-config"),
-            pytest.param({"s3": {"us_east_1_regional_endpoint": "regional"}}, id="botocore-config-as-dict"),
+            pytest.param({"signature_version": "unsigned"}, id="botocore-config-as-dict"),
         ],
     )
     @pytest.mark.parametrize("method_region_name", [None, "cn-north-1"])

--- a/tests/providers/amazon/aws/operators/test_base_aws.py
+++ b/tests/providers/amazon/aws/operators/test_base_aws.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import pytest
+from botocore import UNSIGNED
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
@@ -75,13 +76,17 @@ class TestAwsBaseOperator:
             aws_conn_id=TEST_CONN,
             region_name="eu-central-1",
             verify=False,
-            botocore_config={"read_timeout": 777, "connect_timeout": 42},
+            botocore_config={"read_timeout": 777, "connect_timeout": 42, "signature_version": UNSIGNED},
         )
 
         assert op.aws_conn_id == TEST_CONN
         assert op.region_name == "eu-central-1"
         assert op.verify is False
-        assert op.botocore_config == {"read_timeout": 777, "connect_timeout": 42}
+        assert op.botocore_config == {
+            "read_timeout": 777,
+            "connect_timeout": 42,
+            "signature_version": "unsigned",
+        }
 
         hook = op.hook
         assert isinstance(hook, FakeS3Hook)
@@ -90,6 +95,7 @@ class TestAwsBaseOperator:
         assert hook._verify == op.verify
         assert hook._config.read_timeout == 777
         assert hook._config.connect_timeout == 42
+        assert hook._config.signature_version is UNSIGNED
 
     @pytest.mark.db_test
     @pytest.mark.parametrize(

--- a/tests/providers/amazon/aws/sensors/test_base_aws.py
+++ b/tests/providers/amazon/aws/sensors/test_base_aws.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import pytest
+from botocore import UNSIGNED
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
@@ -77,13 +78,17 @@ class TestAwsBaseSensor:
             aws_conn_id=TEST_CONN,
             region_name="eu-central-1",
             verify=False,
-            botocore_config={"read_timeout": 777, "connect_timeout": 42},
+            botocore_config={"read_timeout": 777, "connect_timeout": 42, "signature_version": UNSIGNED},
         )
 
         assert op.aws_conn_id == TEST_CONN
         assert op.region_name == "eu-central-1"
         assert op.verify is False
-        assert op.botocore_config == {"read_timeout": 777, "connect_timeout": 42}
+        assert op.botocore_config == {
+            "read_timeout": 777,
+            "connect_timeout": 42,
+            "signature_version": "unsigned",
+        }
 
         hook = op.hook
         assert isinstance(hook, FakeDynamoDbHook)
@@ -92,6 +97,7 @@ class TestAwsBaseSensor:
         assert hook._verify == op.verify
         assert hook._config.read_timeout == 777
         assert hook._config.connect_timeout == 42
+        assert hook._config.signature_version == UNSIGNED
 
     @pytest.mark.db_test
     @pytest.mark.parametrize(

--- a/tests/providers/amazon/aws/utils/test_boto.py
+++ b/tests/providers/amazon/aws/utils/test_boto.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+from botocore import UNSIGNED
+from botocore.config import Config
+
+from airflow.providers.amazon.aws.utils.boto import (
+    build_botocore_config,
+    deserialize_botocore_config_params,
+    serialize_botocore_config_params,
+)
+
+
+def test_serde_botocore_config():
+    params = {"signature_version": UNSIGNED, "retries": {"mode": "standard", "max_attempts": 10}}
+
+    ser_params = serialize_botocore_config_params(**params)
+    assert ser_params["signature_version"] == "unsigned"
+    assert ser_params["retries"] == {"mode": "standard", "max_attempts": 10}
+
+    de_params = deserialize_botocore_config_params(**ser_params)
+    assert de_params["signature_version"] is UNSIGNED
+    assert de_params["retries"] == {"mode": "standard", "max_attempts": 10}
+
+    config1 = build_botocore_config(**de_params)
+    assert config1.signature_version is UNSIGNED
+    assert config1.retries == {"mode": "standard", "max_attempts": 10}
+
+    config2 = Config(**de_params)
+    assert config2.signature_version == config1.signature_version
+    assert config2.retries == config1.retries
+
+
+@pytest.mark.parametrize(
+    "signature_version", [pytest.param(None, id="not-set"), pytest.param("s3v4", id="SigV4")]
+)
+def test_serde_other_signature_versions(signature_version):
+    ser_params = serialize_botocore_config_params(signature_version=signature_version)
+    de_params = deserialize_botocore_config_params(**ser_params)
+
+    assert ser_params["signature_version"] == de_params["signature_version"] == signature_version

--- a/tests/providers/amazon/aws/utils/test_connection_wrapper.py
+++ b/tests/providers/amazon/aws/utils/test_connection_wrapper.py
@@ -516,6 +516,18 @@ class TestAwsConnectionWrapper:
 
             assert str(record[0].message) == expected_deprecation_message
 
+    @pytest.mark.parametrize("variant", ["unsigned", "UNSIGNED", "uNsIgNeD"])
+    def test_unsigned_signature_version(self, variant):
+        wrap_conn = AwsConnectionWrapper(
+            conn=mock_connection_factory(
+                extra={
+                    "config_kwargs": {"signature_version": variant},
+                },
+            ),
+        )
+        assert wrap_conn.botocore_config.signature_version is UNSIGNED
+        assert wrap_conn.config_kwargs == {"signature_version": UNSIGNED}
+
     @pytest.mark.parametrize("conn_id", [None, "mock-conn-id"])
     @pytest.mark.parametrize("profile_name", [None, "mock-profile"])
     @pytest.mark.parametrize("role_arn", [None, MOCK_ROLE_ARN])


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This changes help to resolve `botocore.UNSIGNED` -> `unsigned` -> `botocore.UNSIGNED` in different places of Amazon provider:

- Operators/Sensors: replace `botocore.UNSIGNED` to `unsigned`, so it could be pass to Triggers without problem with serialisation
- Hooks: if config retrieved as dictionary, then replace `unsigned` to `botocore.UNSIGNED` before build `botocore.config.Config`
- AwsConnectionWrapper: add new attribute `config_kwargs` which already replace `unsigned` to `botocore.UNSIGNED`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
