### PR TITLE
SQLCheckOperator fails if it returns dict with any Falsy values

### DIFF
--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -729,6 +729,8 @@ class SQLCheckOperator(BaseSQLOperator):
     The ``SQLCheckOperator`` expects a sql query that will return a single row.
     Each value on that first row is evaluated using python ``bool`` casting.
     If any of the values return ``False`` the check is failed and errors out.
+    If a Python dict is returned, and any values in the Python dict are ``False``,
+    the check is failed and errors out.
 
     Note that Python bool casting evals the following as ``False``:
 
@@ -737,6 +739,7 @@ class SQLCheckOperator(BaseSQLOperator):
     * Empty string (``""``)
     * Empty list (``[]``)
     * Empty dictionary or set (``{}``)
+    * Dictionary with value = ``False`` (``{'DUPLICATE_ID_CHECK': False}``)
 
     Given a query like ``SELECT COUNT(*) FROM foo``, it will fail only if
     the count ``== 0``. You can craft much more complex query that could,
@@ -785,6 +788,8 @@ class SQLCheckOperator(BaseSQLOperator):
         self.log.info("Record: %s", records)
         if not records:
             self._raise_exception(f"The following query returned zero rows: {self.sql}")
+        elif isinstance(records, dict) and not all(records.values()):
+            self._raise_exception(f"Test failed.\nQuery:\n{self.sql}\nResults:\n{records!s}")
         elif not all(records):
             self._raise_exception(f"Test failed.\nQuery:\n{self.sql}\nResults:\n{records!s}")
 

--- a/tests/providers/common/sql/operators/test_sql.py
+++ b/tests/providers/common/sql/operators/test_sql.py
@@ -642,6 +642,16 @@ class TestCheckOperator:
             self._operator.execute({})
 
     @mock.patch.object(SQLCheckOperator, "get_db_hook")
+    def test_execute_records_dict_not_all_values_are_true(self, mock_get_db_hook):
+        mock_get_db_hook.return_value.get_first.return_value = {
+            "DUPLICATE_ID_CHECK": False,
+            "NULL_VALUES_CHECK": True,
+        }
+
+        with pytest.raises(AirflowException, match=r"Test failed."):
+            self._operator.execute({})
+
+    @mock.patch.object(SQLCheckOperator, "get_db_hook")
     def test_sqlcheckoperator_parameters(self, mock_get_db_hook):
         self._operator.execute({})
         mock_get_db_hook.return_value.get_first.assert_called_once_with("sql", "parameters")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

closes: #34794

This PR modifys the SQLCheckOperator's behaviour in how it handles reading a Python `dict`.

Previously, if a Python `dict` was returned by the SQL query, the SQLCheckOperator would always pass. As suggested in the linked issue, if a Python `dict` is returned it is recommended that if any of the dict's values are False-y , then the Operator should fail. This PR makes that change.

For example, if the SQL query being tested returns:

```sql
{'DUPLICATE_ID_CHECK': False, 'NULL_VALUES_CHECK': True}
```

then the operator should return False, since there is a Falsy value present.

The PR also adds an additional unit test and updated the documentation of the Operator.

**Question for reviewers**: I am concerned that users may be implementing this operator under the assumption that any `dict` returned means the task should pass. With this change, that would now lead to the task failing.

---