### PR TITLE
Refactor cursor retrieval in PostgresHook.

### DIFF
--- a/airflow/providers/postgres/hooks/postgres.py
+++ b/airflow/providers/postgres/hooks/postgres.py
@@ -111,13 +111,19 @@ class PostgresHook(DbApiHook):
 
     def _get_cursor(self, raw_cursor: str) -> CursorType:
         _cursor = raw_cursor.lower()
-        if _cursor == "dictcursor":
-            return psycopg2.extras.DictCursor
-        if _cursor == "realdictcursor":
-            return psycopg2.extras.RealDictCursor
-        if _cursor == "namedtuplecursor":
-            return psycopg2.extras.NamedTupleCursor
-        raise ValueError(f"Invalid cursor passed {_cursor}")
+
+        cursor_types = {
+            "dictcursor": psycopg2.extras.DictCursor,
+            "realdictcursor": psycopg2.extras.RealDictCursor,
+            "namedtuplecursor": psycopg2.extras.NamedTupleCursor,
+        }
+
+        if _cursor in cursor_types:
+            return cursor_types[_cursor]
+        else:
+            valid_cursors = ", ".join(cursor_types.keys())
+            raise ValueError(f"Invalid cursor passed {_cursor}. Valid options are: {valid_cursors}")
+
 
     def get_conn(self) -> connection:
         """Establishes a connection to a postgres database."""

--- a/airflow/providers/postgres/hooks/postgres.py
+++ b/airflow/providers/postgres/hooks/postgres.py
@@ -111,19 +111,16 @@ class PostgresHook(DbApiHook):
 
     def _get_cursor(self, raw_cursor: str) -> CursorType:
         _cursor = raw_cursor.lower()
-
         cursor_types = {
             "dictcursor": psycopg2.extras.DictCursor,
             "realdictcursor": psycopg2.extras.RealDictCursor,
             "namedtuplecursor": psycopg2.extras.NamedTupleCursor,
         }
-
         if _cursor in cursor_types:
             return cursor_types[_cursor]
         else:
             valid_cursors = ", ".join(cursor_types.keys())
             raise ValueError(f"Invalid cursor passed {_cursor}. Valid options are: {valid_cursors}")
-
 
     def get_conn(self) -> connection:
         """Establishes a connection to a postgres database."""


### PR DESCRIPTION
Refactored the `_get_cursor` method for improved efficiency and error handling.
The method now uses a dictionary for cursor type lookup, streamlining the addition of future cursor types and providing clearer error messages for invalid cursors.