### PR TITLE
Add version suffix if it is set during image builds

### DIFF
--- a/dev/breeze/src/airflow_breeze/params/build_ci_params.py
+++ b/dev/breeze/src/airflow_breeze/params/build_ci_params.py
@@ -21,7 +21,6 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from airflow_breeze.branch_defaults import DEFAULT_AIRFLOW_CONSTRAINTS_BRANCH
-from airflow_breeze.global_constants import get_airflow_version
 from airflow_breeze.params.common_build_params import CommonBuildParams
 from airflow_breeze.utils.path_utils import BUILD_CACHE_DIR
 
@@ -46,7 +45,7 @@ class BuildCiParams(CommonBuildParams):
 
     @property
     def airflow_version(self):
-        return get_airflow_version()
+        return self._get_version_with_suffix()
 
     @property
     def image_type(self) -> str:

--- a/dev/breeze/src/airflow_breeze/params/build_prod_params.py
+++ b/dev/breeze/src/airflow_breeze/params/build_prod_params.py
@@ -26,7 +26,6 @@ from airflow_breeze.global_constants import (
     AIRFLOW_SOURCES_FROM,
     AIRFLOW_SOURCES_TO,
     get_airflow_extras,
-    get_airflow_version,
 )
 from airflow_breeze.params.common_build_params import CommonBuildParams
 from airflow_breeze.utils.console import get_console
@@ -62,7 +61,7 @@ class BuildProdParams(CommonBuildParams):
         if self.install_airflow_version:
             return self.install_airflow_version
         else:
-            return get_airflow_version()
+            return self._get_version_with_suffix()
 
     @property
     def image_type(self) -> str:

--- a/dev/breeze/src/airflow_breeze/params/common_build_params.py
+++ b/dev/breeze/src/airflow_breeze/params/common_build_params.py
@@ -28,6 +28,7 @@ from airflow_breeze.global_constants import (
     ALLOWED_INSTALL_MYSQL_CLIENT_TYPES,
     APACHE_AIRFLOW_GITHUB_REPOSITORY,
     DOCKER_DEFAULT_PLATFORM,
+    get_airflow_version,
 )
 from airflow_breeze.utils.console import get_console
 from airflow_breeze.utils.platforms import get_real_platform
@@ -196,3 +197,16 @@ class CommonBuildParams:
         for arg in self.build_arg_values:
             build_args.extend(["--build-arg", arg])
         return build_args
+
+    def _get_version_with_suffix(self) -> str:
+        from packaging.version import Version
+
+        airflow_version = get_airflow_version()
+        try:
+            if self.version_suffix_for_pypi and self.version_suffix_for_pypi not in airflow_version:
+                version = Version(airflow_version)
+                return version.base_version + f".{self.version_suffix_for_pypi}"
+        except Exception:
+            # in case of any failure just fall back to the original version set
+            pass
+        return airflow_version


### PR DESCRIPTION
When we are building CI/PROD images, AIRFLOW_VERSION arg is retrieved from the current Airflow version set in version.py. This is find for main build when we are running image build tests, because there, the version contains `.dev0` and when we extend the image we can use `pip install airflow-version=${AIRFLOW_VERSION}`. However in release builds, the version in `version.py` does not contain version suffix, and this version of Airflow is not released yet.

This PR fixes it by checking if version_suffix_for_pypi is set, and it case it is and airflow version does not contain it, we will add the suffix automatically.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
