### PR TITLE
Add flask config: `MAX_CONTENT_LENGTH`

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1858,7 +1858,7 @@ webserver:
     allowed_payload_size:
       description: |
         The maximum size of the request payload (in MB) that can be sent.
-      version_added: 2.9.0
+      version_added: 2.8.1
       type: float
       example: ~
       default: "1.0"

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1855,7 +1855,7 @@ webserver:
       type: boolean
       example: "False"
       default: "False"
-    allowed_payload:
+    allowed_payload_size:
       description: |
         The maximum size of the request payload (in MB) that can be sent.
       version_added: 2.9.0

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1855,6 +1855,13 @@ webserver:
       type: boolean
       example: "False"
       default: "False"
+    allowed_payload:
+      description: |
+        The maximum size of the request payload (in MB) that can be sent.
+      version_added: 2.9.0
+      type: float
+      example: ~
+      default: "1.0"
 email:
   description: |
     Configuration email backend and whether to

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -75,7 +75,7 @@ def create_app(config=None, testing=False):
 
     flask_app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(minutes=settings.get_session_lifetime_config())
 
-    flask_app.config["MAX_CONTENT_LENGTH"] = conf.getfloat("webserver", "allowed_payload") * 1024 * 1024
+    flask_app.config["MAX_CONTENT_LENGTH"] = conf.getfloat("webserver", "allowed_payload_size") * 1024 * 1024
 
     webserver_config = conf.get_mandatory_value("webserver", "config_file")
     # Enable customizations in webserver_config.py to be applied via Flask.current_app.

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -75,6 +75,9 @@ def create_app(config=None, testing=False):
 
     flask_app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(minutes=settings.get_session_lifetime_config())
 
+    limit_in_mb = 1
+    flask_app.config["MAX_CONTENT_LENGTH"] = limit_in_mb * 1024 * 1024
+
     webserver_config = conf.get_mandatory_value("webserver", "config_file")
     # Enable customizations in webserver_config.py to be applied via Flask.current_app.
     with flask_app.app_context():

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -75,8 +75,7 @@ def create_app(config=None, testing=False):
 
     flask_app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(minutes=settings.get_session_lifetime_config())
 
-    limit_in_mb = 1
-    flask_app.config["MAX_CONTENT_LENGTH"] = limit_in_mb * 1024 * 1024
+    flask_app.config["MAX_CONTENT_LENGTH"] = conf.getfloat("webserver", "allowed_payload") * 1024 * 1024
 
     webserver_config = conf.get_mandatory_value("webserver", "config_file")
     # Enable customizations in webserver_config.py to be applied via Flask.current_app.


### PR DESCRIPTION
Add flask config to limit the allowed payload.
closes: https://github.com/apache/airflow/issues/35196

I set it to limit to 1MB.
Before and after adding this config, I tried sending a string larger than 1MB from the Edit User page.
Before adding the config, it was possible to send; after adding, I confirmed that the attached error page was received.

<img width="516" alt="request_entity_too_large_2023-12-24 14 35 41" src="https://github.com/apache/airflow/assets/39612448/c32617a0-c835-4a91-bb41-3ea853917e3e">

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
