### PR TITLE
Fix list dags command for get_dagmodel is None

### DIFF
--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -409,7 +409,7 @@ def dag_list_dags(args, session=NEW_SESSION) -> None:
             file=sys.stderr,
         )
 
-    def get_dag_detail(dag: DAG) -> dict | None:
+    def get_dag_detail(dag: DAG) -> dict:
         dag_model = DagModel.get_dagmodel(dag.dag_id, session=session)
         if dag_model:
             dag_detail = dag_schema.dump(dag_model)
@@ -420,7 +420,7 @@ def dag_list_dags(args, session=NEW_SESSION) -> None:
     AirflowConsole().print_as(
         data=sorted(dagbag.dags.values(), key=operator.attrgetter("dag_id")),
         output=args.output,
-        mapper=get_dag_detail,  # type: ignore[arg-type]
+        mapper=get_dag_detail,
     )
 
 

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -285,6 +285,40 @@ def _save_dot_to_file(dot: Dot, filename: str) -> None:
     print(f"File {filename} saved")
 
 
+def _get_dagbag_dag_details(dag: DAG) -> dict:
+    """Return a dagbag dag details dict."""
+    return {
+        "dag_id": dag.dag_id,
+        "root_dag_id": dag.parent_dag.dag_id if dag.parent_dag else None,
+        "is_paused": dag.get_is_paused(),
+        "is_active": dag.get_is_active(),
+        "is_subdag": dag.is_subdag,
+        "last_parsed_time": None,
+        "last_pickled": None,
+        "last_expired": None,
+        "scheduler_lock": None,
+        "pickle_id": dag.pickle_id,
+        "default_view": dag.default_view,
+        "fileloc": dag.fileloc,
+        "file_token": None,
+        "owners": dag.owner,
+        "description": dag.description,
+        "schedule_interval": dag.schedule_interval,
+        "timetable_description": dag.timetable.description,
+        "tags": dag.tags,
+        "max_active_tasks": dag.max_active_tasks,
+        "max_active_runs": dag.max_active_runs,
+        "has_task_concurrency_limits": any(
+            t.max_active_tis_per_dag is not None or t.max_active_tis_per_dagrun is not None for t in dag.tasks
+        ),
+        "has_import_errors": False,
+        "next_dagrun": None,
+        "next_dagrun_data_interval_start": None,
+        "next_dagrun_data_interval_end": None,
+        "next_dagrun_create_after": None,
+    }
+
+
 @cli_utils.action_cli
 @providers_configuration_loaded
 @provide_session
@@ -377,9 +411,10 @@ def dag_list_dags(args, session=NEW_SESSION) -> None:
 
     def get_dag_detail(dag: DAG) -> dict | None:
         dag_model = DagModel.get_dagmodel(dag.dag_id, session=session)
-        if not dag_model:
-            return None
-        dag_detail = dag_schema.dump(dag_model)
+        if dag_model:
+            dag_detail = dag_schema.dump(dag_model)
+        else:
+            dag_detail = _get_dagbag_dag_details(dag)
         return {col: dag_detail[col] for col in valid_cols}
 
     AirflowConsole().print_as(

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -375,8 +375,10 @@ def dag_list_dags(args, session=NEW_SESSION) -> None:
             file=sys.stderr,
         )
 
-    def get_dag_detail(dag: DAG) -> dict:
+    def get_dag_detail(dag: DAG) -> dict | None:
         dag_model = DagModel.get_dagmodel(dag.dag_id, session=session)
+        if not dag_model:
+            return None
         dag_detail = dag_schema.dump(dag_model)
         return {col: dag_detail[col] for col in valid_cols}
 

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -385,7 +385,7 @@ def dag_list_dags(args, session=NEW_SESSION) -> None:
     AirflowConsole().print_as(
         data=sorted(dagbag.dags.values(), key=operator.attrgetter("dag_id")),
         output=args.output,
-        mapper=get_dag_detail,
+        mapper=get_dag_detail,  # type: ignore[arg-type]
     )
 
 

--- a/airflow/cli/simple_table.py
+++ b/airflow/cli/simple_table.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import inspect
 import json
-from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 from rich.box import ASCII_DOUBLE_HEAD
 from rich.console import Console

