### PR TITLE
Add mising common.io test_file_transfer.py

### DIFF
--- a/tests/always/test_project_structure.py
+++ b/tests/always/test_project_structure.py
@@ -120,7 +120,6 @@ class TestProjectStructure:
             "tests/providers/cncf/kubernetes/utils/test_delete_from.py",
             "tests/providers/cncf/kubernetes/utils/test_k8s_hashlib_wrapper.py",
             "tests/providers/cncf/kubernetes/utils/test_xcom_sidecar.py",
-            "tests/providers/common/io/operators/test_file_transfer.py",
             "tests/providers/daskexecutor/executors/test_dask_executor.py",
             "tests/providers/databricks/hooks/test_databricks_base.py",
             "tests/providers/dbt/cloud/hooks/test_dbt.py",

--- a/tests/providers/common/io/operators/__init__.py
+++ b/tests/providers/common/io/operators/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/common/io/operators/test_file_transfer.py
+++ b/tests/providers/common/io/operators/test_file_transfer.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from unittest import mock
+
+from airflow.providers.common.io.operators.file_transfer import FileTransferOperator
+
+
+def test_file_transfer_copy():
+    with mock.patch(
+        "airflow.providers.common.io.operators.file_transfer.ObjectStoragePath"
+    ) as mock_object_storage_path:
+        source_path = mock.MagicMock()
+        target_path = mock.MagicMock()
+        mock_object_storage_path.side_effect = [source_path, target_path]
+        source_path.exists.return_value = True
+        target_path.exists.return_value = False
+        operator = FileTransferOperator(
+            task_id="test_common_io_file_transfer_task",
+            src="test_source",
+            dst="test_target",
+        )
+        operator.execute(context={})
+        mock_object_storage_path.assert_has_calls(
+            [
+                mock.call("test_source", None),
+                mock.call("test_target", None),
+            ],
+        )
+        source_path.copy.assert_called_once_with(target_path)
+        target_path.copy.assert_not_called()


### PR DESCRIPTION
Since our test to detect missing tests was broken, lack of the test_file_transfer.py (among many others) has not been detected before.

This PR adds a simple test that mocks out ObjectStoragePath and tests that they are initialized properly and that execute method executes `copy` on the source Object poth (but also does not call copy on the target one).

Part of #35442

Also unblocks #35241 which fails becasuse Pytest fails when it sees no tests collected when `Providers[common.io]` TEST_TYPE is used.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
