### PR TITLE
SparkSubmit Connection Extras can be overridden

### DIFF
--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -78,8 +78,13 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
     :param verbose: Whether to pass the verbose flag to spark-submit process for debugging
     :param spark_binary: The command to use for spark submit.
                          Some distros may use spark2-submit or spark3-submit.
+                         (will overwrite any spark_binary defined in the connection's extra JSON)
     :param properties_file: Path to a file from which to load extra properties. If not
                               specified, this will look for conf/spark-defaults.conf.
+    :param queue: The name of the YARN queue to which the application is submitted.
+                        (will overwrite any yarn queue defined in the connection's extra JSON)
+    :param deploy_mode: Whether to deploy your driver on the worker nodes (cluster) or locally as an    client.
+                        (will overwrite any deployment mode defined in the connection's extra JSON)
     :param use_krb5ccache: if True, configure spark to use ticket cache instead of relying
         on keytab for Kerberos login
     """
@@ -125,6 +130,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         verbose: bool = False,
         spark_binary: str | None = None,
         properties_file: str | None = None,
+        queue: str | None = None,
+        deploy_mode: str | None = None,
         *,
         use_krb5ccache: bool = False,
     ) -> None:
@@ -159,6 +166,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         self._kubernetes_driver_pod: str | None = None
         self.spark_binary = spark_binary
         self._properties_file = properties_file
+        self._queue = queue
+        self._deploy_mode = deploy_mode
         self._connection = self._resolve_connection()
         self._is_yarn = "yarn" in self._connection["master"]
         self._is_kubernetes = "k8s" in self._connection["master"]
@@ -204,8 +213,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
             # Determine optional yarn queue from the extra field
             extra = conn.extra_dejson
-            conn_data["queue"] = extra.get("queue")
-            conn_data["deploy_mode"] = extra.get("deploy-mode")
+            conn_data["queue"] = self._queue if self._queue else extra.get("queue")
+            conn_data["deploy_mode"] = self._deploy_mode if self._deploy_mode else extra.get("deploy-mode")
             if not self.spark_binary:
                 self.spark_binary = extra.get("spark-binary", "spark-submit")
                 if self.spark_binary is not None and self.spark_binary not in ALLOWED_SPARK_BINARIES:

--- a/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/airflow/providers/apache/spark/operators/spark_submit.py
@@ -205,7 +205,7 @@ class SparkSubmitOperator(BaseOperator):
             verbose=self._verbose,
             spark_binary=self._spark_binary,
             properties_file=self._properties_file,
-            queue= self._queue ,
-            deploy_mode=self._deploy_mode ,
+            queue=self._queue,
+            deploy_mode=self._deploy_mode,
             use_krb5ccache=self._use_krb5ccache,
         )

--- a/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/airflow/providers/apache/spark/operators/spark_submit.py
@@ -69,6 +69,7 @@ class SparkSubmitOperator(BaseOperator):
     :param verbose: Whether to pass the verbose flag to spark-submit process for debugging
     :param spark_binary: The command to use for spark submit.
                          Some distros may use spark2-submit or spark3-submit.
+                         (will overwrite any spark_binary defined in the connection's extra JSON)
     :param properties_file: Path to a file from which to load extra properties. If not
                               specified, this will look for conf/spark-defaults.conf.
     :param queue: The name of the YARN queue to which the application is submitted.

--- a/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/airflow/providers/apache/spark/operators/spark_submit.py
@@ -71,6 +71,10 @@ class SparkSubmitOperator(BaseOperator):
                          Some distros may use spark2-submit or spark3-submit.
     :param properties_file: Path to a file from which to load extra properties. If not
                               specified, this will look for conf/spark-defaults.conf.
+    :param queue: The name of the YARN queue to which the application is submitted.
+                        (will overwrite any yarn queue defined in the connection's extra JSON)
+    :param deploy_mode: Whether to deploy your driver on the worker nodes (cluster) or locally as an    client.
+                        (will overwrite any deployment mode defined in the connection's extra JSON)
     :param use_krb5ccache: if True, configure spark to use ticket cache instead of relying
                            on keytab for Kerberos login
     """
@@ -124,6 +128,8 @@ class SparkSubmitOperator(BaseOperator):
         verbose: bool = False,
         spark_binary: str | None = None,
         properties_file: str | None = None,
+        queue: str | None = None,
+        deploy_mode: str | None = None,
         use_krb5ccache: bool = False,
         **kwargs: Any,
     ) -> None:
@@ -154,6 +160,8 @@ class SparkSubmitOperator(BaseOperator):
         self._verbose = verbose
         self._spark_binary = spark_binary
         self._properties_file = properties_file
+        self._queue = queue
+        self._deploy_mode = deploy_mode
         self._hook: SparkSubmitHook | None = None
         self._conn_id = conn_id
         self._use_krb5ccache = use_krb5ccache
@@ -197,5 +205,7 @@ class SparkSubmitOperator(BaseOperator):
             verbose=self._verbose,
             spark_binary=self._spark_binary,
             properties_file=self._properties_file,
+            queue= self._queue ,
+            deploy_mode=self._deploy_mode ,
             use_krb5ccache=self._use_krb5ccache,
         )

--- a/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/airflow/providers/apache/spark/operators/spark_submit.py
@@ -73,7 +73,7 @@ class SparkSubmitOperator(BaseOperator):
                               specified, this will look for conf/spark-defaults.conf.
     :param queue: The name of the YARN queue to which the application is submitted.
                         (will overwrite any yarn queue defined in the connection's extra JSON)
-    :param deploy_mode: Whether to deploy your driver on the worker nodes (cluster) or locally as an    client.
+    :param deploy_mode: Whether to deploy your driver on the worker nodes (cluster) or locally as a client.
                         (will overwrite any deployment mode defined in the connection's extra JSON)
     :param use_krb5ccache: if True, configure spark to use ticket cache instead of relying
                            on keytab for Kerberos login

--- a/airflow/providers/fab/auth_manager/cli_commands/user_command.py
+++ b/airflow/providers/fab/auth_manager/cli_commands/user_command.py
@@ -194,10 +194,10 @@ def users_import(args):
 
     users_created, users_updated = _import_users(users_list)
     if users_created:
-        print("Created the following users:\n\t{}".format("\n\t".join(users_created)))
+        print(f"Created the following users:\n\t{'\\n\\t'.join(users_created)}")
 
     if users_updated:
-        print("Updated the following users:\n\t{}".format("\n\t".join(users_updated)))
+        print(f"Updated the following users:\n\t{'\\n\\t'.join(users_updated)}")
 
 
 def _import_users(users_list: list[dict[str, Any]]):
@@ -213,9 +213,7 @@ def _import_users(users_list: list[dict[str, Any]]):
                 msg.append(f"[Item {row_num}]")
                 for key, value in failure.items():
                     msg.append(f"\t{key}: {value}")
-            raise SystemExit(
-                "Error: Input file didn't pass validation. See below:\n{}".format("\n".join(msg))
-            )
+            raise SystemExit(f"Error: Input file didn't pass validation. See below:\n{'\\n'.join(msg)}")
 
         for user in users_list:
             roles = []

--- a/airflow/providers/fab/auth_manager/cli_commands/user_command.py
+++ b/airflow/providers/fab/auth_manager/cli_commands/user_command.py
@@ -194,10 +194,10 @@ def users_import(args):
 
     users_created, users_updated = _import_users(users_list)
     if users_created:
-        print(f"Created the following users:\n\t{'\\n\\t'.join(users_created)}")
+        print("Created the following users:\n\t{}".format("\n\t".join(users_created)))
 
     if users_updated:
-        print(f"Updated the following users:\n\t{'\\n\\t'.join(users_updated)}")
+        print("Updated the following users:\n\t{}".format("\n\t".join(users_updated)))
 
 
 def _import_users(users_list: list[dict[str, Any]]):
@@ -213,7 +213,9 @@ def _import_users(users_list: list[dict[str, Any]]):
                 msg.append(f"[Item {row_num}]")
                 for key, value in failure.items():
                     msg.append(f"\t{key}: {value}")
-            raise SystemExit(f"Error: Input file didn't pass validation. See below:\n{'\\n'.join(msg)}")
+            raise SystemExit(
+                "Error: Input file didn't pass validation. See below:\n{}".format("\n".join(msg))
+            )
 
         for user in users_list:
             roles = []

--- a/tests/providers/apache/spark/operators/test_spark_submit.py
+++ b/tests/providers/apache/spark/operators/test_spark_submit.py
@@ -68,7 +68,7 @@ class TestSparkSubmitOperator:
         ],
         "use_krb5ccache": True,
         "queue": "yarn_dev_queue2",
-        "deploy_mode": "client2"
+        "deploy_mode": "client2",
     }
 
     def setup_method(self):
@@ -164,10 +164,7 @@ class TestSparkSubmitOperator:
         # _build_spark_submit_command
         config["use_krb5ccache"] = False
         operator = SparkSubmitOperator(
-            task_id="spark_submit_job",
-            spark_binary="sparky",
-            dag=self.dag,
-            **config
+            task_id="spark_submit_job", spark_binary="sparky", dag=self.dag, **config
         )
 
         cmd = operator._get_hook()._build_spark_submit_command("test")[0]

--- a/tests/providers/apache/spark/operators/test_spark_submit.py
+++ b/tests/providers/apache/spark/operators/test_spark_submit.py
@@ -158,6 +158,23 @@ class TestSparkSubmitOperator:
         assert expected_dict["properties_file"] == operator._properties_file
         assert expected_dict["use_krb5ccache"] == operator._use_krb5ccache
 
+    def test_spark_submit_cmd_connection_overrides(self):
+        config = self._config
+        # have to add this otherwise wee can't run
+        # _build_spark_submit_command
+        config["use_krb5ccache"] = False
+        operator = SparkSubmitOperator(
+            task_id="spark_submit_job",
+            spark_binary="sparky",
+            dag=self.dag,
+            **config
+        )
+
+        cmd = operator._get_hook()._build_spark_submit_command("test")[0]
+        assert "--queue yarn_dev_queue2" in cmd
+        assert "--deploy-mode client2" in cmd
+        assert "sparky" in cmd
+
     @pytest.mark.db_test
     def test_render_template(self):
         # Given

--- a/tests/providers/apache/spark/operators/test_spark_submit.py
+++ b/tests/providers/apache/spark/operators/test_spark_submit.py
@@ -158,9 +158,10 @@ class TestSparkSubmitOperator:
         assert expected_dict["properties_file"] == operator._properties_file
         assert expected_dict["use_krb5ccache"] == operator._use_krb5ccache
 
+    @pytest.mark.db_test
     def test_spark_submit_cmd_connection_overrides(self):
         config = self._config
-        # have to add this otherwise wee can't run
+        # have to add this otherwise we can't run
         # _build_spark_submit_command
         config["use_krb5ccache"] = False
         operator = SparkSubmitOperator(

--- a/tests/providers/apache/spark/operators/test_spark_submit.py
+++ b/tests/providers/apache/spark/operators/test_spark_submit.py
@@ -67,6 +67,8 @@ class TestSparkSubmitOperator:
             "args should keep embedded spaces",
         ],
         "use_krb5ccache": True,
+        "queue": "yarn_dev_queue2",
+        "deploy_mode": "client2"
     }
 
     def setup_method(self):