--- a/airflow/cli/simple_table.py
+++ b/airflow/cli/simple_table.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import inspect
 import json
-from typing import TYPE_CHECKING, Any, Callable, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence
 
 from rich.box import ASCII_DOUBLE_HEAD
 from rich.console import Console
@@ -118,8 +118,9 @@ class AirflowConsole(Console):
             dict_data = data
         else:
             raise ValueError("To tabulate non-dictionary data you need to provide `mapper` function")
-        dict_data = [{k: self._normalize_data(v, output) for k, v in d.items()} for d in dict_data]
-        renderer(dict_data)
+        dict_data = [{k: self._normalize_data(v, output) for k, v in d.items()} for d in dict_data if d]
+        if dict_data:
+            renderer(dict_data)
 
 
 class SimpleTable(Table):

--- a/airflow/cli/simple_table.py
+++ b/airflow/cli/simple_table.py
@@ -118,9 +118,8 @@ class AirflowConsole(Console):
             dict_data = data
         else:
             raise ValueError("To tabulate non-dictionary data you need to provide `mapper` function")
-        dict_data = [{k: self._normalize_data(v, output) for k, v in d.items()} for d in dict_data if d]
-        if dict_data:
-            renderer(dict_data)
+        dict_data = [{k: self._normalize_data(v, output) for k, v in d.items()} for d in dict_data]
+        renderer(dict_data)
 
 
 class SimpleTable(Table):

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -565,6 +565,16 @@ class TestCliDags:
             out = temp_stderr.getvalue()
         assert "Failed to load all files." in out
 
+    @conf_vars({("core", "load_examples"): "true"})
+    @mock.patch("airflow.models.DagModel.get_dagmodel")
+    def test_list_dags_none_get_dagmodel(self, mock_get_dagmodel):
+        mock_get_dagmodel.return_value = None
+        args = self.parser.parse_args(["dags", "list", "--output", "json"])
+        with contextlib.redirect_stdout(StringIO()) as temp_stdout:
+            dag_command.dag_list_dags(args)
+            out = temp_stdout.getvalue()
+        assert out == ""
+
     @conf_vars({("core", "load_examples"): "false"})
     def test_cli_list_import_errors(self):
         dag_path = os.path.join(TEST_DAGS_FOLDER, "test_invalid_cron.py")

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -30,7 +30,7 @@ import pytest
 import time_machine
 
 from airflow import settings
-from airflow.api_connexion.schemas.dag_schema import DAGSchema
+from airflow.api_connexion.schemas.dag_schema import DAGSchema, dag_schema
 from airflow.cli import cli_parser
 from airflow.cli.commands import dag_command
 from airflow.decorators import task
@@ -573,7 +573,17 @@ class TestCliDags:
         with contextlib.redirect_stdout(StringIO()) as temp_stdout:
             dag_command.dag_list_dags(args)
             out = temp_stdout.getvalue()
-        assert out == ""
+            dag_list = json.loads(out)
+        for key in ["dag_id", "fileloc", "owners", "is_paused"]:
+            assert key in dag_list[0]
+        assert any("airflow/example_dags/example_complex.py" in d["fileloc"] for d in dag_list)
+
+    @conf_vars({("core", "load_examples"): "true"})
+    def test_dagbag_dag_col(self):
+        valid_cols = [c for c in dag_schema.fields]
+        dagbag = DagBag(include_examples=True)
+        dag_details = dag_command._get_dagbag_dag_details(dagbag.get_dag("tutorial_dag"))
+        assert list(dag_details.keys()) == valid_cols
 
     @conf_vars({("core", "load_examples"): "false"})
     def test_cli_list_import_errors(self):


### PR DESCRIPTION
In the `dags list` command, we initially retrieve the `dag_id` from the `dagbag`. For each DAG, we fetch the corresponding DAG details from the metadata database. If the data at both locations is not in sync, the `DagModel.get_dagmodel` function returns `None`, leading to a serialization failure. ~~This pull request introduces a condition to prevent serialization when the `dagmodel` is `None`~~. This PR trying to use the field available from dagbag to initialise dag details. some fields are not available and I'm setting the None value for those    
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
