### PR TITLE
SparkSubmit: Adding propertyfiles option

### DIFF
--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -100,7 +100,6 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
     def __init__(
         self,
         conf: dict[str, Any] | None = None,
-        properties_file: str | None = None,
         conn_id: str = "spark_default",
         files: str | None = None,
         py_files: str | None = None,
@@ -125,12 +124,12 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         env_vars: dict[str, Any] | None = None,
         verbose: bool = False,
         spark_binary: str | None = None,
+        properties_file: str | None = None,
         *,
         use_krb5ccache: bool = False,
     ) -> None:
         super().__init__()
         self._conf = conf or {}
-        self._properties_file = properties_file
         self._conn_id = conn_id
         self._files = files
         self._py_files = py_files
@@ -159,6 +158,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         self._yarn_application_id: str | None = None
         self._kubernetes_driver_pod: str | None = None
         self.spark_binary = spark_binary
+        self._properties_file = properties_file
         self._connection = self._resolve_connection()
         self._is_yarn = "yarn" in self._connection["master"]
         self._is_kubernetes = "k8s" in self._connection["master"]

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -98,6 +98,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
     def __init__(
         self,
         conf: dict[str, Any] | None = None,
+        properties_file: str | None = None,
         conn_id: str = "spark_default",
         files: str | None = None,
         py_files: str | None = None,
@@ -127,6 +128,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
     ) -> None:
         super().__init__()
         self._conf = conf or {}
+        self._properties_file = properties_file
         self._conn_id = conn_id
         self._files = files
         self._py_files = py_files
@@ -292,6 +294,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                 "--conf",
                 f"spark.kubernetes.namespace={self._connection['namespace']}",
             ]
+        if self._properties_file:
+            connection_cmd += ["--properties-file", self._properties_file]
         if self._files:
             connection_cmd += ["--files", self._files]
         if self._py_files:

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -78,6 +78,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
     :param verbose: Whether to pass the verbose flag to spark-submit process for debugging
     :param spark_binary: The command to use for spark submit.
                          Some distros may use spark2-submit or spark3-submit.
+    :param properties_file: Path to a file from which to load extra properties. If not
+                              specified, this will look for conf/spark-defaults.conf.
     :param use_krb5ccache: if True, configure spark to use ticket cache instead of relying
         on keytab for Kerberos login
     """

--- a/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/airflow/providers/apache/spark/operators/spark_submit.py
@@ -76,7 +76,7 @@ class SparkSubmitOperator(BaseOperator):
     template_fields: Sequence[str] = (
         "_application",
         "_conf",
-        "_properties-file"
+        "_properties_file",
         "_files",
         "_py_files",
         "_jars",

--- a/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/airflow/providers/apache/spark/operators/spark_submit.py
@@ -76,6 +76,7 @@ class SparkSubmitOperator(BaseOperator):
     template_fields: Sequence[str] = (
         "_application",
         "_conf",
+        "_properties-file"
         "_files",
         "_py_files",
         "_jars",
@@ -96,6 +97,7 @@ class SparkSubmitOperator(BaseOperator):
         *,
         application: str = "",
         conf: dict[str, Any] | None = None,
+        properties_file: str | None = None,
         conn_id: str = "spark_default",
         files: str | None = None,
         py_files: str | None = None,
@@ -126,6 +128,7 @@ class SparkSubmitOperator(BaseOperator):
         super().__init__(**kwargs)
         self._application = application
         self._conf = conf
+        self._properties_file = properties_file
         self._files = files
         self._py_files = py_files
         self._archives = archives
@@ -164,14 +167,10 @@ class SparkSubmitOperator(BaseOperator):
             self._hook = self._get_hook()
         self._hook.on_kill()
 
-    def property_files(self) -> None:
-        if self.hook is None:
-            self._hook = self._get_hook()
-        self._hook.property_files()
-
     def _get_hook(self) -> SparkSubmitHook:
         return SparkSubmitHook(
             conf=self._conf,
+            properties_file=self._properties_file,
             conn_id=self._conn_id,
             files=self._files,
             py_files=self._py_files,

--- a/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/airflow/providers/apache/spark/operators/spark_submit.py
@@ -164,6 +164,11 @@ class SparkSubmitOperator(BaseOperator):
             self._hook = self._get_hook()
         self._hook.on_kill()
 
+    def property_files(self) -> None:
+        if self.hook is None:
+            self._hook = self._get_hook()
+        self.hook.property_files()
+
     def _get_hook(self) -> SparkSubmitHook:
         return SparkSubmitHook(
             conf=self._conf,

--- a/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/airflow/providers/apache/spark/operators/spark_submit.py
@@ -167,7 +167,7 @@ class SparkSubmitOperator(BaseOperator):
     def property_files(self) -> None:
         if self.hook is None:
             self._hook = self._get_hook()
-        self.hook.property_files()
+        self._hook.property_files()
 
     def _get_hook(self) -> SparkSubmitHook:
         return SparkSubmitHook(

--- a/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/airflow/providers/apache/spark/operators/spark_submit.py
@@ -69,6 +69,8 @@ class SparkSubmitOperator(BaseOperator):
     :param verbose: Whether to pass the verbose flag to spark-submit process for debugging
     :param spark_binary: The command to use for spark submit.
                          Some distros may use spark2-submit or spark3-submit.
+    :param properties_file: Path to a file from which to load extra properties. If not
+                              specified, this will look for conf/spark-defaults.conf.
     :param use_krb5ccache: if True, configure spark to use ticket cache instead of relying
                            on keytab for Kerberos login
     """
