### PR TITLE
Added support for multiple cron expressions

### DIFF
--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -115,7 +115,15 @@
             { "type": "null" },
             { "type": "string" },
             { "$ref": "#/definitions/typed_timedelta" },
-            { "$ref": "#/definitions/typed_relativedelta" }
+            { "$ref": "#/definitions/typed_relativedelta" },
+            {
+              "description": "List of cron expressions (string)",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true
+            }
           ]
         },
         "dataset_triggers": {

--- a/airflow/timetables/interval.py
+++ b/airflow/timetables/interval.py
@@ -129,12 +129,12 @@ class CronDataIntervalTimetable(CronMixin, _DataIntervalTimetable):
     def deserialize(cls, data: dict[str, Any]) -> Timetable:
         from airflow.serialization.serialized_objects import decode_timezone
 
-        return cls(data["expression"], decode_timezone(data["timezone"]))
+        return cls(data["expressions"], decode_timezone(data["timezone"]))
 
     def serialize(self) -> dict[str, Any]:
         from airflow.serialization.serialized_objects import encode_timezone
 
-        return {"expression": self._expression, "timezone": encode_timezone(self._timezone)}
+        return {"expressions": self._expressions, "timezone": encode_timezone(self._timezone)}
 
     def _skip_to_latest(self, earliest: DateTime | None) -> DateTime:
         """Bound the earliest time a run can be scheduled.

--- a/airflow/timetables/trigger.py
+++ b/airflow/timetables/trigger.py
@@ -32,11 +32,11 @@ if TYPE_CHECKING:
 
 
 class CronTriggerTimetable(CronMixin, Timetable):
-    """Timetable that triggers DAG runs according to a cron expression.
+    """Timetable that triggers DAG runs according to a cron expressions.
 
     This is different from ``CronDataIntervalTimetable``, where the cron
-    expression specifies the *data interval* of a DAG run. With this timetable,
-    the data intervals are specified independently from the cron expression.
+    expressions specifies the *data interval* of a DAG run. With this timetable,
+    the data intervals are specified independently from the cron expressions.
     Also for the same reason, this timetable kicks off a DAG run immediately at
     the start of the period (similar to POSIX cron), instead of needing to wait
     for one data interval to pass.
@@ -46,7 +46,7 @@ class CronTriggerTimetable(CronMixin, Timetable):
 
     def __init__(
         self,
-        cron: str,
+        cron: str | list[str],
         *,
         timezone: str | Timezone,
         interval: datetime.timedelta | relativedelta = datetime.timedelta(),
@@ -63,7 +63,7 @@ class CronTriggerTimetable(CronMixin, Timetable):
             interval = decode_relativedelta(data["interval"])
         else:
             interval = datetime.timedelta(seconds=data["interval"])
-        return cls(data["expression"], timezone=decode_timezone(data["timezone"]), interval=interval)
+        return cls(data["expressions"], timezone=decode_timezone(data["timezone"]), interval=interval)
 
     def serialize(self) -> dict[str, Any]:
         from airflow.serialization.serialized_objects import encode_relativedelta, encode_timezone
@@ -74,7 +74,7 @@ class CronTriggerTimetable(CronMixin, Timetable):
         else:
             interval = encode_relativedelta(self._interval)
         timezone = encode_timezone(self._timezone)
-        return {"expression": self._expression, "timezone": timezone, "interval": interval}
+        return {"expressions": self._expressions, "timezone": timezone, "interval": interval}
 
     def infer_manual_data_interval(self, *, run_after: DateTime) -> DataInterval:
         return DataInterval(run_after - self._interval, run_after)

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -195,6 +195,11 @@ The ``schedule`` argument takes any value that is a valid `Crontab <https://en.w
     with DAG("my_daily_dag", schedule="0 0 * * *"):
         ...
 
+You can also specify a list of Crontab values for complex schedules::
+
+    with DAG("multicron_dag", schedule=["*/20 3 5 * *", "0 12 * * MON,TUE"]):
+        ...
+
 .. tip::
 
     For more information on ``schedule`` values, see :doc:`DAG Run <dag-run>`.

--- a/tests/timetables/test_trigger_timetable.py
+++ b/tests/timetables/test_trigger_timetable.py
@@ -228,6 +228,6 @@ def test_serialization(timetable: CronTriggerTimetable, data: dict[str, typing.A
 
     tt = CronTriggerTimetable.deserialize(data)
     assert isinstance(tt, CronTriggerTimetable)
-    assert tt._expression == timetable._expression
+    assert tt._expressions == timetable._expressions
     assert tt._timezone == timetable._timezone
     assert tt._interval == timetable._interval


### PR DESCRIPTION
This PR adds the ability to use a list of CRON expressions for a DAG schedule.
About a year ago another developer tried to do this (#24733).
Here I completely reworked the code of his idea.

Usage example:

```python
@dag(
    start_date=pendulum.datetime(2023, 11, 1),
    schedule=["*/20 3 5 * *", "0 12 * * MON,TUE"],
    catchup=False,
)
def multicron_test_dag():
    ...
```

My implementation only supports `List[str]`.
Tests have been added and are working.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
