### PR TITLE
Ignore E402 (import not at the top of file) in pre-commits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ combine-as-imports = true
 
 # All of the modules which have an extra license header (i.e. that we copy from another project) need to
 # ignore E402 -- module level import not at top level
+"scripts/ci/pre_commit/*.py" = ["E402"]
 "airflow/api/auth/backend/kerberos_auth.py" = ["E402"]
 "airflow/security/kerberos.py" = ["E402"]
 "airflow/security/utils.py" = ["E402"]

--- a/scripts/ci/pre_commit/common_precommit_black_utils.py
+++ b/scripts/ci/pre_commit/common_precommit_black_utils.py
@@ -25,7 +25,7 @@ from black import Mode, TargetVersion, format_str, parse_pyproject_toml
 
 sys.path.insert(0, str(Path(__file__).parent.resolve()))  # make sure common_precommit_utils is imported
 
-from common_precommit_utils import AIRFLOW_BREEZE_SOURCES_PATH  # isort: skip # noqa E402
+from common_precommit_utils import AIRFLOW_BREEZE_SOURCES_PATH
 
 
 @lru_cache(maxsize=None)

--- a/scripts/ci/pre_commit/pre_commit_check_pre_commit_hooks.py
+++ b/scripts/ci/pre_commit/pre_commit_check_pre_commit_hooks.py
@@ -26,19 +26,18 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.resolve()))  # make sure common_precommit_utils is imported
-from common_precommit_utils import (  # isort: skip # noqa: E402
+from collections import defaultdict
+from typing import Any
+
+import yaml
+from common_precommit_black_utils import black_format
+from common_precommit_utils import (
     AIRFLOW_BREEZE_SOURCES_PATH,
     AIRFLOW_SOURCES_ROOT_PATH,
     insert_documentation,
 )
-from common_precommit_black_utils import black_format  # isort: skip # noqa E402
-
-from collections import defaultdict  # noqa: E402
-from typing import Any  # noqa: E402
-
-import yaml  # noqa: E402
-from rich.console import Console  # noqa: E402
-from tabulate import tabulate  # noqa: E402
+from rich.console import Console
+from tabulate import tabulate
 
 console = Console(width=400, color_system="standard")
 

--- a/scripts/ci/pre_commit/pre_commit_check_setup_extra_packages_ref.py
+++ b/scripts/ci/pre_commit/pre_commit_check_setup_extra_packages_ref.py
@@ -39,12 +39,12 @@ sys.path.insert(0, os.fspath(AIRFLOW_SOURCES_DIR))
 
 os.environ["_SKIP_PYTHON_VERSION_CHECK"] = "true"
 
-from setup import (  # noqa # isort:skip
-    add_all_provider_packages,
-    EXTRAS_DEPRECATED_ALIASES,
+from setup import (
     EXTRAS_DEPENDENCIES,
-    PREINSTALLED_PROVIDERS,
+    EXTRAS_DEPRECATED_ALIASES,
     EXTRAS_DEPRECATED_ALIASES_IGNORED_FROM_REF_DOCS,
+    PREINSTALLED_PROVIDERS,
+    add_all_provider_packages,
 )
 
 

--- a/scripts/ci/pre_commit/pre_commit_compile_www_assets.py
+++ b/scripts/ci/pre_commit/pre_commit_compile_www_assets.py
@@ -23,7 +23,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.resolve()))  # make sure common_precommit_utils is imported
-from common_precommit_utils import get_directory_hash  # isort: skip # noqa E402
+from common_precommit_utils import get_directory_hash
 
 AIRFLOW_SOURCES_PATH = Path(__file__).parents[3].resolve()
 WWW_HASH_FILE = AIRFLOW_SOURCES_PATH / ".build" / "www" / "hash.txt"

--- a/scripts/ci/pre_commit/pre_commit_insert_extras.py
+++ b/scripts/ci/pre_commit/pre_commit_insert_extras.py
@@ -30,8 +30,9 @@ sys.path.insert(0, str(AIRFLOW_SOURCES_DIR))  # make sure setup is imported from
 
 os.environ["_SKIP_PYTHON_VERSION_CHECK"] = "true"
 
-from common_precommit_utils import insert_documentation  # isort: skip  # noqa: E402
-from setup import EXTRAS_DEPENDENCIES  # isort:skip  # noqa: E402
+from common_precommit_utils import insert_documentation
+
+from setup import EXTRAS_DEPENDENCIES
 
 sys.path.append(str(AIRFLOW_SOURCES_DIR))
 

--- a/scripts/ci/pre_commit/pre_commit_update_common_sql_api_stubs.py
+++ b/scripts/ci/pre_commit/pre_commit_update_common_sql_api_stubs.py
@@ -36,8 +36,8 @@ if __name__ not in ("__main__", "__mp_main__"):
 
 sys.path.insert(0, str(Path(__file__).parent.resolve()))  # make sure common_precommit_utils is imported
 
-from common_precommit_utils import AIRFLOW_SOURCES_ROOT_PATH  # isort: skip # noqa E402
-from common_precommit_black_utils import black_format  # isort: skip # noqa E402
+from common_precommit_black_utils import black_format
+from common_precommit_utils import AIRFLOW_SOURCES_ROOT_PATH
 
 PROVIDERS_ROOT = AIRFLOW_SOURCES_ROOT_PATH / "providers"
 COMMON_SQL_ROOT = PROVIDERS_ROOT / "common" / "sql"

--- a/scripts/ci/pre_commit/pre_commit_update_versions.py
+++ b/scripts/ci/pre_commit/pre_commit_update_versions.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.resolve()))  # make sure common_precommit_utils is importable
 
-from common_precommit_utils import AIRFLOW_SOURCES_ROOT_PATH, read_airflow_version  # noqa: E402
+from common_precommit_utils import AIRFLOW_SOURCES_ROOT_PATH, read_airflow_version
 
 
 def update_version(pattern: re.Pattern, v: str, file_path: Path):


### PR DESCRIPTION
Pre-commits often import some modules from elsewhere after inserting a common folder at PYTHONPATH. Pre-commits are pretty special, because they are supposed to be run as standalone scripts by pre-commit framework as git hooks, and they often do similar things, so some common code in pre-commits is good to have.

Ignoring E402 error in all pre-commits seems like best way to avoid unnecessary individual exclusions.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
