### PR TITLE
Fix TriggerDagRunOperator failing to trigger subsequent runs when reset_dag_run=True

### DIFF
--- a/airflow/operators/trigger_dagrun.py
+++ b/airflow/operators/trigger_dagrun.py
@@ -174,15 +174,14 @@ class TriggerDagRunOperator(BaseOperator):
                 self.log.info("Clearing %s on %s", self.trigger_dag_id, parsed_execution_date)
 
                 # Get target dag object and call clear()
-
                 dag_model = DagModel.get_current(self.trigger_dag_id)
                 if dag_model is None:
                     raise DagNotFound(f"Dag id {self.trigger_dag_id} not found in DagModel")
 
                 dag_bag = DagBag(dag_folder=dag_model.fileloc, read_dags_from_db=True)
                 dag = dag_bag.get_dag(self.trigger_dag_id)
-                dag.clear(start_date=e.dag_run.execution_date, end_date=e.dag_run.execution_date)
                 dag_run = e.dag_run
+                dag.clear(start_date=dag_run.execution_date, end_date=dag_run.execution_date)
             else:
                 raise e
         if dag_run is None:

--- a/airflow/operators/trigger_dagrun.py
+++ b/airflow/operators/trigger_dagrun.py
@@ -181,7 +181,7 @@ class TriggerDagRunOperator(BaseOperator):
 
                 dag_bag = DagBag(dag_folder=dag_model.fileloc, read_dags_from_db=True)
                 dag = dag_bag.get_dag(self.trigger_dag_id)
-                dag.clear(start_date=parsed_execution_date, end_date=parsed_execution_date)
+                dag.clear(start_date=e.dag_run.execution_date, end_date=e.dag_run.execution_date)
                 dag_run = e.dag_run
             else:
                 raise e

--- a/tests/operators/test_trigger_dagrun.py
+++ b/tests/operators/test_trigger_dagrun.py
@@ -279,12 +279,39 @@ class TestDagRunOperator:
             assert dagruns[0].conf == {"foo": TEST_DAG_ID}
 
     def test_trigger_dagrun_with_reset_dag_run_false(self):
-        """Test TriggerDagRunOperator with reset_dag_run."""
+        """Test TriggerDagRunOperator without reset_dag_run."""
         execution_date = DEFAULT_DATE
         task = TriggerDagRunOperator(
             task_id="test_task",
             trigger_dag_id=TRIGGERED_DAG_ID,
-            execution_date=execution_date,
+            trigger_run_id=None,
+            execution_date=None,
+            reset_dag_run=False,
+            dag=self.dag,
+        )
+        task.run(start_date=execution_date, end_date=execution_date, ignore_ti_state=True)
+        task.run(start_date=execution_date, end_date=execution_date, ignore_ti_state=True)
+
+        with create_session() as session:
+            dagruns = session.query(DagRun).filter(DagRun.dag_id == TRIGGERED_DAG_ID).all()
+            assert len(dagruns) == 2
+
+    @pytest.mark.parametrize(
+        "trigger_run_id, trigger_execution_date",
+        [
+            (None, DEFAULT_DATE),
+            ("dummy_run_id", None),
+            ("dummy_run_id", DEFAULT_DATE),
+        ],
+    )
+    def test_trigger_dagrun_with_reset_dag_run_false_fail(self, trigger_run_id, trigger_execution_date):
+        """Test TriggerDagRunOperator without reset_dag_run but triggered dag fails."""
+        execution_date = DEFAULT_DATE
+        task = TriggerDagRunOperator(
+            task_id="test_task",
+            trigger_dag_id=TRIGGERED_DAG_ID,
+            trigger_run_id=trigger_run_id,
+            execution_date=trigger_execution_date,
             reset_dag_run=False,
             dag=self.dag,
         )
@@ -293,28 +320,35 @@ class TestDagRunOperator:
         with pytest.raises(DagRunAlreadyExists):
             task.run(start_date=execution_date, end_date=execution_date, ignore_ti_state=True)
 
