### PR TITLE
openlineage, snowflake: fix Snowflake information schema query

### DIFF
--- a/airflow/providers/openlineage/utils/sql.py
+++ b/airflow/providers/openlineage/utils/sql.py
@@ -193,6 +193,7 @@ def create_filter_clauses(
             name.upper() if uppercase_names else name for name in tables
         )
         if schema:
+            schema = schema.upper() if uppercase_names else schema
             filter_clause = and_(information_schema_table.c.table_schema == schema, filter_clause)
         filter_clauses.append(filter_clause)
     return filter_clauses

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -440,6 +440,7 @@ class SnowflakeHook(DbApiHook):
                 "column_name",
                 "ordinal_position",
                 "data_type",
+                "table_catalog",
             ],
             database=database,
             is_information_schema_cross_db=True,

--- a/tests/providers/snowflake/operators/test_snowflake_sql.py
+++ b/tests/providers/snowflake/operators/test_snowflake_sql.py
@@ -17,11 +17,18 @@
 # under the License.
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from databricks.sql.types import Row
-from openlineage.client.facet import SchemaDatasetFacet, SchemaField, SqlJobFacet
+from openlineage.client.facet import (
+    ColumnLineageDatasetFacet,
+    ColumnLineageDatasetFacetFieldsAdditional,
+    ColumnLineageDatasetFacetFieldsAdditionalInputFields,
+    SchemaDatasetFacet,
+    SchemaField,
+    SqlJobFacet,
+)
 from openlineage.client.run import Dataset
 
 from airflow.models.connection import Connection
@@ -148,6 +155,9 @@ def test_execute_openlineage_events():
     DB_NAME = "DATABASE"
     DB_SCHEMA_NAME = "PUBLIC"
 
+    ANOTHER_DB_NAME = "ANOTHER_DB"
+    ANOTHER_DB_SCHEMA = "ANOTHER_SCHEMA"
+
     class SnowflakeHookForTests(SnowflakeHook):
         get_conn = MagicMock(name="conn")
         get_connection = MagicMock()
@@ -161,17 +171,42 @@ def test_execute_openlineage_events():
         def get_db_hook(self):
             return dbapi_hook
 
