### PR TITLE
Add optional exit code to list import errors

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -259,11 +259,6 @@ ARG_JOB_STATE = Arg(
     choices=job_states,
 )
 
-# list_import_errors
-ARG_EXIT_CODE = Arg(
-    ("--strict",), help="Return exit code '1' if there are import errors", action="store_true"
-)
-
 # next_execution
 ARG_NUM_EXECUTIONS = Arg(
     ("-n", "--num-executions"),
@@ -1043,7 +1038,7 @@ DAGS_COMMANDS = (
         name="list-import-errors",
         help="List all the DAGs that have import errors",
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_list_import_errors"),
-        args=(ARG_SUBDIR, ARG_OUTPUT, ARG_VERBOSE, ARG_EXIT_CODE),
+        args=(ARG_SUBDIR, ARG_OUTPUT, ARG_VERBOSE),
     ),
     ActionCommand(
         name="report",

--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -259,6 +259,11 @@ ARG_JOB_STATE = Arg(
     choices=job_states,
 )
 
+# list_import_errors
+ARG_EXIT_CODE = Arg(
+    ("--strict",), help="Return exit code '1' if there are import errors", action="store_true"
+)
+
 # next_execution
 ARG_NUM_EXECUTIONS = Arg(
     ("-n", "--num-executions"),
@@ -1038,7 +1043,7 @@ DAGS_COMMANDS = (
         name="list-import-errors",
         help="List all the DAGs that have import errors",
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_list_import_errors"),
-        args=(ARG_SUBDIR, ARG_OUTPUT, ARG_VERBOSE),
+        args=(ARG_SUBDIR, ARG_OUTPUT, ARG_VERBOSE, ARG_EXIT_CODE),
     ),
     ActionCommand(
         name="report",

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -409,6 +409,9 @@ def dag_list_import_errors(args) -> None:
         data=data,
         output=args.output,
     )
+    if args.strict and data:
+        # pass
+        sys.exit(1)
 
 
 @cli_utils.action_cli

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -409,7 +409,7 @@ def dag_list_import_errors(args) -> None:
         data=data,
         output=args.output,
     )
-    if args.strict and data:
+    if data:
         sys.exit(1)
 
 

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -410,7 +410,6 @@ def dag_list_import_errors(args) -> None:
         output=args.output,
     )
     if args.strict and data:
-        # pass
         sys.exit(1)
 
 

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -546,23 +546,9 @@ class TestCliDags:
         dag_path = os.path.join(TEST_DAGS_FOLDER, "test_invalid_cron.py")
         args = self.parser.parse_args(["dags", "list", "--output", "yaml", "--subdir", dag_path])
         with contextlib.redirect_stdout(StringIO()) as temp_stdout:
-            dag_command.dag_list_import_errors(args)
-            out = temp_stdout.getvalue()
-        assert "[0 100 * * *] is not acceptable, out of range" in out
-        assert dag_path in out
-
-    @conf_vars({("core", "load_examples"): "false"})
-    def test_cli_list_import_errors_exit_code_1(self):
-        dag_path = os.path.join(TEST_DAGS_FOLDER, "test_invalid_cron.py")
-        args = self.parser.parse_args(
-            ["dags", "list-import-errors", "--output", "yaml", "--subdir", dag_path, "--strict"]
-        )
-        with contextlib.redirect_stdout(StringIO()) as temp_stdout:
             with TestCase.assertRaises(TestCase(), SystemExit) as context:
                 dag_command.dag_list_import_errors(args)
-
             out = temp_stdout.getvalue()
-
         assert "[0 100 * * *] is not acceptable, out of range" in out
         assert dag_path in out
         assert context.exception.code == 1

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -22,7 +22,7 @@ import json
 import os
 from datetime import datetime, timedelta
 from io import StringIO
-from unittest import mock
+from unittest import TestCase, mock
 from unittest.mock import MagicMock
 
 import pendulum
@@ -550,6 +550,22 @@ class TestCliDags:
             out = temp_stdout.getvalue()
         assert "[0 100 * * *] is not acceptable, out of range" in out
         assert dag_path in out
+
+    @conf_vars({("core", "load_examples"): "false"})
+    def test_cli_list_import_errors_exit_code_1(self):
+        dag_path = os.path.join(TEST_DAGS_FOLDER, "test_invalid_cron.py")
+        args = self.parser.parse_args(
+            ["dags", "list-import-errors", "--output", "yaml", "--subdir", dag_path, "--strict"]
+        )
+        with contextlib.redirect_stdout(StringIO()) as temp_stdout:
+            with TestCase.assertRaises(TestCase(), SystemExit) as context:
+                dag_command.dag_list_import_errors(args)
+
+            out = temp_stdout.getvalue()
+
+        assert "[0 100 * * *] is not acceptable, out of range" in out
+        assert dag_path in out
+        assert context.exception.code == 1
 
     def test_cli_list_dag_runs(self):
         dag_command.dag_trigger(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

Added a flag to list-import-errors command that returns exit code '1' if there are import errors. Will be useful when used in CI pipelines.