### PR TITLE
[WIP] Mapping tasks from ObjectStoragePath

### DIFF
--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import collections.abc
 import contextlib
 import copy
+import json
 import warnings
 from typing import TYPE_CHECKING, Any, ClassVar, Collection, Iterable, Iterator, Mapping, Sequence, Union
 
@@ -27,6 +28,7 @@ import attr
 
 from airflow.compat.functools import cache
 from airflow.exceptions import AirflowException, UnmappableOperator
+from airflow.io.path import ObjectStoragePath
 from airflow.models.abstractoperator import (
     DEFAULT_IGNORE_FIRST_DEPENDS_ON_PAST,
     DEFAULT_OWNER,
@@ -180,6 +182,8 @@ class OperatorPartial:
     def expand_kwargs(self, kwargs: OperatorExpandKwargsArgument, *, strict: bool = True) -> MappedOperator:
         from airflow.models.xcom_arg import XComArg
 
+        if isinstance(kwargs, ObjectStoragePath):
+            kwargs = json.loads(kwargs.read_text())
         if isinstance(kwargs, collections.abc.Sequence):
             for item in kwargs:
                 if not isinstance(item, (XComArg, collections.abc.Mapping)):

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -21,6 +21,7 @@ import collections.abc
 import contextlib
 import hashlib
 import itertools
+import json
 import logging
 import math
 import operator
@@ -84,6 +85,7 @@ from airflow.exceptions import (
     UnmappableXComTypePushed,
     XComForMappingNotPushed,
 )
+from airflow.io.path import ObjectStoragePath
 from airflow.listeners.listener import get_listener_manager
 from airflow.models.base import Base, StringID
 from airflow.models.dagbag import DagBag
@@ -913,6 +915,8 @@ def _record_task_map_for_downstreams(
         return
     if value is None:
         raise XComForMappingNotPushed()
+    if isinstance(value, ObjectStoragePath):
+        value = json.loads(value.read_text())
     if not _is_mappable_value(value):
         raise UnmappableXComTypePushed(value)
     task_map = TaskMap.from_task_instance_xcom(task_instance, value)


### PR DESCRIPTION
As discussed on [Slack](https://apache-airflow.slack.com/archives/CCPRP7943/p1696584611030439?thread_ts=1696535089.906339&cid=CCPRP7943), this PR implements mapping from files using the new experimental feature Airflow ObjectStore.

The PR is not ready yet; I will add some unit tests and then update the dynamic mapping task doc once it's ready.