### PR TITLE
Fix configuration of mypy plugins to point to paths not modules

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -206,8 +206,8 @@ no_implicit_optional = True
 warn_redundant_casts = True
 warn_unused_ignores = False
 plugins =
-  dev.mypy.plugin.decorators,
-  dev.mypy.plugin.outputs
+  dev/mypy/plugin/decorators.py,
+  dev/mypy/plugin/outputs.py
 pretty = True
 show_error_codes = True
 # Mypy since 0.991 warns about type annotations being present in an untyped


### PR DESCRIPTION
The configuration of our MyPy plugins was wrongly pointing to modules rather than paths. This caused problems in the environment where you had no PYTHONPATH set pointing to the root of your Airflow sources. One of the side effects was that MyPy Plugin for IntelliJ failed with "invalid plugin" error.

This PR changes the plugins to use relative paths instead - which should work when mypy is invoked from the root of the project (which in general is how our mypy gets invoked anyway and is the default settings for most IDE integrations.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
