### PR TITLE
ECS Executor - add support to adopt orphaned tasks.

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -710,6 +710,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             if state == TaskInstanceState.QUEUED:
                 ti.external_executor_id = info
                 self.log.info("Setting external_id for %s to %s", ti, info)
+                session.commit()
                 continue
 
             msg = (

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -709,8 +709,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
             if state == TaskInstanceState.QUEUED:
                 ti.external_executor_id = info
-                self.log.info("Setting external_id for %s to %s", ti, info)
-                session.commit()
+                # TODO don't actually commit this log change
+                self.log.warning("Setting external_id for %s to %s", ti, info)
                 continue
 
             msg = (

--- a/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
+++ b/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
@@ -531,7 +531,7 @@ class AwsEcsExecutor(BaseExecutor):
                         ti.queue,
                         ti.command_as_list(),
                         ti.executor_config,
-                        ti.prev_attempted_tries + 1,
+                        ti.prev_attempted_tries,
                     )
                     adopted_tis.append(ti)
 

--- a/airflow/providers/amazon/aws/executors/ecs/utils.py
+++ b/airflow/providers/amazon/aws/executors/ecs/utils.py
@@ -47,6 +47,7 @@ CONFIG_DEFAULTS = {
     "assign_public_ip": "False",
     "platform_version": "LATEST",
     "check_health_on_startup": "True",
+    "adopt_task_instances": "False",
 }
 
 
@@ -84,22 +85,23 @@ class RunTaskKwargsConfigKeys(BaseConfigKeys):
     ASSIGN_PUBLIC_IP = "assign_public_ip"
     CAPACITY_PROVIDER_STRATEGY = "capacity_provider_strategy"
     CLUSTER = "cluster"
+    CONTAINER_NAME = "container_name"
     LAUNCH_TYPE = "launch_type"
     PLATFORM_VERSION = "platform_version"
     SECURITY_GROUPS = "security_groups"
     SUBNETS = "subnets"
     TASK_DEFINITION = "task_definition"
-    CONTAINER_NAME = "container_name"
 
 
 class AllEcsConfigKeys(RunTaskKwargsConfigKeys):
     """All keys loaded into the config which are related to the ECS Executor."""
 
-    MAX_RUN_TASK_ATTEMPTS = "max_run_task_attempts"
+    ADOPT_TASK_INSTANCES = "adopt_task_instances"
     AWS_CONN_ID = "conn_id"
-    RUN_TASK_KWARGS = "run_task_kwargs"
-    REGION_NAME = "region_name"
     CHECK_HEALTH_ON_STARTUP = "check_health_on_startup"
+    MAX_RUN_TASK_ATTEMPTS = "max_run_task_attempts"
+    REGION_NAME = "region_name"
+    RUN_TASK_KWARGS = "run_task_kwargs"
 
 
 class EcsExecutorException(Exception):

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -959,6 +959,17 @@ config:
         type: boolean
         example: "True"
         default: "True"
+      adopt_task_instances:
+        description: |
+          If True, the executor will try to adopt orphaned task instances from a SchedulerJob
+          shutdown event, for example when a scheduler container is re-deployed or terminated.
+          If False, the executor will terminate all active AWS Batch Jobs when the scheduler shuts down.
+          More documentation can be found in the Airflow docs:
+          ``https://airflow.apache.org/docs/apache-airflow/stable/scheduler.html#scheduler-tuneables``.
+        version_added: "8.17"
+        type: boolean
+        example: "True"
+        default: "False"
   aws_auth_manager:
     description: |
       This section only applies if you are using the AwsAuthManager. In other words, if you set

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -963,7 +963,7 @@ config:
         description: |
           If True, the executor will try to adopt orphaned task instances from a SchedulerJob
           shutdown event, for example when a scheduler container is re-deployed or terminated.
-          If False, the executor will terminate all active AWS Batch Jobs when the scheduler shuts down.
+          If False, the executor will terminate all active AWS ECS Tasks when the scheduler shuts down.
           More documentation can be found in the Airflow docs:
           ``https://airflow.apache.org/docs/apache-airflow/stable/scheduler.html#scheduler-tuneables``.
         version_added: "8.17"


### PR DESCRIPTION
Adds support for "adopt orphaned tasks" to the ECS Executor.  

A task can become orphaned, for example, when the scheduler container is re-deployed or terminated or other cases where the SchedulerJob got interrupted.  `try_adopt_task_instances` is defined in the BaseExecutor (this PR implements it in the ECS Executor) and is called by the Scheduler [here](https://github.com/apache/airflow/blob/main/airflow/jobs/scheduler_job_runner.py#L1667).

Based heavily on the [work here](https://github.com/aelzeiny/airflow-aws-executors/pull/15) by Matt Ellis (who I can't tag for some reason) .

closes: https://github.com/apache/airflow/issues/35491

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
