### PR TITLE
Use dropdown instead of buttons when there are more than 10 retries in log tab

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -26,6 +26,7 @@ import {
   Checkbox,
   Icon,
   Spinner,
+  Select,
 } from "@chakra-ui/react";
 import { MdWarning } from "react-icons/md";
 
@@ -152,6 +153,9 @@ const Logs = ({
     [data, fileSourceFilters, logLevelFilters, timezone]
   );
 
+  const logAttemptDropdownLimit = 10;
+  const showDropdown = internalIndexes.length > logAttemptDropdownLimit;
+
   useEffect(() => {
     // Reset fileSourceFilters and selected attempt when changing to
     // a task that do not have those filters anymore.
@@ -193,24 +197,44 @@ const Logs = ({
       {tryNumber !== undefined && (
         <>
           <Box>
-            <Text as="span"> (by attempts)</Text>
-            <Flex my={1} justifyContent="space-between">
-              <Flex flexWrap="wrap">
-                {internalIndexes.map((index) => (
-                  <Button
-                    key={index}
-                    variant={taskTryNumber === index ? "solid" : "ghost"}
-                    colorScheme="blue"
-                    onClick={() => setSelectedTryNumber(index)}
-                    data-testid={`log-attempt-select-button-${index}`}
-                  >
-                    {index}
-                  </Button>
-                ))}
-              </Flex>
-            </Flex>
+            {!showDropdown && (
+              <Box>
+                <Text as="span"> (by attempts)</Text>
+                <Flex my={1} justifyContent="space-between">
+                  <Flex flexWrap="wrap">
+                    {internalIndexes.map((index) => (
+                      <Button
+                        key={index}
+                        variant={taskTryNumber === index ? "solid" : "ghost"}
+                        colorScheme="blue"
+                        onClick={() => setSelectedTryNumber(index)}
+                        data-testid={`log-attempt-select-button-${index}`}
+                      >
+                        {index}
+                      </Button>
+                    ))}
+                  </Flex>
+                </Flex>
+              </Box>
+            )}
             <Flex my={1} justifyContent="space-between" flexWrap="wrap">
               <Flex alignItems="center" flexGrow={1} mr={10}>
+                {showDropdown && (
+                  <Box width="100%" mr={2}>
+                    <Select
+                      placeholder="Select log attempt"
+                      onChange={(e) => {
+                        setSelectedTryNumber(Number(e.target.value));
+                      }}
+                    >
+                      {internalIndexes.map((index) => (
+                        <option key={index} value={index}>
+                          {index}
+                        </option>
+                      ))}
+                    </Select>
+                  </Box>
+                )}
                 <Box width="100%" mr={2}>
                   <MultiSelect
                     size="sm"

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -222,6 +222,7 @@ const Logs = ({
                 {showDropdown && (
                   <Box width="100%" mr={2}>
                     <Select
+                      size="sm"
                       placeholder="Select log attempt"
                       onChange={(e) => {
                         setSelectedTryNumber(Number(e.target.value));


### PR DESCRIPTION
Use dropdown instead of button to select log attempt when there are more than 10 retries.

Less than 10 retries

![image](https://github.com/apache/airflow/assets/3972343/8242f9d3-fe58-46e4-b82d-cf1d97f7dac3)

More than 10 retries

![image](https://github.com/apache/airflow/assets/3972343/12a98a00-a84d-4b8c-99e2-0c42ad596fee)


closes: #35889
related: #35889 

Sample dag :

```python
from datetime import datetime, timedelta

from airflow import DAG
from airflow.decorators import task


with DAG(
    dag_id="retry_issue_dag",
    start_date=datetime(2023, 10, 10),
    catchup=False,
    schedule_interval="@once",
) as dag:

    @task(retries=8, retry_delay=timedelta(seconds=1))
    def retry_less_than_10():
        raise Exception("fail")

    @task(retries=15, retry_delay=timedelta(seconds=1))
    def retry_more_than_10():
        raise Exception("fail")

    retry_less_than_10()
    retry_more_than_10()

```