### PR TITLE
Use cards when describing priority weighting methods

### DIFF
--- a/docs/apache-airflow/administration-and-deployment/priority-weight.rst
+++ b/docs/apache-airflow/administration-and-deployment/priority-weight.rst
@@ -22,40 +22,43 @@ Priority Weights
 
 ``priority_weight`` defines priorities in the executor queue. The default ``priority_weight`` is ``1``, and can be
 bumped to any integer. Moreover, each task has a true ``priority_weight`` that is calculated based on its
-``weight_rule`` which defines weighting method used for the effective total priority weight of the task.
+``weight_rule`` which defines the weighting method used for the effective total priority weight of the task.
 
-By default, Airflow's weighting method is ``downstream``. You can find other weighting methods in
-:class:`airflow.utils.WeightRule`.
+Below are the weighting methods. By default, Airflow's weighting method is ``downstream``.
 
-There are three weighting methods.
 
-- downstream
+.. grid:: 3
 
-  The effective weight of the task is the aggregate sum of all
-  downstream descendants. As a result, upstream tasks will have
-  higher weight and will be scheduled more aggressively when
-  using positive weight values. This is useful when you have
-  multiple DAG run instances and desire to have all upstream
-  tasks to complete for all runs before each DAG can continue
-  processing downstream tasks.
+  .. grid-item-card:: ``downstream``
+    :shadow: none
 
-- upstream
+    The effective weight of the task is the aggregate sum of all
+    downstream descendants. As a result, upstream tasks will have
+    higher weight and will be scheduled more aggressively when
+    using positive weight values. This is useful when you have
+    multiple DAG run instances and desire to have all upstream
+    tasks to complete for all runs before each DAG can continue
+    processing downstream tasks.
 
-  The effective weight is the aggregate sum of all upstream ancestors.
-  This is the opposite where downstream tasks have higher weight
-  and will be scheduled more aggressively when using positive weight
-  values. This is useful when you have multiple DAG run instances
-  and prefer to have each DAG complete before starting upstream
-  tasks of other DAG runs.
+  .. grid-item-card:: ``upstream``
+    :shadow: none
 
-- absolute
+    The effective weight is the aggregate sum of all upstream ancestors.
+    This is the opposite where downstream tasks have higher weight
+    and will be scheduled more aggressively when using positive weight
+    values. This is useful when you have multiple DAG run instances
+    and prefer to have each DAG complete before starting upstream
+    tasks of other DAG runs.
 
-  The effective weight is the exact ``priority_weight`` specified
-  without additional weighting. You may want to do this when you
-  know exactly what priority weight each task should have.
-  Additionally, when set to ``absolute``, there is bonus effect of
-  significantly speeding up the task creation process as for very
-  large DAGs
+  .. grid-item-card:: ``absolute``
+    :shadow: none
+
+    The effective weight is the exact ``priority_weight`` specified
+    without additional weighting. You may want to do this when you
+    know exactly what priority weight each task should have.
+    Additionally, when set to ``absolute``, there is bonus effect of
+    significantly speeding up the task creation process as for very
+    large DAGs.
 
 
 The ``priority_weight`` parameter can be used in conjunction with :ref:`concepts:pool`.


### PR DESCRIPTION
This PR is a a small facelift to improve the readability of the Priority Weights doc. Instead of using a bulleted list to outline and describe the different weighting methods, let's use a cards visualization.
