### PR TITLE
Add `scripts\in_container` folder when all other sources are removed.

### DIFF
--- a/scripts/ci/docker-compose/remove-sources.yml
+++ b/scripts/ci/docker-compose/remove-sources.yml
@@ -17,6 +17,13 @@
 ---
 services:
   airflow:
-    # Removes airflow sources from container
     volumes:
-      - ./empty:/opt/airflow/airflow:cached
+      # Removes airflow sources from container
+      - type: bind
+        source: ./empty
+        target: /opt/airflow/airflow:cached
+      # However we keep in_container scripts in order to be able to debug easily the scripts that
+      # are run with --mount-sources removed flag - such as installing airflow and providers
+      - type: bind
+        source: ../../../scripts/in_container
+        target: /opt/airflow/scripts/in_container:cached


### PR DESCRIPTION
This allows to tests the scripts that require --mount-sources remove but you run some scripts inside the container (for example this was the case when modifying installation of airflow and providers to be run in Python in #36094. In order to debug those, image needed to be rebuild to run the "in-container" scripts..

More importantly - users will also have to rebuild the image after they rebase to latest main - in order to use the new scripts when runinng `--use-airflow-version`.

This change will make the modification coming from main visible in
their images even without rebuilding the image.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
