### PR TITLE
Fix run type icon alignment with run type text

### DIFF
--- a/airflow/www/static/js/components/RunTypeIcon.tsx
+++ b/airflow/www/static/js/components/RunTypeIcon.tsx
@@ -29,16 +29,21 @@ interface Props extends IconBaseProps {
   runType: DagRun["runType"];
 }
 
+const iconStyle = {
+  display: "inline",
+  verticalAlign: "bottom",
+};
+
 const DagRunTypeIcon = ({ runType, ...rest }: Props) => {
   switch (runType) {
     case "manual":
-      return <MdPlayArrow style={{ display: "inline" }} {...rest} />;
+      return <MdPlayArrow style={iconStyle} {...rest} />;
     case "backfill":
-      return <RiArrowGoBackFill style={{ display: "inline" }} {...rest} />;
+      return <RiArrowGoBackFill style={iconStyle} {...rest} />;
     case "scheduled":
-      return <MdOutlineSchedule style={{ display: "inline" }} {...rest} />;
+      return <MdOutlineSchedule style={iconStyle} {...rest} />;
     case "dataset_triggered":
-      return <HiDatabase style={{ display: "inline" }} {...rest} />;
+      return <HiDatabase style={iconStyle} {...rest} />;
     default:
       return null;
   }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

closes: #36574
There is a mis-alignment with the run type icon and the run type text.
This PR resolve this issue by declaring the `vertical-align` property.
Before this PR, the run type looked like this:
<img width="435" alt="Screen Shot 2024-01-05 at 16 01 28" src="https://github.com/apache/airflow/assets/46799583/c7aaea75-791b-4782-b96f-d312f3ecfa9b">
After this PR, the run type will look like this:
<img width="436" alt="Screen Shot 2024-01-05 at 16 02 39" src="https://github.com/apache/airflow/assets/46799583/887fd1e6-766b-466f-886d-fe19c9770835">

I have tested all other icons (scheduled, backfill, dataset_triggered) as well, all looks better now :)
