### PR TITLE
add param proxy user for hive

### DIFF
--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -96,6 +96,7 @@ class HiveCliHook(BaseHook):
         mapred_job_name: str | None = None,
         hive_cli_params: str = "",
         auth: str | None = None,
+        proxy_user: str | None = None,
     ) -> None:
         super().__init__()
         conn = self.get_connection(hive_cli_conn_id)
@@ -105,7 +106,6 @@ class HiveCliHook(BaseHook):
         self.conn = conn
         self.run_as = run_as
         self.sub_process: Any = None
-
         if mapred_queue_priority:
             mapred_queue_priority = mapred_queue_priority.upper()
             if mapred_queue_priority not in HIVE_QUEUE_PRIORITIES:
@@ -116,6 +116,7 @@ class HiveCliHook(BaseHook):
         self.mapred_queue = mapred_queue or conf.get("hive", "default_hive_mapred_queue")
         self.mapred_queue_priority = mapred_queue_priority
         self.mapred_job_name = mapred_job_name
+        self.proxy_user = proxy_user
 
     def _get_proxy_user(self) -> str:
         """Set the proper proxy_user value in case the user overwrite the default."""
@@ -126,6 +127,8 @@ class HiveCliHook(BaseHook):
             return f"hive.server2.proxy.user={conn.login}"
         if proxy_user_value == "owner" and self.run_as:
             return f"hive.server2.proxy.user={self.run_as}"
+        if proxy_user_value == "param" and self.proxy_user:
+            return f"hive.server2.proxy.user={self.proxy_user}"
         if proxy_user_value != "":  # There is a custom proxy user
             return f"hive.server2.proxy.user={proxy_user_value}"
         return proxy_user_value  # The default proxy user (undefined)

--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -128,7 +128,7 @@ class HiveCliHook(BaseHook):
             return f"hive.server2.proxy.user={conn.login}"
         if proxy_user_value == "owner" and self.run_as:
             return f"hive.server2.proxy.user={self.run_as}"
-        if proxy_user_value == "param" and self.proxy_user:
+        if proxy_user_value == "as_param" and self.proxy_user:
             return f"hive.server2.proxy.user={self.proxy_user}"
         if proxy_user_value != "":  # There is a custom proxy user
             return f"hive.server2.proxy.user={proxy_user_value}"

--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -80,7 +80,7 @@ class HiveCliHook(BaseHook):
         This can make monitoring easier.
     :param hive_cli_params: Space separated list of hive command parameters to add to the
         hive command.
-    :param proxy_user: Proxy user for connecting.
+    :param proxy_user: Run HQL code as this user.
     """
 
     conn_name_attr = "hive_cli_conn_id"

--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -80,6 +80,7 @@ class HiveCliHook(BaseHook):
         This can make monitoring easier.
     :param hive_cli_params: Space separated list of hive command parameters to add to the
         hive command.
+    :param proxy_user: Proxy user for connecting.
     """
 
     conn_name_attr = "hive_cli_conn_id"

--- a/airflow/providers/apache/hive/operators/hive.py
+++ b/airflow/providers/apache/hive/operators/hive.py
@@ -72,6 +72,7 @@ class HiveOperator(BaseOperator):
         "hiveconfs",
         "mapred_job_name",
         "mapred_queue_priority",
