### PR TITLE
Fix Exception FabAirflowSecurityManagerOverride

### DIFF
--- a/airflow/auth/managers/fab/fab_auth_manager.py
+++ b/airflow/auth/managers/fab/fab_auth_manager.py
@@ -339,7 +339,7 @@ class FabAuthManager(BaseAuthManager):
 
         sm_from_config = self.appbuilder.get_app.config.get("SECURITY_MANAGER_CLASS")
         if sm_from_config:
-            if not issubclass(sm_from_config, AirflowSecurityManager):
+            if issubclass(sm_from_config, AirflowSecurityManager):
                 raise Exception(
                     """Your CUSTOM_SECURITY_MANAGER must extend FabAirflowSecurityManagerOverride,
                      not FAB's own security manager."""


### PR DESCRIPTION

related: #36432 
The exception raised Your CUSTOM_SECURITY_MANAGER must extend FabAirflowSecurityManagerOverride, not FAB's own security manager.
My English is not good, so I ask you to be patient.
The error happens when extending the FabAirflow SecurityManagerOverride class to create custom authentication