### PR TITLE
Remove optimization to install wheel packages for affected providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -834,12 +834,10 @@ jobs:
         run: >
           breeze release-management prepare-provider-documentation --include-not-ready-providers
           --non-interactive
-          ${{ needs.build-info.outputs.affected-providers-list-as-string }}
       - name: "Prepare provider packages: wheel"
         run: >
           breeze release-management prepare-provider-packages --include-not-ready-providers
-          --version-suffix-for-pypi dev0
-          --package-format wheel ${{ needs.build-info.outputs.affected-providers-list-as-string }}
+          --version-suffix-for-pypi dev0 --package-format wheel
       - name: "Prepare airflow package: wheel"
         run: breeze release-management prepare-airflow-package --version-suffix-for-pypi dev0
       - name: "Verify wheel packages with twine"
@@ -862,25 +860,11 @@ jobs:
           --airflow-constraints-reference default
           --providers-constraints-location
           /files/constraints-${{env.PYTHON_MAJOR_MINOR_VERSION}}/constraints-source-providers-${{env.PYTHON_MAJOR_MINOR_VERSION}}.txt
-        if: needs.build-info.outputs.affected-providers-list-as-string == ''
-        env:
-          AIRFLOW_SKIP_CONSTRAINTS: "${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}"
-      - name: "Install affected provider packages and airflow via wheel files"
-        run: >
-          breeze release-management install-provider-packages
-          --use-packages-from-dist
-          --package-format wheel
-          --use-airflow-version wheel
-          --airflow-constraints-reference default
-          --providers-constraints-location
-          /files/constraints-${{env.PYTHON_MAJOR_MINOR_VERSION}}/constraints-source-providers-${{env.PYTHON_MAJOR_MINOR_VERSION}}.txt
-        if: needs.build-info.outputs.affected-providers-list-as-string != ''
         env:
           AIRFLOW_SKIP_CONSTRAINTS: "${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}"
       - name: "Prepare airflow package: wheel without suffix and skipping the tag check"
         run: >
-          breeze release-management prepare-provider-packages --skip-tag-check
-          --package-format wheel ${{ needs.build-info.outputs.affected-providers-list-as-string }}
+          breeze release-management prepare-provider-packages --skip-tag-check --package-format wheel
 
   prepare-install-provider-packages-sdist:
     timeout-minutes: 80
@@ -975,7 +959,7 @@ jobs:
       - name: "Prepare provider packages: wheel"
         run: >
           breeze release-management prepare-provider-packages --include-not-ready-providers
-          --package-format wheel ${{ needs.build-info.outputs.affected-providers-list-as-string }}
+          --package-format wheel
       - name: >
           Remove incompatible Airflow
           ${{matrix.airflow-version}}:Python ${{matrix.python-version}} provider packages
@@ -996,19 +980,6 @@ jobs:
           --use-airflow-version wheel
           --airflow-constraints-reference constraints-${{matrix.airflow-version}}
           --providers-skip-constraints
-        if: needs.build-info.outputs.affected-providers-list-as-string == ''
-      - name: >
-          Install affected provider packages and airflow on
-          Airflow ${{matrix.airflow-version}}:Python ${{matrix.python-version}}
-        run: >
-          breeze release-management install-provider-packages
-          --use-packages-from-dist
-          --package-format wheel
-          --use-airflow-version wheel
-          --airflow-constraints-reference constraints-${{matrix.airflow-version}}
-          --providers-skip-constraints
-          --run-in-parallel
-        if: needs.build-info.outputs.affected-providers-list-as-string != ''
 
   test-airflow-release-commands:
     timeout-minutes: 80


### PR DESCRIPTION
When building wheel providers took a lot of time (12 minutes) there was an optimisation implemented to only build the affected providers and in this case we could not run verification, because having only subset of providers would generate errors during imports.

However, changes to make our package bulds reproducible with flit #35693 also improve building time for provider packages (all of them are built under 1 minute) and .whl installation had always been rather quick - so we can remove the optimisation now, because side effect of it that in some cases (like #36799) it caused the backwards compatibility check succeed - and subsequently continue failing in main canary build.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
