### PR TITLE
Replace deprecated `get_accessible_dag_ids` and use `get_readable_dags` in get_dag_warnings

### DIFF
--- a/airflow/api_connexion/endpoints/dag_warning_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_warning_endpoint.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from flask import g
 from sqlalchemy import select
 
 from airflow.api_connexion import security
@@ -27,9 +26,9 @@ from airflow.api_connexion.schemas.dag_warning_schema import (
     DagWarningCollection,
     dag_warning_collection_schema,
 )
+from airflow.api_connexion.security import get_readable_dags
 from airflow.auth.managers.models.resource_details import DagAccessEntity
 from airflow.models.dagwarning import DagWarning as DagWarningModel
-from airflow.utils.airflow_flask_app import get_airflow_app
 from airflow.utils.db import get_query_count
 from airflow.utils.session import NEW_SESSION, provide_session
 
@@ -61,7 +60,7 @@ def get_dag_warnings(
     if dag_id:
         query = query.where(DagWarningModel.dag_id == dag_id)
     else:
-        readable_dags = get_airflow_app().appbuilder.sm.get_accessible_dag_ids(g.user)
+        readable_dags = get_readable_dags()
         query = query.where(DagWarningModel.dag_id.in_(readable_dags))
     if warning_type:
         query = query.where(DagWarningModel.warning_type == warning_type)

--- a/airflow/api_connexion/security.py
+++ b/airflow/api_connexion/security.py
@@ -267,5 +267,5 @@ def requires_access_custom_view(
     return requires_access_decorator
 
 
-def get_readable_dags() -> list[str]:
-    return get_airflow_app().appbuilder.sm.get_accessible_dag_ids(g.user)
+def get_readable_dags() -> set[str]:
+    return get_auth_manager().get_permitted_dag_ids(user=g.user)


### PR DESCRIPTION
This PR updates the method `get_readable_dags` by replacing the deprecated method with the new one, and uses this method in the endpoint  `get_dag_warnings`.