### PR TITLE
 Reuse get_default_azure_credential method from Azure utils for Azure key valut

### DIFF
--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -35,6 +35,7 @@ from azure.identity import ClientSecretCredential, DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
+from airflow.providers.microsoft.azure.utils import get_default_azure_credential
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.version import version as airflow_version
@@ -142,14 +143,10 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
         if all([self.tenant_id, self.client_id, self.client_secret]):
             credential = ClientSecretCredential(self.tenant_id, self.client_id, self.client_secret)
         else:
-            if self.managed_identity_client_id and self.workload_identity_tenant_id:
-                credential = DefaultAzureCredential(
-                    managed_identity_client_id=self.managed_identity_client_id,
-                    workload_identity_tenant_id=self.workload_identity_tenant_id,
-                    additionally_allowed_tenants=[self.workload_identity_tenant_id],
-                )
-            else:
-                credential = DefaultAzureCredential()
+            credential = get_default_azure_credential(
+                managed_identity_client_id=self.managed_identity_client_id,
+                workload_identity_tenant_id=self.workload_identity_tenant_id,
+            )
         client = SecretClient(vault_url=self.vault_url, credential=credential, **self.kwargs)
         return client
 

--- a/tests/providers/microsoft/azure/secrets/test_azure_key_vault.py
+++ b/tests/providers/microsoft/azure/secrets/test_azure_key_vault.py
@@ -35,7 +35,7 @@ class TestAzureKeyVaultBackend:
         conn = AzureKeyVaultBackend().get_connection("fake_conn")
         assert conn.host == "host"
 
-    @mock.patch(f"{KEY_VAULT_MODULE}.DefaultAzureCredential")
+    @mock.patch(f"{KEY_VAULT_MODULE}.get_default_azure_credential")
     @mock.patch(f"{KEY_VAULT_MODULE}.SecretClient")
     def test_get_conn_uri(self, mock_secret_client, mock_azure_cred):
         mock_cred = mock.Mock()
@@ -153,7 +153,7 @@ class TestAzureKeyVaultBackend:
         assert backend.get_config("test_mysql") is None
         mock_get_secret.assert_not_called()
 
-    @mock.patch(f"{KEY_VAULT_MODULE}.DefaultAzureCredential")
+    @mock.patch(f"{KEY_VAULT_MODULE}.get_default_azure_credential")
     @mock.patch(f"{KEY_VAULT_MODULE}.ClientSecretCredential")
     @mock.patch(f"{KEY_VAULT_MODULE}.SecretClient")
     def test_client_authenticate_with_default_azure_credential(
@@ -169,7 +169,7 @@ class TestAzureKeyVaultBackend:
         assert not mock_client_secret_credential.called
         mock_defaul_azure_credential.assert_called_once()
 
-    @mock.patch(f"{KEY_VAULT_MODULE}.DefaultAzureCredential")
+    @mock.patch(f"{KEY_VAULT_MODULE}.get_default_azure_credential")
     @mock.patch(f"{KEY_VAULT_MODULE}.ClientSecretCredential")
     @mock.patch(f"{KEY_VAULT_MODULE}.SecretClient")
     def test_client_authenticate_with_default_azure_credential_and_customized_configuration(
@@ -179,17 +179,15 @@ class TestAzureKeyVaultBackend:
             vault_url="https://example-akv-resource-name.vault.azure.net/",
             managed_identity_client_id="managed_identity_client_id",
             workload_identity_tenant_id="workload_identity_tenant_id",
-            additionally_allowed_tenants=["workload_identity_tenant_id"],
         )
         backend.client
         assert not mock_client_secret_credential.called
         mock_defaul_azure_credential.assert_called_once_with(
             managed_identity_client_id="managed_identity_client_id",
             workload_identity_tenant_id="workload_identity_tenant_id",
-            additionally_allowed_tenants=["workload_identity_tenant_id"],
         )
 
-    @mock.patch(f"{KEY_VAULT_MODULE}.DefaultAzureCredential")
+    @mock.patch(f"{KEY_VAULT_MODULE}.get_default_azure_credential")
     @mock.patch(f"{KEY_VAULT_MODULE}.ClientSecretCredential")
     @mock.patch(f"{KEY_VAULT_MODULE}.SecretClient")
     def test_client_authenticate_with_client_secret_credential(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
