### PR TITLE
Fix parameter syntax in Amazon docstrings

### DIFF
--- a/airflow/providers/amazon/aws/notifications/chime.py
+++ b/airflow/providers/amazon/aws/notifications/chime.py
@@ -38,9 +38,9 @@ class ChimeNotifier(BaseNotifier):
     """
     Chime notifier to send messages to a chime room via callbacks.
 
-    :param: chime_conn_id: The chime connection to use with Endpoint as "https://hooks.chime.aws" and
-                           the webhook token in the form of ```{webhook.id}?token{webhook.token}```
-    :param: message: The message to send to the chime room associated with the webhook.
+    :param chime_conn_id: The chime connection to use with Endpoint as "https://hooks.chime.aws" and
+        the webhook token in the form of ```{webhook.id}?token{webhook.token}```
+    :param message: The message to send to the chime room associated with the webhook.
 
     """
 

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -205,9 +205,9 @@ class EmrStartNotebookExecutionOperator(BaseOperator):
     :param notebook_execution_name: Optional name for the notebook execution.
     :param notebook_params: Input parameters in JSON format passed to the EMR notebook at
         runtime for execution.
-    :param: notebook_instance_security_group_id: The unique identifier of the Amazon EC2
+    :param notebook_instance_security_group_id: The unique identifier of the Amazon EC2
         security group to associate with the EMR notebook for this notebook execution.
-    :param: master_instance_security_group_id: Optional unique ID of an EC2 security
+    :param master_instance_security_group_id: Optional unique ID of an EC2 security
         group to associate with the master instance of the EMR cluster for this notebook execution.
     :param tags: Optional list of key value pair to associate with the notebook execution.
     :param waiter_max_attempts: Maximum number of tries before failing.


### PR DESCRIPTION
In some of the classes and functions for the Amazon provider, there is an extra colon present when specifying parameters in docstrings. This was causing the parameters to not render correctly in API documentation.

