### PR TITLE
Stop converting state to TaskInstanceState when it's None

### DIFF
--- a/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -480,7 +480,7 @@ class KubernetesExecutor(BaseExecutor):
             from airflow.models.taskinstance import TaskInstance
 
             state = session.scalar(select(TaskInstance.state).where(TaskInstance.filter_for_tis([key])))
-            state = TaskInstanceState(state)
+            state = TaskInstanceState(state) if state else None
 
         self.event_buffer[key] = state, None
 


### PR DESCRIPTION
This PR fixes a bug introduced by #32627, where we try to get the state from the database when it's None in the executor, and for some reason, it's None in the database(maybe the task is cleared or its state is set manually to None...); in this case, we cannot convert it to `TaskInstanceState`, and we should use None as before the mentioned PR.

closes: #35888