### PR TITLE
[DRAFT] Unified database interface

### DIFF
--- a/airflow/providers/common/sql/db.py
+++ b/airflow/providers/common/sql/db.py
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import contextlib
+import functools
+import logging
+import typing
+
+from airflow.hooks.base import BaseHook
+
+if typing.TYPE_CHECKING:
+    from typing_extensions import Self
+
+    from airflow.providers.common.sql.hooks.sql import DbApiHook
+
+logger = logging.getLogger(__name__)
+
+
+class Database:
+    """Represent a database."""
+
+    def __init__(self, *, conn_id: str) -> None:
+        self._conn_id = conn_id
+
+    @classmethod
+    def default(cls, *, protocol: str) -> Self:
+        from airflow.providers_manager import ProvidersManager
+
+        if (hook_class := ProvidersManager().hooks.get(protocol)) is None:
+            raise KeyError(f"Hook definition not found for {protocol}")
+        if (conn_id := getattr(hook_class, hook_class.connection_id_attribute_name, None)) is None:
+            raise RuntimeError(f"No default connection for {protocol}")
+        return cls(conn_id=conn_id)
+
+    @functools.cached_property
+    def uri(self) -> str:
+        return BaseHook.get_connection(self._conn_id).get_uri()
+
+    def create_hook(self, **kwargs) -> DbApiHook:
+        return BaseHook.get_connection(self._conn_id).get_hook(hook_params=kwargs)
+
+    def connect(self, **kwargs) -> typing.ContextManager:
+        return contextlib.closing(self.create_hook(**kwargs).get_conn())

--- a/airflow/providers/sqlite/db/__init__.py
+++ b/airflow/providers/sqlite/db/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.


### PR DESCRIPTION
Small thing I’ve been cooking…

This is heavily inspired by the Object Store. Internally it just calls to hooks, but allows you to do

```python
from airflow.providers.common.sql.db import Database

db = Database(conn_id="my-db-conn")
hook = db.create_hook(...)  # Additional flags to hook.

db = Database.default(protocol="sqlite3")  # Use default conn defined by the provider.
with db.connect(...) as conn:  # Shorthand for db.create_hook(...).get_conn() with management.
    conn.execute("SELECT 1")
```

Definition is currently provided for SQLite. More will be added once the interface is figured out.

----

One thought on this to @bolkedebruin: Does the Object Store intend to cover non-file sources in the future? If it does, that should take precedence over this. But if not, I feel we should rename it to something less generic, maybe IO Store or File Store instead, since SQL databases are also a kind of object storage (for a certain definition of objects) but don’t fit into the current Object Store design.