### PR TITLE
Fix Properly parse out the value from a jsonpath match in SQS

### DIFF
--- a/airflow/providers/amazon/aws/utils/sqs.py
+++ b/airflow/providers/amazon/aws/utils/sqs.py
@@ -79,7 +79,7 @@ def filter_messages_jsonpath(messages, message_filtering_match_values, message_f
         results = jsonpath_expr.find(body)
         if results and (
             message_filtering_match_values is None
-            or any(result.value in message_filtering_match_values for result in results)
+            or any(result.value["Value"] in message_filtering_match_values for result in results)
         ):
             filtered_messages.append(message)
     return filtered_messages


### PR DESCRIPTION
Properly pull the value out of a jsonpath_ng match object.  The object looks like:

```
DatumInContext(value={'Type': 'String', 'Value': '2023-11-27T16:12:36+00:00'}, path=Fields('batch_id'), context=...)
```

The current version of the code expects the `value` attribute to hold the matched value, while in reality it holds a `dict` that describes both the type and value of the string.

Closes: #35932