### PR TITLE
Support IAM authentication for Redshift serverless

### DIFF
--- a/docs/apache-airflow-providers-amazon/connections/redshift.rst
+++ b/docs/apache-airflow-providers-amazon/connections/redshift.rst
@@ -97,3 +97,20 @@ inferred by the **Host** field in Connection.
       "database": "dev",
       "profile": "default"
     }
+
+If you want to use IAM with Amazon Redshift Serverless, you need to set **is_serverless** to true and provide
+**serverless_work_group**.
+
+* **Extra**:
+
+.. code-block:: json
+
+    {
+      "iam": true,
+      "is_serverless": true,
+      "serverless_work_group": "default",
+      "port": 5439,
+      "region": "us-east-1",
+      "database": "dev",
+      "profile": "default"
+    }

--- a/docs/apache-airflow-providers-amazon/connections/redshift.rst
+++ b/docs/apache-airflow-providers-amazon/connections/redshift.rst
@@ -99,7 +99,9 @@ inferred by the **Host** field in Connection.
     }
 
 If you want to use IAM with Amazon Redshift Serverless, you need to set **is_serverless** to true and provide
-**serverless_work_group**.
+**serverless_work_group**. You can also set **serverless_token_duration_seconds** to specify the number of seconds
+until the returned temporary password expires; the minimum is 900 seconds, the maximum is 3600 seconds and by default
+it's 3600 seconds.
 
 * **Extra**:
 
@@ -109,6 +111,7 @@ If you want to use IAM with Amazon Redshift Serverless, you need to set **is_ser
       "iam": true,
       "is_serverless": true,
       "serverless_work_group": "default",
+      "serverless_token_duration_seconds": 3600,
       "port": 5439,
       "region": "us-east-1",
       "database": "dev",

--- a/tests/providers/amazon/aws/hooks/test_redshift_sql.py
+++ b/tests/providers/amazon/aws/hooks/test_redshift_sql.py
@@ -120,6 +120,51 @@ class TestRedshiftSQLHookConn:
             iam=True,
         )
 
+    @mock.patch("airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook.conn")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.redshift_connector.connect")
+    @pytest.mark.parametrize("aws_conn_id", [NOTSET, None, "mock_aws_conn"])
+    def test_get_conn_iam_serverless_redshift(self, mock_connect, mock_aws_hook_conn, aws_conn_id):
+        mock_work_group = "my-test-workgroup"
+        mock_conn_extra = {
+            "iam": True,
+            "is_serverless": True,
+            "profile": "default",
+            "serverless_work_group": mock_work_group,
+        }
+        if aws_conn_id is not NOTSET:
+            self.db_hook.aws_conn_id = aws_conn_id
+        self.connection.extra = json.dumps(mock_conn_extra)
+
+        mock_db_user = f"IAM:{self.connection.login}"
+        mock_db_pass = "aws_token"
+
+        # Mock AWS Connection
+        mock_aws_hook_conn.get_cluster_credentials.return_value = {
+            "DbPassword": mock_db_pass,
+            "DbUser": mock_db_user,
+        }
+
+        self.db_hook.get_conn()
+
+        # Check boto3 'redshift' client method `get_cluster_credentials` call args
+        mock_aws_hook_conn.get_cluster_credentials.assert_called_once_with(
+            DbName=LOGIN_SCHEMA,
+            workgroupName=mock_work_group,
+            durationSeconds=3600,
+        )
+
+        mock_connect.assert_called_once_with(
+            user=mock_db_user,
+            password=mock_db_pass,
+            host=LOGIN_HOST,
+            port=LOGIN_PORT,
+            serverless_work_group=mock_work_group,
+            profile="default",
+            database=LOGIN_SCHEMA,
+            iam=True,
+            is_serverless=True,
+        )
+
     @pytest.mark.parametrize(
         "conn_params, conn_extra, expected_call_args",
         [


### PR DESCRIPTION
This PR adds some extra parameters to Redshift connection to support IAM authentication for AWS Redshift Serverless. When `is_serverless` extra is set to `True`, it uses `redshift-serverless` client instead of `redshift`, and provides the same param to `redshift_connector.connect` to initiate serverless connection.

closes: #35805