### PR TITLE
Fix tests to adopt changes in Jinja 3.1.3

### DIFF
--- a/tests/models/test_mappedoperator.py
+++ b/tests/models/test_mappedoperator.py
@@ -21,7 +21,6 @@ import logging
 from collections import defaultdict
 from datetime import timedelta
 from typing import TYPE_CHECKING
-from unittest import mock
 from unittest.mock import patch
 
 import pendulum
@@ -405,7 +404,12 @@ def test_mapped_expand_against_params(dag_maker, dag_params, task_params, expect
     assert t.expand_input.value == {"params": [{"c": "x"}, {"d": 1}]}
 
 
-def test_mapped_render_template_fields_validating_operator(dag_maker, session):
+def test_mapped_render_template_fields_validating_operator(dag_maker, session, tmp_path):
+    file_template_dir = tmp_path / "path" / "to"
+    file_template_dir.mkdir(parents=True, exist_ok=True)
+    file_template = file_template_dir / "file.ext"
+    file_template.write_text("loaded data")
+
     with set_current_task_instance_session(session=session):
 
         class MyOperator(BaseOperator):
@@ -427,7 +431,7 @@ def test_mapped_render_template_fields_validating_operator(dag_maker, session):
         def execute(self, context):
             pass
 
-        with dag_maker(session=session):
+        with dag_maker(session=session, template_searchpath=tmp_path.__fspath__()):
             task1 = BaseOperator(task_id="op1")
             output1 = task1.output
             mapped = MyOperator.partial(
@@ -455,10 +459,7 @@ def test_mapped_render_template_fields_validating_operator(dag_maker, session):
         mapped_ti.map_index = 0
 
         assert isinstance(mapped_ti.task, MappedOperator)
-        with patch("builtins.open", mock.mock_open(read_data=b"loaded data")), patch(
-            "os.path.isfile", return_value=True
-        ), patch("os.path.getmtime", return_value=0):
-            mapped.render_template_fields(context=mapped_ti.get_template_context(session=session))
+        mapped.render_template_fields(context=mapped_ti.get_template_context(session=session))
         assert isinstance(mapped_ti.task, MyOperator)
 
         assert mapped_ti.task.partial_template == "a", "Should be templated!"
@@ -468,7 +469,12 @@ def test_mapped_render_template_fields_validating_operator(dag_maker, session):
         assert mapped_ti.task.file_template == "loaded data", "Should be templated!"
 
 
-def test_mapped_expand_kwargs_render_template_fields_validating_operator(dag_maker, session):
+def test_mapped_expand_kwargs_render_template_fields_validating_operator(dag_maker, session, tmp_path):
+    file_template_dir = tmp_path / "path" / "to"
+    file_template_dir.mkdir(parents=True, exist_ok=True)
+    file_template = file_template_dir / "file.ext"
+    file_template.write_text("loaded data")
+
     with set_current_task_instance_session(session=session):
 
         class MyOperator(BaseOperator):
@@ -490,7 +496,7 @@ def test_mapped_expand_kwargs_render_template_fields_validating_operator(dag_mak
             def execute(self, context):
                 pass
 
-        with dag_maker(session=session):
+        with dag_maker(session=session, template_searchpath=tmp_path.__fspath__()):
             mapped = MyOperator.partial(
                 task_id="a", partial_template="{{ ti.task_id }}", partial_static="{{ ti.task_id }}"
             ).expand_kwargs(
@@ -502,10 +508,7 @@ def test_mapped_expand_kwargs_render_template_fields_validating_operator(dag_mak
         mapped_ti: TaskInstance = dr.get_task_instance(mapped.task_id, session=session, map_index=0)
 
         assert isinstance(mapped_ti.task, MappedOperator)
-        with patch("builtins.open", mock.mock_open(read_data=b"loaded data")), patch(
-            "os.path.isfile", return_value=True
-        ), patch("os.path.getmtime", return_value=0):
-            mapped.render_template_fields(context=mapped_ti.get_template_context(session=session))
+        mapped.render_template_fields(context=mapped_ti.get_template_context(session=session))
         assert isinstance(mapped_ti.task, MyOperator)
 
         assert mapped_ti.task.partial_template == "a", "Should be templated!"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Recently was released new version of Jinja2 (3.1.3) which seems like change some internal mechanism of load templates in `jinja2.FileSystemLoader` so our current mocking approach doesn't work anymore. This PR create templates files in temporary directory and add this directory to search path

Related to: https://github.com/apache/airflow/pull/36728#issuecomment-1886363489

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
