### PR TITLE
Move external logs links to top of react logs page

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -22,7 +22,6 @@ import {
   Text,
   Box,
   Flex,
-  Divider,
   Button,
   Checkbox,
   Icon,
@@ -175,6 +174,22 @@ const Logs = ({
 
   return (
     <>
+      {externalLogName && externalIndexes.length > 0 && (
+        <Box my={1}>
+          <Text>View Logs in {externalLogName} (by attempts):</Text>
+          <Flex flexWrap="wrap">
+            {externalIndexes.map((index) => (
+              <LogLink
+                key={index}
+                dagId={dagId}
+                taskId={taskId}
+                executionDate={executionDate}
+                tryNumber={index}
+              />
+            ))}
+          </Flex>
+        </Box>
+      )}
       {tryNumber !== undefined && (
         <>
           <Box>
@@ -278,25 +293,6 @@ const Logs = ({
               />
             )
           )}
-        </>
-      )}
-      {externalLogName && externalIndexes.length > 0 && (
-        <>
-          <Box>
-            <Text>View Logs in {externalLogName} (by attempts):</Text>
-            <Flex flexWrap="wrap">
-              {externalIndexes.map((index) => (
-                <LogLink
-                  key={index}
-                  dagId={dagId}
-                  taskId={taskId}
-                  executionDate={executionDate}
-                  tryNumber={index}
-                />
-              ))}
-            </Flex>
-          </Box>
-          <Divider my={2} />
         </>
       )}
     </>


### PR DESCRIPTION
Move the links to external logs to be above the internal log buttons and text so it doesn't get hidden underneath long logs.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
