### PR TITLE
Avoid initiating SQLAlchemy session twice in dag_next_execution

### DIFF
--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -320,13 +320,13 @@ def dag_next_execution(args) -> None:
     """
     dag = get_dag(args.subdir, args.dag_id)
 
-    if dag.get_is_paused():
-        print("[INFO] Please be reminded this DAG is PAUSED now.", file=sys.stderr)
-
     with create_session() as session:
         last_parsed_dag: DagModel = session.scalars(
             select(DagModel).where(DagModel.dag_id == dag.dag_id)
         ).one()
+
+    if last_parsed_dag.get_is_paused():
+        print("[INFO] Please be reminded this DAG is PAUSED now.", file=sys.stderr)
 
     def print_execution_interval(interval: DataInterval | None):
         if interval is None:


### PR DESCRIPTION
No-issue

**Modifications:**
We don't have to initiate SQLAlchemy session twice when we call the method `get_is_paused`

`dag.get_is_paused()` will query the database which is redundant.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
