### PR TITLE
sqlite_file_error_note

### DIFF
--- a/docs/apache-airflow/start.rst
+++ b/docs/apache-airflow/start.rst
@@ -52,6 +52,8 @@ constraint files to enable reproducible installation, so using ``pip`` and const
 
       export AIRFLOW_HOME=~/airflow
 
+   Make sure that `AIRFLOW_HOME` points to absolute path, otherwise, on next steps, you may receive sqlite errors like `sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) unable to open database file`
+
 2. Install Airflow using the constraints file, which is determined based on the URL we pass:
 
    .. code-block:: bash


### PR DESCRIPTION
Hello, I am newcomer here

Did tried to follow getting started guide and on very first step where you asking to create `AIRFLOW_HOME` environment variable, my thinking was - I do not want to mess my home directory, and instead will do something like:

```bash
export AIRFLOW_HOME=./airflow
```

and exactly because of that, on a next steps I received an "strange" error:

```log
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) unable to open database file
```

I bed, I am not a first one and not last one who struggled with this

Found short discussing here - https://github.com/apache/airflow/discussions/27692

Hopefully this will help someone in future