### PR TITLE
Avoid side-effects when plyvel tests are run in parallel

### DIFF
--- a/tests/providers/google/leveldb/hooks/test_leveldb.py
+++ b/tests/providers/google/leveldb/hooks/test_leveldb.py
@@ -31,18 +31,18 @@ except AirflowOptionalProviderFeatureException:
 
 class TestLevelDBHook:
     @mock.patch.dict("os.environ", AIRFLOW_CONN_LEVELDB_DEFAULT="test")
-    def test_get_conn_db_is_not_none(self):
+    def test_get_conn_db_is_not_none(self, tmp_path):
         """Test get_conn method of hook"""
         hook = LevelDBHook(leveldb_conn_id="leveldb_default")
-        hook.get_conn(name="/tmp/testdb/", create_if_missing=True)
+        hook.get_conn(name=tmp_path.as_posix(), create_if_missing=True)
         assert hook.db is not None, "Check existence of DB object in connection creation"
         hook.close_conn()
 
     @mock.patch.dict("os.environ", AIRFLOW_CONN_LEVELDB_DEFAULT="test")
-    def test_run(self):
+    def test_run(self, tmp_path):
         """Test run method of hook"""
         hook = LevelDBHook(leveldb_conn_id="leveldb_default")
-        hook.get_conn(name="/tmp/testdb/", create_if_missing=True)
+        hook.get_conn(name=tmp_path.as_posix(), create_if_missing=True)
         assert hook.run("get", b"test_key0") is None, "Initially, this key in LevelDB is empty"
         hook.run("put", b"test_key0", b"test_value0")
         assert (
@@ -53,38 +53,38 @@ class TestLevelDBHook:
         hook.close_conn()
 
     @mock.patch.dict("os.environ", AIRFLOW_CONN_LEVELDB_DEFAULT="test")
-    def test_get(self):
+    def test_get(self, tmp_path):
         """Test get method of hook"""
         hook = LevelDBHook(leveldb_conn_id="leveldb_default")
-        db = hook.get_conn(name="/tmp/testdb/", create_if_missing=True)
+        db = hook.get_conn(name=tmp_path.as_posix(), create_if_missing=True)
         db.put(b"test_key", b"test_value")
         assert hook.get(b"test_key") == b"test_value"
         hook.close_conn()
 
     @mock.patch.dict("os.environ", AIRFLOW_CONN_LEVELDB_DEFAULT="test")
-    def test_put(self):
+    def test_put(self, tmp_path):
         """Test put method of hook"""
         hook = LevelDBHook(leveldb_conn_id="leveldb_default")
-        db = hook.get_conn(name="/tmp/testdb/", create_if_missing=True)
+        db = hook.get_conn(name=tmp_path.as_posix(), create_if_missing=True)
         hook.put(b"test_key2", b"test_value2")
         assert db.get(b"test_key2") == b"test_value2"
         hook.close_conn()
 
     @mock.patch.dict("os.environ", AIRFLOW_CONN_LEVELDB_DEFAULT="test")
-    def test_delete(self):
+    def test_delete(self, tmp_path):
         """Test delete method of hook"""
         hook = LevelDBHook(leveldb_conn_id="leveldb_default")
-        db = hook.get_conn(name="/tmp/testdb/", create_if_missing=True)
+        db = hook.get_conn(name=tmp_path.as_posix(), create_if_missing=True)
         db.put(b"test_key3", b"test_value3")
         hook.delete(b"test_key3")
         assert db.get(b"test_key3") is None
         hook.close_conn()
 
     @mock.patch.dict("os.environ", AIRFLOW_CONN_LEVELDB_DEFAULT="test")
-    def test_write_batch(self):
+    def test_write_batch(self, tmp_path):
         """Test write batch method of hook"""
         hook = LevelDBHook(leveldb_conn_id="leveldb_default")
-        db = hook.get_conn(name="/tmp/testdb/", create_if_missing=True)
+        db = hook.get_conn(name=tmp_path.as_posix(), create_if_missing=True)
         keys = [b"key", b"another-key"]
         values = [b"value", b"another-value"]
         hook.write_batch(keys, values)
@@ -93,15 +93,15 @@ class TestLevelDBHook:
         hook.close_conn()
 
     @mock.patch.dict("os.environ", AIRFLOW_CONN_LEVELDB_DEFAULT="test")
-    def test_exception(self):
+    def test_exception(self, tmp_path):
         """Test raising exception of hook in run method if we have unknown command in input"""
         hook = LevelDBHook(leveldb_conn_id="leveldb_default")
-        hook.get_conn(name="/tmp/testdb/", create_if_missing=True)
+        hook.get_conn(name=tmp_path.as_posix(), create_if_missing=True)
         with pytest.raises(LevelDBHookException):
             hook.run(command="other_command", key=b"key", value=b"value")
 
     @mock.patch.dict("os.environ", AIRFLOW_CONN_LEVELDB_DEFAULT="test")
-    def test_comparator(self):
+    def test_comparator(self, tmp_path):
         """Test comparator"""
 
         def comparator(a, b):
@@ -121,7 +121,7 @@ class TestLevelDBHook:
 
         hook = LevelDBHook(leveldb_conn_id="leveldb_default")
         hook.get_conn(
-            name="/tmp/testdb2/",
+            name=tmp_path.as_posix(),
             create_if_missing=True,
             comparator=comparator,
             comparator_name=b"CaseInsensitiveComparator",


### PR DESCRIPTION
Plyvel tests were using the same temporary directory and when they were run in parallell it could lead to error where plyvel could not lock the directory:

lock /tmp/testdb//LOCK: Resource temporarily unavailable

We are now using pytest's tmpdir fixture to give each test separate temporary directory (and delete it automatically as well)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
