### PR TITLE
improved visibility of tasks in ActionModal for taskInstance

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/taskActions/ActionModal.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/taskActions/ActionModal.tsx
@@ -108,7 +108,7 @@ const ActionModal = ({
                   <AccordionIcon />
                 </AccordionButton>
                 <AccordionPanel>
-                  <Box maxHeight="30vh" overflowY="auto">
+                  <Box maxHeight="35vh" overflowY="auto">
                     <AffectedTasksTable affectedTasks={affectedTasks} />
                   </Box>
                 </AccordionPanel>

--- a/airflow/www/static/js/dag/details/taskInstance/taskActions/ActionModal.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/taskActions/ActionModal.tsx
@@ -108,7 +108,7 @@ const ActionModal = ({
                   <AccordionIcon />
                 </AccordionButton>
                 <AccordionPanel>
-                  <Box maxHeight="400px" overflowY="auto">
+                  <Box maxHeight="30vh" overflowY="auto">
                     <AffectedTasksTable affectedTasks={affectedTasks} />
                   </Box>
                 </AccordionPanel>


### PR DESCRIPTION
The ActionModal (for both Clear and Mark as Success/Failed) for taskInstance wasn't completely visible on my screen when several tasks were present. Adjusted the maximum box height according to screen size. 

Before
![Screenshot (330)](https://github.com/apache/airflow/assets/101169283/e66b7011-bdce-47ae-8024-8be572b29c1f)

After
![Screenshot (329)](https://github.com/apache/airflow/assets/101169283/2a7659f1-80fd-4f8e-8e29-48ca3f8eefba)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->