### PR TITLE
Improve error handling in AWS Links

### DIFF
--- a/airflow/providers/amazon/aws/links/base_aws.py
+++ b/airflow/providers/amazon/aws/links/base_aws.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, ClassVar
 
 from airflow.models import BaseOperatorLink, XCom
+from airflow.providers.amazon.aws.utils.suppress import return_on_error
 
 if TYPE_CHECKING:
     from airflow.models import BaseOperator
@@ -60,6 +61,7 @@ class BaseAwsLink(BaseOperatorLink):
         except KeyError:
             return ""
 
+    @return_on_error("")
     def get_link(
         self,
         operator: BaseOperator,
@@ -77,6 +79,7 @@ class BaseAwsLink(BaseOperatorLink):
         return self.format_link(**conf) if conf else ""
 
     @classmethod
+    @return_on_error(None)
     def persist(
         cls, context: Context, operator: BaseOperator, region_name: str, aws_partition: str, **kwargs
     ) -> None:

--- a/airflow/providers/amazon/aws/links/emr.py
+++ b/airflow/providers/amazon/aws/links/emr.py
@@ -43,7 +43,7 @@ class EmrLogsLink(BaseAwsLink):
     format_str = BASE_AWS_CONSOLE_LINK + "/s3/buckets/{log_uri}?region={region_name}&prefix={job_flow_id}/"
 
     def format_link(self, **kwargs) -> str:
-        if not kwargs["log_uri"]:
+        if not kwargs.get("log_uri"):
             return ""
         return super().format_link(**kwargs)
 

--- a/tests/providers/amazon/aws/links/test_base_aws.py
+++ b/tests/providers/amazon/aws/links/test_base_aws.py
@@ -228,7 +228,6 @@ class BaseAwsLinksTestCase:
     def test_suppress_error_on_xcom_pull(self):
         """Test ignore any error on XCom pull"""
         with mock.patch.object(XCom, "get_value", side_effect=OSError("FakeError")) as m:
-            # m.get_value = mock.MagicMock(name="Foo")
             op, ti = self.create_op_and_ti(
                 self.link_class, dag_id="test_error_on_xcom_pull", task_id=self.task_id
             )

--- a/tests/providers/amazon/aws/links/test_base_aws.py
+++ b/tests/providers/amazon/aws/links/test_base_aws.py
@@ -18,16 +18,17 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from typing import TYPE_CHECKING, NamedTuple
-from unittest.mock import MagicMock
+from unittest import mock
 
 import pytest
 
+from airflow.models.xcom import XCom
 from airflow.providers.amazon.aws.links.base_aws import BaseAwsLink
 from airflow.serialization.serialized_objects import SerializedDAG
 from tests.test_utils.mock_operators import MockOperator
 
 if TYPE_CHECKING:
-    from airflow.models import TaskInstance
+    from airflow.models.taskinstance import TaskInstance
 
 XCOM_KEY = "test_xcom_key"
 CUSTOM_KEYS = {
@@ -63,7 +64,7 @@ class TestBaseAwsLink:
         ],
     )
     def test_persist(self, region_name, aws_partition, keywords, expected_value):
-        mock_context = MagicMock()
+        mock_context = mock.MagicMock()
 
         SimpleBaseAwsLink.persist(
             context=mock_context,
@@ -81,7 +82,7 @@ class TestBaseAwsLink:
         )
 
     def test_disable_xcom_push(self):
-        mock_context = MagicMock()
+        mock_context = mock.MagicMock()
         SimpleBaseAwsLink.persist(
             context=mock_context,
             operator=MockOperator(task_id="test_task_id", do_xcom_push=False),
@@ -90,6 +91,21 @@ class TestBaseAwsLink:
         )
         ti = mock_context["ti"]
         ti.xcom_push.assert_not_called()
+
+    def test_suppress_error_on_xcom_push(self):
+        mock_context = mock.MagicMock()
+        with mock.patch.object(MockOperator, "xcom_push", side_effect=PermissionError("FakeError")) as m:
+            SimpleBaseAwsLink.persist(
+                context=mock_context,
+                operator=MockOperator(task_id="test_task_id"),
+                region_name="eu-east-1",
+                aws_partition="aws",
+            )
+            m.assert_called_once_with(
+                mock_context,
+                key="test_xcom_key",
+                value={"region_name": "eu-east-1", "aws_domain": "aws.amazon.com"},
+            )
 
 
 def link_test_operator(*links):
@@ -162,7 +178,7 @@ class BaseAwsLinksTestCase:
         """Helper method for create extra link URL from the parameters."""
         task, ti = self.create_op_and_ti(self.link_class, dag_id="test_extra_link", task_id=self.task_id)
 
-        mock_context = MagicMock()
+        mock_context = mock.MagicMock()
         mock_context.__getitem__.side_effect = {"ti": ti}.__getitem__
 
         self.link_class.persist(
@@ -208,6 +224,16 @@ class BaseAwsLinksTestCase:
         assert (
             deserialized_task.get_extra_links(ti, self.link_class.name) == ""
         ), "Operator link should be empty for deserialized task with no XCom push"
+
+    def test_suppress_error_on_xcom_pull(self):
+        """Test ignore any error on XCom pull"""
+        with mock.patch.object(XCom, "get_value", side_effect=OSError("FakeError")) as m:
+            # m.get_value = mock.MagicMock(name="Foo")
+            op, ti = self.create_op_and_ti(
+                self.link_class, dag_id="test_error_on_xcom_pull", task_id=self.task_id
+            )
+            self.link_class().get_link(op, ti_key=ti.key)
+            m.assert_called_once()
 
     @abstractmethod
     def test_extra_link(self, **kwargs):

--- a/tests/providers/amazon/aws/links/test_emr.py
+++ b/tests/providers/amazon/aws/links/test_emr.py
@@ -68,7 +68,7 @@ class TestEmrLogsLink(BaseAwsLinksTestCase):
     @pytest.mark.parametrize(
         "log_url_extra",
         [
-            pytest.param({}, id="no-log-uri", marks=pytest.mark.xfail),
+            pytest.param({}, id="no-log-uri"),
             pytest.param({"log_uri": None}, id="log-uri-none"),
             pytest.param({"log_uri": ""}, id="log-uri-empty"),
         ],


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Follow-up: #35484

Do not fail on call `BaseAwsLink.get_link` and `BaseAwsLink.persist ` methods, if something going wrong then it won't affect Operators/Sensors execution

Fix handling missing `log_uri` into the EmrLogsLink XCOM value


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
