### PR TITLE
Add version check for k8s setup venv command

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/kubernetes_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/kubernetes_utils.py
@@ -32,7 +32,13 @@ from time import sleep
 from typing import Any, NamedTuple
 from urllib import request
 
-from airflow_breeze.global_constants import ALLOWED_ARCHITECTURES, HELM_VERSION, KIND_VERSION, PIP_VERSION
+from airflow_breeze.global_constants import (
+    ALLOWED_ARCHITECTURES,
+    ALLOWED_PYTHON_MAJOR_MINOR_VERSIONS,
+    HELM_VERSION,
+    KIND_VERSION,
+    PIP_VERSION,
+)
 from airflow_breeze.utils.console import Output, get_console
 from airflow_breeze.utils.host_info_utils import Architecture, get_host_architecture, get_host_os
 from airflow_breeze.utils.path_utils import AIRFLOW_SOURCES_ROOT, BUILD_CACHE_DIR
@@ -330,6 +336,26 @@ def create_virtualenv(force_venv_setup: bool) -> RunCommandResult:
         get_console().print(f"[info]Dry run - would be removing {K8S_ENV_PATH}")
     else:
         shutil.rmtree(K8S_ENV_PATH, ignore_errors=True)
+    max_python_version = ALLOWED_PYTHON_MAJOR_MINOR_VERSIONS[-1]
+    max_python_version_tuple = tuple(int(x) for x in max_python_version.split("."))
+    higher_python_version_tuple = max_python_version_tuple[0], max_python_version_tuple[1] + 1
+    if sys.version_info >= higher_python_version_tuple:
+        get_console().print(
+            f"[red]This is not supported in Python {higher_python_version_tuple} and above[/]\n"
+        )
+        get_console().print(f"[warning]Please use Python version before {higher_python_version_tuple}[/]\n")
+        get_console().print(
+            "[info]You can uninstall breeze and install it again with earlier Python "
+            "version. For example:[/]\n"
+        )
+        get_console().print("pipx uninstall apache-airflow-breeze")
+        get_console().print("pipx install --python PYTHON_PATH -e ./dev/breeze\n")
+        get_console().print(
+            f"[info]PYTHON_PATH - path to your Python binary(< {higher_python_version_tuple})[/]\n"
+        )
+        get_console().print("[info]Then recreate your k8s virtualenv with:[/]\n")
+        get_console().print("breeze k8s setup-env --force-venv-setup\n")
+        sys.exit(1)
     venv_command_result = run_command(
         [sys.executable, "-m", "venv", str(K8S_ENV_PATH)],
         check=False,


### PR DESCRIPTION
This command install airflow in k8s venv and in case version of Python is not yet supported by Airflow, it might fail.

We do not have check it lower-bound because breeze supports the same minimum version of Airflow as Airflow itself.

The command prints instructions on how to reinstall breeze with different Python version in such case.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
