### PR TITLE
Yet another attempt to fix flakey `test_disable_logging` test

### DIFF
--- a/tests/providers/google/cloud/utils/test_credentials_provider.py
+++ b/tests/providers/google/cloud/utils/test_credentials_provider.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import re
+from contextlib import contextmanager
 from io import StringIO
 from tempfile import NamedTemporaryFile
 from unittest import mock
@@ -53,6 +54,31 @@ ACCOUNT_2_SAME_PROJECT = "account_2@project_id.iam.gserviceaccount.com"
 ACCOUNT_3_ANOTHER_PROJECT = "account_3@another_project_id.iam.gserviceaccount.com"
 ANOTHER_PROJECT_ID = "another_project_id"
 CRED_PROVIDER_LOGGER_NAME = "airflow.providers.google.cloud.utils.credentials_provider._CredentialProvider"
+
+
+@pytest.fixture
+def assert_no_logs(caplog):
+    """
+    Helper fixture for assert if any log message for the specific logger captured.
+
+    This is workaround for fix issue with asyncio in ``test_disable_logging``, see:
+        - https://github.com/apache/airflow/pull/26871
+        - https://github.com/apache/airflow/pull/26973
+        - https://github.com/apache/airflow/pull/36453
+    """
+
+    @contextmanager
+    def wrapper(level: str, logger: str):
+        with caplog.at_level(level=level, logger=logger):
+            caplog.clear()
+            yield
+        if records := list(filter(lambda lr: lr[0] == logger, caplog.record_tuples)):
+            msg = f"Did not expect any log message from logger={logger!r} but got:"
+            for log_record in records:
+                msg += f"\n * logger name: {log_record[0]!r}, level: {log_record[1]}, msg: {log_record[2]!r}"
+            raise AssertionError(msg)
+
+    return wrapper
 
 
 class TestHelper:
@@ -364,32 +390,26 @@ class TestGetGcpCredentialsAndProjectId:
     @mock.patch(
         "google.oauth2.service_account.Credentials.from_service_account_file",
     )
-    def test_disable_logging(self, mock_default, mock_info, mock_file, caplog):
+    def test_disable_logging(self, mock_default, mock_info, mock_file, assert_no_logs):
         """Test disable logging in ``get_credentials_and_project_id``"""
 
         # assert no logs
-        with caplog.at_level(level=logging.DEBUG, logger=CRED_PROVIDER_LOGGER_NAME):
-            caplog.clear()
+        with assert_no_logs(level="DEBUG", logger=CRED_PROVIDER_LOGGER_NAME):
             get_credentials_and_project_id(disable_logging=True)
-            assert not caplog.record_tuples
 
         # assert no debug logs emitted from get_credentials_and_project_id
-        with caplog.at_level(level=logging.DEBUG, logger=CRED_PROVIDER_LOGGER_NAME):
-            caplog.clear()
+        with assert_no_logs(level="DEBUG", logger=CRED_PROVIDER_LOGGER_NAME):
             get_credentials_and_project_id(
                 keyfile_dict={"private_key": "PRIVATE_KEY"},
                 disable_logging=True,
             )
-            assert not caplog.record_tuples
 
         # assert no debug logs emitted from get_credentials_and_project_id
-        with caplog.at_level(level=logging.DEBUG, logger=CRED_PROVIDER_LOGGER_NAME):
-            caplog.clear()
+        with assert_no_logs(level="DEBUG", logger=CRED_PROVIDER_LOGGER_NAME):
             get_credentials_and_project_id(
                 key_path="KEY.json",
                 disable_logging=True,
             )
-            assert not caplog.record_tuples
 
 
 class TestGetScopes:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This one revert approach which was used in https://github.com/apache/airflow/pull/26973 but replaced by `caplog` during `unittests` -> `pytest` migration.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
