### PR TITLE
openlineage: set extractors None in config

### DIFF
--- a/airflow/providers/openlineage/extractors/manager.py
+++ b/airflow/providers/openlineage/extractors/manager.py
@@ -63,8 +63,9 @@ class ExtractorManager(LoggingMixin):
             for operator_class in extractor.get_operator_classnames():
                 self.extractors[operator_class] = extractor
 
-        env_extractors = conf.get("openlinege", "extractors", fallback=os.getenv("OPENLINEAGE_EXTRACTORS"))
-        if env_extractors is not None:
+        env_extractors = conf.get("openlineage", "extractors", fallback=os.getenv("OPENLINEAGE_EXTRACTORS"))
+        # skip either when it's empty string or None
+        if env_extractors:
             for extractor in env_extractors.split(";"):
                 extractor: type[BaseExtractor] = try_import_from_string(extractor.strip())
                 for operator_class in extractor.get_operator_classnames():

--- a/airflow/providers/openlineage/provider.yaml
+++ b/airflow/providers/openlineage/provider.yaml
@@ -85,7 +85,7 @@ config:
           Semicolon separated paths to custom OpenLineage extractors.
         type: string
         example: full.path.to.ExtractorClass;full.path.to.AnotherExtractorClass
-        default: ""
+        default: ~
         version_added: ~
       config_path:
         description: |

--- a/tests/providers/openlineage/extractors/test_base.py
+++ b/tests/providers/openlineage/extractors/test_base.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import os
 from typing import Any
 from unittest import mock
 
@@ -27,11 +28,13 @@ from openlineage.client.run import Dataset
 from airflow.models.baseoperator import BaseOperator
 from airflow.operators.python import PythonOperator
 from airflow.providers.openlineage.extractors.base import (
+    BaseExtractor,
     DefaultExtractor,
     OperatorLineage,
 )
 from airflow.providers.openlineage.extractors.manager import ExtractorManager
 from airflow.providers.openlineage.extractors.python import PythonExtractor
+from tests.test_utils.config import conf_vars
 
 pytestmark = pytest.mark.db_test
 
@@ -50,6 +53,12 @@ class CompleteRunFacet(BaseFacet):
 
 
 FINISHED_FACETS: dict[str, BaseFacet] = {"complete": CompleteRunFacet(True)}
+
+
+class ExampleExtractor(BaseExtractor):
+    @classmethod
+    def get_operator_classnames(cls):
+        return ["ExampleOperator"]
 
 
 class ExampleOperator(BaseOperator):
@@ -219,6 +228,24 @@ def test_extraction_without_on_start():
         run_facets=RUN_FACETS,
         job_facets=FINISHED_FACETS,
     )
+
+
+@mock.patch.dict(
+    os.environ,
+    {"OPENLINEAGE_EXTRACTORS": "tests.providers.openlineage.extractors.test_base.ExampleExtractor"},
+)
+def test_extractors_env_var():
+    extractor = ExtractorManager().get_extractor_class(ExampleOperator(task_id="example"))
+    assert extractor is ExampleExtractor
+
+
+@mock.patch.dict(os.environ, {"OPENLINEAGE_EXTRACTORS": "no.such.extractor"})
+@conf_vars(
+    {("openlineage", "extractors"): "tests.providers.openlineage.extractors.test_base.ExampleExtractor"}
+)
+def test_config_has_precedence_over_env_var():
+    extractor = ExtractorManager().get_extractor_class(ExampleOperator(task_id="example"))
+    assert extractor is ExampleExtractor
 
 
 def test_does_not_use_default_extractor_when_not_a_method():


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR fixes typo. It also changes `extractors` under `openlineage` section to None. In other case default Airflow config would never lead to fallback to `OPENLINEAGE_EXTRACTORS` env var.