### PR TITLE
Increase ConflictException retries to 4 total

### DIFF
--- a/airflow/providers/amazon/aws/hooks/sagemaker.py
+++ b/airflow/providers/amazon/aws/hooks/sagemaker.py
@@ -1138,7 +1138,7 @@ class SageMakerHook(AwsBaseHook):
         if check_interval is None:
             check_interval = 10
 
-        for retries in (4, 3, 2, 1, 0):
+        for retries in reversed(range(5)):
             try:
                 self.conn.stop_pipeline_execution(PipelineExecutionArn=pipeline_exec_arn)
             except ClientError as ce:

--- a/airflow/providers/amazon/aws/hooks/sagemaker.py
+++ b/airflow/providers/amazon/aws/hooks/sagemaker.py
@@ -1138,7 +1138,7 @@ class SageMakerHook(AwsBaseHook):
         if check_interval is None:
             check_interval = 10
 
-        for retries in (2, 1, 0):
+        for retries in (4, 3, 2, 1, 0):
             try:
                 self.conn.stop_pipeline_execution(PipelineExecutionArn=pipeline_exec_arn)
             except ClientError as ce:

--- a/tests/providers/amazon/aws/hooks/test_sagemaker.py
+++ b/tests/providers/amazon/aws/hooks/test_sagemaker.py
@@ -813,13 +813,15 @@ class TestSageMakerHook:
         mock_conn().stop_pipeline_execution.side_effect = [
             conflict_error,
             conflict_error,
+            conflict_error,
+            conflict_error,
             None,
         ]
 
         hook = SageMakerHook(aws_conn_id="aws_default")
         hook.stop_pipeline(pipeline_exec_arn="test")
 
-        assert mock_conn().stop_pipeline_execution.call_count == 3
+        assert mock_conn().stop_pipeline_execution.call_count == 5
 
     @patch("airflow.providers.amazon.aws.hooks.sagemaker.SageMakerHook.conn", new_callable=mock.PropertyMock)
     def test_stop_pipeline_fails_if_all_retries_error(self, mock_conn):
@@ -833,7 +835,7 @@ class TestSageMakerHook:
         with pytest.raises(ClientError) as raised_exception:
             hook.stop_pipeline(pipeline_exec_arn="test")
 
-        assert mock_conn().stop_pipeline_execution.call_count == 3
+        assert mock_conn().stop_pipeline_execution.call_count == 5
         assert raised_exception.value == conflict_error
 
     @patch("airflow.providers.amazon.aws.hooks.sagemaker.SageMakerHook.conn", new_callable=mock.PropertyMock)


### PR DESCRIPTION
We have seen a recent uptick in ConflictExceptions we receive from SageMaker. It's not many, but enough to fail our system tests unnecessarily.

Bumping the retires to 4 which I still think is very reasonable, considering it's a very tight loop of 0.3 seconds sleep per retry.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
