### PR TITLE
Revert "Fix pre-mature evaluation of tasks in mapped task group (#34337)"

### DIFF
--- a/tests/models/test_mappedoperator.py
+++ b/tests/models/test_mappedoperator.py
@@ -1305,8 +1305,8 @@ class TestMappedSetupTeardown:
         states = self.get_states(dr)
         expected = {
             "file_transforms.my_setup": {0: "success", 1: "failed", 2: "skipped"},
-            "file_transforms.my_work": {2: "upstream_failed", 1: "upstream_failed", 0: "upstream_failed"},
-            "file_transforms.my_teardown": {2: "success", 1: "success", 0: "success"},
+            "file_transforms.my_work": {0: "success", 1: "upstream_failed", 2: "skipped"},
+            "file_transforms.my_teardown": {0: "success", 1: "upstream_failed", 2: "skipped"},
         }
 
         assert states == expected

--- a/tests/ti_deps/deps/test_trigger_rule_dep.py
+++ b/tests/ti_deps/deps/test_trigger_rule_dep.py
@@ -1165,23 +1165,19 @@ def test_upstream_in_mapped_group_triggers_only_relevant(dag_maker, session):
     tis = _one_scheduling_decision_iteration()
     assert sorted(tis) == [("tg.t1", 0), ("tg.t1", 1), ("tg.t1", 2)]
 
-    # After running the first t1, the remaining t1 must be run before t2 is available.
+    # After running the first t1, the first t2 becomes immediately available.
     tis["tg.t1", 0].run()
     tis = _one_scheduling_decision_iteration()
-    assert sorted(tis) == [("tg.t1", 1), ("tg.t1", 2)]
+    assert sorted(tis) == [("tg.t1", 1), ("tg.t1", 2), ("tg.t2", 0)]
 
-    # After running all t1, t2 is available.
-    tis["tg.t1", 1].run()
+    # Similarly for the subsequent t2 instances.
     tis["tg.t1", 2].run()
     tis = _one_scheduling_decision_iteration()
-    assert sorted(tis) == [("tg.t2", 0), ("tg.t2", 1), ("tg.t2", 2)]
-
-    # Similarly for t2 instances. They both have to complete before t3 is available
-    tis["tg.t2", 0].run()
-    tis = _one_scheduling_decision_iteration()
-    assert sorted(tis) == [("tg.t2", 1), ("tg.t2", 2)]
+    assert sorted(tis) == [("tg.t1", 1), ("tg.t2", 0), ("tg.t2", 2)]
 
     # But running t2 partially does not make t3 available.
+    tis["tg.t1", 1].run()
+    tis["tg.t2", 0].run()
     tis["tg.t2", 2].run()
     tis = _one_scheduling_decision_iteration()
     assert sorted(tis) == [("tg.t2", 1)]
@@ -1411,34 +1407,3 @@ class TestTriggerRuleDepSetupConstraint:
             (status,) = self.get_dep_statuses(dr, "w2", flag_upstream_failed=True, session=session)
         assert status.reason.startswith("All setup tasks must complete successfully")
         assert self.get_ti(dr, "w2").state == expected
-
-
-def test_mapped_tasks_in_mapped_task_group_waits_for_upstreams_to_complete(dag_maker, session):
-    """Test that one failed trigger rule works well in mapped task group"""
-    with dag_maker() as dag:
-
-        @dag.task
-        def t1():
-            return [1, 2, 3]
-
-        @task_group("tg1")
-        def tg1(a):
-            @dag.task()
-            def t2(a):
-                return a
-
-            @dag.task(trigger_rule=TriggerRule.ONE_FAILED)
-            def t3(a):
-                return a
-
-            t2(a) >> t3(a)
-
-        t = t1()
-        tg1.expand(a=t)
-
-    dr = dag_maker.create_dagrun()
-    ti = dr.get_task_instance(task_id="t1")
-    ti.run()
-    dr.task_instance_scheduling_decisions()
-    ti3 = dr.get_task_instance(task_id="tg1.t3")
-    assert not ti3.state


### PR DESCRIPTION
This reverts commit 69938fd163045d750b8c218500d79bc89858f9c1.

This commit brought about a change in behaviour in mapped task group. Reverting it while we investigate the correct fix

Related: #35541