### PR TITLE
Remove elasticsearch getattr only required for Airflow < 2.6

### DIFF
--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -457,8 +457,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
         if self.closed:
             return
 
-        # todo: remove `getattr` when min airflow version >= 2.6
-        if not self.mark_end_on_close or getattr(self, "ctx_task_deferred", None):
+        if not self.mark_end_on_close or self.ctx_task_deferred:
             # when we're closing due to task deferral, don't mark end of log
             self.closed = True
             return

--- a/airflow/providers/elasticsearch/provider.yaml
+++ b/airflow/providers/elasticsearch/provider.yaml
@@ -56,7 +56,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.5.0
+  - apache-airflow>=2.6.0
   - apache-airflow-providers-common-sql>=1.3.1
   - elasticsearch>=8.10,<9
 

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -371,7 +371,7 @@
   "elasticsearch": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.5.0",
+      "apache-airflow>=2.6.0",
       "elasticsearch>=8.10,<9"
     ],
     "cross-providers-deps": [


### PR DESCRIPTION
When min airflow version is 2.6 or greater, this getattr is unnecessary.  Should wait for december round.