### PR TITLE
Refacto CloudwatchTaskHandler set_context method

### DIFF
--- a/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
+++ b/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
@@ -96,15 +96,15 @@ class CloudwatchTaskHandler(FileTaskHandler, LoggingMixin):
         # Replace unsupported log group name characters
         return super()._render_filename(ti, try_number).replace(":", "_")
 
-    def set_context(self, ti):
+    def set_context(self, ti: TaskInstance, *, identifier: str | None = None):
         super().set_context(ti)
-        self.json_serialize = conf.getimport("aws", "cloudwatch_task_handler_json_serializer")
+        _json_serialize = conf.getimport("aws", "cloudwatch_task_handler_json_serializer")
         self.handler = watchtower.CloudWatchLogHandler(
             log_group_name=self.log_group,
             log_stream_name=self._render_filename(ti, ti.try_number),
             use_queues=not getattr(ti, "is_trigger_log_context", False),
             boto3_client=self.hook.get_conn(),
-            json_serialize_default=self.json_serialize,
+            json_serialize_default=_json_serialize,
         )
 
     def close(self):


### PR DESCRIPTION
Update `set_context` method signature to match superclass one, and stop setting the instance attribute `json_serialize` which doesn't exist.