### PR TITLE
Numeric values in DAG details are incorrectly rendered as timestamps

### DIFF
--- a/airflow/www/static/js/dag/details/Dag.tsx
+++ b/airflow/www/static/js/dag/details/Dag.tsx
@@ -129,9 +129,14 @@ const Dag = () => {
   const firstStart = dagRuns[0]?.startDate;
   const lastStart = dagRuns[dagRuns.length - 1]?.startDate;
 
+  console.log(String(1));
+  console.log(Date.parse(String(1)))
+
   // parse value for each key if date or not
+  // Check "!Number.isNaN(value)" is needed due to 
+  // Date.parse() sometimes returning valid date for numbers.
   const parseStringData = (value: string) =>
-    Number.isNaN(Date.parse(value)) ? value : <Time dateTime={value} />;
+    Number.isNaN(Date.parse(value)) || !Number.isNaN(value) ? value : <Time dateTime={value} />;
 
   // render dag and dag_details data
   const renderDagDetailsData = (

--- a/airflow/www/static/js/dag/details/Dag.tsx
+++ b/airflow/www/static/js/dag/details/Dag.tsx
@@ -131,7 +131,7 @@ const Dag = () => {
 
   // parse value for each key if date or not
   // check "!Number.isNaN(value)" is needed due to 
-  // Date.parse() sometimes returning valid date for numbers.
+  // Date.parse() sometimes returning valid date's timestamp for numbers.
   const parseStringData = (value: string) =>
     Number.isNaN(Date.parse(value)) || !Number.isNaN(value) ? value : <Time dateTime={value} />;
 

--- a/airflow/www/static/js/dag/details/Dag.tsx
+++ b/airflow/www/static/js/dag/details/Dag.tsx
@@ -130,10 +130,14 @@ const Dag = () => {
   const lastStart = dagRuns[dagRuns.length - 1]?.startDate;
 
   // parse value for each key if date or not
-  // check "!Number.isNaN(value)" is needed due to 
+  // check "!Number.isNaN(value)" is needed due to
   // Date.parse() sometimes returning valid date's timestamp for numbers.
   const parseStringData = (value: string) =>
-    Number.isNaN(Date.parse(value)) || !Number.isNaN(value) ? value : <Time dateTime={value} />;
+    Number.isNaN(Date.parse(value)) || !Number.isNaN(value) ? (
+      value
+    ) : (
+      <Time dateTime={value} />
+    );
 
   // render dag and dag_details data
   const renderDagDetailsData = (

--- a/airflow/www/static/js/dag/details/Dag.tsx
+++ b/airflow/www/static/js/dag/details/Dag.tsx
@@ -129,11 +129,8 @@ const Dag = () => {
   const firstStart = dagRuns[0]?.startDate;
   const lastStart = dagRuns[dagRuns.length - 1]?.startDate;
 
-  console.log(String(1));
-  console.log(Date.parse(String(1)))
-
   // parse value for each key if date or not
-  // Check "!Number.isNaN(value)" is needed due to 
+  // check "!Number.isNaN(value)" is needed due to 
   // Date.parse() sometimes returning valid date for numbers.
   const parseStringData = (value: string) =>
     Number.isNaN(Date.parse(value)) || !Number.isNaN(value) ? value : <Time dateTime={value} />;


### PR DESCRIPTION
Resolves issue of rendering certain numbers in some browsers as dates as opposed to numbers. This issue is well described: [on this page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#non-standard_date_strings).


Before:
![Screenshot 2023-11-08 at 19 19 30](https://github.com/apache/airflow/assets/10106152/007bf028-9b28-4b35-a748-8623bf6e6720)


After:
![Screenshot 2023-11-08 at 19 18 53](https://github.com/apache/airflow/assets/10106152/76301bc2-c77e-4b7e-99c9-647f09a52b4d)



closes: https://github.com/apache/airflow/issues/35500

