### PR TITLE
Improve handling of backwards compat for airflow.io

### DIFF
--- a/airflow/io/__init__.py
+++ b/airflow/io/__init__.py
@@ -93,11 +93,18 @@ def get_fs(
         raise ValueError(f"No filesystem registered for scheme {scheme}") from None
 
     options = storage_options or {}
+
     # MyPy does not recognize dynamic parameters inspection when we call the method, and we have to do
     # it for compatibility reasons with already released providers, that's why we need to ignore
     # mypy errors here
     parameters = inspect.signature(fs).parameters
     if len(parameters) == 1:
+        if len(options) > 0:
+            raise AttributeError(
+                f"Filesystem {scheme} does not support storage options, but options were passed."
+                f"This most likely means that you are using an old version of the provider that does not "
+                f"support storage options. Please upgrade the provider if possible."
+            )
         return fs(conn_id)  # type: ignore[call-arg]
     return fs(conn_id, options)  # type: ignore[call-arg]
 

--- a/airflow/io/__init__.py
+++ b/airflow/io/__init__.py
@@ -99,7 +99,7 @@ def get_fs(
     # mypy errors here
     parameters = inspect.signature(fs).parameters
     if len(parameters) == 1:
-        if len(options) > 0:
+        if options:
             raise AttributeError(
                 f"Filesystem {scheme} does not support storage options, but options were passed."
                 f"This most likely means that you are using an old version of the provider that does not "

--- a/tests/io/test_path.py
+++ b/tests/io/test_path.py
@@ -26,7 +26,7 @@ import pytest
 from fsspec.implementations.local import LocalFileSystem
 from fsspec.utils import stringify_path
 
-from airflow.io import get_fs
+from airflow.io import _register_filesystems, get_fs
 from airflow.io.path import ObjectStoragePath
 from airflow.io.store import _STORE_CACHE, ObjectStore, attach
 from airflow.utils.module_loading import qualname
@@ -292,6 +292,7 @@ class TestFs:
         assert store == d
 
     def test_backwards_compat(self):
+        _register_filesystems.cache_clear()
         from airflow.io import _BUILTIN_SCHEME_TO_FS as SCHEMES
 
         SCHEMES["file"] = get_fs_no_storage_options  # type: ignore[call-arg]
@@ -300,3 +301,6 @@ class TestFs:
 
         with pytest.raises(AttributeError):
             get_fs("file", storage_options={"foo": "bar"})
+
+        # Reset the cache to avoid side effects
+        _register_filesystems.cache_clear()

--- a/tests/io/test_path.py
+++ b/tests/io/test_path.py
@@ -295,12 +295,14 @@ class TestFs:
         _register_filesystems.cache_clear()
         from airflow.io import _BUILTIN_SCHEME_TO_FS as SCHEMES
 
-        SCHEMES["file"] = get_fs_no_storage_options  # type: ignore[call-arg]
+        try:
+            SCHEMES["file"] = get_fs_no_storage_options  # type: ignore[call-arg]
 
-        assert get_fs("file")
+            assert get_fs("file")
 
-        with pytest.raises(AttributeError):
-            get_fs("file", storage_options={"foo": "bar"})
+            with pytest.raises(AttributeError):
+                get_fs("file", storage_options={"foo": "bar"})
 
-        # Reset the cache to avoid side effects
-        _register_filesystems.cache_clear()
+        finally:
+            # Reset the cache to avoid side effects
+            _register_filesystems.cache_clear()


### PR DESCRIPTION
Older providers do not have a get_fs method that takes storage_options as arguments. If we encounter such provider and storage_options are passed we should error out instead if silently ignoring.

@potiuk 

@ephraimbuddy if we do a rc3 for 2.8 this would be great to have in. 

Closes: https://github.com/apache/airflow/issues/36187

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
