### PR TITLE
Add support for extra CronJobs in Airflow helm chart

### DIFF
--- a/chart/templates/jobs/extra-cronjobs.yaml
+++ b/chart/templates/jobs/extra-cronjobs.yaml
@@ -1,0 +1,65 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+####################################################
+## Extra CronJobs provisioned via the chart values
+####################################################
+{{- $Global := . }}
+{{- range $cronJobName, $cronJobContent := .Values.extraCronJobs }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ tpl $cronJobName $Global | quote }}
+  labels:
+    release: {{ $Global.Release.Name }}
+    chart: "{{ $Global.Chart.Name }}-{{ $Global.Chart.Version }}"
+    heritage: {{ $Global.Release.Service }}
+    {{- with $Global.Values.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if $cronJobContent.labels }}
+      {{- toYaml $cronJobContent.labels | nindent 4 }}
+    {{- end }}
+  {{- if $cronJobContent.annotations }}
+  annotations: {{- toYaml $cronJobContent.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  schedule: {{ tpl $cronJobContent.spec.schedule $Global }}
+  {{- if $cronJobContent.spec.startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ $cronJobContent.spec.startingDeadlineSeconds }}
+  {{- end }}
+  {{- if $cronJobContent.spec.concurrencyPolicy }}
+  concurrencyPolicy: {{ $cronJobContent.spec.concurrencyPolicy }}
+  {{- end }}
+  {{- if $cronJobContent.spec.suspend }}
+  suspend: {{ $cronJobContent.spec.suspend }}
+  {{- end }}
+  {{- if $cronJobContent.spec.failedJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ $cronJobContent.spec.failedJobsHistoryLimit }}
+  {{- end }}
+  {{- if $cronJobContent.spec.successfulJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ $cronJobContent.spec.successfulJobsHistoryLimit }}
+  {{- end }}
+  {{- if $cronJobContent.spec.timeZone }}
+  timeZone: {{ $cronJobContent.spec.timeZone }}
+  {{- end }}
+  jobTemplate:
+    {{- toYaml $cronJobContent.spec.jobTemplate | nindent 4 }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -356,6 +356,38 @@ extraConfigMaps: {}
 #       AIRFLOW_VAR_HELLO_MESSAGE: "Hi!"
 #       AIRFLOW_VAR_KUBERNETES_NAMESPACE: "{{ .Release.Namespace }}"
 
+# Extra CronJobs that will be managed by the chart
+extraCronJobs: {}
+# eg:
+# extraCronJobs:
+#   '{{ .Release.Name }}-clean-db':
+#     labels:
+#       my.cronjob.label: custom_cronjob_label
+#     annotations:
+#       my.cronjob.annotation: custom_cronjob_annotation
+#     spec:
+#       schedule: '30 3 1 * *'
+#       concurrencyPolicy: Allow
+#       jobTemplate:
+#         spec:
+#           backoffLimit: 1
+#           template:
+#             metadata:
+#               labels:
+#                 my.cronjob.label: custom_cronjob_label
+#               annotations:
+#                 my.cronjob.annotation: custom_cronjob_annotation
+#             spec:
+#               restartPolicy: Never
+#               serviceAccountName: CronJobCustomServiceAccount
+#               containers:
+#                 - name: custom-cronjob-container
+#                   image: apache/airflow
+#                   imagePullPolicy: IfNotPresent
+#                   securityContext: {}
+#                   command: ~
+#                   args: ["bash", "-c", "exec custom command"]
+
 # Extra env 'items' that will be added to the definition of airflow containers
 # a string is expected (can be templated).
 # TODO: difference from `env`? This is a templated string. Probably should template `env` and remove this.


### PR DESCRIPTION

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
closes: #34399

This PR aims to add support for custom CronJobs that can be deployed and managed with the official Airflow helm chart.
I am working on tests on this feature right now, but I would like to hear what do you think about the implementation.

- [ ] needs tests