### PR TITLE
OpenLineage: Add parent_run_id for COMPLETE and FAIL events

### DIFF
--- a/tests/providers/openlineage/plugins/test_listener.py
+++ b/tests/providers/openlineage/plugins/test_listener.py
@@ -223,7 +223,6 @@ def test_adapter_start_task_is_called_with_proper_arguments(
         owners=["Test Owner"],
         task=listener.extractor_manager.extract_metadata(),
         run_facets={
-            "run_facet": 1,
             "custom_facet": 2,
             "airflow_run_facet": 3,
         },
@@ -243,11 +242,14 @@ def test_adapter_fail_task_is_called_with_proper_arguments(mock_get_job_name, mo
     listener, task_instance = _create_listener_and_task_instance()
     mock_get_job_name.return_value = "job_name"
     mocked_adapter.build_task_instance_run_id.side_effect = lambda x, y, z: f"{x}.{y}.{z}"
+    mocked_adapter.build_dag_run_id.side_effect = lambda x, y: f"{x}.{y}"
 
     listener.on_task_instance_failed(None, task_instance, None)
     listener.adapter.fail_task.assert_called_once_with(
         end_time="2023-01-03T13:01:01",
         job_name="job_name",
+        parent_job_name="dag_id",
+        parent_run_id="dag_id.dag_run_run_id",
         run_id="task_id.execution_date.1",
         task=listener.extractor_manager.extract_metadata(),
     )
@@ -267,6 +269,7 @@ def test_adapter_complete_task_is_called_with_proper_arguments(mock_get_job_name
     listener, task_instance = _create_listener_and_task_instance()
     mock_get_job_name.return_value = "job_name"
     mocked_adapter.build_task_instance_run_id.side_effect = lambda x, y, z: f"{x}.{y}.{z}"
+    mocked_adapter.build_dag_run_id.side_effect = lambda x, y: f"{x}.{y}"
 
     listener.on_task_instance_success(None, task_instance, None)
     # This run_id will be different as we did NOT simulate increase of the try_number attribute,
@@ -274,6 +277,8 @@ def test_adapter_complete_task_is_called_with_proper_arguments(mock_get_job_name
     listener.adapter.complete_task.assert_called_once_with(
         end_time="2023-01-03T13:01:01",
         job_name="job_name",
+        parent_job_name="dag_id",
+        parent_run_id="dag_id.dag_run_run_id",
         run_id="task_id.execution_date.0",
         task=listener.extractor_manager.extract_metadata(),
     )
@@ -285,6 +290,8 @@ def test_adapter_complete_task_is_called_with_proper_arguments(mock_get_job_name
     listener.adapter.complete_task.assert_called_once_with(
         end_time="2023-01-03T13:01:01",
         job_name="job_name",
+        parent_job_name="dag_id",
+        parent_run_id="dag_id.dag_run_run_id",
         run_id="task_id.execution_date.1",
         task=listener.extractor_manager.extract_metadata(),
     )

--- a/tests/providers/openlineage/plugins/test_openlineage_adapter.py
+++ b/tests/providers/openlineage/plugins/test_openlineage_adapter.py
@@ -27,10 +27,15 @@ import pytest
 from openlineage.client.facet import (
     DocumentationJobFacet,
     ErrorMessageRunFacet,
+    ExternalQueryRunFacet,
     NominalTimeRunFacet,
+    OwnershipJobFacet,
+    OwnershipJobFacetOwners,
+    ParentRunFacet,
     ProcessingEngineRunFacet,
+    SqlJobFacet,
 )
-from openlineage.client.run import Job, Run, RunEvent, RunState
+from openlineage.client.run import Dataset, Job, Run, RunEvent, RunState
 
 from airflow.providers.openlineage.extractors import OperatorLineage
 from airflow.providers.openlineage.plugins.adapter import _DAG_NAMESPACE, _PRODUCER, OpenLineageAdapter
@@ -174,6 +179,90 @@ def test_emit_start_event(mock_stats_incr, mock_stats_timer):
 
 @mock.patch("airflow.providers.openlineage.plugins.adapter.Stats.timer")
 @mock.patch("airflow.providers.openlineage.plugins.adapter.Stats.incr")
+def test_emit_start_event_with_additional_information(mock_stats_incr, mock_stats_timer):
+    client = MagicMock()
+    adapter = OpenLineageAdapter(client)
+
+    run_id = str(uuid.uuid4())
+    event_time = datetime.datetime.now().isoformat()
+    adapter.start_task(
+        run_id=run_id,
+        job_name="job",
+        job_description="description",
+        event_time=event_time,
+        parent_job_name="parent_job_name",
+        parent_run_id="parent_run_id",
+        code_location=None,
+        nominal_start_time=datetime.datetime(2022, 1, 1).isoformat(),
+        nominal_end_time=datetime.datetime(2022, 1, 1).isoformat(),
+        owners=["owner1", "owner2"],
+        task=OperatorLineage(
+            inputs=[Dataset(namespace="bigquery", name="a.b.c"), Dataset(namespace="bigquery", name="x.y.z")],
+            outputs=[Dataset(namespace="gs://bucket", name="exported_folder")],
+            job_facets={"sql": SqlJobFacet(query="SELECT 1;")},
+            run_facets={"externalQuery1": ExternalQueryRunFacet(externalQueryId="123", source="source")},
+        ),
+        run_facets={"externalQuery2": ExternalQueryRunFacet(externalQueryId="999", source="source")},
+    )
+
+    assert (
+        call(
+            RunEvent(
+                eventType=RunState.START,
+                eventTime=event_time,
+                run=Run(
+                    runId=run_id,
+                    facets={
+                        "nominalTime": NominalTimeRunFacet(
+                            nominalStartTime="2022-01-01T00:00:00",
+                            nominalEndTime="2022-01-01T00:00:00",
+                        ),
+                        "processing_engine": ProcessingEngineRunFacet(
+                            version=ANY, name="Airflow", openlineageAdapterVersion=ANY
+                        ),
+                        "parent": ParentRunFacet(
+                            run={"runId": "parent_run_id"},
+                            job={"namespace": "default", "name": "parent_job_name"},
+                        ),
+                        "parentRun": ParentRunFacet(
+                            run={"runId": "parent_run_id"},
+                            job={"namespace": "default", "name": "parent_job_name"},
+                        ),
+                        "externalQuery1": ExternalQueryRunFacet(externalQueryId="123", source="source"),
+                        "externalQuery2": ExternalQueryRunFacet(externalQueryId="999", source="source"),
+                    },
+                ),
+                job=Job(
+                    namespace="default",
+                    name="job",
+                    facets={
+                        "documentation": DocumentationJobFacet(description="description"),
+                        "ownership": OwnershipJobFacet(
+                            owners=[
+                                OwnershipJobFacetOwners(name="owner1", type=None),
+                                OwnershipJobFacetOwners(name="owner2", type=None),
+                            ]
+                        ),
+                        "sql": SqlJobFacet(query="SELECT 1;"),
+                    },
+                ),
+                producer=_PRODUCER,
+                inputs=[
+                    Dataset(namespace="bigquery", name="a.b.c"),
+                    Dataset(namespace="bigquery", name="x.y.z"),
+                ],
+                outputs=[Dataset(namespace="gs://bucket", name="exported_folder")],
+            )
+        )
+        in client.emit.mock_calls
+    )
+
+    mock_stats_incr.assert_not_called()
+    mock_stats_timer.assert_called_with("ol.emit.attempts")
+
+
+@mock.patch("airflow.providers.openlineage.plugins.adapter.Stats.timer")
+@mock.patch("airflow.providers.openlineage.plugins.adapter.Stats.incr")
 def test_emit_complete_event(mock_stats_incr, mock_stats_timer):
     client = MagicMock()
     adapter = OpenLineageAdapter(client)
@@ -183,6 +272,8 @@ def test_emit_complete_event(mock_stats_incr, mock_stats_timer):
     adapter.complete_task(
         run_id=run_id,
         end_time=event_time,
+        parent_job_name=None,
+        parent_run_id=None,
         job_name="job",
         task=OperatorLineage(),
     )
@@ -208,6 +299,63 @@ def test_emit_complete_event(mock_stats_incr, mock_stats_timer):
 
 @mock.patch("airflow.providers.openlineage.plugins.adapter.Stats.timer")
 @mock.patch("airflow.providers.openlineage.plugins.adapter.Stats.incr")
+def test_emit_complete_event_with_additional_information(mock_stats_incr, mock_stats_timer):
+    client = MagicMock()
+    adapter = OpenLineageAdapter(client)
+
+    run_id = str(uuid.uuid4())
+    event_time = datetime.datetime.now().isoformat()
+    adapter.complete_task(
+        run_id=run_id,
+        end_time=event_time,
+        parent_job_name="parent_job_name",
+        parent_run_id="parent_run_id",
+        job_name="job",
+        task=OperatorLineage(
+            inputs=[Dataset(namespace="bigquery", name="a.b.c"), Dataset(namespace="bigquery", name="x.y.z")],
+            outputs=[Dataset(namespace="gs://bucket", name="exported_folder")],
+            job_facets={"sql": SqlJobFacet(query="SELECT 1;")},
+            run_facets={"externalQuery": ExternalQueryRunFacet(externalQueryId="123", source="source")},
+        ),
+    )
+
+    assert (
+        call(
+            RunEvent(
+                eventType=RunState.COMPLETE,
+                eventTime=event_time,
+                run=Run(
+                    runId=run_id,
+                    facets={
+                        "parent": ParentRunFacet(
+                            run={"runId": "parent_run_id"},
+                            job={"namespace": "default", "name": "parent_job_name"},
+                        ),
+                        "parentRun": ParentRunFacet(
+                            run={"runId": "parent_run_id"},
+                            job={"namespace": "default", "name": "parent_job_name"},
+                        ),
+                        "externalQuery": ExternalQueryRunFacet(externalQueryId="123", source="source"),
+                    },
+                ),
+                job=Job(namespace="default", name="job", facets={"sql": SqlJobFacet(query="SELECT 1;")}),
+                producer=_PRODUCER,
+                inputs=[
+                    Dataset(namespace="bigquery", name="a.b.c"),
+                    Dataset(namespace="bigquery", name="x.y.z"),
+                ],
+                outputs=[Dataset(namespace="gs://bucket", name="exported_folder")],
+            )
+        )
+        in client.emit.mock_calls
+    )
+
+    mock_stats_incr.assert_not_called()
+    mock_stats_timer.assert_called_with("ol.emit.attempts")
+
+
+@mock.patch("airflow.providers.openlineage.plugins.adapter.Stats.timer")
+@mock.patch("airflow.providers.openlineage.plugins.adapter.Stats.incr")
 def test_emit_failed_event(mock_stats_incr, mock_stats_timer):
     client = MagicMock()
     adapter = OpenLineageAdapter(client)
@@ -217,6 +365,8 @@ def test_emit_failed_event(mock_stats_incr, mock_stats_timer):
     adapter.fail_task(
         run_id=run_id,
         end_time=event_time,
+        parent_job_name=None,
+        parent_run_id=None,
         job_name="job",
         task=OperatorLineage(),
     )
@@ -231,6 +381,63 @@ def test_emit_failed_event(mock_stats_incr, mock_stats_timer):
                 producer=_PRODUCER,
                 inputs=[],
                 outputs=[],
+            )
+        )
+        in client.emit.mock_calls
+    )
+
+    mock_stats_incr.assert_not_called()
+    mock_stats_timer.assert_called_with("ol.emit.attempts")
+
+
+@mock.patch("airflow.providers.openlineage.plugins.adapter.Stats.timer")
+@mock.patch("airflow.providers.openlineage.plugins.adapter.Stats.incr")
+def test_emit_failed_event_with_additional_information(mock_stats_incr, mock_stats_timer):
+    client = MagicMock()
+    adapter = OpenLineageAdapter(client)
+
+    run_id = str(uuid.uuid4())
+    event_time = datetime.datetime.now().isoformat()
+    adapter.fail_task(
+        run_id=run_id,
+        end_time=event_time,
+        parent_job_name="parent_job_name",
+        parent_run_id="parent_run_id",
+        job_name="job",
+        task=OperatorLineage(
+            inputs=[Dataset(namespace="bigquery", name="a.b.c"), Dataset(namespace="bigquery", name="x.y.z")],
+            outputs=[Dataset(namespace="gs://bucket", name="exported_folder")],
+            run_facets={"externalQuery": ExternalQueryRunFacet(externalQueryId="123", source="source")},
+            job_facets={"sql": SqlJobFacet(query="SELECT 1;")},
+        ),
+    )
+
+    assert (
+        call(
+            RunEvent(
+                eventType=RunState.FAIL,
+                eventTime=event_time,
+                run=Run(
+                    runId=run_id,
+                    facets={
+                        "parent": ParentRunFacet(
+                            run={"runId": "parent_run_id"},
+                            job={"namespace": "default", "name": "parent_job_name"},
+                        ),
+                        "parentRun": ParentRunFacet(
+                            run={"runId": "parent_run_id"},
+                            job={"namespace": "default", "name": "parent_job_name"},
+                        ),
+                        "externalQuery": ExternalQueryRunFacet(externalQueryId="123", source="source"),
+                    },
+                ),
+                job=Job(namespace="default", name="job", facets={"sql": SqlJobFacet(query="SELECT 1;")}),
+                producer=_PRODUCER,
+                inputs=[
+                    Dataset(namespace="bigquery", name="a.b.c"),
+                    Dataset(namespace="bigquery", name="x.y.z"),
+                ],
+                outputs=[Dataset(namespace="gs://bucket", name="exported_folder")],
             )
         )
         in client.emit.mock_calls


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Add information about parent_run_id to FAIL and COMPLETE event in Openlineage. 

This way You can easily assign all the events to their parent run.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
