### PR TITLE
[API] can return the specified field when get dag/dagRun

### DIFF
--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -30,7 +30,9 @@ from airflow.api_connexion.exceptions import AlreadyExists, BadRequest, NotFound
 from airflow.api_connexion.parameters import apply_sorting, check_limit, format_parameters
 from airflow.api_connexion.schemas.dag_schema import (
     DAGCollection,
-    dag_detail_schema,
+    DAGCollectionSchema,
+    DAGDetailSchema,
+    DAGSchema,
     dag_schema,
     dags_collection_schema,
 )
@@ -50,19 +52,32 @@ if TYPE_CHECKING:
 
 @security.requires_access_dag("GET")
 @provide_session
-def get_dag(*, dag_id: str, session: Session = NEW_SESSION) -> APIResponse:
+def get_dag(
+    *, 
+    dag_id: str, 
+    fields: Collection[str] | None = None,
+    session: Session = NEW_SESSION
+) -> APIResponse:
     """Get basic information about a DAG."""
     dag = session.scalar(select(DagModel).where(DagModel.dag_id == dag_id))
-
+    print(f"{fields=}")
     if dag is None:
         raise NotFound("DAG not found", detail=f"The DAG with dag_id: {dag_id} was not found")
-
-    return dag_schema.dump(dag)
+    try:
+        dag_schema = DAGSchema(only = fields) if fields else DAGSchema()
+    except ValueError as e:
+        raise BadRequest("DAGSchema init error", detail=str(e))
+    return dag_schema.dump(dag, )
 
 
 @security.requires_access_dag("GET")
 @provide_session
-def get_dag_details(*, dag_id: str, session: Session = NEW_SESSION) -> APIResponse:
+def get_dag_details(
+    *, 
+    dag_id: str, 
+    fields: Collection[str] | None = None,
+    session: Session = NEW_SESSION
+) -> APIResponse:
     """Get details of DAG."""
     dag: DAG = get_airflow_app().dag_bag.get_dag(dag_id)
     if not dag:
@@ -71,7 +86,10 @@ def get_dag_details(*, dag_id: str, session: Session = NEW_SESSION) -> APIRespon
     for key, value in dag.__dict__.items():
         if not key.startswith("_") and not hasattr(dag_model, key):
             setattr(dag_model, key, value)
-
+    try:
+        dag_detail_schema = DAGDetailSchema(only = fields) if fields else DAGDetailSchema()
+    except ValueError as e:
+        raise BadRequest("DAGDetailSchema init error", detail=str(e))
     return dag_detail_schema.dump(dag_model)
 
 
@@ -87,6 +105,7 @@ def get_dags(
     only_active: bool = True,
     paused: bool | None = None,
     order_by: str = "dag_id",
+    fields: Collection[str] | None = None,
     session: Session = NEW_SESSION,
 ) -> APIResponse:
     """Get all DAGs."""
