### PR TITLE
Improve the error message displayed when there is a webserver error

### DIFF
--- a/airflow/www/templates/airflow/traceback.html
+++ b/airflow/www/templates/airflow/traceback.html
@@ -27,25 +27,24 @@
       <h1> Ooops! </h1>
       <div>
           <pre>
-Something bad has happened.
+Something bad has happened. For security reasons detailed information about the error is not logged.
 
-Airflow is used by many users, and it is very likely that others had similar problems and you can easily find
-a solution to your problem.
+  * You should check your webserver logs and retrieve details of this error.
 
-Consider following these steps:
+  * When you get the logs, it might explain the reasons, you should also Look for similar issues using:
 
-  * gather the relevant information (detailed logs with errors, reproduction steps, details of your deployment)
-
-  * find similar issues using:
      * <b><a href="https://github.com/apache/airflow/discussions">GitHub Discussions</a></b>
      * <b><a href="https://github.com/apache/airflow/issues">GitHub Issues</a></b>
      * <b><a href="https://stackoverflow.com/questions/tagged/airflow">Stack Overflow</a></b>
      * the usual search engine you use on a daily basis
 
+    All those resources might help you to find a solution to your problem.
+
   * if you run Airflow on a Managed Service, consider opening an issue using the service support channels
 
-  * if you tried and have difficulty with diagnosing and fixing the problem yourself, consider creating a <b><a href="https://github.com/apache/airflow/issues/new/choose">bug report</a></b>.
-    Make sure however, to include all relevant details and results of your investigation so far.
+  * only after you tried it all, and have difficulty with diagnosing and fixing the problem yourself,
+    get the logs with errors, describe results of your investigation so far, and consider creating a
+    <b><a href="https://github.com/apache/airflow/issues/new/choose">bug report</a></b> including this information.
 
 Python version: {{ python_version }}
 Airflow version: {{ airflow_version }}


### PR DESCRIPTION
The error message displayed when errors happen in the webserver did not properly communicate, that the user MUST look at the logs and provide more information to investigate the root cause (after looking at the logs themselves). We have a number of users just copy&pasting the generic error message without understanding that this is not nearly enough to help them.

This PR proposes a bit more explicit call to look at the logs and explains why details are not displayed (for security reasons).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
