### PR TITLE
Add libxml2 install command for macOS in contributor quick start doc

### DIFF
--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -543,9 +543,17 @@ To avoid burden on CI infrastructure and to save time, Pre-commit hooks can be r
 
 1.  Installing required packages
 
+on Linux, install via
+
 .. code-block:: bash
 
   sudo apt install libxml2-utils
+
+on macOS, install via
+
+.. code-block:: bash
+
+  brew install libxml2
 
 2. Installing required Python packages
 

--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -543,7 +543,7 @@ To avoid burden on CI infrastructure and to save time, Pre-commit hooks can be r
 
 1.  Installing required packages
 
-on Linux, install via
+on Debian / Ubuntu, install via
 
 .. code-block:: bash
 


### PR DESCRIPTION
The both documents below states that libxml2 should be installed as a required package for the pre-commit hook.
While the first document includes installation commands for both Linux and Mac, the next document lacks instructions for Mac. So, I have added the Mac installation commands here.

https://github.com/apache/airflow/blob/main/STATIC_CODE_CHECKS.rst#pre-commit-hooks
https://github.com/apache/airflow/blob/main/CONTRIBUTORS_QUICK_START.rst#configuring-pre-commit

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
