### PR TITLE
Add documentation about "providers.jdbc" in provider.yaml

### DIFF
--- a/airflow/providers/jdbc/CHANGELOG.rst
+++ b/airflow/providers/jdbc/CHANGELOG.rst
@@ -74,9 +74,9 @@ Breaking changes
 To configure driver parameters (driver path and driver class), you can use the following methods:
 
 1. Supply them as constructor arguments when instantiating the hook.
-2. Set the "driver_path" and/or "driver_class" parameters in the "hook_params" dictionary when creating the hook using SQL operators.
-3. Set the "driver_path" and/or "driver_class" extra in the connection and correspondingly enable the "allow_driver_path_in_extra" and/or "allow_driver_class_in_extra" options in the "providers.jdbc" section of the Airflow configuration.
-4. Patch the "JdbcHook.default_driver_path" and/or "JdbcHook.default_driver_class" values in the "local_settings.py" file.
+2. Set the ``driver_path`` and/or ``driver_class`` parameters in the ``hook_params`` dictionary when creating the hook using SQL operators.
+3. Set the ``driver_path`` and/or ``driver_class`` extra in the connection and correspondingly enable the ``allow_driver_path_in_extra`` and/or ``allow_driver_class_in_extra`` options in the ``providers.jdbc`` section of the Airflow configuration.
+4. Patch the ``JdbcHook.default_driver_path`` and/or ``JdbcHook.default_driver_class`` values in the ``local_settings.py`` file.
 
 * ``Restrict direct usage of driver params via extras for JDBC connection (#31849)``
 

--- a/airflow/providers/jdbc/hooks/jdbc.py
+++ b/airflow/providers/jdbc/hooks/jdbc.py
@@ -44,7 +44,7 @@ class JdbcHook(DbApiHook):
            configuration, you should make sure that you trust the users who can edit connections in the UI
            to not use it maliciously.
         4. Patch the ``JdbcHook.default_driver_path`` and/or ``JdbcHook.default_driver_class`` values in the
-           "local_settings.py" file.
+           ``local_settings.py`` file.
 
     See :doc:`/connections/jdbc` for full documentation.
 

--- a/airflow/providers/jdbc/provider.yaml
+++ b/airflow/providers/jdbc/provider.yaml
@@ -64,7 +64,29 @@ hooks:
     python-modules:
       - airflow.providers.jdbc.hooks.jdbc
 
-
 connection-types:
   - hook-class-name: airflow.providers.jdbc.hooks.jdbc.JdbcHook
     connection-type: jdbc
+
+config:
+  providers.jdbc:
+    description: This section applies for the JDBC provider and connection type.
+    options:
+      allow_driver_path_in_extra:
+        description: |
+          Whether to allow using ``driver_path`` set in the connection's ``extra`` field. If set to False,
+          ``driver_path`` will be ignored. If enabling this functionality, you should make sure that you
+          trust the users who can edit connections to not use it maliciously.
+        version_added: "4.0.0"
+        type: boolean
+        example: ~
+        default: "False"
+      allow_driver_class_in_extra:
+        description: |
+          Whether to allow using ``driver_class`` set in the connection's ``extra`` field. If set to False,
+          ``driver_class`` will be ignored. If enabling this functionality, you should make sure that you
+          trust the users who can edit connections to not use it maliciously.
+        version_added: "4.0.0"
+        type: boolean
+        example: ~
+        default: "False"

--- a/docs/apache-airflow-providers-jdbc/configurations-ref.rst
+++ b/docs/apache-airflow-providers-jdbc/configurations-ref.rst
@@ -1,0 +1,18 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. include:: ../exts/includes/providers-configurations-ref.rst

--- a/docs/apache-airflow-providers-jdbc/index.rst
+++ b/docs/apache-airflow-providers-jdbc/index.rst
@@ -34,8 +34,9 @@
     :maxdepth: 1
     :caption: Guides
 
-    Operators <operators>
+    Configuration <configurations-ref>
     Connection types <connections/jdbc>
+    Operators <operators>
 
 .. toctree::
     :hidden:


### PR DESCRIPTION
Version 4.0.0 of the JDBC provider added configuration options 
in airflow.cfg to be configured so that based on its value the 
driver_path and driver_class values set in the connection's extra 
field are utilised. The definition and description of this configuraiton 
is missing in provider.yaml. Adding the same here.

closes: #35499

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
