### PR TITLE
Fix Python-based decorators templating

### DIFF
--- a/airflow/decorators/branch_external_python.py
+++ b/airflow/decorators/branch_external_python.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 class _BranchExternalPythonDecoratedOperator(_PythonDecoratedOperator, BranchExternalPythonOperator):
     """Wraps a Python callable and captures args/kwargs when called for execution."""
 
+    template_fields = BranchExternalPythonOperator.template_fields
     custom_operator_name: str = "@task.branch_external_python"
 
 

--- a/airflow/decorators/branch_python.py
+++ b/airflow/decorators/branch_python.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 class _BranchPythonDecoratedOperator(_PythonDecoratedOperator, BranchPythonOperator):
     """Wraps a Python callable and captures args/kwargs when called for execution."""
 
+    template_fields = BranchPythonOperator.template_fields
     custom_operator_name: str = "@task.branch"
 
 

--- a/airflow/decorators/branch_virtualenv.py
+++ b/airflow/decorators/branch_virtualenv.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 class _BranchPythonVirtualenvDecoratedOperator(_PythonDecoratedOperator, BranchPythonVirtualenvOperator):
     """Wraps a Python callable and captures args/kwargs when called for execution."""
 
+    template_fields = BranchPythonVirtualenvOperator.template_fields
     custom_operator_name: str = "@task.branch_virtualenv"
 
 

--- a/airflow/decorators/external_python.py
+++ b/airflow/decorators/external_python.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 class _PythonExternalDecoratedOperator(_PythonDecoratedOperator, ExternalPythonOperator):
     """Wraps a Python callable and captures args/kwargs when called for execution."""
 
+    template_fields = ExternalPythonOperator.template_fields
     custom_operator_name: str = "@task.external_python"
 
 

--- a/airflow/decorators/python_virtualenv.py
+++ b/airflow/decorators/python_virtualenv.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 class _PythonVirtualenvDecoratedOperator(_PythonDecoratedOperator, PythonVirtualenvOperator):
     """Wraps a Python callable and captures args/kwargs when called for execution."""
 
+    template_fields = PythonVirtualenvOperator.template_fields
     custom_operator_name: str = "@task.virtualenv"
 
 

--- a/airflow/decorators/short_circuit.py
+++ b/airflow/decorators/short_circuit.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 class _ShortCircuitDecoratedOperator(_PythonDecoratedOperator, ShortCircuitOperator):
     """Wraps a Python callable and captures args/kwargs when called for execution."""
 
+    template_fields = ShortCircuitOperator.template_fields
     custom_operator_name: str = "@task.short_circuit"
 
 

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -679,7 +679,6 @@ class AbstractOperator(Templater, DAGNode):
                     f"{attr_name!r} is configured as a template field "
                     f"but {parent.task_type} does not have this attribute."
                 )
-
             try:
                 if not value:
                     continue

--- a/tests/decorators/test_external_python.py
+++ b/tests/decorators/test_external_python.py
@@ -74,6 +74,20 @@ class TestExternalPythonDecorator:
 
         ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
+    def test_with_templated_python(self, dag_maker, venv_python_with_dill):
+        # add template that produces empty string when rendered
+        templated_python_with_dill = venv_python_with_dill.as_posix() + "{{ '' }}"
+
+        @task.external_python(python=templated_python_with_dill, use_dill=True)
+        def f():
+            """Import dill to double-check it is installed ."""
+            import dill  # noqa: F401
+
+        with dag_maker():
+            ret = f()
+
+        ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
     def test_no_dill_installed_raises_exception_when_use_dill(self, dag_maker, venv_python):
         @task.external_python(python=venv_python, use_dill=True)
         def f():

--- a/tests/decorators/test_python_virtualenv.py
+++ b/tests/decorators/test_python_virtualenv.py
@@ -103,6 +103,32 @@ class TestPythonVirtualenvDecorator:
 
         ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
+    def test_with_requirements_file(self, dag_maker, tmp_path):
+        requirements_file = tmp_path / "requirements.txt"
+        requirements_file.write_text("funcsigs==0.4\nattrs==23.1.0")
+
+        @task.virtualenv(
+            system_site_packages=False,
+            requirements="requirements.txt",
+            python_version=PYTHON_VERSION,
+            use_dill=True,
+        )
+        def f():
+            import funcsigs
+
+            if funcsigs.__version__ != "0.4":
+                raise Exception
+
+            import attrs
+
+            if attrs.__version__ != "23.1.0":
+                raise Exception
+
+        with dag_maker(template_searchpath=tmp_path.as_posix()):
+            ret = f()
+
+        ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
     def test_unpinned_requirements(self, dag_maker):
         @task.virtualenv(
             system_site_packages=False,


### PR DESCRIPTION
Templating of Python-based decorators has been broken since implementation. The decorators used template_fields definition as defined originally in PythonOperator rather than the ones from virtualenv because template fields were redefined in _PythonDecoratedOperator class and they took precedence (MRU).

This PR add explicit copying of template_fields from the operators that they are decorating.

Fixes: #36102

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
