### PR TITLE
GCSHook only perform list if delimiter specified

### DIFF
--- a/airflow/providers/google/cloud/hooks/gcs.py
+++ b/airflow/providers/google/cloud/hooks/gcs.py
@@ -821,11 +821,12 @@ class GCSHook(GoogleBaseHook):
                     delimiter=delimiter,
                     versions=versions,
                 )
-                list(blobs)
+                if delimiter:
+                    next(blobs, None)
 
             if blobs.prefixes:
                 ids.extend(blobs.prefixes)
-            else:
+            elif not delimiter or (match_glob and delimiter == "/"):
                 ids.extend(blob.name for blob in blobs)
 
             page_token = blobs.next_page_token
@@ -933,11 +934,12 @@ class GCSHook(GoogleBaseHook):
                     delimiter=delimiter,
                     versions=versions,
                 )
-                list(blobs)
+                if delimiter:
+                    next(blobs, None)
 
             if blobs.prefixes:
                 ids.extend(blobs.prefixes)
-            else:
+            elif not delimiter or (match_glob and delimiter == "/"):
                 ids.extend(
                     blob.name
                     for blob in blobs

--- a/tests/providers/google/cloud/hooks/test_gcs.py
+++ b/tests/providers/google/cloud/hooks/test_gcs.py
@@ -821,6 +821,7 @@ class TestGCSHook:
     @mock.patch(GCS_STRING.format("GCSHook.get_conn"))
     def test_list__delimiter(self, mock_service, prefix, result):
         mock_service.return_value.bucket.return_value.list_blobs.return_value.next_page_token = None
+        mock_service.return_value.bucket.return_value.list_blobs.return_value.prefixes = None
         with pytest.deprecated_call():
             self.gcs_hook.list(
                 bucket_name="test_bucket",
@@ -828,6 +829,10 @@ class TestGCSHook:
                 delimiter=",",
             )
         assert mock_service.return_value.bucket.return_value.list_blobs.call_args_list == result
+        assert (
+            mock_service.return_value.bucket.return_value.list_blobs.return_value.__next__.call_count
+            == len(result)
+        )
 
     @mock.patch(GCS_STRING.format("GCSHook.get_conn"))
     @mock.patch("airflow.providers.google.cloud.hooks.gcs.functools")


### PR DESCRIPTION
This fixes the issue raised [here](https://github.com/apache/airflow/pull/34919#issuecomment-1846993082) against https://github.com/apache/airflow/pull/34919

When testing locally the list only appears to be required when a delimiter is passed in. 

A sample test can be performed with:

```python
from airflow.providers.google.cloud.hooks.gcs import GCSHook
res = GCSHook().list(
        bucket_name='a-testbucket',
        prefix='a/prefix/in/the/bucket/'
)
print(res)
```

With this fix, the code no longer fails with:

```
ValueError: ('Iterator has already started', <google.api_core.page_iterator.HTTPIterator object at 0x7efe067c3880>)
```

To confirm that this block:

```
                if delimiter:
                    list(blobs)
```

Is still required, when this is removed, and this is ran:
```
res = GCSHook().list(
        bucket_name='a-testbucket',
        prefix='a/prefix/in/the/bucket/',
        delimiter='.csv'
)
print(res)
```

No results are returned. Everything works as expected however once the block is in place. 


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
