### PR TITLE
Fix nits in LOCAL_VIRTUALENV.rst

### DIFF
--- a/LOCAL_VIRTUALENV.rst
+++ b/LOCAL_VIRTUALENV.rst
@@ -252,7 +252,7 @@ before running ``pip install`` command:
 .. code-block:: bash
 
   INSTALL_PROVIDERS_FROM_SOURCES="true" pip install -U -e ".[devel,<OTHER EXTRAS>]" \
-     --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-3.8.txt"
+     --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-source-providers-3.8.txt"
 
 This way no providers packages will be installed and they will always be imported from the "airflow/providers"
 folder.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

* In "https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-3.8.txt"  we get `docutils==0.20.1`, which conflicts with https://github.com/apache/airflow/blob/4a9824de8e063ee78a18583de24cd59718adc7f7/setup.py#L303 . After changing it to "https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-source-providers-3.8.txt", things work well.
* BTW, I think https://github.com/apache/airflow/blob/4a9824de8e063ee78a18583de24cd59718adc7f7/LOCAL_VIRTUALENV.rst?plain=1#L254

`-e` flag works negatively here. I had spent quite some time with the environment errors when using this install command. After I had removed the `-e` flag, things started to work.

With `-e` flag, I got some errors like:

```
ERROR:airflow.configuration:cannot import name '__version__' from 'airflow' (unknown location)
ERROR:airflow.cli.cli_parser:cannot load CLI commands from auth manager
```

If `-e` no more works here, what about removing it? In case the instruction causes trouble for other developers.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
