### PR TITLE
Make environment tests for breeze branch-agnostic

### DIFF
--- a/dev/breeze/tests/test_shell_params.py
+++ b/dev/breeze/tests/test_shell_params.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 import pytest
 from rich.console import Console
 
+from airflow_breeze.branch_defaults import AIRFLOW_BRANCH
 from airflow_breeze.params.shell_params import ShellParams
 
 console = Console(width=400, color_system="standard")
@@ -34,9 +35,9 @@ console = Console(width=400, color_system="standard")
             {},
             {"python": 3.12},
             {
-                "DEFAULT_BRANCH": "main",
-                "AIRFLOW_CI_IMAGE": "ghcr.io/apache/airflow/main/ci/python3.12",
-                "AIRFLOW_CI_IMAGE_WITH_TAG": "ghcr.io/apache/airflow/main/ci/python3.12",
+                "DEFAULT_BRANCH": AIRFLOW_BRANCH,
+                "AIRFLOW_CI_IMAGE": f"ghcr.io/apache/airflow/{AIRFLOW_BRANCH}/ci/python3.12",
+                "AIRFLOW_CI_IMAGE_WITH_TAG": f"ghcr.io/apache/airflow/{AIRFLOW_BRANCH}/ci/python3.12",
                 "PYTHON_MAJOR_MINOR_VERSION": "3.12",
             },
             id="python3.12",
@@ -45,8 +46,8 @@ console = Console(width=400, color_system="standard")
             {},
             {"python": 3.9},
             {
-                "AIRFLOW_CI_IMAGE": "ghcr.io/apache/airflow/main/ci/python3.9",
-                "AIRFLOW_CI_IMAGE_WITH_TAG": "ghcr.io/apache/airflow/main/ci/python3.9",
+                "AIRFLOW_CI_IMAGE": f"ghcr.io/apache/airflow/{AIRFLOW_BRANCH}/ci/python3.9",
+                "AIRFLOW_CI_IMAGE_WITH_TAG": f"ghcr.io/apache/airflow/{AIRFLOW_BRANCH}/ci/python3.9",
                 "PYTHON_MAJOR_MINOR_VERSION": "3.9",
             },
             id="python3.9",
@@ -55,8 +56,8 @@ console = Console(width=400, color_system="standard")
             {},
             {"python": 3.9, "image_tag": "a_tag"},
             {
-                "AIRFLOW_CI_IMAGE": "ghcr.io/apache/airflow/main/ci/python3.9",
-                "AIRFLOW_CI_IMAGE_WITH_TAG": "ghcr.io/apache/airflow/main/ci/python3.9:a_tag",
+                "AIRFLOW_CI_IMAGE": f"ghcr.io/apache/airflow/{AIRFLOW_BRANCH}/ci/python3.9",
+                "AIRFLOW_CI_IMAGE_WITH_TAG": f"ghcr.io/apache/airflow/{AIRFLOW_BRANCH}/ci/python3.9:a_tag",
                 "PYTHON_MAJOR_MINOR_VERSION": "3.9",
             },
             id="With tag",
@@ -72,11 +73,11 @@ console = Console(width=400, color_system="standard")
             id="With release branch",
         ),
         pytest.param(
-            {"DEFAULT_BRANCH": "v2-8-test"},
+            {"DEFAULT_BRANCH": "v2-4-test"},
             {},
             {
-                "DEFAULT_BRANCH": "main",  # DEFAULT_BRANCH is overridden from sources
-                "AIRFLOW_CI_IMAGE": "ghcr.io/apache/airflow/main/ci/python3.8",
+                "DEFAULT_BRANCH": AIRFLOW_BRANCH,  # DEFAULT_BRANCH is overridden from sources
+                "AIRFLOW_CI_IMAGE": f"ghcr.io/apache/airflow/{AIRFLOW_BRANCH}/ci/python3.8",
                 "PYTHON_MAJOR_MINOR_VERSION": "3.8",
             },
             id="Branch variable from sources not from original env",


### PR DESCRIPTION
The new tests in breeze depended implicitly on the fact they were running in `main` branch, but when run in v2*test, they should use the AIRFLOW_BRANCH as the expected branch rather than `main` explicitly - otherwise the tests fail.

This PR makes the test branch-agnostic, no matter what branch they run in, they should expect the right branch.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
