### PR TITLE
Remove usage of deprecated method from BigQueryToBigQueryOperator

### DIFF
--- a/tests/providers/google/cloud/transfers/test_bigquery_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_bigquery_to_bigquery.py
@@ -23,64 +23,90 @@ from airflow.providers.google.cloud.transfers.bigquery_to_bigquery import BigQue
 
 BQ_HOOK_PATH = "airflow.providers.google.cloud.transfers.bigquery_to_bigquery.BigQueryHook"
 TASK_ID = "test-bq-create-table-operator"
+TEST_GCP_PROJECT_ID = "test-project"
 TEST_DATASET = "test-dataset"
 TEST_TABLE_ID = "test-table-id"
+
+SOURCE_PROJECT_DATASET_TABLES = f"{TEST_GCP_PROJECT_ID}.{TEST_DATASET}.{TEST_TABLE_ID}"
+DESTINATION_PROJECT_DATASET_TABLE = f"{TEST_GCP_PROJECT_ID}.{TEST_DATASET + '_new'}.{TEST_TABLE_ID}"
+WRITE_DISPOSITION = "WRITE_EMPTY"
+CREATE_DISPOSITION = "CREATE_IF_NEEDED"
+LABELS = {"k1": "v1"}
+ENCRYPTION_CONFIGURATION = {"key": "kk"}
+
+
+def split_tablename_side_effect(*args, **kwargs):
+    if kwargs["table_input"] == SOURCE_PROJECT_DATASET_TABLES:
+        return (
+            TEST_GCP_PROJECT_ID,
+            TEST_DATASET,
+            TEST_TABLE_ID,
+        )
+    elif kwargs["table_input"] == DESTINATION_PROJECT_DATASET_TABLE:
+        return (
+            TEST_GCP_PROJECT_ID,
+            TEST_DATASET + "_new",
+            TEST_TABLE_ID,
+        )
 
 
 class TestBigQueryToBigQueryOperator:
     @mock.patch(BQ_HOOK_PATH)
     def test_execute_without_location_should_execute_successfully(self, mock_hook):
-        source_project_dataset_tables = f"{TEST_DATASET}.{TEST_TABLE_ID}"
-        destination_project_dataset_table = f"{TEST_DATASET + '_new'}.{TEST_TABLE_ID}"
-        write_disposition = "WRITE_EMPTY"
-        create_disposition = "CREATE_IF_NEEDED"
-        labels = {"k1": "v1"}
-        encryption_configuration = {"key": "kk"}
-
         operator = BigQueryToBigQueryOperator(
             task_id=TASK_ID,
-            source_project_dataset_tables=source_project_dataset_tables,
-            destination_project_dataset_table=destination_project_dataset_table,
-            write_disposition=write_disposition,
-            create_disposition=create_disposition,
-            labels=labels,
-            encryption_configuration=encryption_configuration,
+            source_project_dataset_tables=SOURCE_PROJECT_DATASET_TABLES,
+            destination_project_dataset_table=DESTINATION_PROJECT_DATASET_TABLE,
+            write_disposition=WRITE_DISPOSITION,
+            create_disposition=CREATE_DISPOSITION,
+            labels=LABELS,
+            encryption_configuration=ENCRYPTION_CONFIGURATION,
         )
 
+        mock_hook.return_value.split_tablename.side_effect = split_tablename_side_effect
         operator.execute(context=mock.MagicMock())
-        mock_hook.return_value.run_copy.assert_called_once_with(
-            source_project_dataset_tables=source_project_dataset_tables,
-            destination_project_dataset_table=destination_project_dataset_table,
-            write_disposition=write_disposition,
-            create_disposition=create_disposition,
-            labels=labels,
-            encryption_configuration=encryption_configuration,
+        mock_hook.return_value.insert_job.assert_called_once_with(
+            configuration={
+                "copy": {
+                    "createDisposition": CREATE_DISPOSITION,
+                    "destinationEncryptionConfiguration": ENCRYPTION_CONFIGURATION,
+                    "destinationTable": {
+                        "datasetId": TEST_DATASET + "_new",
+                        "projectId": TEST_GCP_PROJECT_ID,
+                        "tableId": TEST_TABLE_ID,
+                    },
+                    "sourceTables": [
+                        {
+                            "datasetId": TEST_DATASET,
+                            "projectId": TEST_GCP_PROJECT_ID,
+                            "tableId": TEST_TABLE_ID,
+                        },
+                    ],
+                    "writeDisposition": WRITE_DISPOSITION,
+                },
+                "labels": LABELS,
+            },
+            project_id=mock_hook.return_value.project_id,
         )
 
     @mock.patch(BQ_HOOK_PATH)
     def test_execute_single_regional_location_should_execute_successfully(self, mock_hook):
-        source_project_dataset_tables = f"{TEST_DATASET}.{TEST_TABLE_ID}"
-        destination_project_dataset_table = f"{TEST_DATASET + '_new'}.{TEST_TABLE_ID}"
-        write_disposition = "WRITE_EMPTY"
-        create_disposition = "CREATE_IF_NEEDED"
-        labels = {"k1": "v1"}
         location = "us-central1"
-        encryption_configuration = {"key": "kk"}
-        mock_hook.return_value.run_copy.return_value = "job-id"
 
         operator = BigQueryToBigQueryOperator(
             task_id=TASK_ID,
-            source_project_dataset_tables=source_project_dataset_tables,
-            destination_project_dataset_table=destination_project_dataset_table,
-            write_disposition=write_disposition,
-            create_disposition=create_disposition,
-            labels=labels,
-            encryption_configuration=encryption_configuration,
+            source_project_dataset_tables=SOURCE_PROJECT_DATASET_TABLES,
+            destination_project_dataset_table=DESTINATION_PROJECT_DATASET_TABLE,
+            write_disposition=WRITE_DISPOSITION,
+            create_disposition=CREATE_DISPOSITION,
+            labels=LABELS,
+            encryption_configuration=ENCRYPTION_CONFIGURATION,
             location=location,
         )
 
+        mock_hook.return_value.split_tablename.side_effect = split_tablename_side_effect
         operator.execute(context=mock.MagicMock())
         mock_hook.return_value.get_job.assert_called_once_with(
-            job_id="job-id",
+            job_id=mock_hook.return_value.insert_job.return_value.job_id,
             location=location,
         )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In this PR I have removed usage of deprecated methods from BigQueryToBigQueryOperator

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
