### PR TITLE
Add username authenticating to the Redis hook

### DIFF
--- a/airflow/providers/redis/hooks/redis.py
+++ b/airflow/providers/redis/hooks/redis.py
@@ -49,6 +49,7 @@ class RedisHook(BaseHook):
         self.redis = None
         self.host = None
         self.port = None
+        self.username = None
         self.password = None
         self.db = None
 
@@ -57,6 +58,7 @@ class RedisHook(BaseHook):
         conn = self.get_connection(self.redis_conn_id)
         self.host = conn.host
         self.port = conn.port
+        self.username = conn.login
         self.password = None if str(conn.password).lower() in ["none", "false", ""] else conn.password
         self.db = conn.extra_dejson.get("db")
 
@@ -79,6 +81,13 @@ class RedisHook(BaseHook):
                 self.port,
                 self.db,
             )
-            self.redis = Redis(host=self.host, port=self.port, password=self.password, db=self.db, **ssl_args)
+            self.redis = Redis(
+                host=self.host,
+                port=self.port,
+                username=self.username,
+                password=self.password,
+                db=self.db,
+                **ssl_args,
+            )
 
         return self.redis

--- a/tests/providers/redis/hooks/test_redis.py
+++ b/tests/providers/redis/hooks/test_redis.py
@@ -42,6 +42,7 @@ class TestRedisHook:
     @mock.patch(
         "airflow.providers.redis.hooks.redis.RedisHook.get_connection",
         return_value=Connection(
+            login="user",
             password="password",
             host="remote_host",
             port=1234,
@@ -63,6 +64,7 @@ class TestRedisHook:
         hook.get_conn()
         mock_redis.assert_called_once_with(
             host=connection.host,
+            username=connection.login,
             password=connection.password,
             port=connection.port,
             db=connection.extra_dejson["db"],


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

Redis 6 and above introduced an option to authenticate with username in addition to password.
This PR aims to add support for this kind of authentication.
For more info, see [here](https://redis.io/docs/management/security/acl/#:~:text=The%20Redis%20AUTH%20command%20was%20extended%20in%20Redis%206%2C)
