### PR TITLE
Move removal of chicken-egg providers to before releasing image

### DIFF
--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -40,6 +40,7 @@
 - [Publish the final Apache Airflow release](#publish-the-final-apache-airflow-release)
   - [Summarize the voting for the Apache Airflow release](#summarize-the-voting-for-the-apache-airflow-release)
   - [Publish release to SVN](#publish-release-to-svn)
+  - [Remove chicken-egg providers](#remove-chicken-egg-providers)
   - [Manually prepare production Docker Image](#manually-prepare-production-docker-image)
   - [Verify production images](#verify-production-images)
   - [Publish documentation](#publish-documentation)
@@ -764,6 +765,20 @@ export AIRFLOW_REPO_ROOT=$(pwd)
 breeze release-management start-release --release-candidate ${RC} --previous-release <PREVIOUS RELEASE>
 ```
 
+## Remove chicken-egg providers
+
+For the first MINOR (X.Y.0) release - remove all providers from ``CHICKEN_EGG_PROVIDERS`` list
+in ``src/airflow_breeze/global_constants.py`` that have >= ``X.Y.0`` in the corresponding provider.yaml file.
+
+In case the provider should also be installed in the image (it is part of ``airflow/providers/installed_providers.txt``)
+it should also be added at this moment to ``Dockerfile`` to the list of default extras in the lin with ``AIRFLOW_EXTRAS``:
+
+```Dockerfile
+ARG AIRFLOW_EXTRAS=".....,<provider>,...."
+```
+
+This change needs to be merged to ``main`` and cherry-picked to ``v2-*-test`` branch before building the image.
+
 ## Manually prepare production Docker Image
 
 Building the image is triggered by running the
@@ -774,7 +789,7 @@ When you trigger it you need to pass:
 * Airflow Version
 * Optional "true" in skip latest field if you do not want to re-tag the latest image
 
-Make sure you use v2-*-stable branch to run the workflow.
+Make sure you use ``v2-*-test`` branch to run the workflow.
 
 ![Release prod image](images/release_prod_image.png)
 
@@ -980,8 +995,6 @@ This includes:
 - Sync `RELEASE_NOTES.rst` (including deleting relevant `newsfragments`) and `README.md` changes.
 - Updating `Dockerfile` with the new version.
 - Updating `airflow_bug_report.yml` issue template in `.github/ISSUE_TEMPLATE/` with the new version.
-- For the first MINOR (X.Y.0) release - remove all providers from ``CHICKEN_EGG_PROVIDERS`` list
-  in ``src/airflow_breeze/global_constants.py`` that have >= ``X.Y.0`` in the corresponding provider.yaml file.
 
 ## Update default Airflow version in the helm chart
 


### PR DESCRIPTION
Once Airflow is relesed to PyPI we should remove chicken-egg providers for that release and cherry-pick them to v2-*-test in order to prepare container images in case the image contains the providers as default extras.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
