### PR TITLE
Fix using extras when `--use-airflow-version` is used in Breeze

### DIFF
--- a/dev/breeze/src/airflow_breeze/params/shell_params.py
+++ b/dev/breeze/src/airflow_breeze/params/shell_params.py
@@ -328,6 +328,13 @@ class ShellParams:
 
         if self.executor == "CeleryExecutor":
             compose_file_list.append(DOCKER_COMPOSE_DIR / "integration-celery.yml")
+            if self.use_airflow_version:
+                current_extras = self.airflow_extras
+                if "celery" not in current_extras.split(","):
+                    get_console().print(
+                        "[warning]Adding `celery` extras as it is implicitly needed by celery executor"
+                    )
+                    self.airflow_extras = ",".join(current_extras.split(",") + ["celery"])
 
         compose_file_list.append(DOCKER_COMPOSE_DIR / "base.yml")
         self.add_docker_in_docker(compose_file_list)

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -751,20 +751,6 @@ def enter_shell(shell_params: ShellParams, output: Output | None = None) -> RunC
             f"Changing the executor to {SEQUENTIAL_EXECUTOR}.\n"
         )
         shell_params.executor = SEQUENTIAL_EXECUTOR
-
-    if shell_params.executor == "CeleryExecutor" and shell_params.use_airflow_version:
-        if shell_params.airflow_extras and "celery" not in shell_params.airflow_extras.split():
-            get_console().print(
-                f"\n[warning]CeleryExecutor requires airflow_extras: celery. "
-                f"Adding celery to extras: '{shell_params.airflow_extras}'.\n"
-            )
-            shell_params.airflow_extras += ",celery"
-        elif not shell_params.airflow_extras:
-            get_console().print(
-                "\n[warning]CeleryExecutor requires airflow_extras: celery. "
-                "Setting airflow extras to 'celery'.\n"
-            )
-            shell_params.airflow_extras = "celery"
     if shell_params.restart:
         bring_compose_project_down(preserve_volumes=False, shell_params=shell_params)
     if shell_params.include_mypy_volume:

--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -253,7 +253,7 @@ def find_installation_spec(
         )
     else:
         console.print(f"\nInstalling airflow via apache-airflow=={use_airflow_version}")
-        airflow_package_spec = f"apache-airflow=={use_airflow_version}{airflow_extras}"
+        airflow_package_spec = f"apache-airflow{airflow_extras}=={use_airflow_version}"
         airflow_constraints_location = get_airflow_constraints_location(
             airflow_skip_constraints=airflow_skip_constraints,
             airflow_constraints_mode=airflow_constraints_mode,


### PR DESCRIPTION
When we are installing a released version of Airflow in Breeze, we can pass additional extras to install (For example, we need to pass celery extra in order to start airflow with celery executor.

The extras could be specified as:

```
breeze start-airflow --use-airflow-version 2.8.0rc4  \
  --executor CeleryExecutor --airflow-extras "celery"

```

However recent refactors caused a problem that the extras added were specified after version (which is rejected by newer versions of `pip`).

This PR fixes it and also moves the place where CeleryExecutor use triggers adding celery extra when`--use-airflow-version` is used.

The warning about this is better visible when moving to Shell Params.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
