### PR TITLE
Stop serializing timezone-naive datetime as a timezone-aware datetime with UTC tz

### DIFF
--- a/tests/serialization/serializers/test_serializers.py
+++ b/tests/serialization/serializers/test_serializers.py
@@ -84,6 +84,11 @@ class TestSerializers:
         d = deserialize(s)
         assert i.timestamp() == d.timestamp()
 
+        i = datetime.datetime.now()
+        s = serialize(i)
+        d = deserialize(s)
+        assert i.timestamp() == d.timestamp()
+
     def test_deserialize_datetime_v1(self):
         s = {
             "__classname__": "pendulum.datetime.DateTime",


### PR DESCRIPTION
related: #36363

Currently, the timezone-naive datetimes are serialized as timezone-aware dateimes with a timezone UTC, which makes the deserialized values different from the original ones. This PR stops this conversion and serializes the provided datetime as it is.

It's also backward compatible, where the serialized values will be deserialized just like before this change, but it will avoid some unexpected results like the issue explained in #36363.

@bolkedebruin Is there any specific reason for this conversion?