-    def test_trigger_dagrun_with_reset_dag_run_true(self):
+    @pytest.mark.parametrize(
+        "trigger_run_id, trigger_execution_date, expected_dagruns_count",
+        [
+            (None, DEFAULT_DATE, 1),
+            (None, None, 2),
+            ("dummy_run_id", DEFAULT_DATE, 1),
+            ("dummy_run_id", None, 1),
+        ],
+    )
+    def test_trigger_dagrun_with_reset_dag_run_true(
+        self, trigger_run_id, trigger_execution_date, expected_dagruns_count
+    ):
         """Test TriggerDagRunOperator with reset_dag_run."""
         execution_date = DEFAULT_DATE
         task = TriggerDagRunOperator(
             task_id="test_task",
             trigger_dag_id=TRIGGERED_DAG_ID,
-            execution_date=execution_date,
+            trigger_run_id=trigger_run_id,
+            execution_date=trigger_execution_date,
             reset_dag_run=True,
             dag=self.dag,
         )
         task.run(start_date=execution_date, end_date=execution_date, ignore_ti_state=True)
-
-        with create_session() as session:
-            all_dagruns_before_trigger = session.query(DagRun).filter(DagRun.dag_id == TRIGGERED_DAG_ID).all()
-
         task.run(start_date=execution_date, end_date=execution_date, ignore_ti_state=True)
 
         with create_session() as session:
-            all_dagruns_after_trigger = session.query(DagRun).filter(DagRun.dag_id == TRIGGERED_DAG_ID).all()
-            assert all_dagruns_before_trigger[0].execution_date == all_dagruns_after_trigger[0].execution_date
-            assert len(all_dagruns_after_trigger) == 1
-            assert all_dagruns_after_trigger[0].external_trigger
+            dag_runs = session.query(DagRun).filter(DagRun.dag_id == TRIGGERED_DAG_ID).all()
+            assert len(dag_runs) == expected_dagruns_count
+            assert dag_runs[0].external_trigger
 
     def test_trigger_dagrun_with_wait_for_completion_true(self):
         """Test TriggerDagRunOperator with wait_for_completion."""

--- a/tests/operators/test_trigger_dagrun.py
+++ b/tests/operators/test_trigger_dagrun.py
@@ -304,12 +304,17 @@ class TestDagRunOperator:
             dag=self.dag,
         )
         task.run(start_date=execution_date, end_date=execution_date, ignore_ti_state=True)
+
+        with create_session() as session:
+            all_dagruns_before_trigger = session.query(DagRun).filter(DagRun.dag_id == TRIGGERED_DAG_ID).all()
+
         task.run(start_date=execution_date, end_date=execution_date, ignore_ti_state=True)
 
         with create_session() as session:
-            dagruns = session.query(DagRun).filter(DagRun.dag_id == TRIGGERED_DAG_ID).all()
-            assert len(dagruns) == 1
-            assert dagruns[0].external_trigger
+            all_dagruns_after_trigger = session.query(DagRun).filter(DagRun.dag_id == TRIGGERED_DAG_ID).all()
+            assert all_dagruns_before_trigger[0].execution_date == all_dagruns_after_trigger[0].execution_date
+            assert len(all_dagruns_after_trigger) == 1
+            assert all_dagruns_after_trigger[0].external_trigger
 
     def test_trigger_dagrun_with_wait_for_completion_true(self):
         """Test TriggerDagRunOperator with wait_for_completion."""


### PR DESCRIPTION
closes: #34953

**In brief:**
The operator failed to reset the dag run because it failed to handle a case when `trigger_run_id` argument is defined within the `TriggerDagRunOperator`, and when it encounters this code:
```python
parsed_execution_date = timezone.utcnow()
```
This causes the code in:
```python
dag.clear(start_date=parsed_execution_date, end_date=parsed_execution_date)
```
to fail because `parsed_execution_date` will be used as arguments for a where clause to filter out task instances to be cleared.  This would cause a bug since no task instances would be able to be returned from the call when we set the filter to `parsed_execution_date = timezone.utcnow()`.

**Modification:**
- Use `dagrun.execution_date` to guarantee that task instances can always be correctly filtered and cleared when resetting the DAG run. 
- Add more test cases.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
