### PR TITLE
Fix: Implement support for `fetchone()` in the ODBCHook and the Databricks SQL Hook

### DIFF
--- a/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/airflow/providers/databricks/hooks/databricks_sql.py
@@ -21,6 +21,7 @@ from copy import copy
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, TypeVar, overload
 
 from databricks import sql  # type: ignore[attr-defined]
+from databricks.sql.types import Row
 
 from airflow.exceptions import AirflowException
 from airflow.providers.common.sql.hooks.sql import DbApiHook, return_single_query_results
@@ -242,9 +243,11 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
 
     @staticmethod
     def _make_serializable(result):
-        """Transform the databricks Row objects into a JSON-serializable list of rows."""
-        if result is not None:
+        """Transform the databricks Row objects into JSON-serializable lists."""
+        if isinstance(result, list):
             return [list(row) for row in result]
+        elif isinstance(result, Row):
+            return list(result)
         return result
 
     def bulk_dump(self, table, tmp_file):

--- a/airflow/providers/odbc/hooks/odbc.py
+++ b/airflow/providers/odbc/hooks/odbc.py
@@ -217,11 +217,12 @@ class OdbcHook(DbApiHook):
         """Transform the pyodbc.Row objects returned from an SQL command into JSON-serializable NamedTuple."""
         # Below ignored lines respect NamedTuple docstring, but mypy do not support dynamically
         # instantiated Namedtuple, and will never do: https://github.com/python/mypy/issues/848
+        columns: list[tuple[str, type]] | None = None
         if isinstance(result, list):
-            columns: list[tuple[str, type]] = [col[:2] for col in result[0].cursor_description]
+            columns = [col[:2] for col in result[0].cursor_description]
             row_object = NamedTuple("Row", columns)  # type: ignore[misc]
             return [row_object(*row) for row in result]
         elif isinstance(result, pyodbc.Row):
-            columns: list[tuple[str, type]] = [col[:2] for col in result.cursor_description]
-            return NamedTuple("Row", columns)(*result)  # type: ignore[misc]
+            columns = [col[:2] for col in result.cursor_description]
+            return NamedTuple("Row", columns)(*result)  # type: ignore[misc, operator]
         return result

--- a/airflow/providers/odbc/hooks/odbc.py
+++ b/airflow/providers/odbc/hooks/odbc.py
@@ -213,12 +213,15 @@ class OdbcHook(DbApiHook):
         return cnx
 
     @staticmethod
-    def _make_serializable(result: list[pyodbc.Row] | None) -> list[NamedTuple] | None:
+    def _make_serializable(result: list[pyodbc.Row] | pyodbc.Row | None) -> list[NamedTuple] | None:
         """Transform the pyodbc.Row objects returned from an SQL command into JSON-serializable NamedTuple."""
-        if result is not None:
+        # Below ignored lines respect NamedTuple docstring, but mypy do not support dynamically
+        # instantiated Namedtuple, and will never do: https://github.com/python/mypy/issues/848
+        if isinstance(result, list):
             columns: list[tuple[str, type]] = [col[:2] for col in result[0].cursor_description]
-            # Below line respects NamedTuple docstring, but mypy do not support dynamically
-            # instantiated Namedtuple, and will never do: https://github.com/python/mypy/issues/848
             row_object = NamedTuple("Row", columns)  # type: ignore[misc]
             return [row_object(*row) for row in result]
+        elif isinstance(result, pyodbc.Row):
+            columns: list[tuple[str, type]] = [col[:2] for col in result.cursor_description]
+            return NamedTuple("Row", columns)(*result)  # type: ignore[misc]
         return result

--- a/tests/providers/databricks/hooks/test_databricks_sql.py
+++ b/tests/providers/databricks/hooks/test_databricks_sql.py
@@ -172,6 +172,17 @@ def get_cursor_descriptions(fields: list[str]) -> list[tuple[str]]:
             [[[1, 2], [11, 12]], [[3, 4], [13, 14]]],
             id="The return_last not set on multiple queries not set",
         ),
