### PR TITLE
Separate building docs and spellcheck docs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -720,8 +720,8 @@ jobs:
         run: breeze ci fix-ownership
         if: always()
 
-  docs:
-    timeout-minutes: 90
+  build-docs:
+    timeout-minutes: 60
     name: "Build docs"
     runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
     needs: [build-info, wait-for-ci-images]
@@ -749,7 +749,7 @@ jobs:
             docs-inventory-
       - name: "Build docs"
         run: >
-          breeze build-docs ${{ needs.build-info.outputs.docs-list-as-string }}
+          breeze build-docs ${{ needs.build-info.outputs.docs-list-as-string }} --docs-only
       - name: "Clone airflow-site"
         run: >
           git clone https://github.com/apache/airflow-site.git ${GITHUB_WORKSPACE}/airflow-site &&
@@ -783,6 +783,40 @@ jobs:
       - name: "Upload documentation to AWS S3"
         if: needs.build-info.outputs.canary-run == 'true' && needs.build-info.outputs.default-branch == 'main'
         run: aws s3 sync --delete ./files/documentation s3://apache-airflow-docs
+      - name: "Fix ownership"
+        run: breeze ci fix-ownership
+        if: always()
+
+  spellcheck-docs:
+    timeout-minutes: 60
+    name: "Spellcheck docs"
+    runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
+    needs: [build-info, wait-for-ci-images]
+    if: needs.build-info.outputs.docs-build == 'true'
+    env:
+      RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
+      PYTHON_MAJOR_MINOR_VERSION: "${{needs.build-info.outputs.default-python-version}}"
+    steps:
+      - name: Cleanup repo
+        run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: >
+          Prepare breeze & CI image: ${{needs.build-info.outputs.default-python-version}}:${{env.IMAGE_TAG}}
+        uses: ./.github/actions/prepare_breeze_and_image
+      - uses: actions/cache@v3
+        id: cache-doc-inventories
+        with:
+          path: ./docs/_inventory_cache/
+          key: docs-inventory-${{ hashFiles('setup.py','setup.cfg','pyproject.toml;') }}
+          restore-keys: |
+            docs-inventory-${{ hashFiles('setup.py','setup.cfg','pyproject.toml;') }}
+            docs-inventory-
+      - name: "Spellcheck docs"
+        run: >
+          breeze build-docs ${{ needs.build-info.outputs.docs-list-as-string }} --spellcheck-only
       - name: "Fix ownership"
         run: breeze ci fix-ownership
         if: always()
@@ -1810,7 +1844,8 @@ jobs:
     runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
     needs:
       - build-info
-      - docs
+      - build-docs
+      - spellcheck-docs
       - wait-for-ci-images
       - wait-for-prod-images
       - static-checks
@@ -1970,7 +2005,8 @@ jobs:
     runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
     needs:
       - build-info
-      - docs
+      - build-docs
+      - spellcheck-docs
       - static-checks
       - tests-sqlite
       - tests-mysql

--- a/CI.rst
+++ b/CI.rst
@@ -386,6 +386,8 @@ This workflow is a regular workflow that performs all checks of Airflow code.
 +---------------------------------+----------------------------------------------------------+----------+----------+-----------+-------------------+
 | Build docs                      | Builds and tests publishing of the documentation         | Yes      | Yes      | Yes       | Yes               |
 +---------------------------------+----------------------------------------------------------+----------+----------+-----------+-------------------+
+| Spellcheck docs                 | Spellcheck docs                                          | Yes      | Yes      | Yes       | Yes               |
++---------------------------------+----------------------------------------------------------+----------+----------+-----------+-------------------+
 | Tests wheel provider packages   | Tests if provider packages can be built and released     | Yes      | Yes      | Yes       | -                 |
 +---------------------------------+----------------------------------------------------------+----------+----------+-----------+-------------------+
 | Tests Airflow compatibility     | Compatibility of provider packages with older Airflow    | Yes      | Yes      | Yes       | -                 |

--- a/CI_DIAGRAMS.md
+++ b/CI_DIAGRAMS.md
@@ -68,7 +68,7 @@ sequenceDiagram
     and
         opt
             GitHub Registry ->> Tests: Pull CI Images<br>[COMMIT_SHA]
-            Note over Tests: Build docs
+            Note over Tests: Build docs / Spellcheck docs
         end
     and
         opt
@@ -180,7 +180,7 @@ sequenceDiagram
     and
         opt
             GitHub Registry ->> Tests: Pull CI Images<br>[COMMIT_SHA]
-            Note over Tests: Build docs
+            Note over Tests: Build docs/ Spellcheck docs
         end
     and
         opt
@@ -279,7 +279,7 @@ sequenceDiagram
         Note over Tests: Run static checks
     and
         GitHub Registry ->> Tests: Pull CI Images<br>[COMMIT_SHA]
-        Note over Tests: Build docs
+        Note over Tests: Build docs / Spellcheck docs
     and
         GitHub Registry ->> Tests: Pull CI Images<br>[COMMIT_SHA]
         Note over Tests: Test Pytest collection<br>[COMMIT_SHA]
@@ -365,7 +365,7 @@ sequenceDiagram
         Note over Tests: Run static checks
     and
         GitHub Registry ->> Tests: Pull CI Images<br>[COMMIT_SHA]
-        Note over Tests: Build docs
+        Note over Tests: Build docs / Spellcheck docs
     and
         GitHub Registry ->> Tests: Pull CI Images<br>[COMMIT_SHA]
         Note over Tests: Test Pytest collection<br>[COMMIT_SHA]


### PR DESCRIPTION
Building and spellchecking of docs is run indepenently as two separate sphinx runs. Spellchecking is faster than building but not a lot - so if we separate these two, instead of one 17 minute job we will have two <10 minutes ones. This means that:

* elapsed time of running docs build will be much faster (as long as we have enough parallell runners)
* it will be easier to see if the structure of the docs is wrong or if spellcheck is a problem

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
