### PR TITLE
docs: Enhance documentation for providers.jdbc configuration in provi…

### DIFF
--- a/airflow/providers/jdbc/provider.yaml
+++ b/airflow/providers/jdbc/provider.yaml
@@ -64,7 +64,17 @@ hooks:
     python-modules:
       - airflow.providers.jdbc.hooks.jdbc
 
-
 connection-types:
   - hook-class-name: airflow.providers.jdbc.hooks.jdbc.JdbcHook
     connection-type: jdbc
+
+# Add documentation for "allow_driver_path_in_extra" configuration
+configuration:
+  - section: providers.jdbc
+    key: allow_driver_path_in_extra
+    default: false
+    type: bool
+    description: |
+      Whether to allow specifying the driver path in the extra field of the connection.
+      If set to true, the driver path can be provided in the extra field; otherwise, it will be ignored.
+      Default is false.


### PR DESCRIPTION
This commit enhances the documentation for the `providers.jdbc` configuration in the `provider.yaml` file. Specifically, it addresses the missing information about the `allow_driver_path_in_extra` configuration. The added documentation includes details such as the configuration key, default value, type, and a description of its purpose.
This PR has been raised in context of the issue #35499 

Closes: https://github.com/apache/airflow/issues/35499