### PR TITLE
Update the redshift hostname check to avoid possible bugs

### DIFF
--- a/airflow/providers/amazon/aws/hooks/redshift_sql.py
+++ b/airflow/providers/amazon/aws/hooks/redshift_sql.py
@@ -239,7 +239,7 @@ class RedshiftSQLHook(DbApiHook):
 
     def _get_identifier_from_hostname(self, hostname: str) -> str:
         parts = hostname.split(".")
-        if "amazonaws.com" in hostname and len(parts) == 6:
+        if hostname.endswith("amazonaws.com") and len(parts) == 6:
             return f"{parts[0]}.{parts[2]}"
         else:
             self.log.debug(


### PR DESCRIPTION
This PR replaces `"amazonaws.com" in hostname` with `hostname.endswith("amazonaws.com")` because we expect that this substring comes at the end of the hostname and not anywhere in the hostname string as explained in the log message below it.