### PR TITLE
Fix wrong sample code for "dag level permissions" 

### DIFF
--- a/docs/apache-airflow-providers-fab/auth-manager/access-control.rst
+++ b/docs/apache-airflow-providers-fab/auth-manager/access-control.rst
@@ -259,7 +259,7 @@ Setting ``access_control`` on a DAG will overwrite any previously existing DAG-l
         dag_id="example_fine_grained_access",
         start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
         access_control={
-            "Viewer": {"can_edit", "can_create", "can_delete"},
+            "Viewer": {"can_edit", "can_read", "can_delete"},
         },
     )
 


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/36349

----

this PR fix the wrong sample code [here](https://airflow.apache.org/docs/apache-airflow/stable/security/access-control.html#order-of-precedence-for-dag-level-permissions)

Only these three `"can_edit", "can_read", "can_delete"` are valid!
