### PR TITLE
Fix airflow scheduler getting stuck due to timezone issue

### DIFF
--- a/airflow/timetables/_cron.py
+++ b/airflow/timetables/_cron.py
@@ -102,20 +102,14 @@ class CronMixin:
         naive = make_naive(current, self._timezone)
         cron = croniter(self._expression, start_time=naive)
         scheduled = cron.get_next(datetime.datetime)
-        if not self._should_fix_dst:
-            return convert_to_utc(make_aware(scheduled, self._timezone))
-        delta = scheduled - naive
-        return convert_to_utc(current.in_timezone(self._timezone) + delta)
+        return convert_to_utc(make_aware(scheduled, self._timezone))
 
     def _get_prev(self, current: DateTime) -> DateTime:
         """Get the first schedule before specified time, with DST fixed."""
         naive = make_naive(current, self._timezone)
         cron = croniter(self._expression, start_time=naive)
         scheduled = cron.get_prev(datetime.datetime)
-        if not self._should_fix_dst:
-            return convert_to_utc(make_aware(scheduled, self._timezone))
-        delta = naive - scheduled
-        return convert_to_utc(current.in_timezone(self._timezone) - delta)
+        return convert_to_utc(make_aware(scheduled, self._timezone))
 
     def _align_to_next(self, current: DateTime) -> DateTime:
         """Get the next scheduled time.

--- a/airflow/timetables/interval.py
+++ b/airflow/timetables/interval.py
@@ -98,7 +98,6 @@ class _DataIntervalTimetable(Timetable):
             start = earliest
         else:  # There's a previous run.
             # Alignment is needed when DAG has new schedule interval.
-            # TODO: The issue is here with 4-5am interval (which is in UTC, so 5-6am in Belgium), this aligns 6am BELG to prev and it's 21:45
             align_last_data_interval_end = self._align_to_prev(last_automated_data_interval.end)
             if earliest is not None:
                 # Catchup is False or DAG has new start date in the future.
@@ -109,8 +108,6 @@ class _DataIntervalTimetable(Timetable):
                 start = align_last_data_interval_end
         if restriction.latest is not None and start > restriction.latest:
             return None
-        # TODO: This is giving incorrect time as well. This is the real issue here!!!
-        # self._get_next(DateTime(2023, 10, 28, 20, 45, 0), tzinfo=UTC) == 2023,10,29,4,0,0
         end = self._get_next(start)
         return DagRunInfo.interval(start=start, end=end)
 

--- a/airflow/timetables/interval.py
+++ b/airflow/timetables/interval.py
@@ -98,6 +98,7 @@ class _DataIntervalTimetable(Timetable):
             start = earliest
         else:  # There's a previous run.
             # Alignment is needed when DAG has new schedule interval.
+            # TODO: The issue is here with 4-5am interval (which is in UTC, so 5-6am in Belgium), this aligns 6am BELG to prev and it's 21:45
             align_last_data_interval_end = self._align_to_prev(last_automated_data_interval.end)
             if earliest is not None:
                 # Catchup is False or DAG has new start date in the future.
@@ -108,6 +109,8 @@ class _DataIntervalTimetable(Timetable):
                 start = align_last_data_interval_end
         if restriction.latest is not None and start > restriction.latest:
             return None
+        # TODO: This is giving incorrect time as well. This is the real issue here!!!
+        # self._get_next(DateTime(2023, 10, 28, 20, 45, 0), tzinfo=UTC) == 2023,10,29,4,0,0
         end = self._get_next(start)
         return DagRunInfo.interval(start=start, end=end)
 


### PR DESCRIPTION
Airflow scheduler is getting stuck for the following DAG:
```
from airflow.decorators import task

import pendulum
from airflow.models import DAG
from datetime import timedelta

default_args = {
    "depends_on_past": False,
    "start_date": pendulum.datetime(year=2023, month=10, day=28, tz="Europe/Brussels"),
    "email": [],
    "email_on_failure": False,
    "email_on_retry": False,
    "retries": 3,
    "retry_delay": timedelta(minutes=5),
}

with DAG(
        "time-zone-issue",
        default_args=default_args,
        max_active_runs=1,
        schedule_interval="0,15,30,45 6-22 * * *",
) as dag:
    @task(task_id="print_the_context")
    def print_context(ds=None, **kwargs):
        """Print the Airflow context and ds variable from the context."""
        print(ds)
        return "finished!"

    run_this = print_context()
```

Scheduler keeps switching between two incorrect states:
```
test-airflow-scheduler-1  | [2023-10-30T12:50:08.811+0000] {dag.py:3722} INFO - Setting next_dagrun for time-zone-issue to 2023-10-29T04:00:00+00:00, run_after=2023-10-29T05:00:00+00:00
test-airflow-scheduler-1  | [2023-10-30T12:50:09.671+0000] {dag.py:3722} INFO - Setting next_dagrun for time-zone-issue to 2023-10-28T21:45:00+00:00, run_after=2023-10-29T04:00:00+00:00
test-airflow-scheduler-1  | [2023-10-30T12:50:10.793+0000] {dag.py:3722} INFO - Setting next_dagrun for time-zone-issue to 2023-10-29T04:00:00+00:00, run_after=2023-10-29T05:00:00+00:00
test-airflow-scheduler-1  | [2023-10-30T12:50:11.894+0000] {dag.py:3722} INFO - Setting next_dagrun for time-zone-issue to 2023-10-28T21:45:00+00:00, run_after=2023-10-29T04:00:00+00:00
test-airflow-scheduler-1  | [2023-10-30T12:50:12.813+0000] {dag.py:3722} INFO - Setting next_dagrun for time-zone-issue to 2023-10-29T04:00:00+00:00, run_after=2023-10-29T05:00:00+00:00
```

Note than in Belgium Oct, 28 is CEST (UTC+2), while Oct, 29 is CET (UTC+1) due to Daylight Saving Time (DST).

From the DAG above it looks like "2023-10-29T04:00:00+00:00" is an incorrect state as it is Oct, 29 5am CEST, which was never a part of the scheduling interval, while specifying the DAG.

After the fix scheduling proceeds as expected, I will attach screenshots for 3 intervals:
1. Oct, 28 20:30 UTC - Oct, 28 20:45 UTC
![Screenshot 2023-11-04 at 20 04 21](https://github.com/apache/airflow/assets/10106152/dd65f631-1dfb-44e0-ad84-95c67f188c0c)
2. Oct, 28 20:45 UTC - Oct, 29 05:00 UTC
![Screenshot 2023-11-04 at 20 04 28](https://github.com/apache/airflow/assets/10106152/9cdd2aac-9f85-4ded-ad1c-189470ce078a)
3. Oct, 29 05:00 UTC - Oct, 29 05:15 UTC
![Screenshot 2023-11-04 at 20 04 35](https://github.com/apache/airflow/assets/10106152/59ed61f6-679e-4032-93e6-91686df82985)


closes: [#35272](https://github.com/apache/airflow/issues/35272)

