### PR TITLE
Fix airflow-scheduler exiting with code 0 on exceptions

### DIFF
--- a/airflow/cli/commands/scheduler_command.py
+++ b/airflow/cli/commands/scheduler_command.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 from argparse import Namespace
-from contextlib import contextmanager, ExitStack
+from contextlib import ExitStack, contextmanager
 from multiprocessing import Process
 
 from airflow import settings

--- a/airflow/cli/commands/scheduler_command.py
+++ b/airflow/cli/commands/scheduler_command.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 from argparse import Namespace
-from contextlib import contextmanager
+from contextlib import contextmanager, ExitStack
 from multiprocessing import Process
 
 from airflow import settings
@@ -44,11 +44,18 @@ def _run_scheduler_job(args) -> None:
     ExecutorLoader.validate_database_executor_compatibility(job_runner.job.executor)
     InternalApiConfig.force_database_direct_access()
     enable_health_check = conf.getboolean("scheduler", "ENABLE_HEALTH_CHECK")
-    with _serve_logs(args.skip_serve_logs), _serve_health_check(enable_health_check):
+    with ExitStack() as stack:
+        stack.enter_context(_serve_logs(args.skip_serve_logs))
+        stack.enter_context(_serve_health_check(enable_health_check))
+
         try:
             run_job(job=job_runner.job, execute_callable=job_runner._execute)
         except Exception:
             log.exception("Exception when running scheduler job")
+            raise
+        finally:
+            # Ensure that the contexts are closed
+            stack.close()
 
 
 @cli_utils.action_cli

--- a/tests/cli/commands/test_scheduler_command.py
+++ b/tests/cli/commands/test_scheduler_command.py
@@ -169,7 +169,8 @@ class TestSchedulerCommand:
         mock_scheduler_job,
     ):
         args = self.parser.parse_args(["scheduler"])
-        scheduler_command.scheduler(args)
+        with pytest.raises(Exception, match="run_job failed"):
+            scheduler_command.scheduler(args)
 
         # Make sure that run_job is called, that the exception has been logged, and that the serve_logs
         # sub-process has been terminated


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The https://github.com/apache/airflow/pull/32707 has changed the scheduler to capture the exceptions (and not re-raising it) and it is making the scheduler always exit with code 0 (that means exit without error). In case of an `airflow-scheduler` running in a docker container with the `--restart always` option set, the exit code 0 will make the container stop and not restart because docker will interpret it as the code ran and finished with success. So if you have a DB quick unavailability, the `airflow-scheduler` will not try to recover by restarting it and it will stop, causing the airflow instance to crash (without the scheduler).

So, this PR is raising the exception and forcing the process in context to terminate (closing the contexts in `stack` on `finally` to keep avoiding the zombie scheduler https://github.com/apache/airflow/issues/32706) and avoid the scheduler exiting with code 0.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
