### PR TITLE
Adds support for capacity providers to ECS Executor

### DIFF
--- a/airflow/providers/amazon/aws/executors/ecs/ecs_executor_config.py
+++ b/airflow/providers/amazon/aws/executors/ecs/ecs_executor_config.py
@@ -62,8 +62,8 @@ def build_task_kwargs() -> dict:
     task_kwargs.update(_fetch_templated_kwargs())
 
     try:
-        has_launch_type: bool = task_kwargs.get("launch_type") is not None
-        has_capacity_provider: bool = task_kwargs.get("capacity_provider_strategy") is not None
+        has_launch_type: bool = "launch_type" in task_kwargs
+        has_capacity_provider: bool = "capacity_provider_strategy" in task_kwargs
 
         if has_capacity_provider and has_launch_type:
             raise ValueError(

--- a/airflow/providers/amazon/aws/executors/ecs/ecs_executor_config.py
+++ b/airflow/providers/amazon/aws/executors/ecs/ecs_executor_config.py
@@ -78,7 +78,7 @@ def build_task_kwargs() -> dict:
             if not cluster.get("defaultCapacityProviderStrategy"):
                 task_kwargs["launch_type"] = "FARGATE"
 
-    except IndexError:
+    except KeyError:
         pass
 
     # There can only be 1 count of these containers

--- a/airflow/providers/amazon/aws/executors/ecs/utils.py
+++ b/airflow/providers/amazon/aws/executors/ecs/utils.py
@@ -44,7 +44,6 @@ CONFIG_DEFAULTS = {
     "conn_id": "aws_default",
     "max_run_task_attempts": "3",
     "assign_public_ip": "False",
-    "launch_type": "FARGATE",
     "platform_version": "LATEST",
     "check_health_on_startup": "True",
 }
@@ -81,6 +80,7 @@ class RunTaskKwargsConfigKeys(BaseConfigKeys):
     """Keys loaded into the config which are valid ECS run_task kwargs."""
 
     ASSIGN_PUBLIC_IP = "assign_public_ip"
+    CAPACITY_PROVIDER_STRATEGY = "capacity_provider_strategy"
     CLUSTER = "cluster"
     LAUNCH_TYPE = "launch_type"
     PLATFORM_VERSION = "platform_version"

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -832,12 +832,12 @@ config:
         description: |
           The capacity provider strategy to use for the task.
 
-          If a capacityProviderStrategy is specified, the launchType parameter must be omitted. If
-          no capacityProviderStrategy or launchType is specified, the defaultCapacityProviderStrategy
+          If a Capacity Provider Strategy is specified, the Launch Type parameter must be omitted. If
+          no Capacity Provider Strategy or Launch Type is specified, the Default CapacityProvider Strategy
           for the cluster is used, if present.
 
-          When you use cluster auto scaling, you must specify capacityProviderStrategy and not launchType.
-        version_added: "8.13"
+          When you use cluster auto scaling, you must specify Capacity Provider Strategy and not Launch Type.
+        version_added: "8.17"
         type: string
         example: "[{'capacityProvider': 'cp1', 'weight': 5}, {'capacityProvider': 'cp2', 'weight': 1}]"
         default: ~

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -828,6 +828,19 @@ config:
         type: string
         example: "ecs_executor_cluster"
         default: ~
+      capacity_provider_strategy:
+        description: |
+          The capacity provider strategy to use for the task.
+
+          If a capacityProviderStrategy is specified, the launchType parameter must be omitted. If
+          no capacityProviderStrategy or launchType is specified, the defaultCapacityProviderStrategy
+          for the cluster is used, if present.
+
+          When you use cluster auto scaling, you must specify capacityProviderStrategy and not launchType.
+        version_added: "8.13"
+        type: string
+        example: "[{'capacityProvider': 'cp1', 'weight': 5}, {'capacityProvider': 'cp2', 'weight': 1}]"
+        default: ~
       container_name:
         description: |
           Name of the container that will be used to execute Airflow tasks via the ECS executor.
@@ -843,6 +856,10 @@ config:
           Launch type can either be 'FARGATE' OR 'EC2'. For more info see url to
           Boto3 docs above.
 
+          If a launchType is specified, the capacityProviderStrategy parameter must be omitted. If
+          no capacityProviderStrategy or launchType is specified, the defaultCapacityProviderStrategy
+          for the cluster is used, if present.
+
           If the launch type is EC2, the executor will attempt to place tasks on
           empty EC2 instances. If there are no EC2 instances available, no task
           is placed and this function will be called again in the next heart-beat.
@@ -852,7 +869,7 @@ config:
         version_added: "8.10"
         type: string
         example: "FARGATE"
-        default: "FARGATE"
+        default: ~
       platform_version:
         description: |
           The platform version the task uses. A platform version is only specified

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -856,8 +856,8 @@ config:
           Launch type can either be 'FARGATE' OR 'EC2'. For more info see url to
           Boto3 docs above.
 
-          If a launchType is specified, the capacityProviderStrategy parameter must be omitted. If
-          no capacityProviderStrategy or launchType is specified, the defaultCapacityProviderStrategy
+          If a Launch Type is specified, the Capacity Provider Strategy parameter must be omitted. If
+          no Capacity Provider Strategy or Launch Type is specified, the Default Capacity Provider Strategy
           for the cluster is used, if present.
 
           If the launch type is EC2, the executor will attempt to place tasks on

--- a/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -945,10 +945,8 @@ class TestEcsExecutorConfig:
         assert task_kwargs["platformVersion"] == templated_version
 
     @mock.patch.object(EcsHook, "conn")
-    def test_count_can_not_be_modified_by_the_user(self, mock_conn, assign_subnets):
+    def test_count_can_not_be_modified_by_the_user(self, _, assign_subnets):
         """The ``count`` parameter must always be 1; verify that the user can not override this value."""
-        mock_conn.describe_clusters.return_value = {"clusters": [{"status": "ACTIVE"}]}
-
         templated_version = "1"
         templated_cluster = "templated_cluster_name"
         provided_run_task_kwargs = {


### PR DESCRIPTION
Users have asked to be able to use Capacity Provider Strategies instead of the Launch Type (they are mutually exclusive) with the new ECS Executor, so this PR adds that support.

Passes all static checks locally and added unit tests for coverage of new code.

closes: https://github.com/apache/airflow/issues/35489

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
