### PR TITLE
Cli export / import roles including permissions

### DIFF
--- a/airflow/providers/fab/auth_manager/cli_commands/role_command.py
+++ b/airflow/providers/fab/auth_manager/cli_commands/role_command.py
@@ -161,7 +161,7 @@ def roles_export(args):
         exporting_roles = [role for role in roles if role.name not in EXISTING_ROLES]
     filename = os.path.expanduser(args.file)
 
-    permission_map : dict[tuple[str, str], list[str]] = defaultdict(list)
+    permission_map: dict[tuple[str, str], list[str]] = defaultdict(list)
     for role in exporting_roles:
         if role.permissions:
             for permission in role.permissions:
@@ -170,11 +170,13 @@ def roles_export(args):
             permission_map[(role.name, "")].append("")
     export_data = [
         {"name": role, "resource": resource, "action": ",".join(sorted(permissions))}
-        for (role, resource), permissions in permission_map.items()]
+        for (role, resource), permissions in permission_map.items()
+    ]
     kwargs = {} if not args.pretty else {"sort_keys": False, "indent": 4}
     with open(filename, "w", encoding="utf-8") as f:
         json.dump(export_data, f, **kwargs)
     print(f"{len(export_data)} roles with permissions successfully exported to {filename}")
+
 
 @cli_utils.action_cli
 @suppress_logs_and_warning

--- a/tests/providers/fab/auth_manager/cli_commands/test_role_command.py
+++ b/tests/providers/fab/auth_manager/cli_commands/test_role_command.py
@@ -176,6 +176,7 @@ class TestCliRoles:
                     permissions.RESOURCE_POOL,
                     "-a",
                     permissions.ACTION_CAN_EDIT,
+                    permissions.ACTION_CAN_READ
                 ]
             )
         )
@@ -183,5 +184,5 @@ class TestCliRoles:
         with open(fn) as outfile:
             roles_exported = json.load(outfile)
         print(roles_exported)
-        assert {"name" : "FakeTeamA", "resource": "Pools", "action": "can_edit"} in roles_exported
+        assert {"name" : "FakeTeamA", "resource": "Pools", "action": "can_edit,can_read"} in roles_exported
         assert {"name" : "FakeTeamB", "resource": "", "action": ""} in roles_exported

--- a/tests/providers/fab/auth_manager/cli_commands/test_role_command.py
+++ b/tests/providers/fab/auth_manager/cli_commands/test_role_command.py
@@ -176,12 +176,12 @@ class TestCliRoles:
                     permissions.RESOURCE_POOL,
                     "-a",
                     permissions.ACTION_CAN_EDIT,
-                    permissions.ACTION_CAN_READ
+                    permissions.ACTION_CAN_READ,
                 ]
             )
         )
         role_command.roles_export(self.parser.parse_args(["roles", "export", str(fn)]))
         with open(fn) as outfile:
             roles_exported = json.load(outfile)
-        assert {"name" : "FakeTeamA", "resource": "Pools", "action": "can_edit,can_read"} in roles_exported
-        assert {"name" : "FakeTeamB", "resource": "", "action": ""} in roles_exported
+        assert {"name": "FakeTeamA", "resource": "Pools", "action": "can_edit,can_read"} in roles_exported
+        assert {"name": "FakeTeamB", "resource": "", "action": ""} in roles_exported

--- a/tests/providers/fab/auth_manager/cli_commands/test_role_command.py
+++ b/tests/providers/fab/auth_manager/cli_commands/test_role_command.py
@@ -183,6 +183,5 @@ class TestCliRoles:
         role_command.roles_export(self.parser.parse_args(["roles", "export", str(fn)]))
         with open(fn) as outfile:
             roles_exported = json.load(outfile)
-        print(roles_exported)
         assert {"name" : "FakeTeamA", "resource": "Pools", "action": "can_edit,can_read"} in roles_exported
         assert {"name" : "FakeTeamB", "resource": "", "action": ""} in roles_exported


### PR DESCRIPTION
closes: #36128

This PR contains both an updated ``airflow roles export`` and ``airflow roles import`` cli command, according to the above mentioned issue. 

The export command now exports resources and actions by default in the following structure:
```
[{"name": "FakeTeamA", "resource": "Pools", "action": "can_edit,can_read"}, 
 {"name": "FakeTeamA", "resource": "Admin", "action": ",menu_access"}, 
{"name": "FakeTeamB", "resource": "", "action": ""}]
```

- When a role has no permissions the values for the respective keys are set to empty Strings. 
This way the import function can later easily distinguish if the imported role needs permissions to be set or not

- @potiuk I originally mentioned that we could use the ``-p`` flag to say whether we want to export names and permissions or just the names. However the function already uses the ``-p`` flag (--pretty) thus I believe this will not work. That's why the function currently also exports permissions by default. 

- Previously the ``-p`` flag sorted the list of names in alphabetical order and set the indent to 4 . However with the function now returning a list of dictionaries, I disabled the sorting if ``-p``is set, because in this case the order of the keys would be switched. 

The ``airflow roles import`` commands expect the json to be in the same structure as the exported one. In it I have reused the ``__roles_add_or_remove_permissions``which was already contained in the file and handles the logic for adding permissions. 

- to pass args to __roles_add_or_remove_permissions from the imported json, I used Namespace from argparse. argparse is already a dependency of airflow. 

- In the beginning, I remove all roles that are already contained within the db from the json. By this I can ensure that only new roles are being added. Due to the structure of the json, role names are contained multiple time with different resources, thus I need to check for each dictionary, whether the role has been already added and thus I only need to add the permissions within this dictionary or a new role needs to be created. 

Unit tests have been added to test the new functions. 
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
