### PR TITLE
Change default `parquet_row_group_size` in `BaseSQLToGCSOperator`

### DIFF
--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -26,6 +26,7 @@
 
 Changelog
 ---------
+* ``Change default parquet_row_group_size in BaseSQLToGCSOperator (#36817)``
 
 10.13.1
 .......

--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -35,7 +35,7 @@ Changelog
   more memory to execute the operator, in which case users can override the ``parquet_row_group_size``
   parameter in the operator. All operators that are derived from ``BaseSQLToGCSOperator`` are affected
   when ``export_format`` is ``parquet``: ``MySQLToGCSOperator``, ``PrestoToGCSOperator``,
-  ``OracleToGCSOperator``, ``TrinoToGCSOperator``, ``MSSQLToGCSOperator`` and ``PostgresToGCSOperator``.
+  ``OracleToGCSOperator``, ``TrinoToGCSOperator``, ``MSSQLToGCSOperator`` and ``PostgresToGCSOperator``. Due to the above we treat this change as bug fix.
 
 10.13.1
 .......

--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -26,7 +26,15 @@
 
 Changelog
 ---------
-* ``Change default parquet_row_group_size in BaseSQLToGCSOperator (#36817)``
+The default value of ``parquet_row_group_size`` in ``BaseSQLToGCSOperator`` has changed from 1 to
+100000, in order to have a default that provides better compression efficiency and performance of
+reading the data in the output Parquet files. In many cases, the previous value of 1 resulted in
+very large files, long task durations and out of memory issues. A default value of 100000 may require
+more memory to execute the operator, in which case users can override the ``parquet_row_group_size``
+parameter in the operator. All operators that are derived from ``BaseSQLToGCSOperator`` are affected
+when ``export_format`` is ``parquet``: ``MySQLToGCSOperator``, ``PrestoToGCSOperator``,
+``OracleToGCSOperator``, ``TrinoToGCSOperator``, ``MSSQLToGCSOperator`` and ``PostgresToGCSOperator``.
+
 
 10.13.1
 .......

--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -26,14 +26,16 @@
 
 Changelog
 ---------
-The default value of ``parquet_row_group_size`` in ``BaseSQLToGCSOperator`` has changed from 1 to
-100000, in order to have a default that provides better compression efficiency and performance of
-reading the data in the output Parquet files. In many cases, the previous value of 1 resulted in
-very large files, long task durations and out of memory issues. A default value of 100000 may require
-more memory to execute the operator, in which case users can override the ``parquet_row_group_size``
-parameter in the operator. All operators that are derived from ``BaseSQLToGCSOperator`` are affected
-when ``export_format`` is ``parquet``: ``MySQLToGCSOperator``, ``PrestoToGCSOperator``,
-``OracleToGCSOperator``, ``TrinoToGCSOperator``, ``MSSQLToGCSOperator`` and ``PostgresToGCSOperator``.
+
+.. note::
+  The default value of ``parquet_row_group_size`` in ``BaseSQLToGCSOperator`` has changed from 1 to
+  100000, in order to have a default that provides better compression efficiency and performance of
+  reading the data in the output Parquet files. In many cases, the previous value of 1 resulted in
+  very large files, long task durations and out of memory issues. A default value of 100000 may require
+  more memory to execute the operator, in which case users can override the ``parquet_row_group_size``
+  parameter in the operator. All operators that are derived from ``BaseSQLToGCSOperator`` are affected
+  when ``export_format`` is ``parquet``: ``MySQLToGCSOperator``, ``PrestoToGCSOperator``,
+  ``OracleToGCSOperator``, ``TrinoToGCSOperator``, ``MSSQLToGCSOperator`` and ``PostgresToGCSOperator``.
 
 10.13.1
 .......

--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -35,7 +35,6 @@ parameter in the operator. All operators that are derived from ``BaseSQLToGCSOpe
 when ``export_format`` is ``parquet``: ``MySQLToGCSOperator``, ``PrestoToGCSOperator``,
 ``OracleToGCSOperator``, ``TrinoToGCSOperator``, ``MSSQLToGCSOperator`` and ``PostgresToGCSOperator``.
 
-
 10.13.1
 .......
 

--- a/airflow/providers/google/cloud/transfers/sql_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/sql_to_gcs.py
@@ -85,7 +85,7 @@ class BaseSQLToGCSOperator(BaseOperator):
     :param parquet_row_group_size: The approximate number of rows in each row group
         when using parquet format. Using a large row group size can reduce the file size
         and improve the performance of reading the data, but it needs more memory to
-        execute the operator. (default: 1)
+        execute the operator. (default: 100000)
     """
 
     template_fields: Sequence[str] = (
@@ -123,7 +123,7 @@ class BaseSQLToGCSOperator(BaseOperator):
         exclude_columns: set | None = None,
         partition_columns: list | None = None,
         write_on_empty: bool = False,
-        parquet_row_group_size: int = 1,
+        parquet_row_group_size: int = 100000,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #36793 

As mentioned in #36793, a default setting of 1 for `parquet_row_group_size` leads to quite a few problems. For example the output Parquet files become huge, the tasks run into OOM issues and the task duration is extended.

I must note that the documentation says that a large number means the worker needs more memory to execute, while on the contrary I noticed that with 1 row per row group the tasks get killed with OOM issues very quickly and with a large number everything seems fine...

I changed it to 100000 based on what other Parquet writers are doing (DuckDB and Polars), but of course this number is open for debate. @Taragolis suggested a much lower value between 100 and 1000.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
