### PR TITLE
Remove tenacity on KPO logs inner func consume_logs

### DIFF
--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -383,11 +383,6 @@ class PodManager(LoggingMixin):
         specific exception.
         """
 
-        @tenacity.retry(
-            retry=tenacity.retry_if_exception_type(ApiException),
-            stop=tenacity.stop_after_attempt(10),
-            wait=tenacity.wait_fixed(1),
-        )
         def consume_logs(
             *,
             since_time: DateTime | None = None,


### PR DESCRIPTION
There are many overlapping layers and strategies of retrying in this area of code.  It appears this particular layer may be unnecessary.  See discussion starting at https://github.com/apache/airflow/pull/31622#issuecomment-1793124398.
