### PR TITLE
Move RDS hook to a cached property in RDS trigger

### DIFF
--- a/airflow/providers/amazon/aws/triggers/rds.py
+++ b/airflow/providers/amazon/aws/triggers/rds.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import warnings
+from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
@@ -83,8 +84,11 @@ class RdsDbInstanceTrigger(BaseTrigger):
             },
         )
 
+    @cached_property
+    def hook(self) -> RdsHook:
+        return RdsHook(aws_conn_id=self.aws_conn_id, region_name=self.region_name)
+
     async def run(self):
-        self.hook = RdsHook(aws_conn_id=self.aws_conn_id, region_name=self.region_name)
         async with self.hook.async_conn as client:
             waiter = client.get_waiter(self.waiter_name)
             await async_wait(


### PR DESCRIPTION
Consolidating the way used to create the hook, also adding an attribute to the instance outside the `__init__` method is a very bad practice.