### PR TITLE
Limit `atlassian-python-api` to <3.41.6

### DIFF
--- a/airflow/providers/atlassian/jira/provider.yaml
+++ b/airflow/providers/atlassian/jira/provider.yaml
@@ -37,7 +37,10 @@ versions:
 
 dependencies:
   - apache-airflow>=2.6.0
-  - atlassian-python-api>=1.14.2
+  # Changes in `3.41.6` introduce incorrect import of `beautifulsoup4`
+  - atlassian-python-api>=1.14.2,<3.41.6
+  # `beautifulsoup4` not listed in `atlassian-python-api` install requirements however depend on it
+  - beautifulsoup4
 
 integrations:
   - integration-name: Atlassian Jira

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -275,7 +275,8 @@
   "atlassian.jira": {
     "deps": [
       "apache-airflow>=2.6.0",
-      "atlassian-python-api>=1.14.2"
+      "atlassian-python-api>=1.14.2,<3.41.6",
+      "beautifulsoup4"
     ],
     "devel-deps": [],
     "cross-providers-deps": [],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -614,7 +614,8 @@ asana = [
   "asana>=0.10,<4.0.0",
 ]
 atlassian-jira = [
-  "atlassian-python-api>=1.14.2",
+  "atlassian-python-api>=1.14.2,<3.41.6",
+  "beautifulsoup4",
 ]
 celery = [
   "celery>=5.3.0,<6,!=5.3.3,!=5.3.2",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

`atlassian-python-api` 3.41.5 introduce a bug with beautifulsoup (missing dependency) it not failed in our CI because one because we pre-install it for some other package, [hotfix version `3.41.6` ](https://github.com/atlassian-api/atlassian-python-api/commit/450700f03bc7bd353d5e72f97a6717db98fd0717) introduce another bug with import unknown package.

For avoid any issues better to upper bound dependency until it properly fixed
In addition add `beautifulsoup` as dependency for a provider

Upstream issue/PRs:
- https://github.com/atlassian-api/atlassian-python-api/issues/1295
- https://github.com/atlassian-api/atlassian-python-api/pull/1296

```console
----------------------------------------
Exception when importing: airflow.providers.atlassian.jira.hooks.jira


Traceback (most recent call last):
  File "/opt/airflow/scripts/in_container/verify_providers.py", line 199, in import_all_classes
    _module = importlib.import_module(modinfo.name)
  File "/usr/local/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name, package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/usr/local/lib/python3.8/site-packages/airflow/providers/atlassian/jira/hooks/jira.py", line 24, in <module>
    from atlassian import Jira
  File "/usr/local/lib/python3.8/site-packages/atlassian/__init__.py", line 5, in <module>
    from .confluence import Confluence
  File "/usr/local/lib/python3.8/site-packages/atlassian/confluence.py", line 10, in <module>
    from beautifulsoup4 import BeautifulSoup
ModuleNotFoundError: No module named 'beautifulsoup4'

----------------------------------------
Exception when importing: airflow.providers.atlassian.jira.notifications.jira


Traceback (most recent call last):
  File "/opt/airflow/scripts/in_container/verify_providers.py", line 199, in import_all_classes
    _module = importlib.import_module(modinfo.name)
  File "/usr/local/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name, package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/usr/local/lib/python3.8/site-packages/airflow/providers/atlassian/jira/notifications/jira.py", line 24, in <module>
    from airflow.providers.atlassian.jira.hooks.jira import JiraHook
  File "/usr/local/lib/python3.8/site-packages/airflow/providers/atlassian/jira/hooks/jira.py", line 24, in <module>
    from atlassian import Jira
  File "/usr/local/lib/python3.8/site-packages/atlassian/__init__.py", line 5, in <module>
    from .confluence import Confluence
  File "/usr/local/lib/python3.8/site-packages/atlassian/confluence.py", line 10, in <module>
    from beautifulsoup4 import BeautifulSoup
ModuleNotFoundError: No module named 'beautifulsoup4'

----------------------------------------
Exception when importing: airflow.providers.atlassian.jira.operators.jira


Traceback (most recent call last):
  File "/opt/airflow/scripts/in_container/verify_providers.py", line 199, in import_all_classes
    _module = importlib.import_module(modinfo.name)
  File "/usr/local/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name, package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/usr/local/lib/python3.8/site-packages/airflow/providers/atlassian/jira/operators/jira.py", line 23, in <module>
    from airflow.providers.atlassian.jira.hooks.jira import JiraHook
  File "/usr/local/lib/python3.8/site-packages/airflow/providers/atlassian/jira/hooks/jira.py", line 24, in <module>
    from atlassian import Jira
  File "/usr/local/lib/python3.8/site-packages/atlassian/__init__.py", line 5, in <module>
    from .confluence import Confluence
  File "/usr/local/lib/python3.8/site-packages/atlassian/confluence.py", line 10, in <module>
    from beautifulsoup4 import BeautifulSoup
ModuleNotFoundError: No module named 'beautifulsoup4'

----------------------------------------
Exception when importing: airflow.providers.atlassian.jira.sensors.jira


Traceback (most recent call last):
  File "/opt/airflow/scripts/in_container/verify_providers.py", line 199, in import_all_classes
    _module = importlib.import_module(modinfo.name)
  File "/usr/local/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name, package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/usr/local/lib/python3.8/site-packages/airflow/providers/atlassian/jira/sensors/jira.py", line 22, in <module>
    from airflow.providers.atlassian.jira.hooks.jira import JiraHook
  File "/usr/local/lib/python3.8/site-packages/airflow/providers/atlassian/jira/hooks/jira.py", line 24, in <module>
    from atlassian import Jira
  File "/usr/local/lib/python3.8/site-packages/atlassian/__init__.py", line 5, in <module>
    from .confluence import Confluence
  File "/usr/local/lib/python3.8/site-packages/atlassian/confluence.py", line 10, in <module>
    from beautifulsoup4 import BeautifulSoup
ModuleNotFoundError: No module named 'beautifulsoup4'
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
