### PR TITLE
Avoid creating the hook in the EmrServerlessCancelJobsTrigger init

### DIFF
--- a/airflow/providers/amazon/aws/triggers/emr.py
+++ b/airflow/providers/amazon/aws/triggers/emr.py
@@ -461,3 +461,8 @@ class EmrServerlessCancelJobsTrigger(AwsBaseWaiterTrigger):
 
     def hook(self) -> AwsGenericHook:
         return EmrServerlessHook(self.aws_conn_id)
+
+    @property
+    def hook_instance(self) -> AwsGenericHook:
+        """This property is added for backward compatibility."""
+        return self.hook()

--- a/airflow/providers/amazon/aws/triggers/emr.py
+++ b/airflow/providers/amazon/aws/triggers/emr.py
@@ -444,8 +444,7 @@ class EmrServerlessCancelJobsTrigger(AwsBaseWaiterTrigger):
         waiter_delay: int,
         waiter_max_attempts: int,
     ) -> None:
-        self.hook_instance = EmrServerlessHook(aws_conn_id)
-        states = list(self.hook_instance.JOB_INTERMEDIATE_STATES.union({"CANCELLING"}))
+        states = list(EmrServerlessHook.JOB_INTERMEDIATE_STATES.union({"CANCELLING"}))
         super().__init__(
             serialized_fields={"application_id": application_id},
             waiter_name="no_job_running",
@@ -461,4 +460,4 @@ class EmrServerlessCancelJobsTrigger(AwsBaseWaiterTrigger):
         )
 
     def hook(self) -> AwsGenericHook:
-        return self.hook_instance
+        return EmrServerlessHook(self.aws_conn_id)


### PR DESCRIPTION
This might be considered a breaking change, but it's completely useless to create the hook in the init method because we create an instance from the trigger in the operator when we defer it, which means an extra needed DB query to fetch the secrets.

The original reason for this implementation was accessing `JOB_INTERMEDIATE_STATES` list, which is a class param, so no need to create an instance from the class to get it.

cc: @eladkal 