### PR TITLE
Add temporary limit for jsonschema-specification package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -116,6 +116,18 @@ install_requires =
     itsdangerous>=2.0
     jinja2>=3.0.0
     jsonschema>=4.18.0
+    # The jsonschema-specifications 2023.11.1 has referencing>=0.31 dependency
+    # where jsonschema-path used under-the-hood has referencing<0.31.0 which
+    # makes the two incompatible.
+    #
+    # That makes pip to find a resolution where latest
+    # jsonschema-specification 2023.11.1 gets installed, while it removes
+    # jsonschema-path but also downgrades openapi-schema-validator and
+    # openapi-spec-validator causing failures when importing moto.
+    #
+    # See https://github.com/p1c2u/jsonschema-path/issues/91
+    # This line should be removed once jsonschema-path release version that removes referencing limit
+    jsonschema-specifications<2023.11.1
     lazy-object-proxy
     linkify-it-py>=2.0.0
     lockfile>=0.12.2


### PR DESCRIPTION
The jsonschema-specifications 2023.11.1 has referencing>=0.31 dependency where jsonschema-path used under-the-hood has referencing<0.31.0 which makes the two incompatible.

That makes pip to find a resolution where latest
jsonschema-specification 2023.11.1 gets installed, while it removes jsonschema-path but also downgrades openapi-schema-validator and openapi-spec-validator causing failures when importing moto.

See https://github.com/p1c2u/jsonschema-path/issues/91

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
