### PR TITLE
Add a fuzzy/regex pattern-matching for metric allow and block list

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -944,6 +944,14 @@ metrics:
   description: |
     StatsD (https://github.com/etsy/statsd) integration settings.
   options:
+    metrics_use_fuzzy_match:
+      description: |
+        If true, metrics_allow_list and metrics_block_list will match anywhere in the metric
+        name and not just start of the name.
+      version_added: 2.7.4
+      type: boolean
+      example: ~
+      default: "False"
     metrics_allow_list:
       description: |
         If you want to avoid emitting all the available metrics, you can configure an

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -948,7 +948,7 @@ metrics:
       description: |
         If true, metrics_allow_list and metrics_block_list will use regex pattern matching
         anywhere within the metric name instead of only prefix matching at the start of the name.
-      version_added: 2.8.1
+      version_added: 2.9.0
       type: boolean
       example: ~
       default: "False"

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -946,8 +946,8 @@ metrics:
   options:
     metrics_use_pattern_match:
       description: |
-        If true, metrics_allow_list and metrics_block_list will use regex pattern matching in the metric
-        name and not just start of the name.
+        If true, metrics_allow_list and metrics_block_list will use regex pattern matching anywhere within the metric
+        name instead of only prefix matching at the start of the name.
       version_added: 2.7.4
       type: boolean
       example: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -946,8 +946,8 @@ metrics:
   options:
     metrics_use_pattern_match:
       description: |
-        If true, metrics_allow_list and metrics_block_list will use regex pattern matching anywhere within the metric
-        name instead of only prefix matching at the start of the name.
+        If true, metrics_allow_list and metrics_block_list will use regex pattern matching
+        anywhere within the metric name instead of only prefix matching at the start of the name.
       version_added: 2.7.4
       type: boolean
       example: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -948,28 +948,28 @@ metrics:
       description: |
         If true, metrics_allow_list and metrics_block_list will use regex pattern matching
         anywhere within the metric name instead of only prefix matching at the start of the name.
-      version_added: 2.7.4
+      version_added: 2.8.1
       type: boolean
       example: ~
       default: "False"
     metrics_allow_list:
       description: |
-        If you want to avoid emitting all the available metrics, you can configure an
-        allow list of prefixes (comma separated) to send only the metrics that start
-        with the elements of the list (e.g: "scheduler,executor,dagrun")
+        Configure an allow list (comma separated string) to send only certain metrics.
+        If metrics_use_pattern_match is false, match only the exact metric name prefix.
+        If metrics_use_pattern_match is true, provide regex patterns to match.
       version_added: 2.6.0
       type: string
-      example: ~
+      example: "\"scheduler,executor,dagrun\" or \"^scheduler,^executor,heartbeat|timeout\""
       default: ""
     metrics_block_list:
       description: |
-        If you want to avoid emitting all the available metrics, you can configure a
-        block list of prefixes (comma separated) to filter out metrics that start with
-        the elements of the list (e.g: "scheduler,executor,dagrun").
+        Configure a block list (comma separated string) to block certain metrics from being emitted.
         If metrics_allow_list and metrics_block_list are both configured, metrics_block_list is ignored.
+        If metrics_use_pattern_match is false, match only the exact metric name prefix.
+        If metrics_use_pattern_match is true, provide regex patterns to match.
       version_added: 2.6.0
       type: string
-      example: ~
+      example: "\"scheduler,executor,dagrun\" or \"^scheduler,^executor,heartbeat|timeout\""
       default: ""
     statsd_on:
       description: |

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -944,9 +944,9 @@ metrics:
   description: |
     StatsD (https://github.com/etsy/statsd) integration settings.
   options:
-    metrics_use_fuzzy_match:
+    metrics_use_pattern_match:
       description: |
-        If true, metrics_allow_list and metrics_block_list will match anywhere in the metric
+        If true, metrics_allow_list and metrics_block_list will use regex pattern matching in the metric
         name and not just start of the name.
       version_added: 2.7.4
       type: boolean

--- a/airflow/metrics/validators.py
+++ b/airflow/metrics/validators.py
@@ -85,6 +85,35 @@ BACK_COMPAT_METRIC_NAME_PATTERNS: set[str] = {
 BACK_COMPAT_METRIC_NAMES: set[Pattern[str]] = {re2.compile(name) for name in BACK_COMPAT_METRIC_NAME_PATTERNS}
 
 OTEL_NAME_MAX_LENGTH = 63
+DEFAULT_VALIDATOR_TYPE = "allow"
+
+
+def get_validator() -> ListValidator:
+    validators = {
+        "basic": {"allow": AllowListValidator, "block": BlockListValidator},
+        "fuzzy": {"allow": FuzzyAllowListValidator, "block": FuzzyBlockListValidator},
+    }
+    metric_lists = {
+        "allow": (metric_allow_list := conf.get("metrics", "metrics_allow_list", fallback=None)),
+        "block": (metric_block_list := conf.get("metrics", "metrics_block_list", fallback=None)),
+    }
+
+    validator_type = (
+        "fuzzy" if conf.getboolean("metrics", "metrics_use_fuzzy_match", fallback=False) else "basic"
+    )
+
+    if metric_allow_list:
+        list_type = "allow"
+        if metric_block_list:
+            log.warning(
+                "Ignoring metrics_block_list as both metrics_allow_list and metrics_block_list have been set."
+            )
+    elif metric_block_list:
+        list_type = "block"
+    else:
+        list_type = DEFAULT_VALIDATOR_TYPE
+
+    return validators[validator_type][list_type](metric_lists[list_type])
 
 
 def validate_stat(fn: Callable) -> Callable:
@@ -221,6 +250,12 @@ class ListValidator(metaclass=abc.ABCMeta):
         """Test if name is allowed."""
         raise NotImplementedError
 
+    def _has_fuzzy_match(self, name: str) -> bool:
+        for entry in self.validate_list or ():
+            if re2.findall(entry, name.strip().lower()):
+                return True
+        return False
+
 
 class AllowListValidator(ListValidator):
     """AllowListValidator only allows names that match the allowed prefixes."""
@@ -232,11 +267,31 @@ class AllowListValidator(ListValidator):
             return True  # default is all metrics are allowed
 
 
+class FuzzyAllowListValidator(ListValidator):
+    """Match the provided strings anywhere in the metric name."""
+
+    def test(self, name: str) -> bool:
+        if self.validate_list is not None:
+            return super()._has_fuzzy_match(name)
+        else:
+            return True  # default is all metrics are allowed
+
+
 class BlockListValidator(ListValidator):
     """BlockListValidator only allows names that do not match the blocked prefixes."""
 
     def test(self, name: str) -> bool:
         if self.validate_list is not None:
             return not name.strip().lower().startswith(self.validate_list)
+        else:
+            return True  # default is all metrics are allowed
+
+
+class FuzzyBlockListValidator(ListValidator):
+    """Only allow names that do not match the blocked strings."""
+
+    def test(self, name: str) -> bool:
+        if self.validate_list is not None:
+            return not super()._has_fuzzy_match(name)
         else:
             return True  # default is all metrics are allowed

--- a/airflow/metrics/validators.py
+++ b/airflow/metrics/validators.py
@@ -29,7 +29,7 @@ from typing import Callable, Iterable, Pattern, cast
 import re2
 
 from airflow.configuration import conf
-from airflow.exceptions import AirflowProviderDeprecationWarning, InvalidStatsNameException
+from airflow.exceptions import InvalidStatsNameException, RemovedInAirflow3Warning
 
 log = logging.getLogger(__name__)
 
@@ -105,7 +105,7 @@ def get_validator() -> ListValidator:
         warnings.warn(
             "The basic metric validator will be deprecated in the future in favor of pattern-matching.  "
             "You can try this now by setting config option metrics_use_pattern_match to True.",
-            AirflowProviderDeprecationWarning,
+            RemovedInAirflow3Warning,
             stacklevel=2,
         )
 

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import importlib
+import logging
 import re
 from unittest import mock
 from unittest.mock import Mock
@@ -29,7 +30,12 @@ import airflow
 from airflow.exceptions import AirflowConfigException, InvalidStatsNameException
 from airflow.metrics.datadog_logger import SafeDogStatsdLogger
 from airflow.metrics.statsd_logger import SafeStatsdLogger
-from airflow.metrics.validators import AllowListValidator, BlockListValidator
+from airflow.metrics.validators import (
+    AllowListValidator,
+    BlockListValidator,
+    FuzzyAllowListValidator,
+    FuzzyBlockListValidator,
+)
 from tests.test_utils.config import conf_vars
 
 
@@ -265,40 +271,105 @@ class TestDogStats:
         importlib.reload(airflow.stats)
 
 
-class TestStatsWithAllowList:
-    def setup_method(self):
-        self.statsd_client = Mock(spec=statsd.StatsClient)
-        self.stats = SafeStatsdLogger(self.statsd_client, AllowListValidator("stats_one, stats_two"))
+class TestStatsAllowAndBlockLists:
+    @pytest.mark.parametrize(
+        "validator, stat_name, expect_incr",
+        [
+            (FuzzyAllowListValidator, "stats_one", True),
+            (FuzzyAllowListValidator, "stats_two.bla", True),
+            (FuzzyAllowListValidator, "stats_three.foo", True),
+            (FuzzyAllowListValidator, "stats_foo_three", True),
+            (FuzzyAllowListValidator, "stats_three", False),
+            (AllowListValidator, "stats_one", True),
+            (AllowListValidator, "stats_two.bla", True),
+            (AllowListValidator, "stats_three.foo", False),
+            (AllowListValidator, "stats_foo_three", False),
+            (AllowListValidator, "stats_three", False),
+            (FuzzyBlockListValidator, "stats_one", False),
+            (FuzzyBlockListValidator, "stats_two.bla", False),
+            (FuzzyBlockListValidator, "stats_three.foo", False),
+            (FuzzyBlockListValidator, "stats_foo_three", False),
+            (FuzzyBlockListValidator, "stats_foo", False),
+            (FuzzyBlockListValidator, "stats_three", True),
+            (BlockListValidator, "stats_one", False),
+            (BlockListValidator, "stats_two.bla", False),
+            (BlockListValidator, "stats_three.foo", True),
+            (BlockListValidator, "stats_foo_three", True),
+            (BlockListValidator, "stats_three", True),
+        ],
+    )
+    def test_allow_and_block_list(self, validator, stat_name, expect_incr):
+        statsd_client = Mock(spec=statsd.StatsClient)
+        stats = SafeStatsdLogger(statsd_client, validator("stats_one, stats_two, foo"))
 
-    def test_increment_counter_with_allowed_key(self):
-        self.stats.incr("stats_one")
-        self.statsd_client.incr.assert_called_once_with("stats_one", 1, 1)
-
-    def test_increment_counter_with_allowed_prefix(self):
-        self.stats.incr("stats_two.bla")
-        self.statsd_client.incr.assert_called_once_with("stats_two.bla", 1, 1)
-
-    def test_not_increment_counter_if_not_allowed(self):
-        self.stats.incr("stats_three")
-        self.statsd_client.assert_not_called()
+        stats.incr(stat_name)
+        if expect_incr:
+            statsd_client.incr.assert_called_once_with(stat_name, 1, 1)
+        else:
+            statsd_client.assert_not_called()
 
 
-class TestStatsWithBlockList:
-    def setup_method(self):
-        self.statsd_client = Mock(spec=statsd.StatsClient)
-        self.stats = SafeStatsdLogger(self.statsd_client, BlockListValidator("stats_one, stats_two"))
+class TestFuzzyOrBasicValidatorConfigOption:
+    def teardown_method(self):
+        # Avoid side-effects
+        importlib.reload(airflow.stats)
 
-    def test_increment_counter_with_allowed_key(self):
-        self.stats.incr("stats_one")
-        self.statsd_client.assert_not_called()
+    stats_on = {("metrics", "statsd_on"): "True"}
+    fuzzy_on = {("metrics", "metrics_use_fuzzy_match"): "True"}
+    fuzzy_off = {("metrics", "metrics_use_fuzzy_match"): "False"}
+    allow_list = {("metrics", "metrics_allow_list"): "foo,bar"}
+    block_list = {("metrics", "metrics_block_list"): "foo,bar"}
 
-    def test_increment_counter_with_allowed_prefix(self):
-        self.stats.incr("stats_two.bla")
-        self.statsd_client.assert_not_called()
+    @pytest.mark.parametrize(
+        "config, expected",
+        [
+            pytest.param(
+                {**stats_on, **fuzzy_on},
+                FuzzyAllowListValidator,
+                id="fuzzy_allow_by_default",
+            ),
+            pytest.param(
+                stats_on,
+                AllowListValidator,
+                id="basic_allow_by_default",
+            ),
+            pytest.param(
+                {**stats_on, **fuzzy_on, **allow_list},
+                FuzzyAllowListValidator,
+                id="fuzzy_allow_list_provided",
+            ),
+            pytest.param(
+                {**stats_on, **fuzzy_off, **allow_list},
+                AllowListValidator,
+                id="basic_allow_list_provided",
+            ),
+            pytest.param(
+                {**stats_on, **fuzzy_on, **block_list},
+                FuzzyBlockListValidator,
+                id="fuzzy_block_list_provided",
+            ),
+            pytest.param(
+                {**stats_on, **block_list},
+                BlockListValidator,
+                id="basic_block_list_provided",
+            ),
+        ],
+    )
+    def test_fuzzy_or_basic_picker(self, config, expected):
+        with conf_vars(config):
+            importlib.reload(airflow.stats)
 
-    def test_not_increment_counter_if_not_allowed(self):
-        self.stats.incr("stats_three")
-        self.statsd_client.incr.assert_called_once_with("stats_three", 1, 1)
+            assert isinstance(airflow.stats.Stats.statsd, statsd.StatsClient)
+            assert type(airflow.stats.Stats.instance.metrics_validator) == expected
+
+    @conf_vars({**stats_on, **block_list, ("metrics", "metrics_allow_list"): "bax,qux"})
+    def test_setting_allow_and_block_logs_warning(self, caplog):
+        importlib.reload(airflow.stats)
+
+        assert isinstance(airflow.stats.Stats.statsd, statsd.StatsClient)
+        assert type(airflow.stats.Stats.instance.metrics_validator) == AllowListValidator
+        with caplog.at_level(logging.WARNING):
+            assert "Ignoring metrics_block_list" in caplog.text
 
 
 class TestDogStatsWithAllowList:

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -313,7 +313,7 @@ class TestStatsAllowAndBlockLists:
         "match_pattern, expect_incr",
         [
             ("^stat", True),
-            ("s.{6}o", True),
+            ("a.{4}o", True),
             ("^banana", False),
         ],
     )

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -303,6 +303,29 @@ class TestStatsAllowAndBlockLists:
         stats = SafeStatsdLogger(statsd_client, validator("stats_one, stats_two, foo"))
 
         stats.incr(stat_name)
+
+        if expect_incr:
+            statsd_client.incr.assert_called_once_with(stat_name, 1, 1)
+        else:
+            statsd_client.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "match_pattern, expect_incr",
+        [
+            ("^stat", True),
+            ("s.{6}o", True),
+            ("^banana", False),
+        ],
+    )
+    def test_regex_matches(self, match_pattern, expect_incr):
+        stat_name = "stats_foo_one"
+        validator = FuzzyAllowListValidator
+
+        statsd_client = Mock(spec=statsd.StatsClient)
+        stats = SafeStatsdLogger(statsd_client, validator(match_pattern))
+
+        stats.incr(stat_name)
+
         if expect_incr:
             statsd_client.incr.assert_called_once_with(stat_name, 1, 1)
         else:


### PR DESCRIPTION
Current metric allow and block lists allow the user to set which metric names to emit, but they only match on `startswith()`.  This PR adds two new Validators - FuzzyAllow and FuzzyBlock, which match using regex - along with a config option to chooze between the "basic" or "fuzzy" match and unit testing.

While I was in there I also noticed that the OTel metrics never implemented Blocklist, it only had an AllowList.  This could maybe have been a separate PR, but I fixed that bug while I was working on it since that would have required adjustments either way.

The new `get_validator()` method is a modified version of the decision logic previously used in the statsd logger, expanded to include the Fuzzy options, and then also applied to the otel logger.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
