### PR TITLE
Use reproducible builds for provider packages

### DIFF
--- a/.github/actions/build-prod-images/action.yml
+++ b/.github/actions/build-prod-images/action.yml
@@ -46,9 +46,9 @@ runs:
       run: >
         breeze release-management prepare-airflow-package
         --package-format wheel --version-suffix-for-pypi dev0
-    - name: "Move dist packages to docker-context files"
+    - name: "Copy dist packages to docker-context files"
       shell: bash
-      run: mv -v ./dist/*.whl ./docker-context-files
+      run: cp -v --no-preserve=mode,ownership ./dist/*.whl ./docker-context-files
     - name: "Download constraints from the CI build"
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1930,8 +1930,8 @@ jobs:
           DEBUG_RESOURCES: ${{needs.build-info.outputs.debug-resources}}
           COMMIT_SHA: ${{ github.sha }}
         if: matrix.platform == 'linux/amd64'
-      - name: "Move dist packages to docker-context files"
-        run: mv -v ./dist/*.whl ./docker-context-files
+      - name: "Copy dist packages to docker-context files"
+        run: cp -v --no-preserve=mode,ownership ./dist/*.whl ./docker-context-files
       - name: "Push PROD cache ${{ matrix.python-version }} ${{ matrix.platform }}"
         run: >
           breeze prod-image build

--- a/airflow/provider.yaml.schema.json
+++ b/airflow/provider.yaml.schema.json
@@ -380,6 +380,16 @@
                     "type": "string"
                 }
             }
+        },
+        "source-date-epoch": {
+            "type": "integer",
+            "description": "Source date epoch - seconds since epoch (gmtime) when the release documentation was prepared. Used to generate reproducible package builds with flint.",
+
+            "minimum": 0,
+            "default": 0,
+            "examples": [
+                1609459200
+            ]
         }
     },
     "additionalProperties": false,
@@ -442,6 +452,7 @@
         "package-name",
         "description",
         "suspended",
+        "source-date-epoch",
         "dependencies",
         "versions"
     ]

--- a/airflow/providers/airbyte/provider.yaml
+++ b/airflow/providers/airbyte/provider.yaml
@@ -22,6 +22,7 @@ description: |
   `Airbyte <https://airbyte.io/>`__
 
 suspended: false
+source-date-epoch: 1700148043
 versions:
   - 3.4.0
   - 3.3.2

--- a/airflow/providers/alibaba/provider.yaml
+++ b/airflow/providers/alibaba/provider.yaml
@@ -22,6 +22,7 @@ description: |
     Alibaba Cloud integration (including `Alibaba Cloud <https://www.alibabacloud.com//>`__).
 
 suspended: false
+source-date-epoch: 1700148044
 versions:
   - 2.6.0
   - 2.5.3

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -22,6 +22,7 @@ description: |
   Amazon integration (including `Amazon Web Services (AWS) <https://aws.amazon.com/>`__).
 
 suspended: false
+source-date-epoch: 1700148045
 versions:
   - 8.11.0
   - 8.10.0

--- a/airflow/providers/apache/beam/provider.yaml
+++ b/airflow/providers/apache/beam/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Apache Beam <https://beam.apache.org/>`__.
 
 suspended: false
+source-date-epoch: 1700148046
 versions:
   - 5.3.0
   - 5.2.3

--- a/airflow/providers/apache/cassandra/provider.yaml
+++ b/airflow/providers/apache/cassandra/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Apache Cassandra <http://cassandra.apache.org/>`__.
 
 suspended: false
+source-date-epoch: 1700148046
 versions:
   - 3.3.0
   - 3.2.1

--- a/airflow/providers/apache/drill/provider.yaml
+++ b/airflow/providers/apache/drill/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Apache Drill <https://drill.apache.org/>`__.
 
 suspended: false
+source-date-epoch: 1700148047
 versions:
   - 2.5.0
   - 2.4.4

--- a/airflow/providers/apache/druid/provider.yaml
+++ b/airflow/providers/apache/druid/provider.yaml
@@ -22,6 +22,7 @@ description: |
   `Apache Druid <https://druid.apache.org/>`__.
 
 suspended: false
+source-date-epoch: 1700148047
 versions:
   - 3.6.0
   - 3.5.0

--- a/airflow/providers/apache/flink/provider.yaml
+++ b/airflow/providers/apache/flink/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Apache Flink <https://flink.apache.org/>`__
 
 suspended: false
+source-date-epoch: 1700148048
 versions:
   - 1.2.0
   - 1.1.3

--- a/airflow/providers/apache/hdfs/provider.yaml
+++ b/airflow/providers/apache/hdfs/provider.yaml
@@ -23,6 +23,7 @@ description: |
   and `WebHDFS <https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/WebHDFS.html>`__.
 
 suspended: false
+source-date-epoch: 1700148048
 versions:
   - 4.2.0
   - 4.1.1

--- a/airflow/providers/apache/hive/provider.yaml
+++ b/airflow/providers/apache/hive/provider.yaml
@@ -22,6 +22,7 @@ description: |
   `Apache Hive <https://hive.apache.org/>`__
 
 suspended: false
+source-date-epoch: 1700148049
 versions:
   - 6.2.0
   - 6.1.6

--- a/airflow/providers/apache/impala/provider.yaml
+++ b/airflow/providers/apache/impala/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Apache Impala <https://impala.apache.org/>`__.
 
 suspended: false
+source-date-epoch: 1700148050
 versions:
   - 1.2.0
   - 1.1.3

--- a/airflow/providers/apache/kafka/provider.yaml
+++ b/airflow/providers/apache/kafka/provider.yaml
@@ -20,6 +20,7 @@ package-name: apache-airflow-providers-apache-kafka
 name: Apache Kafka
 
 suspended: false
+source-date-epoch: 1700148050
 description: |
   `Apache Kafka  <https://kafka.apache.org/>`__
 versions:

--- a/airflow/providers/apache/kylin/provider.yaml
+++ b/airflow/providers/apache/kylin/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Apache Kylin <https://kylin.apache.org/>`__
 
 suspended: false
+source-date-epoch: 1700148051
 versions:
   - 3.3.0
   - 3.2.1

--- a/airflow/providers/apache/livy/provider.yaml
+++ b/airflow/providers/apache/livy/provider.yaml
@@ -22,6 +22,7 @@ description: |
   `Apache Livy <https://livy.apache.org/>`__
 
 suspended: false
+source-date-epoch: 1700148051
 versions:
   - 3.6.0
   - 3.5.4

--- a/airflow/providers/apache/pig/provider.yaml
+++ b/airflow/providers/apache/pig/provider.yaml
@@ -22,6 +22,7 @@ description: |
   `Apache Pig <https://pig.apache.org/>`__
 
 suspended: false
+source-date-epoch: 1700148052
 versions:
   - 4.2.0
   - 4.1.2

--- a/airflow/providers/apache/pinot/provider.yaml
+++ b/airflow/providers/apache/pinot/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Apache Pinot <https://pinot.apache.org/>`__
 
 suspended: false
+source-date-epoch: 1700148052
 versions:
   - 4.2.0
   - 4.1.4

--- a/airflow/providers/apache/spark/provider.yaml
+++ b/airflow/providers/apache/spark/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Apache Spark <https://spark.apache.org/>`__
 
 suspended: false
+source-date-epoch: 1700148053
 versions:
   - 4.4.0
   - 4.3.0

--- a/airflow/providers/apache/sqoop/provider.yaml
+++ b/airflow/providers/apache/sqoop/provider.yaml
@@ -22,6 +22,7 @@ description: |
   `Apache Sqoop <https://sqoop.apache.org/>`__
 
 suspended: false
+source-date-epoch: 1700148053
 versions:
   - 4.1.0
   - 4.0.0

--- a/airflow/providers/apprise/provider.yaml
+++ b/airflow/providers/apprise/provider.yaml
@@ -24,6 +24,7 @@ description: |
     `Apprise <https://github.com/caronc/apprise>`__
 
 suspended: false
+source-date-epoch: 1700148054
 
 versions:
   - 1.1.0

--- a/airflow/providers/arangodb/provider.yaml
+++ b/airflow/providers/arangodb/provider.yaml
@@ -26,6 +26,7 @@ dependencies:
   - python-arango>=7.3.2
 
 suspended: false
+source-date-epoch: 1700148054
 versions:
   - 2.3.0
   - 2.2.2

--- a/airflow/providers/asana/provider.yaml
+++ b/airflow/providers/asana/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Asana <https://app.asana.com/>`__
 
 suspended: false
+source-date-epoch: 1700148055
 versions:
   - 2.3.0
   - 2.2.2

--- a/airflow/providers/atlassian/jira/provider.yaml
+++ b/airflow/providers/atlassian/jira/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Atlassian Jira <https://www.atlassian.com/>`__
 
 suspended: false
+source-date-epoch: 1700148055
 versions:
   - 2.2.0
   - 2.1.1

--- a/airflow/providers/celery/provider.yaml
+++ b/airflow/providers/celery/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Celery <http://www.celeryproject.org/>`__
 
 suspended: false
+source-date-epoch: 1700148056
 versions:
   - 3.4.1
   - 3.4.0

--- a/airflow/providers/cloudant/provider.yaml
+++ b/airflow/providers/cloudant/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `IBM Cloudant <https://www.ibm.com/cloud/cloudant>`__
 
 suspended: false
+source-date-epoch: 1700148056
 versions:
   - 3.3.0
   - 3.2.1

--- a/airflow/providers/cncf/kubernetes/provider.yaml
+++ b/airflow/providers/cncf/kubernetes/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Kubernetes <https://kubernetes.io/>`__
 
 suspended: false
+source-date-epoch: 1700148057
 versions:
   - 7.9.0
   - 7.8.0

--- a/airflow/providers/cohere/provider.yaml
+++ b/airflow/providers/cohere/provider.yaml
@@ -24,6 +24,7 @@ description: |
     `Cohere <https://docs.cohere.com/docs>`__
 
 suspended: false
+source-date-epoch: 1700148058
 
 versions:
   - 1.0.0

--- a/airflow/providers/common/io/provider.yaml
+++ b/airflow/providers/common/io/provider.yaml
@@ -22,6 +22,7 @@ description: |
   ``Common IO Provider``
 
 suspended: false
+source-date-epoch: 1700148058
 versions:
   - 1.0.1
   - 1.0.0

--- a/airflow/providers/common/sql/provider.yaml
+++ b/airflow/providers/common/sql/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Common SQL Provider <https://en.wikipedia.org/wiki/SQL>`__
 
 suspended: false
+source-date-epoch: 1700148058
 versions:
   - 1.8.1
   - 1.8.0

--- a/airflow/providers/daskexecutor/provider.yaml
+++ b/airflow/providers/daskexecutor/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Dask <https://www.dask.org/>`__
 
 suspended: false
+source-date-epoch: 1700148059
 versions:
   - 1.1.0
   - 1.0.1

--- a/airflow/providers/databricks/provider.yaml
+++ b/airflow/providers/databricks/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Databricks <https://databricks.com/>`__
 
 suspended: false
+source-date-epoch: 1700148060
 versions:
   - 5.0.0
   - 4.7.0

--- a/airflow/providers/datadog/provider.yaml
+++ b/airflow/providers/datadog/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Datadog <https://www.datadoghq.com/>`__
 
 suspended: false
+source-date-epoch: 1700148060
 versions:
   - 3.4.0
   - 3.3.2

--- a/airflow/providers/dbt/cloud/provider.yaml
+++ b/airflow/providers/dbt/cloud/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `dbt Cloud <https://www.getdbt.com/product/what-is-dbt/>`__
 
 suspended: false
+source-date-epoch: 1700148061
 versions:
   - 3.4.0
   - 3.3.0

--- a/airflow/providers/dingding/provider.yaml
+++ b/airflow/providers/dingding/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `DingTalk <https://www.dingtalk.com/>`__
 
 suspended: false
+source-date-epoch: 1700148061
 versions:
   - 3.3.0
   - 3.2.1

--- a/airflow/providers/discord/provider.yaml
+++ b/airflow/providers/discord/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Discord <https://discordapp.com/>`__
 
 suspended: false
+source-date-epoch: 1700148062
 versions:
   - 3.4.1
   - 3.4.0

--- a/airflow/providers/docker/provider.yaml
+++ b/airflow/providers/docker/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Docker <https://docs.docker.com/install/>`__
 
 suspended: false
+source-date-epoch: 1700148062
 versions:
   - 3.8.1
   - 3.8.0

--- a/airflow/providers/elasticsearch/provider.yaml
+++ b/airflow/providers/elasticsearch/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Elasticsearch <https://www.elastic.co/elasticsearch>`__
 
 suspended: false
+source-date-epoch: 1700148063
 versions:
   - 5.1.1
   - 5.1.0

--- a/airflow/providers/exasol/provider.yaml
+++ b/airflow/providers/exasol/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Exasol <https://docs.exasol.com/home.htm>`__
 
 suspended: false
+source-date-epoch: 1700148064
 versions:
   - 4.3.0
   - 4.2.5

--- a/airflow/providers/facebook/provider.yaml
+++ b/airflow/providers/facebook/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Facebook Ads <http://business.facebook.com/>`__
 
 suspended: false
+source-date-epoch: 1700148064
 versions:
   - 3.3.0
   - 3.2.2

--- a/airflow/providers/ftp/provider.yaml
+++ b/airflow/providers/ftp/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `File Transfer Protocol (FTP) <https://tools.ietf.org/html/rfc114>`__
 
 suspended: false
+source-date-epoch: 1700148065
 versions:
   - 3.6.1
   - 3.6.0

--- a/airflow/providers/github/provider.yaml
+++ b/airflow/providers/github/provider.yaml
@@ -29,6 +29,7 @@ dependencies:
   - PyGithub!=1.58
 
 suspended: false
+source-date-epoch: 1700148065
 versions:
   - 2.4.0
   - 2.3.2

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -29,6 +29,7 @@ description: |
       - `Google Workspace <https://workspace.google.com/>`__ (formerly Google Suite)
 
 suspended: false
+source-date-epoch: 1700148066
 versions:
   - 10.11.1
   - 10.11.0

--- a/airflow/providers/grpc/provider.yaml
+++ b/airflow/providers/grpc/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `gRPC <https://grpc.io/>`__
 
 suspended: false
+source-date-epoch: 1700148067
 versions:
   - 3.3.0
   - 3.2.2

--- a/airflow/providers/hashicorp/provider.yaml
+++ b/airflow/providers/hashicorp/provider.yaml
@@ -22,6 +22,7 @@ description: |
     Hashicorp including `Hashicorp Vault <https://www.vaultproject.io/>`__
 
 suspended: false
+source-date-epoch: 1700148068
 versions:
   - 3.5.0
   - 3.4.3

--- a/airflow/providers/http/provider.yaml
+++ b/airflow/providers/http/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Hypertext Transfer Protocol (HTTP) <https://www.w3.org/Protocols/>`__
 
 suspended: false
+source-date-epoch: 1700148068
 versions:
   - 4.7.0
   - 4.6.0

--- a/airflow/providers/imap/provider.yaml
+++ b/airflow/providers/imap/provider.yaml
@@ -23,6 +23,7 @@ description: |
     `Internet Message Access Protocol (IMAP) <https://tools.ietf.org/html/rfc3501>`__
 
 suspended: false
+source-date-epoch: 1700148069
 versions:
   - 3.4.0
   - 3.3.2

--- a/airflow/providers/influxdb/provider.yaml
+++ b/airflow/providers/influxdb/provider.yaml
@@ -29,6 +29,7 @@ dependencies:
   - requests>=2.26.0
 
 suspended: false
+source-date-epoch: 1700148070
 versions:
   - 2.3.0
   - 2.2.3

--- a/airflow/providers/jdbc/provider.yaml
+++ b/airflow/providers/jdbc/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Java Database Connectivity (JDBC) <https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/>`__
 
 suspended: false
+source-date-epoch: 1700148070
 versions:
   - 4.1.0
   - 4.0.2

--- a/airflow/providers/jenkins/provider.yaml
+++ b/airflow/providers/jenkins/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Jenkins <https://jenkins.io/>`__
 
 suspended: false
+source-date-epoch: 1700148071
 versions:
   - 3.4.0
   - 3.3.2

--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -20,6 +20,7 @@ name: Microsoft Azure
 description: |
   `Microsoft Azure <https://azure.microsoft.com/>`__
 suspended: false
+source-date-epoch: 1700148071
 versions:
   - 8.2.0
   - 8.1.0

--- a/airflow/providers/microsoft/mssql/provider.yaml
+++ b/airflow/providers/microsoft/mssql/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Microsoft SQL Server (MSSQL) <https://www.microsoft.com/en-us/sql-server/sql-server-downloads>`__
 
 suspended: false
+source-date-epoch: 1700148072
 versions:
   - 3.5.0
   - 3.4.2

--- a/airflow/providers/microsoft/psrp/provider.yaml
+++ b/airflow/providers/microsoft/psrp/provider.yaml
@@ -24,6 +24,7 @@ description: |
     <https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/>`__.
 
 suspended: false
+source-date-epoch: 1700148073
 versions:
   - 2.4.0
   - 2.3.2

--- a/airflow/providers/microsoft/winrm/provider.yaml
+++ b/airflow/providers/microsoft/winrm/provider.yaml
@@ -22,6 +22,7 @@ description: |
   `Windows Remote Management (WinRM) <https://docs.microsoft.com/en-us/windows/win32/winrm/portal>`__
 
 suspended: false
+source-date-epoch: 1700148073
 versions:
   - 3.3.0
   - 3.2.2

--- a/airflow/providers/mongo/provider.yaml
+++ b/airflow/providers/mongo/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `MongoDB <https://www.mongodb.com/what-is-mongodb>`__
 
 suspended: false
+source-date-epoch: 1700148074
 versions:
   - 3.4.0
   - 3.3.0

--- a/airflow/providers/mysql/provider.yaml
+++ b/airflow/providers/mysql/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `MySQL <https://www.mysql.com/products/>`__
 
 suspended: false
+source-date-epoch: 1700148074
 versions:
   - 5.4.0
   - 5.3.1

--- a/airflow/providers/neo4j/provider.yaml
+++ b/airflow/providers/neo4j/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Neo4j <https://neo4j.com/>`__
 
 suspended: false
+source-date-epoch: 1700148075
 versions:
   - 3.4.0
   - 3.3.3

--- a/airflow/providers/odbc/provider.yaml
+++ b/airflow/providers/odbc/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `ODBC <https://github.com/mkleehammer/pyodbc/wiki>`__
 
 suspended: false
+source-date-epoch: 1700148076
 versions:
   - 4.1.0
   - 4.0.0

--- a/airflow/providers/openai/provider.yaml
+++ b/airflow/providers/openai/provider.yaml
@@ -24,6 +24,7 @@ description: |
     `OpenAI <https://platform.openai.com/docs/introduction>`__
 
 suspended: false
+source-date-epoch: 1700148076
 
 versions:
   - 1.0.0

--- a/airflow/providers/openfaas/provider.yaml
+++ b/airflow/providers/openfaas/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `OpenFaaS <https://www.openfaas.com/>`__
 
 suspended: false
+source-date-epoch: 1700148077
 versions:
   - 3.3.0
   - 3.2.1

--- a/airflow/providers/openlineage/provider.yaml
+++ b/airflow/providers/openlineage/provider.yaml
@@ -22,6 +22,7 @@ description: |
   `OpenLineage <https://openlineage.io/>`__
 
 suspended: false
+source-date-epoch: 1700148077
 versions:
   - 1.2.1
   - 1.2.0

--- a/airflow/providers/opensearch/provider.yaml
+++ b/airflow/providers/opensearch/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Opensearch <https://opensearch.org/>`__
 
 suspended: false
+source-date-epoch: 1700148078
 versions:
   - 1.0.0
 

--- a/airflow/providers/opsgenie/provider.yaml
+++ b/airflow/providers/opsgenie/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Opsgenie <https://www.opsgenie.com/>`__
 
 suspended: false
+source-date-epoch: 1700148078
 versions:
   - 5.2.0
   - 5.1.1

--- a/airflow/providers/oracle/provider.yaml
+++ b/airflow/providers/oracle/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Oracle <https://www.oracle.com/en/database/>`__
 
 suspended: false
+source-date-epoch: 1700148079
 versions:
   - 3.8.0
   - 3.7.4

--- a/airflow/providers/pagerduty/provider.yaml
+++ b/airflow/providers/pagerduty/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Pagerduty <https://www.pagerduty.com/>`__
 
 suspended: false
+source-date-epoch: 1700148079
 versions:
   - 3.4.0
   - 3.3.1

--- a/airflow/providers/papermill/provider.yaml
+++ b/airflow/providers/papermill/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Papermill <https://github.com/nteract/papermill>`__
 
 suspended: false
+source-date-epoch: 1700148080
 versions:
   - 3.4.0
   - 3.2.1

--- a/airflow/providers/pgvector/provider.yaml
+++ b/airflow/providers/pgvector/provider.yaml
@@ -24,6 +24,7 @@ description: |
     `pgvector <https://github.com/pgvector/pgvector>`__
 
 suspended: false
+source-date-epoch: 1700148080
 
 versions:
   - 1.0.0

--- a/airflow/providers/pinecone/provider.yaml
+++ b/airflow/providers/pinecone/provider.yaml
@@ -24,6 +24,7 @@ description: |
     `Pinecone <https://docs.pinecone.io/docs/overview>`__
 
 suspended: false
+source-date-epoch: 1700148081
 
 versions:
   - 1.0.0

--- a/airflow/providers/plexus/provider.yaml
+++ b/airflow/providers/plexus/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Plexus <https://plexus.corescientific.com/>`__
 
 suspended: false
+source-date-epoch: 1700148081
 versions:
   - 3.3.0
   - 3.2.2

--- a/airflow/providers/postgres/provider.yaml
+++ b/airflow/providers/postgres/provider.yaml
@@ -22,6 +22,7 @@ description: |
   `PostgreSQL <https://www.postgresql.org/>`__
 
 suspended: false
+source-date-epoch: 1700148082
 versions:
   - 5.8.0
   - 5.7.1

--- a/airflow/providers/presto/provider.yaml
+++ b/airflow/providers/presto/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Presto <https://prestodb.github.io/>`__
 
 suspended: false
+source-date-epoch: 1700148082
 versions:
   - 5.2.1
   - 5.2.0

--- a/airflow/providers/redis/provider.yaml
+++ b/airflow/providers/redis/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Redis <https://redis.io/>`__
 
 suspended: false
+source-date-epoch: 1700148083
 versions:
   - 3.4.0
   - 3.3.2

--- a/airflow/providers/salesforce/provider.yaml
+++ b/airflow/providers/salesforce/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Salesforce <https://www.salesforce.com/>`__
 
 suspended: false
+source-date-epoch: 1700148084
 versions:
   - 5.5.1
   - 5.5.0

--- a/airflow/providers/samba/provider.yaml
+++ b/airflow/providers/samba/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Samba <https://www.samba.org/>`__
 
 suspended: false
+source-date-epoch: 1700148084
 versions:
   - 4.3.0
   - 4.2.2

--- a/airflow/providers/segment/provider.yaml
+++ b/airflow/providers/segment/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Segment <https://segment.com/>`__
 
 suspended: false
+source-date-epoch: 1700148085
 versions:
   - 3.3.0
   - 3.2.1

--- a/airflow/providers/sendgrid/provider.yaml
+++ b/airflow/providers/sendgrid/provider.yaml
@@ -26,6 +26,7 @@ dependencies:
   - sendgrid>=6.0.0
 
 suspended: false
+source-date-epoch: 1700148085
 versions:
   - 3.3.0
   - 3.2.2

--- a/airflow/providers/sftp/provider.yaml
+++ b/airflow/providers/sftp/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `SSH File Transfer Protocol (SFTP) <https://tools.ietf.org/wg/secsh/draft-ietf-secsh-filexfer/>`__
 
 suspended: false
+source-date-epoch: 1700148086
 versions:
   - 4.7.0
   - 4.6.1

--- a/airflow/providers/singularity/provider.yaml
+++ b/airflow/providers/singularity/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Singularity <https://sylabs.io/guides/latest/user-guide/>`__
 
 suspended: false
+source-date-epoch: 1700148086
 versions:
   - 3.3.0
   - 3.2.2

--- a/airflow/providers/slack/provider.yaml
+++ b/airflow/providers/slack/provider.yaml
@@ -25,6 +25,7 @@ description: |
       - `Slack Incoming Webhook <https://api.slack.com/messaging/webhooks>`__
 
 suspended: false
+source-date-epoch: 1700148087
 versions:
   - 8.4.0
   - 8.3.0

--- a/airflow/providers/smtp/provider.yaml
+++ b/airflow/providers/smtp/provider.yaml
@@ -23,6 +23,7 @@ description: |
   `Simple Mail Transfer Protocol (SMTP) <https://tools.ietf.org/html/rfc5321>`__
 
 suspended: false
+source-date-epoch: 1700148088
 versions:
   - 1.4.1
   - 1.4.0

--- a/airflow/providers/snowflake/provider.yaml
+++ b/airflow/providers/snowflake/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Snowflake <https://www.snowflake.com/>`__
 
 suspended: false
+source-date-epoch: 1700148088
 versions:
   - 5.1.1
   - 5.1.0

--- a/airflow/providers/sqlite/provider.yaml
+++ b/airflow/providers/sqlite/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `SQLite <https://www.sqlite.org/>`__
 
 suspended: false
+source-date-epoch: 1700148089
 versions:
   - 3.5.0
   - 3.4.3

--- a/airflow/providers/ssh/provider.yaml
+++ b/airflow/providers/ssh/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Secure Shell (SSH) <https://tools.ietf.org/html/rfc4251>`__
 
 suspended: false
+source-date-epoch: 1700148090
 versions:
   - 3.8.1
   - 3.8.0

--- a/airflow/providers/tableau/provider.yaml
+++ b/airflow/providers/tableau/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Tableau <https://www.tableau.com/>`__
 
 suspended: false
+source-date-epoch: 1700148090
 versions:
   - 4.3.0
   - 4.2.2

--- a/airflow/providers/tabular/provider.yaml
+++ b/airflow/providers/tabular/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Tabular <https://tabular.io/>`__
 
 suspended: false
+source-date-epoch: 1700148091
 versions:
   - 1.3.0
   - 1.2.1

--- a/airflow/providers/telegram/provider.yaml
+++ b/airflow/providers/telegram/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Telegram <https://telegram.org/>`__
 
 suspended: false
+source-date-epoch: 1700148091
 versions:
   - 4.2.0
   - 4.1.1

--- a/airflow/providers/trino/provider.yaml
+++ b/airflow/providers/trino/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Trino <https://trino.io/>`__
 
 suspended: false
+source-date-epoch: 1700148092
 versions:
   - 5.4.0
   - 5.3.1

--- a/airflow/providers/vertica/provider.yaml
+++ b/airflow/providers/vertica/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Vertica <https://www.vertica.com/>`__
 
 suspended: false
+source-date-epoch: 1700148092
 versions:
   - 3.6.0
   - 3.5.2

--- a/airflow/providers/weaviate/provider.yaml
+++ b/airflow/providers/weaviate/provider.yaml
@@ -24,6 +24,7 @@ description: |
     `Weaviate <https://weaviate.io/developers/weaviate>`__
 
 suspended: false
+source-date-epoch: 1700148093
 
 versions:
   - 1.0.0

--- a/airflow/providers/yandex/provider.yaml
+++ b/airflow/providers/yandex/provider.yaml
@@ -21,6 +21,7 @@ name: Yandex
 description: |
     Yandex including `Yandex.Cloud <https://cloud.yandex.com/>`__
 suspended: false
+source-date-epoch: 1700148093
 versions:
   - 3.6.0
   - 3.5.0

--- a/airflow/providers/zendesk/provider.yaml
+++ b/airflow/providers/zendesk/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Zendesk <https://www.zendesk.com/>`__
 
 suspended: false
+source-date-epoch: 1700148094
 versions:
   - 4.4.0
   - 4.3.2

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -481,7 +481,6 @@ def prepare_provider_packages(
                 cleanup_build_remnants(target_provider_root_sources_path)
                 build_provider_package(
                     provider_id=provider_id,
-                    version_suffix=version_suffix_for_pypi,
                     package_format=package_format,
                     target_provider_root_sources_path=target_provider_root_sources_path,
                 )

--- a/dev/refresh_images.sh
+++ b/dev/refresh_images.sh
@@ -42,7 +42,7 @@ breeze release-management prepare-provider-packages \
 
 breeze release-management prepare-airflow-package --package-format wheel --version-suffix-for-pypi dev0
 
-mv -v ./dist/*.whl ./docker-context-files
+mv -v ./dist/*.whl ./docker-context-files && chmod a+r ./docker-context-files/*
 
 breeze prod-image build \
      --builder airflow_cache \


### PR DESCRIPTION
Flit allows to build reproducible packages (packages that can be
compared bit-by-bit) providing that source date epoch is set to
repeatable value when package is built. This PR implements
reproducibility of our builds by freezing the documentation preparation
time in provider.yaml as "source date epoch" and always using it when
building the package. This way anyone using breeze to build the package
will have exactly the same binary package produced, which will make it
way easier to verify if the packages are ready for release by the PMC
member.

We will no longer have to check the sources, PMC members will simply
need to build the same packages locally using breeze and see if the
generated packages are exactly the same.

That also includes permissions bits - flit sets permissions of
the generated packages to "no permissions for other/group" in
order to get bit-to-bit reproducibility - because on some systems
umask is set differently by default and created file would be
different because of the permission bit. This caused problems
when building docker images - so we had it changed when moving
packages to 'dist' folder, but this PR changes it so that CI
build does it when moving packages from dist to docker-context-files
instead

The "source-date-epoch" fields have been regenerated in this PR as
well. Also this PR replaces `lru_cache` method of storing output
of `get_provider_metadata_packages` with custom-stored dictionary -
thanks to that instead of invalidating whole cache of providers
metadata refreshed from yaml files we can refresh individual provider
metadata entries after they have been updated. This saves a lot
of time for validation - because every time when provider yaml is
updated we need to re-read it and re-validate it with json schema,
with this change we only do it for the updated provider yaml - which
saves about 0.5 a second per provider yaml update and when you
update all provides it is done way faster.

Based on #35617  so it should only be merged after that one

(Only last commit counts)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
