### PR TITLE
Fix ODBC Hook sql select return empty table

### DIFF
--- a/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/airflow/providers/databricks/hooks/databricks_sql.py
@@ -278,8 +278,6 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         """Transform the databricks Row objects into namedtuple."""
         # Below ignored lines respect namedtuple docstring, but mypy do not support dynamically
         # instantiated namedtuple, and will never do: https://github.com/python/mypy/issues/848
-        if not result:
-            return []
         if isinstance(result, list):
             rows: list[Row] = result
             rows_fields = rows[0].__fields__

--- a/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/airflow/providers/databricks/hooks/databricks_sql.py
@@ -278,6 +278,8 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         """Transform the databricks Row objects into namedtuple."""
         # Below ignored lines respect namedtuple docstring, but mypy do not support dynamically
         # instantiated namedtuple, and will never do: https://github.com/python/mypy/issues/848
+        if not result:
+            return []
         if isinstance(result, list):
             rows: list[Row] = result
             rows_fields = rows[0].__fields__

--- a/airflow/providers/odbc/hooks/odbc.py
+++ b/airflow/providers/odbc/hooks/odbc.py
@@ -234,6 +234,8 @@ class OdbcHook(DbApiHook):
         # instantiated typed Namedtuple, and will never do: https://github.com/python/mypy/issues/848
         field_names: list[tuple[str, type]] | None = None
         if isinstance(result, Sequence):
+            if not result:
+                return []
             field_names = [col[:2] for col in result[0].cursor_description]
             row_object = NamedTuple("Row", field_names)  # type: ignore[misc]
             return cast(List[tuple], [row_object(*row) for row in result])

--- a/airflow/providers/odbc/hooks/odbc.py
+++ b/airflow/providers/odbc/hooks/odbc.py
@@ -233,9 +233,9 @@ class OdbcHook(DbApiHook):
         # Below ignored lines respect NamedTuple docstring, but mypy do not support dynamically
         # instantiated typed Namedtuple, and will never do: https://github.com/python/mypy/issues/848
         field_names: list[tuple[str, type]] | None = None
+        if not result:
+            return []
         if isinstance(result, Sequence):
-            if not result:
-                return []
             field_names = [col[:2] for col in result[0].cursor_description]
             row_object = NamedTuple("Row", field_names)  # type: ignore[misc]
             return cast(List[tuple], [row_object(*row) for row in result])

--- a/tests/providers/odbc/hooks/test_odbc.py
+++ b/tests/providers/odbc/hooks/test_odbc.py
@@ -329,9 +329,7 @@ class TestOdbcHook:
             result = hook.run("SQL", handler=mock_handler)
         assert hook_result == result
 
-    def test_query_return_serializable_result_empty(
-        self, pyodbc_row_mock, monkeypatch, pyodbc_instancecheck
-    ):
+    def test_query_return_serializable_result_empty(self, pyodbc_row_mock, monkeypatch, pyodbc_instancecheck):
         """
         Simulate a cursor.fetchall which returns an iterable of pyodbc.Row object, and check if this iterable
         get converted into a list of tuples.

--- a/tests/providers/odbc/hooks/test_odbc.py
+++ b/tests/providers/odbc/hooks/test_odbc.py
@@ -329,6 +329,25 @@ class TestOdbcHook:
             result = hook.run("SQL", handler=mock_handler)
         assert hook_result == result
 
+    def test_query_return_serializable_result_empty(
+        self, pyodbc_row_mock, monkeypatch, pyodbc_instancecheck
+    ):
+        """
+        Simulate a cursor.fetchall which returns an iterable of pyodbc.Row object, and check if this iterable
+        get converted into a list of tuples.
+        """
+        pyodbc_result = []
+        hook_result = []
+
+        def mock_handler(*_):
+            return pyodbc_result
+
+        hook = self.get_hook()
+        with monkeypatch.context() as patcher:
+            patcher.setattr("pyodbc.Row", pyodbc_instancecheck)
+            result = hook.run("SQL", handler=mock_handler)
+        assert hook_result == result
+
     def test_query_return_serializable_result_with_fetchone(
         self, pyodbc_row_mock, monkeypatch, pyodbc_instancecheck
     ):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

When querying using a select statement with the odbc hook and the return is an empty table (sqlalchemy []). 
```python 
File "/usr/local/lib/python3.9/site-packages/airflow/providers/odbc/hooks/odbc.py", line 219, in _make_serializable
    columns: list[tuple[str, type]] = [col[:2] for col in result[0].cursor_description]
IndexError: list index out of range
```

because of result[0]
This early return fixes this issue.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
