### PR TITLE
Cleanup code for elasticsearch<8

### DIFF
--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -70,17 +70,6 @@ def get_es_kwargs_from_config() -> dict[str, Any]:
         if elastic_search_config
         else {}
     )
-    # For elasticsearch>8 retry_timeout have changed for elasticsearch to retry_on_timeout
-    # in Elasticsearch() compared to previous versions.
-    # Read more at: https://elasticsearch-py.readthedocs.io/en/v8.8.2/api.html#module-elasticsearch
-    if (
-        elastic_search_config
-        and "retry_timeout" in elastic_search_config
-        and not kwargs_dict.get("retry_on_timeout")
-    ):
-        retry_timeout = elastic_search_config.get("retry_timeout")
-        if retry_timeout is not None:
-            kwargs_dict["retry_on_timeout"] = retry_timeout
     return kwargs_dict
 
 

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -70,6 +70,20 @@ def get_es_kwargs_from_config() -> dict[str, Any]:
         if elastic_search_config
         else {}
     )
+    # TODO: Remove in next major release (drop support for elasticsearch<8 parameters)
+    if (
+        elastic_search_config
+        and "retry_timeout" in elastic_search_config
+        and not kwargs_dict.get("retry_on_timeout")
+    ):
+        warnings.warn(
+            "retry_timeout is not supported with elasticsearch>=8. Please use `retry_on_timeout`.",
+            AirflowProviderDeprecationWarning,
+            stacklevel=2,
+        )
+        retry_timeout = elastic_search_config.get("retry_timeout")
+        if retry_timeout is not None:
+            kwargs_dict["retry_on_timeout"] = retry_timeout
     return kwargs_dict
 
 

--- a/docs/apache-airflow-providers-elasticsearch/logging/index.rst
+++ b/docs/apache-airflow-providers-elasticsearch/logging/index.rst
@@ -61,7 +61,6 @@ cert, etc.) use the ``elasticsearch_configs`` setting in your ``airflow.cfg``
     remote_logging = True
 
     [elasticsearch_configs]
-    use_ssl=True # (This setting is valid only for ``elasticsearch<8``)
     verify_certs=True
     ca_certs=/path/to/CA_certs
 

--- a/docs/apache-airflow-providers-elasticsearch/logging/index.rst
+++ b/docs/apache-airflow-providers-elasticsearch/logging/index.rst
@@ -61,7 +61,7 @@ cert, etc.) use the ``elasticsearch_configs`` setting in your ``airflow.cfg``
     remote_logging = True
 
     [elasticsearch_configs]
-    use_ssl=True
+    use_ssl=True # (This setting is valid only for ``elasticsearch<8``)
     verify_certs=True
     ca_certs=/path/to/CA_certs
 

--- a/tests/providers/elasticsearch/log/test_es_task_handler.py
+++ b/tests/providers/elasticsearch/log/test_es_task_handler.py
@@ -691,7 +691,7 @@ def test_retrieve_retry_on_timeout():
     """
     with conf_vars(
         {
-            ("elasticsearch_configs", "retry_on_timeout"): "True",
+            ("elasticsearch_configs", "retry_timeout"): "True",
         }
     ):
         args_from_config = get_es_kwargs_from_config().keys()

--- a/tests/providers/elasticsearch/log/test_es_task_handler.py
+++ b/tests/providers/elasticsearch/log/test_es_task_handler.py
@@ -671,14 +671,11 @@ def test_retrieve_config_keys():
     """
     with conf_vars(
         {
-            ("elasticsearch_configs", "use_ssl"): "True",
             ("elasticsearch_configs", "http_compress"): "False",
             ("elasticsearch_configs", "timeout"): "10",
         }
     ):
         args_from_config = get_es_kwargs_from_config().keys()
-        # use_ssl is removed from config
-        assert "use_ssl" not in args_from_config
         # verify_certs comes from default config value
         assert "verify_certs" in args_from_config
         # timeout comes from config provided value
@@ -694,12 +691,10 @@ def test_retrieve_retry_on_timeout():
     """
     with conf_vars(
         {
-            ("elasticsearch_configs", "retry_timeout"): "True",
+            ("elasticsearch_configs", "retry_on_timeout"): "True",
         }
     ):
         args_from_config = get_es_kwargs_from_config().keys()
-        # use_ssl is removed from config
-        assert "retry_timeout" not in args_from_config
         # verify_certs comes from default config value
         assert "retry_on_timeout" in args_from_config
 


### PR DESCRIPTION
Starting `elasticsearch>=8` there is no more `use_ssl`
see https://github.com/apache/airflow/pull/33135/files#r1285347163

mentioning also open question about supporting `elasticsearch<8`
https://github.com/apache/airflow/pull/33281#issuecomment-1816741321

cc @sunank200 @Owen-CH-Leung 

------------------

**EDIT:**
This PR practically reverts https://github.com/apache/airflow/pull/33281 as provider setup is to support elasticsearch>=8

https://github.com/apache/airflow/blob/177da9016bbedcfa49c08256fdaf2fb537b97d6c/airflow/providers/elasticsearch/provider.yaml#L62

Thus users can't install older version of the library anyway.

