### PR TITLE
add unit test for SubprocessHook.send_sigterm()

### DIFF
--- a/tests/hooks/test_subprocess.py
+++ b/tests/hooks/test_subprocess.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import signal
 from pathlib import Path
 from subprocess import PIPE, STDOUT
 from tempfile import TemporaryDirectory
@@ -105,3 +106,11 @@ class TestSubprocessHook:
         command = ["bash", "-c", 'printf "This will cause a coding error \\xb1\\xa6\\x01\n"']
         result = hook.run_command(command=command)
         assert result.exit_code == 0
+
+    @mock.patch("os.getpgid", return_value=123)
+    @mock.patch("os.killpg")
+    def test_send_sigterm(self, mock_killpg, mock_getpgid):
+        hook = SubprocessHook()
+        hook.sub_process = MagicMock()
+        hook.send_sigterm()
+        mock_killpg.assert_called_with(123, signal.SIGTERM)


### PR DESCRIPTION
Small and self-explanatory PR. This just adds a unit-test for the `SubprocessHook`'s `send_sigterm()`, which was not directly covered by tests.