### PR TITLE
Fixing template_fields for WeaviateIngestOperator

### DIFF
--- a/airflow/providers/weaviate/operators/weaviate.py
+++ b/airflow/providers/weaviate/operators/weaviate.py
@@ -51,7 +51,7 @@ class WeaviateIngestOperator(BaseOperator):
     :param vector_col: key/column name in which the vectors are stored.
     """
 
-    template_fields: Sequence[str] = ("input_json",)
+    template_fields: Sequence[str] = ("input_json", "input_data")
 
     def __init__(
         self,
@@ -69,7 +69,7 @@ class WeaviateIngestOperator(BaseOperator):
         self.class_name = class_name
         self.conn_id = conn_id
         self.vector_col = vector_col
-
+        self.input_json = input_json
         if input_data is not None:
             self.input_data = input_data
         elif input_json is not None:

--- a/tests/providers/weaviate/operators/test_weaviate.py
+++ b/tests/providers/weaviate/operators/test_weaviate.py
@@ -51,6 +51,7 @@ class TestWeaviateIngestOperator:
         )
         mock_log.debug.assert_called_once_with("Input data: %s", {"data": "sample_data"})
 
+    @pytest.mark.db_test
     def test_templates(self, create_task_instance_of_operator):
         dag_id = "TestWeaviateIngestOperator"
         ti = create_task_instance_of_operator(

--- a/tests/providers/weaviate/operators/test_weaviate.py
+++ b/tests/providers/weaviate/operators/test_weaviate.py
@@ -16,11 +16,31 @@
 # under the License.
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from airflow.models import Connection
+from airflow.providers.weaviate.hooks.weaviate import WeaviateHook
 from airflow.providers.weaviate.operators.weaviate import WeaviateIngestOperator
+
+
+@pytest.fixture
+def mock_weaviate_connection():
+    conn_id = "weaviate_conn"
+    conn = Connection(
+        conn_id=conn_id,
+        conn_type="weaviate",
+    )
+    os.environ[f"AIRFLOW_CONN_{conn.conn_id.upper()}"] = conn.get_uri()
+    yield conn
+
+
+@pytest.fixture
+def mock_weaviate_hook(mock_weaviate_connection):
+    with patch("airflow.providers.weaviate.hooks.weaviate.WeaviateHook"):
+        yield WeaviateHook(conn_id=mock_weaviate_connection.conn_id)
 
 
 class TestWeaviateIngestOperator:
@@ -50,3 +70,19 @@ class TestWeaviateIngestOperator:
             "my_class", {"data": "sample_data"}, vector_col="Vector", **{}
         )
         mock_log.debug.assert_called_once_with("Input data: %s", {"data": "sample_data"})
+
+    def test_templates(self, create_task_instance_of_operator):
+        dag_id = "TestWeaviateIngestOperator"
+        ti = create_task_instance_of_operator(
+            WeaviateIngestOperator,
+            dag_id=dag_id,
+            task_id="task-id",
+            conn_id="weaviate_conn",
+            class_name="my_class",
+            input_json="{{ dag.dag_id }}",
+            input_data="{{ dag.dag_id }}",
+        )
+        ti.render_templates()
+
+        assert dag_id == ti.task.input_json
+        assert dag_id == ti.task.input_data

--- a/tests/providers/weaviate/operators/test_weaviate.py
+++ b/tests/providers/weaviate/operators/test_weaviate.py
@@ -16,31 +16,11 @@
 # under the License.
 from __future__ import annotations
 
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from airflow.models import Connection
-from airflow.providers.weaviate.hooks.weaviate import WeaviateHook
 from airflow.providers.weaviate.operators.weaviate import WeaviateIngestOperator
-
-
-@pytest.fixture
-def mock_weaviate_connection():
-    conn_id = "weaviate_conn"
-    conn = Connection(
-        conn_id=conn_id,
-        conn_type="weaviate",
-    )
-    os.environ[f"AIRFLOW_CONN_{conn.conn_id.upper()}"] = conn.get_uri()
-    yield conn
-
-
-@pytest.fixture
-def mock_weaviate_hook(mock_weaviate_connection):
-    with patch("airflow.providers.weaviate.hooks.weaviate.WeaviateHook"):
-        yield WeaviateHook(conn_id=mock_weaviate_connection.conn_id)
 
 
 class TestWeaviateIngestOperator:


### PR DESCRIPTION


"WeaviateIngestOperator was breaking with the error **'AttributeError: 'input_json' is configured as a template field, but WeaviateIngestOperator does not have this attribute.**' This PR addresses the issue by reintroducing the 'input_json' attribute and adding 'input_data' as a templated field."

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
