### PR TITLE
Refactor _manage_executor_state by refreshing TIs in batch

### DIFF
--- a/airflow/jobs/backfill_job_runner.py
+++ b/airflow/jobs/backfill_job_runner.py
@@ -265,9 +265,10 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
         """
         executor = self.job.executor
         # list of tuples (dag_id, task_id, execution_date, map_index) of running tasks in executor
+        buffered_events = list(executor.get_event_buffer().items())
         running_tis_ids = [
             (key.dag_id, key.task_id, key.run_id, key.map_index)
-            for key in executor.get_event_buffer()
+            for key, _ in buffered_events
             if key in running
         ]
         # list of TaskInstance of running tasks in executor (refreshed from db in batch)
@@ -282,15 +283,18 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
             )
         ).all()
         # dict of refreshed TaskInstance by key to easily find them
-        refreshed_running_tis_dict = {ti.key: ti for ti in refreshed_running_tis}
+        refreshed_running_tis_dict = {
+            (ti.dag_id, ti.task_id, ti.run_id, ti.map_index): ti for ti in refreshed_running_tis
+        }
 
-        for key, value in list(executor.get_event_buffer().items()):
+        for key, value in buffered_events:
             state, info = value
-            if key not in refreshed_running_tis_dict:
+            ti_key = (key.dag_id, key.task_id, key.run_id, key.map_index)
+            if ti_key not in refreshed_running_tis_dict:
                 self.log.warning("%s state %s not in running=%s", key, state, running.values())
                 continue
 
-            ti = refreshed_running_tis_dict[key]
+            ti = refreshed_running_tis_dict[ti_key]
 
             self.log.debug("Executor state: %s task %s", state, ti)
 


### PR DESCRIPTION
related: #7370

This PR improves the performance of the method `_manage_executor_state` by fetching the state of all the running TIs in a single query instead of refreshing them one by one from the DB. 