### PR TITLE
Rewording text in CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -144,9 +144,9 @@ code is maintained.
 
 The term "committer" and "maintainer" is used interchangeably. The term "committer" is the official term used by the
 Apache Software Foundation, while "maintainer" is more commonly used in the Open Source community and is used
-in GitHub context in a number of guidelines and documentation, so this document will mostly use "maintainer",
-when speaking about Github, Pull Request, Github Issues and Discussion, committer on the other hand is more
-often used in devlist discussions, official communication, Airflow website and every time when we formally
+in context of GitHub in a number of guidelines and documentation, so this document will mostly use "maintainer",
+when speaking about Github, Pull Request, Github Issues and Discussions. On the other hand, "committer" is more
+often used in devlist discussions, official communications, Airflow website and every time when we formally
 refer to the role.
 
 The official list of committers can be found `here <https://airflow.apache.org/docs/apache-airflow/stable/project.html#committers>`__.
@@ -459,7 +459,7 @@ Step 4: Prepare PR
 3. Re-run static code checks again.
 
 4. Make sure your commit has a good title and description of the context of your change, enough
-   for the maintainer reviewing it to understand why you are proposing a change. Make sure to follow other
+   for maintainers reviewing it to understand why you are proposing a change. Make sure to follow other
    PR guidelines described in `Pull Request guidelines <#pull-request-guidelines>`_.
    Create Pull Request! Make yourself ready for the discussion!
 
@@ -473,17 +473,17 @@ Step 4: Prepare PR
    feedback on the direction of your PR or if you want to get feedback on the design of your PR.
 
 6. Avoid @-mentioning individual maintainers in your PR, unless you have good reason to believe that they are
-   available, have time and interest in your PR. Generally speaking there are no "exclusive" reviewers for
+   available, have time and/or interest in your PR. Generally speaking there are no "exclusive" reviewers for
    different parts of the code. Reviewers review PRs and respond when they have some free time to spare and
-   when they feel they can provide valuable feedback. If you want to get attention of maintainers, you can just
+   when they feel they can provide some valuable feedback. If you want to get attention of maintainers, you can just
    follow-up on your PR and ask for review in general, however be considerate and do not expect "immediate"
    reviews. People review when they have time, most of the maintainers do such reviews in their
-   free time, which is taken away from their families and other interests so allow sufficient time before you
+   free time, which is taken away from their families and other interests, so allow sufficient time before you
    follow-up - but if you see no reaction in several days, do follow-up, as with the number of PRs we have
    daily, some of them might simply fall through the cracks, and following up shows your interest in completing
-   the PR as well as puts it at the top of "Recently commented" PRs. However, be considerate and mindful for
-   the time zones, holidays, busy periods and expect that some discussions and conversation might take time
-   and get stalled occasionally. Generally speaking it's author's responsibility to follow-up on the PR when
+   the PR as well as puts it at the top of "Recently commented" PRs. However, be considerate and mindful of
+   the time zones, holidays, busy periods, and expect that some discussions and conversation might take time
+   and get stalled occasionally. Generally speaking it's the author's responsibility to follow-up on the PR when
    they want to get it reviewed and merged.
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Made some very tiny rewording(s) to the contributing guide after coming across it again while rebasing my PR.
No harsh intentions, just thought that it made it slightly correct, semantically.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
