### PR TITLE
Create latest log dir symlink as relative link

### DIFF
--- a/airflow/utils/log/file_processor_handler.py
+++ b/airflow/utils/log/file_processor_handler.py
@@ -118,18 +118,19 @@ class FileProcessorHandler(logging.Handler):
         log_directory = self._get_log_directory()
         latest_log_directory_path = os.path.join(self.base_log_folder, "latest")
         if os.path.isdir(log_directory):
+            rel_link_target = Path(log_directory).relative_to(Path(latest_log_directory_path).parent)
             try:
                 # if symlink exists but is stale, update it
                 if os.path.islink(latest_log_directory_path):
-                    if os.readlink(latest_log_directory_path) != log_directory:
+                    if os.path.realpath(latest_log_directory_path) != log_directory:
                         os.unlink(latest_log_directory_path)
-                        os.symlink(log_directory, latest_log_directory_path)
+                        os.symlink(rel_link_target, latest_log_directory_path)
                 elif os.path.isdir(latest_log_directory_path) or os.path.isfile(latest_log_directory_path):
                     logging.warning(
                         "%s already exists as a dir/file. Skip creating symlink.", latest_log_directory_path
                     )
                 else:
-                    os.symlink(log_directory, latest_log_directory_path)
+                    os.symlink(rel_link_target, latest_log_directory_path)
             except OSError:
                 logging.warning("OSError while attempting to symlink the latest log directory")
 

--- a/tests/utils/log/test_file_processor_handler.py
+++ b/tests/utils/log/test_file_processor_handler.py
@@ -80,13 +80,13 @@ class TestFileProcessorHandler:
         with time_machine.travel(date1, tick=False):
             handler.set_context(filename=os.path.join(self.dag_dir, "log1"))
             assert os.path.islink(link)
-            assert os.path.basename(os.readlink(link)) == date1
+            assert os.path.basename(os.path.realpath(link)) == date1
             assert os.path.exists(os.path.join(link, "log1"))
 
         with time_machine.travel(date2, tick=False):
             handler.set_context(filename=os.path.join(self.dag_dir, "log2"))
             assert os.path.islink(link)
-            assert os.path.basename(os.readlink(link)) == date2
+            assert os.path.basename(os.path.realpath(link)) == date2
             assert os.path.exists(os.path.join(link, "log2"))
 
     def test_symlink_latest_log_directory_exists(self):


### PR DESCRIPTION
So `logs/**/*` is self-contained and the symlink doesn't break for exporting, build artifact, etc

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
<!--
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
<!--