### PR TITLE
fix(datasets): persist dataset extra dict to dataset event

### DIFF
--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -67,6 +67,16 @@ class DatasetManager(LoggingMixin):
         if not dataset_model:
             self.log.warning("DatasetModel %s not found", dataset)
             return
+
+        # merge dataset extra dict and extra dict parameter
+        event_extra = None
+        if dataset.extra is not None or extra is not None:
+            event_extra = {}
+            if dataset.extra:
+                event_extra.update(dataset.extra)
+            if extra:
+                event_extra.update(extra)
+
         session.add(
             DatasetEvent(
                 dataset_id=dataset_model.id,
@@ -74,7 +84,7 @@ class DatasetManager(LoggingMixin):
                 source_dag_id=task_instance.dag_id,
                 source_run_id=task_instance.run_id,
                 source_map_index=task_instance.map_index,
-                extra=extra,
+                extra=event_extra,
             )
         )
         session.flush()

--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -55,7 +55,7 @@ class DatasetManager(LoggingMixin):
             self.notify_dataset_created(dataset=Dataset(uri=dataset_model.uri, extra=dataset_model.extra))
 
     def register_dataset_change(
-        self, *, task_instance: TaskInstance, dataset: Dataset, extra=None, session: Session, **kwargs
+        self, *, task_instance: TaskInstance, dataset: Dataset, session: Session, **kwargs
     ) -> None:
         """
         Register dataset related changes.
@@ -68,15 +68,6 @@ class DatasetManager(LoggingMixin):
             self.log.warning("DatasetModel %s not found", dataset)
             return
 
-        # merge dataset extra dict and extra dict parameter
-        event_extra = None
-        if dataset.extra is not None or extra is not None:
-            event_extra = {}
-            if dataset.extra:
-                event_extra.update(dataset.extra)
-            if extra:
-                event_extra.update(extra)
-
         session.add(
             DatasetEvent(
                 dataset_id=dataset_model.id,
@@ -84,7 +75,7 @@ class DatasetManager(LoggingMixin):
                 source_dag_id=task_instance.dag_id,
                 source_run_id=task_instance.run_id,
                 source_map_index=task_instance.map_index,
-                extra=event_extra,
+                extra=dataset.extra,
             )
         )
         session.flush()

--- a/tests/datasets/test_manager.py
+++ b/tests/datasets/test_manager.py
@@ -108,15 +108,15 @@ class TestDatasetManager:
         assert extras["extra_2"] == 123
         assert session.query(DatasetDagRunQueue).count() == 2
 
-    def test_register_dataset_change_with_extra_override(self, session, dag_maker, mock_task_instance):
+    def test_register_dataset_change_with_extra_none(self, session, dag_maker, mock_task_instance):
         dsem = DatasetManager()
 
-        ds = Dataset(uri="test_dataset_uri_with_extra_override", extra={"extra_1": "hello", "extra_2": 123})
+        ds = Dataset(uri="test_dataset_uri_with_extra_none")
         dag1 = DagModel(dag_id="dag1")
         dag2 = DagModel(dag_id="dag2")
         session.add_all([dag1, dag2])
 
-        dsm = DatasetModel(uri="test_dataset_uri_with_extra_override")
+        dsm = DatasetModel(uri="test_dataset_uri_with_extra_none")
         session.add(dsm)
         dsm.consuming_dags = [DagScheduleDatasetReference(dag_id=dag.dag_id) for dag in (dag1, dag2)]
         session.flush()
@@ -129,8 +129,7 @@ class TestDatasetManager:
 
         # Ensure we've created a dataset
         assert session.query(DatasetEvent).filter_by(dataset_id=dsm.id).count() == 1
-        assert extras["extra_1"] == "overridden"
-        assert extras["extra_2"] == 123
+        assert extras == {}
         assert session.query(DatasetDagRunQueue).count() == 2
 
     def test_register_dataset_change_no_downstreams(self, session, mock_task_instance):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Persists Dataset extras to the according DatasetEvent to be used in Tasks invoked by Data aware scheduling. Please see linked issue for more information

closes: #35297
