### PR TITLE
Note unsupported ExternalTaskSensor deferrable modes

### DIFF
--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -131,6 +131,12 @@ class ExternalTaskSensor(BaseSensorOperator):
         or DAG does not exist (default value: False).
     :param poll_interval: polling period in seconds to check for the status
     :param deferrable: Run sensor in deferrable mode
+
+    .. warning::
+
+        In deferrable mode, this operator only supports sensing exactly 1 external task right now.
+        Support for sensing full DAGs, multiple tasks, or task groups is not yet supported with
+        `deferrable=True`.
     """
 
     template_fields = ["external_dag_id", "external_task_id", "external_task_ids", "external_task_group_id"]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: #34207

Based on issue #34207 and my own testing, it seems ExternalTaskSensor doesn't work properly with `deferrable=True` when trying to sense a full DAG (i.e. when passing a DAG ID but external_task_id=None), blocking for some time then timing out with an unclear failure. The Trigger also doesn't look to be set up for other use cases supported in the usual blocking implementation - multiple task IDs, or task groups. I don't have the confidence to fix the trigger for these use cases, but wanted to add a warning so other people would be aware of this limitation from the documentation rather than stumbling into it like me! =)

Things that I'm still unsure of:
* Is there a good way to reference an issue from within a warning block? (And is a warning block appropriate for this?)
* Is it worth adding a doc newsfragment for this?

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
