### PR TITLE
fix(timetable): CronMixin issue when DST

### DIFF
--- a/tests/timetables/test_cron_mixin.py
+++ b/tests/timetables/test_cron_mixin.py
@@ -1,0 +1,46 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from pendulum import DateTime
+from pendulum.tz.timezone import UTC
+
+from airflow.timetables._cron import CronMixin
+
+
+class TestCronMixin:
+    def test_get_next_true(self):
+        cron_mixin = CronMixin("0 7-21 * * *", timezone="Europe/Paris")
+        print("\n")
+        for day, hour in [
+            (28, 20),
+            (28, 21),
+            (28, 22),
+            (28, 23),
+            (29, 0),
+            (29, 1),
+            (29, 2),
+            (29, 3),
+            (29, 4),
+            (29, 5),
+            (29, 6),
+            (29, 7),
+        ]:
+            date = DateTime(year=2023, month=10, day=day, hour=hour, minute=0, second=0, tzinfo=UTC)
+            align_prev_date = cron_mixin._align_to_prev(date)
+            print(f"the {day} at {hour}: pre_date={align_prev_date}")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Follow-up of #35558.

This is an attempt to figure out how the `CronMixin` class was working, and especially `_get_prev` and `_get_next` methods.

By making timezone aware the `scheduled` variable in the two methods, I managed to suppress the issue. Therefore, I am questioning the two methods logic (which I still didn't figure out). I found the introduction of those two methods in #17414 (Hello @uranusjr 👋 ). Do we really need to compute the `delta` with `scheduled` and `naive` variables? This is error prone since, during a [DST](https://en.wikipedia.org/wiki/DST_(disambiguation)#:~:text=DST%20is%20daylight%20saving%20time%2C%20a%20seasonal%20adjustment%20to%20civil%20time.), the delta will not be coherent? If I am missing something, I think we would really benefit from documentation + tests on those two methods.

###$ Before my changes:
```
the 28 at 20: pre_date=2023-10-28T19:00:00+00:00
the 28 at 21: pre_date=2023-10-28T19:00:00+00:00
the 28 at 22: pre_date=2023-10-28T19:00:00+00:00
the 28 at 23: pre_date=2023-10-28T19:00:00+00:00
the 29 at 0: pre_date=2023-10-28T19:00:00+00:00
the 29 at 1: pre_date=2023-10-28T20:00:00+00:00 <== here it switches
the 29 at 2: pre_date=2023-10-28T20:00:00+00:00
the 29 at 3: pre_date=2023-10-28T20:00:00+00:00
the 29 at 4: pre_date=2023-10-28T20:00:00+00:00
the 29 at 5: pre_date=2023-10-29T05:00:00+00:00
the 29 at 6: pre_date=2023-10-28T20:00:00+00:00 <== Here it is messed up
the 29 at 7: pre_date=2023-10-29T07:00:00+00:00
```

#### After them
```
the 28 at 20: pre_date=2023-10-28T19:00:00+00:00
the 28 at 21: pre_date=2023-10-28T19:00:00+00:00
the 28 at 22: pre_date=2023-10-28T19:00:00+00:00
the 28 at 23: pre_date=2023-10-28T19:00:00+00:00
the 29 at 0: pre_date=2023-10-28T19:00:00+00:00
the 29 at 1: pre_date=2023-10-28T19:00:00+00:00
the 29 at 2: pre_date=2023-10-28T19:00:00+00:00
the 29 at 3: pre_date=2023-10-28T19:00:00+00:00
the 29 at 4: pre_date=2023-10-28T19:00:00+00:00
the 29 at 5: pre_date=2023-10-28T19:00:00+00:00
the 29 at 6: pre_date=2023-10-29T06:00:00+00:00
the 29 at 7: pre_date=2023-10-29T07:00:00+00:00
```

We notice that the the value are coherent in the second batch

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
