### PR TITLE
Fix stacklevel in warnings.warn into the providers

### DIFF
--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -716,7 +716,9 @@ class EmrCreateJobFlowOperator(BaseOperator):
             warnings.warn(
                 "The parameter waiter_countdown has been deprecated to standardize "
                 "naming conventions.  Please use waiter_max_attempts instead.  In the "
-                "future this will default to None and defer to the waiter's default value."
+                "future this will default to None and defer to the waiter's default value.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
             # waiter_countdown defaults to never timing out, which is not supported
             # by boto waiters, so we will set it here to "a very long time" for now.
@@ -725,7 +727,9 @@ class EmrCreateJobFlowOperator(BaseOperator):
             warnings.warn(
                 "The parameter waiter_check_interval_seconds has been deprecated to "
                 "standardize naming conventions.  Please use waiter_delay instead.  In the "
-                "future this will default to None and defer to the waiter's default value."
+                "future this will default to None and defer to the waiter's default value.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
             waiter_delay = waiter_check_interval_seconds
         super().__init__(**kwargs)
@@ -1024,7 +1028,9 @@ class EmrServerlessCreateApplicationOperator(BaseOperator):
             warnings.warn(
                 "The parameter waiter_check_interval_seconds has been deprecated to standardize "
                 "naming conventions.  Please use waiter_delay instead.  In the "
-                "future this will default to None and defer to the waiter's default value."
+                "future this will default to None and defer to the waiter's default value.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
         if waiter_countdown is NOTSET:
             waiter_max_attempts = 25 if waiter_max_attempts is NOTSET else waiter_max_attempts
@@ -1036,7 +1042,9 @@ class EmrServerlessCreateApplicationOperator(BaseOperator):
             warnings.warn(
                 "The parameter waiter_countdown has been deprecated to standardize "
                 "naming conventions.  Please use waiter_max_attempts instead. In the "
-                "future this will default to None and defer to the waiter's default value."
+                "future this will default to None and defer to the waiter's default value.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
         self.aws_conn_id = aws_conn_id
         self.release_label = release_label
@@ -1205,7 +1213,9 @@ class EmrServerlessStartJobOperator(BaseOperator):
             warnings.warn(
                 "The parameter waiter_check_interval_seconds has been deprecated to standardize "
                 "naming conventions.  Please use waiter_delay instead.  In the "
-                "future this will default to None and defer to the waiter's default value."
+                "future this will default to None and defer to the waiter's default value.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
         if waiter_countdown is NOTSET:
             waiter_max_attempts = 25 if waiter_max_attempts is NOTSET else waiter_max_attempts
@@ -1217,7 +1227,9 @@ class EmrServerlessStartJobOperator(BaseOperator):
             warnings.warn(
                 "The parameter waiter_countdown has been deprecated to standardize "
                 "naming conventions.  Please use waiter_max_attempts instead.  In the "
-                "future this will default to None and defer to the waiter's default value."
+                "future this will default to None and defer to the waiter's default value.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
         self.aws_conn_id = aws_conn_id
         self.application_id = application_id
@@ -1408,7 +1420,9 @@ class EmrServerlessStopApplicationOperator(BaseOperator):
             warnings.warn(
                 "The parameter waiter_check_interval_seconds has been deprecated to standardize "
                 "naming conventions.  Please use waiter_delay instead.  In the "
-                "future this will default to None and defer to the waiter's default value."
+                "future this will default to None and defer to the waiter's default value.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
         if waiter_countdown is NOTSET:
             waiter_max_attempts = 25 if waiter_max_attempts is NOTSET else waiter_max_attempts
@@ -1420,7 +1434,9 @@ class EmrServerlessStopApplicationOperator(BaseOperator):
             warnings.warn(
                 "The parameter waiter_countdown has been deprecated to standardize "
                 "naming conventions.  Please use waiter_max_attempts instead.  In the "
-                "future this will default to None and defer to the waiter's default value."
+                "future this will default to None and defer to the waiter's default value.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
         self.aws_conn_id = aws_conn_id
         self.application_id = application_id
@@ -1569,7 +1585,9 @@ class EmrServerlessDeleteApplicationOperator(EmrServerlessStopApplicationOperato
             warnings.warn(
                 "The parameter waiter_check_interval_seconds has been deprecated to standardize "
                 "naming conventions.  Please use waiter_delay instead.  In the "
-                "future this will default to None and defer to the waiter's default value."
+                "future this will default to None and defer to the waiter's default value.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
         if waiter_countdown is NOTSET:
             waiter_max_attempts = 25 if waiter_max_attempts is NOTSET else waiter_max_attempts
@@ -1581,7 +1599,9 @@ class EmrServerlessDeleteApplicationOperator(EmrServerlessStopApplicationOperato
             warnings.warn(
                 "The parameter waiter_countdown has been deprecated to standardize "
                 "naming conventions.  Please use waiter_max_attempts instead.  In the "
-                "future this will default to None and defer to the waiter's default value."
+                "future this will default to None and defer to the waiter's default value.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
         self.wait_for_delete_completion = wait_for_completion
         # super stops the app

--- a/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/airflow/providers/celery/executors/celery_executor_utils.py
@@ -41,7 +41,7 @@ from sqlalchemy import select
 
 import airflow.settings as settings
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.executors.base_executor import BaseExecutor
 from airflow.stats import Stats
 from airflow.utils.dag_parsing_context import _airflow_parsing_context_manager
@@ -88,7 +88,8 @@ def _get_celery_app() -> Celery:
             "Change it to `airflow.providers.celery.executors.celery_executor`, and "
             "update the `-app` flag in your Celery Health Checks "
             "to use `airflow.providers.celery.executors.celery_executor.app`.",
-            RemovedInAirflow3Warning,
+            AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
 
     return Celery(celery_app_name, config_source=celery_configuration)

--- a/airflow/providers/cncf/kubernetes/pod_generator.py
+++ b/airflow/providers/cncf/kubernetes/pod_generator.py
@@ -39,7 +39,7 @@ from kubernetes.client.api_client import ApiClient
 from airflow.exceptions import (
     AirflowConfigException,
     AirflowException,
-    RemovedInAirflow3Warning,
+    AirflowProviderDeprecationWarning,
 )
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
     POD_NAME_MAX_LENGTH,
@@ -155,7 +155,7 @@ class PodGenerator:
 
     def gen_pod(self) -> k8s.V1Pod:
         """Generate pod."""
-        warnings.warn("This function is deprecated. ", RemovedInAirflow3Warning)
+        warnings.warn("This function is deprecated. ", AirflowProviderDeprecationWarning, stacklevel=2)
         result = self.ud_pod
 
         result.metadata.name = add_pod_suffix(pod_name=result.metadata.name)
@@ -170,7 +170,9 @@ class PodGenerator:
         """Add sidecar."""
         warnings.warn(
             "This function is deprecated. "
-            "Please use airflow.providers.cncf.kubernetes.utils.xcom_sidecar.add_xcom_sidecar instead"
+            "Please use airflow.providers.cncf.kubernetes.utils.xcom_sidecar.add_xcom_sidecar instead",
+            AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         pod_cp = copy.deepcopy(pod)
         pod_cp.spec.volumes = pod.spec.volumes or []
@@ -207,7 +209,8 @@ class PodGenerator:
                 "Using a dictionary for the executor_config is deprecated and will soon be removed."
                 'please use a `kubernetes.client.models.V1Pod` class with a "pod_override" key'
                 " instead. ",
-                category=RemovedInAirflow3Warning,
+                category=AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
             return PodGenerator.from_legacy_obj(obj)
         else:
@@ -386,7 +389,10 @@ class PodGenerator:
         """
         if len(pod_id) > POD_NAME_MAX_LENGTH:
             warnings.warn(
-                f"pod_id supplied is longer than {POD_NAME_MAX_LENGTH} characters; truncating and adding unique suffix."
+                f"pod_id supplied is longer than {POD_NAME_MAX_LENGTH} characters; "
+                f"truncating and adding unique suffix.",
+                UserWarning,
+                stacklevel=2,
             )
             pod_id = add_pod_suffix(pod_name=pod_id, max_len=POD_NAME_MAX_LENGTH)
         try:
@@ -583,7 +589,8 @@ class PodGenerator:
         """
         warnings.warn(
             "This function is deprecated. Use `add_pod_suffix` in `kubernetes_helper_functions`.",
-            RemovedInAirflow3Warning,
+            AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
 
         if not pod_id:

--- a/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/airflow/providers/dbt/cloud/operators/dbt.py
@@ -184,6 +184,8 @@ class DbtCloudRunJobOperator(BaseOperator):
                 warnings.warn(
                     "Argument `wait_for_termination` is False and `deferrable` is True , hence "
                     "`deferrable` parameter doesn't have any effect",
+                    UserWarning,
+                    stacklevel=2,
                 )
             return self.run_id
 

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -171,6 +171,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
             warnings.warn(
                 "Passing log_id_template to ElasticsearchTaskHandler is deprecated and has no effect",
                 AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
 
         self.log_id_template = log_id_template  # Only used on Airflow < 2.3.2.

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -145,6 +145,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         warnings.warn(
             "This method will be deprecated. Please use `BigQueryHook.get_client` method",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         http_authorized = self._authorize()
         return build("bigquery", "v2", http=http_authorized, cache_discovery=False)
@@ -624,6 +625,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             "This method is deprecated. Please use `BigQueryHook.create_empty_table` method with "
             "passing the `table_resource` object. This gives more flexibility than this method.",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         location = location or self.location
         src_fmt_configs = src_fmt_configs or {}
@@ -808,6 +810,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         warnings.warn(
             "This method is deprecated, please use ``BigQueryHook.update_table`` method.",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         table_resource: dict[str, Any] = {}
 
@@ -958,7 +961,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :param project_id: The Google Cloud Project ID
         """
         warnings.warn(
-            "This method is deprecated. Please use ``update_dataset``.", AirflowProviderDeprecationWarning
+            "This method is deprecated. Please use ``update_dataset``.",
+            AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         project_id = project_id or self.project_id
         if not dataset_id or not isinstance(dataset_id, str):
@@ -1007,7 +1012,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :return: List of tables associated with the dataset
         """
         warnings.warn(
-            "This method is deprecated. Please use ``get_dataset_tables``.", AirflowProviderDeprecationWarning
+            "This method is deprecated. Please use ``get_dataset_tables``.",
+            AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         project_id = project_id or self.project_id
         tables = self.get_client().list_tables(
@@ -1197,7 +1204,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :return:
         """
         warnings.warn(
-            "This method is deprecated. Please use `delete_table`.", AirflowProviderDeprecationWarning
+            "This method is deprecated. Please use `delete_table`.",
+            AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         return self.delete_table(table_id=deletion_dataset_table, not_found_ok=ignore_if_missing)
 
@@ -1250,7 +1259,11 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :param start_index: zero based index of the starting row to read.
         :return: list of rows
         """
-        warnings.warn("This method is deprecated. Please use `list_rows`.", AirflowProviderDeprecationWarning)
+        warnings.warn(
+            "This method is deprecated. Please use `list_rows`.",
+            AirflowProviderDeprecationWarning,
+            stacklevel=2,
+        )
         rows = self.list_rows(
             dataset_id=dataset_id,
             table_id=table_id,
@@ -1458,6 +1471,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         warnings.warn(
             "This method is deprecated. Please use `BigQueryHook.cancel_job`.",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         if self.running_job_id:
             self.cancel_job(job_id=self.running_job_id)
@@ -1617,6 +1631,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         warnings.warn(
             "This method is deprecated. Please use `BigQueryHook.insert_job`",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         job = self.insert_job(configuration=configuration, project_id=self.project_id)
         self.running_job_id = job.job_id
@@ -1714,6 +1729,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         warnings.warn(
             "This method is deprecated. Please use `BigQueryHook.insert_job` method.",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
 
         if not self.project_id:
@@ -1901,6 +1917,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         warnings.warn(
             "This method is deprecated. Please use `BigQueryHook.insert_job` method.",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         if not self.project_id:
             raise ValueError("The project_id should be set")
@@ -1982,6 +1999,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         warnings.warn(
             "This method is deprecated. Please use `BigQueryHook.insert_job` method.",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         if not self.project_id:
             raise ValueError("The project_id should be set")
@@ -2109,6 +2127,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         warnings.warn(
             "This method is deprecated. Please use `BigQueryHook.insert_job` method.",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         if not self.project_id:
             raise ValueError("The project_id should be set")

--- a/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
@@ -250,7 +250,11 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
                 request_filter = kwargs["filter"]
                 if not isinstance(request_filter, dict):
                     raise ValueError(f"The request_filter should be dict and is {type(request_filter)}")
-                warnings.warn("Use 'request_filter' instead of 'filter'", AirflowProviderDeprecationWarning)
+                warnings.warn(
+                    "Use 'request_filter' instead of 'filter'",
+                    AirflowProviderDeprecationWarning,
+                    stacklevel=2,
+                )
             else:
                 raise TypeError("list_transfer_job missing 1 required positional argument: 'request_filter'")
 
@@ -374,7 +378,11 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
                 request_filter = kwargs["filter"]
                 if not isinstance(request_filter, dict):
                     raise ValueError(f"The request_filter should be dict and is {type(request_filter)}")
-                warnings.warn("Use 'request_filter' instead of 'filter'", AirflowProviderDeprecationWarning)
+                warnings.warn(
+                    "Use 'request_filter' instead of 'filter'",
+                    AirflowProviderDeprecationWarning,
+                    stacklevel=2,
+                )
             else:
                 raise TypeError(
                     "list_transfer_operations missing 1 required positional argument: 'request_filter'"

--- a/airflow/providers/google/cloud/hooks/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/hooks/kubernetes_engine.py
@@ -102,6 +102,7 @@ class GKEHook(GoogleBaseHook):
         warnings.warn(
             "The get_conn method has been deprecated. You should use the get_cluster_manager_client method.",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         return self.get_cluster_manager_client()
 
@@ -111,6 +112,7 @@ class GKEHook(GoogleBaseHook):
         warnings.warn(
             "The get_client method has been deprecated. You should use the get_conn method.",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         return self.get_conn()
 

--- a/airflow/providers/google/cloud/hooks/vertex_ai/custom_job.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/custom_job.py
@@ -391,6 +391,7 @@ class CustomJobHook(GoogleBaseHook):
         warnings.warn(
             "This method is deprecated, please use `PipelineJobHook.cancel_pipeline_job` method.",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         client = self.get_pipeline_service_client(region)
         name = client.pipeline_job_path(project_id, region, pipeline_job)
@@ -516,6 +517,7 @@ class CustomJobHook(GoogleBaseHook):
         warnings.warn(
             "This method is deprecated, please use `PipelineJobHook.create_pipeline_job` method.",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         client = self.get_pipeline_service_client(region)
         parent = client.common_location_path(project_id, region)
@@ -1777,6 +1779,7 @@ class CustomJobHook(GoogleBaseHook):
         warnings.warn(
             "This method is deprecated, please use `PipelineJobHook.delete_pipeline_job` method.",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         client = self.get_pipeline_service_client(region)
         name = client.pipeline_job_path(project_id, region, pipeline_job)
@@ -1882,6 +1885,7 @@ class CustomJobHook(GoogleBaseHook):
         warnings.warn(
             "This method is deprecated, please use `PipelineJobHook.get_pipeline_job` method.",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         client = self.get_pipeline_service_client(region)
         name = client.pipeline_job_path(project_id, region, pipeline_job)
@@ -2038,6 +2042,7 @@ class CustomJobHook(GoogleBaseHook):
         warnings.warn(
             "This method is deprecated, please use `PipelineJobHook.list_pipeline_jobs` method.",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         client = self.get_pipeline_service_client(region)
         parent = client.common_location_path(project_id, region)

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1487,6 +1487,7 @@ class BigQueryCreateEmptyTableOperator(GoogleCloudBaseOperator):
             warnings.warn(
                 "`exists_ok` parameter is deprecated, please use `if_exists`",
                 AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
             self.if_exists = IfExistAction.IGNORE if exists_ok else IfExistAction.LOG
         else:
@@ -1995,6 +1996,7 @@ class BigQueryCreateEmptyDatasetOperator(GoogleCloudBaseOperator):
             warnings.warn(
                 "`exists_ok` parameter is deprecated, please use `if_exists`",
                 AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
             self.if_exists = IfExistAction.IGNORE if exists_ok else IfExistAction.LOG
         else:

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -608,7 +608,7 @@ class DataprocCreateClusterOperator(GoogleCloudBaseOperator):
                 "You can use `airflow.dataproc.ClusterGenerator.generate_cluster` "
                 "method to obtain cluster object.",
                 AirflowProviderDeprecationWarning,
-                stacklevel=1,
+                stacklevel=2,
             )
             # Remove result of apply defaults
             if "params" in kwargs:
@@ -878,7 +878,7 @@ class DataprocScaleClusterOperator(GoogleCloudBaseOperator):
             f"The `{type(self).__name__}` operator is deprecated, "
             "please use `DataprocUpdateClusterOperator` instead.",
             AirflowProviderDeprecationWarning,
-            stacklevel=1,
+            stacklevel=2,
         )
 
     def _build_scale_cluster_data(self) -> dict:
@@ -1311,7 +1311,7 @@ class DataprocSubmitPigJobOperator(DataprocJobBaseOperator):
             " `generate_job` method of `{cls}` to generate dictionary representing your job"
             " and use it with the new operator.".format(cls=type(self).__name__),
             AirflowProviderDeprecationWarning,
-            stacklevel=1,
+            stacklevel=2,
         )
 
         super().__init__(
@@ -1403,7 +1403,7 @@ class DataprocSubmitHiveJobOperator(DataprocJobBaseOperator):
             " `generate_job` method of `{cls}` to generate dictionary representing your job"
             " and use it with the new operator.".format(cls=type(self).__name__),
             AirflowProviderDeprecationWarning,
-            stacklevel=1,
+            stacklevel=2,
         )
 
         super().__init__(
@@ -1496,7 +1496,7 @@ class DataprocSubmitSparkSqlJobOperator(DataprocJobBaseOperator):
             " `generate_job` method of `{cls}` to generate dictionary representing your job"
             " and use it with the new operator.".format(cls=type(self).__name__),
             AirflowProviderDeprecationWarning,
-            stacklevel=1,
+            stacklevel=2,
         )
 
         super().__init__(
@@ -1591,7 +1591,7 @@ class DataprocSubmitSparkJobOperator(DataprocJobBaseOperator):
             " `generate_job` method of `{cls}` to generate dictionary representing your job"
             " and use it with the new operator.".format(cls=type(self).__name__),
             AirflowProviderDeprecationWarning,
-            stacklevel=1,
+            stacklevel=2,
         )
 
         super().__init__(
@@ -1682,7 +1682,7 @@ class DataprocSubmitHadoopJobOperator(DataprocJobBaseOperator):
             " `generate_job` method of `{cls}` to generate dictionary representing your job"
             " and use it with the new operator.".format(cls=type(self).__name__),
             AirflowProviderDeprecationWarning,
-            stacklevel=1,
+            stacklevel=2,
         )
 
         super().__init__(
@@ -1796,7 +1796,7 @@ class DataprocSubmitPySparkJobOperator(DataprocJobBaseOperator):
             " `generate_job` method of `{cls}` to generate dictionary representing your job"
             " and use it with the new operator.".format(cls=type(self).__name__),
             AirflowProviderDeprecationWarning,
-            stacklevel=1,
+            stacklevel=2,
         )
 
         super().__init__(

--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -325,7 +325,9 @@ class GKECreateClusterOperator(GoogleCloudBaseOperator):
         for deprecated_field, replacement in deprecated_body_fields_with_replacement:
             if self._body_field(deprecated_field):
                 warnings.warn(
-                    f"The body field '{deprecated_field}' is deprecated. Use '{replacement}' instead."
+                    f"The body field '{deprecated_field}' is deprecated. Use '{replacement}' instead.",
+                    AirflowProviderDeprecationWarning,
+                    stacklevel=2,
                 )
 
     def execute(self, context: Context) -> str:
@@ -513,7 +515,7 @@ class GKEStartPodOperator(KubernetesPodOperator):
             "The `get_gke_config_file` method is deprecated, "
             "please use `fetch_cluster_info` instead to get the cluster info for connecting to it.",
             AirflowProviderDeprecationWarning,
-            stacklevel=1,
+            stacklevel=2,
         )
 
     @cached_property

--- a/airflow/providers/google/cloud/sensors/bigquery.py
+++ b/airflow/providers/google/cloud/sensors/bigquery.py
@@ -305,6 +305,7 @@ class BigQueryTableExistenceAsyncSensor(BigQueryTableExistenceSensor):
             "Please use `BigQueryTableExistenceSensor` and "
             "set `deferrable` attribute to `True` instead",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         super().__init__(deferrable=True, **kwargs)
 
@@ -346,5 +347,6 @@ class BigQueryTableExistencePartitionAsyncSensor(BigQueryTablePartitionExistence
             "Please use `BigQueryTablePartitionExistenceSensor` and "
             "set `deferrable` attribute to `True` instead",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         super().__init__(deferrable=True, **kwargs)

--- a/airflow/providers/google/cloud/sensors/gcs.py
+++ b/airflow/providers/google/cloud/sensors/gcs.py
@@ -169,6 +169,7 @@ class GCSObjectExistenceAsyncSensor(GCSObjectExistenceSensor):
             "Class `GCSObjectExistenceAsyncSensor` is deprecated and will be removed in a future release. "
             "Please use `GCSObjectExistenceSensor` and set `deferrable` attribute to `True` instead",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         super().__init__(deferrable=True, **kwargs)
 

--- a/airflow/providers/google/cloud/transfers/bigquery_to_mssql.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_mssql.py
@@ -64,6 +64,7 @@ class BigQueryToMsSqlOperator(BigQueryToSqlBaseOperator):
             warnings.warn(
                 "The `mssql_table` parameter has been deprecated. Use `target_table_name` instead.",
                 AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
 
             if target_table_name is not None:

--- a/airflow/providers/google/cloud/transfers/bigquery_to_mysql.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_mysql.py
@@ -54,6 +54,7 @@ class BigQueryToMySqlOperator(BigQueryToSqlBaseOperator):
             warnings.warn(
                 "The `mysql_table` parameter has been deprecated. Use `target_table_name` instead.",
                 AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
 
             if target_table_name is not None:

--- a/airflow/providers/google/cloud/triggers/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/triggers/kubernetes_engine.py
@@ -101,6 +101,7 @@ class GKEStartPodTrigger(KubernetesPodTrigger):
             warnings.warn(
                 "`should_delete_pod` parameter is deprecated, please use `on_finish_action`",
                 AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
             self.on_finish_action = (
                 OnFinishAction.DELETE_POD if should_delete_pod else OnFinishAction.KEEP_POD

--- a/airflow/providers/google/marketing_platform/hooks/analytics.py
+++ b/airflow/providers/google/marketing_platform/hooks/analytics.py
@@ -36,7 +36,7 @@ class GoogleAnalyticsHook(GoogleBaseHook):
             f"The `{type(self).__name__}` class is deprecated, please use "
             f"`GoogleAnalyticsAdminHook` instead.",
             AirflowProviderDeprecationWarning,
-            stacklevel=1,
+            stacklevel=2,
         )
 
         self.api_version = api_version

--- a/airflow/providers/google/marketing_platform/operators/analytics.py
+++ b/airflow/providers/google/marketing_platform/operators/analytics.py
@@ -80,7 +80,7 @@ class GoogleAnalyticsListAccountsOperator(BaseOperator):
             f"The `{type(self).__name__}` operator is deprecated, please use "
             f"`GoogleAnalyticsAdminListAccountsOperator` instead.",
             AirflowProviderDeprecationWarning,
-            stacklevel=1,
+            stacklevel=2,
         )
 
         super().__init__(**kwargs)
@@ -153,7 +153,7 @@ class GoogleAnalyticsGetAdsLinkOperator(BaseOperator):
             f"The `{type(self).__name__}` operator is deprecated, please use "
             f"`GoogleAnalyticsAdminGetGoogleAdsLinkOperator` instead.",
             AirflowProviderDeprecationWarning,
-            stacklevel=1,
+            stacklevel=2,
         )
 
         self.account_id = account_id
@@ -228,7 +228,7 @@ class GoogleAnalyticsRetrieveAdsLinksListOperator(BaseOperator):
             f"The `{type(self).__name__}` operator is deprecated, please use "
             f"`GoogleAnalyticsAdminListGoogleAdsLinksOperator` instead.",
             AirflowProviderDeprecationWarning,
-            stacklevel=1,
+            stacklevel=2,
         )
 
         self.account_id = account_id
@@ -307,7 +307,7 @@ class GoogleAnalyticsDataImportUploadOperator(BaseOperator):
             f"The `{type(self).__name__}` operator is deprecated, please use "
             f"`GoogleAnalyticsAdminCreateDataStreamOperator` instead.",
             AirflowProviderDeprecationWarning,
-            stacklevel=1,
+            stacklevel=2,
         )
         super().__init__(**kwargs)
         self.storage_bucket = storage_bucket
@@ -399,7 +399,7 @@ class GoogleAnalyticsDeletePreviousDataUploadsOperator(BaseOperator):
             f"The `{type(self).__name__}` operator is deprecated, please use "
             f"`GoogleAnalyticsAdminDeleteDataStreamOperator` instead.",
             AirflowProviderDeprecationWarning,
-            stacklevel=1,
+            stacklevel=2,
         )
         super().__init__(**kwargs)
 

--- a/airflow/providers/http/operators/http.py
+++ b/airflow/providers/http/operators/http.py
@@ -349,5 +349,6 @@ class SimpleHttpOperator(HttpOperator):
             "Class `SimpleHttpOperator` is deprecated and "
             "will be removed in a future release. Please use `HttpOperator` instead.",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         super().__init__(**kwargs)

--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -142,7 +142,9 @@ class AzureDataExplorerHook(BaseHook):
                 warnings.warn(
                     f"Conflicting params `{key}` and `{backcompat_key}` found in extras for conn "
                     f"{self.conn_id}. Using value for `{key}`.  Please ensure this is the correct value "
-                    f"and remove the backcompat key `{backcompat_key}`."
+                    f"and remove the backcompat key `{backcompat_key}`.",
+                    UserWarning,
+                    stacklevel=2,
                 )
 
         def get_required_param(name: str) -> str:

--- a/airflow/providers/microsoft/azure/operators/data_factory.py
+++ b/airflow/providers/microsoft/azure/operators/data_factory.py
@@ -229,6 +229,8 @@ class AzureDataFactoryRunPipelineOperator(BaseOperator):
                 warnings.warn(
                     "Argument `wait_for_termination` is False and `deferrable` is True , hence "
                     "`deferrable` parameter doesn't have any effect",
+                    UserWarning,
+                    stacklevel=2,
                 )
 
     def execute_complete(self, context: Context, event: dict[str, str]) -> None:

--- a/airflow/providers/microsoft/azure/utils.py
+++ b/airflow/providers/microsoft/azure/utils.py
@@ -43,7 +43,9 @@ def get_field(*, conn_id: str, conn_type: str, extras: dict, field_name: str):
             warnings.warn(
                 f"Conflicting params `{field_name}` and `{backcompat_key}` found in extras for conn "
                 f"{conn_id}. Using value for `{field_name}`.  Please ensure this is the correct "
-                f"value and remove the backcompat key `{backcompat_key}`."
+                f"value and remove the backcompat key `{backcompat_key}`.",
+                UserWarning,
+                stacklevel=2,
             )
         ret = extras[field_name]
     elif backcompat_key in extras:

--- a/airflow/providers/pagerduty/hooks/pagerduty_events.py
+++ b/airflow/providers/pagerduty/hooks/pagerduty_events.py
@@ -125,7 +125,7 @@ class PagerdutyEventsHook(BaseHook):
             "This method will be deprecated. Please use the "
             "`PagerdutyEventsHook.send_event` to interact with the Events API",
             AirflowProviderDeprecationWarning,
-            stacklevel=1,
+            stacklevel=2,
         )
 
         data = PagerdutyEventsHook.prepare_event_data(

--- a/airflow/providers/slack/utils/__init__.py
+++ b/airflow/providers/slack/utils/__init__.py
@@ -48,7 +48,9 @@ class ConnectionExtraConfig:
                 warnings.warn(
                     f"Conflicting params `{field}` and `{backcompat_key}` found in extras for conn "
                     f"{self.conn_id}. Using value for `{field}`.  Please ensure this is the correct value "
-                    f"and remove the backcompat key `{backcompat_key}`."
+                    f"and remove the backcompat key `{backcompat_key}`.",
+                    UserWarning,
+                    stacklevel=2,
                 )
             return self.extra[field]
         elif backcompat_key in self.extra and self.extra[backcompat_key] not in (None, ""):

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -170,7 +170,9 @@ class SnowflakeHook(DbApiHook):
                 warnings.warn(
                     f"Conflicting params `{field_name}` and `{backcompat_key}` found in extras. "
                     f"Using value for `{field_name}`.  Please ensure this is the correct "
-                    f"value and remove the backcompat key `{backcompat_key}`."
+                    f"value and remove the backcompat key `{backcompat_key}`.",
+                    UserWarning,
+                    stacklevel=2,
                 )
             return extra_dict[field_name] or None
         return extra_dict.get(backcompat_key) or None

--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -129,6 +129,7 @@ class TableauHook(BaseHook):
             "Authentication via personal access token is deprecated. "
             "Please, use the password authentication to avoid inconsistencies.",
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         tableau_auth = PersonalAccessTokenAuth(
             token_name=self.conn.extra_dejson["token_name"],

--- a/airflow/providers/weaviate/operators/weaviate.py
+++ b/airflow/providers/weaviate/operators/weaviate.py
@@ -81,6 +81,7 @@ class WeaviateIngestOperator(BaseOperator):
                 "Passing 'input_json' to WeaviateIngestOperator is deprecated and"
                 " you should use 'input_data' instead",
                 AirflowProviderDeprecationWarning,
+                stacklevel=2,
             )
             self.input_data = input_json
         else:

--- a/airflow/providers/yandex/hooks/yandex.py
+++ b/airflow/providers/yandex/hooks/yandex.py
@@ -104,7 +104,12 @@ class YandexCloudBaseHook(BaseHook):
                 )
             ).strip()
         except KeyError:
-            warnings.warn(f"Hook '{cls.hook_name}' info is not initialized in airflow.ProviderManager")
+            warnings.warn(
+                f"Hook '{cls.hook_name}' info is not initialized in airflow.ProviderManager",
+                UserWarning,
+                stacklevel=2,
+            )
+
             return None
 
     @classmethod

--- a/airflow/providers/yandex/operators/yandexcloud_dataproc.py
+++ b/airflow/providers/yandex/operators/yandexcloud_dataproc.py
@@ -20,6 +20,7 @@ import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterable, Sequence
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.yandex.hooks.yandexcloud_dataproc import DataprocHook
 
@@ -261,7 +262,11 @@ class DataprocBaseOperator(BaseOperator):
         if self.yandex_conn_id is None:
             xcom_yandex_conn_id = context["task_instance"].xcom_pull(key="yandexcloud_connection_id")
             if xcom_yandex_conn_id:
-                warnings.warn("Implicit pass of `yandex_conn_id` is deprecated, please pass it explicitly")
+                warnings.warn(
+                    "Implicit pass of `yandex_conn_id` is deprecated, please pass it explicitly",
+                    AirflowProviderDeprecationWarning,
+                    stacklevel=2,
+                )
                 self.yandex_conn_id = xcom_yandex_conn_id
 
         return DataprocHook(yandex_conn_id=self.yandex_conn_id)

--- a/tests/providers/amazon/conftest.py
+++ b/tests/providers/amazon/conftest.py
@@ -33,13 +33,13 @@ def botocore_version():
     try:
         version = importlib_metadata.version("botocore")
     except importlib_metadata.PackageNotFoundError:
-        warnings.warn("'botocore' package not found'", UserWarning)
+        warnings.warn("'botocore' package not found'", UserWarning, stacklevel=2)
         return None
 
     try:
         return tuple(map(int, version.split(".")[:3]))
     except Exception:
-        warnings.warn(f"Unable to parse botocore {version!r}", UserWarning)
+        warnings.warn(f"Unable to parse botocore {version!r}", UserWarning, stacklevel=2)
         return None
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

During check warnings which generated in our CI I've found that time to time we use `stacklevel=1` or even do not define it at all. This make it harder to find where actual call is happen.

```console
airflow/models/baseoperator.py:439: [W0513(warning), ] The `GoogleAnalyticsListAccountsOperator` operator is deprecated, please use `GoogleAnalyticsAdminListAccountsOperator` instead.
airflow/models/baseoperator.py:439: [W0513(warning), ] The `GoogleAnalyticsGetAdsLinkOperator` operator is deprecated, please use `GoogleAnalyticsAdminGetGoogleAdsLinkOperator` instead.
airflow/models/baseoperator.py:439: [W0513(warning), ] The `GoogleAnalyticsRetrieveAdsLinksListOperator` operator is deprecated, please use `GoogleAnalyticsAdminListGoogleAdsLinksOperator` instead.
airflow/models/baseoperator.py:439: [W0513(warning), ] The `GoogleAnalyticsDataImportUploadOperator` operator is deprecated, please use `GoogleAnalyticsAdminCreateDataStreamOperator` instead.
airflow/models/baseoperator.py:439: [W0513(warning), ] The `GoogleAnalyticsDeletePreviousDataUploadsOperator` operator is deprecated, please use `GoogleAnalyticsAdminDeleteDataStreamOperator` instead.
```

There is rule [`B028`](https://docs.astral.sh/ruff/rules/no-explicit-stacklevel/) exists into the `ruff` for validate missing `stacklevel` into the code, however nothing it could do with explicit `stacklevel=1`

There is additional changes exists in warnings, which I point into the separate discussions

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
