### PR TITLE
Fix EC2Hook get_instance for client_type api

### DIFF
--- a/airflow/providers/amazon/aws/hooks/ec2.py
+++ b/airflow/providers/amazon/aws/hooks/ec2.py
@@ -85,7 +85,7 @@ class EC2Hook(AwsBaseHook):
         :return: Instance object
         """
         if self._api_type == "client_type":
-            return self.get_instances(filters=filters, instance_ids=[instance_id])
+            return self.get_instances(filters=filters, instance_ids=[instance_id])[0]
 
         return self.conn.Instance(id=instance_id)
 

--- a/tests/providers/amazon/aws/hooks/test_ec2.py
+++ b/tests/providers/amazon/aws/hooks/test_ec2.py
@@ -78,6 +78,14 @@ class TestEC2Hook:
         assert created_instance_id == existing_instance.instance_id
 
     @mock_ec2
+    def test_get_instance_client_type(self):
+        ec2_hook = EC2Hook(api_type="client_type")
+        created_instance_id = self._create_instance(ec2_hook)
+        # test get_instance method
+        existing_instance = ec2_hook.get_instance(instance_id=created_instance_id)
+        assert created_instance_id == existing_instance["InstanceId"]
+
+    @mock_ec2
     def test_get_instance_state(self):
         ec2_hook = EC2Hook()
         created_instance_id = self._create_instance(ec2_hook)


### PR DESCRIPTION
The method `get_instance` should return a single instance and not a list.