### PR TITLE
OpenLineage: Add dag_id when generating run_id for task instance.

### DIFF
--- a/airflow/providers/dbt/cloud/utils/openlineage.py
+++ b/airflow/providers/dbt/cloud/utils/openlineage.py
@@ -121,7 +121,10 @@ def generate_openlineage_events_from_dbt_cloud_run(
 
         # generate same run id of current task instance
         parent_run_id = OpenLineageAdapter.build_task_instance_run_id(
-            operator.task_id, task_instance.execution_date, task_instance.try_number - 1
+            dag_id=task_instance.dag_id,
+            task_id=operator.task_id,
+            execution_date=task_instance.execution_date,
+            try_number=task_instance.try_number - 1,
         )
 
         parent_job = ParentRunMetadata(

--- a/airflow/providers/openlineage/plugins/adapter.py
+++ b/airflow/providers/openlineage/plugins/adapter.py
@@ -102,11 +102,11 @@ class OpenLineageAdapter(LoggingMixin):
         return str(uuid.uuid3(uuid.NAMESPACE_URL, f"{_DAG_NAMESPACE}.{dag_id}.{dag_run_id}"))
 
     @staticmethod
-    def build_task_instance_run_id(task_id, execution_date, try_number):
+    def build_task_instance_run_id(dag_id, task_id, execution_date, try_number):
         return str(
             uuid.uuid3(
                 uuid.NAMESPACE_URL,
-                f"{_DAG_NAMESPACE}.{task_id}.{execution_date}.{try_number}",
+                f"{_DAG_NAMESPACE}.{dag_id}.{task_id}.{execution_date}.{try_number}",
             )
         )
 

--- a/airflow/providers/openlineage/plugins/listener.py
+++ b/airflow/providers/openlineage/plugins/listener.py
@@ -77,7 +77,10 @@ class OpenLineageListener:
             parent_run_id = self.adapter.build_dag_run_id(dag.dag_id, dagrun.run_id)
 
             task_uuid = self.adapter.build_task_instance_run_id(
-                task.task_id, task_instance.execution_date, task_instance.try_number
+                dag_id=dag.dag_id,
+                task_id=task.task_id,
+                execution_date=task_instance.execution_date,
+                try_number=task_instance.try_number,
             )
 
             task_metadata = self.extractor_manager.extract_metadata(dagrun, task)
@@ -116,13 +119,16 @@ class OpenLineageListener:
         task = task_instance.task
         dag = task.dag
 
-        task_uuid = OpenLineageAdapter.build_task_instance_run_id(
-            task.task_id, task_instance.execution_date, task_instance.try_number - 1
-        )
-
         @print_warning(self.log)
         def on_success():
             parent_run_id = OpenLineageAdapter.build_dag_run_id(dag.dag_id, dagrun.run_id)
+
+            task_uuid = OpenLineageAdapter.build_task_instance_run_id(
+                dag_id=dag.dag_id,
+                task_id=task.task_id,
+                execution_date=task_instance.execution_date,
+                try_number=task_instance.try_number - 1,
+            )
 
             task_metadata = self.extractor_manager.extract_metadata(
                 dagrun, task, complete=True, task_instance=task_instance
@@ -149,13 +155,16 @@ class OpenLineageListener:
         task = task_instance.task
         dag = task.dag
 
-        task_uuid = OpenLineageAdapter.build_task_instance_run_id(
-            task.task_id, task_instance.execution_date, task_instance.try_number
-        )
-
         @print_warning(self.log)
         def on_failure():
             parent_run_id = OpenLineageAdapter.build_dag_run_id(dag.dag_id, dagrun.run_id)
+
+            task_uuid = OpenLineageAdapter.build_task_instance_run_id(
+                dag_id=dag.dag_id,
+                task_id=task.task_id,
+                execution_date=task_instance.execution_date,
+                try_number=task_instance.try_number,
+            )
 
             task_metadata = self.extractor_manager.extract_metadata(
                 dagrun, task, complete=True, task_instance=task_instance

--- a/airflow/providers/openlineage/plugins/macros.py
+++ b/airflow/providers/openlineage/plugins/macros.py
@@ -39,7 +39,10 @@ def lineage_run_id(task_instance: TaskInstance):
         :ref:`howto/macros:openlineage`
     """
     return OpenLineageAdapter.build_task_instance_run_id(
-        task_instance.task.task_id, task_instance.execution_date, task_instance.try_number
+        dag_id=task_instance.dag_id,
+        task_id=task_instance.task.task_id,
+        execution_date=task_instance.execution_date,
+        try_number=task_instance.try_number,
     )
 
 
@@ -55,6 +58,9 @@ def lineage_parent_id(run_id: str, task_instance: TaskInstance):
         :ref:`howto/macros:openlineage`
     """
     job_name = OpenLineageAdapter.build_task_instance_run_id(
-        task_instance.task.task_id, task_instance.execution_date, task_instance.try_number
+        dag_id=task_instance.dag_id,
+        task_id=task_instance.task.task_id,
+        execution_date=task_instance.execution_date,
+        try_number=task_instance.try_number,
     )
     return f"{_JOB_NAMESPACE}/{job_name}/{run_id}"

--- a/tests/always/test_project_structure.py
+++ b/tests/always/test_project_structure.py
@@ -163,7 +163,6 @@ class TestProjectStructure:
             "tests/providers/openlineage/extractors/test_manager.py",
             "tests/providers/openlineage/plugins/test_adapter.py",
             "tests/providers/openlineage/plugins/test_facets.py",
-            "tests/providers/openlineage/plugins/test_macros.py",
             "tests/providers/openlineage/test_sqlparser.py",
             "tests/providers/redis/operators/test_redis_publish.py",
             "tests/providers/redis/sensors/test_redis_key.py",

--- a/tests/providers/openlineage/plugins/test_macros.py
+++ b/tests/providers/openlineage/plugins/test_macros.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import uuid
+from unittest import mock
+
+from airflow.providers.openlineage.plugins.adapter import _DAG_NAMESPACE
+from airflow.providers.openlineage.plugins.macros import lineage_parent_id, lineage_run_id
+
+
+def test_lineage_run_id():
+    task = mock.MagicMock(
+        dag_id="dag_id", execution_date="execution_date", try_number=1, task=mock.MagicMock(task_id="task_id")
+    )
+    actual = lineage_run_id(task)
+    expected = str(
+        uuid.uuid3(
+            uuid.NAMESPACE_URL,
+            f"{_DAG_NAMESPACE}.dag_id.task_id.execution_date.1",
+        )
+    )
+    assert actual == expected
+
+
+def test_lineage_parent_id():
+    task = mock.MagicMock(
+        dag_id="dag_id", execution_date="execution_date", try_number=1, task=mock.MagicMock(task_id="task_id")
+    )
+    actual = lineage_parent_id(run_id="run_id", task_instance=task)
+    job_name = str(
+        uuid.uuid3(
+            uuid.NAMESPACE_URL,
+            f"{_DAG_NAMESPACE}.dag_id.task_id.execution_date.1",
+        )
+    )
+    expected = f"{_DAG_NAMESPACE}/{job_name}/run_id"
+    assert actual == expected

--- a/tests/providers/openlineage/plugins/test_openlineage_adapter.py
+++ b/tests/providers/openlineage/plugins/test_openlineage_adapter.py
@@ -161,7 +161,7 @@ def test_emit_start_event(mock_stats_incr, mock_stats_timer):
                     },
                 ),
                 job=Job(
-                    namespace="default",
+                    namespace=_DAG_NAMESPACE,
                     name="job",
                     facets={"documentation": DocumentationJobFacet(description="description")},
                 ),
@@ -222,18 +222,18 @@ def test_emit_start_event_with_additional_information(mock_stats_incr, mock_stat
                         ),
                         "parent": ParentRunFacet(
                             run={"runId": "parent_run_id"},
-                            job={"namespace": "default", "name": "parent_job_name"},
+                            job={"namespace": _DAG_NAMESPACE, "name": "parent_job_name"},
                         ),
                         "parentRun": ParentRunFacet(
                             run={"runId": "parent_run_id"},
-                            job={"namespace": "default", "name": "parent_job_name"},
+                            job={"namespace": _DAG_NAMESPACE, "name": "parent_job_name"},
                         ),
                         "externalQuery1": ExternalQueryRunFacet(externalQueryId="123", source="source"),
                         "externalQuery2": ExternalQueryRunFacet(externalQueryId="999", source="source"),
                     },
                 ),
                 job=Job(
-                    namespace="default",
+                    namespace=_DAG_NAMESPACE,
                     name="job",
                     facets={
                         "documentation": DocumentationJobFacet(description="description"),
@@ -284,7 +284,7 @@ def test_emit_complete_event(mock_stats_incr, mock_stats_timer):
                 eventType=RunState.COMPLETE,
                 eventTime=event_time,
                 run=Run(runId=run_id, facets={}),
-                job=Job(namespace="default", name="job", facets={}),
+                job=Job(namespace=_DAG_NAMESPACE, name="job", facets={}),
                 producer=_PRODUCER,
                 inputs=[],
                 outputs=[],
@@ -329,16 +329,16 @@ def test_emit_complete_event_with_additional_information(mock_stats_incr, mock_s
                     facets={
                         "parent": ParentRunFacet(
                             run={"runId": "parent_run_id"},
-                            job={"namespace": "default", "name": "parent_job_name"},
+                            job={"namespace": _DAG_NAMESPACE, "name": "parent_job_name"},
                         ),
                         "parentRun": ParentRunFacet(
                             run={"runId": "parent_run_id"},
-                            job={"namespace": "default", "name": "parent_job_name"},
+                            job={"namespace": _DAG_NAMESPACE, "name": "parent_job_name"},
                         ),
                         "externalQuery": ExternalQueryRunFacet(externalQueryId="123", source="source"),
                     },
                 ),
-                job=Job(namespace="default", name="job", facets={"sql": SqlJobFacet(query="SELECT 1;")}),
+                job=Job(namespace=_DAG_NAMESPACE, name="job", facets={"sql": SqlJobFacet(query="SELECT 1;")}),
                 producer=_PRODUCER,
                 inputs=[
                     Dataset(namespace="bigquery", name="a.b.c"),
@@ -377,7 +377,7 @@ def test_emit_failed_event(mock_stats_incr, mock_stats_timer):
                 eventType=RunState.FAIL,
                 eventTime=event_time,
                 run=Run(runId=run_id, facets={}),
-                job=Job(namespace="default", name="job", facets={}),
+                job=Job(namespace=_DAG_NAMESPACE, name="job", facets={}),
                 producer=_PRODUCER,
                 inputs=[],
                 outputs=[],
@@ -422,16 +422,16 @@ def test_emit_failed_event_with_additional_information(mock_stats_incr, mock_sta
                     facets={
                         "parent": ParentRunFacet(
                             run={"runId": "parent_run_id"},
-                            job={"namespace": "default", "name": "parent_job_name"},
+                            job={"namespace": _DAG_NAMESPACE, "name": "parent_job_name"},
                         ),
                         "parentRun": ParentRunFacet(
                             run={"runId": "parent_run_id"},
-                            job={"namespace": "default", "name": "parent_job_name"},
+                            job={"namespace": _DAG_NAMESPACE, "name": "parent_job_name"},
                         ),
                         "externalQuery": ExternalQueryRunFacet(externalQueryId="123", source="source"),
                     },
                 ),
-                job=Job(namespace="default", name="job", facets={"sql": SqlJobFacet(query="SELECT 1;")}),
+                job=Job(namespace=_DAG_NAMESPACE, name="job", facets={"sql": SqlJobFacet(query="SELECT 1;")}),
                 producer=_PRODUCER,
                 inputs=[
                     Dataset(namespace="bigquery", name="a.b.c"),
@@ -485,7 +485,7 @@ def test_emit_dag_started_event(mock_stats_incr, mock_stats_timer, uuid):
                         )
                     },
                 ),
-                job=Job(namespace="default", name="dag_id", facets={}),
+                job=Job(namespace=_DAG_NAMESPACE, name="dag_id", facets={}),
                 producer=_PRODUCER,
                 inputs=[],
                 outputs=[],
@@ -527,7 +527,7 @@ def test_emit_dag_complete_event(mock_stats_incr, mock_stats_timer, uuid):
                 eventType=RunState.COMPLETE,
                 eventTime=event_time.isoformat(),
                 run=Run(runId=random_uuid, facets={}),
-                job=Job(namespace="default", name="dag_id", facets={}),
+                job=Job(namespace=_DAG_NAMESPACE, name="dag_id", facets={}),
                 producer=_PRODUCER,
                 inputs=[],
                 outputs=[],
@@ -576,7 +576,7 @@ def test_emit_dag_failed_event(mock_stats_incr, mock_stats_timer, uuid):
                         )
                     },
                 ),
