### PR TITLE
Fix `common.io' provider missing in tests package

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/run_tests.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_tests.py
@@ -253,7 +253,11 @@ def convert_test_type_to_pytest_args(
             if (AIRFLOW_SOURCES_ROOT / provider_path).is_dir():
                 providers_to_test.append(provider_path)
             else:
-                get_console().print(f"[warning]Provider {provider} does not exist. Ignoring it.")
+                get_console().print(
+                    f"[error]Provider directory {provider_path} does not exist for {provider}. "
+                    f"This is bad. Please add it (all providers should have a package in tests)"
+                )
+                sys.exit(1)
         return providers_to_test
     if test_type == "Other":
         return find_all_other_tests()

--- a/dev/breeze/tests/test_pytest_args_for_test_types.py
+++ b/dev/breeze/tests/test_pytest_args_for_test_types.py
@@ -88,6 +88,11 @@ from airflow_breeze.utils.run_tests import convert_parallel_types_to_folders, co
             False,
         ),
         (
+            "Providers[common.io]",
+            ["tests/providers/common/io"],
+            False,
+        ),
+        (
             "Providers[amazon,google,apache.hive]",
             ["tests/providers/amazon", "tests/providers/google", "tests/providers/apache/hive"],
             False,
@@ -186,6 +191,11 @@ def test_pytest_args_for_regular_test_types(
         )
         == pytest_args
     )
+
+
+def test_pytest_args_for_missing_provider():
+    with pytest.raises(SystemExit):
+        convert_test_type_to_pytest_args(test_type="Providers[missing.provider]", skip_provider_tests=False)
 
 
 @pytest.mark.parametrize(

--- a/tests/providers/common/io/__init__.py
+++ b/tests/providers/common/io/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.


### PR DESCRIPTION
The common.io provider has been missing from the "tests" folder and a side effect of it was that if this was the only provider in "Providers[common.io]" the tests were run for absolutely everything (but a kitchen sink) - and failed, because we do not have working `pytest` without selecting the test suite (tests, helm_tests and the like)

This PR fixes it:

* when there is a provider with mising folder, it will fail the breeze tests command when specified in "Providers["

* the common.io has now empty test provider package.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
