### PR TITLE
Fix misconfiguration of redis client with ssl

### DIFF
--- a/tests/providers/redis/hooks/test_redis.py
+++ b/tests/providers/redis/hooks/test_redis.py
@@ -21,6 +21,7 @@ from unittest import mock
 
 import pytest
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
 from airflow.providers.redis.hooks.redis import RedisHook
 
@@ -28,6 +29,11 @@ pytestmark = pytest.mark.db_test
 
 
 class TestRedisHook:
+    deprecation_message = (
+        "Extra parameter `ssl_cert_file` deprecated and will be removed "
+        "in a future release. Please use `ssl_certfile` instead."
+    )
+
     def test_get_conn(self):
         hook = RedisHook(redis_conn_id="redis_default")
         assert hook.redis is None
@@ -51,7 +57,7 @@ class TestRedisHook:
                         "ssl_cert_reqs": "required",
                         "ssl_ca_certs": "/path/to/custom/ca-cert",
                         "ssl_keyfile": "/path/to/key-file",
-                        "ssl_cert_file": "/path/to/cert-file",
+                        "ssl_certfile": "/path/to/cert-file",
                         "ssl_check_hostname": true
                     }""",
         ),
@@ -70,7 +76,44 @@ class TestRedisHook:
             ssl_cert_reqs=connection.extra_dejson["ssl_cert_reqs"],
             ssl_ca_certs=connection.extra_dejson["ssl_ca_certs"],
             ssl_keyfile=connection.extra_dejson["ssl_keyfile"],
-            ssl_cert_file=connection.extra_dejson["ssl_cert_file"],
+            ssl_certfile=connection.extra_dejson["ssl_certfile"],
+            ssl_check_hostname=connection.extra_dejson["ssl_check_hostname"],
+        )
+
+    @mock.patch("airflow.providers.redis.hooks.redis.Redis")
+    @mock.patch(
+        "airflow.providers.redis.hooks.redis.RedisHook.get_connection",
+        return_value=Connection(
+            password="password",
+            host="remote_host",
+            port=1234,
+            extra="""{
+                        "db": 2,
+                        "ssl": true,
+                        "ssl_cert_reqs": "required",
+                        "ssl_ca_certs": "/path/to/custom/ca-cert",
+                        "ssl_keyfile": "/path/to/key-file",
+                        "ssl_cert_file": "/path/to/cert-file",
+                        "ssl_check_hostname": true
+                    }""",
+        ),
+    )
+    def test_get_conn_with_deprecated_extra_config(self, mock_get_connection, mock_redis):
+        connection = mock_get_connection.return_value
+        hook = RedisHook()
+
+        with pytest.warns(AirflowProviderDeprecationWarning, match=self.deprecation_message):
+            hook.get_conn()
+        mock_redis.assert_called_once_with(
+            host=connection.host,
+            password=connection.password,
+            port=connection.port,
+            db=connection.extra_dejson["db"],
+            ssl=connection.extra_dejson["ssl"],
+            ssl_cert_reqs=connection.extra_dejson["ssl_cert_reqs"],
+            ssl_ca_certs=connection.extra_dejson["ssl_ca_certs"],
+            ssl_keyfile=connection.extra_dejson["ssl_keyfile"],
+            ssl_certfile=connection.extra_dejson["ssl_cert_file"],
             ssl_check_hostname=connection.extra_dejson["ssl_check_hostname"],
         )
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

Closes: #36552
Fix the instantiation of the Redis client when connection via SSL.