### PR TITLE
Remove pytest-asyncio upper-binding limitation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -475,9 +475,9 @@ _devel_only_tests = [
     "beautifulsoup4>=4.7.1",
     "coverage>=7.2",
     "pytest>=7.1",
-    # Pytest-asyncio 0.23.1 breaks our tests. The limitation should be removed when the issue is fixed:
-    # https://github.com/pytest-dev/pytest-asyncio/issues/703
-    "pytest-asyncio<0.23.0",
+    # Pytest-asyncio 0.23.0 and 0.23.1 break test collection
+    # See https://github.com/pytest-dev/pytest-asyncio/issues/703 for details.
+    "pytest-asyncio!=0.23.0,!=0.23.1",
     "pytest-cov",
     "pytest-httpx",
     "pytest-icdiff",


### PR DESCRIPTION
Thahnks to our report and bisecting the reason (it was caused by bad handling of the "test*.txt" handling) we can now remove the upper-binding for pytest-asyncio as 0.23.2 version has been released

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
