### PR TITLE
(AIP-44) Migrate TaskCommand._get_ti to Internal API

### DIFF
--- a/airflow/api/common/experimental/get_task_instance.py
+++ b/airflow/api/common/experimental/get_task_instance.py
@@ -43,5 +43,6 @@ def get_task_instance(dag_id: str, task_id: str, execution_date: datetime) -> Ta
         error_message = f"Task {task_id} instance for date {execution_date} not found"
         raise TaskInstanceNotFound(error_message)
     # API methods has access to the database.
-    assert isinstance(task_instance, TaskInstance)
-    return task_instance
+    if isinstance(task_instance, TaskInstance):
+        return task_instance
+    raise ValueError("not a TaskInstance")

--- a/airflow/api/common/experimental/get_task_instance.py
+++ b/airflow/api/common/experimental/get_task_instance.py
@@ -42,5 +42,6 @@ def get_task_instance(dag_id: str, task_id: str, execution_date: datetime) -> Ta
     if not task_instance:
         error_message = f"Task {task_id} instance for date {execution_date} not found"
         raise TaskInstanceNotFound(error_message)
-
+    # API methods has access to the database.
+    assert isinstance(task_instance, TaskInstance)
     return task_instance

--- a/airflow/api/common/experimental/get_task_instance.py
+++ b/airflow/api/common/experimental/get_task_instance.py
@@ -24,11 +24,10 @@ from deprecated import deprecated
 
 from airflow.api.common.experimental import check_and_get_dag, check_and_get_dagrun
 from airflow.exceptions import TaskInstanceNotFound
+from airflow.models import TaskInstance
 
 if TYPE_CHECKING:
     from datetime import datetime
