### PR TITLE
Limit botocore in upgrade tests temporarily

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1045,7 +1045,9 @@ if [[ ${UPGRADE_BOTO=} == "true" ]]; then
     echo "${COLOR_BLUE}Upgrading boto3, botocore to latest version to run Amazon tests with them${COLOR_RESET}"
     echo
     pip uninstall --root-user-action ignore aiobotocore s3fs -y || true
-    pip install --root-user-action ignore --upgrade boto3 botocore
+    # The limits for boto3 and botocore are set only because moto does not handle some changes implemented in botocore 1.32.1
+    # They should be removed as soon as https://github.com/getmoto/moto/issues/7031 is fixed and moto with the fixes is released
+    pip install --root-user-action ignore --upgrade "boto3<1.29.1" "botocore<1.32.1"
     pip check
 fi
 if [[ ${DOWNGRADE_SQLALCHEMY=} == "true" ]]; then

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -345,7 +345,9 @@ if [[ ${UPGRADE_BOTO=} == "true" ]]; then
     echo "${COLOR_BLUE}Upgrading boto3, botocore to latest version to run Amazon tests with them${COLOR_RESET}"
     echo
     pip uninstall --root-user-action ignore aiobotocore s3fs -y || true
-    pip install --root-user-action ignore --upgrade boto3 botocore
+    # The limits for boto3 and botocore are set only because moto does not handle some changes implemented in botocore 1.32.1
+    # They should be removed as soon as https://github.com/getmoto/moto/issues/7031 is fixed and moto with the fixes is released
+    pip install --root-user-action ignore --upgrade "boto3<1.29.1" "botocore<1.32.1"
     pip check
 fi
 if [[ ${DOWNGRADE_SQLALCHEMY=} == "true" ]]; then


### PR DESCRIPTION
Mote does not handle some compressed models in botocore 1.32.1, and it fails our "latest botocore" tests. Moto should be released with a fix to handle compressed versions but until that we limit botocore and boto3 when upgrading then. This limit should be removed as soon as https://github.com/getmoto/moto/issues/7031 is fixed and moto with the fixes is releasedi

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
