### PR TITLE
Delete get_python_source from Kubernetes decorator after bumping min airflow version to 2.6.0

### DIFF
--- a/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
@@ -17,10 +17,8 @@
 from __future__ import annotations
 
 import base64
-import inspect
 import os
 import pickle
-import textwrap
 import uuid
 from shlex import quote
 from tempfile import TemporaryDirectory
@@ -32,7 +30,6 @@ from kubernetes.client import models as k8s
 from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.python_kubernetes_script import (
-    remove_task_decorator,
     write_python_script,
 )
 
@@ -76,13 +73,6 @@ class _KubernetesDecoratedOperator(DecoratedOperator, KubernetesPodOperator):
             cmds=["placeholder-command"],
             **kwargs,
         )
-
-    # TODO: Remove me once this provider min supported Airflow version is 2.6
-    def get_python_source(self):
-        raw_source = inspect.getsource(self.python_callable)
-        res = textwrap.dedent(raw_source)
-        res = remove_task_decorator(res, self.custom_operator_name)
-        return res
 
     def _generate_cmds(self) -> list[str]:
         script_filename = "/tmp/script.py"


### PR DESCRIPTION
The method has existed in the Airflow base decorator since 2.6.0 which is currently the min supported Airflow version in the provider.