@@ -76,7 +78,6 @@ class SparkSubmitOperator(BaseOperator):
     template_fields: Sequence[str] = (
         "_application",
         "_conf",
-        "_properties_file",
         "_files",
         "_py_files",
         "_jars",
@@ -89,6 +90,7 @@ class SparkSubmitOperator(BaseOperator):
         "_name",
         "_application_args",
         "_env_vars",
+        "_properties_file",
     )
     ui_color = WEB_COLORS["LIGHTORANGE"]
 
@@ -97,7 +99,6 @@ class SparkSubmitOperator(BaseOperator):
         *,
         application: str = "",
         conf: dict[str, Any] | None = None,
-        properties_file: str | None = None,
         conn_id: str = "spark_default",
         files: str | None = None,
         py_files: str | None = None,
@@ -122,13 +123,13 @@ class SparkSubmitOperator(BaseOperator):
         env_vars: dict[str, Any] | None = None,
         verbose: bool = False,
         spark_binary: str | None = None,
+        properties_file: str | None = None,
         use_krb5ccache: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self._application = application
         self._conf = conf
-        self._properties_file = properties_file
         self._files = files
         self._py_files = py_files
         self._archives = archives
@@ -152,6 +153,7 @@ class SparkSubmitOperator(BaseOperator):
         self._env_vars = env_vars
         self._verbose = verbose
         self._spark_binary = spark_binary
+        self._properties_file = properties_file
         self._hook: SparkSubmitHook | None = None
         self._conn_id = conn_id
         self._use_krb5ccache = use_krb5ccache
@@ -170,7 +172,6 @@ class SparkSubmitOperator(BaseOperator):
     def _get_hook(self) -> SparkSubmitHook:
         return SparkSubmitHook(
             conf=self._conf,
-            properties_file=self._properties_file,
             conn_id=self._conn_id,
             files=self._files,
             py_files=self._py_files,
@@ -195,5 +196,6 @@ class SparkSubmitOperator(BaseOperator):
             env_vars=self._env_vars,
             verbose=self._verbose,
             spark_binary=self._spark_binary,
+            properties_file=self._properties_file,
             use_krb5ccache=self._use_krb5ccache,
         )

--- a/tests/providers/apache/spark/operators/test_spark_submit.py
+++ b/tests/providers/apache/spark/operators/test_spark_submit.py
@@ -53,6 +53,7 @@ class TestSparkSubmitOperator:
         "application": "test_application.py",
         "driver_memory": "3g",
         "java_class": "com.foo.bar.AppMain",
+        "properties_file": "conf/spark-custom.conf",
         "application_args": [
             "-f",
             "foo",
@@ -120,6 +121,7 @@ class TestSparkSubmitOperator:
             ],
             "spark_binary": "sparky",
             "use_krb5ccache": True,
+            "properties_file": "conf/spark-custom.conf",
         }
 
         assert conn_id == operator._conn_id
@@ -147,6 +149,7 @@ class TestSparkSubmitOperator:
         assert expected_dict["driver_memory"] == operator._driver_memory
         assert expected_dict["application_args"] == operator._application_args
         assert expected_dict["spark_binary"] == operator._spark_binary
+        assert expected_dict["properties_file"] == operator._properties_file
         assert expected_dict["use_krb5ccache"] == operator._use_krb5ccache
 
     @pytest.mark.db_test

--- a/tests/system/providers/apache/hive/example_twitter_README.md
+++ b/tests/system/providers/apache/hive/example_twitter_README.md
@@ -33,7 +33,7 @@
 1. Save Summary to MySQL
 
 ***Screenshot:***
-<img src="http://i.imgur.com/rRpSO12.png" width="99%"/>
+<img src="http://i.imgur.com/rRpSO12.png" width="99%" alt="Dag for Collecting tweets for four users account"/>
 
 ***Example Structure:*** In this example dag, we are collecting tweets for four users account or twitter handle. Each twitter handle has two channels, incoming tweets and outgoing tweets. Hence, in this example, by running the fetch_tweet task, we should have eight output files. For better management, each of the eight output files should be saved with the yesterday's date (we are collecting tweets from yesterday), i.e. toTwitter_A_2016-03-21.csv. We are using two kinds of operators (BashOperator and HiveOperator) along with task-decorated functions. However, for this example only the Python scripts are stored externally. Hence this example DAG only has the following directory structure:
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #34838

## Description
There is an option to override the default conf/spark-defaults.conf properties in Spark-submit
![image](https://github.com/apache/airflow/assets/16856802/473a31fb-2607-4c18-bfdc-cfb7e7dc8c1e)

We want to have that option in SparkSubmitOperator and Hook as well.


