### PR TITLE
Provide the logger_name param to base hook in order to override the logger name

### DIFF
--- a/airflow/hooks/filesystem.py
+++ b/airflow/hooks/filesystem.py
@@ -59,8 +59,8 @@ class FSHook(BaseHook):
             "placeholders": {},
         }
 
-    def __init__(self, fs_conn_id: str = default_conn_name):
-        super().__init__()
+    def __init__(self, fs_conn_id: str = default_conn_name, **kwargs):
+        super().__init__(**kwargs)
         conn = self.get_connection(fs_conn_id)
         self.basepath = conn.extra_dejson.get("path", "")
         self.conn = conn

--- a/airflow/hooks/package_index.py
+++ b/airflow/hooks/package_index.py
@@ -33,8 +33,8 @@ class PackageIndexHook(BaseHook):
     conn_type = "package_index"
     hook_name = "Package Index (Python)"
 
-    def __init__(self, pi_conn_id: str = default_conn_name) -> None:
-        super().__init__()
+    def __init__(self, pi_conn_id: str = default_conn_name, **kwargs) -> None:
+        super().__init__(**kwargs)
         self.pi_conn_id = pi_conn_id
         self.conn = None
 

--- a/airflow/hooks/subprocess.py
+++ b/airflow/hooks/subprocess.py
@@ -31,9 +31,9 @@ SubprocessResult = namedtuple("SubprocessResult", ["exit_code", "output"])
 class SubprocessHook(BaseHook):
     """Hook for running processes with the ``subprocess`` module."""
 
-    def __init__(self) -> None:
+    def __init__(self, **kwargs) -> None:
         self.sub_process: Popen[bytes] | None = None
-        super().__init__()
+        super().__init__(**kwargs)
 
     def run_command(
         self,


### PR DESCRIPTION
The BaseHook accepts a parameter `logger_name` to override the logger_name in the LoggingMixin. Unfortunately, some of the hooks don't provide this parameter to the parent class, and the only way to override the logger name is doing it on an extra step and overriding a protected class attribute:
```python
hook = SomeHook(...)
hook._logger_name = "<some name>"
```