### PR TITLE
Humanise log output about retrieved DAG(s)

### DIFF
--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -830,7 +830,7 @@ class DagFileProcessor(LoggingMixin):
             return 0, 0
 
         if dagbag.dags:
-            self.log.info("DAG(s) %s retrieved from %s", dagbag.dags.keys(), file_path)
+            self.log.info("DAG(s) %s retrieved from %s", ", ".join(map(repr, dagbag.dags)), file_path)
         else:
             self.log.warning("No viable dags retrieved from %s", file_path)
             DagFileProcessor.update_import_errors(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Simple replace `dict_keys(['dag1', 'dag2'])` output to a bit more humanise representation `'dag1', 'dag2'`

**WAS**

```console
[2023-11-01T12:24:14.820+0000] {logging_mixin.py:154} INFO - [2023-11-01T12:24:14.819+0000] {dagbag.py:538} INFO - Filling up the DagBag from /files/dags/pr_35338_multiple.py
[2023-11-01T12:24:14.857+0000] {processor.py:833} INFO - DAG(s) dict_keys(['issue_35338_dag_5', 'issue_35338_dag_1', 'issue_35338_dag_3', 'issue_35338_dag_2', 'issue_35338_dag_4']) retrieved from /files/dags/pr_35338_multiple.py
```

```console
[2023-11-01T12:24:14.820+0000] {logging_mixin.py:154} INFO - [2023-11-01T12:24:14.819+0000] {dagbag.py:538} INFO - Filling up the DagBag from /files/dags/pr_35338_multiple.py
[2023-11-01T12:24:14.857+0000] {processor.py:833} INFO - DAG(s) dict_keys(['issue_35338_dag_5', 'issue_35338_dag_1', 'issue_35338_dag_3', 'issue_35338_dag_2', 'issue_35338_dag_4']) retrieved from /files/dags/pr_35338_multiple.py
```

**IS**

```console
[2023-11-01T12:26:29.814+0000] {logging_mixin.py:154} INFO - [2023-11-01T12:26:29.813+0000] {dagbag.py:538} INFO - Filling up the DagBag from /files/dags/pr_35338_single.py
[2023-11-01T12:26:29.843+0000] {processor.py:833} INFO - DAG(s) 'issue_35338_dag_0' retrieved from /files/dags/pr_35338_single.py
```

```console
[2023-11-01T12:26:29.820+0000] {logging_mixin.py:154} INFO - [2023-11-01T12:26:29.820+0000] {dagbag.py:538} INFO - Filling up the DagBag from /files/dags/pr_35338_multiple.py
[2023-11-01T12:26:29.844+0000] {processor.py:833} INFO - DAG(s) 'issue_35338_dag_4', 'issue_35338_dag_5', 'issue_35338_dag_3', 'issue_35338_dag_1', 'issue_35338_dag_2' retrieved from /files/dags/pr_35338_multiple.py
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
