### PR TITLE
Fix reproducibility of source-tarballs prepared as part of release

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
@@ -88,6 +88,8 @@ def tarball_release(version: str, version_without_rc: str, source_date_epoch: in
         run_command(
             [
                 "git",
+                "-c",
+                "tar.umask=0077",
                 "archive",
                 "--format=tar.gz",
                 f"{version}",

--- a/dev/breeze/src/airflow_breeze/utils/reproducible.py
+++ b/dev/breeze/src/airflow_breeze/utils/reproducible.py
@@ -100,7 +100,7 @@ def archive_deterministically(dir_to_archive, dest_archive, prepend_path=None, t
         # packaging (in case of exceptional situations like running out of disk space).
         temp_file = f"{dest_archive}.temp~"
         with os.fdopen(os.open(temp_file, os.O_WRONLY | os.O_CREAT, 0o644), "wb") as out_file:
-            with gzip.GzipFile("wb", fileobj=out_file, mtime=0) as gzip_file:
+            with gzip.GzipFile(fileobj=out_file, mtime=0, mode="wb") as gzip_file:
                 with tarfile.open(fileobj=gzip_file, mode="w:") as tar_file:
                     for entry in file_list:
                         arcname = entry


### PR DESCRIPTION
The source-tarball that was supposed to be reproducible, was "almost" reproducible. It turned out that we forgot that group permissions are bound to change depending on the umask that is configured in the system (because using umask is the default git configuration when files are checked out). This means that the packages were reproducible only if the two people who built it had the same umask set.

Since it is unlikely that default owner umask is different than rwx allowed, all the tools that are bound to provide reproducibility approach it via setting the umask to clear any permissions for group and other - this way the files in archive have only owner permissions set.

This is what this PR does - we set the tar.umask when running the `git archive` command to 0077 which effectively cleans all the group and other permissions.

In this PR we also fix FutureDeprecation warning raised in newer versions of Python where GzipFile should take keyword parameters rather than positional ones.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
