### PR TITLE
feat(EcsRunTaskOperator): add `count` param

### DIFF
--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -640,7 +640,7 @@ class EcsRunTaskOperator(EcsBaseOperator):
         if self.propagate_tags is not None:
             run_opts["propagateTags"] = self.propagate_tags
         if self.count is not None:
-            run_opts["count"] = count
+            run_opts["count"] = self.count
 
         response = self.client.run_task(**run_opts)
 

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -188,6 +188,7 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
             "number_logs_exception",
             "wait_for_completion",
             "deferrable",
+            "count",
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Noticed that this was missing from `EcsRunTaskOperator` as an option.

Reference: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs/client/run_task.html