### PR TITLE
Bump min version for grpcio-status in spark provider

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1117,14 +1117,11 @@ RUN echo "Airflow version: ${AIRFLOW_VERSION}"
 # force them on the main Airflow package. Currently we need no extra limits as PIP 23.1+ has much better
 # dependency resolution and we do not need to limit the versions of the dependencies
 #
-# Without grpcio-status limit, pip gets into very long backtracking
-# We should attempt to remove it in the future
-#
 # Aiobotocore is limited for eager upgrade because it either causes a long backtracking or
 # conflict when we do not limit it. It seems that `pip` has a hard time figuring the right
 # combination of dependencies for aiobotocore, botocore, boto3 and s3fs together
 #
-ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="grpcio-status>=1.55.0 aiobotocore>=2.5.4"
+ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="aiobotocore>=2.5.4"
 ARG UPGRADE_TO_NEWER_DEPENDENCIES="false"
 ARG VERSION_SUFFIX_FOR_PYPI=""
 

--- a/airflow/providers/apache/spark/provider.yaml
+++ b/airflow/providers/apache/spark/provider.yaml
@@ -55,7 +55,7 @@ versions:
 dependencies:
   - apache-airflow>=2.6.0
   - pyspark
-  - grpcio-status
+  - grpcio-status>=1.59.0
 
 integrations:
   - integration-name: Apache Spark

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -206,7 +206,7 @@
   "apache.spark": {
     "deps": [
       "apache-airflow>=2.6.0",
-      "grpcio-status",
+      "grpcio-status>=1.59.0",
       "pyspark"
     ],
     "cross-providers-deps": [


### PR DESCRIPTION
Previously we limited grpcio minimum version to stop backtracking of `pip` from happening and we could not do it in the limits of spark provider, becaue some google dependencies used it and conflicted with it. This problem is now gone as we have newer versions of google dependencies and we can not only safely move it to spark provider but also bump it slightly higher to limit the amount of backtracking we need to do.

Extracted from #36537

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
