### PR TITLE
Remove redundant `docker` decorator type annotations

### DIFF
--- a/airflow/decorators/__init__.pyi
+++ b/airflow/decorators/__init__.pyi
@@ -356,8 +356,6 @@ class TaskDecoratorCollection:
         privileged: bool = False,
         cap_add: str | None = None,
         extra_hosts: dict[str, str] | None = None,
-        retrieve_output: bool = False,
-        retrieve_output_path: str | None = None,
         timeout: int = 60,
         device_requests: list[dict] | None = None,
         log_opts_max_size: str | None = None,
@@ -443,10 +441,6 @@ class TaskDecoratorCollection:
         :param cap_add: Include container capabilities
         :param extra_hosts: Additional hostnames to resolve inside the container,
             as a mapping of hostname to IP address.
-        :param retrieve_output: Should this docker image consistently attempt to pull from and output
-            file before manually shutting down the image. Useful for cases where users want a pickle serialized
-            output that is not posted to logs
-        :param retrieve_output_path: path for output file that will be retrieved and passed to xcom
         :param device_requests: Expose host resources such as GPUs to the container.
         :param log_opts_max_size: The maximum size of the log before it is rolled.
             A positive integer plus a modifier representing the unit of measure (k, m, or g).


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This parameters are filled by `_DockerDecoratedOperator` so there is no way to overwrite it/

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
