### PR TITLE
Use slightly nicer job name for Non-DB tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1577,7 +1577,7 @@ jobs:
       - name: "Post Tests success: Non-DB"
         uses: ./.github/actions/post_tests_success
         if: success()
-      - name: "Post Tests failure: NoN-DB"
+      - name: "Post Tests failure: Non-DB"
         uses: ./.github/actions/post_tests_failure
         if: failure()
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1543,7 +1543,8 @@ jobs:
 
   tests-no-db:
     timeout-minutes: 60
-    name: "Non-DB"
+    name: >
+      Non-DB: Py${{matrix.python-version}}:${{needs.build-info.outputs.parallel-test-types-list-as-string}}
     runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
     needs: [build-info, wait-for-ci-images]
     strategy:
@@ -1569,14 +1570,14 @@ jobs:
       - name: >
           Prepare breeze & CI image: ${{needs.build-info.outputs.default-python-version}}:${{env.IMAGE_TAG}}
         uses: ./.github/actions/prepare_breeze_and_image
-      - name: "Tests: ${{matrix.python-version}}:NoDB"
+      - name: "Tests: ${{matrix.python-version}}:Non-DB"
         run: >
           breeze testing non-db-tests
           --parallel-test-types "${{needs.build-info.outputs.parallel-test-types-list-as-string}}"
-      - name: "Post Tests success: NoDB"
+      - name: "Post Tests success: Non-DB"
         uses: ./.github/actions/post_tests_success
         if: success()
-      - name: "Post Tests failure: NoDB"
+      - name: "Post Tests failure: NoN-DB"
         uses: ./.github/actions/post_tests_failure
         if: failure()
 


### PR DESCRIPTION
To be consistend with DB tests - we show both Python version and set of test types we use for the job.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
