### PR TITLE
Update "problems with Non-DB test collection" section in TESTING.rst

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -703,6 +703,36 @@ You can make the code conditional and mock out the Variable to avoid hitting the
       def test_rendered_task_detail_env_secret(patch_app, admin_client, request, env, expected):
           ...
 
+You can also use fixture to create object that needs database just like this.
+
+
+  .. code-block:: python
+
+      from airflow.models import Connection
+
+      pytestmark = pytest.mark.db_test
+
+
+      @pytest.fixture()
+      def get_connection1():
+          return Connection()
+
+
+      @pytest.fixture()
+      def get_connection2():
+          return Connection(host="apache.org", extra={})
+
+
+      @pytest.mark.parametrize(
+          "conn",
+          [
+              pytest.param("get_connection1", "{}", id="empty"),
+              pytest.param("get_connection2", '{"host": "apache.org"}', id="empty-extra"),
+          ],
+      )
+      def test_as_json_from_connection(self, conn: Connection):
+          conn = request.getfixturevalue(conn)
+          ...
 
 
 Running Unit tests

--- a/TESTING.rst
+++ b/TESTING.rst
@@ -726,8 +726,8 @@ You can also use fixture to create object that needs database just like this.
       @pytest.mark.parametrize(
           "conn",
           [
-              pytest.param("get_connection1", "{}", id="empty"),
-              pytest.param("get_connection2", '{"host": "apache.org"}', id="empty-extra"),
+              "get_connection1",
+              "get_connection2",
           ],
       )
       def test_as_json_from_connection(self, conn: Connection):


### PR DESCRIPTION
This PR adding to  "problems with Non-DB test collection" section in TESTING.rst according to this PR: https://github.com/apache/airflow/pull/36258/
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
