### PR TITLE
Adding log to airflow-github for disabled progress bar

### DIFF
--- a/dev/airflow-github
+++ b/dev/airflow-github
@@ -324,6 +324,10 @@ def changelog(previous_version, target_version, github_token, disable_progress):
     repo = git.Repo(".", search_parent_directories=True)
     # Get a list of issues/PRs that have been committed on the current branch.
     log = get_commits_between(repo, previous_version, target_version)
+
+    if disable_progress:
+        print(f"Processing {len(log)} commits")
+
     gh = Github(github_token)
     gh_repo = gh.get_repo("apache/airflow")
     sections = defaultdict(list)

--- a/dev/airflow-github
+++ b/dev/airflow-github
@@ -319,13 +319,13 @@ def compare(target_version, github_token, previous_version=None, show_uncherrypi
 @click.argument("previous_version")
 @click.argument("target_version")
 @click.argument("github-token", envvar="GITHUB_TOKEN")
-@click.option("--disable-progress", is_flag=True, help="Disable the progress bar")
-def changelog(previous_version, target_version, github_token, disable_progress):
+@click.option("--disable-progress-bar", is_flag=True, help="Disable the progress bar")
+def changelog(previous_version, target_version, github_token, disable_progress_bar):
     repo = git.Repo(".", search_parent_directories=True)
     # Get a list of issues/PRs that have been committed on the current branch.
     log = get_commits_between(repo, previous_version, target_version)
 
-    if disable_progress:
+    if disable_progress_bar:
         print(f"Processing {len(log)} commits")
 
     gh = Github(github_token)
@@ -340,7 +340,7 @@ def changelog(previous_version, target_version, github_token, disable_progress):
 
     console = Console(width=180)
 
-    with Progress(console=console, disable=disable_progress) as progress:
+    with Progress(console=console, disable=disable_progress_bar) as progress:
         task = progress.add_task("Processing commits from changelog", total=len(log))
         for commit in progress.track(log, description="Processing commits from changelog"):
             tickets = pr_title_re.findall(commit["subject"])


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In case we disable the progress bar using `--disable-progress` flag, there was no way to tell if the command started processing or not, because it was a blank screen, stuck. Added a log for that and also changed the flag to `disable-progress-bar` instead


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
