### PR TITLE
Tracking airflow-github changelog activities using progress bar

### DIFF
--- a/dev/airflow-github
+++ b/dev/airflow-github
@@ -31,6 +31,8 @@ import git
 import rich_click as click
 from github import Github
 from packaging import version
+from rich.console import Console
+from rich.progress import Progress
 
 if TYPE_CHECKING:
     from github.Issue import Issue
@@ -39,7 +41,6 @@ if TYPE_CHECKING:
 GIT_COMMIT_FIELDS = ["id", "author_name", "author_email", "date", "subject", "body"]
 GIT_LOG_FORMAT = "%x1f".join(["%h", "%an", "%ae", "%ad", "%s", "%b"]) + "%x1e"
 pr_title_re = re.compile(r".*\((#[0-9]{1,6})\)$")
-
 
 STATUS_COLOR_MAP = {
     "Closed": "green",
@@ -322,9 +323,6 @@ def changelog(previous_version, target_version, github_token):
     repo = git.Repo(".", search_parent_directories=True)
     # Get a list of issues/PRs that have been committed on the current branch.
     log = get_commits_between(repo, previous_version, target_version)
-
-    print("Number of commits", len(log))
-
     gh = Github(github_token)
     gh_repo = gh.get_repo("apache/airflow")
     sections = defaultdict(list)
@@ -335,18 +333,28 @@ def changelog(previous_version, target_version, github_token):
             if match:
                 existing_commits.add(match.group(1))
 
-    for commit in log:
-        tickets = pr_title_re.findall(commit["subject"])
-        if tickets:
-            issue = gh_repo.get_issue(number=int(tickets[0][1:]))
-            issue_type = get_issue_type(issue)
-            files = files_touched(repo, commit["id"])
-            if commit["id"] in existing_commits:
-                continue
-            if is_core_commit(files):
-                sections[issue_type].append(commit["subject"])
-        else:
-            sections[DEFAULT_SECTION_NAME].append(commit["subject"])
+    # To disable the progress bar, set to True
+    disable_progress = False
+    console = Console(width=180)
+
+    with Progress(console=console, disable=disable_progress) as progress:
+        task = progress.add_task("Processing commits from changelog", total=len(log))
+        for commit in progress.track(log, description="Processing commits from changelog"):
+            tickets = pr_title_re.findall(commit["subject"])
+            if tickets:
+                issue = gh_repo.get_issue(number=int(tickets[0][1:]))
+                issue_type = get_issue_type(issue)
+                files = files_touched(repo, commit["id"])
+                if commit["id"] in existing_commits:
+                    continue
+                if is_core_commit(files):
+                    sections[issue_type].append(commit["subject"])
+                progress.update(task, advance=1)
+            else:
+                sections[DEFAULT_SECTION_NAME].append(commit["subject"])
+                progress.update(task, advance=1)
+
+    console.print("\n")
     print_changelog(sections)
 
 

--- a/dev/airflow-github
+++ b/dev/airflow-github
@@ -319,7 +319,8 @@ def compare(target_version, github_token, previous_version=None, show_uncherrypi
 @click.argument("previous_version")
 @click.argument("target_version")
 @click.argument("github-token", envvar="GITHUB_TOKEN")
-def changelog(previous_version, target_version, github_token):
+@click.option("--disable-progress", is_flag=True, help="Disable the progress bar")
+def changelog(previous_version, target_version, github_token, disable_progress):
     repo = git.Repo(".", search_parent_directories=True)
     # Get a list of issues/PRs that have been committed on the current branch.
     log = get_commits_between(repo, previous_version, target_version)
@@ -333,8 +334,6 @@ def changelog(previous_version, target_version, github_token):
             if match:
                 existing_commits.add(match.group(1))
 
-    # To disable the progress bar, set to True
-    disable_progress = False
     console = Console(width=180)
 
     with Progress(console=console, disable=disable_progress) as progress:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

As suggested by Jarek, long running tasks like changelog in airflow-github are hard to track without a progress bar, adding Rich library's progress bar to this task

Small excerpt into how it looks:

https://github.com/apache/airflow/assets/35884252/7a7e5fd1-10e9-4d3e-a361-30df6e0d4b62




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
