### PR TITLE
feat(helm): Add `enable` property to metric-exporter sidecar

### DIFF
--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -154,6 +154,7 @@ spec:
           {{- if $containerLifecycleHooks }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
           {{- end }}
+        {{- if .Values.pgbouncer.metricsExporterSidecar.enabled }}
         - name: metrics-exporter
           resources: {{- toYaml .Values.pgbouncer.metricsExporterSidecar.resources | nindent 12 }}
           image: {{ template "pgbouncer_exporter_image" . }}
@@ -191,6 +192,7 @@ spec:
           {{- if $containerLifecycleHooksMetricsExporter }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooksMetricsExporter) . | nindent 12 }}
           {{- end }}
+        {{- end }}
         {{- if .Values.pgbouncer.extraContainers }}
           {{- toYaml .Values.pgbouncer.extraContainers | nindent 8 }}
         {{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -6146,7 +6146,7 @@
                         "enabled": {
                             "description": "Enable PgBouncer metric exporter sidecar.",
                             "type": "boolean",
-                            "default": false
+                            "default": true
                         },
                         "resources": {
                             "description": "Resources for the PgBouncer metric exporter.",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -6143,6 +6143,11 @@
                     "x-docsSection": "PgBouncer",
                     "additionalProperties": false,
                     "properties": {
+                        "enabled": {
+                            "description": "Enable PgBouncer metric exporter sidecar.",
+                            "type": "boolean",
+                            "default": false
+                        },
                         "resources": {
                             "description": "Resources for the PgBouncer metric exporter.",
                             "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2056,6 +2056,7 @@ pgbouncer:
         command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
 
   metricsExporterSidecar:
+    enabled: false
     resources: {}
     #  limits:
     #   cpu: 100m

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2056,7 +2056,7 @@ pgbouncer:
         command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
 
   metricsExporterSidecar:
-    enabled: false
+    enabled: true
     resources: {}
     #  limits:
     #   cpu: 100m

--- a/helm_tests/other/test_pgbouncer.py
+++ b/helm_tests/other/test_pgbouncer.py
@@ -257,6 +257,19 @@ class TestPgbouncer:
             },
         } == jmespath.search("spec.template.spec.containers[1].resources", docs[0])
 
+    def test_disabling_metrics_exporter(self):
+        docs = render_chart(
+            values={
+                "pgbouncer": {
+                    "enabled": True,
+                    "metricsExporterSidecar": {"enabled": False},
+                }
+            },
+            show_only=["templates/pgbouncer/pgbouncer-deployment.yaml"],
+        )
+
+        assert jmespath.search("spec.template.spec.containers[1]", docs[0]) is None
+
     def test_default_command_and_args(self):
         docs = render_chart(
             values={"pgbouncer": {"enabled": True}},


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

We have an issue with our Leboncoin's Airflow deployment where `metrics-exporter` sidecar was in `crashloopbackoff restart` because of its liveness probe. We figured out that we didn't need and want this container. Therefore, I am adding a property to let the user the choice if he wants to have `metrics-exporter`.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
