### PR TITLE
Remove deprecated input parameters in the k8s pod operator

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -289,20 +289,6 @@ class KubernetesPodOperator(BaseOperator):
         progress_callback: Callable[[str], None] | None = None,
         **kwargs,
     ) -> None:
-        # TODO: remove in provider 6.0.0 release. This is a mitigate step to advise users to switch to the
-        # container_resources parameter.
-        if isinstance(kwargs.get("resources"), k8s.V1ResourceRequirements):
-            raise AirflowException(
-                "Specifying resources for the launched pod with 'resources' is deprecated. "
-                "Use 'container_resources' instead."
-            )
-        # TODO: remove in provider 6.0.0 release. This is a mitigate step to advise users to switch to the
-        # node_selector parameter.
-        if "node_selectors" in kwargs:
-            raise ValueError(
-                "Param `node_selectors` supplied. This param is no longer supported. "
-                "Use `node_selector` instead."
-            )
         super().__init__(**kwargs)
         self.kubernetes_conn_id = kubernetes_conn_id
         self.do_xcom_push = do_xcom_push

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -1162,28 +1162,6 @@ class TestKubernetesPodOperatorSystem:
                 k.execute(context)
             create_mock.assert_called_once()
 
-    def test_using_resources(self, mock_get_connection):
-        exception_message = (
-            "Specifying resources for the launched pod with 'resources' is deprecated. "
-            "Use 'container_resources' instead."
-        )
-        with pytest.raises(AirflowException, match=exception_message):
-            resources = k8s.V1ResourceRequirements(
-                requests={"memory": "64Mi", "cpu": "250m", "ephemeral-storage": "1Gi"},
-                limits={"memory": "64Mi", "cpu": 0.25, "nvidia.com/gpu": None, "ephemeral-storage": "2Gi"},
-            )
-            KubernetesPodOperator(
-                namespace="default",
-                image="ubuntu:16.04",
-                cmds=["bash", "-cx"],
-                arguments=["echo 10"],
-                labels=self.labels,
-                task_id=str(uuid4()),
-                in_cluster=False,
-                do_xcom_push=False,
-                resources=resources,
-            )
-
     def test_changing_base_container_name_with_get_logs(self, mock_get_connection):
         k = KubernetesPodOperator(
             namespace="default",


### PR DESCRIPTION
Remove deprecated input parameters in the k8s pod operator when provider version >= 6.0.0