### PR TITLE
Fix check on subclass for `typing.Union` in `_infer_multiple_outputs` for Python 3.10+

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -350,7 +350,7 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
         except TypeError:  # Can't evaluate return type.
             return False
         ttype = getattr(return_type, "__origin__", return_type)
-        return issubclass(ttype, Mapping)
+        return isinstance(ttype, type) and issubclass(ttype, Mapping)
 
     def __attrs_post_init__(self):
         if "self" in self.function_signature.parameters:

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -109,13 +109,23 @@ class TestAirflowTaskDecorator(BasePythonTest):
 
         assert t1().operator.multiple_outputs is True
 
-    def test_infer_multiple_outputs_union_type(self):
+    # We do not enable `from __future__ import annotations` for particular this test module,
+    # that mean `str | None` annotation would raise TypeError in Python 3.9 and below
+    @pytest.mark.skipif(sys.version_info < (3, 10), reason="PEP 604 is implemented in Python 3.10")
+    def test_infer_multiple_outputs_pep_604_union_type(self):
         @task_decorator
         def t1() -> str | None:
             # Before PEP 604 which are implemented in Python 3.10 `str | None`
             # returns `types.UnionType` which are class and could be check in `issubclass()`.
             # However in Python 3.10+ this construction returns object `typing.Union`
             # which can not be used in `issubclass()`
+            return "foo"
+
+        assert t1().operator.multiple_outputs is False
+
+    def test_infer_multiple_outputs_union_type(self):
+        @task_decorator
+        def t1() -> Union[str, None]:
             return "foo"
 
         assert t1().operator.multiple_outputs is False


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

https://github.com/apache/airflow/pull/36652 introduced bug for Python 3.10+ when task decorated function has annotation as object and not as class

This also fix broken main for Python 3.10+ tests:
- `tests/always/test_example_dags.py::test_should_be_importable[tests/system/providers/google/cloud/cloud_sql/example_cloud_sql_query_postgres.py]`
- `tests/always/test_example_dags.py::test_should_be_importable[tests/system/providers/google/cloud/cloud_sql/example_cloud_sql_query_mysql.py]`

https://github.com/apache/airflow/blob/59b32dc0a0bcdffd124b82d92428f334646cd8cd/tests/system/providers/google/cloud/cloud_sql/example_cloud_sql_query_postgres.py#L197-L198

```console
Traceback (most recent call last):
  File "/Users/taragolis/Projects/common/airflow/tests/system/providers/google/cloud/cloud_sql/example_cloud_sql_query_postgres.py", line 198, in <module>
    def get_public_ip() -> str | None:
  File "/Users/taragolis/Projects/common/airflow/airflow/decorators/python.py", line 75, in python_task
    return task_decorator_factory(
  File "/Users/taragolis/Projects/common/airflow/airflow/decorators/base.py", line 646, in task_decorator_factory
    decorator = _TaskDecorator(
  File "<attrs generated init airflow.decorators.base._TaskDecorator>", line 8, in __init__
    _setattr('multiple_outputs', __attr_factory_multiple_outputs(self))
  File "/Users/taragolis/Projects/common/airflow/airflow/decorators/base.py", line 353, in _infer_multiple_outputs
    return issubclass(ttype, Mapping)
  File "/Users/taragolis/.pyenv/versions/3.10.1/lib/python3.10/typing.py", line 1138, in __subclasscheck__
    return issubclass(cls, self.__origin__)
  File "/Users/taragolis/.pyenv/versions/3.10.1/lib/python3.10/abc.py", line 123, in __subclasscheck__
    return _abc_subclasscheck(cls, subclass)
TypeError: issubclass() arg 1 must be a class
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
