### PR TITLE
Set min pandas dependency to 1.2.5 for all providers and airflow

### DIFF
--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -742,7 +742,7 @@ logging:
 additional-extras:
   - name: pandas
     dependencies:
-      - pandas>=0.17.1
+      - pandas>=1.2.5
   # There is conflict between boto3 and aiobotocore dependency botocore.
   # TODO: We can remove it once boto3 and aiobotocore both have compatible botocore version or
   # boto3 have native async support and we move away from aio aiobotocore

--- a/airflow/providers/apache/hive/provider.yaml
+++ b/airflow/providers/apache/hive/provider.yaml
@@ -66,7 +66,7 @@ dependencies:
   - apache-airflow>=2.6.0
   - apache-airflow-providers-common-sql>=1.3.1
   - hmsclient>=0.1.0
-  - pandas>=0.17.1
+  - pandas>=1.2.5
   - pyhive[hive_pure_sasl]>=0.7.0
   - thrift>=0.9.2
 

--- a/airflow/providers/common/sql/provider.yaml
+++ b/airflow/providers/common/sql/provider.yaml
@@ -54,7 +54,7 @@ dependencies:
 additional-extras:
   - name: pandas
     dependencies:
-      - pandas>=0.17.1
+      - pandas>=1.2.5
 
 integrations:
   - integration-name: Common SQL

--- a/airflow/providers/exasol/provider.yaml
+++ b/airflow/providers/exasol/provider.yaml
@@ -55,7 +55,7 @@ dependencies:
   - apache-airflow>=2.6.0
   - apache-airflow-providers-common-sql>=1.10.0
   - pyexasol>=0.5.1
-  - pandas>=0.17.1
+  - pandas>=1.2.5
 
 integrations:
   - integration-name: Exasol

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -137,7 +137,7 @@ dependencies:
   - json-merge-patch>=0.2
   - looker-sdk>=22.2.0
   - pandas-gbq
-  - pandas>=0.17.1
+  - pandas>=1.2.5
   # A transient dependency of google-cloud-bigquery-datatransfer, but we
   # further constrain it since older versions are buggy.
   - proto-plus>=1.19.6

--- a/airflow/providers/presto/provider.yaml
+++ b/airflow/providers/presto/provider.yaml
@@ -57,7 +57,7 @@ dependencies:
   - apache-airflow>=2.6.0
   - apache-airflow-providers-common-sql>=1.3.1
   - presto-python-client>=0.8.4
-  - pandas>=0.17.1
+  - pandas>=1.2.5
 
 integrations:
   - integration-name: Presto

--- a/airflow/providers/salesforce/provider.yaml
+++ b/airflow/providers/salesforce/provider.yaml
@@ -53,7 +53,7 @@ versions:
 dependencies:
   - apache-airflow>=2.6.0
   - simple-salesforce>=1.0.0
-  - pandas>=0.17.1
+  - pandas>=1.2.5
 
 integrations:
   - integration-name: Salesforce

--- a/airflow/providers/trino/provider.yaml
+++ b/airflow/providers/trino/provider.yaml
@@ -57,7 +57,7 @@ versions:
 dependencies:
   - apache-airflow>=2.6.0
   - apache-airflow-providers-common-sql>=1.3.1
-  - pandas>=0.17.1
+  - pandas>=1.2.5
   - trino>=0.318.0
 
 integrations:

--- a/airflow/providers/weaviate/provider.yaml
+++ b/airflow/providers/weaviate/provider.yaml
@@ -42,7 +42,7 @@ integrations:
 dependencies:
   - apache-airflow>=2.6.0
   - weaviate-client>=3.24.2
-  - pandas>=0.17.1
+  - pandas>=1.2.5
 
 hooks:
   - integration-name: Weaviate

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -125,7 +125,7 @@
       "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.6.0",
       "hmsclient>=0.1.0",
-      "pandas>=0.17.1",
+      "pandas>=1.2.5",
       "pyhive[hive_pure_sasl]>=0.7.0",
       "thrift>=0.9.2"
     ],
@@ -403,7 +403,7 @@
     "deps": [
       "apache-airflow-providers-common-sql>=1.10.0",
       "apache-airflow>=2.6.0",
-      "pandas>=0.17.1",
+      "pandas>=1.2.5",
       "pyexasol>=0.5.1"
     ],
     "cross-providers-deps": [
@@ -509,7 +509,7 @@
       "json-merge-patch>=0.2",
       "looker-sdk>=22.2.0",
       "pandas-gbq",
-      "pandas>=0.17.1",
+      "pandas>=1.2.5",
       "proto-plus>=1.19.6",
       "sqlalchemy-bigquery>=1.2.1",
       "sqlalchemy-spanner>=1.6.2"
@@ -842,7 +842,7 @@
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.6.0",
-      "pandas>=0.17.1",
+      "pandas>=1.2.5",
       "presto-python-client>=0.8.4"
     ],
     "cross-providers-deps": [
@@ -864,7 +864,7 @@
   "salesforce": {
     "deps": [
       "apache-airflow>=2.6.0",
-      "pandas>=0.17.1",
+      "pandas>=1.2.5",
       "simple-salesforce>=1.0.0"
     ],
     "cross-providers-deps": [],
@@ -1007,7 +1007,7 @@
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.6.0",
-      "pandas>=0.17.1",
+      "pandas>=1.2.5",
       "trino>=0.318.0"
     ],
     "cross-providers-deps": [
@@ -1033,7 +1033,7 @@
   "weaviate": {
     "deps": [
       "apache-airflow>=2.6.0",
-      "pandas>=0.17.1",
+      "pandas>=1.2.5",
       "weaviate-client>=3.24.2"
     ],
     "cross-providers-deps": [],

--- a/setup.py
+++ b/setup.py
@@ -350,7 +350,7 @@ ldap = [
 leveldb = ["plyvel"]
 otel = ["opentelemetry-exporter-prometheus"]
 pandas = [
-    "pandas>=0.17.1",
+    "pandas>=1.2.5",
 ]
 password = [
     "bcrypt>=2.0.0",


### PR DESCRIPTION
We had some REALLY old minimum version of Pandas set for all our pandas dependency - Pandas 0.17.1 has been released in 2015 (!)

Looking at the dependency tree - most of our dependencies had
> 1.2.5 set - which is more than reasonable limit as Pandas 1.2.5
had been released in June 2021 - so more than 2.5 years ago.

This limit bump further helps us to limit the pip backtracking that starts happening in certain situations.

Extracted from: #36537

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
