### PR TITLE
Remove backward compatibility check for KubernetesPodTrigger module from google provider

### DIFF
--- a/airflow/providers/google/cloud/triggers/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/triggers/kubernetes_engine.py
@@ -25,13 +25,8 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Sequence
 from google.cloud.container_v1.types import Operation
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
+from airflow.providers.cncf.kubernetes.triggers.pod import KubernetesPodTrigger
 from airflow.providers.cncf.kubernetes.utils.pod_manager import OnFinishAction
-
-try:
-    from airflow.providers.cncf.kubernetes.triggers.pod import KubernetesPodTrigger
-except ImportError:
-    # preserve backward compatibility for older versions of cncf.kubernetes provider
-    from airflow.providers.cncf.kubernetes.triggers.kubernetes_pod import KubernetesPodTrigger
 from airflow.providers.google.cloud.hooks.kubernetes_engine import GKEAsyncHook, GKEPodAsyncHook
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 


### PR DESCRIPTION
The min cncf-kubernetes version is 7.2.0 in google provider:
https://github.com/apache/airflow/blob/ecb2c9f24d1364642604c14f0deb681ab4894135/airflow/providers/google/provider.yaml#L1225-L1227
which already contains the new module:
https://github.com/apache/airflow/blob/providers-cncf-kubernetes/7.2.0/airflow/providers/cncf/kubernetes/triggers/pod.py