### PR TITLE
Remove PodLoggingStatus object

### DIFF
--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -25,7 +25,6 @@ import time
 import warnings
 from collections.abc import Iterable
 from contextlib import closing, suppress
-from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING, Callable, Generator, Protocol, cast
 
@@ -266,14 +265,6 @@ class PodLogsConsumer:
         return self.read_pod_cache
 
 
-@dataclass
-class PodLoggingStatus:
-    """Return the status of the pod and last log time when exiting from `fetch_container_logs`."""
-
-    running: bool
-    last_log_time: DateTime | None
-
-
 class PodManager(LoggingMixin):
     """Create, monitor, and otherwise interact with Kubernetes pods for use with the KubernetesPodOperator."""
 
@@ -358,7 +349,7 @@ class PodManager(LoggingMixin):
                 raise PodLaunchFailedException(msg)
             time.sleep(startup_check_interval)
 
-    def follow_container_logs(self, pod: V1Pod, container_name: str) -> PodLoggingStatus:
+    def follow_container_logs(self, pod: V1Pod, container_name: str) -> None:
         warnings.warn(
             "Method `follow_container_logs` is deprecated.  Use `fetch_container_logs` instead"
             "with option `follow=True`.",
@@ -375,7 +366,7 @@ class PodManager(LoggingMixin):
         follow=False,
         since_time: DateTime | None = None,
         post_termination_timeout: int = 120,
-    ) -> PodLoggingStatus:
+    ) -> None:
         """
         Follow the logs of container and stream to airflow logging.
 
@@ -468,36 +459,31 @@ class PodManager(LoggingMixin):
                 termination_timeout=post_termination_timeout,
                 logs=logs,
             )
-            if not self.container_is_running(pod, container_name=container_name):
-                return PodLoggingStatus(running=False, last_log_time=last_log_time)
             if not follow:
-                return PodLoggingStatus(running=True, last_log_time=last_log_time)
-            else:
+                return
+            if self.container_is_running(pod, container_name=container_name):
                 self.log.warning(
-                    "Pod %s log read interrupted but container %s still running",
-                    pod.metadata.name,
+                    "Follow requested but pod log read interrupted and container %s still running",
                     container_name,
                 )
                 time.sleep(1)
+            else:  # follow requested, but container is done
+                break
 
     def fetch_requested_container_logs(
         self, pod: V1Pod, container_logs: Iterable[str] | str | Literal[True], follow_logs=False
-    ) -> list[PodLoggingStatus]:
+    ) -> None:
         """
         Follow the logs of containers in the specified pod and publish it to airflow logging.
 
         Returns when all the containers exit.
         """
-        pod_logging_statuses = []
         all_containers = self.get_container_names(pod)
         if all_containers:
             if isinstance(container_logs, str):
                 # fetch logs only for requested container if only one container is provided
                 if container_logs in all_containers:
-                    status = self.fetch_container_logs(
-                        pod=pod, container_name=container_logs, follow=follow_logs
-                    )
-                    pod_logging_statuses.append(status)
+                    self.fetch_container_logs(pod=pod, container_name=container_logs, follow=follow_logs)
                 else:
                     self.log.error(
                         "container %s whose logs were requested not found in the pod %s",
@@ -508,10 +494,7 @@ class PodManager(LoggingMixin):
                 # if True is provided, get logs for all the containers
                 if container_logs is True:
                     for container_name in all_containers:
-                        status = self.fetch_container_logs(
-                            pod=pod, container_name=container_name, follow=follow_logs
-                        )
-                        pod_logging_statuses.append(status)
+                        self.fetch_container_logs(pod=pod, container_name=container_name, follow=follow_logs)
                 else:
                     self.log.error(
                         "False is not a valid value for container_logs",
@@ -521,10 +504,7 @@ class PodManager(LoggingMixin):
                 if isinstance(container_logs, Iterable):
                     for container in container_logs:
                         if container in all_containers:
-                            status = self.fetch_container_logs(
-                                pod=pod, container_name=container, follow=follow_logs
-                            )
-                            pod_logging_statuses.append(status)
+                            self.fetch_container_logs(pod=pod, container_name=container, follow=follow_logs)
                         else:
                             self.log.error(
                                 "Container %s whose logs were requests not found in the pod %s",
@@ -537,8 +517,6 @@ class PodManager(LoggingMixin):
                     )
         else:
             self.log.error("Could not retrieve containers for the pod: %s", pod.metadata.name)
-
-        return pod_logging_statuses
 
     def await_container_completion(self, pod: V1Pod, container_name: str) -> None:
         """

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -26,7 +26,7 @@ import warnings
 from collections.abc import Iterable
 from contextlib import closing, suppress
 from datetime import timedelta
-from typing import TYPE_CHECKING, Callable, Generator, Protocol, cast
+from typing import TYPE_CHECKING, Callable, Generator, Literal, Protocol, cast
 
 import pendulum
 import tenacity
@@ -35,7 +35,6 @@ from kubernetes.client.rest import ApiException
 from kubernetes.stream import stream as kubernetes_stream
 from pendulum import DateTime
 from pendulum.parsing.exceptions import ParserError
-from typing_extensions import Literal
 from urllib3.exceptions import HTTPError as BaseHTTPError
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning

--- a/tests/providers/cncf/kubernetes/utils/test_pod_manager.py
+++ b/tests/providers/cncf/kubernetes/utils/test_pod_manager.py
@@ -20,7 +20,6 @@ import logging
 from datetime import datetime
 from json.decoder import JSONDecodeError
 from types import SimpleNamespace