@@ -120,6 +122,8 @@ class TestSparkSubmitOperator:
                 "args should keep embedded spaces",
             ],
             "spark_binary": "sparky",
+            "queue": "yarn_dev_queue2",
+            "deploy_mode": "client2",
             "use_krb5ccache": True,
             "properties_file": "conf/spark-custom.conf",
         }
@@ -149,6 +153,8 @@ class TestSparkSubmitOperator:
         assert expected_dict["driver_memory"] == operator._driver_memory
         assert expected_dict["application_args"] == operator._application_args
         assert expected_dict["spark_binary"] == operator._spark_binary
+        assert expected_dict["queue"] == operator._queue
+        assert expected_dict["deploy_mode"] == operator._deploy_mode
         assert expected_dict["properties_file"] == operator._properties_file
         assert expected_dict["use_krb5ccache"] == operator._use_krb5ccache
 

--- a/tests/providers/apache/spark/operators/test_spark_submit.py
+++ b/tests/providers/apache/spark/operators/test_spark_submit.py
@@ -166,11 +166,19 @@ class TestSparkSubmitOperator:
         operator = SparkSubmitOperator(
             task_id="spark_submit_job", spark_binary="sparky", dag=self.dag, **config
         )
-
-        cmd = operator._get_hook()._build_spark_submit_command("test")[0]
+        cmd = " ".join(operator._get_hook()._build_spark_submit_command("test"))
         assert "--queue yarn_dev_queue2" in cmd
         assert "--deploy-mode client2" in cmd
         assert "sparky" in cmd
+
+        # if we don't pass any overrides in arguments
+        config["queue"] = None
+        config["deploy_mode"] = None
+        operator2 = SparkSubmitOperator(task_id="spark_submit_job2", dag=self.dag, **config)
+        cmd2 = " ".join(operator2._get_hook()._build_spark_submit_command("test"))
+        assert "--queue root.default" in cmd2
+        assert "--deploy-mode client2" not in cmd2
+        assert "spark-submit" in cmd2
 
     @pytest.mark.db_test
     def test_render_template(self):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #35911

related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #35911


## Description
Currently there are some arguments which are being provided using Spark Connection,
but there is no way to override them in **SparkSubmitOperator** and **SparkSubmitHook**
eg.
--queue: option specifies the YARN queue to which the application should be submitted.
--deploy-mode: option specified deploy mode client/cluster

more - https://spark.apache.org/docs/3.2.0/running-on-yarn.html

## Use case/motivation
These use-cases are particularly useful in a multi-tenant environment where different users or groups have allocated resources in specific YARN queues, or want to use different deploy mode in each spark submit job which might be different from option provided in Spark Connection Extras.

