### PR TITLE
Optimise getting changelogs in airflow-github

### DIFF
--- a/dev/airflow-github
+++ b/dev/airflow-github
@@ -326,26 +326,27 @@ def changelog(previous_version, target_version, github_token):
     gh = Github(github_token)
     gh_repo = gh.get_repo("apache/airflow")
     sections = defaultdict(list)
+    existing_commits = set()
+    with open("../RELEASE_NOTES.rst") as file:
+        for line in file.readlines():
+            match = re.search(r"\(#(\w+)\)", line)
+            if match:
+                existing_commits.add(match.group(1))
+
     for commit in log:
         tickets = pr_title_re.findall(commit["subject"])
         if tickets:
             issue = gh_repo.get_issue(number=int(tickets[0][1:]))
             issue_type = get_issue_type(issue)
             files = files_touched(repo, commit["id"])
-            if is_core_commit(files):
-                if issue_type in ["bug-fix", "doc-only", "misc/internal"]:
-                    with open("../RELEASE_NOTES.rst") as file:
-                        for line in file.readlines():
-                            if line.endswith(f"(#{commit['id']})"):
-                                continue
-                        else:
-                            sections[issue_type].append(commit["subject"])
-                else:
-                    sections[issue_type].append(commit["subject"])
-
+            if commit["id"] in existing_commits:
+                continue
+            if is_core_commit(files) and issue_type in ["bug-fix", "doc-only", "misc/internal"]:
+                sections[issue_type].append(commit["subject"])
+            else:
+                sections[issue_type].append(commit["subject"])
         else:
             sections[DEFAULT_SECTION_NAME].append(commit["subject"])
-
     print_changelog(sections)
 
 

--- a/dev/airflow-github
+++ b/dev/airflow-github
@@ -323,6 +323,8 @@ def changelog(previous_version, target_version, github_token):
     # Get a list of issues/PRs that have been committed on the current branch.
     log = get_commits_between(repo, previous_version, target_version)
 
+    print("Number of commits", len(log))
+
     gh = Github(github_token)
     gh_repo = gh.get_repo("apache/airflow")
     sections = defaultdict(list)
@@ -341,9 +343,7 @@ def changelog(previous_version, target_version, github_token):
             files = files_touched(repo, commit["id"])
             if commit["id"] in existing_commits:
                 continue
-            if is_core_commit(files) and issue_type in ["bug-fix", "doc-only", "misc/internal"]:
-                sections[issue_type].append(commit["subject"])
-            else:
+            if is_core_commit(files):
                 sections[issue_type].append(commit["subject"])
         else:
             sections[DEFAULT_SECTION_NAME].append(commit["subject"])


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fix the logic for getting changelog in minor versions so that we get only the changelog that is not present in the RELEASE_NOTES.rst instead of getting everything which is a heavy operation.

How was this tested?
1. Got the result as-is: `./airflow-github changelog origin/v1-8-stable origin/v1-8-test > without-changes`
2. Made the changes and then got the results: `./airflow-github changelog origin/v1-8-stable origin/v1-8-test > with-changes`
3. Manually verified the content to be same
4. Checked using diff tool: `git diff --no-index with-changes without-changes`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