-                job=Job(namespace="default", name="dag_id", facets={}),
+                job=Job(namespace=_DAG_NAMESPACE, name="dag_id", facets={}),
                 producer=_PRODUCER,
                 inputs=[],
                 outputs=[],
@@ -627,25 +627,23 @@ def test_build_dag_run_id_uses_correct_methods_underneath():
 
 
 def test_build_task_instance_run_id_is_valid_uuid():
-    task_id = "task_1"
-    execution_date = "2023-01-01"
-    try_number = 1
-    result = OpenLineageAdapter.build_task_instance_run_id(task_id, execution_date, try_number)
+    result = OpenLineageAdapter.build_task_instance_run_id("dag_1", "task_1", "2023-01-01", 1)
     assert uuid.UUID(result)
 
 
 def test_build_task_instance_run_id_different_inputs_gives_different_results():
-    result1 = OpenLineageAdapter.build_task_instance_run_id("task1", "2023-01-01", 1)
-    result2 = OpenLineageAdapter.build_task_instance_run_id("task2", "2023-01-02", 2)
+    result1 = OpenLineageAdapter.build_task_instance_run_id("dag_1", "task1", "2023-01-01", 1)
+    result2 = OpenLineageAdapter.build_task_instance_run_id("dag_1", "task2", "2023-01-02", 2)
     assert result1 != result2
 
 
 def test_build_task_instance_run_id_uses_correct_methods_underneath():
