### PR TITLE
Fix: test_auth fails

### DIFF
--- a/tests/www/test_auth.py
+++ b/tests/www/test_auth.py
@@ -111,18 +111,6 @@ class TestHasAccessNoDetails:
         assert result.status_code == 302
 
 
-@pytest.mark.parametrize(
-    "decorator_name, is_authorized_method_name, items",
-    [
-        (
-            "has_access_connection",
-            "batch_is_authorized_connection",
-            [Connection("conn_1"), Connection("conn_2")],
-        ),
-        ("has_access_pool", "batch_is_authorized_pool", [Pool(pool="pool_1"), Pool(pool="pool_2")]),
-        ("has_access_variable", "batch_is_authorized_variable", [Variable("var_1"), Variable("var_2")]),
-    ],
-)
 class TestHasAccessWithDetails:
     def setup_method(self):
         mock_call.reset_mock()
@@ -132,9 +120,42 @@ class TestHasAccessWithDetails:
         return True
 
     @patch("airflow.www.auth.get_auth_manager")
-    def test_has_access_with_details_when_authorized(
-        self, mock_get_auth_manager, decorator_name, is_authorized_method_name, items
-    ):
+    def test_has_access_to_connection_with_details_when_authorized(self, mock_get_auth_manager):
+        decorator_name = "has_access_connection"
+        is_authorized_method_name = "batch_is_authorized_connection"
+        items = [Connection("conn_1"), Connection("conn_2")]
+        auth_manager = Mock()
+        is_authorized_method = Mock()
+        is_authorized_method.return_value = True
+        setattr(auth_manager, is_authorized_method_name, is_authorized_method)
+        mock_get_auth_manager.return_value = auth_manager
+
+        result = getattr(auth, decorator_name)("GET")(self.method_test)(None, items)
+
+        mock_call.assert_called_once()
+        assert result is True
+
+    @patch("airflow.www.auth.get_auth_manager")
+    def test_has_access_to_pool_with_details_when_authorized(self, mock_get_auth_manager):
+        decorator_name = "has_access_pool"
+        is_authorized_method_name = "batch_is_authorized_pool"
+        items = [Pool(pool="pool_1"), Pool(pool="pool_2")]
+        auth_manager = Mock()
+        is_authorized_method = Mock()
+        is_authorized_method.return_value = True
+        setattr(auth_manager, is_authorized_method_name, is_authorized_method)
+        mock_get_auth_manager.return_value = auth_manager
+
+        result = getattr(auth, decorator_name)("GET")(self.method_test)(None, items)
+
+        mock_call.assert_called_once()
+        assert result is True
+
+    @patch("airflow.www.auth.get_auth_manager")
+    def test_has_access_to_vairable_with_details_when_authorized(self, mock_get_auth_manager):
+        decorator_name = "has_access_variable"
+        is_authorized_method_name = "batch_is_authorized_variable"
+        items = [Variable("var_1"), Variable("var_2")]
         auth_manager = Mock()
         is_authorized_method = Mock()
         is_authorized_method.return_value = True
@@ -148,9 +169,46 @@ class TestHasAccessWithDetails:
 
     @pytest.mark.db_test
     @patch("airflow.www.auth.get_auth_manager")
-    def test_has_access_with_details_when_unauthorized(
-        self, mock_get_auth_manager, app, decorator_name, is_authorized_method_name, items
-    ):
+    def test_has_access_to_connection_with_details_when_unauthorized(self, mock_get_auth_manager, app):
+        decorator_name = "has_access_connection"
+        is_authorized_method_name = "batch_is_authorized_connection"
+        items = [Connection("conn_1"), Connection("conn_2")]
+        auth_manager = Mock()
+        is_authorized_method = Mock()
+        is_authorized_method.return_value = False
+        setattr(auth_manager, is_authorized_method_name, is_authorized_method)
+        mock_get_auth_manager.return_value = auth_manager
+
+        with app.test_request_context():
+            result = getattr(auth, decorator_name)("GET")(self.method_test)(None, items)
+
+        mock_call.assert_not_called()
+        assert result.status_code == 302
+
+    @pytest.mark.db_test
+    @patch("airflow.www.auth.get_auth_manager")
+    def test_has_access_to_pool_with_details_when_unauthorized(self, mock_get_auth_manager, app):
+        decorator_name = "has_access_pool"
+        is_authorized_method_name = "batch_is_authorized_pool"
+        items = [Pool(pool="pool_1"), Pool(pool="pool_2")]
+        auth_manager = Mock()
+        is_authorized_method = Mock()
+        is_authorized_method.return_value = False
+        setattr(auth_manager, is_authorized_method_name, is_authorized_method)
+        mock_get_auth_manager.return_value = auth_manager
+
+        with app.test_request_context():
+            result = getattr(auth, decorator_name)("GET")(self.method_test)(None, items)
+
+        mock_call.assert_not_called()
+        assert result.status_code == 302
+
+    @pytest.mark.db_test
+    @patch("airflow.www.auth.get_auth_manager")
+    def test_has_access_to_variable_with_details_when_unauthorized(self, mock_get_auth_manager, app):
+        decorator_name = "has_access_variable"
+        is_authorized_method_name = "batch_is_authorized_variable"
+        items = [Variable("var_1"), Variable("var_2")]
         auth_manager = Mock()
         is_authorized_method = Mock()
         is_authorized_method.return_value = False


### PR DESCRIPTION
It's been an error in the [test_auth.py ](https://github.com/apache/airflow/blame/01fd0d31b46682f4d700aaacf19cfe7a0fe9a057/tests/www/test_auth.py#L126)
that makes this command to fails breeze testing non-db-tests --parallel-test-types "Always WWW".

It was a problem to create `Connection, Pool, Variable` in the parametrize section. 
This PR remove the parametrize section and create multiple tests instead of the parametrize.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
