### PR TITLE
Remove invalid todo comment from flink provider

### DIFF
--- a/airflow/providers/apache/flink/provider.yaml
+++ b/airflow/providers/apache/flink/provider.yaml
@@ -42,7 +42,7 @@ integrations:
   - integration-name: Apache Flink
     external-doc-url: https://github.com/apache/flink-kubernetes-operator
     how-to-guide:
-      - /docs/apache-airflow-providers-apache-flink/operators.rst  # TODO
+      - /docs/apache-airflow-providers-apache-flink/operators.rst
     logo: /integration-logos/kubernetes/FlinkOnK8s.png
     tags: [apache]
 


### PR DESCRIPTION
The file already exists, and the comment doesn't explain what should be done later.

related: #28512