### PR TITLE
Fix `enable_logging=True` not working in `DockerSwarmOperator`

### DIFF
--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -17,6 +17,8 @@
 """Run ephemeral Docker Swarm services."""
 from __future__ import annotations
 
+import re
+from datetime import datetime
 from time import sleep
 from typing import TYPE_CHECKING
 
@@ -180,22 +182,29 @@ class DockerSwarmOperator(DockerOperator):
     def _stream_logs_to_output(self) -> None:
         if not self.service:
             raise Exception("The 'service' should be initialized before!")
-        last_line_logged = 0
-
-        def stream_new_logs(last_line_logged):
-            all_logs = self.cli.service_logs(
-                self.service["ID"], follow=False, stdout=True, stderr=True, is_tty=self.tty
+        last_line_logged, last_timestamp  = "", 0
+        def stream_new_logs(last_line_logged, since=0):
+            logs = self.cli.service_logs(
+                self.service["ID"], follow=False, stdout=True, stderr=True, is_tty=self.tty,
+                since=since,
+                timestamps=True
             )
-            new_lines_to_log = b"".join(all_logs).decode().splitlines()
-            new_lines_to_log = new_lines_to_log[last_line_logged:]
-            for line in new_lines_to_log:
-                self.log.info(line)
-            return last_line_logged + len(new_lines_to_log)
+            logs = b"".join(logs).decode().splitlines()
+            if last_line_logged in logs:
+                logs = logs[logs.index(last_line_logged)+1:]
+            for line in logs:
+                match = re.match(r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6,}Z) (.*)", line)
+                timestamp, message = match.groups()
+                self.log.info(message)
+            # Floor nanoseconds to microseconds
+            last_timestamp = re.sub(r"(\.\d{6})\d+Z", r"\1Z", timestamp)
+            last_timestamp = datetime.strptime(last_timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
+            last_timestamp = last_timestamp.timestamp()
+            return last_line_logged, last_timestamp
 
         while not self._has_service_terminated():
             sleep(2)
-            last_line_logged = stream_new_logs(last_line_logged)
-        stream_new_logs(last_line_logged)
+            last_line_logged, last_timestamp = stream_new_logs(last_line_logged, since= last_timestamp)
 
     def on_kill(self) -> None:
         if self.hook.client_created and self.service is not None:

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -184,7 +184,7 @@ class DockerSwarmOperator(DockerOperator):
 
         def stream_new_logs(last_line_logged):
             all_logs = self.cli.service_logs(
-                self.service["ID"], follow=False, stdout=True, stderr=True, is_tty=False
+                self.service["ID"], follow=False, stdout=True, stderr=True, is_tty=self.tty
             )
             new_lines_to_log = b"".join(all_logs).decode().splitlines()
             new_lines_to_log = new_lines_to_log[last_line_logged:]

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -17,6 +17,7 @@
 """Run ephemeral Docker Swarm services."""
 from __future__ import annotations
 
+from time import sleep
 from typing import TYPE_CHECKING
 
 from docker import types
@@ -24,7 +25,6 @@ from docker import types
 from airflow.exceptions import AirflowException
 from airflow.providers.docker.operators.docker import DockerOperator
 from airflow.utils.strings import get_random_string
-from time import sleep
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -182,16 +182,21 @@ class DockerSwarmOperator(DockerOperator):
     def _stream_logs_to_output(self) -> None:
         if not self.service:
             raise Exception("The 'service' should be initialized before!")
-        last_line_logged, last_timestamp  = "", 0
+        last_line_logged, last_timestamp = "", 0
+
         def stream_new_logs(last_line_logged, since=0):
             logs = self.cli.service_logs(
-                self.service["ID"], follow=False, stdout=True, stderr=True, is_tty=self.tty,
+                self.service["ID"],
+                follow=False,
+                stdout=True,
+                stderr=True,
+                is_tty=self.tty,
                 since=since,
-                timestamps=True
+                timestamps=True,
             )
             logs = b"".join(logs).decode().splitlines()
             if last_line_logged in logs:
-                logs = logs[logs.index(last_line_logged)+1:]
+                logs = logs[logs.index(last_line_logged) + 1 :]
             for line in logs:
                 match = re.match(r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6,}Z) (.*)", line)
                 timestamp, message = match.groups()
@@ -204,7 +209,7 @@ class DockerSwarmOperator(DockerOperator):
 
         while not self._has_service_terminated():
             sleep(2)
-            last_line_logged, last_timestamp = stream_new_logs(last_line_logged, since= last_timestamp)
+            last_line_logged, last_timestamp = stream_new_logs(last_line_logged, since=last_timestamp)
 
     def on_kill(self) -> None:
         if self.hook.client_created and self.service is not None:

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -98,7 +98,7 @@ class TestDockerSwarmOperator:
             base_url="unix://var/run/docker.sock", tls=False, version="1.19", timeout=DEFAULT_TIMEOUT_SECONDS
         )
 
