### PR TITLE
Limit aibotocore to help `pip` with backtracking issue for s3fs

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1225,7 +1225,23 @@ RUN echo "Airflow version: ${AIRFLOW_VERSION}"
 # Without grpcio-status limit, pip gets into very long backtracking
 # We should attempt to remove it in the future
 #
-ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="grpcio-status>=1.55.0 aiobotocore>=2.7.0"
+# Aiobotocore is limited for eager upgrade because it either causes a long backtracking or
+# conflict when we do not limit it. It seems that `pip` has a hard time figuring the right
+# combination of dependencies for aiobotocore, botocore, boto3 and s3fs together
+#
+# The root cause of the problem is that botocore (1.33.2), boto3 (1.33.2), aibotocore (2.8.0) all
+# released on November 28/29 2023. They are all compatible with each other but they
+# do not have corresponding s3fs release that would be compatible with them. The
+# s3fs latest 2023.10.0 release has iobotocore ~=2.7.0 which effectively forbids it to use 2.8.0
+# (and friends) and it confuses `pip` enough that it's not able to figure out that latest s3fs has a working
+# combination of aibotocore,botocore,boto3,s3fs - and it either gets into conflict or backtracks for hours.
+#
+# We need to help `pip` a little bit by limiting
+# limiting aiobotocore (limiting s3fs to latest version causes conflict)
+# This limit should be removed once new version of s3fs is released that is compatible with
+# aiobotocore 2.8.0 (beyond 2023.10.0).
+#
+ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="grpcio-status>=1.55.0 aiobotocore>=2.7.0,<2.8.0"
 ARG UPGRADE_TO_NEWER_DEPENDENCIES="false"
 ARG VERSION_SUFFIX_FOR_PYPI=""
 


### PR DESCRIPTION
Recent release of aiobotocore, boto3, botocore conflicts with s3fs and confuses `pip` enough to go into conflict or long backtracking.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
