### PR TITLE
Long custom operator name overflows in graph view

### DIFF
--- a/airflow/www/static/js/dag/details/graph/Node.tsx
+++ b/airflow/www/static/js/dag/details/graph/Node.tsx
@@ -162,6 +162,8 @@ export const BaseNode = ({
             )}
             {task?.operator && (
               <Text
+                noOfLines={1}
+                maxWidth={`calc(${width}px - 12px)`}
                 fontWeight={400}
                 fontSize="md"
                 width="fit-content"


### PR DESCRIPTION
Fixes overflow issue with long custom operator names in the DAG view.

**Before:**
![Screenshot 2023-11-02 at 20 49 35](https://github.com/apache/airflow/assets/10106152/08f0eaef-56c6-416f-865b-26bb80f7e659)



**After:**
![Screenshot 2023-11-02 at 20 49 52](https://github.com/apache/airflow/assets/10106152/54c3e5b2-e2b8-4063-9758-485d380b29a7)



closes: https://github.com/apache/airflow/issues/33693

