### PR TITLE
Add parameter confirm to GCSToSFTPOperator

### DIFF
--- a/airflow/providers/apache/beam/operators/beam.py
+++ b/airflow/providers/apache/beam/operators/beam.py
@@ -522,6 +522,9 @@ class BeamRunJavaPipelineOperator(BeamBasePipelineOperator):
         )
         self.jar = jar
         self.job_class = job_class
+        self.pipeline_options.setdefault("labels", {}).update(
+            {"airflow-version": "v" + version.replace(".", "-").replace("+", "-")}
+        )
         self.deferrable = deferrable
 
     def execute(self, context: Context):

--- a/airflow/providers/google/cloud/transfers/gcs_to_sftp.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_sftp.py
@@ -84,7 +84,7 @@ class GCSToSFTPOperator(BaseOperator):
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
     :param sftp_conn_id: The sftp connection id. The name or identifier for
         establishing a connection to the SFTP server.
-    :param bool confirm: whether to do a stat() on the file afterwards to confirm the file size
+    :param confirm: whether to do a stat() on the file afterwards to confirm the file size
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.

--- a/airflow/providers/google/cloud/transfers/gcs_to_sftp.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_sftp.py
@@ -84,6 +84,7 @@ class GCSToSFTPOperator(BaseOperator):
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
     :param sftp_conn_id: The sftp connection id. The name or identifier for
         establishing a connection to the SFTP server.
+    :param bool confirm: whether to do a stat() on the file afterwards to confirm the file size
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -113,6 +114,7 @@ class GCSToSFTPOperator(BaseOperator):
         gcp_conn_id: str = "google_cloud_default",
         sftp_conn_id: str = "ssh_default",
         impersonation_chain: str | Sequence[str] | None = None,
+        confirm: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -125,6 +127,7 @@ class GCSToSFTPOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.sftp_conn_id = sftp_conn_id
         self.impersonation_chain = impersonation_chain
+        self.confirm = confirm
         self.sftp_dirs = None
 
     def execute(self, context: Context):
@@ -193,7 +196,7 @@ class GCSToSFTPOperator(BaseOperator):
                 object_name=source_object,
                 filename=tmp.name,
             )
-            sftp_hook.store_file(destination_path, tmp.name)
+            sftp_hook.store_file(destination_path, tmp.name, confirm=self.confirm)
 
         if self.move_object:
             self.log.info("Executing delete of gs://%s/%s", self.source_bucket, source_object)

--- a/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
@@ -150,7 +150,7 @@ class TestGoogleCloudStorageToSFTPOperator:
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
-            confirm=confirm
+            confirm=confirm,
         )
         task.execute(None)
         gcs_hook_mock.assert_called_once_with(

--- a/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
@@ -128,7 +128,6 @@ class TestGoogleCloudStorageToSFTPOperator:
             ("folder/subfolder/test_object.txt", "folder/subfolder/test_object.txt", True, True),
             ("folder/test_object.txt", "test_object.txt", False, True),
             ("folder/subfolder/test_object.txt", "test_object.txt", False, True),
-
             ("folder/test_object.txt", "folder/test_object.txt", True, False),
             ("folder/subfolder/test_object.txt", "folder/subfolder/test_object.txt", True, False),
             ("folder/test_object.txt", "test_object.txt", False, False),


### PR DESCRIPTION
If the SFTP server picks up the file immediately Paramiko cannot check the file size. 
The current operator terminates with a fail after the transfer because the file cannot be found.
