### PR TITLE
handle deprecation warning in google system test

### DIFF
--- a/tests/system/providers/google/cloud/storage_transfer/example_cloud_storage_transfer_service_aws.py
+++ b/tests/system/providers/google/cloud/storage_transfer/example_cloud_storage_transfer_service_aws.py
@@ -113,7 +113,7 @@ with DAG(
     upload_file_to_s3 = GCSToS3Operator(
         task_id="upload_file_to_s3",
         gcp_user_project=GCP_PROJECT_ID,
-        bucket=EXAMPLE_BUCKET,
+        gcs_bucket=EXAMPLE_BUCKET,
         prefix=EXAMPLE_FILE,
         dest_s3_key=f"s3://{BUCKET_SOURCE_AWS}",
         replace=True,


### PR DESCRIPTION
Handle:

`tests/system/providers/google/cloud/storage_transfer/example_cloud_storage_transfer_service_aws.py:113: [W0513(warning), ] The ``bucket`` parameter is deprecated and will be removed in a future version. Please use ``gcs_bucket`` instead.`