### PR TITLE
Fixing remove_old_releases.py script to handle an edge case

### DIFF
--- a/dev/provider_packages/remove_old_releases.py
+++ b/dev/provider_packages/remove_old_releases.py
@@ -45,6 +45,7 @@ class VersionedFile(NamedTuple):
 def split_version_and_suffix(file_name: str, suffix: str) -> VersionedFile:
     no_suffix_file = file_name[: -len(suffix)]
     no_version_file, version = no_suffix_file.rsplit("-", 1)
+    no_version_file = no_version_file.replace("_", "-")
     return VersionedFile(
         base=no_version_file + "-",
         version=version,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

There was a bug in the _remove_old_releases.py_ where due to change in the provider tarball format from _ to -,  the script failed to detect the provider packages and lead to the script failing.

For examples, `apache-airflow-providers-amazon-8.11.0.tar.gz` and `apache_airflow_providers_amazon-8.11.0.tar.gz`
Before changes:
_VersionedFile(base='apache-airflow-providers-amazon-', version='8.11.0', suffix='.tar.gz', type='apache-airflow-providers-amazon-.tar.gz', comparable_version=<Version('8.11.0')>)
VersionedFile(base='apache_airflow_providers_amazon-', version='8.12.0', suffix='.tar.gz', type='apache_airflow_providers_amazon-.tar.gz', comparable_version=<Version('8.12.0')>)_

After changes:
_VersionedFile(base='apache-airflow-providers-amazon-', version='8.11.0', suffix='.tar.gz', type='apache-airflow-providers-amazon-.tar.gz', comparable_version=<Version('8.11.0')>)
VersionedFile(base='apache-airflow-providers-amazon-', version='8.11.0', suffix='.tar.gz', type='apache-airflow-providers-amazon-.tar.gz', comparable_version=<Version('8.11.0')>)_


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
