### PR TITLE
Fix gantt chart queued duration when queued_dttm is greater than start_date for deferred tasks.

### DIFF
--- a/airflow/www/static/js/dag/details/gantt/GanttTooltip.tsx
+++ b/airflow/www/static/js/dag/details/gantt/GanttTooltip.tsx
@@ -34,9 +34,11 @@ const GanttTooltip = ({ task, instance }: Props) => {
 
   // Calculate durations in ms
   const taskDuration = getDuration(instance?.startDate, instance?.endDate);
-  const queuedDuration = instance?.queuedDttm
-    ? getDuration(instance.queuedDttm, instance?.startDate)
-    : 0;
+  const queuedDuration =
+    instance?.queuedDttm &&
+    (instance?.startDate ? instance.queuedDttm < instance.startDate : true)
+      ? getDuration(instance.queuedDttm, instance?.startDate)
+      : 0;
   return (
     <Box>
       <Text>

--- a/airflow/www/static/js/dag/details/gantt/Row.tsx
+++ b/airflow/www/static/js/dag/details/gantt/Row.tsx
@@ -53,17 +53,21 @@ const Row = ({
   const instance = task.instances.find((ti) => ti.runId === runId);
   const isSelected = taskId === instance?.taskId;
   const hasQueuedDttm = !!instance?.queuedDttm;
+  const validQueuedDttm =
+    hasQueuedDttm &&
+    (instance?.startDate && instance?.queuedDttm
+      ? instance.queuedDttm < instance.startDate
+      : true);
   const isOpen = openGroupIds.includes(task.id || "");
 
   // Calculate durations in ms
   const taskDuration = getDuration(instance?.startDate, instance?.endDate);
-  const queuedDuration = hasQueuedDttm
+  const queuedDuration = validQueuedDttm
     ? getDuration(instance?.queuedDttm, instance?.startDate)
     : 0;
-  const taskStartOffset = getDuration(
-    ganttStartDate,
-    instance?.queuedDttm || instance?.startDate
-  );
+  const taskStartOffset = validQueuedDttm
+    ? getDuration(ganttStartDate, instance?.queuedDttm || instance?.startDate)
+    : getDuration(ganttStartDate, instance?.startDate);
 
   // Percent of each duration vs the overall dag run
   const taskDurationPercent = taskDuration / runDuration;
@@ -74,8 +78,8 @@ const Row = ({
   // Min width should be 5px
   let width = ganttWidth * taskDurationPercent;
   if (width < 5) width = 5;
-  let queuedWidth = hasQueuedDttm ? ganttWidth * queuedDurationPercent : 0;
-  if (hasQueuedDttm && queuedWidth < 5) queuedWidth = 5;
+  let queuedWidth = validQueuedDttm ? ganttWidth * queuedDurationPercent : 0;
+  if (validQueuedDttm && queuedWidth < 5) queuedWidth = 5;
   const offsetMargin = taskStartOffsetPercent * ganttWidth;
 
   return (

--- a/airflow/www/static/js/dag/details/gantt/Row.tsx
+++ b/airflow/www/static/js/dag/details/gantt/Row.tsx
@@ -52,9 +52,8 @@ const Row = ({
 
   const instance = task.instances.find((ti) => ti.runId === runId);
   const isSelected = taskId === instance?.taskId;
-  const hasQueuedDttm = !!instance?.queuedDttm;
-  const validQueuedDttm =
-    hasQueuedDttm &&
+  const hasValidQueuedDttm =
+    !!instance?.queuedDttm &&
     (instance?.startDate && instance?.queuedDttm
       ? instance.queuedDttm < instance.startDate
       : true);
@@ -62,10 +61,10 @@ const Row = ({
 
   // Calculate durations in ms
   const taskDuration = getDuration(instance?.startDate, instance?.endDate);
-  const queuedDuration = validQueuedDttm
+  const queuedDuration = hasValidQueuedDttm
     ? getDuration(instance?.queuedDttm, instance?.startDate)
     : 0;
-  const taskStartOffset = validQueuedDttm
+  const taskStartOffset = hasValidQueuedDttm
     ? getDuration(ganttStartDate, instance?.queuedDttm || instance?.startDate)
     : getDuration(ganttStartDate, instance?.startDate);
 
@@ -78,8 +77,8 @@ const Row = ({
   // Min width should be 5px
   let width = ganttWidth * taskDurationPercent;
   if (width < 5) width = 5;
-  let queuedWidth = validQueuedDttm ? ganttWidth * queuedDurationPercent : 0;
-  if (validQueuedDttm && queuedWidth < 5) queuedWidth = 5;
+  let queuedWidth = hasValidQueuedDttm ? ganttWidth * queuedDurationPercent : 0;
+  if (hasValidQueuedDttm && queuedWidth < 5) queuedWidth = 5;
   const offsetMargin = taskStartOffsetPercent * ganttWidth;
 
   return (
@@ -110,7 +109,7 @@ const Row = ({
                 });
               }}
             >
-              {instance.state !== "queued" && hasQueuedDttm && (
+              {instance.state !== "queued" && hasValidQueuedDttm && (
                 <SimpleStatus
                   state="queued"
                   width={`${queuedWidth}px`}
@@ -123,7 +122,9 @@ const Row = ({
                 state={instance.state}
                 width={`${width}px`}
                 borderLeftRadius={
-                  instance.state !== "queued" && hasQueuedDttm ? 0 : undefined
+                  instance.state !== "queued" && hasValidQueuedDttm
+                    ? 0
+                    : undefined
                 }
               />
             </Flex>


### PR DESCRIPTION
closes: #35288
related: #35288 

When a task is deferred then the same attempt is used to queue and resume causing the queued_dttm to be greater than start_date for an execution. This causes queued duration to be displayed with incorrect value taking queued_dttm - start_date which is not correct since start_date should always be greater than queued time. Also this causes start offset and to have a fixed queued duration bar width of 5. start offset and queued duration min width are shown only when queued_dttm is valid by being greater than start_date.

Before patch : (Incorrect queued duration of 23 hours and start of the bar is incorrect)

![gantt_before_patch](https://github.com/apache/airflow/assets/3972343/33295f80-c79d-45ca-a70c-8a9b2480be7b)

After patch : (queued duration is 0 since queued_dttm is greater than start_date. start_date position is also correct in gantt as per start_date)

![gantt_after](https://github.com/apache/airflow/assets/3972343/495c93e1-ca6a-4a85-b3c3-f75fb1215c0a)


Sample dag : 

```python
from __future__ import annotations

from datetime import datetime

from airflow import DAG
from airflow.models.baseoperator import BaseOperator
from airflow.triggers.file import FileTrigger


class FileCheckOperator(BaseOperator):
    def __init__(self, filepath, **kwargs):
        self.filepath = filepath
        super().__init__(**kwargs)

    def execute(self, context):
        self.defer(
            trigger=FileTrigger(filepath=self.filepath),
            method_name="execute_complete",
        )

    def execute_complete(self, context, event=None):
        pass


with DAG(
    dag_id="file_trigger",
    start_date=datetime(2021, 1, 1),
    catchup=False,
    schedule_interval=None,
) as dag:
    t1 = FileCheckOperator(task_id="t1", filepath="/tmp/a")
    t2 = FileCheckOperator(task_id="t2", filepath="/tmp/b")

    t1
    t2
```