### PR TITLE
Remove option ot set a task instance to running state in UI

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -5450,7 +5450,6 @@ class TaskInstanceModelView(AirflowModelView):
         "action_clear": "edit",
         "action_clear_downstream": "edit",
         "action_muldelete": "delete",
-        "action_set_running": "edit",
         "action_set_failed": "edit",
         "action_set_success": "edit",
         "action_set_retry": "edit",
@@ -5726,15 +5725,6 @@ class TaskInstanceModelView(AirflowModelView):
             flash(f"{count} task instances were set to '{target_state}'")
         except Exception:
             flash("Failed to set state", "error")
-
-    @action("set_running", "Set state to 'running'", "", single=False)
-    @auth.has_access_dag_entities("PUT", DagAccessEntity.TASK_INSTANCE)
-    @action_logging
-    def action_set_running(self, tis):
-        """Set state to 'running'."""
-        self.set_task_instance_state(tis, TaskInstanceState.RUNNING)
-        self.update_redirect()
-        return redirect(self.get_redirect())
 
     @action("set_failed", "Set state to 'failed'", "", single=False)
     @auth.has_access_dag_entities("PUT", DagAccessEntity.TASK_INSTANCE)

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -943,13 +943,12 @@ def test_task_instance_clear_failure(admin_client):
 @pytest.mark.parametrize(
     "action, expected_state",
     [
-        ("set_running", State.RUNNING),
         ("set_failed", State.FAILED),
         ("set_success", State.SUCCESS),
         ("set_retry", State.UP_FOR_RETRY),
         ("set_skipped", State.SKIPPED),
     ],
-    ids=["running", "failed", "success", "retry", "skipped"],
+    ids=["failed", "success", "retry", "skipped"],
 )
 def test_task_instance_set_state(session, admin_client, action, expected_state):
     task_id = "runme_0"
@@ -972,7 +971,6 @@ def test_task_instance_set_state(session, admin_client, action, expected_state):
 @pytest.mark.parametrize(
     "action",
     [
-        "set_running",
         "set_failed",
         "set_success",
         "set_retry",


### PR DESCRIPTION
Removes the "Set to state 'running'" option from UI for Task instances. If users are using this, immediately an "Zombie task" error like the following is produced in the task logs:
```
[2023-12-31, 18:57:01 CET] {scheduler_job_runner.py:1766} ERROR - Detected zombie job: {'full_filepath': '/opt/airflow/airflow/example_dags/example_params_ui_tutorial.py', 'processor_subdir': '/files/dags', 'msg': "{'DAG Id': 'example_params_ui_tutorial', 'Task Id': 'show_params', 'Run Id': 'manual__2023-12-31T18:56:01+01:00', 'Hostname': 'c01bb381ee62', 'External Executor Id': '0464fee6-8ba2-4a3b-87cc-f9c0d891bfa9'}", 'simple_task_instance': <airflow.models.taskinstance.SimpleTaskInstance object at 0x7f8ac6c4b6a0>, 'is_failure_callback': True} (See https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/tasks.html#zombie-undead-tasks)
```
See also https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/tasks.html#zombie-undead-tasks

Reason for removal is that the setting to state "running" just creates an inconsistent state in the meta database, no background activity is started. For advanced user who know what they are doing, rather the API `HTTP PATCH /dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}' is the right way. But we should not leave a standard option in the normal user UI as this is mis-leading.

closes: #35729
