### PR TITLE
Add batch is_authorized APIs to auth manager

### DIFF
--- a/airflow/auth/managers/models/batch_apis.py
+++ b/airflow/auth/managers/models/batch_apis.py
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
+
+if TYPE_CHECKING:
+    from airflow.auth.managers.base_auth_manager import ResourceMethod
+    from airflow.auth.managers.models.base_user import BaseUser
+    from airflow.auth.managers.models.resource_details import (
+        ConnectionDetails,
+        DagAccessEntity,
+        DagDetails,
+        PoolDetails,
+        VariableDetails,
+    )
+
+
+class IsAuthorizedConnectionRequest(TypedDict, total=False):
+    """Represent the parameters of ``is_authorized_connection`` API in the auth manager."""
+
+    method: ResourceMethod
+    details: ConnectionDetails | None
+    user: BaseUser | None
+
+
+class IsAuthorizedDagRequest(TypedDict, total=False):
+    """Represent the parameters of ``is_authorized_dag`` API in the auth manager."""
+
+    method: ResourceMethod
+    access_entity: DagAccessEntity | None
+    details: DagDetails | None
+    user: BaseUser | None
+
+
+class IsAuthorizedPoolRequest(TypedDict, total=False):
+    """Represent the parameters of ``is_authorized_pool`` API in the auth manager."""
+
+    method: ResourceMethod
+    details: PoolDetails | None
+    user: BaseUser | None
+
+
+class IsAuthorizedVariableRequest(TypedDict, total=False):
+    """Represent the parameters of ``is_authorized_variable`` API in the auth manager."""
+
+    method: ResourceMethod
+    details: VariableDetails | None
+    user: BaseUser | None

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -994,7 +994,7 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
         )
         assert response.status_code == 403
         assert response.json == {
-            "detail": "User not allowed to access these DAGs: ['example_skip_dag']",
+            "detail": "User not allowed to access some of these DAGs: ['example_python_operator', 'example_skip_dag']",
             "status": 403,
             "title": "Forbidden",
             "type": EXCEPTIONS_LINK_MAP[403],

--- a/tests/www/test_auth.py
+++ b/tests/www/test_auth.py
@@ -115,9 +115,13 @@ class TestHasAccessNoDetails:
 @pytest.mark.parametrize(
     "decorator_name, is_authorized_method_name, items",
     [
-        ("has_access_connection", "is_authorized_connection", [Connection("conn_1"), Connection("conn_2")]),
-        ("has_access_pool", "is_authorized_pool", [Pool(pool="pool_1"), Pool(pool="pool_2")]),
-        ("has_access_variable", "is_authorized_variable", [Variable("var_1"), Variable("var_2")]),
+        (
+            "has_access_connection",
+            "batch_is_authorized_connection",
+            [Connection("conn_1"), Connection("conn_2")],
+        ),
+        ("has_access_pool", "batch_is_authorized_pool", [Pool(pool="pool_1"), Pool(pool="pool_2")]),
+        ("has_access_variable", "batch_is_authorized_variable", [Variable("var_1"), Variable("var_2")]),
     ],
 )
 class TestHasAccessWithDetails:
@@ -181,7 +185,7 @@ class TestHasAccessDagEntities:
     @patch("airflow.www.auth.get_auth_manager")
     def test_has_access_dag_entities_when_authorized(self, mock_get_auth_manager, dag_access_entity):
         auth_manager = Mock()
-        auth_manager.is_authorized_dag.return_value = True
+        auth_manager.batch_is_authorized_dag.return_value = True
         mock_get_auth_manager.return_value = auth_manager
         items = [Mock(dag_id="dag_1"), Mock(dag_id="dag_2")]
 
@@ -194,7 +198,7 @@ class TestHasAccessDagEntities:
     @patch("airflow.www.auth.get_auth_manager")
     def test_has_access_dag_entities_when_unauthorized(self, mock_get_auth_manager, app, dag_access_entity):
         auth_manager = Mock()
-        auth_manager.is_authorized_dag.return_value = False
+        auth_manager.batch_is_authorized_dag.return_value = False
         mock_get_auth_manager.return_value = auth_manager
         items = [Mock(dag_id="dag_1"), Mock(dag_id="dag_2")]
 


### PR DESCRIPTION
Add batch version of some `is_authorized_*` APIs in auth manager. Allow optimizing, if desired, on the auth manager level when checking permissions on multi resources at the same time.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
