### PR TITLE
Remove remaining Airflow 2.5 backcompat code from Docker Provider

### DIFF
--- a/airflow/providers/docker/decorators/docker.py
+++ b/airflow/providers/docker/decorators/docker.py
@@ -17,10 +17,8 @@
 from __future__ import annotations
 
 import base64
-import inspect
 import os
 import pickle
-import textwrap
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Callable, Sequence
 
@@ -28,7 +26,6 @@ import dill
 
 from airflow.decorators.base import DecoratedOperator, task_decorator_factory
 from airflow.providers.docker.operators.docker import DockerOperator
-from airflow.utils.decorators import remove_task_decorator
 from airflow.utils.python_virtualenv import write_python_script
 
 if TYPE_CHECKING:
@@ -128,13 +125,6 @@ class _DockerDecoratedOperator(DecoratedOperator, DockerOperator):
 
             self.command = self.generate_command()
             return super().execute(context)
-
-    # TODO: Remove me once this provider min supported Airflow version is 2.6
-    def get_python_source(self):
-        raw_source = inspect.getsource(self.python_callable)
-        res = textwrap.dedent(raw_source)
-        res = remove_task_decorator(res, self.custom_operator_name)
-        return res
 
     @property
     def pickling_library(self):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

We could remove backompat code with previous version of Airflow since Docker provider has minimum Airflow 2.6 requirement 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
