### PR TITLE
Adding a tip to resolve ETIMEDOUT error

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -898,7 +898,7 @@ describe your problem.
 ETIMEOUT Error
 --------------
 
-When running ``breeze start-airflow``, the following output might be observed:
+When running ``breeze start-airflow``, either normally or in ``dev-mode``, the following output might be observed:
 
 .. code-block:: bash
 
@@ -962,6 +962,20 @@ In this case, disabling IPv6 in the host machine and using IPv4 instead resolved
 
 The similar issue could happen if you are behind an HTTP/HTTPS proxy and your access to required websites are
 blocked by it, or your proxy setting has not been done properly.
+
+It also could be possible that you have a proxy which is not available from your network, leading to the timeout
+issues. You may try these in the same terminal and then try the ``breeze start-airflow`` command:
+
+.. code-block::
+
+    npm config delete http-proxy
+    npm config delete https-proxy
+
+    npm config rm proxy
+    npm config rm https-proxy
+
+    set HTTP_PROXY=null
+    set HTTPS_PROXY=null
 
 Advanced commands
 =================


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Sometimes, if something is wrong with either your network OR the proxy settings, `breeze start-airflow` will run into a ETIMEDOUT error, which may be hard to debug. Added a tip which worked for me when I ran into this

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
