### PR TITLE
Add encryption methods to serde for primitives

### DIFF
--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -57,7 +57,7 @@ DEFAULT_VERSION = 0
 
 ENCRYPTION_PROTOCOL_VERSION = 1
 ENCRYPTION_PROTO = b"\x90"  # encryption protocol marker
-BOOL = b"\x88"  # boolean marker
+BOOL = b"\xe0"  # boolean marker
 
 T = TypeVar("T", bool, float, int, dict, list, str, tuple, set)
 U = Union[bool, float, int, dict, list, str, tuple, set]

--- a/airflow/serialization/serializers/deltalake.py
+++ b/airflow/serialization/serializers/deltalake.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from airflow.serialization.serde import decrypt, encrypt
 from airflow.utils.module_loading import qualname
 
 serializers = ["deltalake.table.DeltaTable"]
@@ -34,6 +33,8 @@ __version__ = 2
 
 def serialize(o: object) -> tuple[U, str, int, bool]:
     from deltalake.table import DeltaTable
+
+    from airflow.serialization.serde import encrypt
 
     if not isinstance(o, DeltaTable):
         return "", "", 0, False
@@ -57,6 +58,7 @@ def deserialize(classname: str, version: int, data: dict):
     from deltalake.table import DeltaTable
 
     from airflow.models.crypto import get_fernet
+    from airflow.serialization.serde import decrypt
 
     if version > __version__:
         raise TypeError("serialized version is newer than class version")

--- a/airflow/serialization/serializers/iceberg.py
+++ b/airflow/serialization/serializers/iceberg.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from airflow.serialization.serde import decrypt, encrypt
 from airflow.utils.module_loading import qualname
 
 serializers = ["pyiceberg.table.Table"]
@@ -34,6 +33,8 @@ __version__ = 2
 
 def serialize(o: object) -> tuple[U, str, int, bool]:
     from pyiceberg.table import Table
+
+    from airflow.serialization.serde import encrypt
 
     if not isinstance(o, Table):
         return "", "", 0, False
@@ -58,6 +59,7 @@ def deserialize(classname: str, version: int, data: dict):
     from pyiceberg.table import Table
 
     from airflow.models.crypto import get_fernet
+    from airflow.serialization.serde import decrypt
 
     if version > __version__:
         raise TypeError("serialized version is newer than class version")

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -34,7 +34,9 @@ from airflow.serialization.serde import (
     VERSION,
     _get_patterns,
     _match,
+    decrypt,
     deserialize,
+    encrypt,
     serialize,
 )
 from airflow.utils.module_loading import import_string, iter_namespace, qualname
@@ -364,3 +366,15 @@ class TestSerDe:
             TypeError, match="cannot serialize object of type <class 'tests.serialization.test_serde.C'>"
         ):
             serialize(i)
+
+    @pytest.mark.parametrize(
+        "expr",
+        [1, False, True, "test", 1.1234],
+    )
+    def test_encryption_decryption(self, expr):
+        e = encrypt(expr)
+        assert e != expr
+        assert str(e) != str(expr)
+        d = decrypt(e)
+        assert d == expr
+        assert type(d) == type(expr)


### PR DESCRIPTION
Several serialized object could expose sensitive information in the UI
through XCom values. This generalizes how encryption works, 
including versioning of the protocol.

This is a prerequisite for: https://github.com/apache/airflow/pull/35820

cc @eladkal @Taragolis @potiuk 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
