### PR TITLE
DOC multiple vault mount points

### DIFF
--- a/docs/apache-airflow-providers-hashicorp/secrets-backends/hashicorp-vault.rst
+++ b/docs/apache-airflow-providers-hashicorp/secrets-backends/hashicorp-vault.rst
@@ -230,7 +230,7 @@ In order to do this, you will need to setup you configuration this way:
   elements will be the path to the secrets)
 * leave ``config_path`` as the empty string ``""``
 * if you use ``config_path``, each configuration item will need to be prefixed with the ``mount_point`` used for configs,
-  as ``"mount_point/path/to/the/config"`` (here again, the string will be split using the separator ``/``, 
+  as ``"mount_point/path/to/the/config"`` (here again, the string will be split using the separator ``/``,
   the first element will be the mount point, the remaining elements will be the path to the configuration parameter)
 
 For example:

--- a/docs/apache-airflow-providers-hashicorp/secrets-backends/hashicorp-vault.rst
+++ b/docs/apache-airflow-providers-hashicorp/secrets-backends/hashicorp-vault.rst
@@ -169,7 +169,7 @@ Note that the secret ``Key`` is ``value``, and secret ``Value`` is ``world`` and
 ``mount_point`` is ``airflow``.
 
 Storing and Retrieving Config
-""""""""""""""""""""""""""""""""
+"""""""""""""""""""""""""""""
 
 If you have set ``config_path`` as ``config`` and ``mount_point`` as ``airflow``, then for config ``sql_alchemy_conn_secret`` with
 ``sql_alchemy_conn_value`` as value, you would want to store your secret as:
@@ -214,3 +214,31 @@ Add "verify": "absolute path to ca-certificate file"
     [secrets]
     backend = airflow.providers.hashicorp.secrets.vault.VaultBackend
     backend_kwargs = {"connections_path": "airflow-connections", "variables_path": null, "mount_point": "airflow", "url": "http://127.0.0.1:8200", "verify": "/etc/ssl/certs/ca-certificates"}
+
+Using multiple mount points
+"""""""""""""""""""""""""""
+
+You can use multiple mount points to store your secrets. For example, you might want to store the Airflow instance configurations
+in one Vault KV engine only accessible by your Airflow deployment tools, while storing the variables and connections in another KV engine
+available to your DAGs, in order to grant them more specific Vault ACLs.
+
+In order to do this, you will need to setup you configuration this way:
+
+* leave ``mount_point`` as JSON ``null``
+* if you use ``variables_path`` and/or ``connections_path``, set them as ``"mount_point/path/to/the/secrets"``
+  (the string will be split using the separator ``/``, the first element will be the mount point, the remaining
+  elements will be the path to the secrets)
+* leave ``config_path`` as the empty string ``""``
+* if you use ``config_path``, each configuration item will need to be prefixed with the ``mount_point`` used for configs,
+  as ``"mount_point/path/to/the/config"`` (here again, the string will be split using the separator ``/``, 
+  the first element will be the mount point, the remaining elements will be the path to the configuration parameter)
+
+For example:
+
+.. code-block:: ini
+    [core]
+    sql_alchemy_conn_secret: "deployment_mount_point/airflow/configs/sql_alchemy_conn_value"
+
+    [secrets]
+    backend = airflow.providers.hashicorp.secrets.vault.VaultBackend
+    backend_kwargs = {"connections_path": "dags_mount_point/airflow/connections", "variables_path": "dags_mount_point/airflow/variables", "config_path": "", mount_point": null, "url": "http://127.0.0.1:8200", "verify": "/etc/ssl/certs/ca-certificates"}

--- a/docs/apache-airflow-providers-hashicorp/secrets-backends/hashicorp-vault.rst
+++ b/docs/apache-airflow-providers-hashicorp/secrets-backends/hashicorp-vault.rst
@@ -236,6 +236,7 @@ In order to do this, you will need to setup you configuration this way:
 For example:
 
 .. code-block:: ini
+
     [core]
     sql_alchemy_conn_secret: "deployment_mount_point/airflow/configs/sql_alchemy_conn_value"
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: #29734


<!-- Please keep an empty line above the dashes. -->
---

This PR adds a paragraph to the "Hashicorp Vault Secrets Backend" documentation page, in order to better illustrate how the #29734 improvement can be used, following the `vault.py` behaviour in relation to the mount_point variable and the *_path variables.
