### PR TITLE
Fix parameter syntax in OpenSearch docstrings

### DIFF
--- a/airflow/providers/opensearch/hooks/opensearch.py
+++ b/airflow/providers/opensearch/hooks/opensearch.py
@@ -31,8 +31,8 @@ class OpenSearchHook(BaseHook):
     """
     Provide a thin wrapper around the OpenSearch client.
 
-    :param: open_search_conn_id: Connection to use with Open Search
-    :param: log_query: Whether to log the query used for Open Search
+    :param open_search_conn_id: Connection to use with Open Search
+    :param log_query: Whether to log the query used for Open Search
     """
 
     conn_name_attr = "opensearch_conn_id"
@@ -70,8 +70,8 @@ class OpenSearchHook(BaseHook):
         """
         Run a search query against the connected OpenSearch cluster.
 
-        :param: query: The query for the search against OpenSearch.
-        :param: index_name: The name of the index to search against
+        :param query: The query for the search against OpenSearch.
+        :param index_name: The name of the index to search against
         """
         if self.log_query:
             self.log.info("Searching %s with Query: %s", index_name, query)
@@ -81,9 +81,9 @@ class OpenSearchHook(BaseHook):
         """
         Index a document on OpenSearch.
 
-        :param: document: A dictionary representation of the document
-        :param: index_name: the name of the index that this document will be associated with
-        :param: doc_id: the numerical identifier that will be used to identify the document on the index.
+        :param document: A dictionary representation of the document
+        :param index_name: the name of the index that this document will be associated with
+        :param doc_id: the numerical identifier that will be used to identify the document on the index.
         """
         return self.client.index(index=index_name, id=doc_id, body=document, **kwargs)
 
@@ -91,10 +91,10 @@ class OpenSearchHook(BaseHook):
         """
         Delete from an index by either a query or by the document id.
 
-        :param: index_name: the name of the index to delete from
-        :param: query: If deleting by query a dict representation of the query to run to
-                       identify documents to delete.
-        :param: doc_id: The identifier of the document to delete.
+        :param index_name: the name of the index to delete from
+        :param query: If deleting by query a dict representation of the query to run to
+            identify documents to delete.
+        :param doc_id: The identifier of the document to delete.
         """
         if query is not None:
             if self.log_query:

--- a/airflow/providers/opensearch/operators/opensearch.py
+++ b/airflow/providers/opensearch/operators/opensearch.py
@@ -38,11 +38,11 @@ class OpenSearchQueryOperator(BaseOperator):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:OpenSearchQueryOperator`
 
-    :param: query: A Dictionary Open Search DSL query.
-    :param: search_object: A Search object from opensearch-dsl.
-    :param: index_name: The name of the index to search for documents.
-    :param: opensearch_conn_id: opensearch connection to use
-    :param: log_query: Whether to log the query used. Defaults to True and logs query used.
+    :param query: A Dictionary Open Search DSL query.
+    :param search_object: A Search object from opensearch-dsl.
+    :param index_name: The name of the index to search for documents.
+    :param opensearch_conn_id: opensearch connection to use
+    :param log_query: Whether to log the query used. Defaults to True and logs query used.
     """
 
     template_fields: Sequence[str] = ["query"]
@@ -103,9 +103,9 @@ class OpenSearchCreateIndexOperator(BaseOperator):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:OpenSearchCreateIndexOperator`
 
-    :param: index_name: The name of the index to be created.
-    :param: index_body: A dictionary that defines index settings
-    :param: opensearch_conn_id: opensearch connection to use
+    :param index_name: The name of the index to be created.
+    :param index_body: A dictionary that defines index settings
+    :param opensearch_conn_id: opensearch connection to use
     """
 
     def __init__(
@@ -142,11 +142,11 @@ class OpenSearchAddDocumentOperator(BaseOperator):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:OpenSearchAddDocumentOperator`
 
-    :param: index_name: The name of the index to put the document.
-    :param: document: A dictionary representation of the document.
-    :param: document_id: The id for the document in the index.
-    :param: doc_class: A Document subclassed object using opensearch-dsl
-    :param: opensearch_conn_id: opensearch connection to use
+    :param index_name: The name of the index to put the document.
+    :param document: A dictionary representation of the document.
+    :param document_id: The id for the document in the index.
+    :param doc_class: A Document subclassed object using opensearch-dsl
+    :param opensearch_conn_id: opensearch connection to use
     """
 
     def __init__(


### PR DESCRIPTION
In some of the classes and functions for the OpenSearch provider, there is an extra colon present when specifying parameters in docstrings. This was causing the parameters to not render correctly in API documentation.

