### PR TITLE
[FEAT] adds repair run functionality for databricks

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -540,7 +540,6 @@ class DatabricksHook(BaseDatabricksHook):
         else:
             return repair_history[-1]["id"]
 
-
     def get_cluster_state(self, cluster_id: str) -> ClusterState:
         """
         Retrieve run state of the cluster.

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -519,13 +519,14 @@ class DatabricksHook(BaseDatabricksHook):
         json = {"run_id": run_id}
         self._do_api_call(DELETE_RUN_ENDPOINT, json)
 
-    def repair_run(self, json: dict) -> None:
+    def repair_run(self, json: dict) -> int:
         """
         Re-run one or more tasks.
 
         :param json: repair a job run.
         """
-        self._do_api_call(REPAIR_RUN_ENDPOINT, json)
+        response = self._do_api_call(REPAIR_RUN_ENDPOINT, json)
+        return response["repair_id"]
 
     def get_cluster_state(self, cluster_id: str) -> ClusterState:
         """

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -28,7 +28,7 @@ or the ``api/2.1/jobs/runs/submit``
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, Optional
 
 from requests import exceptions as requests_exceptions
 
@@ -527,6 +527,19 @@ class DatabricksHook(BaseDatabricksHook):
         """
         response = self._do_api_call(REPAIR_RUN_ENDPOINT, json)
         return response["repair_id"]
+
+    def get_latest_repair_id(self, run_id: int) -> Optional[int]:
+        """
+        get latest repair id if any exist for run_id else None
+        """
+        json = {"run_id": run_id, "include_history": True}
+        response = self._do_api_call(GET_RUN_ENDPOINT, json)
+        repair_history = response["repair_history"]
+        if len(repair_history) == 1:
+            return None
+        else:
+            return repair_history[-1]["id"]
+
 
     def get_cluster_state(self, cluster_id: str) -> ClusterState:
         """

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -529,9 +529,7 @@ class DatabricksHook(BaseDatabricksHook):
         return response["repair_id"]
 
     def get_latest_repair_id(self, run_id: int) -> Optional[int]:
-        """
-        get latest repair id if any exist for run_id else None
-        """
+        """Get latest repair id if any exist for run_id else None."""
         json = {"run_id": run_id, "include_history": True}
         response = self._do_api_call(GET_RUN_ENDPOINT, json)
         repair_history = response["repair_history"]

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -28,7 +28,7 @@ or the ``api/2.1/jobs/runs/submit``
 from __future__ import annotations
 
 import json
-from typing import Any, Optional
+from typing import Any
 
 from requests import exceptions as requests_exceptions
 
@@ -528,7 +528,7 @@ class DatabricksHook(BaseDatabricksHook):
         response = self._do_api_call(REPAIR_RUN_ENDPOINT, json)
         return response["repair_id"]
 
-    def get_latest_repair_id(self, run_id: int) -> Optional[int]:
+    def get_latest_repair_id(self, run_id: int) -> int | None:
         """Get latest repair id if any exist for run_id else None."""
         json = {"run_id": run_id, "include_history": True}
         response = self._do_api_call(GET_RUN_ENDPOINT, json)

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -90,8 +90,10 @@ def _handle_databricks_operator_execution(operator, hook, log, context) -> None:
                         )
                     if isinstance(operator, DatabricksRunNowOperator) and operator.repair_run:
                         operator.repair_run = False
-                        log.warn(error_message + "but since repair run is set, repairing the run with all "
-                                                 "failed tasks")
+                        log.warn(
+                            error_message + "but since repair run is set, repairing the run with all "
+                            "failed tasks"
+                        )
 
                         latest_repair_id = hook.get_latest_repair_id(operator.run_id)
                         repair_json = {"run_id": operator.run_id, "rerun_all_failed_tasks": True}

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -88,6 +88,15 @@ def _handle_databricks_operator_execution(operator, hook, log, context) -> None:
                             f"{operator.task_id} failed with terminal state: {run_state} "
                             f"and with the error {run_state.state_message}"
                         )
