### PR TITLE
Fix deprecations into the GCP Dataproc links

### DIFF
--- a/airflow/providers/google/cloud/links/dataproc.py
+++ b/airflow/providers/google/cloud/links/dataproc.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Any
 
+import attr
+
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import BaseOperatorLink, XCom
 from airflow.providers.google.cloud.links.base import BASE_LINK, BaseGoogleLink
@@ -42,6 +44,7 @@ def __getattr__(name: str) -> Any:
                 " Please use DATAPROC_JOB_LINK instead"
             ),
             AirflowProviderDeprecationWarning,
+            stacklevel=2,
         )
         return DATAPROC_JOB_LINK
     raise AttributeError(f"module {__name__} has no attribute {name}")
@@ -68,18 +71,15 @@ DATAPROC_CLUSTER_LINK_DEPRECATED = (
 )
 
 
+@attr.s(auto_attribs=True)
 class DataprocLink(BaseOperatorLink):
     """
     Helper class for constructing Dataproc resource link.
 
     .. warning::
-       This link is deprecated.
+       This link is pending to deprecate.
     """
 
-    warnings.warn(
-        "This DataprocLink is deprecated.",
-        AirflowProviderDeprecationWarning,
-    )
     name = "Dataproc resource"
     key = "conf"
 
@@ -116,7 +116,17 @@ class DataprocLink(BaseOperatorLink):
             else ""
         )
 
+    def __attrs_post_init__(self):
+        # This link is still used into the selected operators
+        # - airflow.providers.google.cloud.operators.dataproc.DataprocScaleClusterOperator
+        # - airflow.providers.google.cloud.operators.dataproc.DataprocJobBaseOperator
+        # - airflow.providers.google.cloud.operators.dataproc.DataprocSubmitPigJobOperator
+        # As soon as we remove reference to this link we might deprecate it by add warning message
+        # with `stacklevel=3` below in this method.
+        ...
 
+
+@attr.s(auto_attribs=True)
 class DataprocListLink(BaseOperatorLink):
     """
     Helper class for constructing list of Dataproc resources link.
@@ -125,7 +135,6 @@ class DataprocListLink(BaseOperatorLink):
        This link is deprecated.
     """
 
-    warnings.warn("This DataprocListLink is deprecated.", AirflowProviderDeprecationWarning)
     name = "Dataproc resources"
     key = "list_conf"
 
@@ -157,6 +166,13 @@ class DataprocListLink(BaseOperatorLink):
             )
             if list_conf
             else ""
+        )
+
+    def __attrs_post_init__(self):
+        warnings.warn(
+            "This DataprocListLink is deprecated.",
+            AirflowProviderDeprecationWarning,
+            stacklevel=3,
         )
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Related:
- #31895
- https://github.com/apache/airflow/pull/36831#discussion_r1454659677

`warnings.warn` raised every time when module `airflow.providers.google.cloud.links.dataproc` imported, so this warnings should be implemented inside of the `__attrs_post_init__` method.

`DataprocListLink` has no any references into the Community Providers, that mean we could keep deprecations
`DataprocLink` has 3 references into the Operators, so we can't deprecate this link until we replace/remove this link into the operators:
- [`DataprocJobBaseOperator`](https://github.com/apache/airflow/blob/918552acad136128ea603d765d8be23d3f9bfcbd/airflow/providers/google/cloud/operators/dataproc.py#L1108) (all classes based on this operator are deprecated)
- [`DataprocScaleClusterOperator`](https://github.com/apache/airflow/blob/918552acad136128ea603d765d8be23d3f9bfcbd/airflow/providers/google/cloud/operators/dataproc.py#L851) (operator deprecated)
- [`DataprocSubmitPigJobOperator`](https://github.com/apache/airflow/blob/918552acad136128ea603d765d8be23d3f9bfcbd/airflow/providers/google/cloud/operators/dataproc.py#L1234) (operator deprecated)

cc: @bkossakowska 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
