### PR TITLE
Remove wrong changelog about default Python version in the image

### DIFF
--- a/docs/docker-stack/changelog.rst
+++ b/docs/docker-stack/changelog.rst
@@ -53,14 +53,6 @@ Airflow 2.8
      working with ``Debian Bookworm``. While all reference images of Airflow 2.8.0 are built on ``Debian Bookworm``,
      it is still possible to build deprecated custom ``Debian Bullseye`` based image in 2.8.0 following the
 
-   * The "latest" image (i.e. default Airflow image when ``apache/airflow`` is used or
-     ``apache/airflow:slim-latest``) uses now the newest supported Python version. Previously it was using
-     the "default" Python version which was Python 3.8 as of Airflow 2.7. With Airflow reference images
-     released for Airflow 2.8.0, the images are going to use Python 3.11 as this is the latest supported
-     version for Airflow 2.8 line. Users can use Python 3.8 by using ``apache/airflow:2.8.0-python3.8`` and
-     ``apache/airflow:slim-2.8.0-python-3.8`` images respectively so while the change is potentially
-     breaking, it is very easy to switch to the previous behaviour.
-
    * By default the images now have "MariaDB" client installed. Previous images had "MySQL" client installed.
      The MariaDB client is a drop-in replacement for "MySQL" one and is compatible with MySQL. This might
      be a breaking change for users who used MySQL client in their images, however those should be very


### PR DESCRIPTION
In #36003 we **thought** we changed default "version" image to point to "newest" python version not to the "oldest" supported one - as agreed in https://lists.apache.org/thread/0oxnvct24xlqsj76z42w2ttw2d043oy3

However as observed and tracked in #36740 the change was not effective. We only changed the moment at which latest image is pointing to 2.8.0 but not whether 2.8.0 points to `python-3.8` or `python-3.11'.

This means that we should only do that change for Python 3.9 qnd revert the changelog (and cherry-pick it to 2.8.1)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
