### PR TITLE
Use `batch_is_authorized_dag` to check if user has permission to read DAGs

### DIFF
--- a/airflow/api_connexion/endpoints/dag_source_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_source_endpoint.py
@@ -49,7 +49,7 @@ def get_dag_source(*, file_token: str, session: Session = NEW_SESSION) -> Respon
         requests: Sequence[IsAuthorizedDagRequest] = [
             {
                 "method": "GET",
-                "details": DagDetails(id=dag_id),
+                "details": DagDetails(id=dag_id[0]),
             }
             for dag_id in dag_ids
         ]

--- a/airflow/api_connexion/endpoints/dag_source_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_source_endpoint.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from http import HTTPStatus
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence
 
 from flask import Response, current_app, request
 from itsdangerous import BadSignature, URLSafeSerializer
@@ -25,14 +25,16 @@ from itsdangerous import BadSignature, URLSafeSerializer
 from airflow.api_connexion import security
 from airflow.api_connexion.exceptions import NotFound, PermissionDenied
 from airflow.api_connexion.schemas.dag_source_schema import dag_source_schema
-from airflow.api_connexion.security import get_readable_dags
-from airflow.auth.managers.models.resource_details import DagAccessEntity
+from airflow.auth.managers.models.resource_details import DagAccessEntity, DagDetails
 from airflow.models.dag import DagModel
 from airflow.models.dagcode import DagCode
 from airflow.utils.session import NEW_SESSION, provide_session
+from airflow.www.extensions.init_auth_manager import get_auth_manager
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+
+    from airflow.auth.managers.models.batch_apis import IsAuthorizedDagRequest
 
 
 @security.requires_access_dag("GET", DagAccessEntity.CODE)
@@ -44,9 +46,16 @@ def get_dag_source(*, file_token: str, session: Session = NEW_SESSION) -> Respon
     try:
         path = auth_s.loads(file_token)
         dag_ids = session.query(DagModel.dag_id).filter(DagModel.fileloc == path).all()
-        readable_dags = get_readable_dags()
+        requests: Sequence[IsAuthorizedDagRequest] = [
+            {
+                "method": "GET",
+                "details": DagDetails(id=dag_id),
+            }
+            for dag_id in dag_ids
+        ]
+
         # Check if user has read access to all the DAGs defined in the file
-        if any(dag_id[0] not in readable_dags for dag_id in dag_ids):
+        if not get_auth_manager().batch_is_authorized_dag(requests):
             raise PermissionDenied()
         dag_source = DagCode.code(path, session=session)
     except (BadSignature, FileNotFoundError):

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -418,7 +418,7 @@
       "asgiref>=3.5.2",
       "gcloud-aio-auth>=4.0.0,<5.0.0",
       "gcloud-aio-bigquery>=6.1.2",
-      "gcloud-aio-storage",
+      "gcloud-aio-storage>=9.0.0",
       "gcsfs>=2023.10.0",
       "google-ads>=22.1.0",
       "google-api-core>=2.11.0",


### PR DESCRIPTION
In `get_dag_source`, it first fetch all accessible DAG ids for the current user and then check if the DAGs belong to these. It makes more sense to use the API made to figure out if a user has permission to access multiple DAGs: `batch_is_authorized_dag`.

See #36257.

cc @hussein-awala 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
