### PR TITLE
Added functionality to automatically ingest custom airflow.cfg file upon startup

### DIFF
--- a/docs/apache-airflow/howto/docker-compose/docker-compose.yaml
+++ b/docs/apache-airflow/howto/docker-compose/docker-compose.yaml
@@ -41,7 +41,7 @@
 #                                A better way is to build a custom image or extend the official image
 #                                as described in https://airflow.apache.org/docs/docker-stack/build.html.
 #                                Default: ''
-# 
+#
 # Feel free to modify this file to suit your needs.
 ---
 x-airflow-common:
@@ -69,15 +69,14 @@ x-airflow-common:
     # WARNING: Use _PIP_ADDITIONAL_REQUIREMENTS option ONLY for a quick checks
     # for other purpose (development, test and especially production usage) build/extend Airflow image.
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
-    #The following line can be used to set a custom config file, stored in the local config folder
-    #If you want to use it, outcomment it and replace airflow.cfg with the name of your config file
-    #AIRFLOW_CONFIG: '/opt/airflow/config/airflow.cfg'
+    # The following line can be used to set a custom config file, stored in the local config folder
+    # If you want to use it, outcomment it and replace airflow.cfg with the name of your config file
+    # AIRFLOW_CONFIG: '/opt/airflow/config/airflow.cfg'
   volumes:
     - ${AIRFLOW_PROJ_DIR:-.}/dags:/opt/airflow/dags
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
     - ${AIRFLOW_PROJ_DIR:-.}/config:/opt/airflow/config
     - ${AIRFLOW_PROJ_DIR:-.}/plugins:/opt/airflow/plugins
-
   user: "${AIRFLOW_UID:-50000}:0"
   depends_on:
     &airflow-common-depends-on

--- a/docs/apache-airflow/howto/docker-compose/docker-compose.yaml
+++ b/docs/apache-airflow/howto/docker-compose/docker-compose.yaml
@@ -70,7 +70,7 @@ x-airflow-common:
     # for other purpose (development, test and especially production usage) build/extend Airflow image.
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
     #The following line can be used to set a custom location for a config file 
-    #If you want to use it, outcomment it and replace airfloe.cfg with the name of your config file
+    #If you want to use it, outcomment it and replace airflow.cfg with the name of your config file
     #AIRFLOW_CONFIG: '/opt/airflow/config/airflow.cfg'
   volumes:
     - ${AIRFLOW_PROJ_DIR:-.}/dags:/opt/airflow/dags

--- a/docs/apache-airflow/howto/docker-compose/docker-compose.yaml
+++ b/docs/apache-airflow/howto/docker-compose/docker-compose.yaml
@@ -69,7 +69,7 @@ x-airflow-common:
     # WARNING: Use _PIP_ADDITIONAL_REQUIREMENTS option ONLY for a quick checks
     # for other purpose (development, test and especially production usage) build/extend Airflow image.
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
-    #The following line can be used to set a custom location for a config file 
+    #The following line can be used to set a custom config file, stored in the local config folder
     #If you want to use it, outcomment it and replace airflow.cfg with the name of your config file
     #AIRFLOW_CONFIG: '/opt/airflow/config/airflow.cfg'
   volumes:

--- a/docs/apache-airflow/howto/docker-compose/docker-compose.yaml
+++ b/docs/apache-airflow/howto/docker-compose/docker-compose.yaml
@@ -41,7 +41,7 @@
 #                                A better way is to build a custom image or extend the official image
 #                                as described in https://airflow.apache.org/docs/docker-stack/build.html.
 #                                Default: ''
-#
+# 
 # Feel free to modify this file to suit your needs.
 ---
 x-airflow-common:
@@ -61,7 +61,6 @@ x-airflow-common:
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
     AIRFLOW__CORE__LOAD_EXAMPLES: 'true'
     AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session'
-    TEST: 
     # yamllint disable rule:line-length
     # Use simple http server on scheduler for health checks
     # See https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/check-health.html#scheduler-health-check-server
@@ -70,14 +69,14 @@ x-airflow-common:
     # WARNING: Use _PIP_ADDITIONAL_REQUIREMENTS option ONLY for a quick checks
     # for other purpose (development, test and especially production usage) build/extend Airflow image.
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
+    #The following line can be used to set a custom location for a config file 
+    #If you want to use it, outcomment it and replace airfloe.cfg with the name of your config file
+    #AIRFLOW_CONFIG: '/opt/airflow/config/airflow.cfg'
   volumes:
     - ${AIRFLOW_PROJ_DIR:-.}/dags:/opt/airflow/dags
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
     - ${AIRFLOW_PROJ_DIR:-.}/config:/opt/airflow/config
     - ${AIRFLOW_PROJ_DIR:-.}/plugins:/opt/airflow/plugins
-    #The following line can be used to use a custom airflow.cfg, stored in the AIRFLOW_PROJ_DIR
-    #Uncomment the following line to make use of this
-    #- ${AIRFLOW_PROJ_DIR:-.}/airflow.cfg:/opt/airflow/airflow.cfg
 
   user: "${AIRFLOW_UID:-50000}:0"
   depends_on:

