### PR TITLE
Replace `datetime.datetime.utcnow` by `airflow.utils.timezone.utcnow` in core

### DIFF
--- a/airflow/secrets/cache.py
+++ b/airflow/secrets/cache.py
@@ -21,6 +21,7 @@ import datetime
 import multiprocessing
 
 from airflow.configuration import conf
+from airflow.utils import timezone
 
 
 class SecretCache:
@@ -36,10 +37,10 @@ class SecretCache:
     class _CacheValue:
         def __init__(self, value: str | None) -> None:
             self.value = value
-            self.date = datetime.datetime.utcnow()
+            self.date = timezone.utcnow()
 
         def is_expired(self, ttl: datetime.timedelta) -> bool:
-            return datetime.datetime.utcnow() - self.date > ttl
+            return timezone.utcnow() - self.date > ttl
 
     _VARIABLE_PREFIX = "__v_"
     _CONNECTION_PREFIX = "__c_"

--- a/airflow/task/task_runner/cgroup_task_runner.py
+++ b/airflow/task/task_runner/cgroup_task_runner.py
@@ -18,7 +18,6 @@
 """Task runner for cgroup to run Airflow task."""
 from __future__ import annotations
 
-import datetime
 import os
 import uuid
 from typing import TYPE_CHECKING
@@ -27,6 +26,7 @@ import psutil
 from cgroupspy import trees
 
 from airflow.task.task_runner.base_task_runner import BaseTaskRunner
+from airflow.utils import timezone
 from airflow.utils.operator_resources import Resources
 from airflow.utils.platform import getuser
 from airflow.utils.process_utils import reap_process_group
@@ -137,7 +137,7 @@ class CgroupTaskRunner(BaseTaskRunner):
             return
 
         # Create a unique cgroup name
-        cgroup_name = f"airflow/{datetime.datetime.utcnow():%Y-%m-%d}/{uuid.uuid4()}"
+        cgroup_name = f"airflow/{timezone.utcnow():%Y-%m-%d}/{uuid.uuid4()}"
 
         self.mem_cgroup_name = f"memory/{cgroup_name}"
         self.cpu_cgroup_name = f"cpu/{cgroup_name}"

--- a/airflow/timetables/interval.py
+++ b/airflow/timetables/interval.py
@@ -25,7 +25,7 @@ from pendulum import DateTime
 from airflow.exceptions import AirflowTimetableInvalid
 from airflow.timetables._cron import CronMixin
 from airflow.timetables.base import DagRunInfo, DataInterval, Timetable
-from airflow.utils.timezone import convert_to_utc
+from airflow.utils.timezone import coerce_datetime, convert_to_utc, utcnow
 
 if TYPE_CHECKING:
     from airflow.timetables.base import TimeRestriction
@@ -146,7 +146,7 @@ class CronDataIntervalTimetable(CronMixin, _DataIntervalTimetable):
         If the next schedule should start *right now*, we want the data interval
         that start now, not the one that ends now.
         """
-        current_time = DateTime.utcnow()
+        current_time = coerce_datetime(utcnow())
         last_start = self._get_prev(current_time)
         next_start = self._get_next(last_start)
         if next_start == current_time:  # Current time is on interval boundary.
@@ -257,7 +257,7 @@ class DeltaDataIntervalTimetable(_DataIntervalTimetable):
 
         This is slightly different from the cron version at terminal values.
         """
-        round_current_time = self._round(DateTime.utcnow())
+        round_current_time = self._round(coerce_datetime(utcnow()))
         new_start = self._get_prev(round_current_time)
         if earliest is None:
             return new_start

--- a/airflow/timetables/simple.py
+++ b/airflow/timetables/simple.py
@@ -19,11 +19,11 @@ from __future__ import annotations
 import operator
 from typing import TYPE_CHECKING, Any, Collection
 
-from pendulum import DateTime
-
 from airflow.timetables.base import DagRunInfo, DataInterval, Timetable
+from airflow.utils import timezone
 
 if TYPE_CHECKING:
+    from pendulum import DateTime
     from sqlalchemy import Session
 
     from airflow.models.dataset import DatasetEvent
