### PR TITLE
Update statsd-mapping.yml to support Airflow 2.X pool metrics

### DIFF
--- a/chart/files/statsd-mappings.yml
+++ b/chart/files/statsd-mappings.yml
@@ -76,8 +76,18 @@ mappings:
     labels:
       pool: "$1"
 
-  - match: airflow.pool.used_slots.*
-    name: "airflow_pool_used_slots"
+  - match: airflow.pool.queued_slots.*
+    name: "airflow_pool_queued_slots"
+    labels:
+      pool: "$1"
+
+  - match: airflow.pool.running_slots.*
+    name: "airflow_pool_running_slots"
+    labels:
+      pool: "$1"
+
+  - match: airflow.pool.deferred_slots.*
+    name: "airflow_pool_deferred_slots"
     labels:
       pool: "$1"
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

closes: #36245
Updating the pool metrics in statsd mapping to Airflow 2.X pool metrics
