### PR TITLE
allow multiple elements in impersonation chain

### DIFF
--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -267,6 +267,8 @@ class GoogleBaseHook(BaseHook):
 
         if not self.impersonation_chain:
             self.impersonation_chain = self._get_field("impersonation_chain", None)
+            if isinstance(self.impersonation_chain, str) and "," in self.impersonation_chain:
+                self.impersonation_chain = [s.strip() for s in self.impersonation_chain.split(",")]
 
         target_principal, delegates = _get_target_principal_and_delegates(self.impersonation_chain)
 

--- a/docs/apache-airflow-providers-google/connections/gcp.rst
+++ b/docs/apache-airflow-providers-google/connections/gcp.rst
@@ -131,7 +131,7 @@ Impersonation Chain
     of the last account in the list, which will be impersonated in all requests leveraging this connection.
     If set as a string, the account must grant the originating account
     the Service Account Token Creator IAM role.
-    If set as a sequence, the identities from the list must grant
+    If set as a comma-separated list, the identities from the list must grant
     Service Account Token Creator IAM role to the directly preceding identity, with first
     account from the list granting this role to the originating account.
 

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -683,6 +683,20 @@ class TestGoogleBaseHook:
                 ["ACCOUNT_2", "ACCOUNT_3"],
                 id="multiple_elements_list_with_override",
             ),
+            pytest.param(
+                None,
+                "ACCOUNT_1,ACCOUNT_2,ACCOUNT_3",
+                "ACCOUNT_3",
+                ["ACCOUNT_1", "ACCOUNT_2"],
+                id="multiple_elements_list_as_string",
+            ),
+            pytest.param(
+                None,
+                "ACCOUNT_1, ACCOUNT_2, ACCOUNT_3",
+                "ACCOUNT_3",
+                ["ACCOUNT_1", "ACCOUNT_2"],
+                id="multiple_elements_list_as_string_with_space",
+            ),
         ],
     )
     @mock.patch(MODULE_NAME + ".get_credentials_and_project_id")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


https://github.com/apache/airflow/pull/33715 added the `impersonation_chain` parameter to Google Cloud connections, but didn't allow any way to set multiple values for the impersonation chain. with this change, users can specify a comma-separated list of service accounts to be used in the impersonation chain


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