@@ -134,10 +134,12 @@ class ContinuousTimetable(_TrivialTimetable):
             return None
         if last_automated_data_interval is not None:  # has already run once
             start = last_automated_data_interval.end
-            end = DateTime.utcnow()
+            end = timezone.coerce_datetime(timezone.utcnow())
         else:  # first run
             start = restriction.earliest
-            end = max(restriction.earliest, DateTime.utcnow())  # won't run any earlier than start_date
+            end = max(
+                restriction.earliest, timezone.coerce_datetime(timezone.utcnow())
+            )  # won't run any earlier than start_date
 
         if restriction.latest is not None and end > restriction.latest:
             return None

--- a/airflow/timetables/trigger.py
+++ b/airflow/timetables/trigger.py
@@ -19,13 +19,13 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING, Any
 
-from pendulum import DateTime
-
 from airflow.timetables._cron import CronMixin
 from airflow.timetables.base import DagRunInfo, DataInterval, Timetable
+from airflow.utils import timezone
 
 if TYPE_CHECKING:
     from dateutil.relativedelta import relativedelta
+    from pendulum import DateTime
     from pendulum.tz.timezone import FixedTimezone, Timezone
 
     from airflow.timetables.base import TimeRestriction
@@ -98,7 +98,7 @@ class CronTriggerTimetable(CronMixin, Timetable):
             else:
                 next_start_time = self._align_to_next(restriction.earliest)
         else:
-            start_time_candidates = [self._align_to_prev(DateTime.utcnow())]
+            start_time_candidates = [self._align_to_prev(timezone.coerce_datetime(timezone.utcnow()))]
             if last_automated_data_interval is not None:
                 start_time_candidates.append(self._get_next(last_automated_data_interval.end))
             if restriction.earliest is not None:

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -27,7 +27,6 @@ import threading
 import traceback
 import warnings
 from argparse import Namespace
-from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, TypeVar, cast
 
@@ -36,7 +35,7 @@ from sqlalchemy import select
 
 from airflow import settings
 from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
-from airflow.utils import cli_action_loggers
+from airflow.utils import cli_action_loggers, timezone
 from airflow.utils.log.non_caching_file_handler import NonCachingFileHandler
 from airflow.utils.platform import getuser, is_terminal_support_colors
 from airflow.utils.session import NEW_SESSION, provide_session
@@ -116,7 +115,7 @@ def action_cli(func=None, check_db=True):
                 metrics["error"] = e
                 raise
             finally:
-                metrics["end_datetime"] = datetime.utcnow()
+                metrics["end_datetime"] = timezone.utcnow()
                 cli_action_loggers.on_post_execution(**metrics)
 
         return cast(T, wrapper)
@@ -155,7 +154,7 @@ def _build_metrics(func_name, namespace):
 
     metrics = {
         "sub_command": func_name,
-        "start_datetime": datetime.utcnow(),
+        "start_datetime": timezone.utcnow(),
         "full_command": f"{full_command}",
         "user": getuser(),
     }

--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -152,14 +152,12 @@ def _dump_table_to_file(*, target_table, file_path, export_format, session):
 
 
 def _do_delete(*, query, orm_model, skip_archive, session):
-    from datetime import datetime
-
     import re2
 
     print("Performing Delete...")
     # using bulk delete
     # create a new table and copy the rows there
-    timestamp_str = re2.sub(r"[^\d]", "", datetime.utcnow().isoformat())[:14]
+    timestamp_str = re2.sub(r"[^\d]", "", timezone.utcnow().isoformat())[:14]
     target_table_name = f"{ARCHIVE_TABLE_PREFIX}{orm_model.name}__{timestamp_str}"
     print(f"Moving data to table {target_table_name}")
     bind = session.get_bind()

--- a/airflow/utils/jwt_signer.py
+++ b/airflow/utils/jwt_signer.py
@@ -16,10 +16,12 @@
 # under the License.
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any
 
 import jwt
+
+from airflow.utils import timezone
 
 
 class JWTSigner:
