### PR TITLE
Remove `is_authorized_cluster_activity` from auth manager

### DIFF
--- a/airflow/auth/managers/base_auth_manager.py
+++ b/airflow/auth/managers/base_auth_manager.py
@@ -135,20 +135,6 @@ class BaseAuthManager(LoggingMixin):
         """
 
     @abstractmethod
-    def is_authorized_cluster_activity(
-        self,
-        *,
-        method: ResourceMethod,
-        user: BaseUser | None = None,
-    ) -> bool:
-        """
-        Return whether the user is authorized to perform a given action on the cluster activity.
-
-        :param method: the method to perform
-        :param user: the user to perform the action on. If not provided (or None), it uses the current user
-        """
-
-    @abstractmethod
     def is_authorized_connection(
         self,
         *,

--- a/airflow/providers/amazon/aws/auth_manager/aws_auth_manager.py
+++ b/airflow/providers/amazon/aws/auth_manager/aws_auth_manager.py
@@ -99,9 +99,6 @@ class AwsAuthManager(BaseAuthManager):
             entity_id=config_section,
         )
 
-    def is_authorized_cluster_activity(self, *, method: ResourceMethod, user: BaseUser | None = None) -> bool:
-        return self.is_logged_in()
-
     def is_authorized_connection(
         self,
         *,

--- a/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -193,9 +193,6 @@ class FabAuthManager(BaseAuthManager):
     ) -> bool:
         return self._is_authorized(method=method, resource_type=RESOURCE_CONFIG, user=user)
 
-    def is_authorized_cluster_activity(self, *, method: ResourceMethod, user: BaseUser | None = None) -> bool:
-        return self._is_authorized(method=method, resource_type=RESOURCE_CLUSTER_ACTIVITY, user=user)
-
     def is_authorized_connection(
         self,
         *,

--- a/airflow/www/auth.py
+++ b/airflow/www/auth.py
@@ -182,10 +182,6 @@ def _has_access(*, is_authorized: bool, func: Callable, args, kwargs):
     return redirect(get_auth_manager().get_url_login(next=request.url))
 
 
-def has_access_cluster_activity(method: ResourceMethod) -> Callable[[T], T]:
-    return _has_access_no_details(lambda: get_auth_manager().is_authorized_cluster_activity(method=method))
-
-
 def has_access_configuration(method: ResourceMethod) -> Callable[[T], T]:
     return _has_access_no_details(lambda: get_auth_manager().is_authorized_configuration(method=method))
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1055,7 +1055,7 @@ class Airflow(AirflowBaseView):
         )
 
     @expose("/cluster_activity")
-    @auth.has_access_cluster_activity("GET")
+    @auth.has_access_view(AccessView.CLUSTER_ACTIVITY)
     def cluster_activity(self):
         """Cluster Activity view."""
         state_color_mapping = State.state_color.copy()
@@ -3556,7 +3556,7 @@ class Airflow(AirflowBaseView):
         )
 
     @expose("/object/historical_metrics_data")
-    @auth.has_access_cluster_activity("GET")
+    @auth.has_access_view(AccessView.CLUSTER_ACTIVITY)
     def historical_metrics_data(self):
         """Return cluster activity historical metrics."""
         start_date = _safe_parse_datetime(request.args.get("start_date"))

--- a/tests/auth/managers/test_base_auth_manager.py
+++ b/tests/auth/managers/test_base_auth_manager.py
@@ -57,9 +57,6 @@ class EmptyAuthManager(BaseAuthManager):
     ) -> bool:
         raise NotImplementedError()
 
-    def is_authorized_cluster_activity(self, *, method: ResourceMethod, user: BaseUser | None = None) -> bool:
-        raise NotImplementedError()
-
     def is_authorized_connection(
         self,
         *,

--- a/tests/providers/fab/auth_manager/test_fab_auth_manager.py
+++ b/tests/providers/fab/auth_manager/test_fab_auth_manager.py
@@ -34,7 +34,6 @@ from airflow.security.permissions import (
     ACTION_CAN_DELETE,
     ACTION_CAN_EDIT,
     ACTION_CAN_READ,
-    RESOURCE_CLUSTER_ACTIVITY,
     RESOURCE_CONFIG,
     RESOURCE_CONNECTION,
     RESOURCE_DAG,
@@ -52,7 +51,6 @@ from airflow.www.extensions.init_appbuilder import init_appbuilder
 
 IS_AUTHORIZED_METHODS_SIMPLE = {
     "is_authorized_configuration": RESOURCE_CONFIG,
-    "is_authorized_cluster_activity": RESOURCE_CLUSTER_ACTIVITY,
     "is_authorized_connection": RESOURCE_CONNECTION,
     "is_authorized_dataset": RESOURCE_DATASET,
     "is_authorized_variable": RESOURCE_VARIABLE,

--- a/tests/www/test_auth.py
+++ b/tests/www/test_auth.py
@@ -45,7 +45,6 @@ class TestHasAccessDecorator:
 @pytest.mark.parametrize(
     "decorator_name, is_authorized_method_name",
     [
-        ("has_access_cluster_activity", "is_authorized_cluster_activity"),
         ("has_access_configuration", "is_authorized_configuration"),
         ("has_access_dataset", "is_authorized_dataset"),
         ("has_access_view", "is_authorized_view"),


### PR DESCRIPTION
There is a duplicate way to check permissions access for cluster activity page, `is_authorized_view` is the correct one.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
