### PR TITLE
add managed identity support to AsyncDefaultAzureCredential

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -198,7 +198,10 @@ class AzureDataExplorerHook(BaseHook):
         elif auth_method == "AZURE_TOKEN_CRED":
             managed_identity_client_id = conn.extra_dejson.get("managed_identity_client_id")
             workload_identity_tenant_id = conn.extra_dejson.get("workload_identity_tenant_id")
-            credential = get_default_azure_credential(managed_identity_client_id, workload_identity_tenant_id)
+            credential = get_default_azure_credential(
+                managed_identity_client_id=managed_identity_client_id,
+                workload_identity_tenant_id=workload_identity_tenant_id,
+            )
             kcsb = KustoConnectionStringBuilder.with_azure_token_credential(
                 connection_string=cluster,
                 credential=credential,

--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -36,7 +36,7 @@ from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarni
 from airflow.hooks.base import BaseHook
 from airflow.providers.microsoft.azure.utils import (
     add_managed_identity_connection_widgets,
-    get_default_azure_credential,
+    get_sync_default_azure_credential,
 )
 
 if TYPE_CHECKING:
@@ -198,7 +198,7 @@ class AzureDataExplorerHook(BaseHook):
         elif auth_method == "AZURE_TOKEN_CRED":
             managed_identity_client_id = conn.extra_dejson.get("managed_identity_client_id")
             workload_identity_tenant_id = conn.extra_dejson.get("workload_identity_tenant_id")
-            credential = get_default_azure_credential(
+            credential = get_sync_default_azure_credential(
                 managed_identity_client_id=managed_identity_client_id,
                 workload_identity_tenant_id=workload_identity_tenant_id,
             )

--- a/airflow/providers/microsoft/azure/hooks/asb.py
+++ b/airflow/providers/microsoft/azure/hooks/asb.py
@@ -24,8 +24,8 @@ from azure.servicebus.management import QueueProperties, ServiceBusAdministratio
 from airflow.hooks.base import BaseHook
 from airflow.providers.microsoft.azure.utils import (
     add_managed_identity_connection_widgets,
-    get_default_azure_credential,
     get_field,
+    get_sync_default_azure_credential,
 )
 
 if TYPE_CHECKING:
@@ -119,7 +119,7 @@ class AdminClientHook(BaseAzureServiceBusHook):
                 workload_identity_tenant_id = self._get_field(
                     extras=extras, field_name="workload_identity_tenant_id"
                 )
-                credential = get_default_azure_credential(
+                credential = get_sync_default_azure_credential(
                     managed_identity_client_id=managed_identity_client_id,
                     workload_identity_tenant_id=workload_identity_tenant_id,
                 )
@@ -212,7 +212,7 @@ class MessageHook(BaseAzureServiceBusHook):
                 workload_identity_tenant_id = self._get_field(
                     extras=extras, field_name="workload_identity_tenant_id"
                 )
-                credential = get_default_azure_credential(
+                credential = get_sync_default_azure_credential(
                     managed_identity_client_id=managed_identity_client_id,
                     workload_identity_tenant_id=workload_identity_tenant_id,
                 )

--- a/airflow/providers/microsoft/azure/hooks/asb.py
+++ b/airflow/providers/microsoft/azure/hooks/asb.py
@@ -120,7 +120,8 @@ class AdminClientHook(BaseAzureServiceBusHook):
                     extras=extras, field_name="workload_identity_tenant_id"
                 )
                 credential = get_default_azure_credential(
-                    managed_identity_client_id, workload_identity_tenant_id
+                    managed_identity_client_id=managed_identity_client_id,
+                    workload_identity_tenant_id=workload_identity_tenant_id,
                 )
             client = ServiceBusAdministrationClient(
                 fully_qualified_namespace=fully_qualified_namespace,
@@ -212,7 +213,8 @@ class MessageHook(BaseAzureServiceBusHook):
                     extras=extras, field_name="workload_identity_tenant_id"
                 )
                 credential = get_default_azure_credential(
-                    managed_identity_client_id, workload_identity_tenant_id
+                    managed_identity_client_id=managed_identity_client_id,
+                    workload_identity_tenant_id=workload_identity_tenant_id,
                 )
             client = ServiceBusClient(
                 fully_qualified_namespace=fully_qualified_namespace,

--- a/airflow/providers/microsoft/azure/hooks/container_instance.py
+++ b/airflow/providers/microsoft/azure/hooks/container_instance.py
@@ -27,7 +27,7 @@ from azure.mgmt.containerinstance import ContainerInstanceManagementClient
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.microsoft.azure.hooks.base_azure import AzureBaseHook
-from airflow.providers.microsoft.azure.utils import get_default_azure_credential
+from airflow.providers.microsoft.azure.utils import get_sync_default_azure_credential
 
 if TYPE_CHECKING:
     from azure.mgmt.containerinstance.models import (
@@ -95,7 +95,7 @@ class AzureContainerInstanceHook(AzureBaseHook):
             self.log.info("Using DefaultAzureCredential as credential")
             managed_identity_client_id = conn.extra_dejson.get("managed_identity_client_id")
             workload_identity_tenant_id = conn.extra_dejson.get("workload_identity_tenant_id")
-            credential = get_default_azure_credential(
+            credential = get_sync_default_azure_credential(
                 managed_identity_client_id=managed_identity_client_id,
                 workload_identity_tenant_id=workload_identity_tenant_id,
             )

--- a/airflow/providers/microsoft/azure/hooks/container_instance.py
+++ b/airflow/providers/microsoft/azure/hooks/container_instance.py
@@ -95,7 +95,10 @@ class AzureContainerInstanceHook(AzureBaseHook):
             self.log.info("Using DefaultAzureCredential as credential")
             managed_identity_client_id = conn.extra_dejson.get("managed_identity_client_id")
             workload_identity_tenant_id = conn.extra_dejson.get("workload_identity_tenant_id")
-            credential = get_default_azure_credential(managed_identity_client_id, workload_identity_tenant_id)
+            credential = get_default_azure_credential(
+                managed_identity_client_id=managed_identity_client_id,
+                workload_identity_tenant_id=workload_identity_tenant_id,
+            )
 
         subscription_id = cast(str, conn.extra_dejson.get("subscriptionId"))
         return ContainerInstanceManagementClient(

--- a/airflow/providers/microsoft/azure/hooks/container_registry.py
+++ b/airflow/providers/microsoft/azure/hooks/container_registry.py
@@ -109,10 +109,12 @@ class AzureContainerRegistryHook(BaseHook):
             resource_group = self._get_field(extras, "resource_group")
             managed_identity_client_id = self._get_field(extras, "managed_identity_client_id")
             workload_identity_tenant_id = self._get_field(extras, "workload_identity_tenant_id")
+            credential = get_default_azure_credential(
+                managed_identity_client_id=managed_identity_client_id,
+                workload_identity_tenant_id=workload_identity_tenant_id,
+            )
             client = ContainerRegistryManagementClient(
-                credential=get_default_azure_credential(
-                    managed_identity_client_id, workload_identity_tenant_id
-                ),
+                credential=credential,
                 subscription_id=subscription_id,
             )
             credentials = client.registries.list_credentials(resource_group, conn.login).as_dict()

--- a/airflow/providers/microsoft/azure/hooks/container_registry.py
+++ b/airflow/providers/microsoft/azure/hooks/container_registry.py
@@ -27,8 +27,8 @@ from azure.mgmt.containerregistry import ContainerRegistryManagementClient
 from airflow.hooks.base import BaseHook
 from airflow.providers.microsoft.azure.utils import (
     add_managed_identity_connection_widgets,
-    get_default_azure_credential,
     get_field,
+    get_sync_default_azure_credential,
 )
 
 
@@ -109,7 +109,7 @@ class AzureContainerRegistryHook(BaseHook):
             resource_group = self._get_field(extras, "resource_group")
             managed_identity_client_id = self._get_field(extras, "managed_identity_client_id")
             workload_identity_tenant_id = self._get_field(extras, "workload_identity_tenant_id")
-            credential = get_default_azure_credential(
+            credential = get_sync_default_azure_credential(
                 managed_identity_client_id=managed_identity_client_id,
                 workload_identity_tenant_id=workload_identity_tenant_id,
             )

--- a/airflow/providers/microsoft/azure/hooks/container_volume.py
+++ b/airflow/providers/microsoft/azure/hooks/container_volume.py
@@ -111,10 +111,11 @@ class AzureContainerVolumeHook(BaseHook):
         if subscription_id and storage_account_name and resource_group:
             managed_identity_client_id = self._get_field(extras, "managed_identity_client_id")
             workload_identity_tenant_id = self._get_field(extras, "workload_identity_tenant_id")
-            credentials = get_default_azure_credential(
-                managed_identity_client_id, workload_identity_tenant_id
+            credential = get_default_azure_credential(
+                managed_identity_client_id=managed_identity_client_id,
+                workload_identity_tenant_id=workload_identity_tenant_id,
             )
-            storage_client = StorageManagementClient(credentials, subscription_id)
+            storage_client = StorageManagementClient(credential, subscription_id)
             storage_account_list_keys_result = storage_client.storage_accounts.list_keys(
                 resource_group, storage_account_name
             )

--- a/airflow/providers/microsoft/azure/hooks/container_volume.py
+++ b/airflow/providers/microsoft/azure/hooks/container_volume.py
@@ -24,8 +24,8 @@ from azure.mgmt.storage import StorageManagementClient
 from airflow.hooks.base import BaseHook
 from airflow.providers.microsoft.azure.utils import (
     add_managed_identity_connection_widgets,
-    get_default_azure_credential,
     get_field,
+    get_sync_default_azure_credential,
 )
 
 
@@ -111,7 +111,7 @@ class AzureContainerVolumeHook(BaseHook):
         if subscription_id and storage_account_name and resource_group:
             managed_identity_client_id = self._get_field(extras, "managed_identity_client_id")
             workload_identity_tenant_id = self._get_field(extras, "workload_identity_tenant_id")
-            credential = get_default_azure_credential(
+            credential = get_sync_default_azure_credential(
                 managed_identity_client_id=managed_identity_client_id,
                 workload_identity_tenant_id=workload_identity_tenant_id,
             )

--- a/airflow/providers/microsoft/azure/hooks/cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/cosmos.py
@@ -133,10 +133,12 @@ class AzureCosmosDBHook(BaseHook):
                 managed_identity_client_id = self._get_field(extras, "managed_identity_client_id")
                 workload_identity_tenant_id = self._get_field(extras, "workload_identity_tenant_id")
                 subscritption_id = self._get_field(extras, "subscription_id")
+                credential = get_default_azure_credential(
+                    managed_identity_client_id=managed_identity_client_id,
+                    workload_identity_tenant_id=workload_identity_tenant_id,
+                )
                 management_client = CosmosDBManagementClient(
-                    credential=get_default_azure_credential(
-                        managed_identity_client_id, workload_identity_tenant_id
-                    ),
+                    credential=credential,
                     subscription_id=subscritption_id,
                 )
 

--- a/airflow/providers/microsoft/azure/hooks/cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/cosmos.py
@@ -37,8 +37,8 @@ from airflow.exceptions import AirflowBadRequest, AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.providers.microsoft.azure.utils import (
     add_managed_identity_connection_widgets,
-    get_default_azure_credential,
     get_field,
+    get_sync_default_azure_credential,
 )
 
 
@@ -133,7 +133,7 @@ class AzureCosmosDBHook(BaseHook):
                 managed_identity_client_id = self._get_field(extras, "managed_identity_client_id")
                 workload_identity_tenant_id = self._get_field(extras, "workload_identity_tenant_id")
                 subscritption_id = self._get_field(extras, "subscription_id")
-                credential = get_default_azure_credential(
+                credential = get_sync_default_azure_credential(
                     managed_identity_client_id=managed_identity_client_id,
                     workload_identity_tenant_id=workload_identity_tenant_id,
                 )

--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -212,7 +212,10 @@ class AzureDataFactoryHook(BaseHook):
         else:
             managed_identity_client_id = get_field(extras, "managed_identity_client_id")
             workload_identity_tenant_id = get_field(extras, "workload_identity_tenant_id")
-            credential = get_default_azure_credential(managed_identity_client_id, workload_identity_tenant_id)
+            credential = get_default_azure_credential(
+                managed_identity_client_id=managed_identity_client_id,
+                workload_identity_tenant_id=workload_identity_tenant_id,
+            )
         self._conn = self._create_client(credential, subscription_id)
 
         return self._conn
@@ -1147,7 +1150,13 @@ class AzureDataFactoryAsyncHook(AzureDataFactoryHook):
                 client_id=conn.login, client_secret=conn.password, tenant_id=tenant
             )
         else:
-            credential = AsyncDefaultAzureCredential()
+            managed_identity_client_id = get_field(extras, "managed_identity_client_id")
+            workload_identity_tenant_id = get_field(extras, "workload_identity_tenant_id")
+            credential = get_default_azure_credential(
+                managed_identity_client_id=managed_identity_client_id,
+                workload_identity_tenant_id=workload_identity_tenant_id,
+                use_async=True,
+            )
 
         self._async_conn = AsyncDataFactoryManagementClient(
             credential=credential,

--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -50,7 +50,8 @@ from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarni
 from airflow.hooks.base import BaseHook
 from airflow.providers.microsoft.azure.utils import (
     add_managed_identity_connection_widgets,
-    get_default_azure_credential,
+    get_async_default_azure_credential,
+    get_sync_default_azure_credential,
 )
 
 if TYPE_CHECKING:
@@ -212,7 +213,7 @@ class AzureDataFactoryHook(BaseHook):
         else:
             managed_identity_client_id = get_field(extras, "managed_identity_client_id")
             workload_identity_tenant_id = get_field(extras, "workload_identity_tenant_id")
-            credential = get_default_azure_credential(
+            credential = get_sync_default_azure_credential(
                 managed_identity_client_id=managed_identity_client_id,
                 workload_identity_tenant_id=workload_identity_tenant_id,
             )
@@ -1152,10 +1153,9 @@ class AzureDataFactoryAsyncHook(AzureDataFactoryHook):
         else:
             managed_identity_client_id = get_field(extras, "managed_identity_client_id")
             workload_identity_tenant_id = get_field(extras, "workload_identity_tenant_id")
-            credential = get_default_azure_credential(
+            credential = get_async_default_azure_credential(
                 managed_identity_client_id=managed_identity_client_id,
                 workload_identity_tenant_id=workload_identity_tenant_id,
-                use_async=True,
             )
 
         self._async_conn = AsyncDataFactoryManagementClient(

--- a/airflow/providers/microsoft/azure/hooks/data_lake.py
+++ b/airflow/providers/microsoft/azure/hooks/data_lake.py
@@ -123,7 +123,12 @@ class AzureDataLakeHook(BaseHook):
             if tenant:
                 credential = lib.auth(tenant_id=tenant, client_secret=conn.password, client_id=conn.login)
             else:
-                credential = AzureIdentityCredentialAdapter()
+                managed_identity_client_id = self._get_field(extras, "managed_identity_client_id")
+                workload_identity_tenant_id = self._get_field(extras, "workload_identity_tenant_id")
+                credential = AzureIdentityCredentialAdapter(
+                    managed_identity_client_id=managed_identity_client_id,
+                    workload_identity_tenant_id=workload_identity_tenant_id,
+                )
             self._conn = core.AzureDLFileSystem(credential, store_name=self.account_name)
             self._conn.connect()
         return self._conn
@@ -347,7 +352,12 @@ class AzureDataLakeStorageV2Hook(BaseHook):
         elif conn.password:
             credential = conn.password
         else:
-            credential = AzureIdentityCredentialAdapter()
+            managed_identity_client_id = self._get_field(extra, "managed_identity_client_id")
+            workload_identity_tenant_id = self._get_field(extra, "workload_identity_tenant_id")
+            credential = AzureIdentityCredentialAdapter(
+                managed_identity_client_id=managed_identity_client_id,
+                workload_identity_tenant_id=workload_identity_tenant_id,
+            )
 
         return DataLakeServiceClient(
             account_url=f"https://{conn.host}.dfs.core.windows.net",

--- a/airflow/providers/microsoft/azure/hooks/fileshare.py
+++ b/airflow/providers/microsoft/azure/hooks/fileshare.py
@@ -24,7 +24,7 @@ from azure.storage.fileshare import FileProperties, ShareDirectoryClient, ShareF
 from airflow.hooks.base import BaseHook
 from airflow.providers.microsoft.azure.utils import (
     add_managed_identity_connection_widgets,
-    get_default_azure_credential,
+    get_sync_default_azure_credential,
 )
 
 
@@ -106,12 +106,12 @@ class AzureFileShareHook(BaseHook):
             return f"https://{account_url}.file.core.windows.net"
         return account_url
 
-    def _get_default_azure_credential(self):
+    def _get_sync_default_azure_credential(self):
         conn = self.get_connection(self._conn_id)
         extras = conn.extra_dejson
         managed_identity_client_id = extras.get("managed_identity_client_id")
         workload_identity_tenant_id = extras.get("workload_identity_tenant_id")
-        return get_default_azure_credential(
+        return get_sync_default_azure_credential(
             managed_identity_client_id=managed_identity_client_id,
             workload_identity_tenant_id=workload_identity_tenant_id,
         )
@@ -129,7 +129,7 @@ class AzureFileShareHook(BaseHook):
         else:
             return ShareServiceClient(
                 account_url=self._account_url,
-                credential=self._get_default_azure_credential(),
+                credential=self._get_sync_default_azure_credential(),
                 token_intent="backup",
             )
 
@@ -154,7 +154,7 @@ class AzureFileShareHook(BaseHook):
                 account_url=self._account_url,
                 share_name=self.share_name,
                 directory_path=self.directory_path,
-                credential=self._get_default_azure_credential(),
+                credential=self._get_sync_default_azure_credential(),
                 token_intent="backup",
             )
 
@@ -179,7 +179,7 @@ class AzureFileShareHook(BaseHook):
                 account_url=self._account_url,
                 share_name=self.share_name,
                 file_path=self.file_path,
-                credential=self._get_default_azure_credential(),
+                credential=self._get_sync_default_azure_credential(),
                 token_intent="backup",
             )
 

--- a/airflow/providers/microsoft/azure/hooks/fileshare.py
+++ b/airflow/providers/microsoft/azure/hooks/fileshare.py
@@ -111,7 +111,10 @@ class AzureFileShareHook(BaseHook):
         extras = conn.extra_dejson
         managed_identity_client_id = extras.get("managed_identity_client_id")
         workload_identity_tenant_id = extras.get("workload_identity_tenant_id")
-        return get_default_azure_credential(managed_identity_client_id, workload_identity_tenant_id)
+        return get_default_azure_credential(
+            managed_identity_client_id=managed_identity_client_id,
+            workload_identity_tenant_id=workload_identity_tenant_id,
+        )
 
     @property
     def share_service_client(self):

--- a/airflow/providers/microsoft/azure/hooks/synapse.py
+++ b/airflow/providers/microsoft/azure/hooks/synapse.py
@@ -26,8 +26,8 @@ from airflow.exceptions import AirflowTaskTimeout
 from airflow.hooks.base import BaseHook
 from airflow.providers.microsoft.azure.utils import (
     add_managed_identity_connection_widgets,
-    get_default_azure_credential,
     get_field,
+    get_sync_default_azure_credential,
 )
 
 if TYPE_CHECKING:
@@ -131,7 +131,7 @@ class AzureSynapseHook(BaseHook):
         else:
             managed_identity_client_id = self._get_field(extras, "managed_identity_client_id")
             workload_identity_tenant_id = self._get_field(extras, "workload_identity_tenant_id")
-            credential = get_default_azure_credential(
+            credential = get_sync_default_azure_credential(
                 managed_identity_client_id=managed_identity_client_id,
                 workload_identity_tenant_id=workload_identity_tenant_id,
             )

--- a/airflow/providers/microsoft/azure/hooks/synapse.py
+++ b/airflow/providers/microsoft/azure/hooks/synapse.py
@@ -131,7 +131,10 @@ class AzureSynapseHook(BaseHook):
         else:
             managed_identity_client_id = self._get_field(extras, "managed_identity_client_id")
             workload_identity_tenant_id = self._get_field(extras, "workload_identity_tenant_id")
-            credential = get_default_azure_credential(managed_identity_client_id, workload_identity_tenant_id)
+            credential = get_default_azure_credential(
+                managed_identity_client_id=managed_identity_client_id,
+                workload_identity_tenant_id=workload_identity_tenant_id,
+            )
 
         self._conn = self._create_client(credential, conn.host, spark_pool, livy_api_version, subscription_id)
 

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -49,7 +49,8 @@ from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.providers.microsoft.azure.utils import (
     add_managed_identity_connection_widgets,
-    get_default_azure_credential,
+    get_async_default_azure_credential,
+    get_sync_default_azure_credential,
 )
 
 if TYPE_CHECKING:
@@ -214,7 +215,7 @@ class WasbHook(BaseHook):
         if not credential:
             managed_identity_client_id = self._get_field(extra, "managed_identity_client_id")
             workload_identity_tenant_id = self._get_field(extra, "workload_identity_tenant_id")
-            credential = get_default_azure_credential(
+            credential = get_sync_default_azure_credential(
                 managed_identity_client_id=managed_identity_client_id,
                 workload_identity_tenant_id=workload_identity_tenant_id,
             )
@@ -646,10 +647,9 @@ class WasbAsyncHook(WasbHook):
         if not credential:
             managed_identity_client_id = self._get_field(extra, "managed_identity_client_id")
             workload_identity_tenant_id = self._get_field(extra, "workload_identity_tenant_id")
-            credential = get_default_azure_credential(
+            credential = get_async_default_azure_credential(
                 managed_identity_client_id=managed_identity_client_id,
                 workload_identity_tenant_id=workload_identity_tenant_id,
-                use_async=True,
             )
             self.log.info("Using DefaultAzureCredential as credential")
         self.blob_service_client = AsyncBlobServiceClient(

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -214,8 +214,10 @@ class WasbHook(BaseHook):
         if not credential:
             managed_identity_client_id = self._get_field(extra, "managed_identity_client_id")
             workload_identity_tenant_id = self._get_field(extra, "workload_identity_tenant_id")
-            credential = get_default_azure_credential(managed_identity_client_id, workload_identity_tenant_id)
-
+            credential = get_default_azure_credential(
+                managed_identity_client_id=managed_identity_client_id,
+                workload_identity_tenant_id=workload_identity_tenant_id,
+            )
             self.log.info("Using DefaultAzureCredential as credential")
         return BlobServiceClient(
             account_url=account_url,
@@ -642,7 +644,13 @@ class WasbAsyncHook(WasbHook):
         # Fall back to old auth (password) or use managed identity if not provided.
         credential = conn.password
         if not credential:
-            credential = AsyncDefaultAzureCredential()
+            managed_identity_client_id = self._get_field(extra, "managed_identity_client_id")
+            workload_identity_tenant_id = self._get_field(extra, "workload_identity_tenant_id")
+            credential = get_default_azure_credential(
+                managed_identity_client_id=managed_identity_client_id,
+                workload_identity_tenant_id=workload_identity_tenant_id,
+                use_async=True,
+            )
             self.log.info("Using DefaultAzureCredential as credential")
         self.blob_service_client = AsyncBlobServiceClient(
             account_url=account_url,

--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -35,7 +35,7 @@ from azure.identity import ClientSecretCredential, DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
-from airflow.providers.microsoft.azure.utils import get_default_azure_credential
+from airflow.providers.microsoft.azure.utils import get_sync_default_azure_credential
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.version import version as airflow_version
@@ -143,7 +143,7 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
         if all([self.tenant_id, self.client_id, self.client_secret]):
             credential = ClientSecretCredential(self.tenant_id, self.client_id, self.client_secret)
         else:
-            credential = get_default_azure_credential(
+            credential = get_sync_default_azure_credential(
                 managed_identity_client_id=self.managed_identity_client_id,
                 workload_identity_tenant_id=self.workload_identity_tenant_id,
             )

--- a/tests/providers/microsoft/azure/hooks/test_adx.py
+++ b/tests/providers/microsoft/azure/hooks/test_adx.py
@@ -235,7 +235,7 @@ class TestAzureDataExplorerHook:
         ],
         indirect=True,
     )
-    @mock.patch("airflow.providers.microsoft.azure.hooks.adx.get_default_azure_credential")
+    @mock.patch("airflow.providers.microsoft.azure.hooks.adx.get_sync_default_azure_credential")
     @mock.patch.object(KustoClient, "__init__")
     def test_conn_method_azure_token_cred(self, mock_init, mock_default_azure_credential, mocked_connection):
         mock_init.return_value = None

--- a/tests/providers/microsoft/azure/hooks/test_asb.py
+++ b/tests/providers/microsoft/azure/hooks/test_asb.py
@@ -61,7 +61,7 @@ class TestAdminClientHook:
         hook = AdminClientHook(azure_service_bus_conn_id=self.conn_id)
         assert isinstance(hook.get_conn(), ServiceBusAdministrationClient)
 
-    @mock.patch(f"{MODULE}.get_default_azure_credential")
+    @mock.patch(f"{MODULE}.get_sync_default_azure_credential")
     @mock.patch(f"{MODULE}.AdminClientHook.get_connection")
     def test_get_conn_fallback_to_default_azure_credential_when_schema_is_not_provided(
         self, mock_connection, mock_default_azure_credential
@@ -174,7 +174,7 @@ class TestMessageHook:
         hook = MessageHook(azure_service_bus_conn_id=self.conn_id)
         assert isinstance(hook.get_conn(), ServiceBusClient)
 
-    @mock.patch(f"{MODULE}.get_default_azure_credential")
+    @mock.patch(f"{MODULE}.get_sync_default_azure_credential")
     @mock.patch(f"{MODULE}.MessageHook.get_connection")
     def test_get_conn_fallback_to_default_azure_credential_when_schema_is_not_provided(
         self, mock_connection, mock_default_azure_credential

--- a/tests/providers/microsoft/azure/hooks/test_asb.py
+++ b/tests/providers/microsoft/azure/hooks/test_asb.py
@@ -69,7 +69,9 @@ class TestAdminClientHook:
         mock_connection.return_value = self.mock_conn_without_schema
         hook = AdminClientHook(azure_service_bus_conn_id=self.conn_id)
         assert isinstance(hook.get_conn(), ServiceBusAdministrationClient)
-        mock_default_azure_credential.assert_called_with(None, None)
+        assert mock_default_azure_credential.called_with(
+            managed_identity_client_id=None, workload_identity_tenant_id=None
+        )
 
     @mock.patch("azure.servicebus.management.QueueProperties")
     @mock.patch(f"{MODULE}.AdminClientHook.get_conn")
@@ -180,7 +182,9 @@ class TestMessageHook:
         mock_connection.return_value = self.mock_conn_without_schema
         hook = MessageHook(azure_service_bus_conn_id=self.conn_id)
         assert isinstance(hook.get_conn(), ServiceBusClient)
-        mock_default_azure_credential.assert_called_with(None, None)
+        assert mock_default_azure_credential.called_with(
+            managed_identity_client_id=None, workload_identity_tenant_id=None
+        )
 
     @pytest.mark.parametrize(
         "mock_message, mock_batch_flag",

--- a/tests/providers/microsoft/azure/hooks/test_azure_container_instance.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_container_instance.py
@@ -131,7 +131,7 @@ class TestAzureContainerInstanceHook:
 class TestAzureContainerInstanceHookWithoutSetupCredential:
     @patch("airflow.providers.microsoft.azure.hooks.container_instance.ContainerInstanceManagementClient")
     @patch("azure.common.credentials.ServicePrincipalCredentials")
-    @patch("airflow.providers.microsoft.azure.hooks.container_instance.get_default_azure_credential")
+    @patch("airflow.providers.microsoft.azure.hooks.container_instance.get_sync_default_azure_credential")
     def test_get_conn_fallback_to_default_azure_credential(
         self,
         mock_default_azure_credential,

--- a/tests/providers/microsoft/azure/hooks/test_azure_container_instance.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_container_instance.py
@@ -148,7 +148,9 @@ class TestAzureContainerInstanceHookWithoutSetupCredential:
         hook = AzureContainerInstanceHook(azure_conn_id=connection_without_login_password_tenant_id.conn_id)
         conn = hook.get_conn()
 
-        mock_default_azure_credential.assert_called_with(None, None)
+        assert mock_default_azure_credential.called_with(
+            managed_identity_client_id=None, workload_identity_tenant_id=None
+        )
         assert not mock_service_pricipal_credential.called
         assert conn == mock_client_instance
         mock_client_cls.assert_called_once_with(

--- a/tests/providers/microsoft/azure/hooks/test_azure_container_registry.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_container_registry.py
@@ -80,4 +80,6 @@ class TestAzureContainerRegistryHook:
         assert hook.connection.password == "password"
         assert hook.connection.server == "test.cr"
 
-        mocked_default_azure_credential.assert_called_with(None, None)
+        assert mocked_default_azure_credential.called_with(
+            managed_identity_client_id=None, workload_identity_tenant_id=None
+        )

--- a/tests/providers/microsoft/azure/hooks/test_azure_container_registry.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_container_registry.py
@@ -63,7 +63,9 @@ class TestAzureContainerRegistryHook:
     @mock.patch(
         "airflow.providers.microsoft.azure.hooks.container_registry.ContainerRegistryManagementClient"
     )
-    @mock.patch("airflow.providers.microsoft.azure.hooks.container_registry.get_default_azure_credential")
+    @mock.patch(
+        "airflow.providers.microsoft.azure.hooks.container_registry.get_sync_default_azure_credential"
+    )
     def test_get_conn_with_default_azure_credential(
         self, mocked_default_azure_credential, mocked_client, mocked_connection
     ):

--- a/tests/providers/microsoft/azure/hooks/test_azure_container_volume.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_container_volume.py
@@ -112,4 +112,6 @@ class TestAzureContainerVolumeHook:
         assert volume.azure_file.storage_account_name == "storage"
         assert volume.azure_file.read_only is True
 
-        mocked_default_azure_credential.assert_called_with(None, None)
+        assert mocked_default_azure_credential.called_with(
+            managed_identity_client_id=None, workload_identity_tenant_id=None
+        )

--- a/tests/providers/microsoft/azure/hooks/test_azure_container_volume.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_container_volume.py
@@ -86,7 +86,7 @@ class TestAzureContainerVolumeHook:
         indirect=True,
     )
     @mock.patch("airflow.providers.microsoft.azure.hooks.container_volume.StorageManagementClient")
-    @mock.patch("airflow.providers.microsoft.azure.hooks.container_volume.get_default_azure_credential")
+    @mock.patch("airflow.providers.microsoft.azure.hooks.container_volume.get_sync_default_azure_credential")
     def test_get_file_volume_default_azure_credential(
         self, mocked_default_azure_credential, mocked_client, mocked_connection
     ):

--- a/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
@@ -73,7 +73,7 @@ class TestAzureCosmosDbHook:
         ],
         indirect=True,
     )
-    @mock.patch(f"{MODULE}.get_default_azure_credential")
+    @mock.patch(f"{MODULE}.get_sync_default_azure_credential")
     @mock.patch(f"{MODULE}.CosmosDBManagementClient")
     @mock.patch(f"{MODULE}.CosmosClient")
     def test_get_conn(self, mock_cosmos, mock_cosmos_db, mock_default_azure_credential, mocked_connection):

--- a/tests/providers/microsoft/azure/hooks/test_azure_synapse.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_synapse.py
@@ -106,7 +106,7 @@ def test_get_connection_by_credential_client_secret(mock_credential):
         )
 
 
-@patch(f"{MODULE}.get_default_azure_credential")
+@patch(f"{MODULE}.get_sync_default_azure_credential")
 def test_get_conn_by_default_azure_credential(mock_credential):
     hook = AzureSynapseHook(DEFAULT_CONNECTION_DEFAULT_CREDENTIAL)
 

--- a/tests/providers/microsoft/azure/hooks/test_wasb.py
+++ b/tests/providers/microsoft/azure/hooks/test_wasb.py
@@ -47,7 +47,7 @@ def mocked_blob_service_client():
 
 @pytest.fixture
 def mocked_default_azure_credential():
-    with mock.patch("airflow.providers.microsoft.azure.hooks.wasb.get_default_azure_credential") as m:
+    with mock.patch("airflow.providers.microsoft.azure.hooks.wasb.get_sync_default_azure_credential") as m:
         yield m
 
 

--- a/tests/providers/microsoft/azure/secrets/test_azure_key_vault.py
+++ b/tests/providers/microsoft/azure/secrets/test_azure_key_vault.py
@@ -35,7 +35,7 @@ class TestAzureKeyVaultBackend:
         conn = AzureKeyVaultBackend().get_connection("fake_conn")
         assert conn.host == "host"
 
-    @mock.patch(f"{KEY_VAULT_MODULE}.get_default_azure_credential")
+    @mock.patch(f"{KEY_VAULT_MODULE}.get_sync_default_azure_credential")
     @mock.patch(f"{KEY_VAULT_MODULE}.SecretClient")
     def test_get_conn_uri(self, mock_secret_client, mock_azure_cred):
         mock_cred = mock.Mock()
@@ -153,7 +153,7 @@ class TestAzureKeyVaultBackend:
         assert backend.get_config("test_mysql") is None
         mock_get_secret.assert_not_called()
 
-    @mock.patch(f"{KEY_VAULT_MODULE}.get_default_azure_credential")
+    @mock.patch(f"{KEY_VAULT_MODULE}.get_sync_default_azure_credential")
     @mock.patch(f"{KEY_VAULT_MODULE}.ClientSecretCredential")
     @mock.patch(f"{KEY_VAULT_MODULE}.SecretClient")
     def test_client_authenticate_with_default_azure_credential(
@@ -169,7 +169,7 @@ class TestAzureKeyVaultBackend:
         assert not mock_client_secret_credential.called
         mock_defaul_azure_credential.assert_called_once()
 
-    @mock.patch(f"{KEY_VAULT_MODULE}.get_default_azure_credential")
+    @mock.patch(f"{KEY_VAULT_MODULE}.get_sync_default_azure_credential")
     @mock.patch(f"{KEY_VAULT_MODULE}.ClientSecretCredential")
     @mock.patch(f"{KEY_VAULT_MODULE}.SecretClient")
     def test_client_authenticate_with_default_azure_credential_and_customized_configuration(
@@ -187,7 +187,7 @@ class TestAzureKeyVaultBackend:
             workload_identity_tenant_id="workload_identity_tenant_id",
         )
 
-    @mock.patch(f"{KEY_VAULT_MODULE}.get_default_azure_credential")
+    @mock.patch(f"{KEY_VAULT_MODULE}.get_sync_default_azure_credential")
     @mock.patch(f"{KEY_VAULT_MODULE}.ClientSecretCredential")
     @mock.patch(f"{KEY_VAULT_MODULE}.SecretClient")
     def test_client_authenticate_with_client_secret_credential(


### PR DESCRIPTION
* rename `get_default_azure_credential` as `_get_default_azure_credential` and add `get_sync_default_azure_credential` and `get_async_default_azure_credential`
* make the arguments keyword only args

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