-
-    from airflow.models import TaskInstance
 
 
 @deprecated(version="2.2.4", reason="Use DagRun.get_task_instance instead")

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -213,8 +213,7 @@ def _run_task_by_selected_method(
     - as raw task
     - by executor
     """
-    # Remove the running task is supported with Internal API.
-    assert isinstance(ti, TaskInstance)
+    assert isinstance(ti, TaskInstance), "Wait for AIP-44 implementation to complete"
     if args.local:
         return _run_task_by_local_task_job(args, ti)
     if args.raw:
@@ -468,7 +467,8 @@ def task_failed_deps(args) -> None:
     task = dag.get_task(task_id=args.task_id)
     ti, _ = _get_ti(task, args.map_index, exec_date_or_run_id=args.execution_date_or_run_id)
     # tasks_failed-deps is executed with access to the database.
-    assert isinstance(ti, TaskInstance)
+    if not isinstance(ti, TaskInstance):
+        raise ValueError("not a TaskInstance")
     dep_context = DepContext(deps=SCHEDULER_QUEUED_DEPS)
     failed_deps = list(ti.get_failed_dep_statuses(dep_context=dep_context))
     # TODO, Do we want to print or log this
@@ -494,7 +494,8 @@ def task_state(args) -> None:
     task = dag.get_task(task_id=args.task_id)
     ti, _ = _get_ti(task, args.map_index, exec_date_or_run_id=args.execution_date_or_run_id)
     # task_state is executed with access to the database.
-    assert isinstance(ti, TaskInstance)
+    if not isinstance(ti, TaskInstance):
+        raise ValueError("not a TaskInstance")
     print(ti.current_state())
 
 
@@ -626,7 +627,8 @@ def task_test(args, dag: DAG | None = None) -> None:
         task, args.map_index, exec_date_or_run_id=args.execution_date_or_run_id, create_if_necessary="db"
     )
     # task_test is executed with access to the database.
-    assert isinstance(ti, TaskInstance)
+    if not isinstance(ti, TaskInstance):
+        raise ValueError("not a TaskInstance")
     try:
         with redirect_stdout(RedactedIO()):
             if args.dry_run:
@@ -661,7 +663,8 @@ def task_render(args, dag: DAG | None = None) -> None:
         task, args.map_index, exec_date_or_run_id=args.execution_date_or_run_id, create_if_necessary="memory"
     )
     # task_render is executed with access to the database.
-    assert isinstance(ti, TaskInstance)
+    if not isinstance(ti, TaskInstance):
+        raise ValueError("not a TaskInstance")
     with create_session() as session, set_current_task_instance_session(session=session):
         ti.render_templates()
     for attr in task.template_fields:

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -30,7 +30,6 @@ from typing import TYPE_CHECKING, Generator, Protocol, Union, cast
 import pendulum
 from pendulum.parsing.exceptions import ParserError
 from sqlalchemy import select
-from sqlalchemy.orm.exc import NoResultFound
 
 from airflow import settings
 from airflow.cli.simple_table import AirflowConsole
@@ -46,6 +45,7 @@ from airflow.models.dagrun import DagRun
 from airflow.models.operator import needs_expansion
 from airflow.models.param import ParamsDict
 from airflow.models.taskinstance import TaskReturnCode
+from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
 from airflow.settings import IS_EXECUTOR_CONTAINER, IS_K8S_EXECUTOR_POD
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import SCHEDULER_QUEUED_DEPS
@@ -74,7 +74,6 @@ if TYPE_CHECKING:
 
     from airflow.models.operator import Operator
     from airflow.serialization.pydantic.dag_run import DagRunPydantic
-    from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
 
 log = logging.getLogger(__name__)
 
@@ -119,16 +118,15 @@ def _get_dag_run(
             return dag_run, False
         with suppress(ParserError, TypeError):
             execution_date = timezone.parse(exec_date_or_run_id)
-        try:
+        if execution_date:
             dag_run = dag.get_dagrun(execution_date=execution_date, session=session)
-        except NoResultFound:
-            if not create_if_necessary:
-                raise DagRunNotFound(
-                    f"DagRun for {dag.dag_id} with run_id or execution_date "
-                    f"of {exec_date_or_run_id!r} not found"
-                ) from None
-        else:
+        if dag_run:
             return dag_run, False
+        elif not create_if_necessary:
+            raise DagRunNotFound(
+                f"DagRun for {dag.dag_id} with run_id or execution_date "
+                f"of {exec_date_or_run_id!r} not found"
+            )
 
     if execution_date is not None:
         dag_run_execution_date = execution_date
@@ -213,7 +211,7 @@ def _run_task_by_selected_method(
     - as raw task
     - by executor
     """
-    assert isinstance(ti, TaskInstance), "Wait for AIP-44 implementation to complete"
+    assert not isinstance(ti, TaskInstancePydantic), "Wait for AIP-44 implementation to complete"
     if args.local:
         return _run_task_by_local_task_job(args, ti)
     if args.raw:
@@ -467,7 +465,7 @@ def task_failed_deps(args) -> None:
     task = dag.get_task(task_id=args.task_id)
     ti, _ = _get_ti(task, args.map_index, exec_date_or_run_id=args.execution_date_or_run_id)
     # tasks_failed-deps is executed with access to the database.
-    if not isinstance(ti, TaskInstance):
+    if isinstance(ti, TaskInstancePydantic):
         raise ValueError("not a TaskInstance")
     dep_context = DepContext(deps=SCHEDULER_QUEUED_DEPS)
     failed_deps = list(ti.get_failed_dep_statuses(dep_context=dep_context))
@@ -494,7 +492,7 @@ def task_state(args) -> None:
     task = dag.get_task(task_id=args.task_id)
     ti, _ = _get_ti(task, args.map_index, exec_date_or_run_id=args.execution_date_or_run_id)
     # task_state is executed with access to the database.
-    if not isinstance(ti, TaskInstance):
+    if isinstance(ti, TaskInstancePydantic):
         raise ValueError("not a TaskInstance")
     print(ti.current_state())
 
@@ -627,7 +625,7 @@ def task_test(args, dag: DAG | None = None) -> None:
         task, args.map_index, exec_date_or_run_id=args.execution_date_or_run_id, create_if_necessary="db"
     )
     # task_test is executed with access to the database.
