### PR TITLE
Ignore failed chown during breeze env config

### DIFF
--- a/scripts/in_container/configure_environment.sh
+++ b/scripts/in_container/configure_environment.sh
@@ -24,7 +24,7 @@ readonly TMUX_CONF_FILE=".tmux.conf"
 if [[ -d "${FILES_DIR}" ]]; then
     export AIRFLOW__CORE__DAGS_FOLDER="/files/dags"
     mkdir -pv "${AIRFLOW__CORE__DAGS_FOLDER}"
-    sudo chown "${HOST_USER_ID}":"${HOST_GROUP_ID}" "${AIRFLOW__CORE__DAGS_FOLDER}"
+    sudo chown "${HOST_USER_ID}":"${HOST_GROUP_ID}" "${AIRFLOW__CORE__DAGS_FOLDER}" || true
 else
     export AIRFLOW__CORE__DAGS_FOLDER="${AIRFLOW_HOME}/dags"
 fi


### PR DESCRIPTION
In an edge case, a host's user or group ID may cause the chown method to not succeed if they have special meanings in the container. This does not necessarily make Breeze unfunctional (depending on the actual permission in the host), so it may be better to simply skip the chown instead of failing the entire command and cause Breeze to exit.