+        "proxy_user",
     )
     template_ext: Sequence[str] = (
         ".hql",
@@ -95,6 +96,7 @@ class HiveOperator(BaseOperator):
         mapred_job_name: str | None = None,
         hive_cli_params: str = "",
         auth: str | None = None,
+        proxy_user: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -112,7 +114,7 @@ class HiveOperator(BaseOperator):
         self.mapred_job_name = mapred_job_name
         self.hive_cli_params = hive_cli_params
         self.auth = auth
-
+        self.proxy_user = proxy_user
         job_name_template = conf.get_mandatory_value(
             "hive",
             "mapred_job_name_template",
@@ -131,6 +133,7 @@ class HiveOperator(BaseOperator):
             mapred_job_name=self.mapred_job_name,
             hive_cli_params=self.hive_cli_params,
             auth=self.auth,
+            proxy_user=self.proxy_user,
         )
 
     @deprecated(reason="use `hook` property instead.", category=AirflowProviderDeprecationWarning)

--- a/airflow/providers/apache/hive/operators/hive.py
+++ b/airflow/providers/apache/hive/operators/hive.py
@@ -62,6 +62,7 @@ class HiveOperator(BaseOperator):
         This can make monitoring easier.
     :param hive_cli_params: parameters passed to hive CLO
     :param auth: optional authentication option passed for the Hive connection
+    :param proxy_user: Run HQL code as this user.
     """
 
     template_fields: Sequence[str] = (

--- a/docs/apache-airflow-providers-apache-hive/connections/hive_cli.rst
+++ b/docs/apache-airflow-providers-apache-hive/connections/hive_cli.rst
@@ -71,7 +71,7 @@ Extra (optional)
     * ``use_beeline``
       Specify as ``True`` if using the Beeline CLI. Default is ``False``.
     * ``proxy_user``
-      Specify a proxy user as an ``owner`` or ``login`` or keep blank if using a
+      Specify a proxy user as an ``owner`` or ``login`` or ``param`` keep blank if using a
       custom proxy user.
     * ``principal``
       Specify the JDBC Hive principal to be used with Hive Beeline.

--- a/docs/apache-airflow-providers-apache-hive/connections/hive_cli.rst
+++ b/docs/apache-airflow-providers-apache-hive/connections/hive_cli.rst
@@ -71,8 +71,10 @@ Extra (optional)
     * ``use_beeline``
       Specify as ``True`` if using the Beeline CLI. Default is ``False``.
     * ``proxy_user``
-      Specify a proxy user as an ``owner`` or ``login`` or ``param`` keep blank if using a
+      Specify a proxy user as an ``owner`` or ``login`` or ``as_param`` keep blank if using a
       custom proxy user.
+      When using ``owner`` you will want to pass the operator ``run_as_owner=True`` if you don't you will run the hql as user="owner"
+      When using ``as_param`` you will want to pass the operator ``proxy_user=<some_user>`` if you don't you will run the hql as user="as_param"
     * ``principal``
       Specify the JDBC Hive principal to be used with Hive Beeline.
 

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -885,7 +885,12 @@ class TestHiveCli:
             ({"proxy_user": "a_user_proxy"}, "hive.server2.proxy.user=a_user_proxy", None, None),
             ({"proxy_user": "owner"}, "hive.server2.proxy.user=dummy_dag_owner", "dummy_dag_owner", None),
             ({"proxy_user": "login"}, "hive.server2.proxy.user=admin", None, None),
-            ({"proxy_user": "param"}, "hive.server2.proxy.user=param_proxy_user", None, "param_proxy_user"),
+            (
+                {"proxy_user": "as_param"},
+                "hive.server2.proxy.user=param_proxy_user",
+                None,
+                "param_proxy_user",
+            ),
         ],
     )
     def test_get_proxy_user_value(self, extra_dejson, correct_proxy_user, run_as, proxy_user):

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -879,18 +879,30 @@ class TestHiveCli:
     def setup_method(self):
         self.nondefault_schema = "nondefault"
 
-    def test_get_proxy_user_value(self):
+    @pytest.mark.parametrize(
+        "extra_dejson, correct_proxy_user, run_as, proxy_user",
+        [
+            ({"proxy_user": "a_user_proxy"}, "hive.server2.proxy.user=a_user_proxy", None, None),
+            ({"proxy_user": "owner"}, "hive.server2.proxy.user=dummy_dag_owner", "dummy_dag_owner", None),
+            ({"proxy_user": "login"}, "hive.server2.proxy.user=admin", None, None),
+            ({"proxy_user": "param"}, "hive.server2.proxy.user=param_proxy_user", None, "param_proxy_user"),
+        ],
+    )
+    def test_get_proxy_user_value(self, extra_dejson, correct_proxy_user, run_as, proxy_user):
         hook = MockHiveCliHook()
         returner = mock.MagicMock()
-        returner.extra_dejson = {"proxy_user": "a_user_proxy"}
+        returner.extra_dejson = extra_dejson
+        returner.login = "admin"
         hook.use_beeline = True
         hook.conn = returner
+        hook.proxy_user = proxy_user
+        hook.run_as = run_as
 
         # Run
         result = hook._prepare_cli_cmd()
 
         # Verify
-        assert "hive.server2.proxy.user=a_user_proxy" in result[2]
+        assert correct_proxy_user in result[2]
 
     def test_get_wrong_principal(self):
         hook = MockHiveCliHook()


### PR DESCRIPTION
Know there are [three](https://airflow.apache.org/docs/apache-airflow-providers-apache-hive/stable/connections/hive_cli.html#configuring-the-connection) options to add proxy user to hive cli connection: by dag owner, by connection logging or by custom proxy (as extra in the connection).

This PR add a fourth option param proxy user. by setting `proxy_user=param` in connection allow us to pass the user in HiveOperator.
I think this PR is needed from some option:
1. The user proxy is not as the same name as the owner, we want to seperate the "owner" and the "proxy_user"
2. If we want to use few HiveOperator with different proxy_user in the same dag


Added an option to sent proxy_param in HiveOperator when allow it in the connection.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
