### PR TITLE
Allow changing of `config_file` in `KubernetesResourceBaseOperator`

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/resource.py
+++ b/airflow/providers/cncf/kubernetes/operators/resource.py
@@ -58,6 +58,7 @@ class KubernetesResourceBaseOperator(BaseOperator):
         namespace: str | None = None,
         kubernetes_conn_id: str | None = KubernetesHook.default_conn_name,
         custom_resource_definition: bool = False,
+        config_file: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -65,6 +66,7 @@ class KubernetesResourceBaseOperator(BaseOperator):
         self.kubernetes_conn_id = kubernetes_conn_id
         self.yaml_conf = yaml_conf
         self.custom_resource_definition = custom_resource_definition
+        self.config_file = config_file
 
     @cached_property
     def client(self) -> ApiClient:
@@ -76,7 +78,7 @@ class KubernetesResourceBaseOperator(BaseOperator):
 
     @cached_property
     def hook(self) -> KubernetesHook:
-        hook = KubernetesHook(conn_id=self.kubernetes_conn_id)
+        hook = KubernetesHook(conn_id=self.kubernetes_conn_id, config_file=self.config_file)
         return hook
 
     def get_namespace(self) -> str:

--- a/tests/providers/cncf/kubernetes/operators/test_resource.py
+++ b/tests/providers/cncf/kubernetes/operators/test_resource.py
@@ -91,6 +91,7 @@ class TestKubernetesXResourceOperator:
             dag=self.dag,
             kubernetes_conn_id="kubernetes_default",
             task_id="test_task_id",
+            config_file="/foo/bar",
         )
 
         op.execute(context)
@@ -121,6 +122,7 @@ class TestKubernetesXResourceOperator:
             dag=self.dag,
             kubernetes_conn_id="kubernetes_default",
             task_id="test_task_id",
+            config_file="/foo/bar",
         )
 
         op.execute(context)
@@ -136,6 +138,7 @@ class TestKubernetesXResourceOperator:
             dag=self.dag,
             kubernetes_conn_id="kubernetes_default",
             task_id="test_task_id",
+            config_file="/foo/bar",
         )
 
         op.execute(context)

--- a/tests/providers/cncf/kubernetes/operators/test_resource.py
+++ b/tests/providers/cncf/kubernetes/operators/test_resource.py
@@ -84,8 +84,11 @@ class TestKubernetesXResourceOperator:
         args = {"owner": "airflow", "start_date": timezone.datetime(2020, 2, 1)}
         self.dag = DAG("test_dag_id", default_args=args)
 
+    @patch("kubernetes.config.load_kube_config")
     @patch("kubernetes.client.api.CoreV1Api.create_namespaced_persistent_volume_claim")
-    def test_create_application_from_yaml(self, mock_create_namespaced_persistent_volume_claim, context):
+    def test_create_application_from_yaml(
+        self, mock_create_namespaced_persistent_volume_claim, mock_load_kube_config, context
+    ):
         op = KubernetesCreateResourceOperator(
             yaml_conf=TEST_VALID_RESOURCE_YAML,
             dag=self.dag,
@@ -113,9 +116,10 @@ class TestKubernetesXResourceOperator:
 
         assert mock_create_namespaced_persistent_volume_claim.call_count == 2
 
+    @patch("kubernetes.config.load_kube_config")
     @patch("kubernetes.client.api.CoreV1Api.delete_namespaced_persistent_volume_claim")
     def test_single_delete_application_from_yaml(
-        self, mock_delete_namespaced_persistent_volume_claim, context
+        self, mock_delete_namespaced_persistent_volume_claim, mock_load_kube_config, context
     ):
         op = KubernetesDeleteResourceOperator(
             yaml_conf=TEST_VALID_RESOURCE_YAML,
@@ -129,9 +133,10 @@ class TestKubernetesXResourceOperator:
 
         mock_delete_namespaced_persistent_volume_claim.assert_called()
 
+    @patch("kubernetes.config.load_kube_config")
     @patch("kubernetes.client.api.CoreV1Api.delete_namespaced_persistent_volume_claim")
     def test_multi_delete_application_from_yaml(
-        self, mock_delete_namespaced_persistent_volume_claim, context
+        self, mock_delete_namespaced_persistent_volume_claim, mock_load_kube_config, context
     ):
         op = KubernetesDeleteResourceOperator(
             yaml_conf=TEST_VALID_LIST_RESOURCE_YAML,


### PR DESCRIPTION
This PR fix tests and closes: #34819
The problem was `load_config_file` actually looking for this file.
When mocking it the tests passes.

@champ250

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
