### PR TITLE
Fix failed tasks are not detected in `AzureBatchHook`

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/batch.py
+++ b/airflow/providers/microsoft/azure/hooks/batch.py
@@ -378,7 +378,7 @@ class AzureBatchHook(BaseHook):
         """
         timeout_time = timezone.utcnow() + timedelta(minutes=timeout)
         while timezone.utcnow() < timeout_time:
-            tasks = self.connection.task.list(job_id)
+            tasks = list(self.connection.task.list(job_id))
 
             incomplete_tasks = [task for task in tasks if task.state != batch_models.TaskState.completed]
             if not incomplete_tasks:
@@ -386,7 +386,7 @@ class AzureBatchHook(BaseHook):
                 fail_tasks = [
                     task
                     for task in tasks
-                    if task.executionInfo.result == batch_models.TaskExecutionResult.failure
+                    if task.execution_info.result == batch_models.TaskExecutionResult.failure
                 ]
                 return fail_tasks
             for task in incomplete_tasks:

--- a/tests/providers/microsoft/azure/hooks/test_batch.py
+++ b/tests/providers/microsoft/azure/hooks/test_batch.py
@@ -219,7 +219,7 @@ class TestAzureBatchHook:
 
         results = hook.wait_for_job_tasks_to_complete("myjob", 60)
         assert results == []
-        hook.connection.task.list.assert_called_once_with("myjob", 60)
+        hook.connection.task.list.assert_called_once_with("myjob")
 
     @mock.patch(f"{MODULE}.BatchServiceClient")
     def test_wait_for_all_task_to_complete_failures(self, mock_batch):
@@ -244,7 +244,7 @@ class TestAzureBatchHook:
 
         results = hook.wait_for_job_tasks_to_complete("myjob", 60)
         assert results == [tasks[1]]
-        hook.connection.task.list.assert_called_once_with("myjob", 60)
+        hook.connection.task.list.assert_called_once_with("myjob")
 
     @mock.patch(f"{MODULE}.BatchServiceClient")
     def test_connection_success(self, mock_batch):

--- a/tests/providers/microsoft/azure/hooks/test_batch.py
+++ b/tests/providers/microsoft/azure/hooks/test_batch.py
@@ -190,9 +190,53 @@ class TestAzureBatchHook:
         mock_instance.assert_called_once_with(job_id="myjob", task=task)
 
     @mock.patch(f"{MODULE}.BatchServiceClient")
-    def test_wait_for_all_task_to_complete(self, mock_batch):
-        # TODO: Add test
-        pass
+    def test_wait_for_all_tasks_to_complete_timeout(self, mock_batch):
+        hook = AzureBatchHook(azure_batch_conn_id=self.test_cloud_conn_id)
+        with pytest.raises(TimeoutError):
+            hook.wait_for_job_tasks_to_complete("myjob", -1)
+
+    @mock.patch(f"{MODULE}.BatchServiceClient")
+    def test_wait_for_all_tasks_to_complete_all_success(self, mock_batch):
+        hook = AzureBatchHook(azure_batch_conn_id=self.test_cloud_conn_id)
+        hook.connection.task.list.return_value = iter(
+            [
+                batch_models.CloudTask(
+                    id="mytask_1",
+                    execution_info=batch_models.TaskExecutionResult.failure,
+                    state=batch_models.TaskState.completed,
+                ),
+                batch_models.CloudTask(
+                    id="mytask_2",
+                    execution_info=batch_models.TaskExecutionResult.failure,
+                    state=batch_models.TaskState.completed,
+                ),
+            ]
+        )
+
+        results = hook.wait_for_job_tasks_to_complete("myjob", 60)
+        assert results == []
+        hook.connection.task.list.assert_called_once_with("myjob", 60)
+
+    @mock.patch(f"{MODULE}.BatchServiceClient")
+    def test_wait_for_all_tasks_to_complete_failures(self, mock_batch):
+        hook = AzureBatchHook(azure_batch_conn_id=self.test_cloud_conn_id)
+        tasks = [
+            batch_models.CloudTask(
+                id="mytask_1",
+                execution_info=batch_models.TaskExecutionResult.failure,
+                state=batch_models.TaskState.completed,
+            ),
+            batch_models.CloudTask(
+                id="mytask_2",
+                execution_info=batch_models.TaskExecutionResult.failure,
+                state=batch_models.TaskState.completed,
+            ),
+        ]
+        hook.connection.task.list.return_value = iter(tasks)
+
+        results = hook.wait_for_job_tasks_to_complete("myjob", 60)
+        assert results == [tasks[1]]
+        hook.connection.task.list.assert_called_once_with("myjob", 60)
 
     @mock.patch(f"{MODULE}.BatchServiceClient")
     def test_connection_success(self, mock_batch):

--- a/tests/providers/microsoft/azure/hooks/test_batch.py
+++ b/tests/providers/microsoft/azure/hooks/test_batch.py
@@ -190,24 +190,28 @@ class TestAzureBatchHook:
         mock_instance.assert_called_once_with(job_id="myjob", task=task)
 
     @mock.patch(f"{MODULE}.BatchServiceClient")
-    def test_wait_for_all_tasks_to_complete_timeout(self, mock_batch):
+    def test_wait_for_all_task_to_complete_timeout(self, mock_batch):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_cloud_conn_id)
         with pytest.raises(TimeoutError):
             hook.wait_for_job_tasks_to_complete("myjob", -1)
 
     @mock.patch(f"{MODULE}.BatchServiceClient")
-    def test_wait_for_all_tasks_to_complete_all_success(self, mock_batch):
+    def test_wait_for_all_task_to_complete_all_success(self, mock_batch):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_cloud_conn_id)
         hook.connection.task.list.return_value = iter(
             [
                 batch_models.CloudTask(
                     id="mytask_1",
-                    execution_info=batch_models.TaskExecutionResult.failure,
+                    execution_info=batch_models.TaskExecutionInformation(
+                        retry_count=0, requeue_count=0, result=batch_models.TaskExecutionResult.success
+                    ),
                     state=batch_models.TaskState.completed,
                 ),
                 batch_models.CloudTask(
                     id="mytask_2",
-                    execution_info=batch_models.TaskExecutionResult.failure,
+                    execution_info=batch_models.TaskExecutionInformation(
+                        retry_count=0, requeue_count=0, result=batch_models.TaskExecutionResult.success
+                    ),
                     state=batch_models.TaskState.completed,
                 ),
             ]
@@ -218,17 +222,21 @@ class TestAzureBatchHook:
         hook.connection.task.list.assert_called_once_with("myjob", 60)
 
     @mock.patch(f"{MODULE}.BatchServiceClient")
-    def test_wait_for_all_tasks_to_complete_failures(self, mock_batch):
+    def test_wait_for_all_task_to_complete_failures(self, mock_batch):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_cloud_conn_id)
         tasks = [
             batch_models.CloudTask(
                 id="mytask_1",
-                execution_info=batch_models.TaskExecutionResult.failure,
+                execution_info=batch_models.TaskExecutionInformation(
+                    retry_count=0, requeue_count=0, result=batch_models.TaskExecutionResult.success
+                ),
                 state=batch_models.TaskState.completed,
             ),
             batch_models.CloudTask(
                 id="mytask_2",
-                execution_info=batch_models.TaskExecutionResult.failure,
+                execution_info=batch_models.TaskExecutionInformation(
+                    retry_count=0, requeue_count=0, result=batch_models.TaskExecutionResult.failure
+                ),
                 state=batch_models.TaskState.completed,
             ),
         ]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #36747

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This pull request fixes the issue that failed tasks are not detected by the microsoft azure batch hook. Main origin of the bug is found in using an exhausted iterator again to find the failed tasks. This PR captures the tasks in a list first which is afterwards used to the tasks analysis (task completion and failure detection). A bug in the failure comparison is also resolved.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
