### PR TITLE
Stop getting message from event after migrating EmrContainerTrigger to AwsBaseWaiterTrigger

### DIFF
--- a/airflow/providers/amazon/aws/sensors/emr.py
+++ b/airflow/providers/amazon/aws/sensors/emr.py
@@ -343,7 +343,7 @@ class EmrContainerSensor(BaseSensorOperator):
                 raise AirflowSkipException(message)
             raise AirflowException(message)
         else:
-            self.log.info(event["message"])
+            self.log.info("Job completed.")
 
 
 class EmrNotebookExecutionSensor(EmrBaseSensor):


### PR DESCRIPTION
#32274 migrated the class `EmrContainerTrigger` to the generic waiter `AwsBaseWaiterTrigger`, but it missed removing the access of the `message` from the triggered event, which is not provided anymore. This PR applies the same change applied to the other migrated triggers.

closes: #35882