### PR TITLE
Avoid auto-detection of Airflow Sources during breeze installation

### DIFF
--- a/.github/actions/breeze/action.yml
+++ b/.github/actions/breeze/action.yml
@@ -45,6 +45,8 @@ runs:
     - name: "Free space"
       shell: bash
       run: breeze ci free-space
+      env:
+        AIRFLOW_SOURCES_ROOT: "${{ github.workspace }}"
     - name: "Get Python version"
       shell: bash
       run: >
@@ -54,3 +56,5 @@ runs:
     - name: "Disable cheatsheet"
       shell: bash
       run: breeze setup config --no-cheatsheet --no-asciiart
+      env:
+        AIRFLOW_SOURCES_ROOT: "${{ github.workspace }}"

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -176,6 +176,7 @@ jobs:
           PR_LABELS: "${{ steps.get-latest-pr-labels.outputs.pull-request-labels }}"
           COMMIT_REF: "${{ env.TARGET_COMMIT_SHA }}"
           VERBOSE: "false"
+          AIRFLOW_SOURCES_ROOT: "${{ github.workspace }}"
         run: breeze ci selective-check 2>> ${GITHUB_OUTPUT}
       - name: env
         run: printenv


### PR DESCRIPTION
In some circumstances, when breeze is installed in CI (when we update to newer breeze version in "build-info" workflow in old branches) breeze is not able to auto-detect sources it was installed from.

This PR changes it by passing the sources via environment variable.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
