### PR TITLE
Less verbose information about changed provider.yaml files

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/md5_build_check.py
+++ b/dev/breeze/src/airflow_breeze/utils/md5_build_check.py
@@ -29,6 +29,7 @@ from airflow_breeze.global_constants import ALL_PROVIDER_YAML_FILES, FILES_FOR_R
 from airflow_breeze.utils.console import get_console
 from airflow_breeze.utils.path_utils import AIRFLOW_SOURCES_ROOT
 from airflow_breeze.utils.run_utils import run_command
+from airflow_breeze.utils.shared_options import get_verbose
 
 if TYPE_CHECKING:
     from airflow_breeze.params.build_ci_params import BuildCiParams
@@ -102,11 +103,15 @@ def calculate_md5_checksum_for_files(
         if modified_provider_yaml_files:
             get_console().print(
                 "[info]Attempting to generate provider dependencies. "
-                "Provider yaml files changed since last check:[/]"
+                f"{len(modified_provider_yaml_files)} provider.yaml file(s) changed since last check."
             )
-            get_console().print(
-                [os.fspath(file.relative_to(AIRFLOW_SOURCES_ROOT)) for file in modified_provider_yaml_files]
-            )
+            if get_verbose():
+                get_console().print(
+                    [
+                        os.fspath(file.relative_to(AIRFLOW_SOURCES_ROOT))
+                        for file in modified_provider_yaml_files
+                    ]
+                )
             # Regenerate provider_dependencies.json
             run_command(
                 [


### PR DESCRIPTION
When we attempt to see if provider.yaml files make changes in dependencies, we print verbose information on what provider.yaml files changeed, but this is not necessary or needed. This change makes the output less verbose by detail - just a number of changed files rather than full list of them - the full list is only printed when `--verbose` flag is used.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
