### PR TITLE
Disable `PytestDeprecationWarning` when create warnings_recorder

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 import time_machine
-from _pytest.recwarn import WarningsRecorder
 
 # We should set these before loading _any_ of the rest of airflow so that the
 # unit test mode config is set as early as possible.
@@ -1148,7 +1147,9 @@ def close_all_sqlalchemy_sessions():
 
 captured_warnings: dict[tuple[str, int, type[Warning], str], warnings.WarningMessage] = {}
 captured_warnings_count: dict[tuple[str, int, type[Warning], str], int] = {}
-warnings_recorder = WarningsRecorder()
+# By set ``_ispytest=True`` in WarningsRecorder we suppress annoying warnings:
+# PytestDeprecationWarning: A private pytest class or function was used.
+warnings_recorder = pytest.WarningsRecorder(_ispytest=True)
 default_formatwarning = warnings_recorder._module.formatwarning  # type: ignore[attr-defined]
 default_showwarning = warnings_recorder._module.showwarning  # type: ignore[attr-defined]
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Any time when we run `pytest` it raises additional deprecation warnings when we initialise `pytest.WarningsRecorder`

```console
=============================== warnings summary ===============================
../../../conftest.py:1152
  /Users/taragolis/Projects/common/airflow/tests/conftest.py:1152: PytestDeprecationWarning: A private pytest class or function was used.
    warnings_recorder = WarningsRecorder()
```

The solution might be a hacky or even bad, however that is the best what we could do in this situation

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
