### PR TITLE
feat: support mysql backend as keda trigger

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -84,7 +84,7 @@ If release name contains chart name it will be used as a full name.
         name: {{ template "airflow_metadata_secret" . }}
         key: connection
   {{- end }}
-  {{- if and .Values.workers.keda.enabled .Values.pgbouncer.enabled (not .Values.workers.keda.usePgbouncer) }}
+  {{- if (or (and .Values.workers.keda.enabled (eq .Values.data.metadataConnection.protocol "mysql")) (and .Values.workers.keda.enabled .Values.pgbouncer.enabled (not .Values.workers.keda.usePgbouncer))) }}
   - name: KEDA_DB_CONN
     valueFrom:
       secretKeyRef:

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -84,7 +84,7 @@ If release name contains chart name it will be used as a full name.
         name: {{ template "airflow_metadata_secret" . }}
         key: connection
   {{- end }}
-  {{- if (or (and .Values.workers.keda.enabled (eq .Values.data.metadataConnection.protocol "mysql")) (and .Values.workers.keda.enabled .Values.pgbouncer.enabled (not .Values.workers.keda.usePgbouncer))) }}
+  {{- if and .Values.workers.keda.enabled (or (eq .Values.data.metadataConnection.protocol "mysql") (and .Values.pgbouncer.enabled (not .Values.workers.keda.usePgbouncer))) }}
   - name: KEDA_DB_CONN
     valueFrom:
       secretKeyRef:

--- a/chart/templates/secrets/metadata-connection-secret.yaml
+++ b/chart/templates/secrets/metadata-connection-secret.yaml
@@ -51,5 +51,9 @@ data:
   {{- with .Values.data.metadataConnection }}
   kedaConnection: {{ urlJoin (dict "scheme" .protocol "userinfo" (printf "%s:%s" (.user | urlquery) (.pass | urlquery) ) "host" (printf "%s:%s" $metadataHost $metadataPort) "path" (printf "/%s" $metadataDatabase) "query" $query) | b64enc | quote }}
   {{- end }}
+  {{- else if and .Values.workers.keda.enabled (eq .Values.data.metadataConnection.protocol "mysql") }}
+  {{- with .Values.data.metadataConnection }}
+  kedaConnection: {{ urlJoin (dict "userinfo" (printf "%s:%s" (.user | urlquery) (.pass | urlquery) ) "host" (printf "tcp(%s:%s)" $metadataHost $metadataPort) "path" (printf "/%s" $metadataDatabase) "query" $query) | b64enc | quote }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/workers/worker-kedaautoscaler.yaml
+++ b/chart/templates/workers/worker-kedaautoscaler.yaml
@@ -47,7 +47,14 @@ spec:
   advanced: {{- toYaml .Values.workers.keda.advanced | nindent 4 }}
   {{- end }}
   triggers:
-    - type: postgresql
+    {{- if eq .Values.data.metadataConnection.protocol "mysql" }}
+    - type: "mysql"
+      metadata:
+        queryValue: "1"
+        connectionStringFromEnv: KEDA_DB_CONN
+        query: {{ tpl .Values.workers.keda.query . | quote }}
+    {{- else }}
+    - type: "postgresql"
       metadata:
         targetQueryValue: "1"
         {{- if and .Values.pgbouncer.enabled (not .Values.workers.keda.usePgbouncer) }}
@@ -56,4 +63,6 @@ spec:
         connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
         {{- end }}
         query: {{ tpl .Values.workers.keda.query . | quote }}
+    {{- end }}
+
 {{- end }}

--- a/helm_tests/other/test_keda.py
+++ b/helm_tests/other/test_keda.py
@@ -278,8 +278,6 @@ class TestKeda:
 
     def test_mysql_keda_db_connection(self):
         """Verify keda db connection when pgbouncer is enabled."""
-        import base64
-
         docs = render_chart(
             values={
                 "data": {"metadataConnection": {"protocol": "mysql", "port": 3306}},

--- a/helm_tests/other/test_keda.py
+++ b/helm_tests/other/test_keda.py
@@ -282,7 +282,7 @@ class TestKeda:
 
         docs = render_chart(
             values={
-                "data": {"metadataConnection": {"protocol": "mysql", "port":3306} },
+                "data": {"metadataConnection": {"protocol": "mysql", "port": 3306}},
                 "workers": {"keda": {"enabled": True}},
                 "executor": "CeleryExecutor",
             },
@@ -302,9 +302,7 @@ class TestKeda:
         assert "AIRFLOW_CONN_AIRFLOW_DB" in worker_container_env_vars
         assert "KEDA_DB_CONN" in worker_container_env_vars
 
-        keda_autoscaler_metadata = jmespath.search(
-            "spec.triggers[0].metadata", keda_autoscaler
-        )
+        keda_autoscaler_metadata = jmespath.search("spec.triggers[0].metadata", keda_autoscaler)
         assert "queryValue" in keda_autoscaler_metadata
 
         secret_data = jmespath.search("data", metadata_connection_secret)


### PR DESCRIPTION
Closes: #36166

Airflow currently support two SQL database backend with postgresql and mysql. PostgreSQL being the default one it's also the trigger used by default by the Keda ScaledObject created when enabling autoscaling. Which do not work if using a mysql database. Query has to be changed a bit and [mysql trigger parameters](https://keda.sh/docs/2.12/scalers/mysql/#authentication-parameters) aren't the same (pretty sneaky little changes within key names) and most of all the connection string used isn't the correct one when addressing to mysql.