### PR TITLE
Add pytest-anti-lru to avoid cache side effects in tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -489,6 +489,7 @@ _devel_only_tests = [
     "pytest-httpx",
     "pytest-icdiff",
     "pytest-instafail",
+    "pytest-antilru",
     "pytest-mock",
     "pytest-rerunfailures",
     "pytest-timeouts",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1070,15 +1070,6 @@ def _clear_db(request):
 
 
 @pytest.fixture(autouse=True)
-def clear_lru_cache():
-    from airflow.executors.executor_loader import ExecutorLoader
-    from airflow.utils.entry_points import _get_grouped_entry_points
-
-    ExecutorLoader.validate_database_executor_compatibility.cache_clear()
-    _get_grouped_entry_points.cache_clear()
-
-
-@pytest.fixture(autouse=True)
 def refuse_to_run_test_from_wrongly_named_files(request):
     dirname: str = request.node.fspath.dirname
     filename: str = request.node.fspath.basename

--- a/tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -55,7 +55,6 @@ try:
     from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
         annotations_for_logging_task_metadata,
         annotations_to_key,
-        get_logs_task_metadata,
     )
     from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
 except ImportError:
@@ -1242,7 +1241,6 @@ class TestKubernetesExecutor:
             "task_id": "task",
             "try_number": "1",
         }
-        get_logs_task_metadata.cache_clear()
         with conf_vars({("kubernetes", "logs_task_metadata"): "True"}):
             expected_annotations = {
                 "dag_id": "dag",
@@ -1252,7 +1250,6 @@ class TestKubernetesExecutor:
             }
             annotations_actual = annotations_for_logging_task_metadata(annotations_test)
             assert annotations_actual == expected_annotations
-        get_logs_task_metadata.cache_clear()
 
     def test_annotations_for_logging_task_metadata_fallback(self):
         annotations_test = {
@@ -1261,12 +1258,10 @@ class TestKubernetesExecutor:
             "task_id": "task",
             "try_number": "1",
         }
-        get_logs_task_metadata.cache_clear()
         with conf_vars({("kubernetes", "logs_task_metadata"): "False"}):
             expected_annotations = "<omitted>"
             annotations_actual = annotations_for_logging_task_metadata(annotations_test)
             assert annotations_actual == expected_annotations
-        get_logs_task_metadata.cache_clear()
 
 
 class TestKubernetesJobWatcher:

--- a/tests/providers/openlineage/extractors/test_bash.py
+++ b/tests/providers/openlineage/extractors/test_bash.py
@@ -27,7 +27,6 @@ from openlineage.client.facet import SourceCodeJobFacet
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.providers.openlineage.extractors.bash import BashExtractor
-from airflow.providers.openlineage.utils.utils import is_source_enabled
 from tests.test_utils.config import conf_vars
 
 pytestmark = pytest.mark.db_test
@@ -41,11 +40,6 @@ with DAG(
     max_active_runs=1,
 ) as dag:
     bash_task = BashOperator(task_id="bash-task", bash_command="ls -halt && exit 0", dag=dag)
-
-
-@pytest.fixture(autouse=True, scope="function")
-def clear_cache():
-    is_source_enabled.cache_clear()
 
 
 def test_extract_operator_bash_command_disables_without_env():

--- a/tests/providers/openlineage/extractors/test_python.py
+++ b/tests/providers/openlineage/extractors/test_python.py
@@ -29,7 +29,6 @@ from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
 from airflow.providers.openlineage.extractors.python import PythonExtractor
-from airflow.providers.openlineage.utils.utils import is_source_enabled
 from tests.test_utils.config import conf_vars
 
 pytestmark = pytest.mark.db_test
@@ -56,11 +55,6 @@ def callable():
 
 
 CODE = "def callable():\n    print(10)\n"
-
-
-@pytest.fixture(autouse=True, scope="function")
-def clear_cache():
-    is_source_enabled.cache_clear()
 
 
 def test_extract_source_code():

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -32,18 +32,12 @@ from airflow.serialization.serde import (
     DATA,
     SCHEMA_ID,
     VERSION,
-    _get_patterns,
     _match,
     deserialize,
     serialize,
 )
 from airflow.utils.module_loading import import_string, iter_namespace, qualname
 from tests.test_utils.config import conf_vars
-
-
-@pytest.fixture()
-def recalculate_patterns():
-    _get_patterns.cache_clear()
 
 
 class Z:
@@ -105,7 +99,6 @@ class C:
         return None
 
 
-@pytest.mark.usefixtures("recalculate_patterns")
 class TestSerDe:
     def test_ser_primitives(self):
         i = 10
@@ -217,7 +210,6 @@ class TestSerDe:
             ("core", "allowed_deserialization_classes"): "airflow[.].*",
         }
     )
-    @pytest.mark.usefixtures("recalculate_patterns")
     def test_allow_list_for_imports(self):
         i = Z(10)
         e = serialize(i)
@@ -231,7 +223,6 @@ class TestSerDe:
             ("core", "allowed_deserialization_classes"): "tests.*",
         }
     )
-    @pytest.mark.usefixtures("recalculate_patterns")
     def test_allow_list_replace(self):
         assert _match("tests.airflow.deep")
         assert _match("testsfault") is False

--- a/tests/utils/log/test_secrets_masker.py
+++ b/tests/utils/log/test_secrets_masker.py
@@ -353,12 +353,8 @@ class TestShouldHideValueForKey:
         ],
     )
     def test_hiding_config(self, sensitive_variable_fields, key, expected_result):
-        from airflow.utils.log.secrets_masker import get_sensitive_variables_fields
-
         with conf_vars({("core", "sensitive_var_conn_names"): str(sensitive_variable_fields)}):
-            get_sensitive_variables_fields.cache_clear()
             assert expected_result == should_hide_value_for_key(key)
-        get_sensitive_variables_fields.cache_clear()
 
 
 class ShortExcFormatter(logging.Formatter):


### PR DESCRIPTION
Using cache in tests might have unintended side-effects and you have to add cache invalidation between tests. It also have a possible side-effect for pytest-xdist where cache is potentially cleared while onther test is run.

The `anti-lru` pytest plugin replaces lru_cache with non-caching implementation. That will slow down tests a bit, but it will also make them cache-side-effect free.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
