### PR TITLE
Use fail instead of change_state(failed) in K8S executor

### DIFF
--- a/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -423,7 +423,7 @@ class KubernetesExecutor(BaseExecutor):
                     if e.status in (400, 422):
                         self.log.error("Pod creation failed with reason %r. Failing task", e.reason)
                         key, _, _, _ = task
-                        self.change_state(key, TaskInstanceState.FAILED, e)
+                        self.fail(key, e)
                     else:
                         self.log.warning(
                             "ApiException when attempting to run task, re-queueing. Reason: %r. Message: %s",


### PR DESCRIPTION
This PR consolidates the task failing by calling `self.fail(...)` instead of `self.change_state(..., TaskInstanceState.FAILED, ...)`.