### PR TITLE
Add tests for FAB basic auth

### DIFF
--- a/tests/auth/managers/fab/auth/__init__.py
+++ b/tests/auth/managers/fab/auth/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/auth/managers/fab/auth/backend/__init__.py
+++ b/tests/auth/managers/fab/auth/backend/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/auth/managers/fab/auth/backend/test_basic_auth.py
+++ b/tests/auth/managers/fab/auth/backend/test_basic_auth.py
@@ -1,0 +1,117 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+from flask import Response
+from flask_appbuilder.const import AUTH_LDAP
+
+from airflow.api.auth.backend.basic_auth import requires_authentication
+from airflow.www import app as application
+
+
+@pytest.fixture
+def app():
+    return application.create_app(testing=True)
+
+
+@pytest.fixture
+def mock_sm():
+    return Mock()
+
+
+@pytest.fixture
+def mock_appbuilder(mock_sm):
+    appbuilder = Mock()
+    appbuilder.sm = mock_sm
+    return appbuilder
+
+
+@pytest.fixture
+def mock_app(mock_appbuilder):
+    app = Mock()
+    app.appbuilder = mock_appbuilder
+    return app
+
+
+@pytest.fixture
+def mock_authorization():
+    authorization = Mock()
+    authorization.username = "username"
+    authorization.password = "password"
+    return authorization
+
+
+mock_call = Mock()
+
+
+@requires_authentication
+def function_decorated():
+    mock_call()
+
+
+@pytest.mark.db_test
+class TestBasicAuth:
+    def setup_method(self) -> None:
+        mock_call.reset_mock()
+
+    def test_requires_authentication_with_no_header(self, app):
+        with app.test_request_context() as mock_context:
+            mock_context.request.authorization = None
+            result = function_decorated()
+
+        assert type(result) is Response
+        assert result.status_code == 401
+
+    @patch("airflow.auth.managers.fab.api.auth.backend.basic_auth.get_airflow_app")
+    @patch("airflow.auth.managers.fab.api.auth.backend.basic_auth.login_user")
+    def test_requires_authentication_with_ldap(
+        self, mock_login_user, mock_get_airflow_app, app, mock_app, mock_sm, mock_authorization
+    ):
+        mock_get_airflow_app.return_value = mock_app
+        mock_sm.auth_type = AUTH_LDAP
+        user = Mock()
+        mock_sm.auth_user_ldap.return_value = user
+
+        with app.test_request_context() as mock_context:
+            mock_context.request.authorization = mock_authorization
+            function_decorated()
+
+        mock_sm.auth_user_ldap.assert_called_once_with(
+            mock_authorization.username, mock_authorization.password
+        )
+        mock_login_user.assert_called_once_with(user, remember=False)
+        mock_call.assert_called_once()
+
+    @patch("airflow.auth.managers.fab.api.auth.backend.basic_auth.get_airflow_app")
+    @patch("airflow.auth.managers.fab.api.auth.backend.basic_auth.login_user")
+    def test_requires_authentication_with_db(
+        self, mock_login_user, mock_get_airflow_app, app, mock_app, mock_sm, mock_authorization
+    ):
+        mock_get_airflow_app.return_value = mock_app
+        user = Mock()
+        mock_sm.auth_user_db.return_value = user
+
+        with app.test_request_context() as mock_context:
+            mock_context.request.authorization = mock_authorization
+            function_decorated()
+
+        mock_sm.auth_user_db.assert_called_once_with(mock_authorization.username, mock_authorization.password)
+        mock_login_user.assert_called_once_with(user, remember=False)
+        mock_call.assert_called_once()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
