### PR TITLE
Add a filter for local files in GoogleDisplayVideo360CreateQueryOperator

### DIFF
--- a/airflow/providers/google/marketing_platform/operators/display_video.py
+++ b/airflow/providers/google/marketing_platform/operators/display_video.py
@@ -285,13 +285,15 @@ class GoogleDisplayVideo360DownloadReportV2Operator(BaseOperator):
 
         # If no custom report_name provided, use DV360 name
         file_url = resource["metadata"]["googleCloudStoragePath"]
+        if urllib.parse.urlparse(file_url).scheme == "file":
+            raise AirflowException("Accessing local file is not allowed in this operator")
         report_name = self.report_name or urlsplit(file_url).path.split("/")[-1]
         report_name = self._resolve_file_name(report_name)
 
         # Download the report
         self.log.info("Starting downloading report %s", self.report_id)
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-            with urllib.request.urlopen(file_url) as response:
+            with urllib.request.urlopen(file_url) as response:  # nosec
                 shutil.copyfileobj(response, temp_file, length=self.chunk_size)
 
             temp_file.flush()

--- a/tests/providers/google/marketing_platform/operators/test_display_video.py
+++ b/tests/providers/google/marketing_platform/operators/test_display_video.py
@@ -23,6 +23,7 @@ from unittest import mock
 
 import pytest
 
+from airflow.exceptions import AirflowException
 from airflow.models import DAG, TaskInstance as TI
 from airflow.providers.google.marketing_platform.operators.display_video import (
     GoogleDisplayVideo360CreateQueryOperator,
@@ -78,6 +79,9 @@ class TestGoogleDisplayVideo360DownloadReportV2Operator:
         with create_session() as session:
             session.query(TI).delete()
 
+    @pytest.mark.parametrize(
+        "file_path, should_except", [("https://host/path", False), ("file:/path/to/file", True)]
+    )
     @mock.patch("airflow.providers.google.marketing_platform.operators.display_video.shutil")
     @mock.patch("airflow.providers.google.marketing_platform.operators.display_video.urllib.request")
     @mock.patch("airflow.providers.google.marketing_platform.operators.display_video.tempfile")
@@ -97,12 +101,14 @@ class TestGoogleDisplayVideo360DownloadReportV2Operator:
         mock_temp,
         mock_request,
         mock_shutil,
+        file_path,
+        should_except,
     ):
         mock_temp.NamedTemporaryFile.return_value.__enter__.return_value.name = FILENAME
         mock_hook.return_value.get_report.return_value = {
             "metadata": {
                 "status": {"state": "DONE"},
-                "googleCloudStoragePath": "TEST",
+                "googleCloudStoragePath": file_path,
             }
         }
         op = GoogleDisplayVideo360DownloadReportV2Operator(
@@ -112,6 +118,10 @@ class TestGoogleDisplayVideo360DownloadReportV2Operator:
             report_name=REPORT_NAME,
             task_id="test_task",
         )
+        if should_except:
+            with pytest.raises(AirflowException):
+                op.execute(context=None)
+            return
         op.execute(context=None)
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,


### PR DESCRIPTION
In a complex scenario, this operator could be used to upload local files to GCS instead of uploading DV360 reports.

This PR adds a filter for local files to stop the execution.

```bash
echo "test text" > /tmp/test.txt
python -c "import urllib.request; print(urllib.request.urlopen('file:/tmp/test.txt').file.read())"
``` 

related: #35615