### PR TITLE
Update `retry` param typing in PubSubAsyncHook

### DIFF
--- a/airflow/providers/google/cloud/hooks/pubsub.py
+++ b/airflow/providers/google/cloud/hooks/pubsub.py
@@ -49,6 +49,7 @@ from airflow.version import version
 
 if TYPE_CHECKING:
     from google.api_core.retry import Retry
+    from google.api_core.retry_async import AsyncRetry
     from google.cloud.pubsub_v1.types import (
         DeadLetterPolicy,
         Duration,
@@ -611,7 +612,7 @@ class PubSubAsyncHook(GoogleBaseAsyncHook):
         project_id: str,
         ack_ids: list[str] | None = None,
         messages: list[ReceivedMessage] | None = None,
-        retry: Retry | _MethodDefault = DEFAULT,
+        retry: AsyncRetry | _MethodDefault = DEFAULT,
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
     ) -> None:
@@ -665,7 +666,7 @@ class PubSubAsyncHook(GoogleBaseAsyncHook):
         max_messages: int,
         project_id: str = PROVIDE_PROJECT_ID,
         return_immediately: bool = False,
-        retry: Retry | _MethodDefault = DEFAULT,
+        retry: AsyncRetry | _MethodDefault = DEFAULT,
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
     ) -> list[ReceivedMessage]:

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -115,7 +115,7 @@ dependencies:
   - google-cloud-monitoring>=2.14.1
   - google-cloud-orchestration-airflow>=1.10.0
   - google-cloud-os-login>=2.9.1
-  - google-cloud-pubsub>=2.15.0
+  - google-cloud-pubsub>=2.19.0
   - google-cloud-redis>=2.12.0
   - google-cloud-secret-manager>=2.16.0
   - google-cloud-spanner>=3.11.1

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -454,7 +454,7 @@
       "google-cloud-monitoring>=2.14.1",
       "google-cloud-orchestration-airflow>=1.10.0",
       "google-cloud-os-login>=2.9.1",
-      "google-cloud-pubsub>=2.15.0",
+      "google-cloud-pubsub>=2.19.0",
       "google-cloud-redis>=2.12.0",
       "google-cloud-run>=0.9.0",
       "google-cloud-secret-manager>=2.16.0",


### PR DESCRIPTION
The `google-cloud-pubsub` library was [recently released](https://pypi.org/project/google-cloud-pubsub/2.19.0/) with a bug fix to update the `retry` parameter when using the SubscriberAsyncClient to AsyncRetry from Retry.

Main builds were failing Mypy checks for this reason.