### PR TITLE
Fix write processor_subdir in serialized_dag table

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -622,7 +622,7 @@ class DagBag(LoggingMixin):
 
         log = cls.logger()
 
-        def _serialize_dag_capturing_errors(dag, session):
+        def _serialize_dag_capturing_errors(dag, session, processor_subdir):
             """
             Try to serialize the dag to the DB, but make a note of any errors.
 
@@ -636,6 +636,7 @@ class DagBag(LoggingMixin):
                     dag,
                     min_update_interval=settings.MIN_SERIALIZED_DAG_UPDATE_INTERVAL,
                     session=session,
+                    processor_subdir=processor_subdir,
                 )
                 if dag_was_updated:
                     DagBag._sync_perm_for_dag(dag, session=session)
@@ -665,7 +666,7 @@ class DagBag(LoggingMixin):
                 try:
                     # Write Serialized DAGs to DB, capturing errors
                     for dag in dags.values():
-                        serialize_errors.extend(_serialize_dag_capturing_errors(dag, session))
+                        serialize_errors.extend(_serialize_dag_capturing_errors(dag, session, processor_subdir))
 
                     DAG.bulk_write_to_db(dags.values(), processor_subdir=processor_subdir, session=session)
                 except OperationalError:

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -666,7 +666,9 @@ class DagBag(LoggingMixin):
                 try:
                     # Write Serialized DAGs to DB, capturing errors
                     for dag in dags.values():
-                        serialize_errors.extend(_serialize_dag_capturing_errors(dag, session, processor_subdir))
+                        serialize_errors.extend(
+                            _serialize_dag_capturing_errors(dag, session, processor_subdir)
+                        )
 
                     DAG.bulk_write_to_db(dags.values(), processor_subdir=processor_subdir, session=session)
                 except OperationalError:

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -888,7 +888,9 @@ class TestDagBag:
         # and the session was roll-backed before even reaching 'SerializedDagModel.write_dag'
         mock_s10n_write_dag.assert_has_calls(
             [
-                mock.call(mock_dag, min_update_interval=mock.ANY, session=mock_session),
+                mock.call(
+                    mock_dag, min_update_interval=mock.ANY, processor_subdir=None, session=mock_session
+                ),
             ]
         )
 


### PR DESCRIPTION
After #25935 SerializedDagModel.remove_deleted_dags is supposed to clean up dags only belonging to a single dag processor, but it's being ignored because `processor_subdir` column in serialized_dag table is never populated from dagbag in the first place.