### PR TITLE
Enhance DynamoDBValueSensor to support any attribute value in list

### DIFF
--- a/airflow/providers/amazon/aws/sensors/dynamodb.py
+++ b/airflow/providers/amazon/aws/sensors/dynamodb.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any, Iterable, Sequence
 
 from airflow.providers.amazon.aws.hooks.dynamodb import DynamoDBHook
 from airflow.sensors.base import BaseSensorOperator
@@ -61,7 +61,7 @@ class DynamoDBValueSensor(BaseSensorOperator):
         partition_key_name: str,
         partition_key_value: str,
         attribute_name: str,
-        attribute_value: str,
+        attribute_value: str | Iterable[str],
         sort_key_name: str | None = None,
         sort_key_value: str | None = None,
         aws_conn_id: str | None = DynamoDBHook.default_conn_name,
@@ -99,12 +99,13 @@ class DynamoDBValueSensor(BaseSensorOperator):
         self.log.info("Key: %s", key)
         response = table.get_item(Key=key)
         try:
+            item_attribute_value = response["Item"][self.attribute_name]
             self.log.info("Response: %s", response)
             self.log.info("Want: %s = %s", self.attribute_name, self.attribute_value)
-            self.log.info(
-                "Got: {response['Item'][self.attribute_name]} = %s", response["Item"][self.attribute_name]
+            self.log.info("Got: {response['Item'][self.attribute_name]} = %s", item_attribute_value)
+            return item_attribute_value in (
+                [self.attribute_value] if isinstance(self.attribute_value, str) else self.attribute_value
             )
-            return response["Item"][self.attribute_name] == self.attribute_value
         except KeyError:
             return False
 

--- a/docs/apache-airflow-providers-amazon/operators/dynamodb.rst
+++ b/docs/apache-airflow-providers-amazon/operators/dynamodb.rst
@@ -42,12 +42,27 @@ Wait on Amazon DynamoDB item attribute value match
 Use the :class:`~airflow.providers.amazon.aws.sensors.dynamodb.DynamoDBValueSensor`
 to wait for the presence of a matching DynamoDB item's attribute/value pair.
 
+Wait for a Single Attribute Value Match:
+----------------------------------------
+
+This example shows how to use ``DynamoDBValueSensor`` to wait for a specific attribute/value pair in a DynamoDB item.
+
 .. exampleinclude:: /../../tests/system/providers/amazon/aws/example_dynamodb.py
     :language: python
     :start-after: [START howto_sensor_dynamodb_value]
     :dedent: 4
     :end-before: [END howto_sensor_dynamodb_value]
 
+Wait for Any Value from a List of Attribute Values:
+---------------------------------------------------
+
+In this example, the sensor waits for the DynamoDB item to have an attribute that matches any value from a provided list.
+
+.. exampleinclude:: /../../tests/system/providers/amazon/aws/example_dynamodb.py
+    :language: python
+    :start-after: [START howto_sensor_dynamodb_any_value]
+    :dedent: 4
+    :end-before: [END howto_sensor_dynamodb_any_value]
 
 Reference
 ---------

--- a/tests/providers/amazon/aws/sensors/test_dynamodb.py
+++ b/tests/providers/amazon/aws/sensors/test_dynamodb.py
@@ -17,10 +17,13 @@
 
 from __future__ import annotations
 
+import pytest
 from moto import mock_dynamodb
 
 from airflow.providers.amazon.aws.hooks.dynamodb import DynamoDBHook
 from airflow.providers.amazon.aws.sensors.dynamodb import DynamoDBValueSensor
+
+pytestmark = pytest.mark.db_test
 
 
 class TestDynamoDBValueSensor:
@@ -86,6 +89,76 @@ class TestDynamoDBValueSensor:
                 self.pk_name: self.pk_value,
                 self.sk_name: self.sk_value,
                 self.attribute_name: self.attribute_value,
+            }
+        ]
+        hook.write_batch_data(items)
+
+        assert self.sensor.poke(None)
+
+
+class TestDynamoDBMultipleValuesSensor:
+    def setup_method(self):
+        self.table_name = "test_airflow"
+        self.pk_name = "PK"
+        self.pk_value = "PKTest"
+        self.sk_name = "SK"
+        self.sk_value = "SKTest"
+        self.attribute_name = "Foo"
+        self.attribute_value = ["Bar1", "Bar2", "Bar3"]
+
+        self.sensor = DynamoDBValueSensor(
+            task_id="dynamodb_value_sensor",
+            table_name=self.table_name,
+            partition_key_name=self.pk_name,
+            partition_key_value=self.pk_value,
+            attribute_name=self.attribute_name,
+            attribute_value=self.attribute_value,
+            sort_key_name=self.sk_name,
+            sort_key_value=self.sk_value,
+        )
+
+    @mock_dynamodb
+    def test_sensor_with_pk(self):
+        hook = DynamoDBHook(table_name=self.table_name, table_keys=[self.pk_name])
+
+        hook.conn.create_table(
+            TableName=self.table_name,
+            KeySchema=[{"AttributeName": self.pk_name, "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": self.pk_name, "AttributeType": "S"}],
+            ProvisionedThroughput={"ReadCapacityUnits": 10, "WriteCapacityUnits": 10},
+        )
+
+        assert not self.sensor.poke(None)
+
+        items = [{self.pk_name: self.pk_value, self.attribute_name: self.attribute_value[1]}]
+        hook.write_batch_data(items)
+
+        assert self.sensor.poke(None)
+
+    @mock_dynamodb
+    def test_sensor_with_pk_and_sk(self):
+        hook = DynamoDBHook(table_name=self.table_name, table_keys=[self.pk_name, self.sk_name])
+
+        hook.conn.create_table(
+            TableName=self.table_name,
+            KeySchema=[
+                {"AttributeName": self.pk_name, "KeyType": "HASH"},
+                {"AttributeName": self.sk_name, "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": self.pk_name, "AttributeType": "S"},
+                {"AttributeName": self.sk_name, "AttributeType": "S"},
+            ],
+            ProvisionedThroughput={"ReadCapacityUnits": 10, "WriteCapacityUnits": 10},
+        )
+
+        assert not self.sensor.poke(None)
+
+        items = [
+            {
+                self.pk_name: self.pk_value,
+                self.sk_name: self.sk_value,
+                self.attribute_name: self.attribute_value[1],
             }
         ]
         hook.write_batch_data(items)

