### PR TITLE
Provide the consumed message to consumer.commit in AwaitMessageTrigger

### DIFF
--- a/airflow/providers/apache/kafka/triggers/await_message.py
+++ b/airflow/providers/apache/kafka/triggers/await_message.py
@@ -108,9 +108,9 @@ class AwaitMessageTrigger(BaseTrigger):
             else:
                 rv = await async_message_process(message)
                 if rv:
-                    await async_commit(asynchronous=False)
+                    await async_commit(message=message, asynchronous=False)
                     yield TriggerEvent(rv)
                     break
                 else:
-                    await async_commit(asynchronous=False)
+                    await async_commit(message=message, asynchronous=False)
                     await asyncio.sleep(self.poll_interval)


### PR DESCRIPTION
closes: #32585

This PR tries to fix the issue by providing the consumed message to the commit method as explained by https://github.com/confluentinc/confluent-kafka-python/issues/295#issuecomment-1216555225 which confirms that this solution fixed the issue in the .NET client.

Unfortunately, it was not possible to reproduce the issue locally or in a test.