### PR TITLE
Fix AirflowSkipException message raised by KubernetesPodOperator

### DIFF
--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -1363,25 +1363,33 @@ class TestKubernetesPodOperator:
         assert re.match(r"a-very-reasonable-task-name-[a-z0-9-]+", pod.metadata.name) is not None
 
     @pytest.mark.parametrize(
-        "extra_kwargs, actual_exit_code, expected_exc",
+        "kwargs, actual_exit_code, expected_exc",
         [
-            (None, 99, AirflowException),
+            ({}, 0, None),
+            ({}, 100, AirflowException),
+            ({}, 101, AirflowException),
+            ({"skip_on_exit_code": None}, 0, None),
+            ({"skip_on_exit_code": None}, 100, AirflowException),
+            ({"skip_on_exit_code": None}, 101, AirflowException),
+            ({"skip_on_exit_code": 100}, 0, None),
             ({"skip_on_exit_code": 100}, 100, AirflowSkipException),
             ({"skip_on_exit_code": 100}, 101, AirflowException),
-            ({"skip_on_exit_code": None}, 100, AirflowException),
+            ({"skip_on_exit_code": 0}, 0, AirflowSkipException),
+            ({"skip_on_exit_code": [100]}, 0, None),
             ({"skip_on_exit_code": [100]}, 100, AirflowSkipException),
-            ({"skip_on_exit_code": (100, 101)}, 100, AirflowSkipException),
-            ({"skip_on_exit_code": 100}, 101, AirflowException),
+            ({"skip_on_exit_code": [100]}, 101, AirflowException),
             ({"skip_on_exit_code": [100, 102]}, 101, AirflowException),
-            ({"skip_on_exit_code": None}, 0, None),
+            ({"skip_on_exit_code": (100,)}, 0, None),
+            ({"skip_on_exit_code": (100,)}, 100, AirflowSkipException),
+            ({"skip_on_exit_code": (100,)}, 101, AirflowException),
         ],
     )
     @patch(f"{POD_MANAGER_CLASS}.await_pod_completion")
     def test_task_skip_when_pod_exit_with_certain_code(
-        self, remote_pod, extra_kwargs, actual_exit_code, expected_exc
+        self, remote_pod, kwargs, actual_exit_code, expected_exc
     ):
         """Tests that an AirflowSkipException is raised when the container exits with the skip_on_exit_code"""
-        k = KubernetesPodOperator(task_id="task", on_finish_action="delete_pod", **(extra_kwargs or {}))
+        k = KubernetesPodOperator(task_id="task", on_finish_action="delete_pod", **kwargs)
 
         base_container = MagicMock()
         base_container.name = k.base_container_name
@@ -1619,13 +1627,22 @@ class TestKubernetesPodOperatorAsync:
             )
 
     @pytest.mark.parametrize(
-        "extra_kwargs, actual_exit_code, expected_exc, pod_status, event_status",
+        "kwargs, actual_exit_code, expected_exc, pod_status, event_status",
         [
-            (None, 0, None, "Succeeded", "success"),
-            (None, 99, AirflowException, "Failed", "error"),
+            ({}, 0, None, "Succeeded", "success"),
+            ({}, 100, AirflowException, "Failed", "error"),
+            ({}, 101, AirflowException, "Failed", "error"),
+            ({"skip_on_exit_code": None}, 0, None, "Succeeded", "success"),
+            ({"skip_on_exit_code": None}, 100, AirflowException, "Failed", "error"),
+            ({"skip_on_exit_code": None}, 101, AirflowException, "Failed", "error"),
             ({"skip_on_exit_code": 100}, 100, AirflowSkipException, "Failed", "error"),
             ({"skip_on_exit_code": 100}, 101, AirflowException, "Failed", "error"),
-            ({"skip_on_exit_code": None}, 100, AirflowException, "Failed", "error"),
+            ({"skip_on_exit_code": 0}, 0, AirflowSkipException, "Failed", "error"),
+            ({"skip_on_exit_code": [100]}, 100, AirflowSkipException, "Failed", "error"),
+            ({"skip_on_exit_code": [100]}, 101, AirflowException, "Failed", "error"),
+            ({"skip_on_exit_code": [100, 102]}, 101, AirflowException, "Failed", "error"),
+            ({"skip_on_exit_code": (100,)}, 100, AirflowSkipException, "Failed", "error"),
+            ({"skip_on_exit_code": (100,)}, 101, AirflowException, "Failed", "error"),
         ],
     )
     @patch(KUB_OP_PATH.format("pod_manager"))
@@ -1634,7 +1651,7 @@ class TestKubernetesPodOperatorAsync:
         self,
         mocked_hook,
         mock_manager,
-        extra_kwargs,
+        kwargs,
         actual_exit_code,
         expected_exc,
         pod_status,
@@ -1654,7 +1671,7 @@ class TestKubernetesPodOperatorAsync:
             in_cluster=True,
             get_logs=True,
             deferrable=True,
-            **(extra_kwargs or {}),
+            **kwargs,
         )
 
         base_container = MagicMock()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


* `KubernetesPodOperator.skip_on_exit_code` is always a container (like `list[int]`), it cannot be `None`.
* If pod exited with matching exit code, `AirflowSkipException` should contain exact exit code instead of container value.
* Allow to pass `KubernetesPodOperator(skip_no_exit_code=0)` to skip successfully finished pods. Previously it was the same as `KubernetesPodOperator(skip_no_exit_code=[])`


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
