### PR TITLE
Add  `avp` term to spelling wordlist

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -118,6 +118,7 @@ Autoscale
 autoscale
 autoscaler
 autoscaling
+avp
 Avro
 avro
 aws


### PR DESCRIPTION
Fix broken spelling docs test in main branch.

related: #35804