### PR TITLE
Enable `TCH004` and `TCH005` rules

### DIFF
--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -40,7 +40,7 @@ from airflow.callbacks.callback_requests import (
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, TaskNotFound
 from airflow.models import SlaMiss, errors
-from airflow.models.dag import DagModel
+from airflow.models.dag import DAG, DagModel
 from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun as DR
 from airflow.models.dagwarning import DagWarning, DagWarningType
@@ -63,7 +63,6 @@ if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
 
     from airflow.callbacks.callback_requests import CallbackRequest
-    from airflow.models.dag import DAG
     from airflow.models.operator import Operator
 
 

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -91,6 +91,7 @@ __lazy_imports = {
     "DagPickle": "airflow.models.dagpickle",
     "DagRun": "airflow.models.dagrun",
     "DagTag": "airflow.models.dag",
+    "DagWarning": "airflow.models.dagwarning",
     "DbCallbackRequest": "airflow.models.db_callback_request",
     "ImportError": "airflow.models.errors",
     "Log": "airflow.models.log",
@@ -120,6 +121,7 @@ if TYPE_CHECKING:
     from airflow.models.dagbag import DagBag
     from airflow.models.dagpickle import DagPickle
     from airflow.models.dagrun import DagRun
+    from airflow.models.dagwarning import DagWarning
     from airflow.models.db_callback_request import DbCallbackRequest
     from airflow.models.errors import ImportError
     from airflow.models.log import Log

--- a/airflow/serialization/pydantic/job.py
+++ b/airflow/serialization/pydantic/job.py
@@ -16,15 +16,12 @@
 # under the License.
 import datetime
 from functools import cached_property
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from pydantic import BaseModel as BaseModelPydantic
 
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job_runner import BaseJobRunner
-
-if TYPE_CHECKING:
-    from airflow.jobs.job import Job
 
 
 def check_runner_initialized(job_runner: Optional[BaseJobRunner], job_type: str) -> BaseJobRunner:
@@ -59,11 +56,15 @@ class JobPydantic(BaseModelPydantic):
 
     @cached_property
     def heartrate(self) -> float:
+        from airflow.jobs.job import Job
+
         assert self.job_type is not None
         return Job._heartrate(self.job_type)
 
     def is_alive(self, grace_multiplier=2.1) -> bool:
         """Is this job currently alive."""
+        from airflow.jobs.job import Job
+
         return Job._is_alive(
             job_type=self.job_type,
             heartrate=self.heartrate,

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -80,9 +80,9 @@ if TYPE_CHECKING:
 
     HAS_KUBERNETES: bool
     try:
-        from kubernetes.client import models as k8s
+        from kubernetes.client import models as k8s  # noqa: TCH004
 
-        from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
+        from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator  # noqa: TCH004
     except ImportError:
         pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,7 @@ extend-select = [
     "D403",
     "D412",
     "D419",
-    "TCH001",  # typing-only-first-party-import
-    "TCH002",  # typing-only-third-party-import
+    "TCH",  # Rules around TYPE_CHECKING blocks
     "TID251",  # Specific modules or module members that may not be imported or accessed
     "TID253",  # Ban certain modules from being imported at module level
 ]
@@ -71,6 +70,7 @@ extend-ignore = [
     "D214",
     "D215",
     "E731",
+    "TCH003",  # Do not move imports from stdlib to TYPE_CHECKING block
 ]
 
 namespace-packages = ["airflow/providers"]
@@ -113,7 +113,7 @@ required-imports = ["from __future__ import annotations"]
 combine-as-imports = true
 
 [tool.ruff.per-file-ignores]
-"airflow/models/__init__.py" = ["F401"]
+"airflow/models/__init__.py" = ["F401", "TCH004"]
 "airflow/models/sqla_models.py" = ["F401"]
 
 # The test_python.py is needed because adding __future__.annotations breaks runtime checks that are


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Follow-up: https://github.com/apache/airflow/pull/35465#discussion_r1382726086

Enable two additional rules [TCH](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch) rules in ruff

1. `TCH004` - Check that import only use as type annotation, has false positive alarms so I think that is why it under the `--unsafe-fixes`

```console
airflow/dag_processing/processor.py:66:36: TCH004 Move import `airflow.models.dag.DAG` out of type-checking block. Import is used for more than type hinting.
airflow/serialization/pydantic/job.py:27:34: TCH004 Move import `airflow.jobs.job.Job` out of type-checking block. Import is used for more than type hinting.
```

2. `TCH005` - Remove empty `TYPE_CHECKING` block

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
