### PR TITLE
breeze - docs adding pipx python flag

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -338,6 +338,15 @@ that Breeze works on
 
             pipx install --force -e dev\breeze
 
+    .. note:: creating pipx virtual env ``apache-airflow-breeze`` with a specific python version
+
+        In ``pipx install --force -e ./dev/breeze`` or ``pipx install --force -e dev\breeze``, ``pipx`` uses default system python version to create virtual env for breeze.
+        We can use a specific version by providing python executable in ``--python``  argument. For example:
+
+        .. code-block:: bash
+
+            pipx install -e ./dev/breeze --force --python /Users/airflow/.pyenv/versions/3.8.16/bin/python
+
 
 Running Breeze for the first time
 ---------------------------------


### PR DESCRIPTION
Pipx creating  virtualenv (apache-airflow-breeze) with system python(3.12.0)
>  installed package apache-airflow-breeze 0.0.1, installed using Python 3.12.0

 in turn giving 

> distutils module not found error.
 
Although it can be  resolved by installing breeze with specific python version.

`pipx install -e ./dev/breeze --force --python /Users/airflow/.pyenv/versions/3.8.16/bin/python`

Adding this information into breeze.rst can help others as well 🙏 