### PR TITLE
Added name field to template_fields in EmrServerlessStartJobOperator

### DIFF
--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -1227,7 +1227,7 @@ class EmrServerlessStartJobOperator(BaseOperator):
         self.configuration_overrides = configuration_overrides
         self.wait_for_completion = wait_for_completion
         self.config = config or {}
-        self.name = name or self.config.pop("name", f"emr_serverless_job_airflow_{uuid4()}")
+        self.name = name
         self.waiter_max_attempts = int(waiter_max_attempts)  # type: ignore[arg-type]
         self.waiter_delay = int(waiter_delay)  # type: ignore[arg-type]
         self.job_id: str | None = None
@@ -1269,6 +1269,7 @@ class EmrServerlessStartJobOperator(BaseOperator):
                 status_args=["application.state", "application.stateDetails"],
             )
         self.log.info("Starting job on Application: %s", self.application_id)
+        self.name = self.name or self.config.pop("name", f"emr_serverless_job_airflow_{uuid4()}")
         response = self.hook.conn.start_job_run(
             clientToken=self.client_request_token,
             applicationId=self.application_id,

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -1173,6 +1173,7 @@ class EmrServerlessStartJobOperator(BaseOperator):
         "execution_role_arn",
         "job_driver",
         "configuration_overrides",
+        "name",
     )
 
     template_fields_renderers = {

--- a/tests/providers/amazon/aws/operators/test_emr_serverless.py
+++ b/tests/providers/amazon/aws/operators/test_emr_serverless.py
@@ -375,8 +375,8 @@ class TestEmrServerlessStartJobOperator:
             job_driver=job_driver,
             configuration_overrides=configuration_overrides,
         )
-        default_name = operator.name
         id = operator.execute(None)
+        default_name = operator.name
 
         assert operator.wait_for_completion is True
         mock_conn.get_application.assert_called_once_with(applicationId=application_id)
@@ -413,11 +413,12 @@ class TestEmrServerlessStartJobOperator:
             job_driver=job_driver,
             configuration_overrides=configuration_overrides,
         )
-        default_name = operator.name
         with pytest.raises(AirflowException) as ex_message:
             id = operator.execute(None)
             assert id == job_run_id
         assert "Serverless Job failed:" in str(ex_message.value)
+        default_name = operator.name
+
         mock_conn.get_application.assert_called_once_with(applicationId=application_id)
         mock_conn.start_job_run.assert_called_once_with(
             clientToken=client_request_token,
@@ -446,9 +447,8 @@ class TestEmrServerlessStartJobOperator:
             job_driver=job_driver,
             configuration_overrides=configuration_overrides,
         )
-        default_name = operator.name
-
         id = operator.execute(None)
+        default_name = operator.name
 
         assert operator.wait_for_completion is True
         mock_conn.get_application.assert_called_once_with(applicationId=application_id)
@@ -516,8 +516,8 @@ class TestEmrServerlessStartJobOperator:
             configuration_overrides=configuration_overrides,
             wait_for_completion=False,
         )
-        default_name = operator.name
         id = operator.execute(None)
+        default_name = operator.name
 
         mock_conn.get_application.assert_called_once_with(applicationId=application_id)
         mock_get_waiter().wait.assert_called_once()
@@ -550,9 +550,10 @@ class TestEmrServerlessStartJobOperator:
             configuration_overrides=configuration_overrides,
             wait_for_completion=False,
         )
-        default_name = operator.name
         id = operator.execute(None)
         assert id == job_run_id
+        default_name = operator.name
+
         mock_conn.start_job_run.assert_called_once_with(
             clientToken=client_request_token,
             applicationId=application_id,
@@ -581,11 +582,11 @@ class TestEmrServerlessStartJobOperator:
             job_driver=job_driver,
             configuration_overrides=configuration_overrides,
         )
-        default_name = operator.name
         with pytest.raises(AirflowException) as ex_message:
             operator.execute(None)
-
         assert "EMR serverless job failed to start:" in str(ex_message.value)
+        default_name = operator.name
+
         mock_conn.get_application.assert_called_once_with(applicationId=application_id)
         mock_get_waiter().wait.assert_called_once()
         mock_conn.start_job_run.assert_called_once_with(
@@ -619,11 +620,11 @@ class TestEmrServerlessStartJobOperator:
             job_driver=job_driver,
             configuration_overrides=configuration_overrides,
         )
-        default_name = operator.name
         with pytest.raises(AirflowException) as ex_message:
             operator.execute(None)
-
         assert "Serverless Job failed:" in str(ex_message.value)
+        default_name = operator.name
+
         mock_conn.get_application.call_count == 2
         mock_conn.start_job_run.assert_called_once_with(
             clientToken=client_request_token,


### PR DESCRIPTION
closes: #35341 
1. Added name field to template_fields in EmrServerlessStartJobOperator as requested in issue #35341.
2. Moved default name setting operation from constructor to execute method
3. Updated EmrServerlessStartJobOperator test class

Since [self.name = name or self.config.pop("name", f"emr_serverless_job_airflow_{uuid4()}")](https://github.com/apache/airflow/blob/main/airflow/providers/amazon/aws/operators/emr.py#L1229) code is in operator constructor, error occurs in specific situation . 
As Taragolis showed well in below comment, if name param is not given and config is given no dict type, error occurs. For example, if config is given by upstream operator (like the example in below comment), error occurs because the type of config is PlainXComArg in this case . And it is a kind of bug which should be fixed. 

If the problematic section of code is moved from constructor to execute method, the returned_value of upstream operator is converted to dict type (I do not know the exact principle but checked the fact). So the error above does not occur. So I moved the pop operation to execute method. And I think It might be what @Taragolis intended in his first guide.

I'm a beginner. If I am missing something, comments will make me better :)  
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
