### PR TITLE
Explain the db providers necessity in slim images

### DIFF
--- a/docs/docker-stack/build.rst
+++ b/docs/docker-stack/build.rst
@@ -295,6 +295,11 @@ There are two types of images you can extend your image from:
    for AMD64 platform and Postgres for ARM64 platform, but contains no extras or providers, except
    the 4 default providers.
 
+.. note:: Database clients and database providers in slim images
+    Slim images come with database clients preinstalled for your convenience, however the default
+    providers included do not include any database provider. You will still need to manually install
+    any database provider you need
+
 .. note:: Differences of slim image vs. regular image.
 
     The slim image is small comparing to regular image (~500 MB vs ~1.1GB) and you might need to add a


### PR DESCRIPTION
related: #35255

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: 


How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
This PR adds a small clarification in the documentation, regarding the fact that while extra database clients are installed on a slim images, databases providers are not (and are not part of the default providers installed)
