### PR TITLE
Update black linter example in `STATIC_CODE_CHECKS.rst`

### DIFF
--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -471,6 +471,14 @@ Run the ``ruff for the ``tests.core`` package with verbose output:
 
      breeze static-checks --type ruff --file tests/core/* --verbose
 
+Run the ``black`` check for the files ``airflow/example_dags/example_bash_operator.py`` and
+``airflow/example_dags/example_python_operator.py``:
+
+.. code-block:: bash
+
+     breeze static-checks --type black --file airflow/example_dags/example_bash_operator.py \
+         airflow/example_dags/example_python_operator.py
+
 Run all checks for the currently staged files:
 
 .. code-block:: bash

--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -465,18 +465,18 @@ Run the ``ruff`` check for the ``tests/core.py`` file with verbose output:
 
      breeze static-checks --type ruff --file tests/core.py --verbose
 
-Run the ``ruff for the ``tests.core`` package with verbose output:
+Run the ``ruff`` check for the ``tests.core`` package with verbose output:
 
 .. code-block:: bash
 
      breeze static-checks --type ruff --file tests/core/* --verbose
 
-Run the ``black`` check for the files ``airflow/example_dags/example_bash_operator.py`` and
+Run the ``ruff`` check for the files ``airflow/example_dags/example_bash_operator.py`` and
 ``airflow/example_dags/example_python_operator.py``:
 
 .. code-block:: bash
 
-     breeze static-checks --type black --file airflow/example_dags/example_bash_operator.py \
+     breeze static-checks --type ruff --file airflow/example_dags/example_bash_operator.py \
          airflow/example_dags/example_python_operator.py
 
 Run all checks for the currently staged files:

--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -471,7 +471,7 @@ Run the ``ruff`` check for the ``tests.core`` package with verbose output:
 
      breeze static-checks --type ruff --file tests/core/* --verbose
 
-Run the ``ruff`` check for the files ``airflow/example_dags/example_bash_operator.py`` and
+Run the ``ruff-format`` check for the files ``airflow/example_dags/example_bash_operator.py`` and
 ``airflow/example_dags/example_python_operator.py``:
 
 .. code-block:: bash

--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -476,7 +476,7 @@ Run the ``ruff-format`` check for the files ``airflow/example_dags/example_bash_
 
 .. code-block:: bash
 
-     breeze static-checks --type ruff --file airflow/example_dags/example_bash_operator.py \
+     breeze static-checks --type ruff-format --file airflow/example_dags/example_bash_operator.py \
          airflow/example_dags/example_python_operator.py
 
 Run all checks for the currently staged files:

--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -471,14 +471,6 @@ Run the ``ruff for the ``tests.core`` package with verbose output:
 
      breeze static-checks --type ruff --file tests/core/* --verbose
 
-Run the ``black`` check for the files ``airflow/example_dags/example_bash_operator.py`` and
-``airflow/example_dags/example_python_operator.py``:
-
-.. code-block:: bash
-
-     breeze static-checks --type black --file airflow/example_dags/example_bash_operator.py \
-         airflow/example_dags/example_python_operator.py
-
 Run all checks for the currently staged files:
 
 .. code-block:: bash


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Black linter was replaced by ruff as a pre-commit, so the example showing how to use the former is not relevant anymore.
<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
