### PR TITLE
fix: Repair incorrect display of the deferrable operators in the documentation

### DIFF
--- a/docs/exts/operators_and_hooks_ref.py
+++ b/docs/exts/operators_and_hooks_ref.py
@@ -209,10 +209,16 @@ def _render_deferrable_operator_content(*, header_separator: str):
                         )
 
         if provider_info["operators"]:
+            provider_info["operators"] = sorted(provider_info["operators"])
             provider_yaml_content = yaml.safe_load(Path(provider_yaml_path).read_text())
             provider_info["name"] = provider_yaml_content["package-name"]
             providers.append(provider_info)
-    return _render_template("deferrable_operators_list.rst.jinja2", providers=providers)
+
+    return _render_template(
+        "deferrable_operators_list.rst.jinja2",
+        providers=sorted(providers, key=lambda p: p["name"]),
+        header_separator=header_separator,
+    )
 
 
 class BaseJinjaReferenceDirective(Directive):

--- a/docs/exts/templates/deferrable_operators_list.rst.jinja2
+++ b/docs/exts/templates/deferrable_operators_list.rst.jinja2
@@ -17,15 +17,16 @@
  under the License.
 #}
 {%- for provider in providers %}
-**{{ provider["name"] }}**
+{{ provider["name"] }}
+{{ header_separator * (provider['name']|length) }}
 
-.. list-table::F
+.. list-table::
    :header-rows: 1
 
    * - Modules
      - Operators
    {% for module, operator in provider["operators"] %}
    * - :mod:`{{ module }}`
-     - :mod:`{{ operator}}`
+     - :mod:`{{ operator }}`
    {% endfor %}
 {% endfor %}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The current issue with the incorrect display of the list of deferrable operators in the documentation [here](https://airflow.apache.org/docs/apache-airflow-providers/core-extensions/deferrable-operator-ref.html) stems from an unintentional? [typo](https://github.com/apache/airflow/commit/73b90c48b1933b49086d34176527947bd727ec85#diff-16423db0ea634fde3bad7fb0b68d73d36aa2910dc3cbdfa9361fa04afbe8b6cb) in the .rst.jinja2 file. This PR addresses and resolves that issue.

Additionally, this PR enhances readability by organising each provider into its own section. This change allows these sections to be displayed in the right-hand sidebar, improving navigation. Furthermore, the PR implements alphabetical sorting, ensuring that each provider, module, and operator is listed in an orderly, alphabetical manner.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
