### PR TITLE
Bump Airflow version to 2.9.0dev0

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -26,7 +26,7 @@ isort:skip_file
 """
 from __future__ import annotations
 
-__version__ = "2.8.0.dev0"
+__version__ = "2.9.0.dev0"
 
 # flake8: noqa: F401
 

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -231,7 +231,7 @@ info:
     This means that the server encountered an unexpected condition that prevented it from
     fulfilling the request.
 
-  version: "2.8.0.dev0"
+  version: "2.9.0.dev0"
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/airflow/providers/MANAGING_PROVIDERS_LIFECYCLE.rst
+++ b/airflow/providers/MANAGING_PROVIDERS_LIFECYCLE.rst
@@ -148,8 +148,8 @@ pre-release versions of Airflow - because ``pip`` does not recognize the ``.dev0
 suffixes of those packages as valid in the ``>=X.Y.Z`` comparison.
 
 When you want to install a provider package with ``apache-airflow>=2.8.0`` requirement and you have
-``2.8.0.dev0`` airflow package, ``pip`` will not install the package, because it does not recognize
-``2.8.0.dev0`` as a valid version for ``>=2.8.0`` dependency. This is because ``pip``
+``2.9.0.dev0`` airflow package, ``pip`` will not install the package, because it does not recognize
+``2.9.0.dev0`` as a valid version for ``>=2.8.0`` dependency. This is because ``pip``
 currently implements the minimum version selection algorithm requirement specified in packaging as
 described in the packaging version specification
 https://packaging.python.org/en/latest/specifications/version-specifiers/#handling-of-pre-releases
@@ -163,7 +163,7 @@ not possible.
 To work around this limitation, we have introduced the concept of "chicken-egg" providers. Those providers
 are providers that are released together with the version of Airflow they depend on. They are released
 with the same version number as the Airflow version they depend on, but with a different suffix. For example
-``apache-airflow-providers-common-io==2.8.0.dev0`` is a chicken-egg provider for ``apache-airflow==2.8.0.dev0``.
+``apache-airflow-providers-common-io==2.9.0.dev0`` is a chicken-egg provider for ``apache-airflow==2.9.0.dev0``.
 
 However - we should not release providers with such exclusion to ``pypi``, so in order to allow our
 CI to work with pre-release versions and perform both - constraint generation and image releasing,

--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/logging-tasks.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/logging-tasks.rst
@@ -103,7 +103,7 @@ the example below.
     $ airflow info
 
     Apache Airflow
-    version                | 2.8.0.dev0
+    version                | 2.9.0.dev0
     executor               | LocalExecutor
     task_logging_handler   | airflow.utils.log.file_task_handler.FileTaskHandler
     sql_alchemy_conn       | postgresql+psycopg2://postgres:airflow@postgres/airflow

--- a/docs/docker-stack/README.md
+++ b/docs/docker-stack/README.md
@@ -31,12 +31,12 @@ Every time a new version of Airflow is released, the images are prepared in the
 [apache/airflow DockerHub](https://hub.docker.com/r/apache/airflow)
 for all the supported Python versions.
 
-You can find the following images there (Assuming Airflow version `2.8.0.dev0`):
+You can find the following images there (Assuming Airflow version `2.9.0.dev0`):
 
 * `apache/airflow:latest` - the latest released Airflow image with default Python version (3.8 currently)
 * `apache/airflow:latest-pythonX.Y` - the latest released Airflow image with specific Python version
-* `apache/airflow:2.8.0.dev0` - the versioned Airflow image with default Python version (3.8 currently)
-* `apache/airflow:2.8.0.dev0-pythonX.Y` - the versioned Airflow image with specific Python version
+* `apache/airflow:2.9.0.dev0` - the versioned Airflow image with default Python version (3.8 currently)
+* `apache/airflow:2.9.0.dev0-pythonX.Y` - the versioned Airflow image with specific Python version
 
 Those are "reference" regular images. They contain the most common set of extras, dependencies and providers that are
 often used by the users and they are good to "try-things-out" when you want to just take Airflow for a spin,
@@ -47,8 +47,8 @@ via [Building the image](https://airflow.apache.org/docs/docker-stack/build.html
 
 * `apache/airflow:slim-latest`              - the latest released Airflow image with default Python version (3.8 currently)
 * `apache/airflow:slim-latest-pythonX.Y`    - the latest released Airflow image with specific Python version
-* `apache/airflow:slim-2.8.0.dev0`           - the versioned Airflow image with default Python version (3.8 currently)
-* `apache/airflow:slim-2.8.0.dev0-pythonX.Y` - the versioned Airflow image with specific Python version
+* `apache/airflow:slim-2.9.0.dev0`           - the versioned Airflow image with default Python version (3.8 currently)
+* `apache/airflow:slim-2.9.0.dev0-pythonX.Y` - the versioned Airflow image with specific Python version
 
 The Apache Airflow image provided as convenience package is optimized for size, and
 it provides just a bare minimal set of the extras and dependencies installed and in most cases

--- a/docs/docker-stack/docker-examples/customizing/own-requirements.sh
+++ b/docs/docker-stack/docker-examples/customizing/own-requirements.sh
@@ -28,7 +28,7 @@ mkdir -p docker-context-files
 
 cat <<EOF >./docker-context-files/requirements.txt
 beautifulsoup4==4.10.0
-apache-airflow==2.8.0.dev0
+apache-airflow==2.9.0.dev0
 EOF
 
 export DOCKER_BUILDKIT=1

--- a/docs/docker-stack/docker-examples/extending/add-airflow-configuration/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/add-airflow-configuration/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:2.8.0.dev0
+FROM apache/airflow:2.9.0.dev0
 ENV AIRFLOW__CORE__LOAD_EXAMPLES=True
 ENV AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=my_conn_string
 # [END Dockerfile]

--- a/docs/docker-stack/docker-examples/extending/add-apt-packages/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/add-apt-packages/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:2.8.0.dev0
+FROM apache/airflow:2.9.0.dev0
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docs/docker-stack/docker-examples/extending/add-build-essential-extend/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/add-build-essential-extend/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:2.8.0.dev0
+FROM apache/airflow:2.9.0.dev0
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docs/docker-stack/docker-examples/extending/add-providers/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/add-providers/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:2.8.0.dev0
+FROM apache/airflow:2.9.0.dev0
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docs/docker-stack/docker-examples/extending/add-pypi-packages/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/add-pypi-packages/Dockerfile
@@ -15,6 +15,6 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:2.8.0.dev0
+FROM apache/airflow:2.9.0.dev0
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}" lxml
 # [END Dockerfile]

--- a/docs/docker-stack/docker-examples/extending/add-requirement-packages/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/add-requirement-packages/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:2.8.0.dev0
+FROM apache/airflow:2.9.0.dev0
 COPY requirements.txt /
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}" -r /requirements.txt
 # [END Dockerfile]

--- a/docs/docker-stack/docker-examples/extending/custom-providers/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/custom-providers/Dockerfile
@@ -15,6 +15,6 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:2.8.0.dev0
+FROM apache/airflow:2.9.0.dev0
 RUN pip install "apache-airflow==${AIRFLOW_VERSION}" --no-cache-dir apache-airflow-providers-docker==2.5.1
 # [END Dockerfile]

--- a/docs/docker-stack/docker-examples/extending/embedding-dags/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/embedding-dags/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:2.8.0.dev0
+FROM apache/airflow:2.9.0.dev0
 
 COPY --chown=airflow:root test_dag.py /opt/airflow/dags
 

--- a/docs/docker-stack/docker-examples/extending/writable-directory/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/writable-directory/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:2.8.0.dev0
+FROM apache/airflow:2.9.0.dev0
 RUN umask 0002; \
     mkdir -p ~/writeable-directory
 # [END Dockerfile]

--- a/docs/docker-stack/entrypoint.rst
+++ b/docs/docker-stack/entrypoint.rst
@@ -132,7 +132,7 @@ if you specify extra arguments. For example:
 
 .. code-block:: bash
 
-  docker run -it apache/airflow:2.8.0.dev0-python3.8 bash -c "ls -la"
+  docker run -it apache/airflow:2.9.0.dev0-python3.8 bash -c "ls -la"
   total 16
   drwxr-xr-x 4 airflow root 4096 Jun  5 18:12 .
   drwxr-xr-x 1 root    root 4096 Jun  5 18:12 ..
@@ -144,7 +144,7 @@ you pass extra parameters. For example:
 
 .. code-block:: bash
 
-  > docker run -it apache/airflow:2.8.0.dev0-python3.8 python -c "print('test')"
+  > docker run -it apache/airflow:2.9.0.dev0-python3.8 python -c "print('test')"
   test
 
 If first argument equals to "airflow" - the rest of the arguments is treated as an airflow command
@@ -152,13 +152,13 @@ to execute. Example:
 
 .. code-block:: bash
 
-   docker run -it apache/airflow:2.8.0.dev0-python3.8 airflow webserver
+   docker run -it apache/airflow:2.9.0.dev0-python3.8 airflow webserver
 
 If there are any other arguments - they are simply passed to the "airflow" command
 
 .. code-block:: bash
 
-  > docker run -it apache/airflow:2.8.0.dev0-python3.8 help
+  > docker run -it apache/airflow:2.9.0.dev0-python3.8 help
     usage: airflow [-h] GROUP_OR_COMMAND ...
 
     positional arguments:
@@ -206,7 +206,7 @@ propagation (See the next chapter).
 
 .. code-block:: Dockerfile
 
-    FROM airflow:2.8.0.dev0
+    FROM airflow:2.9.0.dev0
     COPY my_entrypoint.sh /
     ENTRYPOINT ["/usr/bin/dumb-init", "--", "/my_entrypoint.sh"]
 
@@ -250,7 +250,7 @@ Similarly to custom entrypoint, it can be added to the image by extending it.
 
 .. code-block:: Dockerfile
 
-    FROM airflow:2.8.0.dev0
+    FROM airflow:2.9.0.dev0
     COPY my_after_entrypoint_script.sh /
 
 Build your image and then you can run this script by running the command:
@@ -363,7 +363,7 @@ database and creating an ``admin/admin`` Admin user with the following command:
     --env "_AIRFLOW_DB_MIGRATE=true" \
     --env "_AIRFLOW_WWW_USER_CREATE=true" \
     --env "_AIRFLOW_WWW_USER_PASSWORD=admin" \
-      apache/airflow:2.8.0.dev0-python3.8 webserver
+      apache/airflow:2.9.0.dev0-python3.8 webserver
 
 
 .. code-block:: bash
@@ -372,7 +372,7 @@ database and creating an ``admin/admin`` Admin user with the following command:
     --env "_AIRFLOW_DB_MIGRATE=true" \
     --env "_AIRFLOW_WWW_USER_CREATE=true" \
     --env "_AIRFLOW_WWW_USER_PASSWORD_CMD=echo admin" \
-      apache/airflow:2.8.0.dev0-python3.8 webserver
+      apache/airflow:2.9.0.dev0-python3.8 webserver
 
 The commands above perform initialization of the SQLite database, create admin user with admin password
 and Admin role. They also forward local port ``8080`` to the webserver port and finally start the webserver.
@@ -412,6 +412,6 @@ Example:
     --env "_AIRFLOW_DB_MIGRATE=true" \
     --env "_AIRFLOW_WWW_USER_CREATE=true" \
     --env "_AIRFLOW_WWW_USER_PASSWORD_CMD=echo admin" \
-      apache/airflow:2.8.0.dev0-python3.8 webserver
+      apache/airflow:2.9.0.dev0-python3.8 webserver
 
 This method is only available starting from Docker image of Airflow 2.1.1 and above.


### PR DESCRIPTION
We need to bump the version in main to 2.9.0. We do it a bit early because we also need to separate FAB provider that needs to have >=2.9.0 dependency on Airflow. But it's also "proper". The v2-8-test branch is already cut and we just cherry-pick changes to it, so technically whatever we work on in `main` branch is going to go 2.9 by default.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
