### PR TITLE
Fix pre-commit script output

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_breeze_cmd_line.py
+++ b/scripts/ci/pre_commit/pre_commit_breeze_cmd_line.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
                 "\n[bright_blue]Some of the commands changed since last time images were generated.\n"
             )
             console.print("\n[yellow]You should install it and run those commands manually:\n")
-            console.print("\n[magenta]breeze setup regenerate-command images\n")
+            console.print("\n[magenta]breeze setup regenerate-command-images\n")
             console.print("\n[magenta]breeze setup check-all-params-in-groups\n")
             sys.exit(return_code)
         res = subprocess.run(
@@ -102,7 +102,7 @@ if __name__ == "__main__":
             console.print("\n[red]Breeze command configuration has changed.\n")
             console.print("\n[bright_blue]Images have been regenerated.\n")
             console.print("\n[bright_blue]You might want to run it manually:\n")
-            console.print("\n[magenta]breeze setup regenerate-command images\n")
+            console.print("\n[magenta]breeze setup regenerate-command-images\n")
     res = subprocess.run(
         ["breeze", "setup", "check-all-params-in-groups"],
         check=False,


### PR DESCRIPTION
`breeze setup regenerate-command images` does not exist but `breeze setup regenerate-command-images` does.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
