### PR TITLE
Fix 'scheme' and 'schema' handling in HttpHook

### DIFF
--- a/airflow/providers/apache/livy/hooks/livy.py
+++ b/airflow/providers/apache/livy/hooks/livy.py
@@ -575,10 +575,11 @@ class LivyAsyncHook(HttpAsyncHook, LoggingMixin):
         if conn.host and "://" in conn.host:
             base_url: str = conn.host
         else:
-            # schema defaults to HTTP
-            schema = conn.schema if conn.schema else "http"
+            scheme = conn.conn_type
             host = conn.host if conn.host else ""
-            base_url = f"{schema}://{host}"
+            base_url = f"{scheme}://{host}"
+            if conn.schema:  # 'schema' is actually URI path (name kept for backward compatibility)
+                base_url += f"/{conn.schema}"
         if conn.port:
             base_url = f"{base_url}:{conn.port}"
         return base_url

--- a/airflow/providers/http/hooks/http.py
+++ b/airflow/providers/http/hooks/http.py
@@ -100,10 +100,11 @@ class HttpHook(BaseHook):
             if conn.host and "://" in conn.host:
                 self.base_url = conn.host
             else:
-                # schema defaults to HTTP
-                schema = conn.schema if conn.schema else "http"
+                scheme = conn.conn_type
                 host = conn.host if conn.host else ""
-                self.base_url = f"{schema}://{host}"
+                self.base_url = f"{scheme}://{host}"
+                if conn.schema:  # 'schema' is actually URI path (name kept for backward compatibility)
+                    self.base_url += f"/{conn.schema}"
 
             if conn.port:
                 self.base_url += f":{conn.port}"
@@ -323,10 +324,11 @@ class HttpAsyncHook(BaseHook):
             if conn.host and "://" in conn.host:
                 self.base_url = conn.host
             else:
-                # schema defaults to HTTP
-                schema = conn.schema if conn.schema else "http"
+                scheme = conn.conn_type
                 host = conn.host if conn.host else ""
-                self.base_url = schema + "://" + host
+                self.base_url = f"{scheme}://{host}"
+                if conn.schema:  # 'schema' is actually URI path (name kept for backward compatibility)
+                    self.base_url += f"/{conn.schema}"
 
             if conn.port:
                 self.base_url += f":{conn.port}"

--- a/tests/providers/apache/livy/hooks/test_livy.py
+++ b/tests/providers/apache/livy/hooks/test_livy.py
@@ -634,9 +634,7 @@ class TestLivyAsyncHook:
         assert response["status"] == "error"
 
     def set_conn(self):
-        db.merge_conn(
-            Connection(conn_id=LIVY_CONN_ID, conn_type="http", host="host", port=8998)
-        )
+        db.merge_conn(Connection(conn_id=LIVY_CONN_ID, conn_type="http", host="host", port=8998))
         db.merge_conn(Connection(conn_id="default_port", conn_type="http", host="http://host"))
         db.merge_conn(Connection(conn_id="default_protocol", conn_type="http", host="host"))
         db.merge_conn(Connection(conn_id="port_set", host="host", conn_type="http", port=1234))

--- a/tests/providers/http/hooks/test_http.py
+++ b/tests/providers/http/hooks/test_http.py
@@ -226,7 +226,7 @@ class TestHttpHook:
 
     @mock.patch("airflow.providers.http.hooks.http.HttpHook.get_connection")
     def test_http_connection(self, mock_get_connection):
-        conn = Connection(conn_id="http_default", conn_type="http", host="localhost", schema="http")
+        conn = Connection(conn_id="http_default", conn_type="http", host="localhost")
         mock_get_connection.return_value = conn
         hook = HttpHook()
         hook.get_conn({})
@@ -234,11 +234,19 @@ class TestHttpHook:
 
     @mock.patch("airflow.providers.http.hooks.http.HttpHook.get_connection")
     def test_https_connection(self, mock_get_connection):
-        conn = Connection(conn_id="http_default", conn_type="http", host="localhost", schema="https")
+        conn = Connection(conn_id="http_default", conn_type="https", host="localhost")
         mock_get_connection.return_value = conn
         hook = HttpHook()
         hook.get_conn({})
         assert hook.base_url == "https://localhost"
+
+    @mock.patch("airflow.providers.http.hooks.http.HttpHook.get_connection")
+    def test_http_connection_with_path(self, mock_get_connection):
+        conn = Connection(conn_id="http_default", conn_type="http", host="localhost", schema="path")
+        mock_get_connection.return_value = conn
+        hook = HttpHook()
+        hook.get_conn({})
+        assert hook.base_url == "http://localhost/path"
 
     @mock.patch("airflow.providers.http.hooks.http.HttpHook.get_connection")
     def test_host_encoded_http_connection(self, mock_get_connection):

--- a/tests/providers/http/hooks/test_http.py
+++ b/tests/providers/http/hooks/test_http.py
@@ -264,6 +264,22 @@ class TestHttpHook:
         hook.get_conn({})
         assert hook.base_url == "https://localhost"
 
+    @mock.patch("airflow.providers.http.hooks.http.HttpHook.get_connection")
+    def test_host_encoded_https_connection_from_uri(self, mock_get_connection):
+        conn = Connection(conn_id="http_default", uri="https://localhost")
+        mock_get_connection.return_value = conn
+        hook = HttpHook()
+        hook.get_conn({})
+        assert hook.base_url == "https://localhost"
+
+    @mock.patch("airflow.providers.http.hooks.http.HttpHook.get_connection")
+    def test_host_encoded_https_connection_with_path_from_uri(self, mock_get_connection):
+        conn = Connection(conn_id="http_default", uri="https://localhost/path")
+        mock_get_connection.return_value = conn
+        hook = HttpHook()
+        hook.get_conn({})
+        assert hook.base_url == "https://localhost/path"
+
     def test_method_converted_to_uppercase_when_created_in_lowercase(self):
         assert self.get_lowercase_hook.method == "GET"
 


### PR DESCRIPTION
Fixes #10913 

Previously, when building a connection string in HttpHook.get_conn, conn.schema was used as URL scheme, but it should be URL path. Now conn.conn_type ('http' or 'https') is used as URL scheme and conn.schema as URL path which causes base_url in HttpHook to work as expected.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
