### PR TITLE
Fix model loading order of DagRunNote vs User

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -49,6 +49,7 @@ from sqlalchemy.sql.expression import false, select, true
 
 from airflow import settings
 from airflow.api_internal.internal_api_call import internal_api_call
+from airflow.auth.managers.fab.models import User
 from airflow.callbacks.callback_requests import DagCallbackRequest
 from airflow.configuration import conf as airflow_conf
 from airflow.exceptions import AirflowException, RemovedInAirflow3Warning, TaskNotFound
@@ -1489,7 +1490,7 @@ class DagRunNote(Base):
 
     user_id = Column(
         Integer,
-        ForeignKey("ab_user.id", name="dag_run_note_user_fkey"),
+        ForeignKey(User.id, name="dag_run_note_user_fkey"),
         nullable=True,
     )
     dag_run_id = Column(Integer, primary_key=True, nullable=False)


### PR DESCRIPTION
It seems DagRun gets loaded before User, resulting in a
sqlalchemy.exc.NoReferencedTableError (at least when running `airflow
tasks test DAG_ID TASK_ID`) when defining DagRun's foreign key to the
still nonexistent User table.

Referencing the column object instead of using str establishes proper
import ordering and fixes the issue.

Fix: #34109