+                    if operator.repair_run:
+                        operator.repair_run = False
+                        log.warn(error_message + "but since repair run is set, repairing the run with all "
+                                                 "failed tasks")
+                        repair_json = operator.json
+                        repair_json["run_id"] = operator.run_id
+                        repair_json["rerun_all_failed_tasks"] = True
+                        operator.json["latest_repair_id"] = hook.repair_run(operator, repair_json)
+                        _handle_databricks_operator_execution(operator, hook, log, context)
                     raise AirflowException(error_message)
 
             else:
@@ -623,6 +632,7 @@ class DatabricksRunNowOperator(BaseOperator):
         - ``jar_params``
         - ``spark_submit_params``
         - ``idempotency_token``
+        - ``repair_run``
 
     :param job_id: the job_id of the existing Databricks job.
         This field will be templated.
@@ -711,6 +721,7 @@ class DatabricksRunNowOperator(BaseOperator):
     :param do_xcom_push: Whether we should push run_id and run_page_url to xcom.
     :param wait_for_termination: if we should wait for termination of the job run. ``True`` by default.
     :param deferrable: Run operator in the deferrable mode.
+    :param repair_run: Repair the databricks run in case of failure, doesn't work in deferrable mode
     """
 
     # Used in airflow.models.BaseOperator
@@ -741,6 +752,7 @@ class DatabricksRunNowOperator(BaseOperator):
         do_xcom_push: bool = True,
         wait_for_termination: bool = True,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
+        repair_run: bool = False
         **kwargs,
     ) -> None:
         """Create a new ``DatabricksRunNowOperator``."""
@@ -753,6 +765,7 @@ class DatabricksRunNowOperator(BaseOperator):
         self.databricks_retry_args = databricks_retry_args
         self.wait_for_termination = wait_for_termination
         self.deferrable = deferrable
+        self.repair_run = repair_run
 
         if job_id is not None:
             self.json["job_id"] = job_id

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -92,9 +92,11 @@ def _handle_databricks_operator_execution(operator, hook, log, context) -> None:
                         operator.repair_run = False
                         log.warn(error_message + "but since repair run is set, repairing the run with all "
                                                  "failed tasks")
-                        repair_json = operator.json
-                        repair_json["run_id"] = operator.run_id
-                        repair_json["rerun_all_failed_tasks"] = True
+
+                        latest_repair_id = hook.get_latest_repair_id(operator.run_id)
+                        repair_json = {"run_id": operator.run_id, "rerun_all_failed_tasks": True}
+                        if latest_repair_id is not None:
+                            repair_json["latest_repair_id"] = latest_repair_id
                         operator.json["latest_repair_id"] = hook.repair_run(operator, repair_json)
                         _handle_databricks_operator_execution(operator, hook, log, context)
                     raise AirflowException(error_message)

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -90,7 +90,7 @@ def _handle_databricks_operator_execution(operator, hook, log, context) -> None:
                         )
                     if isinstance(operator, DatabricksRunNowOperator) and operator.repair_run:
                         operator.repair_run = False
-                        log.warn(
+                        log.warning(
                             error_message + "but since repair run is set, repairing the run with all "
                             "failed tasks"
                         )

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -91,8 +91,8 @@ def _handle_databricks_operator_execution(operator, hook, log, context) -> None:
                     if isinstance(operator, DatabricksRunNowOperator) and operator.repair_run:
                         operator.repair_run = False
                         log.warning(
-                            error_message + "but since repair run is set, repairing the run with all "
-                            "failed tasks"
+                            "%s but since repair run is set, repairing the run with all failed tasks",
+                            error_message
                         )
 
                         latest_repair_id = hook.get_latest_repair_id(operator.run_id)

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -754,7 +754,7 @@ class DatabricksRunNowOperator(BaseOperator):
         do_xcom_push: bool = True,
         wait_for_termination: bool = True,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
-        repair_run: bool = False
+        repair_run: bool = False,
         **kwargs,
     ) -> None:
         """Create a new ``DatabricksRunNowOperator``."""

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -88,7 +88,7 @@ def _handle_databricks_operator_execution(operator, hook, log, context) -> None:
                             f"{operator.task_id} failed with terminal state: {run_state} "
                             f"and with the error {run_state.state_message}"
                         )
-                    if operator.repair_run:
+                    if isinstance(operator, DatabricksRunNowOperator) and operator.repair_run:
                         operator.repair_run = False
                         log.warn(error_message + "but since repair run is set, repairing the run with all "
                                                  "failed tasks")

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -92,7 +92,7 @@ def _handle_databricks_operator_execution(operator, hook, log, context) -> None:
                         operator.repair_run = False
                         log.warning(
                             "%s but since repair run is set, repairing the run with all failed tasks",
-                            error_message
+                            error_message,
                         )
 
                         latest_repair_id = hook.get_latest_repair_id(operator.run_id)

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -750,7 +750,7 @@ class TestDatabricksHook:
                     "id": 52532060060836,
                     "task_run_ids": [396529700633015, 1111270934390307],
                 },
-            ]
+            ],
         }
         latest_repair_id = self.hook.get_latest_repair_id(RUN_ID)
 

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -689,10 +689,7 @@ class TestDatabricksHook:
         mock_requests.get.return_value.json.return_value = {
             "job_id": JOB_ID,
             "run_id": RUN_ID,
-            "state": {
-                "life_cycle_state": "RUNNING",
-                "result_state": "RUNNING"
-            },
+            "state": {"life_cycle_state": "RUNNING", "result_state": "RUNNING"},
             "repair_history": [
                 {
                     "type": "ORIGINAL",
@@ -702,14 +699,11 @@ class TestDatabricksHook:
                         "life_cycle_state": "RUNNING",
                         "result_state": "RUNNING",
                         "state_message": "dummy",
-                        "user_cancelled_or_timedout": "false"
+                        "user_cancelled_or_timedout": "false",
                     },
-                    "task_run_ids": [
-                        396529700633015,
-                        1111270934390307
-                    ]
+                    "task_run_ids": [396529700633015, 1111270934390307],
                 }
-            ]
+            ],
         }
         latest_repair_id = self.hook.get_latest_repair_id(RUN_ID)
 
@@ -721,10 +715,7 @@ class TestDatabricksHook:
         mock_requests.get.return_value.json.return_value = {
             "job_id": JOB_ID,
             "run_id": RUN_ID,
-            "state": {
-                "life_cycle_state": "RUNNING",
-                "result_state": "RUNNING"
-            },
+            "state": {"life_cycle_state": "RUNNING", "result_state": "RUNNING"},
             "repair_history": [
                 {
                     "type": "ORIGINAL",
@@ -734,12 +725,9 @@ class TestDatabricksHook:
                         "life_cycle_state": "TERMINATED",
                         "result_state": "CANCELED",
                         "state_message": "dummy_original",
-                        "user_cancelled_or_timedout": "false"
+                        "user_cancelled_or_timedout": "false",
                     },
-                    "task_run_ids": [
-                        396529700633015,
-                        1111270934390307
-                    ]
+                    "task_run_ids": [396529700633015, 1111270934390307],
                 },
                 {
                     "type": "REPAIR",
@@ -749,27 +737,18 @@ class TestDatabricksHook:
                         "life_cycle_state": "TERMINATED",
                         "result_state": "CANCELED",
                         "state_message": "dummy_repair_1",
-                        "user_cancelled_or_timedout": "true"
+                        "user_cancelled_or_timedout": "true",
                     },
                     "id": 108607572123234,
-                    "task_run_ids": [
-                        396529700633015,
-                        1111270934390307
-                    ]
+                    "task_run_ids": [396529700633015, 1111270934390307],
                 },
                 {
                     "type": "REPAIR",
                     "start_time": 1704531464690,
                     "end_time": 1704531481590,
-                    "state": {
-                        "life_cycle_state": "RUNNING",
-                        "result_state": "RUNNING"
-                    },
+                    "state": {"life_cycle_state": "RUNNING", "result_state": "RUNNING"},
                     "id": 52532060060836,
-                    "task_run_ids": [
-                        396529700633015,
-                        1111270934390307
-                    ]
+                    "task_run_ids": [396529700633015, 1111270934390307],
                 },
             ]
         }

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -684,6 +684,100 @@ class TestDatabricksHook:
         )
 
     @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests")
+    def test_negative_get_latest_repair_id(self, mock_requests):
+        mock_requests.codes.ok = 200
+        mock_requests.get.return_value.json.return_value = {
+            "job_id": JOB_ID,
+            "run_id": RUN_ID,
+            "state": {
+                "life_cycle_state": "RUNNING",
+                "result_state": "RUNNING"
+            },
+            "repair_history": [
+                {
+                    "type": "ORIGINAL",
+                    "start_time": 1704528798059,
+                    "end_time": 1704529026679,
+                    "state": {
+                        "life_cycle_state": "RUNNING",
+                        "result_state": "RUNNING",
+                        "state_message": "dummy",
+                        "user_cancelled_or_timedout": "false"
+                    },
+                    "task_run_ids": [
+                        396529700633015,
+                        1111270934390307
+                    ]
+                }
+            ]
+        }
+        latest_repair_id = self.hook.get_latest_repair_id(RUN_ID)
+
+        assert latest_repair_id is None
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests")
+    def test_positive_get_latest_repair_id(self, mock_requests):
+        mock_requests.codes.ok = 200
+        mock_requests.get.return_value.json.return_value = {
+            "job_id": JOB_ID,
+            "run_id": RUN_ID,
+            "state": {
+                "life_cycle_state": "RUNNING",
+                "result_state": "RUNNING"
+            },
+            "repair_history": [
+                {
+                    "type": "ORIGINAL",
+                    "start_time": 1704528798059,
+                    "end_time": 1704529026679,
+                    "state": {
+                        "life_cycle_state": "TERMINATED",
+                        "result_state": "CANCELED",
+                        "state_message": "dummy_original",
+                        "user_cancelled_or_timedout": "false"
+                    },
+                    "task_run_ids": [
+                        396529700633015,
+                        1111270934390307
+                    ]
+                },
+                {
+                    "type": "REPAIR",
+                    "start_time": 1704530276423,
+                    "end_time": 1704530363736,
+                    "state": {
+                        "life_cycle_state": "TERMINATED",
+                        "result_state": "CANCELED",
+                        "state_message": "dummy_repair_1",
+                        "user_cancelled_or_timedout": "true"
+                    },
+                    "id": 108607572123234,
+                    "task_run_ids": [
+                        396529700633015,
+                        1111270934390307
+                    ]
+                },
+                {
+                    "type": "REPAIR",
+                    "start_time": 1704531464690,
+                    "end_time": 1704531481590,
+                    "state": {
+                        "life_cycle_state": "RUNNING",
+                        "result_state": "RUNNING"
+                    },
+                    "id": 52532060060836,
+                    "task_run_ids": [
+                        396529700633015,
+                        1111270934390307
+                    ]
+                },
+            ]
+        }
+        latest_repair_id = self.hook.get_latest_repair_id(RUN_ID)
+
+        assert latest_repair_id == 52532060060836
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests")
     def test_get_cluster_state(self, mock_requests):
         """
         Response example from https://docs.databricks.com/api/workspace/clusters/get


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
[FEAT] add repair run functionality in `DatabricksRunNowOperator`
This is useful in MULTI TASK mode, where operator will auto retry only failed tasks rather than relying on airflow retries that will create a new run
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
