### PR TITLE
Bump min telegram-bot version

### DIFF
--- a/airflow/providers/telegram/provider.yaml
+++ b/airflow/providers/telegram/provider.yaml
@@ -43,7 +43,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.6.0
-  - python-telegram-bot>=20.0.0
+  - python-telegram-bot>=20.2
 
 integrations:
   - integration-name: Telegram

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -996,7 +996,7 @@
   "telegram": {
     "deps": [
       "apache-airflow>=2.6.0",
-      "python-telegram-bot>=20.0.0"
+      "python-telegram-bot>=20.2"
     ],
     "cross-providers-deps": [],
     "excluded-python-versions": [],


### PR DESCRIPTION
This is the last one from the long-backtracking series.

Telegram 20.2 has been released in March 2023 and for all practical purposes using recent version is a good idea to interact with such services. Bumping it cuts down on a number of backtracking loops pip has to do when backtracking.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