--- a/docs/apache-airflow/howto/docker-compose/docker-compose.yaml
+++ b/docs/apache-airflow/howto/docker-compose/docker-compose.yaml
@@ -61,6 +61,7 @@ x-airflow-common:
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
     AIRFLOW__CORE__LOAD_EXAMPLES: 'true'
     AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session'
+    TEST: 
     # yamllint disable rule:line-length
     # Use simple http server on scheduler for health checks
     # See https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/check-health.html#scheduler-health-check-server
@@ -74,6 +75,10 @@ x-airflow-common:
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
     - ${AIRFLOW_PROJ_DIR:-.}/config:/opt/airflow/config
     - ${AIRFLOW_PROJ_DIR:-.}/plugins:/opt/airflow/plugins
+    #The following line can be used to use a custom airflow.cfg, stored in the AIRFLOW_PROJ_DIR
+    #Uncomment the following line to make use of this
+    #- ${AIRFLOW_PROJ_DIR:-.}/airflow.cfg:/opt/airflow/airflow.cfg
+
   user: "${AIRFLOW_UID:-50000}:0"
   depends_on:
     &airflow-common-depends-on

--- a/docs/apache-airflow/howto/docker-compose/index.rst
+++ b/docs/apache-airflow/howto/docker-compose/index.rst
@@ -345,10 +345,13 @@ Special case - Adding a custom config file
 
 If you have a custom config file and wish to use it in your Airflow instance, you need to perform the following steps:
 
-1) Remove comment from the ``- ${AIRFLOW_PROJ_DIR:-.}/airflow.cfg:/opt/airflow/airflow.cfg`` line 
+1) Remove comment from the ``AIRFLOW_CONFIG: '/opt/airflow/config/airflow.cfg'`` line 
    in the ``docker-compose.yaml`` file.  
 
-2) Place your custom ``airflow.cfg`` file in the same folder as the ``docker-compose.yaml`` file.
+2) Place your custom ``airflow.cfg`` file in the local config folder.
+
+3) If your config file has a different name than ``airflow.cfg``, adjust the filename in 
+   ``AIRFLOW_CONFIG: '/opt/airflow/config/airflow.cfg'``
 
 Networking
 ==========

--- a/docs/apache-airflow/howto/docker-compose/index.rst
+++ b/docs/apache-airflow/howto/docker-compose/index.rst
@@ -340,6 +340,16 @@ that conflicts with the version of apache-airflow that you are using.
 Run ``docker compose build`` to build the image, or add ``--build`` flag to ``docker compose up`` or
 ``docker compose run`` commands to build the image automatically as needed.
 
+Special case - Adding a custom config file
+==========================================
+
+If you have a custom config file and wish to use it in your Airflow instance, you need to perform the following steps:
+
+1) Remove comment from the ``- ${AIRFLOW_PROJ_DIR:-.}/airflow.cfg:/opt/airflow/airflow.cfg`` line 
+   in the ``docker-compose.yaml`` file.  
+
+2) Place your custom ``airflow.cfg`` file in the same folder as the ``docker-compose.yaml`` file.
+
 Networking
 ==========
 

--- a/docs/apache-airflow/howto/docker-compose/index.rst
+++ b/docs/apache-airflow/howto/docker-compose/index.rst
@@ -345,12 +345,12 @@ Special case - Adding a custom config file
 
 If you have a custom config file and wish to use it in your Airflow instance, you need to perform the following steps:
 
-1) Remove comment from the ``AIRFLOW_CONFIG: '/opt/airflow/config/airflow.cfg'`` line 
-   in the ``docker-compose.yaml`` file.  
+1) Remove comment from the ``AIRFLOW_CONFIG: '/opt/airflow/config/airflow.cfg'`` line
+   in the ``docker-compose.yaml`` file.
 
 2) Place your custom ``airflow.cfg`` file in the local config folder.
 
-3) If your config file has a different name than ``airflow.cfg``, adjust the filename in 
+3) If your config file has a different name than ``airflow.cfg``, adjust the filename in
    ``AIRFLOW_CONFIG: '/opt/airflow/config/airflow.cfg'``
 
 Networking


### PR DESCRIPTION
closes: #35812 

I have made the necessary changes to the docker-compose.yaml file as proposed within the issue. The relevant line is currently outcommented, but the documentation in the index.rst and comments above the outcommented line tell users 
what to do. If one deletes the comment, an airflow.cfg file within ``${AIRFLOW_PROJ_DIR:-.}``  is now added to ``/opt/airflow/airflow.cfg``within the containers, once ``docker compose up``has been executed. The new line also should make it clear where the airflow.cfg is stored in the containers, as brought up by the issue. 

As mentioned, I also added documentation for the changes in the index.rst file, such that users know how to automatically ingest their own airflow.cfg upon startup. 

@potiuk Can you maybe have a look at this, since you also approved the original issue? 

If I should change anything please let me know :) 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