-    if not isinstance(ti, TaskInstance):
+    if isinstance(ti, TaskInstancePydantic):
         raise ValueError("not a TaskInstance")
     try:
         with redirect_stdout(RedactedIO()):
@@ -663,7 +661,7 @@ def task_render(args, dag: DAG | None = None) -> None:
         task, args.map_index, exec_date_or_run_id=args.execution_date_or_run_id, create_if_necessary="memory"
     )
     # task_render is executed with access to the database.
-    if not isinstance(ti, TaskInstance):
+    if isinstance(ti, TaskInstancePydantic):
         raise ValueError("not a TaskInstance")
     with create_session() as session, set_current_task_instance_session(session=session):
         ti.render_templates()

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -77,6 +77,7 @@ if TYPE_CHECKING:
     from airflow.models.dag import DAG
     from airflow.models.operator import Operator
     from airflow.serialization.pydantic.dag_run import DagRunPydantic
+    from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
     from airflow.typing_compat import Literal
     from airflow.utils.types import ArgNotSet
 
@@ -466,7 +467,7 @@ class DagRun(Base, LoggingMixin):
     def fetch_task_instances(
         dag_id: str | None = None,
         run_id: str | None = None,
-        dag: DAG | None = None,
+        task_ids: list[str] | None = None,
         state: Iterable[TaskInstanceState | None] | None = None,
         session: Session = NEW_SESSION,
     ) -> list[TI]:
@@ -494,8 +495,8 @@ class DagRun(Base, LoggingMixin):
                 else:
                     tis = tis.where(TI.state.in_(state))
 
-        if dag and dag.partial:
-            tis = tis.where(TI.task_id.in_(dag.task_ids))
+        if task_ids:
+            tis = tis.where(TI.task_id.in_(task_ids))
         return session.scalars(tis).all()
 
     @provide_session
@@ -510,8 +511,9 @@ class DagRun(Base, LoggingMixin):
         Redirect to DagRun.fetch_task_instances method.
         Keep this method because it is widely used across the code.
         """
+        task_ids = self.dag.task_ids if self.dag and not self.dag.partial else None
         return DagRun.fetch_task_instances(
-            dag_id=self.dag_id, run_id=self.run_id, dag=self.dag, state=state, session=session
+            dag_id=self.dag_id, run_id=self.run_id, task_ids=task_ids, state=state, session=session
         )
 
     @provide_session
@@ -521,7 +523,7 @@ class DagRun(Base, LoggingMixin):
         session: Session = NEW_SESSION,
         *,
         map_index: int = -1,
-    ) -> TI | None:
+    ) -> TI | TaskInstancePydantic | None:
         """
         Return the task instance specified by task_id for this dag run.
 
@@ -545,7 +547,7 @@ class DagRun(Base, LoggingMixin):
         task_id: str,
         session: Session = NEW_SESSION,
         map_index: int = -1,
-    ) -> TI | None:
+    ) -> TI | TaskInstancePydantic | None:
         """
         Returns the task instance specified by task_id for this dag run.
 

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -495,7 +495,7 @@ class DagRun(Base, LoggingMixin):
                 else:
                     tis = tis.where(TI.state.in_(state))
 
-        if task_ids:
+        if task_ids is not None:
             tis = tis.where(TI.task_id.in_(task_ids))
         return session.scalars(tis).all()
 
@@ -511,7 +511,7 @@ class DagRun(Base, LoggingMixin):
         Redirect to DagRun.fetch_task_instances method.
         Keep this method because it is widely used across the code.
         """
