### PR TITLE
Fix Bullseye PROD build step

### DIFF
--- a/.github/actions/build-prod-images/action.yml
+++ b/.github/actions/build-prod-images/action.yml
@@ -25,19 +25,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: "Install Breeze"
-      uses: ./.github/actions/breeze
     - name: "Regenerate dependencies in case they was modified manually so that we can build an image"
       shell: bash
       run: |
         pip install rich>=12.4.4 pyyaml
         python scripts/ci/pre_commit/pre_commit_update_providers_dependencies.py
       if: env.UPGRADE_TO_NEWER_DEPENDENCIES != 'false'
-    - name: "Pull CI image for PROD build: ${{ env.PYTHON_VERSIONS }}:${{ env.IMAGE_TAG }}"
-      shell: bash
-      run: breeze ci-image pull --tag-as-latest
-      env:
-        PYTHON_MAJOR_MINOR_VERSION: "3.8"
     - name: "Cleanup dist and context file"
       shell: bash
       run: rm -fv ./dist/* ./docker-context-files/*

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -299,6 +299,15 @@ jobs:
           mv -v "target-airflow/dev" "."
           rm -rfv ".github/actions"
           mv -v "target-airflow/.github/actions" ".github"
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
+      - name: >
+          Pull CI image for PROD build:
+          ${{ steps.selective-checks.outputs.default-python-version }}:${{ env.IMAGE_TAG }}"
+        shell: bash
+        run: breeze ci-image pull --tag-as-latest
+        env:
+          PYTHON_MAJOR_MINOR_VERSION: ${{ steps.selective-checks.outputs.default-python-version }}
       - name: >
           Build PROD Images
           ${{needs.build-info.outputs.all-python-versions-list-as-string}}:${{env.IMAGE_TAG}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,6 +415,15 @@ jobs:
           ref: ${{ needs.build-info.outputs.targetCommitSha }}
           persist-credentials: false
         if: needs.build-info.outputs.in-workflow-build == 'true'
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
+      - name: >
+          Pull CI image for PROD build:
+          ${{ steps.selective-checks.outputs.default-python-version }}:${{ env.IMAGE_TAG }}"
+        shell: bash
+        run: breeze ci-image pull --tag-as-latest
+        env:
+          PYTHON_MAJOR_MINOR_VERSION: ${{ steps.selective-checks.outputs.default-python-version }}
       - name: >
           Build PROD Images
           ${{needs.build-info.outputs.all-python-versions-list-as-string}}:${{env.IMAGE_TAG}}
@@ -431,7 +440,7 @@ jobs:
   build-prod-images-bullseye:
     timeout-minutes: 80
     name: >
-      ${{needs.build-info.outputs.build-job-description}} PROD images
+      ${{needs.build-info.outputs.build-job-description}} Bullseye PROD images
       ${{needs.build-info.outputs.all-python-versions-list-as-string}}
     runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
     needs: [build-info, build-ci-images, generate-constraints]
@@ -454,8 +463,17 @@ jobs:
           ref: ${{ needs.build-info.outputs.targetCommitSha }}
           persist-credentials: false
           submodules: recursive
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: >
-          Build PROD Images Bullseye
+          Pull CI image for PROD build:
+          ${{ steps.selective-checks.outputs.default-python-version }}:${{ env.IMAGE_TAG }}"
+        shell: bash
+        run: breeze ci-image pull --tag-as-latest
+        env:
+          PYTHON_MAJOR_MINOR_VERSION: ${{ steps.selective-checks.outputs.default-python-version }}
+      - name: >
+          Build Bullseye PROD Images
           ${{needs.build-info.outputs.all-python-versions-list-as-string}}:${{env.IMAGE_TAG}}
         uses: ./.github/actions/build-prod-images
         with:
@@ -468,7 +486,7 @@ jobs:
           DEBIAN_VERSION: "bullseye"
           # Do not override the "bookworm" image - just push a new bullseye image
           # TODO: improve caching for that build
-          IMAGE_TAG: bullseye-"${{ github.event.pull_request.head.sha || github.sha }}"
+          IMAGE_TAG: "bullseye-${{ github.event.pull_request.head.sha || github.sha }}"
 
   run-breeze-tests:
     timeout-minutes: 10


### PR DESCRIPTION
The Bullseye PRD build step in `main` is failing after switching to bookworm - for two reasons:

1) The CI image used to build packages is pulled using bullseye TAG 2) The bullseye tag is wrong - containing `"`

This PR fixes that by:

* separating out CI image pull for the build from composite action to build production image
* fixing the tag
* updates names of job and steps to show clearly Bullseye

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
