### PR TITLE
Stabilize remaining BranchDecoratedOperators tests

### DIFF
--- a/tests/decorators/test_branch_external_python.py
+++ b/tests/decorators/test_branch_external_python.py
@@ -27,7 +27,11 @@ from airflow.utils.state import State
 pytestmark = pytest.mark.db_test
 
 
-class Test_BranchPythonDecoratedOperator:
+class Test_BranchExternalPythonDecoratedOperator:
+    # when run in "Parallel" test run environment, sometimes this test runs for a long time
+    # because creating virtualenv and starting new Python interpreter creates a lot of IO/contention
+    # possibilities. So we are increasing the timeout for this test to 3x of the default timeout
+    @pytest.mark.execution_timeout(180)
     @pytest.mark.parametrize("branch_task_name", ["task_1", "task_2"])
     def test_branch_one(self, dag_maker, branch_task_name):
         @task

--- a/tests/decorators/test_branch_virtualenv.py
+++ b/tests/decorators/test_branch_virtualenv.py
@@ -25,7 +25,11 @@ from airflow.utils.state import State
 pytestmark = pytest.mark.db_test
 
 
-class Test_BranchPythonDecoratedOperator:
+class Test_BranchPythonVirtualenvDecoratedOperator:
+    # when run in "Parallel" test run environment, sometimes this test runs for a long time
+    # because creating virtualenv and starting new Python interpreter creates a lot of IO/contention
+    # possibilities. So we are increasing the timeout for this test to 3x of the default timeout
+    @pytest.mark.execution_timeout(180)
     @pytest.mark.parametrize("branch_task_name", ["task_1", "task_2"])
     def test_branch_one(self, dag_maker, branch_task_name):
         @task


### PR DESCRIPTION
As a follow-up after #35511 it turned out that we have THREE tests which are named Test_BranchDecoratedOperator - because they were copied originally from the "Python" one - there is a Python, ExternalPython and PythonVirtualenv tests :).

The #35551 only added timeout in one of them - and in the least problematic one at that (Python). This PR also adds it in the other tests and renames the tests classes to distinguish between the different tests (to more easily see which one failed).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
