### PR TITLE
Fix incompatibility with google-cloud-monitoring 2.18.0

### DIFF
--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -112,7 +112,7 @@ dependencies:
   - google-cloud-language>=2.9.0
   - google-cloud-logging>=3.5.0
   - google-cloud-memcache>=1.7.0
-  - google-cloud-monitoring>=2.14.1
+  - google-cloud-monitoring>=2.18.0
   - google-cloud-orchestration-airflow>=1.10.0
   - google-cloud-os-login>=2.9.1
   - google-cloud-pubsub>=2.19.0

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -451,7 +451,7 @@
       "google-cloud-language>=2.9.0",
       "google-cloud-logging>=3.5.0",
       "google-cloud-memcache>=1.7.0",
-      "google-cloud-monitoring>=2.14.1",
+      "google-cloud-monitoring>=2.18.0",
       "google-cloud-orchestration-airflow>=1.10.0",
       "google-cloud-os-login>=2.9.1",
       "google-cloud-pubsub>=2.19.0",

--- a/tests/providers/google/cloud/operators/test_stackdriver.py
+++ b/tests/providers/google/cloud/operators/test_stackdriver.py
@@ -112,6 +112,7 @@ class TestStackdriverListAlertPoliciesOperator:
                 "display_name": "",
                 "name": "test-name",
                 "notification_channels": [],
+                "severity": 0,
                 "user_labels": {},
             }
         ] == result


### PR DESCRIPTION
Google cloud monitoring 2.18.0 released yesterday broke our tests. Upgrading minimum version and fixing the tests shoudl fix the problem.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
