### PR TITLE
Typo fix: incorrect date? In supported-versions.rst

### DIFF
--- a/docs/apache-airflow/installation/supported-versions.rst
+++ b/docs/apache-airflow/installation/supported-versions.rst
@@ -61,7 +61,7 @@ They are based on the official release schedule of Python and Kubernetes, nicely
 2. The "oldest" supported version of Python/Kubernetes is the default one. "Default" is only meaningful
    in terms of "smoke tests" in CI PRs which are run using this default version and default reference
    image available in DockerHub. Currently the ``apache/airflow:latest`` and ``apache/airflow:2.5.2`` images
-   are Python 3.8 images, however, in the first MINOR/MAJOR release of Airflow released after 14.19.2023,
+   are Python 3.8 images, however, in the first MINOR/MAJOR release of Airflow released after 14.09.2023,
    they will become Python 3.9 images.
 
 3. We support a new version of Python/Kubernetes in main after they are officially released, as soon as we


### PR DESCRIPTION
I think the date 14.19.2023 is wrong--should it be 14.09.2023 (= September 14, 2023)?
