### PR TITLE
Fix: Paginate on lastest Response

### DIFF
--- a/airflow/providers/http/operators/http.py
+++ b/airflow/providers/http/operators/http.py
@@ -162,16 +162,16 @@ class HttpOperator(BaseOperator):
     def execute_sync(self, context: Context) -> Any:
         self.log.info("Calling HTTP method")
         response = self.hook.run(self.endpoint, self.data, self.headers, self.extra_options)
-        response = self.paginate_sync(first_response=response)
+        response = self.paginate_sync(response=response)
         return self.process_response(context=context, response=response)
 
-    def paginate_sync(self, first_response: Response) -> Response | list[Response]:
+    def paginate_sync(self, response: Response) -> Response | list[Response]:
         if not self.pagination_function:
-            return first_response
+            return response
 
-        all_responses = [first_response]
+        all_responses = [response]
         while True:
-            next_page_params = self.pagination_function(first_response)
+            next_page_params = self.pagination_function(response)
             if not next_page_params:
                 break
             response = self.hook.run(**self._merge_next_page_parameters(next_page_params))

--- a/airflow/providers/http/operators/http.py
+++ b/airflow/providers/http/operators/http.py
@@ -53,14 +53,15 @@ class HttpOperator(BaseOperator):
     :param data: The data to pass. POST-data in POST/PUT and params
         in the URL for a GET request. (templated)
     :param headers: The HTTP headers to be added to the GET request
-    :param pagination_function: A callable that generates the parameters used to call the API again.
-        Typically used when the API is paginated and returns for e.g a cursor, a 'next page id', or
-        a 'next page URL'. When provided, the Operator will call the API repeatedly until this callable
-        returns None. Also, the result of the Operator will become by default a list of Response.text
-        objects (instead of a single response object). Same with the other injected functions (like
-        response_check, response_filter, ...) which will also receive a list of Response object. This
-        function should return a dict of parameters (`endpoint`, `data`, `headers`, `extra_options`),
-        which will be merged and override the one used in the initial API call.
+    :param pagination_function: A callable that generates the parameters used to call the API again,
+        based on the previous response. Typically used when the API is paginated and returns for e.g a
+        cursor, a 'next page id', or a 'next page URL'. When provided, the Operator will call the API
+        repeatedly until this callable returns None. Also, the result of the Operator will become by
+        default a list of Response.text objects (instead of a single response object). Same with the
+        other injected functions (like response_check, response_filter, ...) which will also receive a
+        list of Response object. This function receives a Response object form previous call, and should
+        return a dict of parameters (`endpoint`, `data`, `headers`, `extra_options`), which will be merged
+        and will override the one used in the initial API call.
     :param response_check: A check against the 'requests' response object.
         The callable takes the response object as the first positional argument
         and optionally any number of keyword arguments available in the context dictionary.

--- a/tests/providers/http/operators/test_http.py
+++ b/tests/providers/http/operators/test_http.py
@@ -126,7 +126,7 @@ class TestHttpOperator:
             if iterations < 2:
                 iterations += 1
                 return dict(
-                    endpoint=response.json()['endpoint'],
+                    endpoint=response.json()["endpoint"],
                     data={},
                     headers={},
                     extra_options={},
@@ -141,7 +141,7 @@ class TestHttpOperator:
             endpoint="/foo",
             http_conn_id="HTTP_EXAMPLE",
             pagination_function=pagination_function,
-            response_filter=lambda resp: [entry.json()['value'] for entry in resp]
+            response_filter=lambda resp: [entry.json()["value"] for entry in resp],
         )
         result = operator.execute({})
         assert result == [5, 10, 5]

--- a/tests/providers/http/operators/test_http.py
+++ b/tests/providers/http/operators/test_http.py
@@ -118,32 +118,33 @@ class TestHttpOperator:
         pagination_function is provided, and as long as this function returns
         a dictionary that override previous' call parameters.
         """
-        has_returned: bool = False
+        iterations: int = 0
 
         def pagination_function(response: Response) -> dict | None:
             """Paginated function which returns None at the second call."""
-            nonlocal has_returned
-            if not has_returned:
-                has_returned = True
+            nonlocal iterations
+            if iterations < 2:
+                iterations += 1
                 return dict(
-                    endpoint="/bar",
+                    endpoint=response.json()['endpoint'],
                     data={},
                     headers={},
                     extra_options={},
                 )
             return None
 
-        requests_mock.get("http://www.example.com/foo", json={"value": 5})
-        requests_mock.get("http://www.example.com/bar", json={"value": 10})
+        requests_mock.get("http://www.example.com/foo", json={"value": 5, "endpoint": "bar"})
+        requests_mock.get("http://www.example.com/bar", json={"value": 10, "endpoint": "foo"})
         operator = HttpOperator(
             task_id="test_HTTP_op",
             method="GET",
             endpoint="/foo",
             http_conn_id="HTTP_EXAMPLE",
             pagination_function=pagination_function,
+            response_filter=lambda resp: [entry.json()['value'] for entry in resp]
         )
         result = operator.execute({})
-        assert result == ['{"value": 5}', '{"value": 10}']
+        assert result == [5, 10, 5]
 
     def test_async_paginated_responses(self, requests_mock):
         """

--- a/tests/providers/http/operators/test_http.py
+++ b/tests/providers/http/operators/test_http.py
@@ -126,23 +126,24 @@ class TestHttpOperator:
             if not has_returned:
                 has_returned = True
                 return dict(
-                    endpoint="/",
-                    data={"cursor": "example"},
+                    endpoint="/bar",
+                    data={},
                     headers={},
                     extra_options={},
                 )
             return None
 
-        requests_mock.get("http://www.example.com", json={"value": 5})
+        requests_mock.get("http://www.example.com/foo", json={"value": 5})
+        requests_mock.get("http://www.example.com/bar", json={"value": 10})
         operator = HttpOperator(
             task_id="test_HTTP_op",
             method="GET",
-            endpoint="/",
+            endpoint="/foo",
             http_conn_id="HTTP_EXAMPLE",
             pagination_function=pagination_function,
         )
         result = operator.execute({})
-        assert result == ['{"value": 5}', '{"value": 5}']
+        assert result == ['{"value": 5}', '{"value": 10}']
 
     def test_async_paginated_responses(self, requests_mock):
         """


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The new pagination functionality of the `HttpOperator` do not work as expected when non-deferred:
If should pass the latest response to the pagination_function, instead of always passing the very first response.

This PR clarify and fix this behavior.

<br>
<br>

*Apologize for this. Between all the changes in the initial PR, I overlooked this issue, and my initial test was not strong enough to highlight it. Will definitively take more care !*

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
