### PR TITLE
Add `python_kubernetes_script.jinja2` to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -895,6 +895,8 @@ class AirflowDistribution(Distribution):
                     provider_yaml_file, str(AIRFLOW_SOURCES_ROOT / "airflow")
                 )
                 self.package_data["airflow"].append(provider_relative_path)
+            # Add python_kubernetes_script.jinja2 to package data
+            self.package_data["airflow"].append("providers/cncf/kubernetes/python_kubernetes_script.jinja2")
         else:
             self.install_requires.extend(
                 [


### PR DESCRIPTION
When providers are installed from sources, the `python_kubernetes_script.jinja2` is missing in the kubernetes provider package.

This commit adds the file to package_data so it's available in the kubernetes provider package when installed from sources