### PR TITLE
Adding versioned unit tests for kerberos init container

### DIFF
--- a/helm_tests/airflow_core/test_worker.py
+++ b/helm_tests/airflow_core/test_worker.py
@@ -564,21 +564,28 @@ class TestWorker:
         } in jmespath.search("spec.template.spec.containers[2].volumeMounts", docs[0])
 
     @pytest.mark.parametrize(
-        "airflow_version, expected_init_containers",
+        "airflow_version, init_container_enabled, expected_init_containers",
         [
-            ("1.9.0", 2),
-            ("1.10.14", 2),
-            ("2.0.2", 2),
-            ("2.1.0", 2),
-            ("2.8.0", 3),
+            ("1.9.0", True, 2),
+            ("1.9.0", False, 2),
+            ("1.10.14", True, 2),
+            ("1.10.14", False, 2),
+            ("2.0.2", True, 2),
+            ("2.0.2", False, 2),
+            ("2.1.0", True, 2),
+            ("2.1.0", False, 2),
+            ("2.8.0", True, 3),
+            ("2.8.0", False, 2),
         ],
     )
-    def test_airflow_kerberos_init_container(self, airflow_version, expected_init_containers):
+    def test_airflow_kerberos_init_container(
+        self, airflow_version, init_container_enabled, expected_init_containers
+    ):
         docs = render_chart(
             values={
                 "airflowVersion": airflow_version,
                 "workers": {
-                    "kerberosInitContainer": {"enabled": True},
+                    "kerberosInitContainer": {"enabled": init_container_enabled},
                     "persistence": {"fixPermissions": True},
                 },
             },


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


The condition for adding is a kerberos init container is a conjunction of `kerberosInitContainer` and airflow version. The unit tests however had hardcoded `kerberosInitContainer`.

This PR adds the `kerberosInitContainer` parameter through a pytest parameter.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
