### PR TITLE
Fix the type hint for tis_query in _process_executor_events

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -706,13 +706,13 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         query = select(TI).where(filter_for_tis).options(selectinload(TI.dag_model))
         # row lock this entire set of taskinstances to make sure the scheduler doesn't fail when we have
         # multi-schedulers
-        tis: Iterator[TI] = with_row_locks(
+        tis_query: Query = with_row_locks(
             query,
             of=TI,
             session=session,
             **skip_locked(session=session),
         )
-        tis = session.scalars(tis)
+        tis: Iterator[TI] = session.scalars(tis_query)
         for ti in tis:
             try_number = ti_primary_key_to_try_number_map[ti.key.primary]
             buffer_key = ti.key.with_try_number(try_number)


### PR DESCRIPTION
`with_row_locks` returns a Query; this PR updates the returned value type to avoid the IDE warning.