### PR TITLE
Add posibility using external pgBouncer

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -84,7 +84,7 @@ If release name contains chart name it will be used as a full name.
         name: {{ template "airflow_metadata_secret" . }}
         key: connection
   {{- end }}
-  {{- if and .Values.workers.keda.enabled .Values.pgbouncer.enabled (not .Values.workers.keda.usePgbouncer) }}
+  {{- if and .Values.workers.keda.enabled ( or (and .Values.pgbouncer.enabled (not .Values.workers.keda.usePgbouncer) .Values.workers.keda.useExtPgbouncer )) }}
   - name: KEDA_DB_CONN
     valueFrom:
       secretKeyRef:

--- a/chart/templates/secrets/metadata-connection-secret.yaml
+++ b/chart/templates/secrets/metadata-connection-secret.yaml
@@ -47,7 +47,7 @@ data:
   {{- with .Values.data.metadataConnection }}
   connection: {{ urlJoin (dict "scheme" .protocol "userinfo" (printf "%s:%s" (.user | urlquery) (.pass | urlquery) ) "host" (printf "%s:%s" $host $port) "path" (printf "/%s" $database) "query" $query) | b64enc | quote }}
   {{- end }}
-  {{- if and .Values.workers.keda.enabled .Values.pgbouncer.enabled (not .Values.workers.keda.usePgbouncer) }}
+  {{- if and .Values.workers.keda.enabled ( or (and .Values.pgbouncer.enabled (not .Values.workers.keda.usePgbouncer) .Values.workers.keda.useExtPgbouncer )) }}
   {{- with .Values.data.metadataConnection }}
   kedaConnection: {{ urlJoin (dict "scheme" .protocol "userinfo" (printf "%s:%s" (.user | urlquery) (.pass | urlquery) ) "host" (printf "%s:%s" $metadataHost $metadataPort) "path" (printf "/%s" $metadataDatabase) "query" $query) | b64enc | quote }}
   {{- end }}

--- a/chart/templates/workers/worker-kedaautoscaler.yaml
+++ b/chart/templates/workers/worker-kedaautoscaler.yaml
@@ -50,7 +50,7 @@ spec:
     - type: postgresql
       metadata:
         targetQueryValue: "1"
-        {{- if and .Values.pgbouncer.enabled (not .Values.workers.keda.usePgbouncer) }}
+        {{- if or (and .Values.pgbouncer.enabled (not .Values.workers.keda.usePgbouncer)) .Values.workers.keda.useExtPgbouncer }}
         connectionFromEnv: KEDA_DB_CONN
         {{- else }}
         connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1530,7 +1530,7 @@
                             "default": true
                         },
                         "useExtPgbouncer": {
-                            "description": "Rewrite connection string to pgBouncer. If we used external pgBouncer. For example, it is neccessary to disable prepare statements.",
+                            "description": "Rewrite connection string to pgBouncer. If we used external pgBouncer. For example, it is necessary to disable prepare statements.",
                             "type": "boolean",
                             "default": false
                         }

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1530,7 +1530,7 @@
                             "default": true
                         },
                         "useExtPgbouncer": {
-                            "description": "Rewrite connection string to pgBouncer. If we used external pgBouncer. For example, it is necessary to disable prepare statements.",
+                            "description": "Rewrite connection string to PGBouncer. If we used external PGBouncer. For example, it is necessary to disable prepare statements.",
                             "type": "boolean",
                             "default": false
                         }

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1528,6 +1528,11 @@
                             "description": "Weather to use PGBouncer to connect to the database or not when it is enabled. This configuration will be ignored if PGBouncer is not enabled.",
                             "type": "boolean",
                             "default": true
+                        },
+                        "useExtPgbouncer": {
+                            "description": "Rewrite connection string to pgBouncer. If we used external pgBouncer. For example, it is neccessary to disable prepare statements.",
+                            "type": "boolean",
+                            "default": false
                         }
                     }
                 },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -592,7 +592,7 @@ workers:
     # This configuration will be ignored if PGBouncer is not enabled
     usePgbouncer: true
 
-    # Rewrite connection string to pgBouncer. If we used external pgBouncer.
+    # Rewrite connection string to PGBouncer. If we used external PGBouncer.
     # For example, it is necessary to disable prepare statements.
     useExtPgbouncer: false
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -592,6 +592,10 @@ workers:
     # This configuration will be ignored if PGBouncer is not enabled
     usePgbouncer: true
 
+    # Rewrite connection string to pgBouncer. If we used external pgBouncer.
+    # For example, it is neccessary to disable prepare statements.
+    useExtPgbouncer: false
+
   persistence:
     # Enable persistent volumes
     enabled: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -593,7 +593,7 @@ workers:
     usePgbouncer: true
 
     # Rewrite connection string to pgBouncer. If we used external pgBouncer.
-    # For example, it is neccessary to disable prepare statements.
+    # For example, it is necessary to disable prepare statements.
     useExtPgbouncer: false
 
   persistence:

--- a/helm_tests/other/test_keda.py
+++ b/helm_tests/other/test_keda.py
@@ -239,7 +239,7 @@ class TestKeda:
 
         docs = render_chart(
             values={
-                "workers": {"keda": {"enabled": True, "usePgbouncer": False}},
+                "workers": {"keda": {"enabled": True, "usePgbouncer": False, "useExtPgbouncer": False}},
                 "executor": "CeleryExecutor",
                 "pgbouncer": {"enabled": True},
             },


### PR DESCRIPTION
This PR added possibility using external pgBouncer.
If we use external pgBouncer with transaction pooling we are facing a problem that KEDA using prepare statement by default, but transaction polling do not support it.
So we can change connection adding flag `default_query_exec_mode=simple_protocol`. But it necessary only for Keda.