### PR TITLE
Fixup for the system test example_datacatalog_search_catalog.py

### DIFF
--- a/tests/system/providers/google/datacatalog/example_datacatalog_search_catalog.py
+++ b/tests/system/providers/google/datacatalog/example_datacatalog_search_catalog.py
@@ -47,11 +47,11 @@ DAG_ID = "datacatalog_search_catalog"
 
 BUCKET_NAME = f"bucket_{DAG_ID}_{ENV_ID}"
 LOCATION = "us-central1"
-ENTRY_GROUP_ID = f"id_{DAG_ID}_{ENV_ID}"
+ENTRY_GROUP_ID = f"id_{DAG_ID}_{ENV_ID}".replace("-", "_")
 ENTRY_GROUP_NAME = f"name {DAG_ID} {ENV_ID}"
 ENTRY_ID = "python_files"
 ENTRY_NAME = "Wizard"
-TEMPLATE_ID = f"template_id_search_{ENV_ID}"
+TEMPLATE_ID = f"template_id_search_{ENV_ID}".replace("-", "_")
 TAG_TEMPLATE_DISPLAY_NAME = f"Data Catalog {DAG_ID} {ENV_ID}"
 FIELD_NAME_1 = "first"
 
@@ -147,7 +147,9 @@ with DAG(
     # Search
     # [START howto_operator_gcp_datacatalog_search_catalog]
     search_catalog = CloudDataCatalogSearchCatalogOperator(
-        task_id="search_catalog", scope={"include_project_ids": [PROJECT_ID]}, query=f"projectid:{PROJECT_ID}"
+        task_id="search_catalog",
+        scope={"include_project_ids": [PROJECT_ID]},
+        query=f"name:{ENTRY_GROUP_NAME}",
     )
     # [END howto_operator_gcp_datacatalog_search_catalog]
 


### PR DESCRIPTION
Tiny fixup for the system test example_datacatalog_search_catalog.py - changed query for the `search_catalog` task in order to limit its output. Without this change the following task fails if the output is too big:
```python
# [START howto_operator_gcp_datacatalog_search_catalog_result]
  search_catalog_result = BashOperator(
      task_id="search_catalog_result",
      bash_command=f"echo {search_catalog.output}",
  )
  # [END howto_operator_gcp_datacatalog_search_catalog_result]

```