### PR TITLE
Revert "Add v2-8 branches to codecov.yml and .asf.yaml (#35750)"

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -71,9 +71,6 @@ github:
     v2-7-stable:
       required_pull_request_reviews:
         required_approving_review_count: 1
-    v2-8-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
 
   collaborators:
     - mhenc

--- a/codecov.yml
+++ b/codecov.yml
@@ -55,8 +55,6 @@ coverage:
           - v2-6-test
           - v2-7-stable
           - v2-7-test
-          - v2-8-stable
-          - v2-8-test
         if_not_found: success
         if_ci_failed: error
         informational: true


### PR DESCRIPTION
This reverts commit c07c5925e93ba0a8f37f20c7deb814d0f6925705.

Temporarily revert this so I can push to v2-8-stable branch

