### PR TITLE
Fix `--additional-extras` parameter in Breeze command

### DIFF
--- a/dev/breeze/src/airflow_breeze/params/build_ci_params.py
+++ b/dev/breeze/src/airflow_breeze/params/build_ci_params.py
@@ -94,7 +94,7 @@ class BuildCiParams(CommonBuildParams):
     @property
     def optional_image_args(self) -> list[str]:
         return [
-            "additional_airflow_extras",
+            "additional_extras",
             "additional_dev_apt_command",
             "additional_dev_apt_deps",
             "additional_dev_apt_env",
@@ -108,7 +108,7 @@ class BuildCiParams(CommonBuildParams):
             "additional_dev_apt_command",
             "additional_dev_apt_deps",
             "additional_dev_apt_env",
-            "additional_airflow_extras",
+            "additional_extras",
             "additional_pip_install_flags",
             "additional_python_deps",
             "version_suffix_for_pypi",

--- a/dev/breeze/src/airflow_breeze/params/build_prod_params.py
+++ b/dev/breeze/src/airflow_breeze/params/build_prod_params.py
@@ -226,7 +226,7 @@ class BuildProdParams(CommonBuildParams):
     @property
     def optional_image_args(self) -> list[str]:
         return [
-            "additional_airflow_extras",
+            "additional_extras",
             "additional_dev_apt_command",
             "additional_dev_apt_deps",
             "additional_dev_apt_env",

--- a/dev/breeze/src/airflow_breeze/params/common_build_params.py
+++ b/dev/breeze/src/airflow_breeze/params/common_build_params.py
@@ -37,7 +37,7 @@ class CommonBuildParams:
     Common build parameters. Those parameters are common parameters for CI And PROD build.
     """
 
-    additional_airflow_extras: str = ""
+    additional_extras: str = ""
     additional_dev_apt_command: str = ""
     additional_dev_apt_deps: str = ""
     additional_dev_apt_env: str = ""


### PR DESCRIPTION
The parameter `--additional-extras` does not work in `breeze` under the `build` command.

Example.

`breeze ci-image build --python 3.8 --additional-extras "python3-saml"`

```
Traceback (most recent call last):
  File "/Users/vincbeck/.local/bin/breeze", line 8, in <module>
    sys.exit(main())
  File "/Users/vincbeck/.local/pipx/venvs/apache-airflow-breeze/lib/python3.8/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/vincbeck/.local/pipx/venvs/apache-airflow-breeze/lib/python3.8/site-packages/rich_click/rich_command.py", line 126, in main
    rv = self.invoke(ctx)
  File "/Users/vincbeck/.local/pipx/venvs/apache-airflow-breeze/lib/python3.8/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/vincbeck/.local/pipx/venvs/apache-airflow-breeze/lib/python3.8/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/vincbeck/.local/pipx/venvs/apache-airflow-breeze/lib/python3.8/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/vincbeck/.local/pipx/venvs/apache-airflow-breeze/lib/python3.8/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Volumes/workplace/airflow_team_fork/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py", line 329, in build
    params = BuildCiParams(**parameters_passed)
TypeError: __init__() got an unexpected keyword argument 'additional_extras'
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
