### PR TITLE
Change owner type to stringable

### DIFF
--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -152,7 +152,7 @@ class AbstractOperator(Templater, DAGNode):
         dag = self.get_dag()
         if dag:
             return dag.dag_id
-        return f"adhoc_{self.owner}"
+        return f"adhoc_{self.owner_str}"
 
     @property
     def node_id(self) -> str:

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -111,7 +111,7 @@ if TYPE_CHECKING:
     from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
     from airflow.triggers.base import BaseTrigger
     from airflow.utils.task_group import TaskGroup
-    from airflow.utils.types import ArgNotSet
+    from airflow.utils.types import ArgNotSet, Stringable
 
 ScheduleInterval = Union[str, timedelta, relativedelta]
 
@@ -225,7 +225,7 @@ def partial(
     task_group: TaskGroup | None = None,
     start_date: datetime | ArgNotSet = NOTSET,
     end_date: datetime | ArgNotSet = NOTSET,
-    owner: str | ArgNotSet = NOTSET,
+    owner: Stringable | ArgNotSet = NOTSET,
     email: None | str | Iterable[str] | ArgNotSet = NOTSET,
     params: collections.abc.MutableMapping | None = None,
     resources: dict[str, Any] | None | ArgNotSet = NOTSET,
@@ -735,7 +735,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     def __init__(
         self,
         task_id: str,
-        owner: str = DEFAULT_OWNER,
+        owner: Stringable = DEFAULT_OWNER,
         email: str | Iterable[str] | None = None,
         email_on_retry: bool = conf.getboolean("email", "default_email_on_retry", fallback=True),
         email_on_failure: bool = conf.getboolean("email", "default_email_on_failure", fallback=True),
@@ -814,6 +814,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
             task_group.add(self)
 
         self.owner = owner
+        self.owner_str = str(owner)
         self.email = email
         self.email_on_retry = email_on_retry
         self.email_on_failure = email_on_failure

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1337,7 +1337,7 @@ class DAG(LoggingMixin):
 
         :return: Comma separated list of owners in DAG tasks
         """
-        return ", ".join({t.owner for t in self.tasks})
+        return ", ".join({t.owner_str for t in self.tasks})
 
     @property
     def allow_future_exec_dates(self) -> bool:

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -614,7 +614,7 @@ class EcsRunTaskOperator(EcsBaseOperator):
             "cluster": self.cluster,
             "taskDefinition": self.task_definition,
             "overrides": self.overrides,
-            "startedBy": self._started_by or self.owner,
+            "startedBy": self._started_by or self.owner_str,
         }
 
         if self.capacity_provider_strategy:

--- a/airflow/utils/types.py
+++ b/airflow/utils/types.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import enum
-from typing import TYPE_CHECKING
+from typing import Protocol, runtime_checkable, TYPE_CHECKING
 
 from airflow.typing_compat import TypedDict
 
@@ -71,3 +71,9 @@ class EdgeInfoType(TypedDict):
     """Extra metadata that the DAG can store about an edge, usually generated from an EdgeModifier."""
 
     label: str | None
+
+
+@runtime_checkable
+class Stringable(Protocol):
+    def __str__(self) -> str:
+        pass

--- a/airflow/utils/types.py
+++ b/airflow/utils/types.py
@@ -77,3 +77,4 @@ class EdgeInfoType(TypedDict):
 class Stringable(Protocol):
     def __str__(self) -> str:
         pass
+    

--- a/tests/cluster_policies/__init__.py
+++ b/tests/cluster_policies/__init__.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 # [START example_cluster_policy_rule]
 def task_must_have_owners(task: BaseOperator):
     if task.owner and not isinstance(task.owner, Stringable):
-        raise AirflowClusterPolicyViolation(f"""owner should be a string. Current value: {task.owner!r}""")
+        raise AirflowClusterPolicyViolation(f"""owner should be a Stringable. Current value: {task.owner!r}""")
 
     if not task.owner or task.owner_str.lower() == conf.get("operators", "default_owner"):
         raise AirflowClusterPolicyViolation(

--- a/tests/cluster_policies/__init__.py
+++ b/tests/cluster_policies/__init__.py
@@ -24,18 +24,18 @@ from typing import TYPE_CHECKING, Callable
 from airflow.configuration import conf
 from airflow.exceptions import AirflowClusterPolicySkipDag, AirflowClusterPolicyViolation
 from airflow.models.baseoperator import BaseOperator
+from airflow.utils.types import Stringable
 
 if TYPE_CHECKING:
     from airflow.models.dag import DAG
     from airflow.models.taskinstance import TaskInstance
 
-
 # [START example_cluster_policy_rule]
 def task_must_have_owners(task: BaseOperator):
-    if task.owner and not isinstance(task.owner, str):
+    if task.owner and not isinstance(task.owner, Stringable):
         raise AirflowClusterPolicyViolation(f"""owner should be a string. Current value: {task.owner!r}""")
 
-    if not task.owner or task.owner.lower() == conf.get("operators", "default_owner"):
+    if not task.owner_str or task.owner_str.lower() == conf.get("operators", "default_owner"):
         raise AirflowClusterPolicyViolation(
             f"""Task must have non-None non-default owner. Current value: {task.owner}"""
         )

--- a/tests/cluster_policies/__init__.py
+++ b/tests/cluster_policies/__init__.py
@@ -35,7 +35,7 @@ def task_must_have_owners(task: BaseOperator):
     if task.owner and not isinstance(task.owner, Stringable):
         raise AirflowClusterPolicyViolation(f"""owner should be a string. Current value: {task.owner!r}""")
 
-    if not task.owner_str or task.owner_str.lower() == conf.get("operators", "default_owner"):
+    if not task.owner or task.owner_str.lower() == conf.get("operators", "default_owner"):
         raise AirflowClusterPolicyViolation(
             f"""Task must have non-None non-default owner. Current value: {task.owner}"""
         )

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -1415,7 +1415,7 @@ def test_override_dag_default_args():
             task = EmptyOperator(task_id="task")
 
     assert task.retries == 1
-    assert task.owner_str == "y"
+    assert task.owner == "y"
     assert task.execution_timeout == timedelta(seconds=10)
 
 
@@ -1439,7 +1439,7 @@ def test_override_dag_default_args_in_nested_tg():
                 task = EmptyOperator(task_id="task")
 
     assert task.retries == 1
-    assert task.owner_str == "y"
+    assert task.owner == "y"
     assert task.execution_timeout == timedelta(seconds=10)
 
 
@@ -1470,7 +1470,7 @@ def test_override_dag_default_args_in_multi_level_nested_tg():
                         task = EmptyOperator(task_id="task")
 
     assert task.retries == 1
-    assert task.owner_str == "z"
+    assert task.owner == "z"
     assert task.execution_timeout == timedelta(seconds=10)
 
 

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -1415,7 +1415,7 @@ def test_override_dag_default_args():
             task = EmptyOperator(task_id="task")
 
     assert task.retries == 1
-    assert task.owner == "y"
+    assert task.owner_str == "y"
     assert task.execution_timeout == timedelta(seconds=10)
 
 
@@ -1439,7 +1439,7 @@ def test_override_dag_default_args_in_nested_tg():
                 task = EmptyOperator(task_id="task")
 
     assert task.retries == 1
-    assert task.owner == "y"
+    assert task.owner_str == "y"
     assert task.execution_timeout == timedelta(seconds=10)
 
 
@@ -1470,7 +1470,7 @@ def test_override_dag_default_args_in_multi_level_nested_tg():
                         task = EmptyOperator(task_id="task")
 
     assert task.retries == 1
-    assert task.owner == "z"
+    assert task.owner_str == "z"
     assert task.execution_timeout == timedelta(seconds=10)
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Changed owner type form str to Stringable which can put any type of Strinable class.
This helps users to use custom owner class and make logic to utilize owner to their code.

For example, Users can make SlackOwner class that has owner string to display and has slack user id to mention the user when failed. User can make custom notifier by using this.



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
