### PR TITLE
Fix `airflow db shell` needing an extra keypress to exit

### DIFF
--- a/airflow/utils/process_utils.py
+++ b/airflow/utils/process_utils.py
@@ -222,7 +222,7 @@ def execute_interactive(cmd: list[str], **kwargs) -> None:
             # ignore SIGINT in the parent process
             signal.signal(signal.SIGINT, signal.SIG_IGN)
             while proc.poll() is None:
-                readable_fbs, _, _ = select.select([sys.stdin, primary_fd], [], [])
+                readable_fbs, _, _ = select.select([sys.stdin, primary_fd], [], [], 0)
                 if sys.stdin in readable_fbs:
                     input_data = os.read(sys.stdin.fileno(), 10240)
                     os.write(primary_fd, input_data)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Related: #26186 
As @blag noted in #26186, pressing Ctrl-D (EOF) to exit the interactive shell requires an additional keypress to actually exit.
It seems that `select.select()` was blocking, and setting the `timeout` parameter to 0 fixes the issue of the interactive shell not exiting immediately after pressing Ctrl-D (or typing \q + Enter in psql). The docs for [select](https://docs.python.org/3/library/select.html) state:
>When the timeout argument is omitted the function blocks until at least one file descriptor is ready. A time-out value of zero specifies a poll and never blocks.

I tested the fix with all the supported db backends and saw no adverse effects, but hopefully someone with more experience with `select` can tell if this is a reasonable approach.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