-    sql = """CREATE TABLE IF NOT EXISTS popular_orders_day_of_week (
-        order_day_of_week VARCHAR(64) NOT NULL,
-        order_placed_on   TIMESTAMP NOT NULL,
-        orders_placed     INTEGER NOT NULL
-    );
-FORGOT TO COMMENT"""
+    sql = (
+        "INSERT INTO Test_table\n"
+        "SELECT t1.*, t2.additional_constant FROM ANOTHER_db.another_schema.popular_orders_day_of_week t1\n"
+        "JOIN little_table t2 ON t1.order_day_of_week = t2.order_day_of_week;\n"
+        "FORGOT TO COMMENT"
+    )
+
     op = SnowflakeOperatorForTest(task_id="snowflake-operator", sql=sql)
     rows = [
-        (DB_SCHEMA_NAME, "POPULAR_ORDERS_DAY_OF_WEEK", "ORDER_DAY_OF_WEEK", 1, "TEXT"),
-        (DB_SCHEMA_NAME, "POPULAR_ORDERS_DAY_OF_WEEK", "ORDER_PLACED_ON", 2, "TIMESTAMP_NTZ"),
-        (DB_SCHEMA_NAME, "POPULAR_ORDERS_DAY_OF_WEEK", "ORDERS_PLACED", 3, "NUMBER"),
+        [
+            (
+                ANOTHER_DB_SCHEMA,
+                "POPULAR_ORDERS_DAY_OF_WEEK",
+                "ORDER_DAY_OF_WEEK",
+                1,
+                "TEXT",
+                ANOTHER_DB_NAME,
+            ),
+            (
+                ANOTHER_DB_SCHEMA,
+                "POPULAR_ORDERS_DAY_OF_WEEK",
+                "ORDER_PLACED_ON",
+                2,
+                "TIMESTAMP_NTZ",
+                ANOTHER_DB_NAME,
+            ),
+            (ANOTHER_DB_SCHEMA, "POPULAR_ORDERS_DAY_OF_WEEK", "ORDERS_PLACED", 3, "NUMBER", ANOTHER_DB_NAME),
+            (DB_SCHEMA_NAME, "LITTLE_TABLE", "ORDER_DAY_OF_WEEK", 1, "TEXT", DB_NAME),
+            (DB_SCHEMA_NAME, "LITTLE_TABLE", "ADDITIONAL_CONSTANT", 2, "TEXT", DB_NAME),
+        ],
+        [
+            (DB_SCHEMA_NAME, "TEST_TABLE", "ORDER_DAY_OF_WEEK", 1, "TEXT", DB_NAME),
+            (DB_SCHEMA_NAME, "TEST_TABLE", "ORDER_PLACED_ON", 2, "TIMESTAMP_NTZ", DB_NAME),
+            (DB_SCHEMA_NAME, "TEST_TABLE", "ORDERS_PLACED", 3, "NUMBER", DB_NAME),
+            (DB_SCHEMA_NAME, "TEST_TABLE", "ADDITIONAL_CONSTANT", 4, "TEXT", DB_NAME),
+        ],
     ]
     dbapi_hook.get_connection.return_value = Connection(
         conn_id="snowflake_default",
@@ -183,14 +218,37 @@ FORGOT TO COMMENT"""
             "database": DB_NAME,
         },
     )
-    dbapi_hook.get_conn.return_value.cursor.return_value.fetchall.side_effect = [rows, []]
+    dbapi_hook.get_conn.return_value.cursor.return_value.fetchall.side_effect = rows
 
     lineage = op.get_openlineage_facets_on_start()
-    assert len(lineage.inputs) == 0
-    assert lineage.outputs == [
+    assert dbapi_hook.get_conn.return_value.cursor.return_value.execute.mock_calls == [
+        call(
+            "SELECT database.information_schema.columns.table_schema, database.information_schema.columns.table_name, "
+            "database.information_schema.columns.column_name, database.information_schema.columns.ordinal_position, "
+            "database.information_schema.columns.data_type, database.information_schema.columns.table_catalog \n"
+            "FROM database.information_schema.columns \n"
+            "WHERE database.information_schema.columns.table_name IN ('LITTLE_TABLE') "
+            "UNION ALL "
+            "SELECT another_db.information_schema.columns.table_schema, another_db.information_schema.columns.table_name, "
+            "another_db.information_schema.columns.column_name, another_db.information_schema.columns.ordinal_position, "
+            "another_db.information_schema.columns.data_type, another_db.information_schema.columns.table_catalog \n"
+            "FROM another_db.information_schema.columns \n"
+            "WHERE another_db.information_schema.columns.table_schema = 'ANOTHER_SCHEMA' "
+            "AND another_db.information_schema.columns.table_name IN ('POPULAR_ORDERS_DAY_OF_WEEK')"
+        ),
+        call(
+            "SELECT database.information_schema.columns.table_schema, database.information_schema.columns.table_name, "
+            "database.information_schema.columns.column_name, database.information_schema.columns.ordinal_position, "
+            "database.information_schema.columns.data_type, database.information_schema.columns.table_catalog \n"
+            "FROM database.information_schema.columns \n"
+            "WHERE database.information_schema.columns.table_name IN ('TEST_TABLE')"
+        ),
+    ]
+
+    assert lineage.inputs == [
         Dataset(
             namespace="snowflake://test_account.us-east.aws",
-            name=f"{DB_NAME}.{DB_SCHEMA_NAME}.POPULAR_ORDERS_DAY_OF_WEEK",
+            name=f"{ANOTHER_DB_NAME}.{ANOTHER_DB_SCHEMA}.POPULAR_ORDERS_DAY_OF_WEEK",
             facets={
                 "schema": SchemaDatasetFacet(
                     fields=[
@@ -199,6 +257,49 @@ FORGOT TO COMMENT"""
                         SchemaField(name="ORDERS_PLACED", type="NUMBER"),
                     ]
                 )
+            },
+        ),
+        Dataset(
+            namespace="snowflake://test_account.us-east.aws",
+            name=f"{DB_NAME}.{DB_SCHEMA_NAME}.LITTLE_TABLE",
+            facets={
+                "schema": SchemaDatasetFacet(
+                    fields=[
+                        SchemaField(name="ORDER_DAY_OF_WEEK", type="TEXT"),
+                        SchemaField(name="ADDITIONAL_CONSTANT", type="TEXT"),
+                    ]
+                )
+            },
+        ),
+    ]
+    assert lineage.outputs == [
+        Dataset(
+            namespace="snowflake://test_account.us-east.aws",
+            name=f"{DB_NAME}.{DB_SCHEMA_NAME}.TEST_TABLE",
+            facets={
+                "schema": SchemaDatasetFacet(
+                    fields=[
+                        SchemaField(name="ORDER_DAY_OF_WEEK", type="TEXT"),
+                        SchemaField(name="ORDER_PLACED_ON", type="TIMESTAMP_NTZ"),
+                        SchemaField(name="ORDERS_PLACED", type="NUMBER"),
+                        SchemaField(name="ADDITIONAL_CONSTANT", type="TEXT"),
+                    ]
+                ),
+                "columnLineage": ColumnLineageDatasetFacet(
+                    fields={
+                        "additional_constant": ColumnLineageDatasetFacetFieldsAdditional(
+                            inputFields=[
+                                ColumnLineageDatasetFacetFieldsAdditionalInputFields(
+                                    namespace="snowflake://test_account.us-east.aws",
+                                    name="DATABASE.PUBLIC.little_table",
+                                    field="additional_constant",
+                                )
+                            ],
+                            transformationDescription="",
+                            transformationType="",
+                        )
+                    }
+                ),
             },
         )
     ]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

**Bug description**

When schema is passed explicitly in query in `SnowflakeOperator` information schema query is created in a wrong way. Snowflake expects uppercase names while schema is first normalized to lowercase and never uppercased when constructing information schema query

**Solution**

When `uppercase_names` is `True` in `create_filter_clauses` make schema uppercase.