### PR TITLE
Remove unused `can_read_dags` function from `api_connexion/security.py`

### DIFF
--- a/airflow/api_connexion/security.py
+++ b/airflow/api_connexion/security.py
@@ -247,7 +247,3 @@ def requires_access_website() -> Callable[[T], T]:
 
 def get_readable_dags() -> list[str]:
     return get_airflow_app().appbuilder.sm.get_accessible_dag_ids(g.user)
-
-
-def can_read_dag(dag_id: str) -> bool:
-    return get_airflow_app().appbuilder.sm.can_read_dag(dag_id, g.user)


### PR DESCRIPTION
This function is not used and was introduced in commit #33ec72948f74f56f2adb5e2d388e60e88e8a3fa3. Opening this PR to discuss it

cc @hussein-awala 