### PR TITLE
Add comment for elasticsearch connection schema

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2173,6 +2173,7 @@ elasticsearch:
   # Or an object representing the connection
   # Example:
   # connection:
+  #   scheme: ~
   #   user: ~
   #   pass: ~
   #   host: ~


### PR DESCRIPTION
It's not a straight forward that the schema is changeable. 
I needed to check the elasticsearch-secret for knowing schema is a part of connection and then changed it to https.
Thought it will be nicer for the user to know that schema is under connection.
