### PR TITLE
Temporarily switch to MariaDB client due to mysql repo signing issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -325,9 +325,16 @@ install_mariadb_client() {
 }
 
 if [[ ${INSTALL_MYSQL_CLIENT:="true"} == "true" ]]; then
-    if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
-        INSTALL_MYSQL_CLIENT_TYPE="mariadb"
-    fi
+    # Temporary set mariadb as the client also for x86 until the problem of
+    # badly signed mysql repo is solved (or we decide to switch to mariadb
+    # permanently).
+    #
+    # See:
+    #  https://github.com/apache/airflow/issues/36231
+    #  https://bugs.mysql.com/bug.php?id=113427
+    #  https://bugs.mysql.com/bug.php?id=113428
+    #
+    INSTALL_MYSQL_CLIENT_TYPE="mariadb"
 
     if [[ "${INSTALL_MYSQL_CLIENT_TYPE}" == "mysql" ]]; then
         install_mysql_client "${@}"

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -285,9 +285,16 @@ install_mariadb_client() {
 }
 
 if [[ ${INSTALL_MYSQL_CLIENT:="true"} == "true" ]]; then
-    if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
-        INSTALL_MYSQL_CLIENT_TYPE="mariadb"
-    fi
+    # Temporary set mariadb as the client also for x86 until the problem of
+    # badly signed mysql repo is solved (or we decide to switch to mariadb
+    # permanently).
+    #
+    # See:
+    #  https://github.com/apache/airflow/issues/36231
+    #  https://bugs.mysql.com/bug.php?id=113427
+    #  https://bugs.mysql.com/bug.php?id=113428
+    #
+    INSTALL_MYSQL_CLIENT_TYPE="mariadb"
 
     if [[ "${INSTALL_MYSQL_CLIENT_TYPE}" == "mysql" ]]; then
         install_mysql_client "${@}"

--- a/scripts/docker/install_mysql.sh
+++ b/scripts/docker/install_mysql.sh
@@ -134,9 +134,16 @@ install_mariadb_client() {
 # https://mariadb.com/kb/en/mariadb-clientserver-tcp-protocol/
 # For ARM64 INSTALL_MYSQL_CLIENT_TYPE ignored and always install MariaDB.
 if [[ ${INSTALL_MYSQL_CLIENT:="true"} == "true" ]]; then
-    if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
-        INSTALL_MYSQL_CLIENT_TYPE="mariadb"
-    fi
+    # Temporary set mariadb as the client also for x86 until the problem of
+    # badly signed mysql repo is solved (or we decide to switch to mariadb
+    # permanently).
+    #
+    # See:
+    #  https://github.com/apache/airflow/issues/36231
+    #  https://bugs.mysql.com/bug.php?id=113427
+    #  https://bugs.mysql.com/bug.php?id=113428
+    #
+    INSTALL_MYSQL_CLIENT_TYPE="mariadb"
 
     if [[ "${INSTALL_MYSQL_CLIENT_TYPE}" == "mysql" ]]; then
         install_mysql_client "${@}"


### PR DESCRIPTION
We are temporarily switching to MariaDB client completely on our x86 builds to address a problem that mysql repo is now badly signed and we ar unable to install mysql client in a secure way.

This prevents our users from extending docker images and our CI is only working becasue we are using cache.

The issue is tracked in our repository:

* https://github.com/apache/airflow/issues/36231

And there are high severity issues in mysql where a number of users has the same problem:

https://bugs.mysql.com/bug.php?id=113427
https://bugs.mysql.com/bug.php?id=113428

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
