### PR TITLE
Add `get_permitted_menu_items` in auth manager

### DIFF
--- a/airflow/auth/managers/base_auth_manager.py
+++ b/airflow/auth/managers/base_auth_manager.py
@@ -28,11 +28,13 @@ from airflow.auth.managers.models.resource_details import (
 )
 from airflow.exceptions import AirflowException
 from airflow.models import DagModel
+from airflow.security.permissions import ACTION_CAN_ACCESS_MENU
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
     from flask import Blueprint
+    from flask_appbuilder.menu import MenuItem
     from sqlalchemy.orm import Session
 
     from airflow.auth.managers.models.base_user import BaseUser
@@ -371,6 +373,26 @@ class BaseAuthManager(LoggingMixin):
             for dag_id in dag_ids
             if _is_permitted_dag_id("GET", methods, dag_id) or _is_permitted_dag_id("PUT", methods, dag_id)
         }
+
+    def get_permitted_menu_items(self, menu_items: list[MenuItem]) -> list[MenuItem]:
+        """
+        Filter menu items based on user permissions.
+
+        :param menu_items: list of all menu items
+        """
+        items = filter(
+            lambda item: self.security_manager.has_access(ACTION_CAN_ACCESS_MENU, item.name), menu_items
+        )
+        accessible_items = []
+        for menu_item in items:
+            if menu_item.childs:
+                accessible_children = []
+                for child in menu_item.childs:
+                    if self.security_manager.has_access(ACTION_CAN_ACCESS_MENU, child.name):
+                        accessible_children.append(child)
+                menu_item.childs = accessible_children
+            accessible_items.append(menu_item)
+        return accessible_items
 
     @abstractmethod
     def get_url_login(self, **kwargs) -> str:

--- a/airflow/www/templates/appbuilder/navbar_menu.html
+++ b/airflow/www/templates/appbuilder/navbar_menu.html
@@ -21,8 +21,8 @@
   <a href="{{item.get_url()}}">{{_(item.label)}}</a>
 {% endmacro %}
 
-{% for item1 in menu.get_list() %}
-  {% if item1 | is_menu_visible %}
+{% for item1 in auth_manager.get_permitted_menu_items(menu.get_list()) %}
+  {% if item1 %}
     {% if item1.childs %}
       <li class="dropdown">
         <a class="dropdown-toggle" href="javascript:void(0)">
@@ -34,7 +34,7 @@
                 {% if not loop.last %}
                   <li class="divider"></li>
                 {% endif %}
-              {% elif item2 | is_menu_visible %}
+              {% elif item2 %}
                 <li>{{ menu_item(item2) }}</li>
               {% endif %}
             {% endif %}

--- a/docs/apache-airflow/core-concepts/auth-manager.rst
+++ b/docs/apache-airflow/core-concepts/auth-manager.rst
@@ -124,6 +124,7 @@ The following methods aren't required to override to have a functional Airflow a
 * ``batch_is_authorized_pool``: Batch version of ``is_authorized_pool``. If not overridden, it will call ``is_authorized_pool`` for every single item.
 * ``batch_is_authorized_variable``: Batch version of ``is_authorized_variable``. If not overridden, it will call ``is_authorized_variable`` for every single item.
 * ``get_permitted_dag_ids``: Return the list of DAG IDs the user has access to.  If not overridden, it will call ``is_authorized_dag`` for every single DAG available in the environment.
+* ``get_permitted_menu_items``: Return the menu items the user has access to.  If not overridden, it will call ``has_access`` in :class:`~airflow.www.security_manager.AirflowSecurityManagerV2` for every single menu item.
 
 CLI
 ^^^

--- a/tests/auth/managers/test_base_auth_manager.py
+++ b/tests/auth/managers/test_base_auth_manager.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from flask import Flask
+from flask_appbuilder.menu import Menu
 
 from airflow.auth.managers.base_auth_manager import BaseAuthManager, ResourceMethod
 from airflow.auth.managers.models.resource_details import (
@@ -296,3 +297,22 @@ class TestBaseAuthManager:
         session.execute.return_value = dags
         result = auth_manager.get_permitted_dag_ids(user=user, session=session)
         assert result == expected
+
+    @patch.object(EmptyAuthManager, "security_manager")
+    def test_get_permitted_menu_items(self, mock_security_manager, auth_manager):
+        mock_security_manager.has_access.side_effect = [True, False, True, True, False]
+
+        menu = Menu()
+        menu.add_link("item1")
+        menu.add_link("item2")
+        menu.add_link("item3")
+        menu.add_link("item3.1", category="item3")
+        menu.add_link("item3.2", category="item3")
+
+        result = auth_manager.get_permitted_menu_items(menu.get_list())
+
+        assert len(result) == 2
+        assert result[0].name == "item1"
+        assert result[1].name == "item3"
+        assert len(result[1].childs) == 1
+        assert result[1].childs[0].name == "item3.1"


### PR DESCRIPTION
Currently the menu in Airflow UI is using the filter [is_menu_visible](https://github.com/dpgaspar/Flask-AppBuilder/blob/master/flask_appbuilder/filters.py#L133) to display or not each menu item. Each call to `is_menu_visible` calls [has_access](https://github.com/apache/airflow/blob/main/airflow/www/security_manager.py#L124) which then call an `is_authorized_` method from the auth manager used in the environment. Most likely, all auth managers (with the exception of fab) will call an external service for every `is_authorized_` method. Today, displaying the menu call 26 times an `is_authorized_` method which can be very expensive and make the Airflow UI slower.

Introducing `get_permitted_menu_items` which is responsible of returning the menu given user permissions can replace these 26 calls to one (if the service used by the auth manager is capable of multiple authz requests in one API).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
