### PR TITLE
Disable common.io as preinstalled provider before we cut-off 2.8 branch

### DIFF
--- a/docs/apache-airflow/extra-packages-ref.rst
+++ b/docs/apache-airflow/extra-packages-ref.rst
@@ -285,7 +285,7 @@ These are extras that provide support for integration with external systems via 
 +---------------------+-----------------------------------------------------+--------------------------------------+--------------+
 | extra               | install command                                     | enables                              | Preinstalled |
 +=====================+=====================================================+======================================+==============+
-| common.io           | ``pip install 'apache-airflow[common.io]'``         | Core IO Operators                    |      *       |
+| common.io           | ``pip install 'apache-airflow[common.io]'``         | Core IO Operators                    |              |
 +---------------------+-----------------------------------------------------+--------------------------------------+--------------+
 | common.sql          | ``pip install 'apache-airflow[common.sql]'``        | Core SQL Operators                   |      *       |
 +---------------------+-----------------------------------------------------+--------------------------------------+--------------+

--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -301,16 +301,11 @@ function install_all_providers_from_pypi_with_eager_upgrade() {
     local res
     for provider_package in ${ALL_PROVIDERS_PACKAGES}
     do
-        # Until we release "yandex" provider with protobuf support we need to remove it from the list of providers
-        # to install, because it is impossible to find common requirements for already released yandex provider
-        # and current airflow
-        if [[ ${provider_package} == "apache-airflow-providers-yandex" ]]; then
-            continue
-        fi
-        # Until we release latest `hive` provider with pure-sasl support, we need to remove it from the
-        # list of providers to install for Python 3.11 because we cannot build sasl it for Python 3.11
-        if [[ ${provider_package} == "apache-airflow-providers-apache-hive" \
-            && ${PYTHON_MAJOR_MINOR_VERSION} == "3.11" ]]; then
+        # Remove common.io provider in main branch until we cut-off v2-8-test branch and change
+        # version in main to 2.9.0 - otherwise we won't be able to generate PyPI constraints as
+        # released common-io provider has apache-airflow>2.8.0 as dependency and we cannot install
+        # the provider from PyPI
+        if [[ ${provider_package} == "apache-airflow-providers-common-io" ]]; then
             continue
         fi
         echo -n "Checking if ${provider_package} is available in PyPI: "

--- a/setup.py
+++ b/setup.py
@@ -811,10 +811,11 @@ def sort_extras_dependencies() -> dict[str, list[str]]:
 EXTRAS_DEPENDENCIES = sort_extras_dependencies()
 
 # Those providers are pre-installed always when airflow is installed.
-# Those providers do not have dependency on airflow2.0 because that would lead to circular dependencies.
-# This is not a problem for PIP but some tools (pipdeptree) show those as a warning.
 PREINSTALLED_PROVIDERS = [
-    "common.io",
+    #   Until we cut-off the 2.8.0 branch and bump current airflow version to 2.9.0, we should
+    #   Keep common.io commented out in order ot be able to generate PyPI constraints because
+    #   The version from PyPI has requirement of apache-airflow>=2.8.0
+    #   "common.io",
     "common.sql",
     "ftp",
     "http",


### PR DESCRIPTION
We need to do it in order to be able to generate PyPI constraints, because common.io has apache-airflow>=2.8.0 requirement that conflicts with the current 2.8.0dev0

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
