### PR TITLE
ECS Executor Health Check

### DIFF
--- a/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
+++ b/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
@@ -134,7 +134,7 @@ class AwsEcsExecutor(BaseExecutor):
             # If it got this far, something is wrong.  stop_task() called with an
             # invalid taskID should have thrown a ClientError.  All known reasons are
             # covered in the ``except`` block below, and this should never be reached.
-            status = "failed for an unknown reason."
+            status = "failed for an unknown reason. "
         except ClientError as ex:
             error_code = ex.response["Error"]["Code"]
             error_message = ex.response["Error"]["Message"]

--- a/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
+++ b/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
@@ -106,7 +106,7 @@ class AwsEcsExecutor(BaseExecutor):
         """
         Make a test API call to check the health of the ECS Executor.
 
-        Deliberately use an invalid taskID, some potential outcomes in order:
+        Deliberately use an invalid task ID, some potential outcomes in order:
           1. "AccessDeniedException" is raised if there are insufficient permissions.
           2. "ClusterNotFoundException" is raised if permissions exist but the cluster does not.
           3. The API responds with a failure message if the cluster is found and there

--- a/airflow/providers/amazon/aws/executors/ecs/utils.py
+++ b/airflow/providers/amazon/aws/executors/ecs/utils.py
@@ -46,6 +46,7 @@ CONFIG_DEFAULTS = {
     "assign_public_ip": "False",
     "launch_type": "FARGATE",
     "platform_version": "LATEST",
+    "check_health_on_startup": "True",
 }
 
 
@@ -96,6 +97,7 @@ class AllEcsConfigKeys(RunTaskKwargsConfigKeys):
     AWS_CONN_ID = "conn_id"
     RUN_TASK_KWARGS = "run_task_kwargs"
     REGION_NAME = "region_name"
+    CHECK_HEALTH_ON_STARTUP = "check_health_on_startup"
 
 
 class EcsExecutorException(Exception):

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -889,7 +889,7 @@ config:
         default: ~
       check_health_on_startup:
         description: |
-          Whether or not to check the ECS Executor health on startup
+          Whether or not to check the ECS Executor health on startup.
         version_added: "8.10"
         type: boolean
         example: "True"

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -887,3 +887,10 @@ config:
         type: string
         example: '{"tags": {"key": "schema", "value": "1.0"}}'
         default: ~
+      check_health_on_startup:
+        description: |
+          Whether or not to check the ECS Executor health on startup
+        version_added: "8.10"
+        type: boolean
+        example: "True"
+        default: "True"

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -890,7 +890,7 @@ config:
       check_health_on_startup:
         description: |
           Whether or not to check the ECS Executor health on startup.
-        version_added: "8.10"
+        version_added: "8.11"
         type: boolean
         example: "True"
         default: "True"

--- a/docs/apache-airflow-providers-amazon/executors/ecs-executor.rst
+++ b/docs/apache-airflow-providers-amazon/executors/ecs-executor.rst
@@ -106,6 +106,8 @@ Optional config options:
 -  MAX_RUN_TASK_ATTEMPTS - The maximum number of times the Ecs Executor
    should attempt to run a task. This refers to instances where the task
    fails to start (i.e. ECS API failures, container failures etc.)
+-  CHECK_HEALTH_ON_STARTUP - Whether or not to check the ECS Executor
+   health on startup
 
 For a more detailed description of available options, including type
 hints and examples, see the ``config_templates`` folder in the Amazon

--- a/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -931,7 +931,7 @@ class TestEcsExecutorConfig:
             else:
                 assert run_task_kwargs_network_config[camelized_key] == value.split(",")
 
-    def test_start_failure_with_invalid_permissions(self, set_env_vars, caplog):
+    def test_start_failure_with_invalid_permissions(self, set_env_vars):
         executor = AwsEcsExecutor()
 
         # Replace boto3 ECS client with mock.
@@ -946,11 +946,10 @@ class TestEcsExecutorConfig:
 
         executor.ecs = ecs_mock
 
-        with pytest.raises(AirflowException) as raised:
+        with pytest.raises(AirflowException, match=mock_resp["Error"]["Message"]):
             executor.start()
-        raised.match(mock_resp["Error"]["Message"])
 
-    def test_start_failure_with_invalid_cluster_name(self, set_env_vars, caplog):
+    def test_start_failure_with_invalid_cluster_name(self, set_env_vars):
         executor = AwsEcsExecutor()
 
         # Replace boto3 ECS client with mock.
@@ -960,9 +959,8 @@ class TestEcsExecutorConfig:
 
         executor.ecs = ecs_mock
 
-        with pytest.raises(AirflowException) as raised:
+        with pytest.raises(AirflowException, match=mock_resp["Error"]["Message"]):
             executor.start()
-        raised.match(mock_resp["Error"]["Message"])
 
     def test_start_success(self, set_env_vars, caplog):
         executor = AwsEcsExecutor()
@@ -982,7 +980,7 @@ class TestEcsExecutorConfig:
 
         assert "succeeded" in caplog.text
 
-    def test_start_health_check_config(self, set_env_vars, caplog):
+    def test_start_health_check_config(self, set_env_vars):
         executor = AwsEcsExecutor()
 
         # Replace boto3 ECS client with mock.


### PR DESCRIPTION
During Scheduler startup it calls `start()` on the configured Executor. Attempt an API call to ECS via the Boto client in this method to test the health of the ECS Executor. This will test most of the machinery of the executor (credentials, permissions, configuration, etc). If the check fails and the executor is unhealthy don't allow the scheduler to continue to start up, fail hard and message clearly to the user what is the issue. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