--- a/tests/system/providers/amazon/aws/example_dynamodb.py
+++ b/tests/system/providers/amazon/aws/example_dynamodb.py
@@ -92,12 +92,26 @@ with DAG(
     )
     # [END howto_sensor_dynamodb_value]
 
+    # [START howto_sensor_dynamodb_any_value]
+    dynamodb_sensor_any_value = DynamoDBValueSensor(
+        task_id="waiting_for_dynamodb_item_any_value",
+        table_name=table_name,
+        partition_key_name=PK_ATTRIBUTE_NAME,
+        partition_key_value="Test",
+        sort_key_name=SK_ATTRIBUTE_NAME,
+        sort_key_value="2022-07-12T11:11:25-0400",
+        attribute_name="Value",
+        attribute_value=["Foo", "Testing", "Bar"],
+    )
+    # [END howto_sensor_dynamodb_any_value]
+
     chain(
         # TEST SETUP
         test_context,
         create_table,
         # TEST BODY
         dynamodb_sensor,
+        dynamodb_sensor_any_value,
         # TEST TEARDOWN
         delete_table,
     )


### PR DESCRIPTION
This PR introduces an enhancement to the DynamoDBValueSensor, enabling it to wait for the presence of any value from a specified list of attribute values in a DynamoDB item.

#### Changes Proposed
* Extend the DynamoDBValueSensor to accept a list of attribute values.
* Update the documentation to reflect this new feature and provide examples.
* Include tests to ensure the new functionality works as expected.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