+    dag_id = "dag_1"
     task_id = "task_1"
     execution_date = "2023-01-01"
     try_number = 1
     expected = str(
-        uuid.uuid3(uuid.NAMESPACE_URL, f"{_DAG_NAMESPACE}.{task_id}.{execution_date}.{try_number}")
+        uuid.uuid3(uuid.NAMESPACE_URL, f"{_DAG_NAMESPACE}.{dag_id}.{task_id}.{execution_date}.{try_number}")
     )
-    actual = OpenLineageAdapter.build_task_instance_run_id(task_id, execution_date, try_number)
+    actual = OpenLineageAdapter.build_task_instance_run_id(dag_id, task_id, execution_date, try_number)
     assert actual == expected


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
We might get the same run_id for the corresponding tasks even though they come from different dags. This happens when two dags are almost identical (same task ids, same schedules).

F.e., in this case we have the same dag copied twice, but i changed the name of one of them. When we allow dags to run backfill, we will receive events from two dags, but the run_id for task events will be the same in both cases.
```
from airflow import DAG
from airflow.operators.bash import BashOperator
from airflow.utils.dates import days_ago

with DAG(
    dag_id='test',
    start_date=days_ago(2),
    schedule_interval="@daily",
    catchup=True
) as dag1:
    task1 = BashOperator(
        task_id='run',
        bash_command="echo 'test'; "
    )


with DAG(
    dag_id='test_1',
    start_date=days_ago(2),
    schedule_interval="@daily",
    catchup=True
) as dag2:
    task2 = BashOperator(
        task_id='run',
        bash_command="echo 'test'; "
    )
```

To fix that, I added a dag_id to the function that generates run_id for the task. I also added some macros tests and adjusted all other tests.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
