### PR TITLE
fix(helm): add recreate strategy support

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -995,3 +995,11 @@ capabilities:
             app: keda-operator
   {{- end }}
 {{- end }}
+
+{{- define "deployment_strategy" }}
+  {{- if and .strategy.type (eq .strategy.type "Recreate") }}
+    {{- unset .strategy "rollingUpdate" | toYaml }}
+  {{- else }}
+    {{- toYaml .strategy }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -57,7 +57,7 @@ spec:
       component: dag-processor
       release: {{ .Release.Name }}
   {{- if .Values.dagProcessor.strategy }}
-  strategy: {{- toYaml .Values.dagProcessor.strategy | nindent 4 }}
+  strategy: {{- include "deployment_strategy" .Values.dagProcessor | nindent 4 }}
   {{- end }}
   template:
     metadata:

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -71,7 +71,7 @@ spec:
   updateStrategy: {{- toYaml .Values.triggerer.updateStrategy | nindent 4 }}
   {{- end }}
   {{- if and (not $persistence) (.Values.triggerer.strategy) }}
-  strategy: {{- toYaml .Values.triggerer.strategy | nindent 4 }}
+  strategy: {{- include "deployment_strategy" .Values.triggerer | nindent 4 }}
   {{- end }}
   template:
     metadata:

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -74,7 +74,7 @@ spec:
   updateStrategy: {{- toYaml .Values.workers.updateStrategy | nindent 4 }}
   {{- end }}
   {{- if and (not $persistence) (.Values.workers.strategy) }}
-  strategy: {{- toYaml .Values.workers.strategy | nindent 4 }}
+  strategy: {{- include "deployment_strategy" .Values.workers | nindent 4 }}
   {{- end }}
   template:
     metadata:

--- a/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm_tests/airflow_core/test_dag_processor.py
@@ -660,8 +660,6 @@ class TestDagProcessor:
 
         if strategyType == "RollingUpdate":
             assert strategyUpdate == jmespath.search("spec.strategy.rollingUpdate", docs[0])
-        else:
-            assert jmespath.search("spec.strategy.rollingUpdate", docs[0]) is None
 
 
 class TestDagProcessorLogGroomer(LogGroomerTestBase):

--- a/helm_tests/airflow_core/test_triggerer.py
+++ b/helm_tests/airflow_core/test_triggerer.py
@@ -616,8 +616,6 @@ class TestTriggerer:
 
         if strategyType == "RollingUpdate":
             assert strategyUpdate == jmespath.search("spec.strategy.rollingUpdate", docs[0])
-        else:
-            assert jmespath.search("spec.strategy.rollingUpdate", docs[0]) is None
 
 
 class TestTriggererServiceAccount:

--- a/helm_tests/airflow_core/test_worker.py
+++ b/helm_tests/airflow_core/test_worker.py
@@ -879,8 +879,6 @@ class TestWorker:
 
         if strategyType == "RollingUpdate":
             assert strategyUpdate == jmespath.search("spec.strategy.rollingUpdate", docs[0])
-        else:
-            assert jmespath.search("spec.strategy.rollingUpdate", docs[0]) is None
 
 
 class TestWorkerLogGroomer(LogGroomerTestBase):


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/35227

Currently, these values don't support Recreate type.

- `workers.strategy.type=Recreate`
- `triggerer.strategy.type=Recreate`
- `dagProcessor.strategy.type=Recreate`

Ps. When it's `persistence.enabled=false`, the `strategy` is used on **Deployment** kind.

But it's failing. Because there have default values as below:

```
  ...
  strategy:
    rollingUpdate:
      maxSurge: "100%"
      maxUnavailable: "50%"
```

So the `rollingUpdate` node cannot be mixed with `type` other than `RollingUpdate`.

# The tests

### Workers

```
# pytest helm_tests/airflow_core/test_worker.py::TestWorker::test_deployment_strategy
=================================================================== test session starts ====================================================================
platform linux -- Python 3.8.18, pytest-7.4.3, pluggy-1.3.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /opt/airflow
configfile: pyproject.toml
plugins: requests-mock-1.11.0, xdist-3.3.1, anyio-4.0.0, instafail-0.5.0, rerunfailures-12.0, timeouts-1.2.1, asyncio-0.21.1, mock-3.12.0, icdiff-0.8, httpx-0.21.3, time-machine-2.13.0, cov-4.1.0
asyncio: mode=strict
setup timeout: 0.0s, execution timeout: 0.0s, teardown timeout: 0.0s
collected 4 items

helm_tests/airflow_core/test_worker.py::TestWorker::test_deployment_strategy[Recreate-strategyUpdate0] PASSED                                        [ 25%]
helm_tests/airflow_core/test_worker.py::TestWorker::test_deployment_strategy[Recreate-None] PASSED                                                   [ 50%]
helm_tests/airflow_core/test_worker.py::TestWorker::test_deployment_strategy[RollingUpdate-strategyUpdate2] PASSED                                   [ 75%]
helm_tests/airflow_core/test_worker.py::TestWorker::test_deployment_strategy[RollingUpdate-None] PASSED                                              [100%]

==================================================================== 4 passed in 26.44s ====================================================================
```

### Triggerer

```
# pytest helm_tests/airflow_core/test_triggerer.py::TestTriggerer::test_deployment_strategy
=================================================================== test session starts ====================================================================
platform linux -- Python 3.8.18, pytest-7.4.3, pluggy-1.3.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /opt/airflow
configfile: pyproject.toml
plugins: requests-mock-1.11.0, xdist-3.3.1, anyio-4.0.0, instafail-0.5.0, rerunfailures-12.0, timeouts-1.2.1, asyncio-0.21.1, mock-3.12.0, icdiff-0.8, httpx-0.21.3, time-machine-2.13.0, cov-4.1.0
asyncio: mode=strict
setup timeout: 0.0s, execution timeout: 0.0s, teardown timeout: 0.0s
collected 4 items

helm_tests/airflow_core/test_triggerer.py::TestTriggerer::test_deployment_strategy[Recreate-strategyUpdate0] PASSED                                  [ 25%]
helm_tests/airflow_core/test_triggerer.py::TestTriggerer::test_deployment_strategy[Recreate-None] PASSED                                             [ 50%]
helm_tests/airflow_core/test_triggerer.py::TestTriggerer::test_deployment_strategy[RollingUpdate-strategyUpdate2] PASSED                             [ 75%]
helm_tests/airflow_core/test_triggerer.py::TestTriggerer::test_deployment_strategy[RollingUpdate-None] PASSED                                        [100%]

==================================================================== 4 passed in 26.41s ====================================================================
```

### DAG Processor

```
# pytest helm_tests/airflow_core/test_dag_processor.py::TestDagProcessor::test_deployment_strategy
=================================================================== test session starts ====================================================================
platform linux -- Python 3.8.18, pytest-7.4.3, pluggy-1.3.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /opt/airflow
configfile: pyproject.toml
plugins: requests-mock-1.11.0, xdist-3.3.1, anyio-4.0.0, instafail-0.5.0, rerunfailures-12.0, timeouts-1.2.1, asyncio-0.21.1, mock-3.12.0, icdiff-0.8, httpx-0.21.3, time-machine-2.13.0, cov-4.1.0
asyncio: mode=strict
setup timeout: 0.0s, execution timeout: 0.0s, teardown timeout: 0.0s
collected 4 items

helm_tests/airflow_core/test_dag_processor.py::TestDagProcessor::test_deployment_strategy[Recreate-strategyUpdate0] PASSED                           [ 25%]
helm_tests/airflow_core/test_dag_processor.py::TestDagProcessor::test_deployment_strategy[Recreate-None] PASSED                                      [ 50%]
helm_tests/airflow_core/test_dag_processor.py::TestDagProcessor::test_deployment_strategy[RollingUpdate-strategyUpdate2] PASSED                      [ 75%]
helm_tests/airflow_core/test_dag_processor.py::TestDagProcessor::test_deployment_strategy[RollingUpdate-None] PASSED                                 [100%]

==================================================================== 4 passed in 31.11s ====================================================================
```

Thanks in advance,