### PR TITLE
Introduce `DatasetOrTimeSchedule`

### DIFF
--- a/airflow/example_dags/example_datasets.py
+++ b/airflow/example_dags/example_datasets.py
@@ -43,7 +43,7 @@ import pendulum
 from airflow.datasets import Dataset
 from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
-from airflow.timetables.datasets import DatasetTimetable
+from airflow.timetables.datasets import DatasetOrTimeSchedule
 from airflow.timetables.trigger import CronTriggerTimetable
 
 # [START dataset_def]
@@ -135,7 +135,9 @@ with DAG(
     dag_id="dataset_and_time_based_timetable",
     catchup=False,
     start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
-    schedule=DatasetTimetable(time=CronTriggerTimetable("0 1 * * 3", timezone="UTC"), event=[dag1_dataset]),
+    schedule=DatasetOrTimeSchedule(
+        time=CronTriggerTimetable("0 1 * * 3", timezone="UTC"), datasets=[dag1_dataset]
+    ),
     tags=["dataset-time-based-timetable"],
 ) as dag7:
     BashOperator(

--- a/airflow/example_dags/example_datasets.py
+++ b/airflow/example_dags/example_datasets.py
@@ -43,6 +43,8 @@ import pendulum
 from airflow.datasets import Dataset
 from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
+from airflow.timetables.datasets import DatasetTimetable
+from airflow.timetables.trigger import CronTriggerTimetable
 
 # [START dataset_def]
 dag1_dataset = Dataset("s3://dag1/output_1.txt", extra={"hi": "bye"})
@@ -126,5 +128,18 @@ with DAG(
     BashOperator(
         task_id="unrelated_task",
         outlets=[Dataset("s3://unrelated_task/dataset_other_unknown.txt")],
+        bash_command="sleep 5",
+    )
+
+with DAG(
+    dag_id="dataset_and_time_based_timetable",
+    catchup=False,
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+    schedule=DatasetTimetable(time=CronTriggerTimetable("0 1 * * 3", timezone="UTC"), event=[dag1_dataset]),
+    tags=["dataset-time-based-timetable"],
+) as dag7:
+    BashOperator(
+        outlets=[Dataset("s3://dataset_time_based/dataset_other_unknown.txt")],
+        task_id="consuming_dataset_time_based",
         bash_command="sleep 5",
     )

--- a/airflow/example_dags/example_datasets.py
+++ b/airflow/example_dags/example_datasets.py
@@ -136,7 +136,7 @@ with DAG(
     catchup=False,
     start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
     schedule=DatasetOrTimeSchedule(
-        time=CronTriggerTimetable("0 1 * * 3", timezone="UTC"), datasets=[dag1_dataset]
+        timetable=CronTriggerTimetable("0 1 * * 3", timezone="UTC"), datasets=[dag1_dataset]
     ),
     tags=["dataset-time-based-timetable"],
 ) as dag7:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -109,6 +109,7 @@ from airflow.secrets.local_filesystem import LocalFilesystemBackend
 from airflow.security import permissions
 from airflow.stats import Stats
 from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
+from airflow.timetables.datasets import DatasetTimetable
 from airflow.timetables.interval import CronDataIntervalTimetable, DeltaDataIntervalTimetable
 from airflow.timetables.simple import (
     ContinuousTimetable,
@@ -595,6 +596,8 @@ class DAG(LoggingMixin):
             self.timetable = DatasetTriggeredTimetable()
             self.schedule_interval = self.timetable.summary
         elif timetable:
+            if isinstance(timetable, DatasetTimetable):
+                self.dataset_triggers = timetable.event
             self.timetable = timetable
             self.schedule_interval = self.timetable.summary
         else:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -109,7 +109,7 @@ from airflow.secrets.local_filesystem import LocalFilesystemBackend
 from airflow.security import permissions
 from airflow.stats import Stats
 from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
-from airflow.timetables.datasets import DatasetTimetable
+from airflow.timetables.datasets import DatasetOrTimeSchedule
 from airflow.timetables.interval import CronDataIntervalTimetable, DeltaDataIntervalTimetable
 from airflow.timetables.simple import (
     ContinuousTimetable,
@@ -596,8 +596,8 @@ class DAG(LoggingMixin):
             self.timetable = DatasetTriggeredTimetable()
             self.schedule_interval = self.timetable.summary
         elif timetable:
-            if isinstance(timetable, DatasetTimetable):
-                self.dataset_triggers = timetable.event
+            if isinstance(timetable, DatasetOrTimeSchedule):
+                self.dataset_triggers = timetable.datasets
             self.timetable = timetable
             self.schedule_interval = self.timetable.summary
         else:

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -197,12 +197,14 @@ class _TimetableNotRegistered(ValueError):
         )
 
 
-def _encode_timetable(var: Timetable) -> dict[str, Any]:
+def encode_timetable(var: Timetable) -> dict[str, Any]:
     """
     Encode a timetable instance.
 
     This delegates most of the serialization work to the type, so the behavior
     can be completely controlled by a custom subclass.
+
+    :meta private:
     """
     timetable_class = type(var)
     importable_string = qualname(timetable_class)
@@ -211,12 +213,14 @@ def _encode_timetable(var: Timetable) -> dict[str, Any]:
     return {Encoding.TYPE: importable_string, Encoding.VAR: var.serialize()}
 
 
-def _decode_timetable(var: dict[str, Any]) -> Timetable:
+def decode_timetable(var: dict[str, Any]) -> Timetable:
     """
     Decode a previously serialized timetable.
 
     Most of the deserialization logic is delegated to the actual type, which
     we import from string.
+
+    :meta private:
     """
     importable_string = var[Encoding.TYPE]
     timetable_class = _get_registered_timetable(importable_string)
@@ -401,7 +405,7 @@ class BaseSerialization:
             elif key in decorated_fields:
                 serialized_object[key] = cls.serialize(value)
             elif key == "timetable" and value is not None:
-                serialized_object[key] = _encode_timetable(value)
+                serialized_object[key] = encode_timetable(value)
             else:
                 value = cls.serialize(value)
                 if isinstance(value, dict) and Encoding.TYPE in value:
@@ -1368,7 +1372,7 @@ class SerializedDAG(DAG, BaseSerialization):
                 # Value structure matches exactly
                 pass
             elif k == "timetable":
-                v = _decode_timetable(v)
+                v = decode_timetable(v)
             elif k in cls._decorated_fields:
                 v = cls.deserialize(v)
             elif k == "params":

--- a/airflow/timetables/datasets.py
+++ b/airflow/timetables/datasets.py
@@ -1,0 +1,90 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import collections.abc
+import typing
+
+import attrs
+
+from airflow.datasets import Dataset
+from airflow.exceptions import AirflowTimetableInvalid
+from airflow.timetables.simple import DatasetTriggeredTimetable
+from airflow.utils.types import DagRunType
+
+if typing.TYPE_CHECKING:
+    import pendulum
+
+    from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
+
+
+class DatasetTimetable(DatasetTriggeredTimetable):
+    """Combine time-based scheduling with event-based scheduling."""
+
+    def __init__(self, time: Timetable, event: collections.abc.Collection[Dataset]) -> None:
+        self.time = time
+        self.event = event
+
+        self.description = f"Triggered by datasets or {time.description}"
+        self.periodic = time.periodic
+        self._can_be_scheduled = time._can_be_scheduled
+
+        self.run_ordering = time.run_ordering
+        self.active_runs_limit = time.active_runs_limit
+
+    @classmethod
+    def deserialize(cls, data: dict[str, typing.Any]) -> Timetable:
+        from airflow.serialization.serialized_objects import decode_timetable
+
+        return cls(time=decode_timetable(data["time"]), event=[Dataset(**d) for d in data["event"]])
+
+    def serialize(self) -> dict[str, typing.Any]:
+        from airflow.serialization.serialized_objects import encode_timetable
+
+        return {
+            "time": encode_timetable(self.time),
+            "event": [attrs.asdict(e) for e in self.event],
+        }
+
+    def validate(self) -> None:
+        if isinstance(self.time, DatasetTriggeredTimetable):
+            raise AirflowTimetableInvalid("cannot nest dataset timetables")
+        if not isinstance(self.event, collections.abc.Collection) or not all(
+            isinstance(d, Dataset) for d in self.event
+        ):
+            raise AirflowTimetableInvalid("all elements in 'event' must be datasets")
+
+    @property
+    def summary(self) -> str:
+        return f"Dataset or {self.time.summary}"
+
+    def infer_manual_data_interval(self, *, run_after: pendulum.DateTime) -> DataInterval:
+        return self.time.infer_manual_data_interval(run_after=run_after)
+
+    def next_dagrun_info(
+        self, *, last_automated_data_interval: DataInterval | None, restriction: TimeRestriction
+    ) -> DagRunInfo | None:
+        return self.time.next_dagrun_info(
+            last_automated_data_interval=last_automated_data_interval,
+            restriction=restriction,
+        )
+
+    def generate_run_id(self, *, run_type: DagRunType, **kwargs: typing.Any) -> str:
+        if run_type != DagRunType.DATASET_TRIGGERED:
+            return self.time.generate_run_id(run_type=run_type, **kwargs)
+        return super().generate_run_id(run_type=run_type, **kwargs)

--- a/airflow/timetables/simple.py
+++ b/airflow/timetables/simple.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import operator
-from typing import TYPE_CHECKING, Any, Collection
+from typing import TYPE_CHECKING, Any, Collection, Sequence
 
 from airflow.timetables.base import DagRunInfo, DataInterval, Timetable
 from airflow.utils import timezone
@@ -35,7 +35,7 @@ class _TrivialTimetable(Timetable):
     """Some code reuse for "trivial" timetables that has nothing complex."""
 
     periodic = False
-    run_ordering = ("execution_date",)
+    run_ordering: Sequence[str] = ("execution_date",)
 
     @classmethod
     def deserialize(cls, data: dict[str, Any]) -> Timetable:

--- a/docs/apache-airflow/authoring-and-scheduling/datasets.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/datasets.rst
@@ -236,3 +236,12 @@ Example:
         print_triggering_dataset_events()
 
 Note that this example is using `(.values() | first | first) <https://jinja.palletsprojects.com/en/3.1.x/templates/#jinja-filters.first>`_ to fetch the first of one Dataset given to the DAG, and the first of one DatasetEvent for that Dataset. An implementation may be quite complex if you have multiple Datasets, potentially with multiple DatasetEvents.
+
+Combining Dataset and Time-Based Schedules
+------------------------------------------
+
+DatasetTimetable Integration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+With the introduction of ``DatasetTimetable``, it is now possible to schedule DAGs based on both dataset events and time-based schedules. This feature offers flexibility for scenarios where a DAG needs to be triggered by data updates as well as run periodically according to a fixed timetable.
+
+For more detailed information on ``DatasetTimetable`` and its usage, refer to the corresponding section in :ref:`DatasetTimetable <dataset-timetable-section>`.

--- a/docs/apache-airflow/authoring-and-scheduling/timetable.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/timetable.rst
@@ -177,6 +177,45 @@ first) event for the data interval, otherwise manual runs will run with a ``data
     def example_dag():
         pass
 
+.. _dataset-timetable-section:
+
+DatasetTimetable
+^^^^^^^^^^^^^^^^
+
+The ``DatasetTimetable`` is a specialized timetable allowing for the scheduling of DAGs based on both time-based schedules and dataset events. It facilitates the creation of scheduled runs (as per traditional timetables) and dataset-triggered runs, which operate independently.
+
+This feature is particularly useful in scenarios requiring a DAG to rerun upon dataset updates, while also necessitating periodic execution at set intervals. It ensures that the workflow remains responsive to data changes and consistently maintains regular checks or updates.
+
+Here's an example of a DAG using ``DatasetTimetable``:
+
+.. code-block:: python
+
+    from airflow.timetables.dataset import DatasetTimetable
+    from airflow.timetables.trigger import CronTriggerTimetable
+    from airflow.datasets import Dataset
+    from airflow.models import DAG
+    from airflow.operators.bash import BashOperator
+    import pendulum
+
+    with DAG(
+        dag_id="dataset_and_time_based_timetable",
+        catchup=False,
+        start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+        schedule=DatasetTimetable(time=CronTriggerTimetable("0 1 * * 3", timezone="UTC"), event=[dag1_dataset]),
+        tags=["dataset-time-based-timetable"],
+    ) as dag7:
+        BashOperator(
+            outlets=[Dataset("s3://dataset_time_based/dataset_other_unknown.txt")],
+            task_id="consuming_dataset_time_based",
+            bash_command="sleep 5",
+        )
+
+In this example, the DAG is scheduled to run every Wednesday at 01:00 UTC based on the ``CronTriggerTimetable``, and it is also triggered by updates to ``dag1_dataset``.
+
+Future Enhancements
+~~~~~~~~~~~~~~~~~~~
+Future iterations may introduce more complex combinations for scheduling (e.g., dataset1 OR dataset2 OR timetable), further enhancing the flexibility for scheduling DAGs in various scenarios.
+
 
 Timetables comparisons
 ----------------------

--- a/docs/apache-airflow/authoring-and-scheduling/timetable.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/timetable.rst
@@ -184,7 +184,7 @@ DatasetTimetable
 
 The ``DatasetTimetable`` is a specialized timetable allowing for the scheduling of DAGs based on both time-based schedules and dataset events. It facilitates the creation of scheduled runs (as per traditional timetables) and dataset-triggered runs, which operate independently.
 
-This feature is particularly useful in scenarios requiring a DAG to rerun upon dataset updates, while also necessitating periodic execution at set intervals. It ensures that the workflow remains responsive to data changes and consistently maintains regular checks or updates.
+This feature is particularly useful in scenarios where a DAG needs to run on dataset updates and also at periodic intervals. It ensures that the workflow remains responsive to data changes and consistently runs regular checks or updates.
 
 Here's an example of a DAG using ``DatasetTimetable``:
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2096,6 +2096,7 @@ class TestTaskInstance:
         assert session.query(DatasetDagRunQueue.target_dag_id).filter_by(
             dataset_id=event.dataset.id
         ).order_by(DatasetDagRunQueue.target_dag_id).all() == [
+            ("dataset_and_time_based_timetable",),
             ("dataset_consumes_1",),
             ("dataset_consumes_1_and_2",),
             ("dataset_consumes_1_never_scheduled",),

--- a/tests/timetables/test_datasets_timetable.py
+++ b/tests/timetables/test_datasets_timetable.py
@@ -1,0 +1,182 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pendulum import DateTime
+
+from airflow.datasets import Dataset
+from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
+from airflow.timetables.datasets import DatasetTimetable
+from airflow.utils.types import DagRunType
+
+
+class MockTimetable(Timetable):
+    """
+    A mock Timetable class for testing purposes in Apache Airflow.
+    """
+
+    __test__ = False
+
+    def __init__(self) -> None:
+        """
+        Initializes the MockTimetable with the current DateTime.
+        """
+        self._now = DateTime.now()
+
+    def next_dagrun_info(
+        self, last_automated_data_interval: DataInterval | None, restriction: TimeRestriction
+    ) -> DagRunInfo | None:
+        """
+        Calculates the next DagRun information based on the provided interval and restrictions.
+
+        :param last_automated_data_interval: The last automated data interval.
+        :param restriction: The time restriction to apply.
+        """
+        if last_automated_data_interval is None:
+            next_run_date = self._now
+        else:
+            next_run_date = last_automated_data_interval.end.add(days=1)
+
+        if restriction.earliest and next_run_date < restriction.earliest:
+            next_run_date = restriction.earliest
+
+        if restriction.latest and next_run_date > restriction.latest:
+            return None
+
+        return DagRunInfo.interval(start=next_run_date, end=next_run_date.add(days=1))
+
+    def infer_manual_data_interval(self, run_after: DateTime) -> DataInterval:
+        """
+        Infers the data interval for manual triggers.
+
+        :param run_after: The datetime after which the run is triggered.
+        """
+        return DataInterval.exact(run_after)
+
+
+def serialize_timetable(timetable: Timetable) -> str:
+    """
+    Mock serialization function for Timetable objects.
+
+    :param timetable: The Timetable object to serialize.
+    """
+    return "serialized_timetable"
+
+
+def deserialize_timetable(serialized: str) -> MockTimetable:
+    """
+    Mock deserialization function for Timetable objects.
+
+    :param serialized: The serialized data of the timetable.
+    """
+    return MockTimetable()
+
+
+@pytest.fixture
+def test_timetable() -> MockTimetable:
+    """Pytest fixture for creating a MockTimetable object."""
+    return MockTimetable()
+
+
+@pytest.fixture
+def test_datasets() -> list[Dataset]:
+    """Pytest fixture for creating a list of Dataset objects."""
+    return [Dataset("test_dataset")]
+
+
+@pytest.fixture
+def dataset_timetable(test_timetable: MockTimetable, test_datasets: list[Dataset]) -> DatasetTimetable:
+    """
+    Pytest fixture for creating a DatasetTimetable object.
+
+    :param test_timetable: The test timetable instance.
+    :param test_datasets: A list of Dataset instances.
+    """
+    return DatasetTimetable(time=test_timetable, event=test_datasets)
+
+
+def test_serialization(dataset_timetable: DatasetTimetable, monkeypatch: Any) -> None:
+    """
+    Tests the serialization method of DatasetTimetable.
+
+    :param dataset_timetable: The DatasetTimetable instance to test.
+    :param monkeypatch: The monkeypatch fixture from pytest.
+    """
+    monkeypatch.setattr(
+        "airflow.serialization.serialized_objects.encode_timetable", lambda x: "mock_serialized_timetable"
+    )
+    serialized = dataset_timetable.serialize()
+    assert serialized == {
+        "time": "mock_serialized_timetable",
+        "event": [{"uri": "test_dataset", "extra": None}],
+    }
+
+
+def test_deserialization(monkeypatch: Any) -> None:
+    """
+    Tests the deserialization method of DatasetTimetable.
+
+    :param monkeypatch: The monkeypatch fixture from pytest.
+    """
+    monkeypatch.setattr(
+        "airflow.serialization.serialized_objects.decode_timetable", lambda x: MockTimetable()
+    )
+    mock_serialized_data = {"time": "mock_serialized_timetable", "event": [{"uri": "test_dataset"}]}
+    deserialized = DatasetTimetable.deserialize(mock_serialized_data)
+    assert isinstance(deserialized, DatasetTimetable)
+
+
+def test_infer_manual_data_interval(dataset_timetable: DatasetTimetable) -> None:
+    """
+    Tests the infer_manual_data_interval method of DatasetTimetable.
+
+    :param dataset_timetable: The DatasetTimetable instance to test.
+    """
+    run_after = DateTime.now()
+    result = dataset_timetable.infer_manual_data_interval(run_after=run_after)
+    assert isinstance(result, DataInterval)
+
+
+def test_next_dagrun_info(dataset_timetable: DatasetTimetable) -> None:
+    """
+    Tests the next_dagrun_info method of DatasetTimetable.
+
+    :param dataset_timetable: The DatasetTimetable instance to test.
+    """
+    last_interval = DataInterval.exact(DateTime.now())
+    restriction = TimeRestriction(earliest=DateTime.now(), latest=None, catchup=True)
+    result = dataset_timetable.next_dagrun_info(
+        last_automated_data_interval=last_interval, restriction=restriction
+    )
+    assert result is None or isinstance(result, DagRunInfo)
+
+
+def test_generate_run_id(dataset_timetable: DatasetTimetable) -> None:
+    """
+    Tests the generate_run_id method of DatasetTimetable.
+
+    :param dataset_timetable: The DatasetTimetable instance to test.
+    """
+    run_id = dataset_timetable.generate_run_id(
+        run_type=DagRunType.MANUAL, extra_args="test", logical_date=DateTime.now(), data_interval=None
+    )
+    assert isinstance(run_id, str)

--- a/tests/timetables/test_datasets_timetable.py
+++ b/tests/timetables/test_datasets_timetable.py
@@ -25,7 +25,7 @@ from pendulum import DateTime
 
 from airflow.datasets import Dataset
 from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
-from airflow.timetables.datasets import DatasetTimetable
+from airflow.timetables.datasets import DatasetOrTimeSchedule
 from airflow.utils.types import DagRunType
 
 
@@ -104,17 +104,17 @@ def test_datasets() -> list[Dataset]:
 
 
 @pytest.fixture
-def dataset_timetable(test_timetable: MockTimetable, test_datasets: list[Dataset]) -> DatasetTimetable:
+def dataset_timetable(test_timetable: MockTimetable, test_datasets: list[Dataset]) -> DatasetOrTimeSchedule:
     """
     Pytest fixture for creating a DatasetTimetable object.
 
     :param test_timetable: The test timetable instance.
     :param test_datasets: A list of Dataset instances.
     """
-    return DatasetTimetable(time=test_timetable, event=test_datasets)
+    return DatasetOrTimeSchedule(time=test_timetable, datasets=test_datasets)
 
 
-def test_serialization(dataset_timetable: DatasetTimetable, monkeypatch: Any) -> None:
+def test_serialization(dataset_timetable: DatasetOrTimeSchedule, monkeypatch: Any) -> None:
     """
     Tests the serialization method of DatasetTimetable.
 
@@ -127,7 +127,7 @@ def test_serialization(dataset_timetable: DatasetTimetable, monkeypatch: Any) ->
     serialized = dataset_timetable.serialize()
     assert serialized == {
         "time": "mock_serialized_timetable",
-        "event": [{"uri": "test_dataset", "extra": None}],
+        "datasets": [{"uri": "test_dataset", "extra": None}],
     }
 
 
@@ -140,12 +140,12 @@ def test_deserialization(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         "airflow.serialization.serialized_objects.decode_timetable", lambda x: MockTimetable()
     )
-    mock_serialized_data = {"time": "mock_serialized_timetable", "event": [{"uri": "test_dataset"}]}
-    deserialized = DatasetTimetable.deserialize(mock_serialized_data)
-    assert isinstance(deserialized, DatasetTimetable)
+    mock_serialized_data = {"time": "mock_serialized_timetable", "datasets": [{"uri": "test_dataset"}]}
+    deserialized = DatasetOrTimeSchedule.deserialize(mock_serialized_data)
+    assert isinstance(deserialized, DatasetOrTimeSchedule)
 
 
-def test_infer_manual_data_interval(dataset_timetable: DatasetTimetable) -> None:
+def test_infer_manual_data_interval(dataset_timetable: DatasetOrTimeSchedule) -> None:
     """
     Tests the infer_manual_data_interval method of DatasetTimetable.
 
@@ -156,7 +156,7 @@ def test_infer_manual_data_interval(dataset_timetable: DatasetTimetable) -> None
     assert isinstance(result, DataInterval)
 
 
-def test_next_dagrun_info(dataset_timetable: DatasetTimetable) -> None:
+def test_next_dagrun_info(dataset_timetable: DatasetOrTimeSchedule) -> None:
     """
     Tests the next_dagrun_info method of DatasetTimetable.
 
@@ -170,7 +170,7 @@ def test_next_dagrun_info(dataset_timetable: DatasetTimetable) -> None:
     assert result is None or isinstance(result, DagRunInfo)
 
 
-def test_generate_run_id(dataset_timetable: DatasetTimetable) -> None:
+def test_generate_run_id(dataset_timetable: DatasetOrTimeSchedule) -> None:
     """
     Tests the generate_run_id method of DatasetTimetable.
 

--- a/tests/timetables/test_datasets_timetable.py
+++ b/tests/timetables/test_datasets_timetable.py
@@ -111,7 +111,7 @@ def dataset_timetable(test_timetable: MockTimetable, test_datasets: list[Dataset
     :param test_timetable: The test timetable instance.
     :param test_datasets: A list of Dataset instances.
     """
-    return DatasetOrTimeSchedule(time=test_timetable, datasets=test_datasets)
+    return DatasetOrTimeSchedule(timetable=test_timetable, datasets=test_datasets)
 
 
 def test_serialization(dataset_timetable: DatasetOrTimeSchedule, monkeypatch: Any) -> None:
@@ -126,7 +126,7 @@ def test_serialization(dataset_timetable: DatasetOrTimeSchedule, monkeypatch: An
     )
     serialized = dataset_timetable.serialize()
     assert serialized == {
-        "time": "mock_serialized_timetable",
+        "timetable": "mock_serialized_timetable",
         "datasets": [{"uri": "test_dataset", "extra": None}],
     }
 
@@ -140,7 +140,7 @@ def test_deserialization(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         "airflow.serialization.serialized_objects.decode_timetable", lambda x: MockTimetable()
     )
-    mock_serialized_data = {"time": "mock_serialized_timetable", "datasets": [{"uri": "test_dataset"}]}
+    mock_serialized_data = {"timetable": "mock_serialized_timetable", "datasets": [{"uri": "test_dataset"}]}
     deserialized = DatasetOrTimeSchedule.deserialize(mock_serialized_data)
     assert isinstance(deserialized, DatasetOrTimeSchedule)
 


### PR DESCRIPTION
This special timetable allows a DAG to be run against a time-based schedule and dataset events at the same time. The logic is nothing special---scheduled runs are created based on a time-based timetable, and dataset-triggered runs are created when dataset events happen. The two do not interact in any way.

I aim to maybe refactor this a bit so a DAG can take more complex combinations (e.g. `dataset1 OR dataset2 OR timetable`), but this is the simplest thing for the most common use case of “rerun DAG whenever things update, but also periodically once in a while”.

Please suggest a better name for this class.