### PR TITLE
Update clients versioning policy

### DIFF
--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -1018,7 +1018,7 @@ Clients and Core versioning are completely decoupled. Clients also follow SemVer
 Most of the time, if the [openapi specification](https://github.com/apache/airflow/blob/main/airflow/api_connexion/openapi/v1.yaml) has
 changed, clients need to be released.
 
-To determine if you should release API clients, you can run:
+To determine if you should release API clients, you can run from the airflow repository:
 
 ```shell
 ./dev/airflow-github api-clients-policy 2.3.2 2.4.0

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -1005,29 +1005,27 @@ File `airflow/config_templates/config.yml` contains documentation on all configu
 
 After releasing airflow core, we need to check if we have to follow up with API clients release.
 
-Clients are released in a separate process, with their own vote mostly because their version can mismatch the core release.
-ASF policy does not allow to vote against multiple artifacts with different versions.
+Clients are released in a separate process, with their own vote.
 
-### API Clients versioning policy
-
-For major/minor version release, always release new versions of the API clients.
+Clients can be found here:
 
 - [Python client](https://github.com/apache/airflow-client-python)
 - [Go client](https://github.com/apache/airflow-client-go)
 
-For patch version release, you can also release patch versions of clients **only** if the patch is relevant to the clients.
-A patch is considered relevant to the clients if it updates the [openapi specification](https://github.com/apache/airflow/blob/main/airflow/api_connexion/openapi/v1.yaml).
-There are other external reasons for which we might want to release a patch version for clients only, but they are not
-tied to an airflow release and therefore out of scope.
+### API Clients versioning policy
 
-To determine if you should also release API clients you can run:
+Clients and Core versioning are completely decoupled. Clients also follow SemVer and are updated when core introduce changes relevant to the clients.
+Most of the time, if the [openapi specification](https://github.com/apache/airflow/blob/main/airflow/api_connexion/openapi/v1.yaml) has
+changed, clients need to be released.
+
+To determine if you should release API clients, you can run:
 
 ```shell
-./dev/airflow-github api-clients-policy 2.3.2 2.3.3
+./dev/airflow-github api-clients-policy 2.3.2 2.4.0
 ```
 
-> The patch version of each API client is not necessarily in sync with the patch that you are releasing.
-> You need to check for each client what is the next patch version to be released.
+> All clients follow SemVer and you should check what the appropriate new version for each client should be. Depending on the current
+> client version and type of content added (feature, fix, breaking change etc.) appropriately increment the version number.
 
 ### Releasing the clients
 


### PR DESCRIPTION
Update the clients versioning policy to completely decouple them from core.

Discussion:
https://lists.apache.org/thread/c1n6gqrx3v00z1qr1nr10obvvn2v1rcz

Vote:
https://lists.apache.org/thread/m9jdkq7w38d95jykm0l3cm38pmvkzzl7


> Not exclusively tide to security, but allow flexibility to introduce required breaking change to improve our process.