### PR TITLE
Bugfix/fix Non DB - WWW and Always tests

### DIFF
--- a/tests/www/test_auth.py
+++ b/tests/www/test_auth.py
@@ -111,16 +111,31 @@ class TestHasAccessNoDetails:
         assert result.status_code == 302
 
 
+@pytest.fixture()
+def get_connection():
+    return [Connection("conn_1"), Connection("conn_2")]
+
+
+@pytest.fixture()
+def get_pool():
+    return [Pool(pool="pool_1"), Pool(pool="pool_2")]
+
+
+@pytest.fixture()
+def get_variable():
+    return [Variable("var_1"), Variable("var_2")]
+
+
 @pytest.mark.parametrize(
     "decorator_name, is_authorized_method_name, items",
     [
         (
             "has_access_connection",
             "batch_is_authorized_connection",
-            [Connection("conn_1"), Connection("conn_2")],
+            "get_connection",
         ),
-        ("has_access_pool", "batch_is_authorized_pool", [Pool(pool="pool_1"), Pool(pool="pool_2")]),
-        ("has_access_variable", "batch_is_authorized_variable", [Variable("var_1"), Variable("var_2")]),
+        ("has_access_pool", "batch_is_authorized_pool", "get_pool"),
+        ("has_access_variable", "batch_is_authorized_variable", "get_variable"),
     ],
 )
 class TestHasAccessWithDetails:
@@ -133,8 +148,9 @@ class TestHasAccessWithDetails:
 
     @patch("airflow.www.auth.get_auth_manager")
     def test_has_access_with_details_when_authorized(
-        self, mock_get_auth_manager, decorator_name, is_authorized_method_name, items
+        self, mock_get_auth_manager, decorator_name, is_authorized_method_name, items, request
     ):
+        items = request.getfixturevalue(items)
         auth_manager = Mock()
         is_authorized_method = Mock()
         is_authorized_method.return_value = True
@@ -149,8 +165,9 @@ class TestHasAccessWithDetails:
     @pytest.mark.db_test
     @patch("airflow.www.auth.get_auth_manager")
     def test_has_access_with_details_when_unauthorized(
-        self, mock_get_auth_manager, app, decorator_name, is_authorized_method_name, items
+        self, mock_get_auth_manager, app, decorator_name, is_authorized_method_name, items, request
     ):
+        items = request.getfixturevalue(items)
         auth_manager = Mock()
         is_authorized_method = Mock()
         is_authorized_method.return_value = False


### PR DESCRIPTION
It was a bug when creating object the use sqlalchemy inside paramtrize.
move creation of  object that depends on sqlalchemy into fixtures 
u can find more in this [documentation](https://github.com/apache/airflow/blob/main/TESTING.rst#problems-with-non-db-test-collection) 
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
