### PR TITLE
Raise error when ``DagRun`` fails while running ``dag test``

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -405,6 +405,14 @@ ARG_IMGCAT_DAGRUN = Arg(
     ),
     action="store_true",
 )
+ARG_FAIL_ON_DAGRUN_FAILURE = Arg(
+    (
+        "-f",
+        "--fail-on-dagrun-failure",
+    ),
+    help="Exit with code 1 if the DagRun completes with a failed state.\n",
+    action="store_true",
+)
 ARG_SAVE_DAGRUN = Arg(
     ("--save-dagrun",),
     help="After completing the backfill, saves the diagram for current DAG Run to the indicated file.\n\n",
@@ -1248,6 +1256,7 @@ DAGS_COMMANDS = (
             ARG_SHOW_DAGRUN,
             ARG_IMGCAT_DAGRUN,
             ARG_SAVE_DAGRUN,
+            ARG_FAIL_ON_DAGRUN_FAILURE,
             ARG_VERBOSE,
         ),
     ),

--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -405,14 +405,6 @@ ARG_IMGCAT_DAGRUN = Arg(
     ),
     action="store_true",
 )
-ARG_FAIL_ON_DAGRUN_FAILURE = Arg(
-    (
-        "-f",
-        "--fail-on-dagrun-failure",
-    ),
-    help="Exit with code 1 if the DagRun completes with a failed state.\n",
-    action="store_true",
-)
 ARG_SAVE_DAGRUN = Arg(
     ("--save-dagrun",),
     help="After completing the backfill, saves the diagram for current DAG Run to the indicated file.\n\n",
@@ -1256,7 +1248,6 @@ DAGS_COMMANDS = (
             ARG_SHOW_DAGRUN,
             ARG_IMGCAT_DAGRUN,
             ARG_SAVE_DAGRUN,
-            ARG_FAIL_ON_DAGRUN_FAILURE,
             ARG_VERBOSE,
         ),
     ),

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -536,7 +536,7 @@ def dag_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> No
         if show_dagrun:
             print(dot_graph.source)
 
-    if args.fail_on_dagrun_failure and dr and dr.state == DagRunState.FAILED:
+    if dr and dr.state == DagRunState.FAILED:
         raise SystemExit("DagRun failed")
 
 

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -515,7 +515,7 @@ def dag_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> No
             raise SystemExit(f"Configuration {args.conf!r} is not valid JSON. Error: {e}")
     execution_date = args.execution_date or timezone.utcnow()
     dag = dag or get_dag(subdir=args.subdir, dag_id=args.dag_id)
-    dag.test(execution_date=execution_date, run_conf=run_conf, session=session)
+    dr: DagRun = dag.test(execution_date=execution_date, run_conf=run_conf, session=session)
     show_dagrun = args.show_dagrun
     imgcat = args.imgcat_dagrun
     filename = args.save_dagrun
@@ -535,6 +535,9 @@ def dag_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> No
             _display_dot_via_imgcat(dot_graph)
         if show_dagrun:
             print(dot_graph.source)
+
+    if args.fail_on_dagrun_failure and dr and dr.state == DagRunState.FAILED:
+        raise SystemExit("DagRun failed")
 
 
 @cli_utils.action_cli

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -754,9 +754,7 @@ class TestCliDags:
         mock_get_dag.return_value.test.return_value = DagRun(
             dag_id="example_bash_operator", execution_date=DEFAULT_DATE, state=DagRunState.FAILED
         )
-        cli_args = self.parser.parse_args(
-            ["dags", "test", "example_bash_operator", execution_date_str, "--fail-on-dagrun-failure"]
-        )
+        cli_args = self.parser.parse_args(["dags", "test", "example_bash_operator", execution_date_str])
         with pytest.raises(SystemExit, match=r"DagRun failed"):
             dag_command.dag_test(cli_args)
 


### PR DESCRIPTION
**Motivation**:

Currently, when using `airflow dags test`, there is no easy way to know programmatically if a DagRun fails since the state is not stored in DB. The way to do know relies on log lines as below:

```bash
state=$(airflow dags test exception_dag | grep "DagRun Finished" | awk -F, '{for(i=1;i<=NF;i++) if ($i ~ / state=/) print $i}' | awk -F= '{print $2}') if [[ $state == "failed" ]]; then exit 1 else exit 0 fi
```

This PR will return an exit code 1 when `airflow dags test` command if DagRun fails and makes it easy to integrate in CI for testing.