### PR TITLE
Remove duplicate dropdown entry in providers issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/airflow_providers_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_providers_bug_report.yml
@@ -72,7 +72,6 @@ body:
         - influxdb
         - jdbc
         - jenkins
-        - apache-kafka
         - microsoft-azure
         - microsoft-mssql
         - microsoft-psrp


### PR DESCRIPTION
Because there is a duplicate option in the "Apache Airflow Provider(s)" dropdown, the "Airflow Providers Bug report" template is not available for users to select when logging a bug.
