### PR TITLE
Fix a bug in get_iam_token for Redshift Serverless

### DIFF
--- a/tests/providers/amazon/aws/hooks/test_redshift_sql.py
+++ b/tests/providers/amazon/aws/hooks/test_redshift_sql.py
@@ -139,16 +139,16 @@ class TestRedshiftSQLHookConn:
         mock_db_pass = "aws_token"
 
         # Mock AWS Connection
-        mock_aws_hook_conn.get_cluster_credentials.return_value = {
-            "DbPassword": mock_db_pass,
-            "DbUser": mock_db_user,
+        mock_aws_hook_conn.get_credentials.return_value = {
+            "dbPassword": mock_db_pass,
+            "dbUser": mock_db_user,
         }
 
         self.db_hook.get_conn()
 
         # Check boto3 'redshift' client method `get_cluster_credentials` call args
-        mock_aws_hook_conn.get_cluster_credentials.assert_called_once_with(
-            DbName=LOGIN_SCHEMA,
+        mock_aws_hook_conn.get_credentials.assert_called_once_with(
+            dbName=LOGIN_SCHEMA,
             workgroupName=mock_work_group,
             durationSeconds=3600,
         )


### PR DESCRIPTION
This PR fixes a typo in the method used to get the credentials in the Redshift Credentials client, where its name is `get_credentials` instead of `get_cluster_credentials`, also the arguments and returned parameters names don't start with an upper case.

related: #35897
detected while working on #35966, which will help to avoid this kind of bug.