### PR TITLE
Fix case where pip requiremet version starts with !=

### DIFF
--- a/airflow/providers/github/__init__.py
+++ b/airflow/providers/github/__init__.py
@@ -39,5 +39,5 @@ if packaging.version.parse(packaging.version.parse(airflow_version).base_version
     "2.5.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-github:{__version__}` requires Apache Airflow 2.5.0+"
+        f"The package `apache-airflow-providers-github:{__version__}` needs Apache Airflow 2.5.0+"
     )

--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
@@ -566,7 +566,7 @@ def _convert_pip_requirements_to_table(requirements: Iterable[str], markdown: bo
     headers = ["PIP package", "Version required"]
     table_data = []
     for dependency in requirements:
-        found = re.match(r"(^[^<=>~]*)([^<=>~]?.*)$", dependency)
+        found = re.match(r"(^[^<=>~!]*)([^<=>~!]?.*)$", dependency)
         if found:
             package = found.group(1)
             version_required = found.group(2)

--- a/docs/apache-airflow-providers-github/index.rst
+++ b/docs/apache-airflow-providers-github/index.rst
@@ -68,8 +68,6 @@
     Detailed list of commits <commits>
 
 .. THE REMAINDER OF THE FILE IS AUTOMATICALLY GENERATED. IT WILL BE OVERWRITTEN AT RELEASE TIME!
-
-
 .. toctree::
     :hidden:
     :maxdepth: 1
@@ -108,5 +106,5 @@ The minimum Apache Airflow version supported by this provider package is ``2.5.0
 PIP package         Version required
 ==================  ==================
 ``apache-airflow``  ``>=2.5.0``
-``PyGithub!``       ``=1.58``
+``PyGithub``        ``!=1.58``
 ==================  ==================


### PR DESCRIPTION
Github provider has package starting with `!=` and the documentation generation had a bug (for a long time) to split the package versions wrongly in this case.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
