### PR TITLE
Fix test `test_cli_import_roles`

### DIFF
--- a/tests/providers/fab/auth_manager/cli_commands/test_role_command.py
+++ b/tests/providers/fab/auth_manager/cli_commands/test_role_command.py
@@ -194,9 +194,18 @@ class TestCliRoles:
         assert fakeTeamB is not None
         assert len(fakeTeamB.permissions) == 0
         assert len(fakeTeamA.permissions) == 3
-        assert fakeTeamA.permissions[0].resource.name == permissions.RESOURCE_POOL
-        assert fakeTeamA.permissions[0].action.name == permissions.ACTION_CAN_EDIT
-        assert fakeTeamA.permissions[1].resource.name == permissions.RESOURCE_POOL
-        assert fakeTeamA.permissions[1].action.name == permissions.ACTION_CAN_READ
-        assert fakeTeamA.permissions[2].resource.name == permissions.RESOURCE_ADMIN_MENU
-        assert fakeTeamA.permissions[2].action.name == permissions.ACTION_CAN_ACCESS_MENU
+        assert any(
+            permission.resource.name == permissions.RESOURCE_POOL
+            and permission.action.name == permissions.ACTION_CAN_EDIT
+            for permission in fakeTeamA.permissions
+        )
+        assert any(
+            permission.resource.name == permissions.RESOURCE_POOL
+            and permission.action.name == permissions.ACTION_CAN_READ
+            for permission in fakeTeamA.permissions
+        )
+        assert any(
+            permission.resource.name == permissions.RESOURCE_ADMIN_MENU
+            and permission.action.name == permissions.ACTION_CAN_ACCESS_MENU
+            for permission in fakeTeamA.permissions
+        )


### PR DESCRIPTION
The import and export CI command has been modified in #36347. As part of this change, the order of the roles is not sorted, thus we should not assume in tests they are.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
