### PR TITLE
Revert "Make links in logs as hyperlinks in grid view (#36816)"

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
@@ -73,7 +73,7 @@ const LogBlock = ({ parsedLogs, wrap, tryNumber }: Props) => {
       borderRadius={3}
       borderColor="blue.500"
     >
-      <div dangerouslySetInnerHTML={{ __html: parsedLogs }} />
+      {parsedLogs}
       <div ref={codeBlockBottomDiv} />
     </Code>
   );

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
@@ -97,12 +97,6 @@ export const parseLogs = (
         line.includes(fileSourceFilter)
       )
     ) {
-      // If there are any links, make them hyperlinks
-      parsedLine = parsedLine.replace(
-        /((https?:\/\/|http:\/\/)[^\s]+)/g,
-        '<a href="$1" target="_blank" style="color: blue; text-decoration: underline;">$1</a>'
-      );
-
       parsedLines.push(parsedLine);
     }
   });


### PR DESCRIPTION
This reverts commit af6ae954476ab45fd5776f76f27b2668eb868aef. This introduces at least some html injection from task logs.

More context: https://github.com/apache/airflow/pull/36816#issuecomment-1894601383