-        task_ids = self.dag.task_ids if self.dag and not self.dag.partial else None
+        task_ids = self.dag.task_ids if self.dag and self.dag.partial else None
         return DagRun.fetch_task_instances(
             dag_id=self.dag_id, run_id=self.run_id, task_ids=task_ids, state=state, session=session
         )

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -978,7 +978,7 @@ def _get_previous_execution_date(
     """
     log.debug("previous_execution_date was called")
     prev_ti = task_instance.get_previous_ti(state=state, session=session)
-    return prev_ti and pendulum.instance(prev_ti.execution_date)
+    return pendulum.instance(prev_ti.execution_date) if prev_ti and prev_ti.execution_date else None
 
 
 def _email_alert(
@@ -1161,7 +1161,7 @@ def _get_previous_ti(
     task_instance: TaskInstance | TaskInstancePydantic,
     session: Session,
     state: DagRunState | None = None,
-) -> TaskInstance | None:
+) -> TaskInstance | TaskInstancePydantic | None:
     """
     The task instance for the task that ran before this task instance.
 
@@ -1800,7 +1800,7 @@ class TaskInstance(Base, LoggingMixin):
         self,
         state: DagRunState | None = None,
         session: Session = NEW_SESSION,
-    ) -> TaskInstance | None:
+    ) -> TaskInstance | TaskInstancePydantic | None:
         """
         Return the task instance for the task that ran before this task instance.
 
@@ -1810,7 +1810,7 @@ class TaskInstance(Base, LoggingMixin):
         return _get_previous_ti(task_instance=self, state=state, session=session)
 
     @property
-    def previous_ti(self) -> TaskInstance | None:
+    def previous_ti(self) -> TaskInstance | TaskInstancePydantic | None:
         """
         This attribute is deprecated.
 
@@ -1827,7 +1827,7 @@ class TaskInstance(Base, LoggingMixin):
         return self.get_previous_ti()
 
     @property
-    def previous_ti_success(self) -> TaskInstance | None:
+    def previous_ti_success(self) -> TaskInstance | TaskInstancePydantic | None:
         """
         This attribute is deprecated.
 
@@ -1870,7 +1870,7 @@ class TaskInstance(Base, LoggingMixin):
         self.log.debug("previous_start_date was called")
         prev_ti = self.get_previous_ti(state=state, session=session)
         # prev_ti may not exist and prev_ti.start_date may be None.
-        return prev_ti and prev_ti.start_date and pendulum.instance(prev_ti.start_date)
+        return pendulum.instance(prev_ti.start_date) if prev_ti and prev_ti.start_date else None
 
     @property
     def previous_start_date_success(self) -> pendulum.DateTime | None:

--- a/airflow/serialization/pydantic/dag_run.py
+++ b/airflow/serialization/pydantic/dag_run.py
@@ -24,13 +24,13 @@ from typing_extensions import Annotated
 
 from airflow import DAG
 from airflow.serialization.pydantic.dataset import DatasetEventPydantic
-from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
 from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from airflow.jobs.scheduler_job_runner import TI
+    from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
     from airflow.utils.state import TaskInstanceState
 
 

--- a/airflow/serialization/pydantic/dag_run.py
+++ b/airflow/serialization/pydantic/dag_run.py
@@ -24,6 +24,7 @@ from typing_extensions import Annotated
 
 from airflow import DAG
 from airflow.serialization.pydantic.dataset import DatasetEventPydantic
+from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
 from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
@@ -61,7 +62,6 @@ class DagRunPydantic(BaseModelPydantic):
     dag_id: str
     queued_at: Optional[datetime]
     execution_date: datetime
-    logical_date: datetime
     start_date: Optional[datetime]
     end_date: Optional[datetime]
     state: str
@@ -85,6 +85,10 @@ class DagRunPydantic(BaseModelPydantic):
         orm_mode = True  # Pydantic 1.x compatibility.
         arbitrary_types_allowed = True
 
+    @property
+    def logical_date(self) -> datetime:
+        return self.execution_date
+
     @provide_session
     def get_task_instances(
         self,
@@ -105,7 +109,7 @@ class DagRunPydantic(BaseModelPydantic):
         session: Session = NEW_SESSION,
         *,
         map_index: int = -1,
-    ) -> TI | None:
+    ) -> TI | TaskInstancePydantic | None:
         """
         Return the task instance specified by task_id for this dag run.
 

