### PR TITLE
Revert "Revert "Add v2-8 branches to codecov.yml and .asf.yaml (#35750)" (#35883)"

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -71,6 +71,9 @@ github:
     v2-7-stable:
       required_pull_request_reviews:
         required_approving_review_count: 1
+    v2-8-stable:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
 
   collaborators:
     - mhenc

--- a/codecov.yml
+++ b/codecov.yml
@@ -55,6 +55,8 @@ coverage:
           - v2-6-test
           - v2-7-stable
           - v2-7-test
+          - v2-8-stable
+          - v2-8-test
         if_not_found: success
         if_ci_failed: error
         informational: true


### PR DESCRIPTION
This reverts commit 1e730f21cdb46344eb1e4fc01342e494ef411a33.

Locks v2-8-stable back