-        client_mock.service_logs.assert_called_once_with(
+        client_mock.service_logs.assert_called_with(
             "some_id", follow=False, stdout=True, stderr=True, is_tty=True
         )
 

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -40,7 +40,7 @@ class TestDockerSwarmOperator:
                 yield [{"Status": {"State": "complete"}}]
 
         def _client_service_logs_effect():
-            yield b"Testing is awesome."
+            yield b"2023-12-05T00:00:00.000000000Z Testing is awesome."
 
         client_mock = mock.Mock(spec=APIClient)
         client_mock.create_service.return_value = {"ID": "some_id"}
@@ -99,7 +99,7 @@ class TestDockerSwarmOperator:
         )
 
         client_mock.service_logs.assert_called_with(
-            "some_id", follow=False, stdout=True, stderr=True, is_tty=True
+            "some_id", follow=False, stdout=True, stderr=True, is_tty=True, since=0, timestamps=True
         )
 
         csargs, cskwargs = client_mock.create_service.call_args_list[0]

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -108,7 +108,7 @@ class TestDockerSwarmOperator:
         assert cskwargs["labels"] == {"name": "airflow__adhoc_airflow__unittest"}
         assert cskwargs["name"].startswith("airflow-")
         assert cskwargs["mode"] == types.ServiceMode(mode="replicated", replicas=3)
-        assert client_mock.tasks.call_count == 5
+        assert client_mock.tasks.call_count == 6
         client_mock.remove_service.assert_called_once_with("some_id")
 
     @mock.patch("airflow.providers.docker.operators.docker_swarm.types")

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 import pytest
 from docker import APIClient, types
@@ -209,33 +209,3 @@ class TestDockerSwarmOperator:
         op.on_kill()
         docker_api_client_patcher.return_value.remove_service.assert_not_called()
         mock_service.assert_not_called()
-
-    def test_logging(self):
-        """
-        Test logging of operator.
-        """
-        operator = DockerSwarmOperator(
-            command="""
-            /bin/bash  -c '
-                            echo "Test message 1";
-                            echo "Test message 2";
-                        '
-            """,
-            environment={"UNIT": "TEST"},
-            image="ubuntu:latest",
-            task_id="unit_test_logging",
-            enable_logging=True,
-            tty=False,
-            docker_url="unix://var/run/docker.sock",
-            mode=types.ServiceMode(mode="replicated-job"),
-        )
-
-        this_test = TestCase()
-        with this_test.assertLogs("airflow.task.operators", level="INFO") as logs:
-            operator.execute(None)
-
-        logs = "\n".join(logs.output)
-        this_test.assertRegex(
-            logs,
-            r"INFO:airflow\.task\.operators\.airflow\.providers\.docker\.operators\.docker_swarm.DockerSwarmOperator:Test message 1\nINFO:airflow\.task\.operators\.airflow\.providers\.docker\.operators\.docker_swarm.DockerSwarmOperator:Test message 2\n",
-        )

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -99,7 +99,7 @@ class TestDockerSwarmOperator:
         )
 
         client_mock.service_logs.assert_called_once_with(
-            "some_id", follow=True, stdout=True, stderr=True, is_tty=True
+            "some_id", follow=False, stdout=True, stderr=True, is_tty=True
         )
 
         csargs, cskwargs = client_mock.create_service.call_args_list[0]

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import mock
+from unittest import TestCase, mock
 
 import pytest
 from docker import APIClient, types
@@ -209,3 +209,33 @@ class TestDockerSwarmOperator:
         op.on_kill()
         docker_api_client_patcher.return_value.remove_service.assert_not_called()
         mock_service.assert_not_called()
+
+    def test_logging(self):
+        """
+        Test logging of operator.
+        """
+        operator = DockerSwarmOperator(
+            command="""
+            /bin/bash  -c '
+                            echo "Test message 1";
+                            echo "Test message 2";
+                        '
+            """,
+            environment={"UNIT": "TEST"},
+            image="ubuntu:latest",
+            task_id="unit_test_logging",
+            enable_logging=True,
+            tty=False,
+            docker_url="unix://var/run/docker.sock",
+            mode=types.ServiceMode(mode="replicated-job"),
+        )
+
+        this_test = TestCase()
+        with this_test.assertLogs("airflow.task.operators", level="INFO") as logs:
+            operator.execute(None)
+
+        logs = "\n".join(logs.output)
+        this_test.assertRegex(
+            logs,
+            r"INFO:airflow\.task\.operators\.airflow\.providers\.docker\.operators\.docker_swarm.DockerSwarmOperator:Test message 1\nINFO:airflow\.task\.operators\.airflow\.providers\.docker\.operators\.docker_swarm.DockerSwarmOperator:Test message 2\n",
+        )


### PR DESCRIPTION
 Docker Swarm Operator was impractical as the Docker Service created was never finished in the airflow scheduler. Also logs were not received.  With this fix we make docker swarm services finite and we track their logs properly. 

The logging logic works like this:
For the current service we ask the docker API client to give us the logs with the `follow=False`. Otherwise, `follow=True` hangs for ever when the service has finished. 
We poll the docker API in 2 minute intervals, throwing logs to the console and checking if the service has terminated in order to break the loop.
 
Closes: #28452

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