@@ -56,9 +58,9 @@ class JWTSigner:
         """
         jwt_dict = {
             "aud": self._audience,
-            "iat": datetime.utcnow(),
-            "nbf": datetime.utcnow(),
-            "exp": datetime.utcnow() + timedelta(seconds=self._expiration_time_in_seconds),
+            "iat": timezone.utcnow(),
+            "nbf": timezone.utcnow(),
+            "exp": timezone.utcnow() + timedelta(seconds=self._expiration_time_in_seconds),
         }
         jwt_dict.update(extra_payload)
         token = jwt.encode(

--- a/airflow/utils/log/file_processor_handler.py
+++ b/airflow/utils/log/file_processor_handler.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from pathlib import Path
 
 from airflow import settings
+from airflow.utils import timezone
 from airflow.utils.helpers import parse_template_string
 from airflow.utils.log.logging_mixin import DISABLE_PROPOGATE
 from airflow.utils.log.non_caching_file_handler import NonCachingFileHandler
@@ -102,9 +103,7 @@ class FileProcessorHandler(logging.Handler):
         return self.filename_template.format(filename=ctx["filename"])
 
     def _get_log_directory(self):
-        now = datetime.utcnow()
-
-        return os.path.join(self.base_log_folder, now.strftime("%Y-%m-%d"))
+        return os.path.join(self.base_log_folder, timezone.utcnow().strftime("%Y-%m-%d"))
 
     def _symlink_latest_log_directory(self):
         """

--- a/airflow/utils/timezone.py
+++ b/airflow/utils/timezone.py
@@ -60,13 +60,7 @@ def is_naive(value):
 
 def utcnow() -> dt.datetime:
     """Get the current date and time in UTC."""
-    # pendulum utcnow() is not used as that sets a TimezoneInfo object
-    # instead of a Timezone. This is not picklable and also creates issues
-    # when using replace()
-    result = dt.datetime.utcnow()
-    result = result.replace(tzinfo=utc)
-
-    return result
+    return dt.datetime.now(tz=utc)
 
 
 def utc_epoch() -> dt.datetime:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2975,7 +2975,7 @@ class Airflow(AirflowBaseView):
                 for (date, count) in dates.items()
             )
 
-        now = DateTime.utcnow()
+        now = timezone.utcnow()
         data = {
             "dag_states": data_dag_states,
             "start_date": (dag.start_date or now).date().isoformat(),
@@ -3561,7 +3561,7 @@ class Airflow(AirflowBaseView):
                 select(DagRun.run_type, func.count(DagRun.run_id))
                 .where(
                     DagRun.start_date >= start_date,
-                    func.coalesce(DagRun.end_date, datetime.datetime.utcnow()) <= end_date,
+                    func.coalesce(DagRun.end_date, timezone.utcnow()) <= end_date,
                 )
                 .group_by(DagRun.run_type)
             ).all()
@@ -3570,7 +3570,7 @@ class Airflow(AirflowBaseView):
                 select(DagRun.state, func.count(DagRun.run_id))
                 .where(
                     DagRun.start_date >= start_date,
-                    func.coalesce(DagRun.end_date, datetime.datetime.utcnow()) <= end_date,
+                    func.coalesce(DagRun.end_date, timezone.utcnow()) <= end_date,
                 )
                 .group_by(DagRun.state)
             ).all()
@@ -3581,7 +3581,7 @@ class Airflow(AirflowBaseView):
                 .join(TaskInstance.dag_run)
                 .where(
                     DagRun.start_date >= start_date,
-                    func.coalesce(DagRun.end_date, datetime.datetime.utcnow()) <= end_date,
+                    func.coalesce(DagRun.end_date, timezone.utcnow()) <= end_date,
                 )
                 .group_by(TaskInstance.state)
             ).all()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ import subprocess
 import sys
 import warnings
 from contextlib import ExitStack, suppress
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -584,7 +584,7 @@ def frozen_sleep(monkeypatch):
 
     def fake_sleep(seconds):
         nonlocal traveller
