### PR TITLE
Explicitly passing `raise_on_deleted_version=True` to `read_secret_version` in Hashicorp operator

### DIFF
--- a/airflow/providers/hashicorp/_internal_client/vault_client.py
+++ b/airflow/providers/hashicorp/_internal_client/vault_client.py
@@ -373,7 +373,10 @@ class _VaultClient(LoggingMixin):
                 response = self.client.secrets.kv.v1.read_secret(path=secret_path, mount_point=mount_point)
             else:
                 response = self.client.secrets.kv.v2.read_secret_version(
-                    path=secret_path, mount_point=mount_point, version=secret_version
+                    path=secret_path,
+                    mount_point=mount_point,
+                    version=secret_version,
+                    raise_on_deleted_version=True,
                 )
         except InvalidPath:
             self.log.debug("Secret not found %s with mount point %s", secret_path, mount_point)
@@ -422,7 +425,10 @@ class _VaultClient(LoggingMixin):
         try:
             mount_point, secret_path = self._parse_secret_path(secret_path)
             return self.client.secrets.kv.v2.read_secret_version(
-                path=secret_path, mount_point=mount_point, version=secret_version
+                path=secret_path,
+                mount_point=mount_point,
+                version=secret_version,
+                raise_on_deleted_version=True,
             )
         except InvalidPath:
             self.log.debug(

--- a/airflow/providers/hashicorp/provider.yaml
+++ b/airflow/providers/hashicorp/provider.yaml
@@ -50,7 +50,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.6.0
-  - hvac>=0.10
+  - hvac>=1.1.0
 
 integrations:
   - integration-name: Hashicorp Vault

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -546,7 +546,7 @@
   "hashicorp": {
     "deps": [
       "apache-airflow>=2.6.0",
-      "hvac>=0.10"
+      "hvac>=1.1.0"
     ],
     "cross-providers-deps": [
       "google"

--- a/tests/providers/hashicorp/_internal_client/test_vault_client.py
+++ b/tests/providers/hashicorp/_internal_client/test_vault_client.py
@@ -641,7 +641,7 @@ class TestVaultClient:
         secret = vault_client.get_secret(secret_path="missing")
         assert secret is None
         mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
-            mount_point="secret", path="missing", version=None
+            mount_point="secret", path="missing", version=None, raise_on_deleted_version=True
         )
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -661,7 +661,7 @@ class TestVaultClient:
         assert secret is None
         assert "secret" == vault_client.mount_point
         mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
-            mount_point="secret", path="missing", version=None
+            mount_point="secret", path="missing", version=None, raise_on_deleted_version=True
         )
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -716,7 +716,7 @@ class TestVaultClient:
         secret = vault_client.get_secret(secret_path="path/to/secret")
         assert {"secret_key": "secret_value"} == secret
         mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
-            mount_point="secret", path="path/to/secret", version=None
+            mount_point="secret", path="path/to/secret", version=None, raise_on_deleted_version=True
         )
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -754,7 +754,7 @@ class TestVaultClient:
         secret = vault_client.get_secret(secret_path="mount_point/path/to/secret")
         assert {"secret_key": "secret_value"} == secret
         mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
-            mount_point="mount_point", path="path/to/secret", version=None
+            mount_point="mount_point", path="path/to/secret", version=None, raise_on_deleted_version=True
         )
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -791,7 +791,7 @@ class TestVaultClient:
         secret = vault_client.get_secret(secret_path="missing", secret_version=1)
         assert {"secret_key": "secret_value"} == secret
         mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
-            mount_point="secret", path="missing", version=1
+            mount_point="secret", path="missing", version=1, raise_on_deleted_version=True
         )
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -1015,7 +1015,7 @@ class TestVaultClient:
             "auth": None,
         } == metadata
         mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
-            mount_point="secret", path="missing", version=None
+            mount_point="secret", path="missing", version=None, raise_on_deleted_version=True
         )
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")

--- a/tests/providers/hashicorp/hooks/test_vault.py
+++ b/tests/providers/hashicorp/hooks/test_vault.py
@@ -1005,7 +1005,7 @@ class TestVaultHook:
         secret = test_hook.get_secret(secret_path="missing")
         assert {"secret_key": "secret_value"} == secret
         mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
-            mount_point="secret", path="missing", version=None
+            mount_point="secret", path="missing", version=None, raise_on_deleted_version=True
         )
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -1044,7 +1044,7 @@ class TestVaultHook:
         secret = test_hook.get_secret(secret_path="missing", secret_version=1)
         assert {"secret_key": "secret_value"} == secret
         mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
-            mount_point="secret", path="missing", version=1
+            mount_point="secret", path="missing", version=1, raise_on_deleted_version=True
         )
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -1189,7 +1189,7 @@ class TestVaultHook:
             "auth": None,
         } == metadata
         mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
-            mount_point="secret", path="missing", version=None
+            mount_point="secret", path="missing", version=None, raise_on_deleted_version=True
         )
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")

--- a/tests/providers/hashicorp/secrets/test_vault.py
+++ b/tests/providers/hashicorp/secrets/test_vault.py
@@ -302,7 +302,7 @@ class TestVaultSecrets:
         test_client = VaultBackend(**kwargs)
         assert test_client.get_conn_uri(conn_id="test_mysql") is None
         mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
-            mount_point="airflow", path="connections/test_mysql", version=None
+            mount_point="airflow", path="connections/test_mysql", version=None, raise_on_deleted_version=True
         )
         assert test_client.get_connection(conn_id="test_mysql") is None
 
@@ -454,7 +454,7 @@ class TestVaultSecrets:
         test_client = VaultBackend(**kwargs)
         assert test_client.get_variable("hello") is None
         mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
-            mount_point="airflow", path="variables/hello", version=None
+            mount_point="airflow", path="variables/hello", version=None, raise_on_deleted_version=True
         )
         assert test_client.get_variable("hello") is None
 


### PR DESCRIPTION
closes: #31347

Unfortunately I don't have Hashicorp infrastructure to connect to it so I cannot check this.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
