### PR TITLE
Update release process for providers to include mixed RC versions

### DIFF
--- a/dev/README_RELEASE_PROVIDER_PACKAGES.md
+++ b/dev/README_RELEASE_PROVIDER_PACKAGES.md
@@ -330,11 +330,19 @@ breeze release-management prepare-provider-packages  --include-removed-providers
  --version-suffix-for-pypi rc1 --package-format both
 ```
 
-if you only build few packages, run:
+If you only build few packages, run:
 
 ```shell script
 breeze release-management prepare-provider-packages \
 --version-suffix-for-pypi rc1 --package-format both PACKAGE PACKAGE ....
+```
+
+In case you are ALSO releasing RC2, RC3, etc. for selected packages, they will be skipped automatically because
+the `rc1` tag will be created for them already. In this case you should specify the ``rc*`` that you want to
+build and specify the package id's you want to build.
+
+```shell script
+breeze release-management prepare-provider-packages --version-suffix-for-pypi rc2 --package-format both PACKAGE
 ```
 
 * Verify the artifacts that would be uploaded:
@@ -416,7 +424,7 @@ git pull --rebase
 
 ```shell script
 cd "${AIRFLOW_REPO_ROOT}"
-breeze build-docs --clean-build apache-airflow-providers all-providers
+breeze build-docs --clean-build apache-airflow-providers all-providers --include-removed-providers
 ```
 
 Usually when we release packages we also build documentation for the "documentation-only" packages. This
@@ -461,12 +469,6 @@ breeze release-management publish-docs apache-airflow-providers all-providers --
 breeze release-management add-back-references all-providers
 ```
 
-If you see `ModuleNotFoundError: No module named 'docs'`, set:
-
-```
-export PYTHONPATH=.:${PYTHONPATH}
-```
-
 If you have providers as list of provider ids because you just released them you can build them with
 
 ```shell script
@@ -500,6 +502,8 @@ You can also pass the token as `--github-token` option in the script.
 You can also pass list of PR to be excluded from the issue with `--excluded-pr-list`.
 
 ```shell script
+cd "${AIRFLOW_REPO_ROOT}"
+
 breeze release-management generate-issue-content-providers --only-available-in-dist
 ```
 

--- a/dev/breeze/src/airflow_breeze/provider_issue_TEMPLATE.md.jinja2
+++ b/dev/breeze/src/airflow_breeze/provider_issue_TEMPLATE.md.jinja2
@@ -10,7 +10,7 @@ Let us know in the comment, whether the issue is addressed.
 Those are providers that require testing as there were some substantial changes introduced:
 
 {% for provider_id, provider_info in providers.items()  %}
-## Provider [{{ provider_id }}: {{ provider_info.version }}{{ suffix }}](https://pypi.org/project/{{ provider_info.pypi_package_name }}/{{ provider_info.version }}{{ suffix }})
+## Provider [{{ provider_id }}: {{ provider_info.version }}{{ provider_info.suffix }}](https://pypi.org/project/{{ provider_info.pypi_package_name }}/{{ provider_info.version }}{{ provider_info.suffix }})
 {%- for pr in provider_info.pr_list %}
    - [ ] [{{ pr.title }} (#{{ pr.number }})]({{ pr.html_url }}): @{{ pr.user.login }}
 {%- endfor %}


### PR DESCRIPTION
This PR updates released process for providers to enable releasing providers in more regular batches. Sometimes when we exclude a provider from previous voting, we want to release RCN (2,3 etc.) candidate.

However, especially when time between previous RC and the new one is long (for example because fixing took a long time) we might want to release the RCN release for that cancelled providers and RC1 for all the providers that have been changed in the meantime.

This cchange makes it possible (and easy):

1) release RC1 for all providers (the RCN provider should be skipped,
   because tag for this provider already exists.

2) release the RCN providers with `--version-suffix-for-pypi rcN`.

The release process and tools were updated to account for that - where rc candidate number is retrieved from packages prepared in `dist`.

Fixed a few small missing things in the process.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
