### PR TITLE
Update provider.yaml: To view Azure Synapse Pipeline Connection type in Airflow UI

### DIFF
--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -294,6 +294,8 @@ connection-types:
     connection-type: azure_synapse
   - hook-class-name: airflow.providers.microsoft.azure.hooks.data_lake.AzureDataLakeStorageV2Hook
     connection-type: adls
+  - hook-class-name: airflow.providers.microsoft.azure.hooks.synapse.AzureSynapsePipelineHook
+    connection-type: azure_synapse_pipeline
 
 secrets-backends:
   - airflow.providers.microsoft.azure.secrets.key_vault.AzureKeyVaultBackend


### PR DESCRIPTION
This PR intends to update provider.yaml by adding Azure Synapse Pipeline connection-type.  This would register Azure Synapse Pipeline as separate connection type as shown in screenshot.

 
![image](https://github.com/apache/airflow/assets/70703123/f2d0a620-94b6-4948-ade5-8ed57176aea6)