-from typing import cast
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -260,19 +259,6 @@ class TestPodManager:
 
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_running")
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.read_pod_logs")
-    def test_fetch_container_logs_returning_last_timestamp(
-        self, mock_read_pod_logs, mock_container_is_running
-    ):
-        timestamp_string = "2020-10-08T14:16:17.793417674Z"
-        mock_read_pod_logs.return_value = [bytes(f"{timestamp_string} message", "utf-8"), b"notimestamp"]
-        mock_container_is_running.side_effect = [True, False]
-
-        status = self.pod_manager.fetch_container_logs(mock.MagicMock(), mock.MagicMock(), follow=True)
-
-        assert status.last_log_time == cast(DateTime, pendulum.parse(timestamp_string))
-
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_running")
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.read_pod_logs")
     def test_fetch_container_logs_invoke_progress_callback(
         self, mock_read_pod_logs, mock_container_is_running
     ):
@@ -305,8 +291,7 @@ class TestPodManager:
         with mock.patch.object(PodLogsConsumer, "__iter__") as mock_consumer_iter:
             mock_consumer_iter.side_effect = consumer_iter
             mock_container_is_running.side_effect = [True, True, False]
-            status = self.pod_manager.fetch_container_logs(mock.MagicMock(), mock.MagicMock(), follow=True)
-        assert status.last_log_time == cast(DateTime, pendulum.parse(last_timestamp_string))
+            self.pod_manager.fetch_container_logs(mock.MagicMock(), mock.MagicMock(), follow=True)
         assert self.mock_progress_callback.call_count == expected_call_count
 
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_running")
@@ -411,15 +396,21 @@ class TestPodManager:
         mock_pod = MagicMock()
         logs_available.return_value = False
         container_running.return_value = False
-        ret = self.pod_manager.fetch_container_logs(pod=mock_pod, container_name="base", follow=follow)
-        assert ret.last_log_time is None
-        assert ret.running is False
+        self.pod_manager.fetch_container_logs(pod=mock_pod, container_name="base", follow=follow)
 
     # adds all valid types for container_logs
     @pytest.mark.parametrize("follow", [True, False])
-    @pytest.mark.parametrize("container_logs", ["base", "alpine", True, ["base", "alpine"]])
+    @pytest.mark.parametrize(
+        "container_logs, exp_cont",
+        [
+            ("base", ["base"]),
+            ("alpine", ["alpine"]),
+            (True, ["base", "alpine"]),
+            (["base", "alpine"], ["base", "alpine"]),
+        ],
+    )
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.container_is_running")
-    def test_fetch_requested_container_logs(self, container_is_running, container_logs, follow):
+    def test_fetch_requested_container_logs(self, container_is_running, container_logs, follow, exp_cont):
         mock_pod = MagicMock()
         self.pod_manager.read_pod = MagicMock()
         self.pod_manager.get_container_names = MagicMock()
@@ -429,31 +420,12 @@ class TestPodManager:
             stream=mock.MagicMock(return_value=[b"2021-01-01 hi"])
         )
 
-        ret_values = self.pod_manager.fetch_requested_container_logs(
+        self.pod_manager.fetch_requested_container_logs(
             pod=mock_pod, container_logs=container_logs, follow_logs=follow
         )
-        for ret in ret_values:
-            assert ret.running is False
-
-    # adds all invalid types for container_logs
-    @pytest.mark.parametrize("container_logs", [1, None, 6.8, False])
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.container_is_running")
-    def test_fetch_requested_container_logs_invalid(self, container_running, container_logs):
-        mock_pod = MagicMock()
-        self.pod_manager.read_pod = MagicMock()
-        self.pod_manager.get_container_names = MagicMock()
-        self.pod_manager.get_container_names.return_value = ["base", "alpine"]
-        container_running.return_value = False
-        self.mock_kube_client.read_namespaced_pod_log.return_value = mock.MagicMock(
-            stream=mock.MagicMock(return_value=[b"2021-01-01 hi"])
-        )
-
-        ret_values = self.pod_manager.fetch_requested_container_logs(
-            pod=mock_pod,
-            container_logs=container_logs,
-        )
-
-        assert len(ret_values) == 0
+        calls = {tuple(x[1].values()) for x in container_is_running.call_args_list}
+        pod = self.pod_manager.read_pod.return_value
+        assert calls == {(pod, x) for x in exp_cont}
 
     @mock.patch("pendulum.now")
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.container_is_running")
@@ -472,7 +444,7 @@ class TestPodManager:
         args, kwargs = self.mock_kube_client.read_namespaced_pod_log.call_args_list[0]
         assert kwargs["since_seconds"] == 5
 
-    @pytest.mark.parametrize("follow, is_running_calls, exp_running", [(True, 3, False), (False, 3, False)])
+    @pytest.mark.parametrize("follow, is_running_calls, exp_running", [(True, 3, False), (False, 2, False)])
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.container_is_running")
     def test_fetch_container_running_follow(
         self, container_running_mock, follow, is_running_calls, exp_running
@@ -486,10 +458,8 @@ class TestPodManager:
         self.mock_kube_client.read_namespaced_pod_log.return_value = mock.MagicMock(
             stream=mock.MagicMock(return_value=[b"2021-01-01 hi"])
         )
-        ret = self.pod_manager.fetch_container_logs(pod=mock_pod, container_name="base", follow=follow)
+        self.pod_manager.fetch_container_logs(pod=mock_pod, container_name="base", follow=follow)
         assert len(container_running_mock.call_args_list) == is_running_calls
-        assert ret.last_log_time == DateTime(2021, 1, 1, tzinfo=Timezone("UTC"))
-        assert ret.running is exp_running
 
     @pytest.mark.parametrize(
         "container_state, expected_is_terminated",


### PR DESCRIPTION
This object is not used anywhere.  It is a legacy from the logic to periodically resume deferrable task to grab logs.
