### PR TITLE
Increase timeout for flaky Test_BranchPythonDecoratedOperator test

### DIFF
--- a/tests/decorators/test_branch_python.py
+++ b/tests/decorators/test_branch_python.py
@@ -26,6 +26,10 @@ pytestmark = pytest.mark.db_test
 
 
 class Test_BranchPythonDecoratedOperator:
+    # when run in "Parallel" test run environment, sometimes this test runs for a long time
+    # because creating virtualenv and starting new Python interpreter creates a lot of IO/contention
+    # possibilities. So we are increasing the timeout for this test to 3x of the default timeout
+    @pytest.mark.execution_timeout(180)
     @pytest.mark.parametrize("branch_task_name", ["task_1", "task_2"])
     def test_branch_one(self, dag_maker, branch_task_name):
         @task


### PR DESCRIPTION
Similar to #35473 - this test sometimes (very rarely) exceeds the default 60 seconds timeout when run in Paralllel test environment where we have multiple containers and multiple databases and multiple parallel tests runnign at the same time on single virtual machine (in order to maximise the gains from parallelism).

This test sometimes fails with **just** above 60 seconds, so following the 3x rule explained in the long description of reasoning why we are doing it https://github.com/apache/airflow/pull/35473#issuecomment-1795408176

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
