### PR TITLE
Mount selected sources of Airflow to image when running mypy checks

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_mypy.py
+++ b/scripts/ci/pre_commit/pre_commit_mypy.py
@@ -45,6 +45,10 @@ res = run_command_via_breeze_shell(
     warn_image_upgrade_needed=True,
     extra_env={
         "INCLUDE_MYPY_VOLUME": "true",
+        # Need to mount local sources when running it - to not have to rebuild the image
+        # and to let CI work on it when running on PRs from forks - because mypy-dev uses files
+        # that are not available at the time when image is built in CI
+        "MOUNT_SOURCES": "selected",
     },
 )
 if res.returncode != 0:


### PR DESCRIPTION
When Mypy runs its check it uses breeze image to do so, and by default on CI the images are built using `main` version of scripts/ci and workflow files. This basically means that running static checks with the breeze image reguies mounting the sources if we want to run those checks on the scripts/ci/ folder or .workflow and breeze CI image is used.

The `mypy-dev` check is doing it - it checks `scripts/ci` folder, which means that for mypy checks we need to force mounting the selected sources rather than the ones that are baked in the image.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
