### PR TITLE
Check DAG read permission before accessing DAG code

### DIFF
--- a/airflow/models/dagcode.py
+++ b/airflow/models/dagcode.py
@@ -177,12 +177,13 @@ class DagCode(Base):
         return cls.code(fileloc)
 
     @classmethod
-    def code(cls, fileloc) -> str:
+    @provide_session
+    def code(cls, fileloc, session: Session = NEW_SESSION) -> str:
         """Return source code for this DagCode object.
 
         :return: source code as string
         """
-        return cls._get_code_from_db(fileloc)
+        return cls._get_code_from_db(fileloc, session)
 
     @staticmethod
     def _get_code_from_file(fileloc):

--- a/tests/api_connexion/endpoints/test_dag_source_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_source_endpoint.py
@@ -34,6 +34,10 @@ if TYPE_CHECKING:
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
 EXAMPLE_DAG_FILE = os.path.join("airflow", "example_dags", "example_bash_operator.py")
+EXAMPLE_DAG_ID = "example_bash_operator"
+TEST_DAG_ID = "latest_only"
+NOT_READABLE_DAG_ID = "latest_only_with_trigger"
+TEST_MULTIPLE_DAGS_ID = "dataset_produces_1"
 
 
 @pytest.fixture(scope="module")
@@ -44,6 +48,18 @@ def configured_app(minimal_app_for_api):
         username="test",
         role_name="Test",
         permissions=[(permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_CODE)],  # type: ignore
+    )
+    app.appbuilder.sm.sync_perm_for_dag(  # type: ignore
+        TEST_DAG_ID,
+        access_control={"Test": [permissions.ACTION_CAN_READ]},
+    )
+    app.appbuilder.sm.sync_perm_for_dag(  # type: ignore
+        EXAMPLE_DAG_ID,
+        access_control={"Test": [permissions.ACTION_CAN_READ]},
+    )
+    app.appbuilder.sm.sync_perm_for_dag(  # type: ignore
+        TEST_MULTIPLE_DAGS_ID,
+        access_control={"Test": [permissions.ACTION_CAN_READ]},
     )
     create_user(app, username="test_no_permissions", role_name="TestNoPermissions")  # type: ignore
 
@@ -80,10 +96,10 @@ class TestGetSource:
     def test_should_respond_200_text(self, url_safe_serializer):
         dagbag = DagBag(dag_folder=EXAMPLE_DAG_FILE)
         dagbag.sync_to_db()
-        first_dag: DAG = next(iter(dagbag.dags.values()))
-        dag_docstring = self._get_dag_file_docstring(first_dag.fileloc)
+        test_dag: DAG = dagbag.dags[TEST_DAG_ID]
+        dag_docstring = self._get_dag_file_docstring(test_dag.fileloc)
 
-        url = f"/api/v1/dagSources/{url_safe_serializer.dumps(first_dag.fileloc)}"
+        url = f"/api/v1/dagSources/{url_safe_serializer.dumps(test_dag.fileloc)}"
         response = self.client.get(
             url, headers={"Accept": "text/plain"}, environ_overrides={"REMOTE_USER": "test"}
         )
@@ -95,10 +111,10 @@ class TestGetSource:
     def test_should_respond_200_json(self, url_safe_serializer):
         dagbag = DagBag(dag_folder=EXAMPLE_DAG_FILE)
         dagbag.sync_to_db()
-        first_dag: DAG = next(iter(dagbag.dags.values()))
-        dag_docstring = self._get_dag_file_docstring(first_dag.fileloc)
+        test_dag: DAG = dagbag.dags[TEST_DAG_ID]
+        dag_docstring = self._get_dag_file_docstring(test_dag.fileloc)
 
-        url = f"/api/v1/dagSources/{url_safe_serializer.dumps(first_dag.fileloc)}"
+        url = f"/api/v1/dagSources/{url_safe_serializer.dumps(test_dag.fileloc)}"
         response = self.client.get(
             url, headers={"Accept": "application/json"}, environ_overrides={"REMOTE_USER": "test"}
         )
@@ -110,9 +126,9 @@ class TestGetSource:
     def test_should_respond_406(self, url_safe_serializer):
         dagbag = DagBag(dag_folder=EXAMPLE_DAG_FILE)
         dagbag.sync_to_db()
-        first_dag: DAG = next(iter(dagbag.dags.values()))
+        test_dag: DAG = dagbag.dags[TEST_DAG_ID]
 
-        url = f"/api/v1/dagSources/{url_safe_serializer.dumps(first_dag.fileloc)}"
+        url = f"/api/v1/dagSources/{url_safe_serializer.dumps(test_dag.fileloc)}"
         response = self.client.get(
             url, headers={"Accept": "image/webp"}, environ_overrides={"REMOTE_USER": "test"}
         )
@@ -151,3 +167,38 @@ class TestGetSource:
             environ_overrides={"REMOTE_USER": "test_no_permissions"},
         )
         assert response.status_code == 403
+
+    def test_should_respond_403_not_readable(self, url_safe_serializer):
+        dagbag = DagBag(dag_folder=EXAMPLE_DAG_FILE)
+        dagbag.sync_to_db()
+        dag: DAG = dagbag.dags[NOT_READABLE_DAG_ID]
+
+        response = self.client.get(
+            f"/api/v1/dagSources/{url_safe_serializer.dumps(dag.fileloc)}",
+            headers={"Accept": "text/plain"},
+            environ_overrides={"REMOTE_USER": "test"},
+        )
+        read_dag = self.client.get(
+            f"/api/v1/dags/{NOT_READABLE_DAG_ID}",
+            environ_overrides={"REMOTE_USER": "test"},
+        )
+        assert response.status_code == 403
+        assert read_dag.status_code == 403
+
+    def test_should_respond_403_some_dags_not_readable_in_the_file(self, url_safe_serializer):
+        dagbag = DagBag(dag_folder=EXAMPLE_DAG_FILE)
+        dagbag.sync_to_db()
+        dag: DAG = dagbag.dags[TEST_MULTIPLE_DAGS_ID]
+
+        response = self.client.get(
+            f"/api/v1/dagSources/{url_safe_serializer.dumps(dag.fileloc)}",
+            headers={"Accept": "text/plain"},
+            environ_overrides={"REMOTE_USER": "test"},
+        )
+
+        read_dag = self.client.get(
+            f"/api/v1/dags/{TEST_MULTIPLE_DAGS_ID}",
+            environ_overrides={"REMOTE_USER": "test"},
+        )
+        assert response.status_code == 403
+        assert read_dag.status_code == 200


### PR DESCRIPTION
This PR checks if the user has read access on the DAG before allowing the reading of the DAG code. If the DAG is defined with other DAGs in the same file, the user should have read access to all the other DAGs. Otherwise, he will be forbidden from reading the file code.