### PR TITLE
Fix for EksCreateClusterOperator deferrable mode

### DIFF
--- a/airflow/providers/amazon/aws/operators/eks.py
+++ b/airflow/providers/amazon/aws/operators/eks.py
@@ -16,12 +16,12 @@
 # under the License.
 """This module contains Amazon EKS operators."""
 from __future__ import annotations
-from functools import cached_property
 
 import logging
 import warnings
 from ast import literal_eval
 from datetime import timedelta
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, List, Sequence, cast
 
 from botocore.exceptions import ClientError, WaiterError
@@ -257,6 +257,7 @@ class EksCreateClusterOperator(BaseOperator):
         super().__init__(
             **kwargs,
         )
+
     @cached_property
     def hook(self) -> EksHook:
         return EksHook(aws_conn_id=self.aws_conn_id, region_name=self.region)

--- a/airflow/providers/amazon/aws/triggers/eks.py
+++ b/airflow/providers/amazon/aws/triggers/eks.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Any
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.hooks.eks import EksHook
 from airflow.providers.amazon.aws.triggers.base import AwsBaseWaiterTrigger
 from airflow.providers.amazon.aws.utils.waiter_with_logging import async_wait
@@ -67,6 +67,25 @@ class EksCreateClusterTrigger(AwsBaseWaiterTrigger):
 
     def hook(self) -> AwsGenericHook:
         return EksHook(aws_conn_id=self.aws_conn_id, region_name=self.region_name)
+
+    async def run(self):
+        async with self.hook().async_conn as client:
+            waiter = client.get_waiter(self.waiter_name)
+            try:
+                await async_wait(
+                    waiter,
+                    self.waiter_delay,
+                    self.attempts,
+                    self.waiter_args,
+                    self.failure_message,
+                    self.status_message,
+                    self.status_queries,
+                )
+            except AirflowException as exception:
+                self.log.error("Error creating cluster: %s", exception)
+                yield TriggerEvent({"status": "failed"})
+            else:
+                yield TriggerEvent({"status": "success"})
 
 
 class EksDeleteClusterTrigger(AwsBaseWaiterTrigger):
@@ -125,7 +144,7 @@ class EksDeleteClusterTrigger(AwsBaseWaiterTrigger):
             if self.force_delete_compute:
                 await self.delete_any_nodegroups(client=client)
                 await self.delete_any_fargate_profiles(client=client)
-                await client.delete_cluster(name=self.cluster_name)
+            await client.delete_cluster(name=self.cluster_name)
             await async_wait(
                 waiter=waiter,
                 waiter_delay=int(self.waiter_delay),

--- a/airflow/providers/amazon/aws/triggers/eks.py
+++ b/airflow/providers/amazon/aws/triggers/eks.py
@@ -19,13 +19,13 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Any
 
+from botocore.exceptions import ClientError
+
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.hooks.eks import EksHook
 from airflow.providers.amazon.aws.triggers.base import AwsBaseWaiterTrigger
 from airflow.providers.amazon.aws.utils.waiter_with_logging import async_wait
 from airflow.triggers.base import TriggerEvent
-from botocore.exceptions import ClientError
-
 
 if TYPE_CHECKING:
     from airflow.providers.amazon.aws.hooks.base_aws import AwsGenericHook


### PR DESCRIPTION
This PR addresses the issues that were discovered out in the `EksCreateClusterOperator` deferrable mode. There are several changes made.
1. `EksCreateClusterTrigger` did not set a status as failed, but the operator expected a `failed` status if the cluster creation did not go as expected. I've added a new `run` method that yields a `failed` status on failure.
2. In `deferrable_create_cluster_next`, there was a bug where we were assuming the compute type could only be fargate or nodegroup. This is not true; the compute type can be `None` as well. This is fixed by adding an explicit check.
3. Fixed a typo in the operator, and raised an exception on cluster creation failure
4. In the `EksDeleteClusterTrigger`, there was a bug where the cluster would only get deleted if `force_delete_compute` was `True`.  
closes: #34844 
related: #34966 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
