### PR TITLE
Make livy connection failure test less picky

### DIFF
--- a/tests/providers/apache/livy/triggers/test_livy.py
+++ b/tests/providers/apache/livy/triggers/test_livy.py
@@ -107,18 +107,11 @@ class TestLivyTrigger:
 
         task = [i async for i in trigger.run()]
         assert len(task) == 1
-        assert (
-            TriggerEvent(
-                {
-                    "status": "error",
-                    "batch_id": 1,
-                    "response": "Batch 1 did not succeed with Cannot connect to host livy:8998 ssl:default "
-                    "[Name or service not known]",
-                    "log_lines": None,
-                }
-            )
-            in task
-        )
+        event = task[0]
+        assert isinstance(event, TriggerEvent)
+        assert event.payload.get("status") == "error"
+        assert event.payload.get("batch_id") == 1
+        assert "Cannot connect to host livy:8998 ssl:default" in event.payload.get("response")
 
     @pytest.mark.db_test
     @pytest.mark.asyncio


### PR DESCRIPTION
The new dependencies released changed slightly the response returned when connection failure occured ("Temporary Failure in Name Resolution" instead of "Host name cannot be found").

This PR makes the test less picky w/regards to what exactly error message to expect.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