-        utcnow = datetime.utcnow()
+        utcnow = datetime.now(tz=timezone.utc)
         if traveller is not None:
             traveller.stop()
         traveller = time_machine.travel(utcnow + timedelta(seconds=seconds))

--- a/tests/dags/test_impersonation_subdag.py
+++ b/tests/dags/test_impersonation_subdag.py
@@ -18,14 +18,14 @@
 from __future__ import annotations
 
 import warnings
-from datetime import datetime
 
 from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
 from airflow.operators.subdag import SubDagOperator
+from airflow.utils import timezone
 
-DEFAULT_DATE = datetime(2016, 1, 1)
+DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
 default_args = {"owner": "airflow", "start_date": DEFAULT_DATE, "run_as_user": "airflow_test_user"}
 
@@ -33,7 +33,7 @@ dag = DAG(dag_id="impersonation_subdag", default_args=default_args)
 
 
 def print_today():
-    print(f"Today is {datetime.utcnow()}")
+    print(f"Today is {timezone.utcnow()}")
 
 
 subdag = DAG("impersonation_subdag.test_subdag_operation", default_args=default_args)

--- a/tests/dags/test_scheduler_dags.py
+++ b/tests/dags/test_scheduler_dags.py
@@ -17,16 +17,17 @@
 # under the License.
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from airflow.models.dag import DAG
 from airflow.operators.empty import EmptyOperator
+from airflow.utils import timezone
 
-DEFAULT_DATE = datetime(2016, 1, 1)
+DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
 # DAG tests backfill with pooled tasks
 # Previously backfill would queue the task but never run it
-dag1 = DAG(dag_id="test_start_date_scheduling", start_date=datetime.utcnow() + timedelta(days=1))
+dag1 = DAG(dag_id="test_start_date_scheduling", start_date=timezone.utcnow() + timedelta(days=1))
 dag1_task1 = EmptyOperator(task_id="dummy", dag=dag1, owner="airflow")
 
 dag2 = DAG(dag_id="test_task_start_date_scheduling", start_date=DEFAULT_DATE)

--- a/tests/decorators/test_external_python.py
+++ b/tests/decorators/test_external_python.py
@@ -139,7 +139,7 @@ class TestExternalPythonDecorator:
             return None
 
         with dag_maker():
-            ret = f(datetime.datetime.utcnow())
+            ret = f(datetime.datetime.now(tz=datetime.timezone.utc))
 
         ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 

--- a/tests/decorators/test_python_virtualenv.py
+++ b/tests/decorators/test_python_virtualenv.py
@@ -201,7 +201,7 @@ class TestPythonVirtualenvDecorator:
             return None
 
         with dag_maker():
-            ret = f(datetime.datetime.utcnow())
+            ret = f(datetime.datetime.now(tz=datetime.timezone.utc))
 
         ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 

--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -431,7 +431,7 @@ def test_trigger_from_dead_triggerer(session, create_task_instance):
     session.add(trigger_orm)
     ti_orm = create_task_instance(
         task_id="ti_orm",
-        execution_date=datetime.datetime.utcnow(),
+        execution_date=timezone.utcnow(),
         run_id="orm_run_id",
     )
     ti_orm.trigger_id = trigger_orm.id
@@ -458,7 +458,7 @@ def test_trigger_from_expired_triggerer(session, create_task_instance):
     session.add(trigger_orm)
     ti_orm = create_task_instance(
         task_id="ti_orm",
-        execution_date=datetime.datetime.utcnow(),
+        execution_date=timezone.utcnow(),
         run_id="orm_run_id",
     )
     ti_orm.trigger_id = trigger_orm.id

--- a/tests/models/test_skipmixin.py
+++ b/tests/models/test_skipmixin.py
@@ -55,7 +55,7 @@ class TestSkipMixin:
     @patch("airflow.utils.timezone.utcnow")
     def test_skip(self, mock_now, dag_maker):
         session = settings.Session()
-        now = datetime.datetime.utcnow().replace(tzinfo=pendulum.timezone("UTC"))
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
         mock_now.return_value = now
         with dag_maker("dag"):
             tasks = [EmptyOperator(task_id="task")]