+        pytest.param(
+            True,
+            False,
+            "select * from test.test",
+            ["select * from test.test"],
+            [["id", "value"]],
+            (Row(id=1, value=2),),
+            [[("id",), ("value",)]],
+            [1, 2],
+            id="The return_last set and no split statements set on single query in string",
+        ),
     ],
 )
 def test_query(

--- a/tests/providers/odbc/hooks/test_odbc.py
+++ b/tests/providers/odbc/hooks/test_odbc.py
@@ -64,7 +64,7 @@ def pyodbc_row_mock():
 
 @pytest.fixture
 def pyodbc_instancecheck():
-    """Returns a mock of pyodbc.Row class which returns True to any isinstance() checks."""
+    """Mock a pyodbc.Row class which returns True to any isinstance() checks."""
 
     class PyodbcRowMeta(type):
         def __instancecheck__(self, instance):
@@ -300,7 +300,7 @@ class TestOdbcHook:
         """Ensure that pyodbc.Row object has a `cursor_description` method.
 
         In subsequent tests, pyodbc.Row is replaced by the 'pyodbc_row_mock' fixture, which implements the
-        `cursor_description` method. We want to detect any breaking change in the pyodbc object. If it
+        `cursor_description` method. We want to detect any breaking change in the pyodbc object. If this test
         fails, the 'pyodbc_row_mock' fixture needs to be updated.
         """
         assert hasattr(pyodbc.Row, "cursor_description")

--- a/tests/providers/odbc/hooks/test_odbc.py
+++ b/tests/providers/odbc/hooks/test_odbc.py
@@ -32,9 +32,12 @@ from airflow.providers.odbc.hooks.odbc import OdbcHook
 
 
 @pytest.fixture
-def mock_row():
-    """
-    Mock a pyodbc.Row object - This is a C object that can only be created from C API of pyodbc.
+def pyodbc_row_mock():
+    """Mock a pyodbc.Row instantiated object.
+
+    This object is used in the tests to replace the real pyodbc.Row object.
+    pyodbc.Row is a C object that can only be created from C API of pyodbc.
+
     This mock implements the two features used by the hook:
         - cursor_description: which return column names and type
         - __iter__: which allows exploding a row instance (*row)
@@ -57,6 +60,20 @@ def mock_row():
             ]
 
     return Row
+
+
+@pytest.fixture
+def pyodbc_instancecheck():
+    """Returns a mock of pyodbc.Row class which returns True to any isinstance() checks."""
+
+    class PyodbcRowMeta(type):
+        def __instancecheck__(self, instance):
+            return True
+
+    class PyodbcRow(metaclass=PyodbcRowMeta):
+        pass
+
+    return PyodbcRow
 
 
 class TestOdbcHook:
@@ -282,14 +299,18 @@ class TestOdbcHook:
     def test_pyodbc_mock(self):
         """Ensure that pyodbc.Row object has a `cursor_description` method.
 
-        In subsequent tests, pyodbc.Row is replaced by pure Python mock object, which implements the above
-        method. We want to detect any breaking change in the pyodbc object. If it fails, the 'mock_row'
-        needs to be updated.
+        In subsequent tests, pyodbc.Row is replaced by the 'pyodbc_row_mock' fixture, which implements the
+        `cursor_description` method. We want to detect any breaking change in the pyodbc object. If it
+        fails, the 'pyodbc_row_mock' fixture needs to be updated.
         """
         assert hasattr(pyodbc.Row, "cursor_description")
 
-    def test_query_return_serializable_result(self, mock_row):
-        pyodbc_result = [mock_row(key=1, column="value1"), mock_row(key=2, column="value2")]
+    def test_query_return_serializable_result_with_fetchall(self, pyodbc_row_mock):
+        """
+        Simulate a cursor.fetchall which returns an iterable of pyodbc.Row object, and check if this iterable
+        get converted into a list of tuples.
+        """
+        pyodbc_result = [pyodbc_row_mock(key=1, column="value1"), pyodbc_row_mock(key=2, column="value2")]
         hook_result = [(1, "value1"), (2, "value2")]
 
         def mock_handler(*_):
@@ -297,6 +318,25 @@ class TestOdbcHook:
 
         hook = self.get_hook()
         result = hook.run("SQL", handler=mock_handler)
+        assert hook_result == result
+
+    def test_query_return_serializable_result_with_fetchone(
+        self, pyodbc_row_mock, monkeypatch, pyodbc_instancecheck
+    ):
+        """
+        Simulate a cursor.fetchone which returns one single pyodbc.Row object, and check if this object gets
+        converted into a tuple.
+        """
+        pyodbc_result = pyodbc_row_mock(key=1, column="value1")
+        hook_result = (1, "value1")
+
+        def mock_handler(*_):
+            return pyodbc_result
+
+        hook = self.get_hook()
+        with monkeypatch.context() as patcher:
+            patcher.setattr("pyodbc.Row", pyodbc_instancecheck)
+            result = hook.run("SQL", handler=mock_handler)
         assert hook_result == result
 
     def test_query_no_handler_return_none(self):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


This PR implements support for `fetchone()` in the ODBCHook and the Databricks SQL Hook. Fixing the bug described in https://github.com/apache/airflow/pull/32319#discussion_r1421437350. It also refactors and improves a bit the docstring.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
