### PR TITLE
Fix pre-commit for asset compilation missing rich as dependency

### DIFF
--- a/scripts/ci/pre_commit/common_precommit_utils.py
+++ b/scripts/ci/pre_commit/common_precommit_utils.py
@@ -17,9 +17,7 @@
 from __future__ import annotations
 
 import ast
-import hashlib
 import os
-import re
 import shlex
 import shutil
 import subprocess
@@ -68,18 +66,6 @@ def insert_documentation(file_path: Path, content: list[str], header: str, foote
             result.append(line)
     src = "".join(result)
     file_path.write_text(src)
-
-
-def get_directory_hash(directory: Path, skip_path_regexp: str | None = None) -> str:
-    files = sorted(directory.rglob("*"))
-    if skip_path_regexp:
-        matcher = re.compile(skip_path_regexp)
-        files = [file for file in files if not matcher.match(os.fspath(file.resolve()))]
-    sha = hashlib.sha256()
-    for file in files:
-        if file.is_file() and not file.name.startswith("."):
-            sha.update(file.read_bytes())
-    return sha.hexdigest()
 
 
 def initialize_breeze_precommit(name: str, file: str):

--- a/scripts/ci/pre_commit/pre_commit_compile_www_assets_dev.py
+++ b/scripts/ci/pre_commit/pre_commit_compile_www_assets_dev.py
@@ -21,6 +21,11 @@ import os
 import subprocess
 from pathlib import Path
 
+# NOTE!. This script is executed from node environment created by pre-commit and this environment
+# Cannot have additional Python dependencies installed. We should not import any of the libraries
+# here that are not available in stdlib! You should not import common_precommit_utils.py here because
+# They are importing rich library which is not available in the node environment.
+
 if __name__ not in ("__main__", "__mp_main__"):
     raise SystemExit(
         "This file is intended to be executed as an executable program. You cannot use it as a module."


### PR DESCRIPTION
After recent refactors, common_pre_commit_utils have rich as dependency so any pre-commits that cannot have rich set as dependency should not use it.

The "compile-www-assets" and "compile-www-assets-dev" pre-commits are "node" pre-commits - which means that they are not installing python dependencies - they at most might install node dependencies, and we cannot specify rich as dependency using pre-commit mechanisms.

The "compile-www-assets" and "compile-www-assets-dev" are pretty special, because they are "manual" stage pre-commits so they are not executed in CI and we have not detected them failing in latest refactor.

This PR makes those pre-commit python scripts work only using stdlib imports and add warning to avoid adding other imports.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
