### PR TITLE
Move Jens Scheffler to committer role

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -77,7 +77,6 @@ github:
     - utkarsharma2
     - Lee-W
     - sunank200
-    - jscheffl
     - nathadfield
     - RNHTTR
 

--- a/COMMITTERS.rst
+++ b/COMMITTERS.rst
@@ -196,5 +196,7 @@ To be able to merge PRs, committers have to integrate their GitHub ID with Apach
 6.  Ask in ``#internal-airflow-ci-cd`` channel to be `configured in self-hosted runners <https://github.com/apache/airflow-ci-infra/blob/main/scripts/list_committers>`_
     by the CI maintainers. Wait for confirmation that this is done and some helpful tips from the CI maintainer
 7.  After confirming that step 6 is done, open a PR to include your GitHub ID in:
+
     * ``dev/breeze/src/airflow_breeze/global_constants.py`` (COMMITTERS variable)
     * name and GitHub ID in `project.rst <https://github.com/apache/airflow/blob/main/docs/apache-airflow/project.rst>`__.
+    * If you had been a collaborator role before getting committer, remove your Github ID from ``.asf.yaml``.

--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -317,6 +317,7 @@ COMMITTERS = [
     "jhtimmins",
     "jmcarp",
     "josh-fell",
+    "jscheffl",
     "kaxil",
     "leahecole",
     "malthe",

--- a/docs/apache-airflow/project.rst
+++ b/docs/apache-airflow/project.rst
@@ -62,6 +62,7 @@ Committers
 - James Timmins (@jhtimmins)
 - Jarek Potiuk (@potiuk)
 - Jed Cunningham (@jedcunningham)
+- Jens Scheffler (@jscheffl)
 - Jiajie Zhong (@zhongjiajie)
 - Josh Fell (@josh-fell)
 - Joshua Carp (@jmcarp)


### PR DESCRIPTION
This PR adds the meta data for jscheffl as new committer tu use the self-hosted runners as well makes a small nit on documentation update.