### PR TITLE
Add jsonpath_ng.ext.parse support for SqsSensor

### DIFF
--- a/airflow/providers/amazon/aws/sensors/sqs.py
+++ b/airflow/providers/amazon/aws/sensors/sqs.py
@@ -22,13 +22,12 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, Collection, Sequence
 
 from deprecated import deprecated
-from typing_extensions import Literal
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
 from airflow.providers.amazon.aws.hooks.sqs import SqsHook
 from airflow.providers.amazon.aws.triggers.sqs import SqsSensorTrigger
-from airflow.providers.amazon.aws.utils.sqs import process_response
+from airflow.providers.amazon.aws.utils.sqs import MessageFilteringType, process_response
 from airflow.sensors.base import BaseSensorOperator
 
 if TYPE_CHECKING:
@@ -60,9 +59,9 @@ class SqsSensor(BaseSensorOperator):
     :param visibility_timeout: Visibility timeout, a period of time during which
         Amazon SQS prevents other consumers from receiving and processing the message.
     :param message_filtering: Specified how received messages should be filtered. Supported options are:
-        `None` (no filtering, default), `'literal'` (message Body literal match) or `'jsonpath'`
-        (message Body filtered using a JSONPath expression).
-        You may add further methods by overriding the relevant class methods.
+        `None` (no filtering, default), `'literal'` (message Body literal match), `'jsonpath'`
+        (message Body filtered using a JSONPath expression), or `'jsonpath-ext'` (like `'jsonpath'`, but with
+        an expanded query grammar). You may add further methods by overriding the relevant class methods.
     :param message_filtering_match_values: Optional value/s for the message filter to match on.
         For example, with literal matching, if a message body matches any of the specified values
         then it is included. For JSONPath matching, the result of the JSONPath expression is used
@@ -90,7 +89,7 @@ class SqsSensor(BaseSensorOperator):
         num_batches: int = 1,
         wait_time_seconds: int = 1,
         visibility_timeout: int | None = None,
-        message_filtering: Literal["literal", "jsonpath"] | None = None,
+        message_filtering: MessageFilteringType | None = None,
         message_filtering_match_values: Any = None,
         message_filtering_config: Any = None,
         delete_message_on_reception: bool = True,

--- a/airflow/providers/amazon/aws/triggers/sqs.py
+++ b/airflow/providers/amazon/aws/triggers/sqs.py
@@ -19,11 +19,9 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, AsyncIterator, Collection
 
-from typing_extensions import Literal
-
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.sqs import SqsHook
-from airflow.providers.amazon.aws.utils.sqs import process_response
+from airflow.providers.amazon.aws.utils.sqs import MessageFilteringType, process_response
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 if TYPE_CHECKING:
@@ -66,7 +64,7 @@ class SqsSensorTrigger(BaseTrigger):
         num_batches: int = 1,
         wait_time_seconds: int = 1,
         visibility_timeout: int | None = None,
-        message_filtering: Literal["literal", "jsonpath"] | None = None,
+        message_filtering: MessageFilteringType | None = None,
         message_filtering_match_values: Any = None,
         message_filtering_config: Any = None,
         delete_message_on_reception: bool = True,


### PR DESCRIPTION
This PR extends the `message_filtering` parameter to the `SqsSensor` to add a third type of filtering: `jsonpath-ext`.  The existing JSONPath filtering functionality in `SqsSensor` uses the `jsonpath_ng.parse` method for constructing the JSONPath engine to search for matching values.  This particular engine supports only a subset of the JSONPath language and is missing useful features, such as the ability to retrieve the values for multiple fields at a time.  The new `jsonpath-ext` option uses the `jsonpath_ng.ext.parse` builder instead, which unlocks the full capabilities of the `jsonpath_ng` library.


