### PR TITLE
Remove `require_authentication` decorator from security.py

### DIFF
--- a/airflow/api_connexion/security.py
+++ b/airflow/api_connexion/security.py
@@ -92,17 +92,6 @@ def _requires_access(*, is_authorized_callback: Callable[[], bool], func: Callab
     raise PermissionDenied()
 
 
-def requires_authentication(func: T):
-    """Decorator for functions that require authentication."""
-
-    @wraps(func)
-    def decorated(*args, **kwargs):
-        check_authentication()
-        return func(*args, **kwargs)
-
-    return cast(T, decorated)
-
-
 def requires_access_configuration(method: ResourceMethod) -> Callable[[T], T]:
     def requires_access_decorator(func: T):
         @wraps(func)


### PR DESCRIPTION
This decorator was added in #34317, but it seems it's not used anywhere. Opening this PR to see if I'm missing something

cc @vincbeck 