### PR TITLE
Add method from_uri and deprecate uri param in constructor

### DIFF
--- a/airflow/cli/commands/connection_command.py
+++ b/airflow/cli/commands/connection_command.py
@@ -248,7 +248,9 @@ def connections_add(args):
             )
 
     if args.conn_uri:
-        new_conn = Connection(conn_id=args.conn_id, description=args.conn_description, uri=args.conn_uri)
+        new_conn = Connection.from_uri(
+            conn_id=args.conn_id, description=args.conn_description, uri=args.conn_uri
+        )
         if args.conn_extra is not None:
             new_conn.set_extra(args.conn_extra)
     elif args.conn_json:

--- a/airflow/providers/google/cloud/hooks/cloud_sql.py
+++ b/airflow/providers/google/cloud/hooks/cloud_sql.py
@@ -964,7 +964,7 @@ class CloudSQLDatabaseHook(BaseHook):
         proxy, TCP, UNIX sockets, SSL.
         """
         uri = self._generate_connection_uri()
-        connection = Connection(conn_id=self.db_conn_id, uri=uri)
+        connection = Connection.from_uri(conn_id=self.db_conn_id, uri=uri)
         self.log.info("Creating connection %s", self.db_conn_id)
         return connection
 

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -225,7 +225,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
 
         uri = response.get("conn_uri")
         if uri:
-            return Connection(conn_id, uri=uri)
+            return Connection.from_uri(conn_id=conn_id, uri=uri)
 
         return Connection(conn_id, **response)
 

--- a/airflow/secrets/base_secrets.py
+++ b/airflow/secrets/base_secrets.py
@@ -67,7 +67,7 @@ class BaseSecretsBackend(ABC):
         if value[0] == "{":
             return Connection.from_json(conn_id=conn_id, value=value)
         else:
-            return Connection(conn_id=conn_id, uri=value)
+            return Connection.from_uri(conn_id=conn_id, uri=value)
 
     def get_conn_uri(self, conn_id: str) -> str | None:
         """

--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -190,7 +190,7 @@ def _create_connection(conn_id: str, value: Any):
     from airflow.models.connection import Connection
 
     if isinstance(value, str):
-        return Connection(conn_id=conn_id, uri=value)
+        return Connection.from_uri(conn_id=conn_id, uri=value)
     if isinstance(value, dict):
         connection_parameter_names = get_connection_parameter_names() | {"extra_dejson"}
         current_keys = set(value.keys())

--- a/tests/always/test_connection.py
+++ b/tests/always/test_connection.py
@@ -589,6 +589,8 @@ class TestConnection:
         """two conn_type normalizations are applied: replace - with _ and postgresql with postgres"""
         json_val = json.dumps(dict(password=val))
         assert Connection.from_json(json_val).password == expected
+        if expected:
+            self.mask_secret.assert_called_once_with(expected)
 
     @mock.patch.dict(
         "os.environ",


### PR DESCRIPTION
The param URI in connection has confusion potential because it makes it appear as though URI is a possible attr of the Connection object (which is not exactly a crazy thought).  We can reduce such confusion by forcing users to a class method `from_uri` which makes the meaning of the URI a bit more clear, and has a parallel method in `from_json`.
