### PR TITLE
Remove a check for `objectType` in TimeDeltaSchema & RelativeDeltaSchema

### DIFF
--- a/airflow/api_connexion/schemas/common_schema.py
+++ b/airflow/api_connexion/schemas/common_schema.py
@@ -48,8 +48,6 @@ class TimeDeltaSchema(Schema):
     @marshmallow.post_load
     def make_time_delta(self, data, **kwargs):
         """Create time delta based on data."""
-        if "objectType" in data:
-            del data["objectType"]
         return datetime.timedelta(**data)
 
 
@@ -76,9 +74,6 @@ class RelativeDeltaSchema(Schema):
     @marshmallow.post_load
     def make_relative_delta(self, data, **kwargs):
         """Create relative delta based on data."""
-        if "objectType" in data:
-            del data["objectType"]
-
         return relativedelta.relativedelta(**data)
 
 


### PR DESCRIPTION
Marshmallow validates input data when loading and if data_key is specified,
it's used for serializing and deserializing thus it's not possible to have
objectType as data_key since it's specified that the data_key for objectType
field in both schemas is __type