--- a/airflow/serialization/pydantic/taskinstance.py
+++ b/airflow/serialization/pydantic/taskinstance.py
@@ -25,6 +25,7 @@ from typing_extensions import Annotated
 from airflow.models import Operator
 from airflow.models.baseoperator import BaseOperator
 from airflow.serialization.pydantic.dag_run import DagRunPydantic
+from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.xcom import XCOM_RETURN_KEY
 
@@ -62,7 +63,7 @@ PydanticOperator = Annotated[
 ]
 
 
-class TaskInstancePydantic(BaseModelPydantic):
+class TaskInstancePydantic(BaseModelPydantic, LoggingMixin):
     """Serializable representation of the TaskInstance ORM SqlAlchemyModel used by internal API."""
 
     task_id: str
@@ -107,6 +108,11 @@ class TaskInstancePydantic(BaseModelPydantic):
         from_attributes = True
         orm_mode = True  # Pydantic 1.x compatibility.
         arbitrary_types_allowed = True
+
+    def init_run_context(self, raw: bool = False) -> None:
+        """Set the log context."""
+        self.raw = raw
+        self._set_context(self)
 
     def xcom_pull(
         self,
@@ -334,7 +340,7 @@ class TaskInstancePydantic(BaseModelPydantic):
         self,
         state: DagRunState | None = None,
         session: Session = NEW_SESSION,
-    ) -> TaskInstance | None:
+    ) -> TaskInstance | TaskInstancePydantic | None:
         """
         Return the task instance for the task that ran before this task instance.
 

--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -23,7 +23,7 @@ import logging
 import sys
 from io import IOBase
 from logging import Handler, StreamHandler
-from typing import IO, TYPE_CHECKING, Any, TypeVar, cast
+from typing import IO, TYPE_CHECKING, Any, Optional, TypeVar, cast
 
 import re2
 
@@ -72,9 +72,9 @@ class LoggingMixin:
     # Parent logger used by this class. It should match one of the loggers defined in the
     # `logging_config_class`. By default, this attribute is used to create the final name of the logger, and
     # will prefix the `_logger_name` with a separating dot.
-    _log_config_logger_name: str | None = None
+    _log_config_logger_name: Optional[str] = None  # noqa: UP007
 
-    _logger_name: str | None = None
+    _logger_name: Optional[str] = None  # noqa: UP007
 
     def __init__(self, context=None):
         self._set_context(context)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1543,6 +1543,7 @@ class Airflow(AirflowBaseView):
 
         pod_spec = None
         try:
+            assert isinstance(ti, TaskInstance)
             pod_spec = get_rendered_k8s_spec(ti, session=session)
         except AirflowException as e:
             if not e.__cause__:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1542,8 +1542,9 @@ class Airflow(AirflowBaseView):
             raise AirflowException(f"Task instance {task.task_id} not found.")
 
         pod_spec = None
+        if not isinstance(ti, TaskInstance):
+            raise ValueError("not a TaskInstance")
         try:
-            assert isinstance(ti, TaskInstance)
             pod_spec = get_rendered_k8s_spec(ti, session=session)
         except AirflowException as e:
             if not e.__cause__:


### PR DESCRIPTION
Change TaskCommand._get_ti to return either TaskInstance or TaskInstancePydantic, making sure it calls the InternalAPI in dbless mode.

Some CLI commands, despite calling TaskCommand._get_ti still assume access to database.

closes: #29320
related: #29320