### PR TITLE
Remove build errors output from spellcheck-only output

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -411,12 +411,17 @@ def display_packages_summary(
 def print_build_errors_and_exit(
     build_errors: dict[str, list[DocBuildError]],
     spelling_errors: dict[str, list[SpellingError]],
+    spellcheck_only: bool,
 ) -> None:
     """Prints build errors and exists."""
     if build_errors or spelling_errors:
         if build_errors:
-            display_errors_summary(build_errors)
-            console.print()
+            if spellcheck_only:
+                console.print("f[warning]There were some build errors remaining.")
+                console.print()
+            else:
+                display_errors_summary(build_errors)
+                console.print()
         if spelling_errors:
             display_spelling_error_summary(spelling_errors)
             console.print()
@@ -555,6 +560,7 @@ def main():
     print_build_errors_and_exit(
         all_build_errors,
         all_spelling_errors,
+        spellcheck_only,
     )
 
 


### PR DESCRIPTION
After #36591 has been implemented, in cas of `--spellcheck-only` checks for parallel packages, it might be that some build errors remain in build errors output (depends on some race conditions while parallel build of packages). Those errors, however, are not interesting to us - we are only interested in spellcheck errors (and possibly we want to know if there were also build errors but we are not interested in details.

This PR clears up build errors in case of --spellcheck-only builds.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