@@ -77,7 +77,7 @@ class TestSkipMixin:
     @patch("airflow.utils.timezone.utcnow")
     def test_skip_none_dagrun(self, mock_now, dag_maker):
         session = settings.Session()
-        now = datetime.datetime.utcnow().replace(tzinfo=pendulum.timezone("UTC"))
+        now = datetime.datetime.now(tz=pendulum.timezone("UTC"))
         mock_now.return_value = now
         with dag_maker(
             "dag",

--- a/tests/operators/test_bash.py
+++ b/tests/operators/test_bash.py
@@ -67,7 +67,7 @@ class TestBashOperator:
         """
         Test that env variables are exported correctly to the task bash environment.
         """
-        utc_now = datetime.utcnow().replace(tzinfo=timezone.utc)
+        utc_now = datetime.now(tz=timezone.utc)
         expected = (
             f"{expected_airflow_home}\n"
             "AWESOME_PYTHONPATH\n"

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -26,7 +26,7 @@ import sys
 import tempfile
 import warnings
 from collections import namedtuple
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone as _timezone
 from functools import partial
 from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory
@@ -801,7 +801,7 @@ class BaseTestPythonVirtualenvOperator(BasePythonTest):
         def f(_):
             return None
 
-        self.run_as_task(f, op_args=[datetime.utcnow()])
+        self.run_as_task(f, op_args=[datetime.now(tz=_timezone.utc)])
 
     def test_context(self):
         def f(templates_dict):

--- a/tests/serialization/test_serialized_objects.py
+++ b/tests/serialization/test_serialized_objects.py
@@ -44,6 +44,7 @@ from airflow.serialization.pydantic.job import JobPydantic
 from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
 from airflow.serialization.pydantic.tasklog import LogTemplatePydantic
 from airflow.settings import _ENABLE_AIP_44
+from airflow.utils import timezone
 from airflow.utils.operator_resources import Resources
 from airflow.utils.state import DagRunState, State
 from airflow.utils.task_group import TaskGroup
@@ -113,14 +114,14 @@ TI_WITH_START_DAY = TaskInstance(
     run_id="fake_run",
     state=State.RUNNING,
 )
-TI_WITH_START_DAY.start_date = datetime.utcnow()
+TI_WITH_START_DAY.start_date = timezone.utcnow()
 
 DAG_RUN = DagRun(
     dag_id="test_dag_id",
     run_id="test_dag_run_id",
     run_type=DagRunType.MANUAL,
-    execution_date=datetime.utcnow(),
-    start_date=datetime.utcnow(),
+    execution_date=timezone.utcnow(),
+    start_date=timezone.utcnow(),
     external_trigger=True,
     state=DagRunState.SUCCESS,
 )
@@ -140,7 +141,7 @@ def equal_time(a: datetime, b: datetime) -> bool:
     [
         ("test_str", None, equals),
         (1, None, equals),
-        (datetime.utcnow(), DAT.DATETIME, equal_time),
+        (timezone.utcnow(), DAT.DATETIME, equal_time),
         (timedelta(minutes=2), DAT.TIMEDELTA, equals),
         (Timezone("UTC"), DAT.TIMEZONE, lambda a, b: a.name == b.name),
         (relativedelta.relativedelta(hours=+1), DAT.RELATIVEDELTA, lambda a, b: a.hours == b.hours),
@@ -151,7 +152,7 @@ def equal_time(a: datetime, b: datetime) -> bool:
         (
             k8s.V1Pod(
                 metadata=k8s.V1ObjectMeta(
-                    name="test", annotations={"test": "annotation"}, creation_timestamp=datetime.utcnow()
+                    name="test", annotations={"test": "annotation"}, creation_timestamp=timezone.utcnow()
                 )
             ),
             DAT.POD,
@@ -162,7 +163,7 @@ def equal_time(a: datetime, b: datetime) -> bool:
                 "fake-dag",
                 schedule="*/10 * * * *",
                 default_args={"depends_on_past": True},
-                start_date=datetime.utcnow(),
+                start_date=timezone.utcnow(),
                 catchup=False,
             ),
             DAT.DAG,
@@ -241,7 +242,7 @@ def test_backcompat_deserialize_connection(conn_uri):
     "input, pydantic_class, encoded_type, cmp_func",
     [
         (
-            Job(state=State.RUNNING, latest_heartbeat=datetime.utcnow()),
+            Job(state=State.RUNNING, latest_heartbeat=timezone.utcnow()),
             JobPydantic,
             DAT.BASE_JOB,
             lambda a, b: equal_time(a.latest_heartbeat, b.latest_heartbeat),

--- a/tests/utils/test_cli_util.py
+++ b/tests/utils/test_cli_util.py
@@ -23,7 +23,6 @@ import os
 import sys
 from argparse import Namespace
 from contextlib import contextmanager
-from datetime import datetime
 from pathlib import Path
 from unittest import mock
 
@@ -56,7 +55,7 @@ class TestCliUtil:
         for k, v in expected.items():
             assert v == metrics.get(k)
 
-        assert metrics.get("start_datetime") <= datetime.utcnow()
+        assert metrics.get("start_datetime") <= timezone.utcnow()
         assert metrics.get("full_command")
 
     def test_fail_function(self):
@@ -147,7 +146,7 @@ class TestCliUtil:
 
             log = session.query(Log).order_by(Log.dttm.desc()).first()
 
-        assert metrics.get("start_datetime") <= datetime.utcnow()
+        assert metrics.get("start_datetime") <= timezone.utcnow()
 
         command: str = json.loads(log.extra).get("full_command")
         # Replace single quotes to double quotes to avoid json decode error

--- a/tests/utils/test_db_cleanup.py
+++ b/tests/utils/test_db_cleanup.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 from contextlib import suppress
-from datetime import datetime
 from importlib import import_module
 from io import StringIO
 from pathlib import Path
@@ -34,6 +33,7 @@ from sqlalchemy.ext.declarative import DeclarativeMeta
 from airflow.exceptions import AirflowException
 from airflow.models import DagModel, DagRun, TaskInstance
 from airflow.operators.python import PythonOperator
+from airflow.utils import timezone
 from airflow.utils.db_cleanup import (
     ARCHIVE_TABLE_PREFIX,
     CreateTableAs,
@@ -354,13 +354,13 @@ class TestDBCleanup:
         Ensure every table we have configured (and that is present in the db) can be cleaned successfully.
         For example, this checks that the recency column is actually a column.
         """
-        run_cleanup(clean_before_timestamp=datetime.utcnow(), dry_run=True)
+        run_cleanup(clean_before_timestamp=timezone.utcnow(), dry_run=True)
         assert "Encountered error when attempting to clean table" not in caplog.text
 
         # Lets check we have the right error message just in case
         caplog.clear()
         with patch("airflow.utils.db_cleanup._cleanup_table", side_effect=OperationalError("oops", {}, None)):
-            run_cleanup(clean_before_timestamp=datetime.utcnow(), table_names=["task_instance"], dry_run=True)
+            run_cleanup(clean_before_timestamp=timezone.utcnow(), table_names=["task_instance"], dry_run=True)
         assert "Encountered error when attempting to clean table" in caplog.text
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This one deprecated in Python 3.12, see [What’s New In Python 3.12: Deprecated](https://docs.python.org/3/whatsnew/3.12.html#deprecated)

>[datetime](https://docs.python.org/3/library/datetime.html#module-datetime): [datetime.datetime](https://docs.python.org/3/library/datetime.html#datetime.datetime)’s [utcnow()](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) and [utcfromtimestamp()](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp) are deprecated and will be removed in a future version. Instead, use timezone-aware objects to represent datetimes in UTC: respectively, call [now()](https://docs.python.org/3/library/datetime.html#datetime.datetime.now) and [fromtimestamp()](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromtimestamp) with the tz parameter set to [datetime.UTC](https://docs.python.org/3/library/datetime.html#datetime.UTC). (Contributed by Paul Ganssle in [gh-103857](https://github.com/python/cpython/issues/103857).)

We still far away of support Python 3.12

Related: #32344

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
