### PR TITLE
List permissions required to use S3 logging

### DIFF
--- a/docs/apache-airflow-providers-amazon/logging/s3-task-handler.rst
+++ b/docs/apache-airflow-providers-amazon/logging/s3-task-handler.rst
@@ -79,9 +79,9 @@ Example with sample inputs
 
 If you create your own IAM policy (as is strongly recommended), it should include the following permissions.
 
-- `s3:ListBucket` (for the S3 bucket to which logs are written)
-- `s3:GetObject` (for all objects in the prefix under which logs are written)
-- `s3:PutObject` (for all objects in the prefix under which logs are written)
+- ``s3:ListBucket`` (for the S3 bucket to which logs are written)
+- ``s3:GetObject`` (for all objects in the prefix under which logs are written)
+- ``s3:PutObject`` (for all objects in the prefix under which logs are written)
 
 
 Step2: Update Helm Chart values.yaml with Service Account

--- a/docs/apache-airflow-providers-amazon/logging/s3-task-handler.rst
+++ b/docs/apache-airflow-providers-amazon/logging/s3-task-handler.rst
@@ -77,6 +77,12 @@ Example with sample inputs
 
     eksctl create iamserviceaccount --cluster=airflow-eks-cluster --name=airflow-sa --namespace=airflow --attach-policy-arn=arn:aws:iam::aws:policy/AmazonS3FullAccess --approve
 
+If you create your own IAM policy (as is strongly recommended), it should include the following permissions.
+
+- `s3:ListBucket` (for the S3 bucket to which logs are written)
+- `s3:GetObject` (for all objects in the prefix under which logs are written)
+- `s3:PutObject` (for all objects in the prefix under which logs are written)
+
 
 Step2: Update Helm Chart values.yaml with Service Account
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

Adds a section to the documentation page for S3 logging detailing what permissions are required by Airflow to make use of S3 logging. I found that S3 logging broke for me during an upgrade from Airflow 2.2.5 to 2.7.3 because I had not granted the ListBucket permission to the role Airflow uses.