### PR TITLE
Fix race condition in KubernetesExecutor with concurrently running schedulers

### DIFF
--- a/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -559,6 +559,7 @@ class KubernetesExecutor(BaseExecutor):
                 pod_list = self._list_pods(query_kwargs)
                 for pod in pod_list:
                     self.adopt_launched_task(kube_client, pod, tis_to_flush_by_key)
+            self._delete_orphaned_completed_pods()
             tis_to_flush.extend(tis_to_flush_by_key.values())
             return tis_to_flush
 
@@ -640,6 +641,38 @@ class KubernetesExecutor(BaseExecutor):
 
         del tis_to_flush_by_key[ti_key]
         self.running.add(ti_key)
+
+    @provide_session
+    def _delete_orphaned_completed_pods(self, session: Session = NEW_SESSION) -> None:
+        """
+        Delete orphaned completed pods with completed TaskInstances.
+
+        Pods that have reached the Completed status are usually deleted by the scheduler to which
+        they are attached. In case when the scheduler crashes, there is no one to delete these
+        pods. Therefore, they are deleted from another scheduler using this function.
+        """
+        from airflow.jobs.job import Job, JobState
+
+        if TYPE_CHECKING:
+            assert self.kube_scheduler
+
+        alive_schedulers_ids = session.scalars(
+            select(Job.id).where(Job.job_type == "SchedulerJob", Job.state == JobState.RUNNING)
+        ).all()
+        labels = ["kubernetes_executor=True", f"{POD_EXECUTOR_DONE_KEY}!=True"]
+        for alive_scheduler_id in alive_schedulers_ids:
+            labels.append(f"airflow-worker!={self._make_safe_label_value(str(alive_scheduler_id))}")
+
+        query_kwargs = {"field_selector": "status.phase=Succeeded", "label_selector": ",".join(labels)}
+        pod_list = self._list_pods(query_kwargs)
+        for pod in pod_list:
+            from kubernetes.client.rest import ApiException
+
+            try:
+                self.kube_scheduler.delete_pod(pod_name=pod.metadata.name, namespace=pod.metadata.namespace)
+                self.log.info("Orphaned completed pod %s has been deleted", pod.metadata.name)
+            except ApiException as e:
+                self.log.info("Failed to delete orphaned completed pod %s. Reason: %s", pod.metadata.name, e)
 
     def _flush_task_queue(self) -> None:
         if TYPE_CHECKING:


### PR DESCRIPTION
Closes: #32928

A race condition occurs in the _adopt_completed_pods function when schedulers are running concurrently. _adopt_completed_pods function doesn't keep track of which scheduler went down so it constantly tries to adopt completed pods from normally working schedulers. On Airflow setups with concurrently running schedulers and with a lot of short living DAG's it leads to race condition and open slots leak. You can find detailed analysis of this situation in GitHub issue here (https://github.com/apache/airflow/issues/32928#issuecomment-1820413530) Even if one of the schedulers went down and left some pods in completed state it is not a big deal because: 
1. Completed pods do not consume resources from kubernetes cluster 
2. They can be deleted by airflow cleanup-pods CLI command which you can execute with the cronjob.

Co-authored-by: Vlad Pastushenko iam@vladpi.me

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->