### PR TITLE
Update installation prerequisites after upgrading to Debian Bookworm

### DIFF
--- a/docs/apache-airflow/installation/dependencies.rst
+++ b/docs/apache-airflow/installation/dependencies.rst
@@ -70,23 +70,39 @@ asynchronous workers for Gunicorn. None of those have providers, they are just e
 System dependencies
 '''''''''''''''''''
 
-You need certain system level requirements in order to install Airflow. Those are requirements that are known
-to be needed for Linux system (Tested on Ubuntu Bullseye LTS) :
+You need certain system level requirements in order to install Airflow.
+Those are requirements that are known to be needed for Linux Debian distributions:
+
+Debian Bookworm (12)
+====================
+
+Debian Bookworm is our platform of choice for development and testing. It is the most up-to-date
+Debian distribution and it is the one we use for our CI/CD system. It is also the one we recommend
+for development and testing as well as production use.
 
 .. code-block:: bash
 
-   sudo apt-get install -y --no-install-recommends \
-           freetds-bin \
-           krb5-user \
-           ldap-utils \
-           libffi6 \
-           libsasl2-2 \
-           libsasl2-modules \
-           libssl1.1 \
-           locales  \
-           lsb-release \
-           sasl2-bin \
-           sqlite3 \
-           unixodbc
+  sudo apt install -y --no-install-recommends apt-transport-https apt-utils ca-certificates \
+    curl dumb-init freetds-bin gosu krb5-user libgeos-dev \
+    ldap-utils libsasl2-2 libsasl2-modules libxmlsec1 locales libffi8 libldap-2.5-0 libssl3 netcat-openbsd \
+    lsb-release openssh-client python3-selinux rsync sasl2-bin sqlite3 sudo unixodb
+
+Debian Bullseye (11)
+====================
+
+Debian Bullseye is the previous Debian distribution. It is still supported by Airflow and it is
+the one we also recommend for production use, however we only build images in the CI and we do not
+run any tests there (we do not expect problems though). In Airflow 2.9 we are going to stop building images
+for Bullseye and we will only build images and explain system level dependencies for Bookworm.
+
+.. code-block:: bash
+
+  sudo apt install -y --no-install-recommends apt-transport-https apt-utils ca-certificates \
+    curl dumb-init freetds-bin gosu krb5-user libgeos-dev \
+    ldap-utils libsasl2-2 libsasl2-modules libxmlsec1 locales libffi7 libldap-2.4-2 libssl1.1 netcat \
+    lsb-release openssh-client python3-selinux rsync sasl2-bin sqlite3 sudo unixodb
 
 You also need database client packages (Postgres or MySQL) if you want to use those databases.
+
+
+If you use a different distribution, you will need to adapt the commands accordingly.

--- a/docs/apache-airflow/installation/prerequisites.rst
+++ b/docs/apache-airflow/installation/prerequisites.rst
@@ -51,10 +51,11 @@ wildly on the deployment options you have
 .. warning::
 
   Airflow™ currently can be run on POSIX-compliant Operating Systems. For development it is regularly
-  tested on fairly modern Linux Distros and recent versions of MacOS.
+  tested on fairly modern Linux Distros that our contributors use and recent versions of MacOS.
   On Windows you can run it via WSL2 (Windows Subsystem for Linux 2) or via Linux Containers.
   The work to add Windows support is tracked via `#10388 <https://github.com/apache/airflow/issues/10388>`__
   but it is not a high priority. You should only use Linux-based distros as "Production" execution environment
   as this is the only environment that is supported. The only distro that is used in our CI tests and that
   is used in the `Community managed DockerHub image <https://hub.docker.com/p/apache/airflow>`__ is
-  ``Debian Bullseye``.
+  ``Debian Bookworm``. We also build ``Debian Bullseye`` images in Airflow 2.8 but we do not use them for
+  CI tests and they will be dropped in Airflow 2.9.


### PR DESCRIPTION
We've migrated to Debian Bookworm for our images in #31941 but our installation prerequisites and example system level dependencies mention Bullseye. Since for 2.8 we run all tests on Bookworm but we also suppport custom Bullseye imeage (to be removed likely in 2.9) we should put Bookworm front and center but also explain differences with Bullseye.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