@@ -113,6 +132,14 @@ def get_dags(
     dags_query = apply_sorting(dags_query, order_by, {}, allowed_attrs)
     dags = session.scalars(dags_query.offset(offset).limit(limit)).all()
 
+
+    try:
+        dags_collection_schema = DAGCollectionSchema(
+            only=[f"dags.{field}" for field in fields]
+        ) if fields else DAGCollectionSchema()
+    except ValueError as e:
+        raise BadRequest("DAGCollectionSchema init error", detail=str(e))
+    
     return dags_collection_schema.dump(DAGCollection(dags=dags, total_entries=total_entries))
 
 

--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -53,30 +53,25 @@ if TYPE_CHECKING:
 @security.requires_access_dag("GET")
 @provide_session
 def get_dag(
-    *, 
-    dag_id: str, 
-    fields: Collection[str] | None = None,
-    session: Session = NEW_SESSION
+    *, dag_id: str, fields: Collection[str] | None = None, session: Session = NEW_SESSION
 ) -> APIResponse:
     """Get basic information about a DAG."""
     dag = session.scalar(select(DagModel).where(DagModel.dag_id == dag_id))
-    print(f"{fields=}")
     if dag is None:
         raise NotFound("DAG not found", detail=f"The DAG with dag_id: {dag_id} was not found")
     try:
-        dag_schema = DAGSchema(only = fields) if fields else DAGSchema()
+        dag_schema = DAGSchema(only=fields) if fields else DAGSchema()
     except ValueError as e:
         raise BadRequest("DAGSchema init error", detail=str(e))
-    return dag_schema.dump(dag, )
+    return dag_schema.dump(
+        dag,
+    )
 
 
 @security.requires_access_dag("GET")
 @provide_session
 def get_dag_details(
-    *, 
-    dag_id: str, 
-    fields: Collection[str] | None = None,
-    session: Session = NEW_SESSION
+    *, dag_id: str, fields: Collection[str] | None = None, session: Session = NEW_SESSION
 ) -> APIResponse:
     """Get details of DAG."""
     dag: DAG = get_airflow_app().dag_bag.get_dag(dag_id)
@@ -87,7 +82,7 @@ def get_dag_details(
         if not key.startswith("_") and not hasattr(dag_model, key):
             setattr(dag_model, key, value)
     try:
-        dag_detail_schema = DAGDetailSchema(only = fields) if fields else DAGDetailSchema()
+        dag_detail_schema = DAGDetailSchema(only=fields) if fields else DAGDetailSchema()
     except ValueError as e:
         raise BadRequest("DAGDetailSchema init error", detail=str(e))
     return dag_detail_schema.dump(dag_model)
@@ -132,14 +127,15 @@ def get_dags(
     dags_query = apply_sorting(dags_query, order_by, {}, allowed_attrs)
     dags = session.scalars(dags_query.offset(offset).limit(limit)).all()
 
-
     try:
-        dags_collection_schema = DAGCollectionSchema(
-            only=[f"dags.{field}" for field in fields]
-        ) if fields else DAGCollectionSchema()
+        dags_collection_schema = (
+            DAGCollectionSchema(only=[f"dags.{field}" for field in fields])
+            if fields
+            else DAGCollectionSchema()
+        )
     except ValueError as e:
         raise BadRequest("DAGCollectionSchema init error", detail=str(e))
-    
+
     return dags_collection_schema.dump(DAGCollection(dags=dags, total_entries=total_entries))
 
 

--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -133,10 +133,9 @@ def get_dags(
             if fields
             else DAGCollectionSchema()
         )
+        return dags_collection_schema.dump(DAGCollection(dags=dags, total_entries=total_entries))
     except ValueError as e:
-        raise BadRequest("DAGCollectionSchema init error", detail=str(e))
-
-    return dags_collection_schema.dump(DAGCollection(dags=dags, total_entries=total_entries))
+        raise BadRequest("DAGCollectionSchema error", detail=str(e))
 
 
 @security.requires_access_dag("PUT")

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -41,8 +41,8 @@ from airflow.api_connexion.parameters import (
 )
 from airflow.api_connexion.schemas.dag_run_schema import (
     DAGRunCollection,
-    DAGRunSchema,
     DAGRunCollectionSchema,
+    DAGRunSchema,
     clear_dagrun_form_schema,
     dagrun_collection_schema,
     dagrun_schema,
@@ -94,11 +94,7 @@ def delete_dag_run(*, dag_id: str, dag_run_id: str, session: Session = NEW_SESSI
 @security.requires_access_dag("GET", DagAccessEntity.RUN)
 @provide_session
 def get_dag_run(
-    *,
-    dag_id: str,
-    dag_run_id: str,
-    fields: Collection[str] | None = None,
-    session: Session = NEW_SESSION
+    *, dag_id: str, dag_run_id: str, fields: Collection[str] | None = None, session: Session = NEW_SESSION
 ) -> APIResponse:
     """Get a DAG Run."""
     dag_run = session.scalar(select(DagRun).where(DagRun.dag_id == dag_id, DagRun.run_id == dag_run_id))
@@ -108,7 +104,7 @@ def get_dag_run(
             detail=f"DAGRun with DAG ID: '{dag_id}' and DagRun ID: '{dag_run_id}' not found",
         )
     try:
-        dagrun_schema = DAGRunSchema(only = fields) if fields else DAGRunSchema()
+        dagrun_schema = DAGRunSchema(only=fields) if fields else DAGRunSchema()
     except ValueError as e:
         # Invalid fields
         raise BadRequest("DAGRunSchema init error", detail=str(e))
@@ -256,9 +252,11 @@ def get_dag_runs(
         session=session,
     )
     try:
-        dagrun_collection_schema = DAGRunCollectionSchema(
-            only=[f"dag_runs.{field}" for field in fields]
-        ) if fields else DAGRunCollectionSchema()
+        dagrun_collection_schema = (
+            DAGRunCollectionSchema(only=[f"dag_runs.{field}" for field in fields])
+            if fields
+            else DAGRunCollectionSchema()
+        )
     except ValueError as e:
         raise BadRequest("DAGRunCollectionSchema init error", detail=str(e))
     return dagrun_collection_schema.dump(DAGRunCollection(dag_runs=dag_run, total_entries=total_entries))

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -736,6 +736,7 @@ paths:
         - $ref: "#/components/parameters/FilterUpdatedAtLTE"
         - $ref: "#/components/parameters/FilterState"
         - $ref: "#/components/parameters/OrderBy"
+        - $ref: "#/components/parameters/ReturnFields"
       responses:
         "200":
           description: List of DAG runs.
@@ -817,6 +818,8 @@ paths:
       x-openapi-router-controller: airflow.api_connexion.endpoints.dag_run_endpoint
       operationId: get_dag_run
       tags: [DAGRun]
+      parameters:
+        - $ref: "#/components/parameters/ReturnFields"
       responses:
         "200":
           description: Success.

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3583,11 +3583,11 @@ components:
             catchup:
               type: boolean
               readOnly: true
-              # nullable: true
+              nullable: true
             orientation:
               type: string
               readOnly: true
-              # nullable: true
+              nullable: true
             concurrency:
               type: number
               readOnly: true

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -421,6 +421,7 @@ paths:
         - $ref: "#/components/parameters/FilterTags"
         - $ref: "#/components/parameters/OnlyActive"
         - $ref: "#/components/parameters/Paused"
+        - $ref: "#/components/parameters/ReturnFields"
         - name: dag_id_pattern
           in: query
           schema:
@@ -497,6 +498,8 @@ paths:
       x-openapi-router-controller: airflow.api_connexion.endpoints.dag_endpoint
       operationId: get_dag
       tags: [DAG]
+      parameters:
+        - $ref: "#/components/parameters/ReturnFields"
       responses:
         "200":
           description: Success.
@@ -1755,6 +1758,8 @@ paths:
         The response contains many DAG attributes, so the response can be large.
         If possible, consider using GET /dags/{dag_id}.
       tags: [DAG]
+      parameters:
+        - $ref: "#/components/parameters/ReturnFields"
       responses:
         "200":
           description: Success.
@@ -3571,15 +3576,19 @@ components:
           properties:
             timezone:
               $ref: "#/components/schemas/Timezone"
+              nullable: true
             catchup:
               type: boolean
               readOnly: true
+              # nullable: true
             orientation:
               type: string
               readOnly: true
+              # nullable: true
             concurrency:
               type: number
               readOnly: true
+              nullable: true
             start_date:
               type: string
               format: "date-time"
@@ -3591,6 +3600,7 @@ components:
                 *Changed in version 2.0.1*&#58; Field becomes nullable.
             dag_run_timeout:
               $ref: "#/components/schemas/TimeDelta"
+              nullable: true
             doc_md:
               type: string
               readOnly: true
@@ -5252,6 +5262,16 @@ components:
         A comma-separated list of fully qualified names of fields.
       style: form
       explode: false
+
+    ReturnFields:
+      in: query
+      name: fields
+      schema:
+        type: array
+        items:
+          type: string
+      description: |
+        List of field for return.
 
   # Reusable request bodies
   requestBodies: {}

--- a/airflow/api_connexion/schemas/dag_run_schema.py
+++ b/airflow/api_connexion/schemas/dag_run_schema.py
@@ -108,8 +108,18 @@ class DAGRunSchema(SQLAlchemySchema):
     @post_dump
     def autofill(self, data, **kwargs):
         """Populate execution_date from logical_date for compatibility."""
+        ret_data = {}
         data["execution_date"] = data["logical_date"]
-        return data
+        if self.context.get("fields"):
+            ret_fields = self.context.get("fields")
+            for ret_field in ret_fields:
+                if ret_field not in data:
+                    raise ValueError(f"{ret_field} not in DAGRunSchema")
+                ret_data[ret_field] = data[ret_field]
+        else:
+            ret_data = data
+
+        return ret_data
 
 
 class SetDagRunStateFormSchema(Schema):

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1471,8 +1471,8 @@ export interface components {
      */
     DAGDetail: components["schemas"]["DAG"] & {
       timezone?: components["schemas"]["Timezone"] | null;
-      catchup?: boolean;
-      orientation?: string;
+      catchup?: boolean | null;
+      orientation?: string | null;
       concurrency?: number | null;
       /**
        * Format: date-time

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -3005,6 +3005,8 @@ export interface operations {
          * *New in version 2.1.0*
          */
         order_by?: components["parameters"]["OrderBy"];
+        /** List of field for return. */
+        fields?: components["parameters"]["ReturnFields"];
       };
     };
     responses: {
@@ -3070,6 +3072,10 @@ export interface operations {
         dag_id: components["parameters"]["DAGID"];
         /** The DAG run ID. */
         dag_run_id: components["parameters"]["DAGRunID"];
+      };
+      query: {
+        /** List of field for return. */
+        fields?: components["parameters"]["ReturnFields"];
       };
     };
     responses: {
@@ -5039,7 +5045,8 @@ export type GetDagRunsBatchVariables = CamelCasedPropertiesDeep<
   operations["get_dag_runs_batch"]["requestBody"]["content"]["application/json"]
 >;
 export type GetDagRunVariables = CamelCasedPropertiesDeep<
-  operations["get_dag_run"]["parameters"]["path"]
+  operations["get_dag_run"]["parameters"]["path"] &
+    operations["get_dag_run"]["parameters"]["query"]
 >;
 export type DeleteDagRunVariables = CamelCasedPropertiesDeep<
   operations["delete_dag_run"]["parameters"]["path"]

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1470,10 +1470,10 @@ export interface components {
      * [airflow.models.dag.DAG](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/dag/index.html#airflow.models.dag.DAG)
      */
     DAGDetail: components["schemas"]["DAG"] & {
-      timezone?: components["schemas"]["Timezone"];
+      timezone?: components["schemas"]["Timezone"] | null;
       catchup?: boolean;
       orientation?: string;
-      concurrency?: number;
+      concurrency?: number | null;
       /**
        * Format: date-time
        * @description The DAG's start date.
@@ -1481,7 +1481,7 @@ export interface components {
        * *Changed in version 2.0.1*&#58; Field becomes nullable.
        */
       start_date?: string | null;
-      dag_run_timeout?: components["schemas"]["TimeDelta"];
+      dag_run_timeout?: components["schemas"]["TimeDelta"] | null;
       doc_md?: string | null;
       default_view?: string | null;
       /**
@@ -2472,6 +2472,8 @@ export interface components {
      * A comma-separated list of fully qualified names of fields.
      */
     UpdateMask: string[];
+    /** @description List of field for return. */
+    ReturnFields: string[];
   };
   requestBodies: {};
   headers: {};
@@ -2659,6 +2661,8 @@ export interface operations {
          * *New in version 2.6.0*
          */
         paused?: components["parameters"]["Paused"];
+        /** List of field for return. */
+        fields?: components["parameters"]["ReturnFields"];
         /** If set, only return DAGs with dag_ids matching this pattern. */
         dag_id_pattern?: string;
       };
@@ -2732,6 +2736,10 @@ export interface operations {
       path: {
         /** The DAG ID. */
         dag_id: components["parameters"]["DAGID"];
+      };
+      query: {
+        /** List of field for return. */
+        fields?: components["parameters"]["ReturnFields"];
       };
     };
     responses: {
@@ -4098,6 +4106,10 @@ export interface operations {
         /** The DAG ID. */
         dag_id: components["parameters"]["DAGID"];
       };
+      query: {
+        /** List of field for return. */
+        fields?: components["parameters"]["ReturnFields"];
+      };
     };
     responses: {
       /** Success. */
@@ -4988,7 +5000,8 @@ export type PatchDagsVariables = CamelCasedPropertiesDeep<
     operations["patch_dags"]["requestBody"]["content"]["application/json"]
 >;
 export type GetDagVariables = CamelCasedPropertiesDeep<
-  operations["get_dag"]["parameters"]["path"]
+  operations["get_dag"]["parameters"]["path"] &
+    operations["get_dag"]["parameters"]["query"]
 >;
 export type DeleteDagVariables = CamelCasedPropertiesDeep<
   operations["delete_dag"]["parameters"]["path"]
@@ -5133,7 +5146,8 @@ export type GetLogVariables = CamelCasedPropertiesDeep<
     operations["get_log"]["parameters"]["query"]
 >;
 export type GetDagDetailsVariables = CamelCasedPropertiesDeep<
-  operations["get_dag_details"]["parameters"]["path"]
+  operations["get_dag_details"]["parameters"]["path"] &
+    operations["get_dag_details"]["parameters"]["query"]
 >;
 export type GetTasksVariables = CamelCasedPropertiesDeep<
   operations["get_tasks"]["parameters"]["path"] &

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -259,6 +259,52 @@ class TestGetDag(TestDagEndpoint):
             "/api/v1/dags/TEST_DAG_2", environ_overrides={"REMOTE_USER": "test_granular_permissions"}
         )
         assert response.status_code == 403
+    
+    @pytest.mark.parametrize(
+        "fields",
+        [
+            [],         # empty test
+            ["dag_id"], # only one
+            ["fileloc", "file_token", "owners"], # fields.Method and other
+            ["schedule_interval", "tags"],       # fields.List
+        ],
+    )
+    def test_should_return_specified_fields(self, fields):
+        self._create_dag_models(1)
+        response = self.client.get(f"/api/v1/dags/TEST_DAG_1?fields={','.join(fields)}", environ_overrides={"REMOTE_USER": "test"})
+        res_json = response.json
+        for field in fields:
+            assert field in res_json
+        for field in {
+            "dag_id": "TEST_DAG_1",
+            "description": None,
+            "fileloc": "/tmp/dag_1.py",
+            "file_token": "Ii90bXAvZGFnXzEucHki.EnmIdPaUPo26lHQClbWMbDFD1Pk",
+            "is_paused": False,
+            "is_active": True,
+            "is_subdag": False,
+            "owners": [],
+            "root_dag_id": None,
+            "schedule_interval": {"__type": "CronExpression", "value": "2 2 * * *"},
+            "tags": [],
+            "next_dagrun": None,
+            "has_task_concurrency_limits": True,
+            "next_dagrun_data_interval_start": None,
+            "next_dagrun_data_interval_end": None,
+            "max_active_runs": 16,
+            "next_dagrun_create_after": None,
+            "last_expired": None,
+            "max_active_tasks": 16,
+            "last_pickled": None,
+            "default_view": None,
+            "last_parsed_time": None,
+            "scheduler_lock": None,
+            "timetable_description": None,
+            "has_import_errors": False,
+            "pickle_id": None,
+        }.keys():
+            if field not in fields:
+                assert field not in res_json
 
 
 class TestGetDagDetails(TestDagEndpoint):

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -274,38 +274,9 @@ class TestGetDag(TestDagEndpoint):
             f"/api/v1/dags/TEST_DAG_1?fields={','.join(fields)}", environ_overrides={"REMOTE_USER": "test"}
         )
         res_json = response.json
+        assert len(res_json.keys()) == len(fields)
         for field in fields:
             assert field in res_json
-        for field in {
-            "dag_id": "TEST_DAG_1",
-            "description": None,
-            "fileloc": "/tmp/dag_1.py",
-            "file_token": "Ii90bXAvZGFnXzEucHki.EnmIdPaUPo26lHQClbWMbDFD1Pk",
-            "is_paused": False,
-            "is_active": True,
-            "is_subdag": False,
-            "owners": [],
-            "root_dag_id": None,
-            "schedule_interval": {"__type": "CronExpression", "value": "2 2 * * *"},
-            "tags": [],
-            "next_dagrun": None,
-            "has_task_concurrency_limits": True,
-            "next_dagrun_data_interval_start": None,
-            "next_dagrun_data_interval_end": None,
-            "max_active_runs": 16,
-            "next_dagrun_create_after": None,
-            "last_expired": None,
-            "max_active_tasks": 16,
-            "last_pickled": None,
-            "default_view": None,
-            "last_parsed_time": None,
-            "scheduler_lock": None,
-            "timetable_description": None,
-            "has_import_errors": False,
-            "pickle_id": None,
-        }.keys():
-            if field not in fields:
-                assert field not in res_json
 
     @pytest.mark.parametrize(
         "fields",


### PR DESCRIPTION
relate to #29893

Hard to add generic retrieve capability to all `get` endpoints, so this PR is just add this capability in dag/dag_detail and dagRuns `get` endpoints, which I think need this capability most.

For example, if call `https://airflow.apache.org/api/v1/dags?fields=dag_id,is_paused` API, it returns JSON body contains **only** {dag_id, is_paused} fields.