### PR TITLE
Allow DagProcessorLogging print to file and also to stdout

### DIFF
--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -913,52 +913,6 @@ class TestDagFileProcessor:
             assert import_error.stacktrace == expected_stacktrace.format(invalid_dag_filename)
             session.rollback()
 
-    @conf_vars({("logging", "dag_processor_log_target"): "stdout"})
-    @mock.patch("airflow.dag_processing.processor.settings.dispose_orm", MagicMock)
-    @mock.patch("airflow.dag_processing.processor.redirect_stdout")
-    def test_dag_parser_output_when_logging_to_stdout(self, mock_redirect_stdout_for_file):
-        processor = DagFileProcessorProcess(
-            file_path="abc.txt",
-            pickle_dags=False,
-            dag_ids=[],
-            dag_directory=[],
-            callback_requests=[],
-        )
-        processor._run_file_processor(
-            result_channel=MagicMock(),
-            parent_channel=MagicMock(),
-            file_path="fake_file_path",
-            pickle_dags=False,
-            dag_ids=[],
-            thread_name="fake_thread_name",
-            callback_requests=[],
-            dag_directory=[],
-        )
-        mock_redirect_stdout_for_file.assert_not_called()
-
-    @conf_vars({("logging", "dag_processor_log_target"): "file"})
-    @mock.patch("airflow.dag_processing.processor.settings.dispose_orm", MagicMock)
-    @mock.patch("airflow.dag_processing.processor.redirect_stdout")
-    def test_dag_parser_output_when_logging_to_file(self, mock_redirect_stdout_for_file):
-        processor = DagFileProcessorProcess(
-            file_path="abc.txt",
-            pickle_dags=False,
-            dag_ids=[],
-            dag_directory=[],
-            callback_requests=[],
-        )
-        processor._run_file_processor(
-            result_channel=MagicMock(),
-            parent_channel=MagicMock(),
-            file_path="fake_file_path",
-            pickle_dags=False,
-            dag_ids=[],
-            thread_name="fake_thread_name",
-            callback_requests=[],
-            dag_directory=[],
-        )
-        mock_redirect_stdout_for_file.assert_called_once()
-
     @mock.patch("airflow.dag_processing.processor.settings.dispose_orm", MagicMock)
     @mock.patch.object(DagFileProcessorProcess, "_get_multiprocessing_context")
     def test_no_valueerror_with_parseable_dag_in_zip(self, mock_context, tmpdir):


### PR DESCRIPTION
For now dagProcessor logs print only to file or to stdout.
This PR makes the logs print to stdout and also to file.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
