### PR TITLE
avoid retrying after KubernetesPodOperator has been marked as failed

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -684,7 +684,7 @@ class KubernetesPodOperator(BaseOperator):
                 remote_pod=remote_pod,
             )
         except Exception:
-            # If one task got marked as failed, it should not raise exception which might cause retry.
+            # If task got marked as failed, it should not raise exception (which might cause retry).
             if not self._killed:
                 raise
 

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -581,7 +581,7 @@ class KubernetesPodOperator(BaseOperator):
                     remote_pod=self.remote_pod,
                 )
             except Exception:
-                # If one task got makred as failed, it should not raise exception which might cause retry.
+                # If one task got marked as failed, it should not raise exception which might cause retry.
                 # https://github.com/apache/airflow/issues/36471
                 if not self._killed:
                     raise
@@ -685,7 +685,7 @@ class KubernetesPodOperator(BaseOperator):
                 remote_pod=remote_pod,
             )
         except Exception:
-            # If one task got makred as failed, it should not raise exception which might cause retry.
+            # If one task got marked as failed, it should not raise exception which might cause retry.
             # https://github.com/apache/airflow/issues/36471
             if not self._killed:
                 raise
@@ -846,7 +846,7 @@ class KubernetesPodOperator(BaseOperator):
             try:
                 self.client.delete_namespaced_pod(**kwargs)
             except kubernetes.client.exceptions.ApiException:
-                self.log.warning("The pod no longer exists")
+                self.log.warning("Pod %s no longer exists", self.pod.metadata.name)
 
     def build_pod_request_obj(self, context: Context | None = None) -> k8s.V1Pod:
         """

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -581,8 +581,7 @@ class KubernetesPodOperator(BaseOperator):
                     remote_pod=self.remote_pod,
                 )
             except Exception:
-                # If one task got marked as failed, it should not raise exception which might cause retry.
-                # https://github.com/apache/airflow/issues/36471
+                # If task got marked as failed, it should not raise exception (which might cause retry).
                 if not self._killed:
                     raise
 
@@ -686,7 +685,6 @@ class KubernetesPodOperator(BaseOperator):
             )
         except Exception:
             # If one task got marked as failed, it should not raise exception which might cause retry.
-            # https://github.com/apache/airflow/issues/36471
             if not self._killed:
                 raise
 
@@ -846,7 +844,7 @@ class KubernetesPodOperator(BaseOperator):
             try:
                 self.client.delete_namespaced_pod(**kwargs)
             except kubernetes.client.exceptions.ApiException:
-                self.log.warning("Pod %s no longer exists", self.pod.metadata.name)
+                self.log.exception("Unable to delete pod %s", self.pod.metadata.name)
 
     def build_pod_request_obj(self, context: Context | None = None) -> k8s.V1Pod:
         """


### PR DESCRIPTION
After marking the task as failed, KPO still has a `finally` section to run, which causes #36471. In this PR, I tried to check whether `on_killed` is called and do not raise exception in the `finally` section as it'll overwrite the "Mark as failed" behavior

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
