### PR TITLE
Decrease max parallelism for K8S tests

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -193,8 +193,8 @@ option_upgrade = click.option(
 option_parallelism_cluster = click.option(
     "--parallelism",
     help="Maximum number of processes to use while running the operation in parallel for cluster operations.",
-    type=click.IntRange(1, max(1, (mp.cpu_count() + 1) // 3) if not generating_command_images() else 4),
-    default=max(1, (mp.cpu_count() + 1) // 3) if not generating_command_images() else 2,
+    type=click.IntRange(1, max(1, mp.cpu_count() // 4) if not generating_command_images() else 4),
+    default=max(1, mp.cpu_count() // 4) if not generating_command_images() else 2,
     envvar="PARALLELISM",
     show_default=True,
 )


### PR DESCRIPTION
Currently (and for quite some future) we will run 4 k8s tests max in paralell on CI. Running 4 in parallel is too much (not enough resources) and while running 3 in parallel is possible, since we have 4 runs, we do not gain much by running 3 in parallel (first the 3 of them complete and 4th start and runs generally on its own after fist of the 3 completes, which means generally just before the other 2 complete. Since the parallelism gains are not linear due to contention on common resources, runnning 3x parallel k8s runs is for sure slower than running 2x of them at the same time, so proabbly we can gain a few minutes by running 2 + 2.

This PR changes maximum number of k8s runs as 1/4 of available CPUs - which also makes sense taking into account how many parallell processes we have in each k8s test.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
