### PR TITLE
More detail on mandatory task arguments

### DIFF
--- a/docs/apache-airflow/tutorial/fundamentals.rst
+++ b/docs/apache-airflow/tutorial/fundamentals.rst
@@ -148,7 +148,7 @@ The precedence rules for a task are as follows:
 
 .. note::
     A task must include or inherit the arguments ``task_id`` and ``owner``,
-    otherwise Airflow will raise an exception. A fresh intall of Airflow will 
+    otherwise Airflow will raise an exception. A fresh install of Airflow will 
     have a default value of 'airflow' set for ``owner``, so you only really need 
     to worry about ensuring ``task_id`` has a value.
 

--- a/docs/apache-airflow/tutorial/fundamentals.rst
+++ b/docs/apache-airflow/tutorial/fundamentals.rst
@@ -148,8 +148,8 @@ The precedence rules for a task are as follows:
 
 .. note::
     A task must include or inherit the arguments ``task_id`` and ``owner``,
-    otherwise Airflow will raise an exception. A fresh install of Airflow will 
-    have a default value of 'airflow' set for ``owner``, so you only really need 
+    otherwise Airflow will raise an exception. A fresh install of Airflow will
+    have a default value of 'airflow' set for ``owner``, so you only really need
     to worry about ensuring ``task_id`` has a value.
 
 Templating with Jinja

--- a/docs/apache-airflow/tutorial/fundamentals.rst
+++ b/docs/apache-airflow/tutorial/fundamentals.rst
@@ -146,8 +146,11 @@ The precedence rules for a task are as follows:
 2.  Values that exist in the ``default_args`` dictionary
 3.  The operator's default value, if one exists
 
-A task must include or inherit the arguments ``task_id`` and ``owner``,
-otherwise Airflow will raise an exception.
+.. note::
+    A task must include or inherit the arguments ``task_id`` and ``owner``,
+    otherwise Airflow will raise an exception. A fresh intall of Airflow will 
+    have a default value of 'airflow' set for ``owner``, so you only really need 
+    to worry about ensuring ``task_id`` has a value.
 
 Templating with Jinja
 ---------------------


### PR DESCRIPTION
Current documentation notes that the arguments 'task_id' and 'owner' are both mandatory. This might confuse new users to believe that both arguments require user input to avoid an error. But 'owner' has a default default_value, so this argument should be less of a concern for user task and dag creation. This commit aims to communicate that.