### PR TITLE
Standardize deprecations in providers [part1]

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -29,7 +29,6 @@ import inspect
 import json
 import logging
 import os
-import warnings
 from copy import deepcopy
 from functools import cached_property, wraps
 from pathlib import Path
@@ -44,6 +43,7 @@ import tenacity
 from botocore.config import Config
 from botocore.waiter import Waiter, WaiterModel
 from dateutil.tz import tzlocal
+from deprecated import deprecated
 from slugify import slugify
 
 from airflow.configuration import conf
@@ -1020,6 +1020,13 @@ except ImportError:
     pass
 
 
+@deprecated(
+    reason=(
+        "airflow.providers.amazon.aws.hook.base_aws.BaseAsyncSessionFactory "
+        "has been deprecated and will be removed in future"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class BaseAsyncSessionFactory(BaseSessionFactory):
     """
     Base AWS Session Factory class to handle aiobotocore session creation.
@@ -1029,12 +1036,6 @@ class BaseAsyncSessionFactory(BaseSessionFactory):
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "airflow.providers.amazon.aws.hook.base_aws.BaseAsyncSessionFactory has been deprecated and "
-            "will be removed in future",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(*args, **kwargs)
 
     async def get_role_credentials(self) -> dict:
@@ -1113,6 +1114,13 @@ class BaseAsyncSessionFactory(BaseSessionFactory):
         return self._get_session_with_assume_role()
 
 
+@deprecated(
+    reason=(
+        "airflow.providers.amazon.aws.hook.base_aws.AwsBaseAsyncHook "
+        "has been deprecated and will be removed in future"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class AwsBaseAsyncHook(AwsBaseHook):
     """Interacts with AWS using aiobotocore asynchronously.
 
@@ -1129,12 +1137,6 @@ class AwsBaseAsyncHook(AwsBaseHook):
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "airflow.providers.amazon.aws.hook.base_aws.AwsBaseAsyncHook has been deprecated and "
-            "will be removed in future",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(*args, **kwargs)
 
     def get_async_session(self) -> AioSession:

--- a/airflow/providers/amazon/aws/hooks/quicksight.py
+++ b/airflow/providers/amazon/aws/hooks/quicksight.py
@@ -18,10 +18,10 @@
 from __future__ import annotations
 
 import time
-import warnings
 from functools import cached_property
 
 from botocore.exceptions import ClientError
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
@@ -172,14 +172,15 @@ class QuickSightHook(AwsBaseHook):
         return status
 
     @cached_property
-    def sts_hook(self):
-        warnings.warn(
-            f"`{type(self).__name__}.sts_hook` property is deprecated and will be removed in the future. "
+    @deprecated(
+        reason=(
+            "`QuickSightHook.sts_hook` property is deprecated and will be removed in the future. "
             "This property used for obtain AWS Account ID, "
-            f"please consider to use `{type(self).__name__}.account_id` instead",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
+            "please consider to use `QuickSightHook.account_id` instead"
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
+    def sts_hook(self):
         from airflow.providers.amazon.aws.hooks.sts import StsHook
 
         return StsHook(aws_conn_id=self.aws_conn_id)

--- a/airflow/providers/amazon/aws/hooks/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/hooks/redshift_cluster.py
@@ -17,10 +17,10 @@
 from __future__ import annotations
 
 import asyncio
-import warnings
 from typing import Any, Sequence
 
 import botocore.exceptions
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseAsyncHook, AwsBaseHook
@@ -195,16 +195,17 @@ class RedshiftHook(AwsBaseHook):
             return None
 
 
+@deprecated(
+    reason=(
+        "airflow.providers.amazon.aws.hook.base_aws.RedshiftAsyncHook "
+        "has been deprecated and will be removed in future"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class RedshiftAsyncHook(AwsBaseAsyncHook):
     """Interact with AWS Redshift using aiobotocore library."""
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "airflow.providers.amazon.aws.hook.base_aws.RedshiftAsyncHook has been deprecated and "
-            "will be removed in future",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         kwargs["client_type"] = "redshift"
         super().__init__(*args, **kwargs)
 

--- a/airflow/providers/amazon/aws/operators/eks.py
+++ b/airflow/providers/amazon/aws/operators/eks.py
@@ -25,6 +25,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, List, Sequence, cast
 
 from botocore.exceptions import ClientError, WaiterError
+from deprecated import deprecated
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
@@ -263,13 +264,14 @@ class EksCreateClusterOperator(BaseOperator):
         return EksHook(aws_conn_id=self.aws_conn_id, region_name=self.region)
 
     @property
-    def eks_hook(self):
-        warnings.warn(
+    @deprecated(
+        reason=(
             "`eks_hook` property is deprecated and will be removed in the future. "
-            "Please use `hook` property instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
+            "Please use `hook` property instead."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
+    def eks_hook(self):
         return self.hook
 
     def execute(self, context: Context):

--- a/airflow/providers/amazon/aws/sensors/quicksight.py
+++ b/airflow/providers/amazon/aws/sensors/quicksight.py
@@ -17,9 +17,10 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Sequence
+
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
 from airflow.providers.amazon.aws.hooks.quicksight import QuickSightHook
@@ -80,24 +81,26 @@ class QuickSightSensor(AwsBaseSensor[QuickSightHook]):
         return quicksight_ingestion_state == self.success_status
 
     @cached_property
+    @deprecated(
+        reason=(
+            "`QuickSightSensor.quicksight_hook` property is deprecated, "
+            "please use `QuickSightSensor.hook` property instead."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def quicksight_hook(self):
-        warnings.warn(
-            f"`{type(self).__name__}.quicksight_hook` property is deprecated, "
-            f"please use `{type(self).__name__}.hook` property instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         return self.hook
 
     @cached_property
-    def sts_hook(self):
-        warnings.warn(
-            f"`{type(self).__name__}.sts_hook` property is deprecated and will be removed in the future. "
+    @deprecated(
+        reason=(
+            "`QuickSightSensor.sts_hook` property is deprecated and will be removed in the future. "
             "This property used for obtain AWS Account ID, "
-            f"please consider to use `{type(self).__name__}.hook.account_id` instead",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
+            "please consider to use `QuickSightSensor.hook.account_id` instead"
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
+    def sts_hook(self):
         from airflow.providers.amazon.aws.hooks.sts import StsHook
 
         return StsHook(aws_conn_id=self.aws_conn_id)

--- a/airflow/providers/amazon/aws/triggers/rds.py
+++ b/airflow/providers/amazon/aws/triggers/rds.py
@@ -16,9 +16,10 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
+
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.hooks.rds import RdsHook
@@ -31,6 +32,13 @@ if TYPE_CHECKING:
     from airflow.providers.amazon.aws.hooks.base_aws import AwsGenericHook
 
 
+@deprecated(
+    reason=(
+        "This trigger is deprecated, please use the other RDS triggers "
+        "such as RdsDbDeletedTrigger, RdsDbStoppedTrigger or RdsDbAvailableTrigger"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class RdsDbInstanceTrigger(BaseTrigger):
     """
     Deprecated Trigger for RDS operations. Do not use.
@@ -55,12 +63,6 @@ class RdsDbInstanceTrigger(BaseTrigger):
         region_name: str | None,
         response: dict[str, Any],
     ):
-        warnings.warn(
-            "This trigger is deprecated, please use the other RDS triggers "
-            "such as RdsDbDeletedTrigger, RdsDbStoppedTrigger or RdsDbAvailableTrigger",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         self.db_instance_identifier = db_instance_identifier
         self.waiter_delay = waiter_delay
         self.waiter_max_attempts = waiter_max_attempts

--- a/airflow/providers/amazon/aws/utils/connection_wrapper.py
+++ b/airflow/providers/amazon/aws/utils/connection_wrapper.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 
 from botocore import UNSIGNED
 from botocore.config import Config
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.utils import trim_none_values
@@ -462,6 +463,13 @@ class AwsConnectionWrapper(LoggingMixin):
         return role_arn, assume_role_method, assume_role_kwargs
 
 
+@deprecated(
+    reason=(
+        "Use local credentials file is never documented and well tested. "
+        "Obtain credentials by this way deprecated and will be removed in a future releases."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 def _parse_s3_config(
     config_file_name: str, config_format: str | None = "boto", profile: str | None = None
 ) -> tuple[str | None, str | None]:
@@ -474,13 +482,6 @@ def _parse_s3_config(
         Defaults to "boto"
     :param profile: profile name in AWS type config file
     """
-    warnings.warn(
-        "Use local credentials file is never documented and well tested. "
-        "Obtain credentials by this way deprecated and will be removed in a future releases.",
-        AirflowProviderDeprecationWarning,
-        stacklevel=4,
-    )
-
     import configparser
 
     config = configparser.ConfigParser()

--- a/airflow/providers/amazon/aws/utils/mixins.py
+++ b/airflow/providers/amazon/aws/utils/mixins.py
@@ -31,6 +31,7 @@ import warnings
 from functools import cached_property
 from typing import Any, Generic, NamedTuple, TypeVar
 
+from deprecated import deprecated
 from typing_extensions import final
 
 from airflow.compat.functools import cache
@@ -160,9 +161,12 @@ class AwsBaseHookMixin(Generic[AwsHookType]):
 
     @property
     @final
+    @deprecated(
+        reason="`region` is deprecated and will be removed in the future. Please use `region_name` instead.",
+        category=AirflowProviderDeprecationWarning,
+    )
     def region(self) -> str | None:
         """Alias for ``region_name``, used for compatibility (deprecated)."""
-        warnings.warn(REGION_MSG, AirflowProviderDeprecationWarning, stacklevel=3)
         return self.region_name
 
 

--- a/airflow/providers/apache/beam/triggers/beam.py
+++ b/airflow/providers/apache/beam/triggers/beam.py
@@ -17,9 +17,9 @@
 from __future__ import annotations
 
 import asyncio
-import warnings
 from typing import Any, AsyncIterator, Sequence
 
+from deprecated import deprecated
 from google.cloud.dataflow_v1beta3 import ListJobsRequest
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
@@ -252,6 +252,10 @@ class BeamJavaPipelineTrigger(BeamPipelineBaseTrigger):
         return
 
 
+@deprecated(
+    reason="`BeamPipelineTrigger` is deprecated. Please use `BeamPythonPipelineTrigger`.",
+    category=AirflowProviderDeprecationWarning,
+)
 class BeamPipelineTrigger(BeamPythonPipelineTrigger):
     """
     Trigger to perform checking the Python pipeline status until it reaches terminate state.
@@ -262,9 +266,4 @@ class BeamPipelineTrigger(BeamPythonPipelineTrigger):
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "`BeamPipelineTrigger` is deprecated. Please use `BeamPythonPipelineTrigger`.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(*args, **kwargs)

--- a/airflow/providers/apache/drill/operators/drill.py
+++ b/airflow/providers/apache/drill/operators/drill.py
@@ -17,13 +17,18 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
+
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 
+@deprecated(
+    reason="Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.",
+    category=AirflowProviderDeprecationWarning,
+)
 class DrillOperator(SQLExecuteQueryOperator):
     """
     Executes the provided SQL in the identified Drill environment.
@@ -51,9 +56,3 @@ class DrillOperator(SQLExecuteQueryOperator):
 
     def __init__(self, *, drill_conn_id: str = "drill_default", **kwargs) -> None:
         super().__init__(conn_id=drill_conn_id, **kwargs)
-        warnings.warn(
-            """This class is deprecated.
-            Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.""",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )

--- a/airflow/providers/apache/druid/operators/druid_check.py
+++ b/airflow/providers/apache/druid/operators/druid_check.py
@@ -17,12 +17,16 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLCheckOperator
 
 
+@deprecated(
+    reason="Please use `airflow.providers.common.sql.operators.sql.SQLCheckOperator`.",
+    category=AirflowProviderDeprecationWarning,
+)
 class DruidCheckOperator(SQLCheckOperator):
     """
     This class is deprecated.
@@ -31,10 +35,4 @@ class DruidCheckOperator(SQLCheckOperator):
     """
 
     def __init__(self, druid_broker_conn_id: str = "druid_broker_default", **kwargs):
-        warnings.warn(
-            """This class is deprecated.
-            Please use `airflow.providers.common.sql.operators.sql.SQLCheckOperator`.""",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(conn_id=druid_broker_conn_id, **kwargs)

--- a/airflow/providers/cncf/kubernetes/pod_generator.py
+++ b/airflow/providers/cncf/kubernetes/pod_generator.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING
 
 import re2
 from dateutil import parser
+from deprecated import deprecated
 from kubernetes.client import models as k8s
 from kubernetes.client.api_client import ApiClient
 
@@ -153,9 +154,9 @@ class PodGenerator:
         # Attach sidecar
         self.extract_xcom = extract_xcom
 
+    @deprecated(reason="This function is deprecated.", category=AirflowProviderDeprecationWarning)
     def gen_pod(self) -> k8s.V1Pod:
         """Generate pod."""
-        warnings.warn("This function is deprecated. ", AirflowProviderDeprecationWarning, stacklevel=2)
         result = self.ud_pod
 
         result.metadata.name = add_pod_suffix(pod_name=result.metadata.name)
@@ -166,14 +167,15 @@ class PodGenerator:
         return result
 
     @staticmethod
+    @deprecated(
+        reason=(
+            "This function is deprecated. "
+            "Please use airflow.providers.cncf.kubernetes.utils.xcom_sidecar.add_xcom_sidecar instead"
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def add_xcom_sidecar(pod: k8s.V1Pod) -> k8s.V1Pod:
         """Add sidecar."""
-        warnings.warn(
-            "This function is deprecated. "
-            "Please use airflow.providers.cncf.kubernetes.utils.xcom_sidecar.add_xcom_sidecar instead",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         pod_cp = copy.deepcopy(pod)
         pod_cp.spec.volumes = pod.spec.volumes or []
         pod_cp.spec.volumes.insert(0, PodDefaults.VOLUME)
@@ -570,6 +572,10 @@ class PodGenerator:
         return api_client._ApiClient__deserialize_model(pod_dict, k8s.V1Pod)
 
     @staticmethod
+    @deprecated(
+        reason="This function is deprecated. Use `add_pod_suffix` in `kubernetes_helper_functions`.",
+        category=AirflowProviderDeprecationWarning,
+    )
     def make_unique_pod_id(pod_id: str) -> str | None:
         r"""
         Generate a unique Pod name.

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -22,7 +22,6 @@ import itertools
 import json
 import math
 import time
-import warnings
 from collections.abc import Iterable
 from contextlib import closing, suppress
 from dataclasses import dataclass
@@ -31,6 +30,7 @@ from typing import TYPE_CHECKING, Callable, Generator, Protocol, cast
 
 import pendulum
 import tenacity
+from deprecated import deprecated
 from kubernetes import client, watch
 from kubernetes.client.rest import ApiException
 from kubernetes.stream import stream as kubernetes_stream
@@ -371,13 +371,14 @@ class PodManager(LoggingMixin):
                 raise PodLaunchFailedException(msg)
             time.sleep(startup_check_interval)
 
+    @deprecated(
+        reason=(
+            "Method `follow_container_logs` is deprecated.  Use `fetch_container_logs` instead "
+            "with option `follow=True`."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def follow_container_logs(self, pod: V1Pod, container_name: str) -> PodLoggingStatus:
-        warnings.warn(
-            "Method `follow_container_logs` is deprecated.  Use `fetch_container_logs` instead"
-            "with option `follow=True`.",
-            category=AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         return self.fetch_container_logs(pod=pod, container_name=container_name, follow=True)
 
     def fetch_container_logs(

--- a/airflow/providers/common/sql/hooks/sql.py
+++ b/airflow/providers/common/sql/hooks/sql.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import contextlib
-import warnings
 from contextlib import closing
 from datetime import datetime
 from typing import (
@@ -37,6 +36,7 @@ from typing import (
 from urllib.parse import urlparse
 
 import sqlparse
+from deprecated import deprecated
 from sqlalchemy import create_engine
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
@@ -418,6 +418,14 @@ class DbApiHook(BaseHook):
         else:
             return results
 
+    @deprecated(
+        reason=(
+            "The `_make_serializable` method is deprecated and support will be removed in a future "
+            "version of the common.sql provider. Please update the DbApiHook's provider "
+            "to a version based on common.sql >= 1.9.1."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def _make_common_data_structure(self, result: T | Sequence[T]) -> tuple | list[tuple]:
         """Ensure the data returned from an SQL command is a standard tuple or list[tuple].
 
@@ -432,13 +440,6 @@ class DbApiHook(BaseHook):
         # Back-compatibility call for providers implementing old ´_make_serializable' method.
         with contextlib.suppress(AttributeError):
             result = self._make_serializable(result=result)  # type: ignore[attr-defined]
-            warnings.warn(
-                "The `_make_serializable` method is deprecated and support will be removed in a future "
-                f"version of the common.sql provider. Please update the {self.__class__.__name__}'s provider "
-                "to a version based on common.sql >= 1.9.1.",
-                AirflowProviderDeprecationWarning,
-                stacklevel=2,
-            )
 
         if isinstance(result, Sequence):
             return cast(List[tuple], result)

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -19,10 +19,11 @@
 from __future__ import annotations
 
 import time
-import warnings
 from functools import cached_property
 from logging import Logger
 from typing import TYPE_CHECKING, Any, Sequence
+
+from deprecated import deprecated
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
@@ -562,17 +563,18 @@ class DatabricksSubmitRunOperator(BaseOperator):
         _handle_deferrable_databricks_operator_completion(event, self.log)
 
 
+@deprecated(
+    reason=(
+        "`DatabricksSubmitRunDeferrableOperator` has been deprecated. "
+        "Please use `airflow.providers.databricks.operators.DatabricksSubmitRunOperator` "
+        "with `deferrable=True` instead."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class DatabricksSubmitRunDeferrableOperator(DatabricksSubmitRunOperator):
     """Deferrable version of ``DatabricksSubmitRunOperator``."""
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "`DatabricksSubmitRunDeferrableOperator` has been deprecated. "
-            "Please use `airflow.providers.databricks.operators.DatabricksSubmitRunOperator` with "
-            "`deferrable=True` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(deferrable=True, *args, **kwargs)
 
     def execute(self, context):
@@ -842,15 +844,16 @@ class DatabricksRunNowOperator(BaseOperator):
             self.log.error("Error: Task: %s with invalid run_id was requested to be cancelled.", self.task_id)
 
 
+@deprecated(
+    reason=(
+        "`DatabricksRunNowDeferrableOperator` has been deprecated. "
+        "Please use `airflow.providers.databricks.operators.DatabricksRunNowOperator` "
+        "with `deferrable=True` instead."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class DatabricksRunNowDeferrableOperator(DatabricksRunNowOperator):
     """Deferrable version of ``DatabricksRunNowOperator``."""
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "`DatabricksRunNowDeferrableOperator` has been deprecated. "
-            "Please use `airflow.providers.databricks.operators.DatabricksRunNowOperator` with "
-            "`deferrable=True` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(deferrable=True, *args, **kwargs)

--- a/airflow/providers/dbt/cloud/sensors/dbt.py
+++ b/airflow/providers/dbt/cloud/sensors/dbt.py
@@ -21,6 +21,8 @@ import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
+from deprecated import deprecated
+
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
 from airflow.providers.dbt.cloud.hooks.dbt import DbtCloudHook, DbtCloudJobRunException, DbtCloudJobRunStatus
@@ -149,6 +151,13 @@ class DbtCloudJobRunSensor(BaseSensorOperator):
         return generate_openlineage_events_from_dbt_cloud_run(operator=self, task_instance=task_instance)
 
 
+@deprecated(
+    reason=(
+        "Class `DbtCloudJobRunAsyncSensor` is deprecated and will be removed in a future release. "
+        "Please use `DbtCloudJobRunSensor` and set `deferrable` attribute to `True` instead"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class DbtCloudJobRunAsyncSensor(DbtCloudJobRunSensor):
     """
     This class is deprecated.
@@ -158,10 +167,4 @@ class DbtCloudJobRunAsyncSensor(DbtCloudJobRunSensor):
     """
 
     def __init__(self, **kwargs: Any) -> None:
-        warnings.warn(
-            "Class `DbtCloudJobRunAsyncSensor` is deprecated and will be removed in a future release. "
-            "Please use `DbtCloudJobRunSensor` and set `deferrable` attribute to `True` instead",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(deferrable=True, **kwargs)

--- a/airflow/providers/elasticsearch/hooks/elasticsearch.py
+++ b/airflow/providers/elasticsearch/hooks/elasticsearch.py
@@ -17,11 +17,11 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 from urllib import parse
 
+from deprecated import deprecated
 from elasticsearch import Elasticsearch
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
@@ -138,6 +138,10 @@ class ElasticsearchSQLHook(DbApiHook):
         return uri
 
 
+@deprecated(
+    reason="Please use `airflow.providers.elasticsearch.hooks.elasticsearch.ElasticsearchSQLHook`.",
+    category=AirflowProviderDeprecationWarning,
+)
 class ElasticsearchHook(ElasticsearchSQLHook):
     """
     This class is deprecated and was renamed to ElasticsearchSQLHook.
@@ -146,12 +150,6 @@ class ElasticsearchHook(ElasticsearchSQLHook):
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(
-            """This class is deprecated.
-            Please use `airflow.providers.elasticsearch.hooks.elasticsearch.ElasticsearchSQLHook`.""",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         super().__init__(*args, **kwargs)
 
 

--- a/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any, Callable, Collection, Container, Iterable
 
 import jwt
 import re2
+from deprecated import deprecated
 from flask import flash, g, has_request_context, session
 from flask_appbuilder import const
 from flask_appbuilder.const import (
@@ -688,12 +689,11 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         return self.appbuilder.get_app.config["AUTH_ROLE_ADMIN"]
 
     @property
+    @deprecated(
+        reason="The 'oauth_whitelists' property is deprecated. Please use 'oauth_allow_list' instead.",
+        category=AirflowProviderDeprecationWarning,
+    )
     def oauth_whitelists(self):
-        warnings.warn(
-            "The 'oauth_whitelists' property is deprecated. Please use 'oauth_allow_list' instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         return self.oauth_allow_list
 
     def create_builtin_roles(self):

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -25,12 +25,12 @@ import logging
 import re
 import time
 import uuid
-import warnings
 from copy import deepcopy
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, NoReturn, Sequence, Union, cast
 
 from aiohttp import ClientSession as ClientSession
+from deprecated import deprecated
 from gcloud.aio.bigquery import Job, Table as Table_async
 from google.cloud.bigquery import (
     DEFAULT_RETRY,
@@ -140,13 +140,12 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             hook=self,
         )
 
+    @deprecated(
+        reason=("Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_client`"),
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_service(self) -> Resource:
         """Get a BigQuery service object. Deprecated."""
-        warnings.warn(
-            "This method will be deprecated. Please use `BigQueryHook.get_client` method",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         http_authorized = self._authorize()
         return build("bigquery", "v2", http=http_authorized, cache_discovery=False)
 
@@ -538,6 +537,13 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             not_found_ok=True,
         )
 
+    @deprecated(
+        reason=(
+            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_table` "
+            "method with passing the `table_resource` object. This gives more flexibility than this method."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     @GoogleBaseHook.fallback_to_default_project_id
     def create_external_table(
         self,
@@ -621,12 +627,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
                     "kmsKeyName": "projects/testp/locations/us/keyRings/test-kr/cryptoKeys/test-key",
                 }
         """
-        warnings.warn(
-            "This method is deprecated. Please use `BigQueryHook.create_empty_table` method with "
-            "passing the `table_resource` object. This gives more flexibility than this method.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         location = location or self.location
         src_fmt_configs = src_fmt_configs or {}
         source_format = source_format.upper()
@@ -737,6 +737,12 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         self.log.info("Table %s.%s.%s updated successfully", project_id, dataset_id, table_id)
         return table_object.to_api_repr()
 
+    @deprecated(
+        reason=(
+            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.update_table` method."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     @GoogleBaseHook.fallback_to_default_project_id
     def patch_table(
         self,
@@ -807,11 +813,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
                 }
 
         """
-        warnings.warn(
-            "This method is deprecated, please use ``BigQueryHook.update_table`` method.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         table_resource: dict[str, Any] = {}
 
         if description is not None:
@@ -944,6 +945,12 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         self.log.info("Dataset successfully updated: %s", dataset)
         return dataset
 
+    @deprecated(
+        reason=(
+            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.update_dataset` method."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def patch_dataset(self, dataset_id: str, dataset_resource: dict, project_id: str | None = None) -> dict:
         """Patches information in an existing dataset.
 
@@ -960,11 +967,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets#resource
         :param project_id: The Google Cloud Project ID
         """
-        warnings.warn(
-            "This method is deprecated. Please use ``update_dataset``.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         project_id = project_id or self.project_id
         if not dataset_id or not isinstance(dataset_id, str):
             raise ValueError(
@@ -988,6 +990,12 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
 
         return dataset
 
+    @deprecated(
+        reason=(
+            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset_tables` method."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_dataset_tables_list(
         self,
         dataset_id: str,
@@ -1011,11 +1019,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             Leverage the page tokens to iterate through the entire collection.
         :return: List of tables associated with the dataset
         """
-        warnings.warn(
-            "This method is deprecated. Please use ``get_dataset_tables``.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         project_id = project_id or self.project_id
         tables = self.get_client().list_tables(
             dataset=DatasetReference(project=project_id, dataset_id=dataset_id),
@@ -1188,6 +1191,12 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             ).to_api_repr()
         return table
 
+    @deprecated(
+        reason=(
+            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.delete_table` method."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def run_table_delete(self, deletion_dataset_table: str, ignore_if_missing: bool = False) -> None:
         """Delete an existing table from the dataset.
 
@@ -1203,11 +1212,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             requested table does not exist.
         :return:
         """
-        warnings.warn(
-            "This method is deprecated. Please use `delete_table`.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         return self.delete_table(table_id=deletion_dataset_table, not_found_ok=ignore_if_missing)
 
     @GoogleBaseHook.fallback_to_default_project_id
@@ -1234,6 +1238,10 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         )
         self.log.info("Deleted table %s", table_id)
 
+    @deprecated(
+        reason=("Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.list_rows` method."),
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_tabledata(
         self,
         dataset_id: str,
@@ -1259,11 +1267,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :param start_index: zero based index of the starting row to read.
         :return: list of rows
         """
-        warnings.warn(
-            "This method is deprecated. Please use `list_rows`.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         rows = self.list_rows(
             dataset_id=dataset_id,
             table_id=table_id,
@@ -1466,13 +1469,12 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         job = self.get_client(project_id=project_id, location=location).get_job(job_id=job_id)
         return job.done(retry=retry)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.cancel_job`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def cancel_query(self) -> None:
         """Cancel all started queries that have not yet completed."""
-        warnings.warn(
-            "This method is deprecated. Please use `BigQueryHook.cancel_job`.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         if self.running_job_id:
             self.cancel_job(job_id=self.running_job_id)
         else:
@@ -1616,6 +1618,10 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             job_api_repr.result(timeout=timeout, retry=retry)
         return job_api_repr
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def run_with_configuration(self, configuration: dict) -> str:
         """Execute a BigQuery SQL query.
 
@@ -1628,15 +1634,14 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             https://cloud.google.com/bigquery/docs/reference/v2/jobs for
             details.
         """
-        warnings.warn(
-            "This method is deprecated. Please use `BigQueryHook.insert_job`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         job = self.insert_job(configuration=configuration, project_id=self.project_id)
         self.running_job_id = job.job_id
         return job.job_id
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def run_load(
         self,
         destination_project_dataset_table: str,
@@ -1726,12 +1731,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :param labels: A dictionary containing labels for the BiqQuery table.
         :param description: A string containing the description for the BigQuery table.
         """
-        warnings.warn(
-            "This method is deprecated. Please use `BigQueryHook.insert_job` method.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
-
         if not self.project_id:
             raise ValueError("The project_id should be set")
 
@@ -1879,6 +1878,10 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         self.running_job_id = job.job_id
         return job.job_id
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def run_copy(
         self,
         source_project_dataset_tables: list | str,
@@ -1914,11 +1917,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
                         "kmsKeyName": "projects/testp/locations/us/keyRings/test-kr/cryptoKeys/test-key",
                     }
         """
-        warnings.warn(
-            "This method is deprecated. Please use `BigQueryHook.insert_job` method.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         if not self.project_id:
             raise ValueError("The project_id should be set")
 
@@ -1965,6 +1963,10 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         self.running_job_id = job.job_id
         return job.job_id
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def run_extract(
         self,
         source_project_dataset_table: str,
@@ -1996,11 +1998,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             passed to BigQuery
         :param return_full_job: return full job instead of job id only
         """
-        warnings.warn(
-            "This method is deprecated. Please use `BigQueryHook.insert_job` method.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         if not self.project_id:
             raise ValueError("The project_id should be set")
 
@@ -2039,6 +2036,10 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             return job
         return job.job_id
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def run_query(
         self,
         sql: str,
@@ -2124,11 +2125,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
                         "kmsKeyName": "projects/testp/locations/us/keyRings/test-kr/cryptoKeys/test-key",
                     }
         """
-        warnings.warn(
-            "This method is deprecated. Please use `BigQueryHook.insert_job` method.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         if not self.project_id:
             raise ValueError("The project_id should be set")
 
@@ -2398,174 +2394,154 @@ class BigQueryBaseCursor(LoggingMixin):
         self.labels = labels
         self.hook = hook
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_table`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def create_empty_table(self, *args, **kwargs):
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_table`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_table`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.create_empty_table(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_dataset`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def create_empty_dataset(self, *args, **kwargs) -> dict[str, Any]:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_dataset`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_dataset`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.create_empty_dataset(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset_tables`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_dataset_tables(self, *args, **kwargs) -> list[dict[str, Any]]:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset_tables`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset_tables`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.get_dataset_tables(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.delete_dataset`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def delete_dataset(self, *args, **kwargs) -> None:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.delete_dataset`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.delete_dataset`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.delete_dataset(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_external_table`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def create_external_table(self, *args, **kwargs):
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_external_table`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_external_table`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.create_external_table(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.patch_table`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def patch_table(self, *args, **kwargs) -> None:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.patch_table`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.patch_table`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.patch_table(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_all`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def insert_all(self, *args, **kwargs) -> None:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_all`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_all`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.insert_all(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.update_dataset`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def update_dataset(self, *args, **kwargs) -> dict:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.update_dataset`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.update_dataset`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return Dataset.to_api_repr(self.hook.update_dataset(*args, **kwargs))
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.patch_dataset`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def patch_dataset(self, *args, **kwargs) -> dict:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.patch_dataset`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.patch_dataset`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.patch_dataset(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset_tables_list`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_dataset_tables_list(self, *args, **kwargs) -> list[dict[str, Any]]:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset_tables_list`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset_tables_list`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.get_dataset_tables_list(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_datasets_list`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_datasets_list(self, *args, **kwargs) -> list | HTTPIterator:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_datasets_list`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_datasets_list`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.get_datasets_list(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_dataset(self, *args, **kwargs) -> Dataset:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.get_dataset(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_grant_dataset_view_access`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def run_grant_dataset_view_access(self, *args, **kwargs) -> dict:
         """This method is deprecated.
 
@@ -2573,167 +2549,138 @@ class BigQueryBaseCursor(LoggingMixin):
         :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_grant_dataset_view_access`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks"
-            ".bigquery.BigQueryHook.run_grant_dataset_view_access`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.run_grant_dataset_view_access(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_table_upsert`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def run_table_upsert(self, *args, **kwargs) -> dict:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_table_upsert`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_table_upsert`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.run_table_upsert(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_table_delete`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def run_table_delete(self, *args, **kwargs) -> None:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_table_delete`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_table_delete`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.run_table_delete(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_tabledata`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_tabledata(self, *args, **kwargs) -> list[dict]:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_tabledata`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_tabledata`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.get_tabledata(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_schema`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_schema(self, *args, **kwargs) -> dict:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_schema`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_schema`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.get_schema(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.poll_job_complete`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def poll_job_complete(self, *args, **kwargs) -> bool:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.poll_job_complete`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.poll_job_complete`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.poll_job_complete(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.cancel_query`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def cancel_query(self, *args, **kwargs) -> None:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.cancel_query`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.cancel_query`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.cancel_query(*args, **kwargs)  # type: ignore
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def run_with_configuration(self, *args, **kwargs) -> str:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.run_with_configuration(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_load`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def run_load(self, *args, **kwargs) -> str:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_load`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_load`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.run_load(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_copy`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def run_copy(self, *args, **kwargs) -> str:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_copy`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_copy`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.run_copy(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_extract`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def run_extract(self, *args, **kwargs) -> str | BigQueryJob:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_extract`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_extract`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.run_extract(*args, **kwargs)
 
+    @deprecated(
+        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_query`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def run_query(self, *args, **kwargs) -> str:
         """This method is deprecated.
 
         Please use :func:`~airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_query`
         instead.
         """
-        warnings.warn(
-            "This method is deprecated. "
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_query`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
         return self.hook.run_query(*args, **kwargs)
 
 

--- a/airflow/providers/google/cloud/hooks/cloud_build.py
+++ b/airflow/providers/google/cloud/hooks/cloud_build.py
@@ -18,9 +18,9 @@
 """Hook for Google Cloud Build service."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
+from deprecated import deprecated
 from google.api_core.client_options import ClientOptions
 from google.api_core.exceptions import AlreadyExists
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
@@ -189,6 +189,10 @@ class CloudBuildHook(GoogleBaseHook):
         return operation, id_
 
     @GoogleBaseHook.fallback_to_default_project_id
+    @deprecated(
+        reason="Please use `create_build_without_waiting_for_result`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def create_build(
         self,
         build: dict | Build,
@@ -213,11 +217,6 @@ class CloudBuildHook(GoogleBaseHook):
         :param metadata: Optional, additional metadata that is provided to the method.
 
         """
-        warnings.warn(
-            "This method is deprecated. Please use `create_build_without_waiting_for_result`.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         client = self.get_conn()
 
         self.log.info("Start creating build...")

--- a/airflow/providers/google/cloud/hooks/dataflow.py
+++ b/airflow/providers/google/cloud/hooks/dataflow.py
@@ -29,6 +29,7 @@ import warnings
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Callable, Generator, Sequence, TypeVar, cast
 
+from deprecated import deprecated
 from google.cloud.dataflow_v1beta3 import GetJobRequest, Job, JobState, JobsV1Beta3AsyncClient, JobView
 from google.cloud.dataflow_v1beta3.types.jobs import ListJobsRequest
 from googleapiclient.discovery import build
@@ -567,6 +568,15 @@ class DataflowHook(GoogleBaseHook):
     @_fallback_to_location_from_variables
     @_fallback_to_project_id_from_variables
     @GoogleBaseHook.fallback_to_default_project_id
+    @deprecated(
+        reason=(
+            "This method is deprecated. "
+            "Please use `airflow.providers.apache.beam.hooks.beam.start.start_java_pipeline` "
+            "to start pipeline and `providers.google.cloud.hooks.dataflow.DataflowHook.wait_for_done` "
+            "to wait for the required pipeline state."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def start_java_dataflow(
         self,
         job_name: str,
@@ -593,16 +603,6 @@ class DataflowHook(GoogleBaseHook):
         :param on_new_job_id_callback: Callback called when the job ID is known.
         :param location: Job location.
         """
-        warnings.warn(
-            """"This method is deprecated.
-            Please use `airflow.providers.apache.beam.hooks.beam.start.start_java_pipeline`
-            to start pipeline and `providers.google.cloud.hooks.dataflow.DataflowHook.wait_for_done`
-            to wait for the required pipeline state.
-            """,
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
-
         name = self.build_dataflow_job_name(job_name, append_job_name)
 
         variables["jobName"] = name
@@ -816,6 +816,15 @@ class DataflowHook(GoogleBaseHook):
     @_fallback_to_location_from_variables
     @_fallback_to_project_id_from_variables
     @GoogleBaseHook.fallback_to_default_project_id
+    @deprecated(
+        reason=(
+            "This method is deprecated. "
+            "Please use `airflow.providers.apache.beam.hooks.beam.start.start_python_pipeline` "
+            "to start pipeline and `providers.google.cloud.hooks.dataflow.DataflowHook.wait_for_done` "
+            "to wait for the required pipeline state."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def start_python_dataflow(
         self,
         job_name: str,
@@ -859,16 +868,6 @@ class DataflowHook(GoogleBaseHook):
         :param on_new_job_id_callback: Callback called when the job ID is known.
         :param location: Job location.
         """
-        warnings.warn(
-            """This method is deprecated.
-            Please use `airflow.providers.apache.beam.hooks.beam.start.start_python_pipeline`
-            to start pipeline and `providers.google.cloud.hooks.dataflow.DataflowHook.wait_for_done`
-            to wait for the required pipeline state.
-            """,
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
-
         name = self.build_dataflow_job_name(job_name, append_job_name)
         variables["job_name"] = name
         variables["region"] = location

--- a/airflow/providers/google/cloud/hooks/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/hooks/kubernetes_engine.py
@@ -28,10 +28,10 @@ from __future__ import annotations
 import contextlib
 import json
 import time
-import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Sequence
 
+from deprecated import deprecated
 from gcloud.aio.auth import Token
 from google.api_core.exceptions import NotFound
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
@@ -99,22 +99,23 @@ class GKEHook(GoogleBaseHook):
 
     # To preserve backward compatibility
     # TODO: remove one day
+    @deprecated(
+        reason=(
+            "The get_conn method has been deprecated. "
+            "You should use the get_cluster_manager_client method."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_conn(self) -> container_v1.ClusterManagerClient:
-        warnings.warn(
-            "The get_conn method has been deprecated. You should use the get_cluster_manager_client method.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         return self.get_cluster_manager_client()
 
     # To preserve backward compatibility
     # TODO: remove one day
+    @deprecated(
+        reason="The get_client method has been deprecated. You should use the get_conn method.",
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_client(self) -> ClusterManagerClient:
-        warnings.warn(
-            "The get_client method has been deprecated. You should use the get_conn method.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         return self.get_conn()
 
     def wait_for_operation(self, operation: Operation, project_id: str | None = None) -> Operation:

--- a/airflow/providers/google/cloud/hooks/life_sciences.py
+++ b/airflow/providers/google/cloud/hooks/life_sciences.py
@@ -19,10 +19,10 @@
 from __future__ import annotations
 
 import time
-import warnings
 from typing import Sequence
 
 import google.api_core.path_template
+from deprecated import deprecated
 from googleapiclient.discovery import build
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
@@ -32,6 +32,15 @@ from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 TIME_TO_SLEEP_IN_SECONDS = 5
 
 
+@deprecated(
+    reason=(
+        "This hook is deprecated. Consider using "
+        "Google Cloud Batch Operators' hook instead. "
+        "The Life Sciences API (beta) will be discontinued "
+        "on July 8, 2025 in favor of Google Cloud Batch."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class LifeSciencesHook(GoogleBaseHook):
     """
     Hook for the Google Cloud Life Sciences APIs.
@@ -75,14 +84,6 @@ class LifeSciencesHook(GoogleBaseHook):
             impersonation_chain=impersonation_chain,
         )
         self.api_version = api_version
-
-        warnings.warn(
-            """This hook is deprecated. Consider using Google Cloud Batch Operators' hook instead.
-            The Life Sciences API (beta) will be discontinued on July 8, 2025 in favor
-            of Google Cloud Batch.""",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
 
     def get_conn(self) -> build:
         """

--- a/airflow/providers/google/cloud/hooks/vertex_ai/custom_job.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/custom_job.py
@@ -18,9 +18,9 @@
 """This module contains a Google Cloud Vertex AI hook."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
+from deprecated import deprecated
 from google.api_core.client_options import ClientOptions
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
 from google.cloud.aiplatform import (
@@ -358,6 +358,10 @@ class CustomJobHook(GoogleBaseHook):
         return model, training_id, custom_job_id
 
     @GoogleBaseHook.fallback_to_default_project_id
+    @deprecated(
+        reason="Please use `PipelineJobHook.cancel_pipeline_job`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def cancel_pipeline_job(
         self,
         project_id: str,
@@ -388,11 +392,6 @@ class CustomJobHook(GoogleBaseHook):
         :param timeout: The timeout for this request.
         :param metadata: Strings which should be sent along with the request as metadata.
         """
-        warnings.warn(
-            "This method is deprecated, please use `PipelineJobHook.cancel_pipeline_job` method.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         client = self.get_pipeline_service_client(region)
         name = client.pipeline_job_path(project_id, region, pipeline_job)
 
@@ -488,6 +487,10 @@ class CustomJobHook(GoogleBaseHook):
         )
 
     @GoogleBaseHook.fallback_to_default_project_id
+    @deprecated(
+        reason="Please use `PipelineJobHook.create_pipeline_job`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def create_pipeline_job(
         self,
         project_id: str,
@@ -514,11 +517,6 @@ class CustomJobHook(GoogleBaseHook):
         :param timeout: The timeout for this request.
         :param metadata: Strings which should be sent along with the request as metadata.
         """
-        warnings.warn(
-            "This method is deprecated, please use `PipelineJobHook.create_pipeline_job` method.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         client = self.get_pipeline_service_client(region)
         parent = client.common_location_path(project_id, region)
 
@@ -1755,6 +1753,10 @@ class CustomJobHook(GoogleBaseHook):
         return model, training_id, custom_job_id
 
     @GoogleBaseHook.fallback_to_default_project_id
+    @deprecated(
+        reason="Please use `PipelineJobHook.delete_pipeline_job`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def delete_pipeline_job(
         self,
         project_id: str,
@@ -1776,11 +1778,6 @@ class CustomJobHook(GoogleBaseHook):
         :param timeout: The timeout for this request.
         :param metadata: Strings which should be sent along with the request as metadata.
         """
-        warnings.warn(
-            "This method is deprecated, please use `PipelineJobHook.delete_pipeline_job` method.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         client = self.get_pipeline_service_client(region)
         name = client.pipeline_job_path(project_id, region, pipeline_job)
 
@@ -1861,6 +1858,10 @@ class CustomJobHook(GoogleBaseHook):
         return result
 
     @GoogleBaseHook.fallback_to_default_project_id
+    @deprecated(
+        reason="Please use `PipelineJobHook.get_pipeline_job`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_pipeline_job(
         self,
         project_id: str,
@@ -1882,11 +1883,6 @@ class CustomJobHook(GoogleBaseHook):
         :param timeout: The timeout for this request.
         :param metadata: Strings which should be sent along with the request as metadata.
         """
-        warnings.warn(
-            "This method is deprecated, please use `PipelineJobHook.get_pipeline_job` method.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         client = self.get_pipeline_service_client(region)
         name = client.pipeline_job_path(project_id, region, pipeline_job)
 
@@ -1967,6 +1963,10 @@ class CustomJobHook(GoogleBaseHook):
         return result
 
     @GoogleBaseHook.fallback_to_default_project_id
+    @deprecated(
+        reason="Please use `PipelineJobHook.list_pipeline_jobs`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def list_pipeline_jobs(
         self,
         project_id: str,
@@ -2039,11 +2039,6 @@ class CustomJobHook(GoogleBaseHook):
         :param timeout: The timeout for this request.
         :param metadata: Strings which should be sent along with the request as metadata.
         """
-        warnings.warn(
-            "This method is deprecated, please use `PipelineJobHook.list_pipeline_jobs` method.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         client = self.get_pipeline_service_client(region)
         parent = client.common_location_path(project_id, region)
 

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -25,6 +25,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, Iterable, Sequence, SupportsAbs
 
 import attr
+from deprecated import deprecated
 from google.api_core.exceptions import Conflict
 from google.cloud.bigquery import DEFAULT_RETRY, CopyJob, ExtractJob, LoadJob, QueryJob
 from google.cloud.bigquery.table import RowIterator
@@ -1087,6 +1088,10 @@ class BigQueryGetDataOperator(GoogleCloudBaseOperator):
         return event["records"]
 
 
+@deprecated(
+    reason="This operator is deprecated. Please use `BigQueryInsertJobOperator`.",
+    category=AirflowProviderDeprecationWarning,
+)
 class BigQueryExecuteQueryOperator(GoogleCloudBaseOperator):
     """Executes BigQuery SQL queries in a specific BigQuery database.
 
@@ -1211,12 +1216,6 @@ class BigQueryExecuteQueryOperator(GoogleCloudBaseOperator):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
-        warnings.warn(
-            "This operator is deprecated. Please use `BigQueryInsertJobOperator`.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
-
         self.sql = sql
         self.destination_dataset_table = destination_dataset_table
         self.write_disposition = write_disposition
@@ -2171,6 +2170,10 @@ class BigQueryGetDatasetTablesOperator(GoogleCloudBaseOperator):
         )
 
 
+@deprecated(
+    reason="This operator is deprecated. Please use BigQueryUpdateDatasetOperator.",
+    category=AirflowProviderDeprecationWarning,
+)
 class BigQueryPatchDatasetOperator(GoogleCloudBaseOperator):
     """Patch a dataset for your Project in BigQuery.
 
@@ -2215,11 +2218,6 @@ class BigQueryPatchDatasetOperator(GoogleCloudBaseOperator):
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
-        warnings.warn(
-            "This operator is deprecated. Please use BigQueryUpdateDatasetOperator.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         self.dataset_id = dataset_id
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id

--- a/airflow/providers/google/cloud/operators/dataflow.py
+++ b/airflow/providers/google/cloud/operators/dataflow.py
@@ -21,11 +21,12 @@ from __future__ import annotations
 import copy
 import re
 import uuid
-import warnings
 from contextlib import ExitStack
 from enum import Enum
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Sequence
+
+from deprecated import deprecated
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
@@ -167,6 +168,11 @@ class DataflowConfiguration:
         self.service_account = service_account
 
 
+# TODO: Remove one day
+@deprecated(
+    reason="Please use `providers.apache.beam.operators.beam.BeamRunJavaPipelineOperator` instead.",
+    category=AirflowProviderDeprecationWarning,
+)
 class DataflowCreateJavaJobOperator(GoogleCloudBaseOperator):
     """
     Start a Java Cloud Dataflow batch job; the parameters of the operation will be passed to the job.
@@ -353,13 +359,6 @@ class DataflowCreateJavaJobOperator(GoogleCloudBaseOperator):
         expected_terminal_state: str | None = None,
         **kwargs,
     ) -> None:
-        # TODO: Remove one day
-        warnings.warn(
-            f"The `{self.__class__.__name__}` operator is deprecated, "
-            f"please use `providers.apache.beam.operators.beam.BeamRunJavaPipelineOperator` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(**kwargs)
 
         dataflow_default_options = dataflow_default_options or {}
@@ -1029,6 +1028,11 @@ class DataflowStartSqlJobOperator(GoogleCloudBaseOperator):
             )
 
 
+# TODO: Remove one day
+@deprecated(
+    reason="Please use `providers.apache.beam.operators.beam.BeamRunPythonPipelineOperator` instead.",
+    category=AirflowProviderDeprecationWarning,
+)
 class DataflowCreatePythonJobOperator(GoogleCloudBaseOperator):
     """
     Launching Cloud Dataflow jobs written in python.
@@ -1151,13 +1155,6 @@ class DataflowCreatePythonJobOperator(GoogleCloudBaseOperator):
         wait_until_finished: bool | None = None,
         **kwargs,
     ) -> None:
-        # TODO: Remove one day
-        warnings.warn(
-            f"The `{self.__class__.__name__}` operator is deprecated, "
-            "please use `providers.apache.beam.operators.beam.BeamRunPythonPipelineOperator` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(**kwargs)
 
         self.py_file = py_file

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -31,6 +31,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Sequence
 
+from deprecated import deprecated
 from google.api_core.exceptions import AlreadyExists, NotFound
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
 from google.api_core.retry import Retry, exponential_sleep_generator
@@ -872,6 +873,11 @@ class DataprocCreateClusterOperator(GoogleCloudBaseOperator):
         return event["cluster"]
 
 
+# TODO: Remove one day
+@deprecated(
+    reason="Please use `DataprocUpdateClusterOperator` instead.",
+    category=AirflowProviderDeprecationWarning,
+)
 class DataprocScaleClusterOperator(GoogleCloudBaseOperator):
     """Scale, up or down, a cluster on Google Cloud Dataproc.
 
@@ -939,14 +945,6 @@ class DataprocScaleClusterOperator(GoogleCloudBaseOperator):
         self.graceful_decommission_timeout = graceful_decommission_timeout
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
-
-        # TODO: Remove one day
-        warnings.warn(
-            f"The `{type(self).__name__}` operator is deprecated, "
-            "please use `DataprocUpdateClusterOperator` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
 
     def _build_scale_cluster_data(self) -> dict:
         scale_data = {
@@ -1491,6 +1489,15 @@ class DataprocJobBaseOperator(GoogleCloudBaseOperator):
             self.hook.cancel_job(project_id=self.project_id, job_id=self.dataproc_job_id, region=self.region)
 
 
+# TODO: Remove one day
+@deprecated(
+    reason=(
+        "Please use `DataprocSubmitJobOperator` instead. "
+        "You can use `generate_job` method to generate dictionary representing your job "
+        "and use it with the new operator."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class DataprocSubmitPigJobOperator(DataprocJobBaseOperator):
     """Start a Pig query Job on a Cloud DataProc cluster.
 
@@ -1565,15 +1572,6 @@ class DataprocSubmitPigJobOperator(DataprocJobBaseOperator):
         dataproc_jars: list[str] | None = None,
         **kwargs,
     ) -> None:
-        # TODO: Remove one day
-        warnings.warn(
-            "The `{cls}` operator is deprecated, please use `DataprocSubmitJobOperator` instead. You can use"
-            " `generate_job` method of `{cls}` to generate dictionary representing your job"
-            " and use it with the new operator.".format(cls=type(self).__name__),
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
-
         super().__init__(
             impersonation_chain=impersonation_chain,
             region=region,
@@ -1617,6 +1615,15 @@ class DataprocSubmitPigJobOperator(DataprocJobBaseOperator):
         super().execute(context)
 
 
+# TODO: Remove one day
+@deprecated(
+    reason=(
+        "Please use `DataprocSubmitJobOperator` instead. "
+        "You can use `generate_job` method to generate dictionary representing your job "
+        "and use it with the new operator."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class DataprocSubmitHiveJobOperator(DataprocJobBaseOperator):
     """Start a Hive query Job on a Cloud DataProc cluster.
 
@@ -1657,15 +1664,6 @@ class DataprocSubmitHiveJobOperator(DataprocJobBaseOperator):
         dataproc_jars: list[str] | None = None,
         **kwargs,
     ) -> None:
-        # TODO: Remove one day
-        warnings.warn(
-            "The `{cls}` operator is deprecated, please use `DataprocSubmitJobOperator` instead. You can use"
-            " `generate_job` method of `{cls}` to generate dictionary representing your job"
-            " and use it with the new operator.".format(cls=type(self).__name__),
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
-
         super().__init__(
             impersonation_chain=impersonation_chain,
             region=region,
@@ -1709,6 +1707,15 @@ class DataprocSubmitHiveJobOperator(DataprocJobBaseOperator):
         super().execute(context)
 
 
+# TODO: Remove one day
+@deprecated(
+    reason=(
+        "Please use `DataprocSubmitJobOperator` instead. "
+        "You can use `generate_job` method to generate dictionary representing your job "
+        "and use it with the new operator."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class DataprocSubmitSparkSqlJobOperator(DataprocJobBaseOperator):
     """Start a Spark SQL query Job on a Cloud DataProc cluster.
 
@@ -1750,15 +1757,6 @@ class DataprocSubmitSparkSqlJobOperator(DataprocJobBaseOperator):
         dataproc_jars: list[str] | None = None,
         **kwargs,
     ) -> None:
-        # TODO: Remove one day
-        warnings.warn(
-            "The `{cls}` operator is deprecated, please use `DataprocSubmitJobOperator` instead. You can use"
-            " `generate_job` method of `{cls}` to generate dictionary representing your job"
-            " and use it with the new operator.".format(cls=type(self).__name__),
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
-
         super().__init__(
             impersonation_chain=impersonation_chain,
             region=region,
@@ -1800,6 +1798,15 @@ class DataprocSubmitSparkSqlJobOperator(DataprocJobBaseOperator):
         super().execute(context)
 
 
+# TODO: Remove one day
+@deprecated(
+    reason=(
+        "Please use `DataprocSubmitJobOperator` instead. "
+        "You can use `generate_job` method to generate dictionary representing your job "
+        "and use it with the new operator."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class DataprocSubmitSparkJobOperator(DataprocJobBaseOperator):
     """Start a Spark Job on a Cloud DataProc cluster.
 
@@ -1845,15 +1852,6 @@ class DataprocSubmitSparkJobOperator(DataprocJobBaseOperator):
         dataproc_jars: list[str] | None = None,
         **kwargs,
     ) -> None:
-        # TODO: Remove one day
-        warnings.warn(
-            "The `{cls}` operator is deprecated, please use `DataprocSubmitJobOperator` instead. You can use"
-            " `generate_job` method of `{cls}` to generate dictionary representing your job"
-            " and use it with the new operator.".format(cls=type(self).__name__),
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
-
         super().__init__(
             impersonation_chain=impersonation_chain,
             region=region,
@@ -1891,6 +1889,15 @@ class DataprocSubmitSparkJobOperator(DataprocJobBaseOperator):
         super().execute(context)
 
 
+# TODO: Remove one day
+@deprecated(
+    reason=(
+        "Please use `DataprocSubmitJobOperator` instead. "
+        "You can use `generate_job` method to generate dictionary representing your job "
+        "and use it with the new operator."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class DataprocSubmitHadoopJobOperator(DataprocJobBaseOperator):
     """Start a Hadoop Job on a Cloud DataProc cluster.
 
@@ -1936,15 +1943,6 @@ class DataprocSubmitHadoopJobOperator(DataprocJobBaseOperator):
         dataproc_jars: list[str] | None = None,
         **kwargs,
     ) -> None:
-        # TODO: Remove one day
-        warnings.warn(
-            "The `{cls}` operator is deprecated, please use `DataprocSubmitJobOperator` instead. You can use"
-            " `generate_job` method of `{cls}` to generate dictionary representing your job"
-            " and use it with the new operator.".format(cls=type(self).__name__),
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
-
         super().__init__(
             impersonation_chain=impersonation_chain,
             region=region,
@@ -1981,6 +1979,15 @@ class DataprocSubmitHadoopJobOperator(DataprocJobBaseOperator):
         super().execute(context)
 
 
+# TODO: Remove one day
+@deprecated(
+    reason=(
+        "Please use `DataprocSubmitJobOperator` instead. "
+        "You can use `generate_job` method to generate dictionary representing your job "
+        "and use it with the new operator."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class DataprocSubmitPySparkJobOperator(DataprocJobBaseOperator):
     """Start a PySpark Job on a Cloud DataProc cluster.
 
@@ -2050,15 +2057,6 @@ class DataprocSubmitPySparkJobOperator(DataprocJobBaseOperator):
         dataproc_jars: list[str] | None = None,
         **kwargs,
     ) -> None:
-        # TODO: Remove one day
-        warnings.warn(
-            "The `{cls}` operator is deprecated, please use `DataprocSubmitJobOperator` instead. You can use"
-            " `generate_job` method of `{cls}` to generate dictionary representing your job"
-            " and use it with the new operator.".format(cls=type(self).__name__),
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
-
         super().__init__(
             impersonation_chain=impersonation_chain,
             region=region,

--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -22,6 +22,7 @@ import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Sequence
 
+from deprecated import deprecated
 from google.api_core.exceptions import AlreadyExists
 from google.cloud.container_v1.types import Cluster
 
@@ -510,13 +511,12 @@ class GKEStartPodOperator(KubernetesPodOperator):
             raise AirflowException("config_file is not an allowed parameter for the GKEStartPodOperator.")
 
     @staticmethod
+    @deprecated(
+        reason="Please use `fetch_cluster_info` instead to get the cluster info for connecting to it.",
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_gke_config_file():
-        warnings.warn(
-            "The `get_gke_config_file` method is deprecated, "
-            "please use `fetch_cluster_info` instead to get the cluster info for connecting to it.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
+        pass
 
     @cached_property
     def cluster_hook(self) -> GKEHook:

--- a/airflow/providers/google/cloud/operators/life_sciences.py
+++ b/airflow/providers/google/cloud/operators/life_sciences.py
@@ -18,8 +18,9 @@
 """Operators that interact with Google Cloud Life Sciences service."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Sequence
+
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.google.cloud.hooks.life_sciences import LifeSciencesHook
@@ -30,6 +31,14 @@ if TYPE_CHECKING:
     from airflow.utils.context import Context
 
 
+@deprecated(
+    reason=(
+        "Consider using Google Cloud Batch Operators instead."
+        "The Life Sciences API (beta) will be discontinued "
+        "on July 8, 2025 in favor of Google Cloud Batch."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class LifeSciencesRunPipelineOperator(GoogleCloudBaseOperator):
     """
     Runs a Life Sciences Pipeline.
@@ -86,14 +95,6 @@ class LifeSciencesRunPipelineOperator(GoogleCloudBaseOperator):
         self.api_version = api_version
         self._validate_inputs()
         self.impersonation_chain = impersonation_chain
-
-        warnings.warn(
-            """This operator is deprecated. Consider using Google Cloud Batch Operators instead.
-            The Life Sciences API (beta) will be discontinued on July 8, 2025 in favor
-            of Google Cloud Batch.""",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
 
     def _validate_inputs(self) -> None:
         if not self.body:

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -22,9 +22,9 @@ from __future__ import annotations
 import logging
 import re
 import time
-import warnings
 from typing import TYPE_CHECKING, Any, Sequence
 
+from deprecated import deprecated
 from googleapiclient.errors import HttpError
 
 from airflow.configuration import conf
@@ -78,6 +78,14 @@ def _normalize_mlengine_job_id(job_id: str) -> str:
     return cleansed_job_id
 
 
+@deprecated(
+    reason=(
+        "This operator is deprecated. All the functionality of legacy "
+        "MLEngine and new features are available on the Vertex AI platform. "
+        "Please use `CreateBatchPredictionJobOperator`"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class MLEngineStartBatchPredictionJobOperator(GoogleCloudBaseOperator):
     """
     Start a Google Cloud ML Engine prediction job.
@@ -214,14 +222,6 @@ class MLEngineStartBatchPredictionJobOperator(GoogleCloudBaseOperator):
         self._labels = labels
         self._impersonation_chain = impersonation_chain
 
-        warnings.warn(
-            "This operator is deprecated. All the functionality of legacy "
-            "MLEngine and new features are available on the Vertex AI platform. "
-            "Please use `CreateBatchPredictionJobOperator`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
-
         if not self._project_id:
             raise AirflowException("Google Cloud project id is required.")
         if not self._job_id:
@@ -296,6 +296,13 @@ class MLEngineStartBatchPredictionJobOperator(GoogleCloudBaseOperator):
         return finished_prediction_job["predictionOutput"]
 
 
+@deprecated(
+    reason=(
+        "This operator is deprecated. Consider using operators for specific operations: "
+        "MLEngineCreateModelOperator, MLEngineGetModelOperator."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class MLEngineManageModelOperator(GoogleCloudBaseOperator):
     """
     Operator for managing a Google Cloud ML Engine model.
@@ -345,14 +352,6 @@ class MLEngineManageModelOperator(GoogleCloudBaseOperator):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
-
-        warnings.warn(
-            "This operator is deprecated. Consider using operators for specific operations: "
-            "MLEngineCreateModelOperator, MLEngineGetModelOperator.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
-
         self._project_id = project_id
         self._model = model
         self._operation = operation
@@ -372,6 +371,14 @@ class MLEngineManageModelOperator(GoogleCloudBaseOperator):
             raise ValueError(f"Unknown operation: {self._operation}")
 
 
+@deprecated(
+    reason=(
+        "This operator is deprecated. All the functionality of legacy "
+        "MLEngine and new features are available on the Vertex AI platform. "
+        "Please use appropriate VertexAI operator."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class MLEngineCreateModelOperator(GoogleCloudBaseOperator):
     """
     Creates a new model.
@@ -422,14 +429,6 @@ class MLEngineCreateModelOperator(GoogleCloudBaseOperator):
         self._gcp_conn_id = gcp_conn_id
         self._impersonation_chain = impersonation_chain
 
-        warnings.warn(
-            "This operator is deprecated. All the functionality of legacy "
-            "MLEngine and new features are available on the Vertex AI platform. "
-            "Please use appropriate VertexAI operator.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
-
     def execute(self, context: Context):
         hook = MLEngineHook(
             gcp_conn_id=self._gcp_conn_id,
@@ -448,6 +447,14 @@ class MLEngineCreateModelOperator(GoogleCloudBaseOperator):
         return hook.create_model(project_id=self._project_id, model=self._model)
 
 
+@deprecated(
+    reason=(
+        "This operator is deprecated. All the functionality of legacy "
+        "MLEngine and new features are available on the Vertex AI platform. "
+        "Please use `GetModelOperator`"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class MLEngineGetModelOperator(GoogleCloudBaseOperator):
     """
     Gets a particular model.
@@ -498,14 +505,6 @@ class MLEngineGetModelOperator(GoogleCloudBaseOperator):
         self._gcp_conn_id = gcp_conn_id
         self._impersonation_chain = impersonation_chain
 
-        warnings.warn(
-            "This operator is deprecated. All the functionality of legacy "
-            "MLEngine and new features are available on the Vertex AI platform. "
-            "Please use `GetModelOperator`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
-
     def execute(self, context: Context):
         hook = MLEngineHook(
             gcp_conn_id=self._gcp_conn_id,
@@ -523,6 +522,14 @@ class MLEngineGetModelOperator(GoogleCloudBaseOperator):
         return hook.get_model(project_id=self._project_id, model_name=self._model_name)
 
 
+@deprecated(
+    reason=(
+        "This operator is deprecated. All the functionality of legacy "
+        "MLEngine and new features are available on the Vertex AI platform. "
+        "Please use `DeleteModelOperator`"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class MLEngineDeleteModelOperator(GoogleCloudBaseOperator):
     """
     Deletes a model.
@@ -579,14 +586,6 @@ class MLEngineDeleteModelOperator(GoogleCloudBaseOperator):
         self._gcp_conn_id = gcp_conn_id
         self._impersonation_chain = impersonation_chain
 
-        warnings.warn(
-            "This operator is deprecated. All the functionality of legacy "
-            "MLEngine and new features are available on the Vertex AI platform. "
-            "Please use `DeleteModelOperator`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
-
     def execute(self, context: Context):
         hook = MLEngineHook(
             gcp_conn_id=self._gcp_conn_id,
@@ -606,6 +605,14 @@ class MLEngineDeleteModelOperator(GoogleCloudBaseOperator):
         )
 
 
+@deprecated(
+    reason=(
+        "This operator is deprecated. Consider using operators for specific operations: "
+        "MLEngineCreateVersion, MLEngineSetDefaultVersion, "
+        "MLEngineListVersions, MLEngineDeleteVersion."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class MLEngineManageVersionOperator(GoogleCloudBaseOperator):
     """
     Operator for managing a Google Cloud ML Engine version.
@@ -688,13 +695,6 @@ class MLEngineManageVersionOperator(GoogleCloudBaseOperator):
         self._gcp_conn_id = gcp_conn_id
         self._impersonation_chain = impersonation_chain
 
-        warnings.warn(
-            "This operator is deprecated. Consider using operators for specific operations: "
-            "MLEngineCreateVersion, MLEngineSetDefaultVersion, MLEngineListVersions, MLEngineDeleteVersion.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
-
     def execute(self, context: Context):
         if "name" not in self._version:
             self._version["name"] = self._version_name
@@ -724,6 +724,14 @@ class MLEngineManageVersionOperator(GoogleCloudBaseOperator):
             raise ValueError(f"Unknown operation: {self._operation}")
 
 
+@deprecated(
+    reason=(
+        "This operator is deprecated. All the functionality of legacy "
+        "MLEngine and new features are available on the Vertex AI platform. "
+        "Please use parent_model parameter for VertexAI operators instead."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class MLEngineCreateVersionOperator(GoogleCloudBaseOperator):
     """
     Creates a new version in the model.
@@ -779,14 +787,6 @@ class MLEngineCreateVersionOperator(GoogleCloudBaseOperator):
         self._impersonation_chain = impersonation_chain
         self._validate_inputs()
 
-        warnings.warn(
-            "This operator is deprecated. All the functionality of legacy "
-            "MLEngine and new features are available on the Vertex AI platform. "
-            "Please use parent_model parameter for VertexAI operators instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
-
     def _validate_inputs(self):
         if not self._model_name:
             raise AirflowException("The model_name parameter could not be empty.")
@@ -815,6 +815,14 @@ class MLEngineCreateVersionOperator(GoogleCloudBaseOperator):
         )
 
 
+@deprecated(
+    reason=(
+        "This operator is deprecated. All the functionality of legacy "
+        "MLEngine and new features are available on the Vertex AI platform. "
+        "Please use `SetDefaultVersionOnModelOperator`"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class MLEngineSetDefaultVersionOperator(GoogleCloudBaseOperator):
     """
     Sets a version in the model.
@@ -872,14 +880,6 @@ class MLEngineSetDefaultVersionOperator(GoogleCloudBaseOperator):
         self._impersonation_chain = impersonation_chain
         self._validate_inputs()
 
-        warnings.warn(
-            "This operator is deprecated. All the functionality of legacy "
-            "MLEngine and new features are available on the Vertex AI platform. "
-            "Please use `SetDefaultVersionOnModelOperator` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
-
     def _validate_inputs(self):
         if not self._model_name:
             raise AirflowException("The model_name parameter could not be empty.")
@@ -908,6 +908,14 @@ class MLEngineSetDefaultVersionOperator(GoogleCloudBaseOperator):
         )
 
 
+@deprecated(
+    reason=(
+        "This operator is deprecated. All the functionality of legacy "
+        "MLEngine and new features are available on the Vertex AI platform. "
+        "Please use `ListModelVersionsOperator`"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class MLEngineListVersionsOperator(GoogleCloudBaseOperator):
     """
     Lists all available versions of the model.
@@ -961,14 +969,6 @@ class MLEngineListVersionsOperator(GoogleCloudBaseOperator):
         self._impersonation_chain = impersonation_chain
         self._validate_inputs()
 
-        warnings.warn(
-            "This operator is deprecated. All the functionality of legacy "
-            "MLEngine and new features are available on the Vertex AI platform. "
-            "Please use `ListModelVersionsOperator` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
-
     def _validate_inputs(self):
         if not self._model_name:
             raise AirflowException("The model_name parameter could not be empty.")
@@ -994,6 +994,14 @@ class MLEngineListVersionsOperator(GoogleCloudBaseOperator):
         )
 
 
+@deprecated(
+    reason=(
+        "This operator is deprecated. All the functionality of legacy "
+        "MLEngine and new features are available on the Vertex AI platform. "
+        "Please use `DeleteModelVersionOperator`"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class MLEngineDeleteVersionOperator(GoogleCloudBaseOperator):
     """
     Deletes the version from the model.
@@ -1051,14 +1059,6 @@ class MLEngineDeleteVersionOperator(GoogleCloudBaseOperator):
         self._impersonation_chain = impersonation_chain
         self._validate_inputs()
 
-        warnings.warn(
-            "This operator is deprecated. All the functionality of legacy "
-            "MLEngine and new features are available on the Vertex AI platform. "
-            "Please use `DeleteModelVersionOperator` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
-
     def _validate_inputs(self):
         if not self._model_name:
             raise AirflowException("The model_name parameter could not be empty.")
@@ -1086,6 +1086,14 @@ class MLEngineDeleteVersionOperator(GoogleCloudBaseOperator):
         )
 
 
+@deprecated(
+    reason=(
+        "This operator is deprecated. All the functionality of legacy "
+        "MLEngine and new features are available on the Vertex AI platform. "
+        "Please use `CreateCustomPythonPackageTrainingJobOperator`"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class MLEngineStartTrainingJobOperator(GoogleCloudBaseOperator):
     """
     Operator for launching a MLEngine training job.
@@ -1219,14 +1227,6 @@ class MLEngineStartTrainingJobOperator(GoogleCloudBaseOperator):
         self._impersonation_chain = impersonation_chain
         self.deferrable = deferrable
         self.cancel_on_kill = cancel_on_kill
-
-        warnings.warn(
-            "This operator is deprecated. All the functionality of legacy "
-            "MLEngine and new features are available on the Vertex AI platform. "
-            "Please use `CreateCustomPythonPackageTrainingJobOperator` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
 
         custom = self._scale_tier is not None and self._scale_tier.upper() == "CUSTOM"
         custom_image = (
@@ -1428,6 +1428,14 @@ class MLEngineStartTrainingJobOperator(GoogleCloudBaseOperator):
             self.log.info("Skipping to cancel job: %s:%s.%s", self._project_id, self.job_id)
 
 
+@deprecated(
+    reason=(
+        "This operator is deprecated. All the functionality of legacy "
+        "MLEngine and new features are available on the Vertex AI platform. "
+        "Please use `CancelCustomTrainingJobOperator`"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class MLEngineTrainingCancelJobOperator(GoogleCloudBaseOperator):
     """
     Operator for cleaning up failed MLEngine training job.
@@ -1473,14 +1481,6 @@ class MLEngineTrainingCancelJobOperator(GoogleCloudBaseOperator):
         self._job_id = job_id
         self._gcp_conn_id = gcp_conn_id
         self._impersonation_chain = impersonation_chain
-
-        warnings.warn(
-            "This operator is deprecated. All the functionality of legacy "
-            "MLEngine and new features are available on the Vertex AI platform. "
-            "Please use `CancelCustomTrainingJobOperator` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=3,
-        )
 
         if not self._project_id:
             raise AirflowException("Google Cloud project id is required.")

--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -18,9 +18,9 @@
 from __future__ import annotations
 
 import logging
-import warnings
 from typing import Sequence
 
+from deprecated import deprecated
 from google.auth.exceptions import DefaultCredentialsError
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
@@ -159,6 +159,13 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
 
         return self._get_secret(self.connections_prefix, conn_id)
 
+    @deprecated(
+        reason=(
+            "Method `CloudSecretManagerBackend.get_conn_uri` is deprecated and will be removed "
+            "in a future release.  Please use method `get_conn_value` instead."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_conn_uri(self, conn_id: str) -> str | None:
         """
         Return URI representation of Connection conn_id.
@@ -168,12 +175,6 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
         :param conn_id: the connection id
         :return: deserialized Connection
         """
-        warnings.warn(
-            f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
-            "in a future release.  Please use method `get_conn_value` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         return self.get_conn_value(conn_id)
 
     def get_variable(self, key: str) -> str | None:

--- a/airflow/providers/google/cloud/sensors/bigquery.py
+++ b/airflow/providers/google/cloud/sensors/bigquery.py
@@ -22,6 +22,8 @@ import warnings
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Sequence
 
+from deprecated import deprecated
+
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
@@ -269,6 +271,15 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
         raise AirflowException(message)
 
 
+@deprecated(
+    reason=(
+        "Class `BigQueryTableExistenceAsyncSensor` is deprecated and "
+        "will be removed in a future release. "
+        "Please use `BigQueryTableExistenceSensor` and "
+        "set `deferrable` attribute to `True` instead"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class BigQueryTableExistenceAsyncSensor(BigQueryTableExistenceSensor):
     """
     Checks for the existence of a table in Google Big Query.
@@ -299,17 +310,18 @@ class BigQueryTableExistenceAsyncSensor(BigQueryTableExistenceSensor):
     """
 
     def __init__(self, **kwargs):
-        warnings.warn(
-            "Class `BigQueryTableExistenceAsyncSensor` is deprecated and "
-            "will be removed in a future release. "
-            "Please use `BigQueryTableExistenceSensor` and "
-            "set `deferrable` attribute to `True` instead",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(deferrable=True, **kwargs)
 
 
+@deprecated(
+    reason=(
+        "Class `BigQueryTableExistencePartitionAsyncSensor` is deprecated and "
+        "will be removed in a future release. "
+        "Please use `BigQueryTablePartitionExistenceSensor` and "
+        "set `deferrable` attribute to `True` instead"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class BigQueryTableExistencePartitionAsyncSensor(BigQueryTablePartitionExistenceSensor):
     """
     Checks for the existence of a partition within a table in Google BigQuery.
@@ -341,12 +353,4 @@ class BigQueryTableExistencePartitionAsyncSensor(BigQueryTablePartitionExistence
     """
 
     def __init__(self, **kwargs):
-        warnings.warn(
-            "Class `BigQueryTableExistencePartitionAsyncSensor` is deprecated and "
-            "will be removed in a future release. "
-            "Please use `BigQueryTablePartitionExistenceSensor` and "
-            "set `deferrable` attribute to `True` instead",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(deferrable=True, **kwargs)

--- a/airflow/providers/google/cloud/sensors/cloud_composer.py
+++ b/airflow/providers/google/cloud/sensors/cloud_composer.py
@@ -19,8 +19,9 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any, Sequence
+
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
 from airflow.providers.google.cloud.triggers.cloud_composer import CloudComposerExecutionTrigger
@@ -30,6 +31,15 @@ if TYPE_CHECKING:
     from airflow.utils.context import Context
 
 
+@deprecated(
+    reason=(
+        "The `CloudComposerEnvironmentSensor` operator is deprecated. "
+        "You can achieve the same functionality "
+        "by using operators in deferrable or non-deferrable mode, since every operator for Cloud "
+        "Composer will wait for the operation to complete."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class CloudComposerEnvironmentSensor(BaseSensorOperator):
     """
     Check the status of the Cloud Composer Environment task.
@@ -65,13 +75,6 @@ class CloudComposerEnvironmentSensor(BaseSensorOperator):
         pooling_period_seconds: int = 30,
         **kwargs,
     ):
-        warnings.warn(
-            f"The `{self.__class__.__name__}` operator is deprecated. You can achieve the same functionality "
-            f"by using operators in deferrable or non-deferrable mode, since every operator for Cloud "
-            f"Composer will wait for the operation to complete.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(**kwargs)
         self.project_id = project_id
         self.region = region

--- a/airflow/providers/google/cloud/sensors/gcs.py
+++ b/airflow/providers/google/cloud/sensors/gcs.py
@@ -20,10 +20,10 @@ from __future__ import annotations
 
 import os
 import textwrap
-import warnings
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Callable, Sequence
 
+from deprecated import deprecated
 from google.cloud.storage.retry import DEFAULT_RETRY
 
 from airflow.configuration import conf
@@ -142,6 +142,13 @@ class GCSObjectExistenceSensor(BaseSensorOperator):
         return event["message"]
 
 
+@deprecated(
+    reason=(
+        "Class `GCSObjectExistenceAsyncSensor` is deprecated and will be removed in a future release. "
+        "Please use `GCSObjectExistenceSensor` and set `deferrable` attribute to `True` instead"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class GCSObjectExistenceAsyncSensor(GCSObjectExistenceSensor):
     """
     Checks for the existence of a file in Google Cloud Storage.
@@ -165,12 +172,6 @@ class GCSObjectExistenceAsyncSensor(GCSObjectExistenceSensor):
     """
 
     def __init__(self, **kwargs: Any) -> None:
-        warnings.warn(
-            "Class `GCSObjectExistenceAsyncSensor` is deprecated and will be removed in a future release. "
-            "Please use `GCSObjectExistenceSensor` and set `deferrable` attribute to `True` instead",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(deferrable=True, **kwargs)
 
 

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -24,7 +24,6 @@ import json
 import logging
 import os
 import tempfile
-import warnings
 from contextlib import ExitStack, contextmanager
 from subprocess import check_output
 from typing import TYPE_CHECKING, Any, Callable, Generator, Sequence, TypeVar, cast
@@ -36,6 +35,7 @@ import google_auth_httplib2
 import requests
 import tenacity
 from asgiref.sync import sync_to_async
+from deprecated import deprecated
 from gcloud.aio.auth.token import Token
 from google.api_core.exceptions import Forbidden, ResourceExhausted, TooManyRequests
 from google.auth import _cloud_sdk, compute_engine  # type: ignore[attr-defined]
@@ -390,6 +390,10 @@ class GoogleBaseHook(BaseHook):
             )
 
     @property
+    @deprecated(
+        reason="Please use `airflow.providers.google.common.consts.CLIENT_INFO`.",
+        category=AirflowProviderDeprecationWarning,
+    )
     def client_info(self) -> ClientInfo:
         """
         Return client information used to generate a user-agent for API calls.
@@ -400,11 +404,6 @@ class GoogleBaseHook(BaseHook):
         the Google Cloud. It is not supported by The Google APIs Python Client that use Discovery
         based APIs.
         """
-        warnings.warn(
-            "This method is deprecated, please use `airflow.providers.google.common.consts.CLIENT_INFO`.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         return CLIENT_INFO
 
     @property

--- a/airflow/providers/google/marketing_platform/hooks/analytics.py
+++ b/airflow/providers/google/marketing_platform/hooks/analytics.py
@@ -17,9 +17,9 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import Any
 
+from deprecated import deprecated
 from googleapiclient.discovery import Resource, build
 from googleapiclient.http import MediaFileUpload
 
@@ -27,18 +27,15 @@ from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
+@deprecated(
+    reason="The `GoogleAnalyticsHook` class is deprecated, please use `GoogleAnalyticsAdminHook` instead.",
+    category=AirflowProviderDeprecationWarning,
+)
 class GoogleAnalyticsHook(GoogleBaseHook):
     """Hook for Google Analytics 360."""
 
     def __init__(self, api_version: str = "v3", *args, **kwargs):
         super().__init__(*args, **kwargs)
-        warnings.warn(
-            f"The `{type(self).__name__}` class is deprecated, please use "
-            f"`GoogleAnalyticsAdminHook` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
-
         self.api_version = api_version
         self._conn = None
 

--- a/airflow/providers/google/marketing_platform/operators/analytics.py
+++ b/airflow/providers/google/marketing_platform/operators/analytics.py
@@ -19,9 +19,10 @@
 from __future__ import annotations
 
 import csv
-import warnings
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Any, Sequence
+
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
@@ -32,6 +33,13 @@ if TYPE_CHECKING:
     from airflow.utils.context import Context
 
 
+@deprecated(
+    reason=(
+        "The `GoogleAnalyticsListAccountsOperator` class is deprecated, please use "
+        "`GoogleAnalyticsAdminListAccountsOperator` instead."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class GoogleAnalyticsListAccountsOperator(BaseOperator):
     """
     Lists all accounts to which the user has access.
@@ -76,13 +84,6 @@ class GoogleAnalyticsListAccountsOperator(BaseOperator):
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
-        warnings.warn(
-            f"The `{type(self).__name__}` operator is deprecated, please use "
-            f"`GoogleAnalyticsAdminListAccountsOperator` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
-
         super().__init__(**kwargs)
 
         self.api_version = api_version
@@ -99,6 +100,13 @@ class GoogleAnalyticsListAccountsOperator(BaseOperator):
         return result
 
 
+@deprecated(
+    reason=(
+        "The `GoogleAnalyticsGetAdsLinkOperator` class is deprecated, please use "
+        "`GoogleAnalyticsAdminGetGoogleAdsLinkOperator` instead."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class GoogleAnalyticsGetAdsLinkOperator(BaseOperator):
     """
     Returns a web property-Google Ads link to which the user has access.
@@ -149,12 +157,6 @@ class GoogleAnalyticsGetAdsLinkOperator(BaseOperator):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        warnings.warn(
-            f"The `{type(self).__name__}` operator is deprecated, please use "
-            f"`GoogleAnalyticsAdminGetGoogleAdsLinkOperator` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
 
         self.account_id = account_id
         self.web_property_ad_words_link_id = web_property_ad_words_link_id
@@ -177,6 +179,13 @@ class GoogleAnalyticsGetAdsLinkOperator(BaseOperator):
         return result
 
 
+@deprecated(
+    reason=(
+        "The `GoogleAnalyticsRetrieveAdsLinksListOperator` class is deprecated, please use "
+        "`GoogleAnalyticsAdminListGoogleAdsLinksOperator` instead."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class GoogleAnalyticsRetrieveAdsLinksListOperator(BaseOperator):
     """
     Lists webProperty-Google Ads links for a given web property.
@@ -224,12 +233,6 @@ class GoogleAnalyticsRetrieveAdsLinksListOperator(BaseOperator):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
-        warnings.warn(
-            f"The `{type(self).__name__}` operator is deprecated, please use "
-            f"`GoogleAnalyticsAdminListGoogleAdsLinksOperator` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
 
         self.account_id = account_id
         self.web_property_id = web_property_id
@@ -250,6 +253,13 @@ class GoogleAnalyticsRetrieveAdsLinksListOperator(BaseOperator):
         return result
 
 
+@deprecated(
+    reason=(
+        "The `GoogleAnalyticsDataImportUploadOperator` class is deprecated, please use "
+        "`GoogleAnalyticsAdminCreateDataStreamOperator` instead."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class GoogleAnalyticsDataImportUploadOperator(BaseOperator):
     """
     Take a file from Cloud Storage and uploads it to GA via data import API.
@@ -303,12 +313,6 @@ class GoogleAnalyticsDataImportUploadOperator(BaseOperator):
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
-        warnings.warn(
-            f"The `{type(self).__name__}` operator is deprecated, please use "
-            f"`GoogleAnalyticsAdminCreateDataStreamOperator` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(**kwargs)
         self.storage_bucket = storage_bucket
         self.storage_name_object = storage_name_object
@@ -356,6 +360,13 @@ class GoogleAnalyticsDataImportUploadOperator(BaseOperator):
             )
 
 
+@deprecated(
+    reason=(
+        "The `GoogleAnalyticsDeletePreviousDataUploadsOperator` class is deprecated, please use "
+        "`GoogleAnalyticsAdminDeleteDataStreamOperator` instead."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class GoogleAnalyticsDeletePreviousDataUploadsOperator(BaseOperator):
     """
     Deletes previous GA uploads to leave the latest file to control the size of the Data Set Quota.
@@ -395,12 +406,6 @@ class GoogleAnalyticsDeletePreviousDataUploadsOperator(BaseOperator):
         impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
-        warnings.warn(
-            f"The `{type(self).__name__}` operator is deprecated, please use "
-            f"`GoogleAnalyticsAdminDeleteDataStreamOperator` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(**kwargs)
 
         self.account_id = account_id

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -18,8 +18,9 @@
 """Objects relating to sourcing connections & variables from Hashicorp Vault."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING
+
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.hashicorp._internal_client.vault_client import _VaultClient
@@ -184,6 +185,10 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
             secret_path=(mount_point + "/" if mount_point else "") + secret_path
         )
 
+    @deprecated(
+        reason="Method `VaultBackend.get_conn_uri` is deprecated and will be removed in a future release.",
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_conn_uri(self, conn_id: str) -> str | None:
         """
         Get serialized representation of connection.
@@ -193,12 +198,6 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         """
         # Since VaultBackend implements `get_connection`, `get_conn_uri` is not used. So we
         # don't need to implement (or direct users to use) method `get_conn_value` instead
-        warnings.warn(
-            f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
-            "in a future release.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         response = self.get_response(conn_id)
         return response.get("conn_uri") if response else None
 

--- a/airflow/providers/http/operators/http.py
+++ b/airflow/providers/http/operators/http.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 
 import base64
 import pickle
-import warnings
 from typing import TYPE_CHECKING, Any, Callable, Sequence
 
+from deprecated import deprecated
 from requests import Response
 
 from airflow.configuration import conf
@@ -291,6 +291,13 @@ class HttpOperator(BaseOperator):
         )
 
 
+@deprecated(
+    reason=(
+        "Class `SimpleHttpOperator` is deprecated and "
+        "will be removed in a future release. Please use `HttpOperator` instead."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class SimpleHttpOperator(HttpOperator):
     """
     Calls an endpoint on an HTTP system to execute an action.
@@ -345,10 +352,4 @@ class SimpleHttpOperator(HttpOperator):
     """
 
     def __init__(self, **kwargs: Any):
-        warnings.warn(
-            "Class `SimpleHttpOperator` is deprecated and "
-            "will be removed in a future release. Please use `HttpOperator` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(**kwargs)

--- a/airflow/providers/jdbc/operators/jdbc.py
+++ b/airflow/providers/jdbc/operators/jdbc.py
@@ -17,13 +17,18 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
+
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 
+@deprecated(
+    reason="Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.",
+    category=AirflowProviderDeprecationWarning,
+)
 class JdbcOperator(SQLExecuteQueryOperator):
     """
     Executes sql code in a database using jdbc driver.
@@ -54,9 +59,3 @@ class JdbcOperator(SQLExecuteQueryOperator):
 
     def __init__(self, *, jdbc_conn_id: str = "jdbc_default", **kwargs) -> None:
         super().__init__(conn_id=jdbc_conn_id, **kwargs)
-        warnings.warn(
-            """This class is deprecated.
-            Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.""",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )

--- a/airflow/providers/microsoft/azure/hooks/container_instance.py
+++ b/airflow/providers/microsoft/azure/hooks/container_instance.py
@@ -17,13 +17,13 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 
 from azure.common.client_factory import get_client_from_auth_file, get_client_from_json_dict
 from azure.identity import ClientSecretCredential, DefaultAzureCredential
 from azure.mgmt.containerinstance import ContainerInstanceManagementClient
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.microsoft.azure.hooks.base_azure import AzureBaseHook
@@ -116,6 +116,10 @@ class AzureContainerInstanceHook(AzureBaseHook):
         """
         self.connection.container_groups.begin_create_or_update(resource_group, name, container_group)
 
+    @deprecated(
+        reason="get_state_exitcode_details() is deprecated. Related method is get_state()",
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_state_exitcode_details(self, resource_group: str, name: str) -> tuple:
         """
         Get the state and exitcode of a container group.
@@ -125,17 +129,16 @@ class AzureContainerInstanceHook(AzureBaseHook):
         :return: A tuple with the state, exitcode, and details.
             If the exitcode is unknown 0 is returned.
         """
-        warnings.warn(
-            "get_state_exitcode_details() is deprecated. Related method is get_state()",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         cg_state = self.get_state(resource_group, name)
         container = cg_state.containers[0]
         instance_view: ContainerPropertiesInstanceView = container.instance_view  # type: ignore[assignment]
         c_state: ContainerState = instance_view.current_state  # type: ignore[assignment]
         return c_state.state, c_state.exit_code, c_state.detail_status
 
+    @deprecated(
+        reason="get_messages() is deprecated. Related method is get_state()",
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_messages(self, resource_group: str, name: str) -> list:
         """
         Get the messages of a container group.
@@ -144,11 +147,6 @@ class AzureContainerInstanceHook(AzureBaseHook):
         :param name: the name of the container group
         :return: A list of the event messages
         """
-        warnings.warn(
-            "get_messages() is deprecated. Related method is get_state()",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         cg_state = self.get_state(resource_group, name)
         container = cg_state.containers[0]
         instance_view: ContainerPropertiesInstanceView = container.instance_view  # type: ignore[assignment]

--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -26,12 +26,12 @@ from __future__ import annotations
 
 import logging
 import os
-import warnings
 from functools import cached_property
 
 from azure.core.exceptions import ResourceNotFoundError
 from azure.identity import ClientSecretCredential, DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.microsoft.azure.utils import get_sync_default_azure_credential
@@ -154,6 +154,13 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
 
         return self._get_secret(self.connections_prefix, conn_id)
 
+    @deprecated(
+        reason=(
+            "Method `AzureKeyVaultBackend.get_conn_uri` is deprecated and will be removed "
+            "in a future release.  Please use method `get_conn_value` instead."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_conn_uri(self, conn_id: str) -> str | None:
         """
         Return URI representation of Connection conn_id.
@@ -163,12 +170,6 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
         :param conn_id: the connection id
         :return: deserialized Connection
         """
-        warnings.warn(
-            f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
-            "in a future release.  Please use method `get_conn_value` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         return self.get_conn_value(conn_id)
 
     def get_variable(self, key: str) -> str | None:

--- a/airflow/providers/microsoft/azure/sensors/wasb.py
+++ b/airflow/providers/microsoft/azure/sensors/wasb.py
@@ -17,9 +17,10 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Sequence
+
+from deprecated import deprecated
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
@@ -111,6 +112,15 @@ class WasbBlobSensor(BaseSensorOperator):
             raise AirflowException("Did not receive valid event from the triggerer")
 
 
+@deprecated(
+    reason=(
+        "Class `WasbBlobAsyncSensor` is deprecated and "
+        "will be removed in a future release. "
+        "Please use `WasbBlobSensor` and "
+        "set `deferrable` attribute to `True` instead"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class WasbBlobAsyncSensor(WasbBlobSensor):
     """
     Polls asynchronously for the existence of a blob in a WASB container.
@@ -129,14 +139,6 @@ class WasbBlobAsyncSensor(WasbBlobSensor):
     """
 
     def __init__(self, **kwargs: Any) -> None:
-        warnings.warn(
-            "Class `WasbBlobAsyncSensor` is deprecated and "
-            "will be removed in a future release. "
-            "Please use `WasbBlobSensor` and "
-            "set `deferrable` attribute to `True` instead",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(**kwargs, deferrable=True)
 
 

--- a/airflow/providers/microsoft/azure/transfers/azure_blob_to_gcs.py
+++ b/airflow/providers/microsoft/azure/transfers/azure_blob_to_gcs.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.google.cloud.transfers.azure_blob_to_gcs import (
@@ -25,6 +25,13 @@ from airflow.providers.google.cloud.transfers.azure_blob_to_gcs import (
 )
 
 
+@deprecated(
+    reason=(
+        "Please use "
+        "`airflow.providers.google.cloud.transfers.azure_blob_to_gcs.AzureBlobStorageToGCSOperator`."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class AzureBlobStorageToGCSOperator(AzureBlobStorageToGCSOperatorFromGoogleProvider):
     """
     This class is deprecated.
@@ -34,11 +41,4 @@ class AzureBlobStorageToGCSOperator(AzureBlobStorageToGCSOperatorFromGoogleProvi
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(
-            """This class is deprecated.
-            Please use
-            `airflow.providers.google.cloud.transfers.azure_blob_to_gcs.AzureBlobStorageToGCSOperator`.""",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(*args, **kwargs)

--- a/airflow/providers/microsoft/mssql/operators/mssql.py
+++ b/airflow/providers/microsoft/mssql/operators/mssql.py
@@ -17,13 +17,21 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
+
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 
+@deprecated(
+    reason=(
+        "Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`."
+        "Also, you can provide `hook_params={'schema': <database>}`."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class MsSqlOperator(SQLExecuteQueryOperator):
     """
     Executes sql code in a specific Microsoft SQL database.
@@ -62,10 +70,3 @@ class MsSqlOperator(SQLExecuteQueryOperator):
             kwargs["hook_params"] = {"schema": database, **hook_params}
 
         super().__init__(conn_id=mssql_conn_id, **kwargs)
-        warnings.warn(
-            """This class is deprecated.
-            Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.
-            Also, you can provide `hook_params={'schema': <database>}`.""",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )

--- a/airflow/providers/mysql/operators/mysql.py
+++ b/airflow/providers/mysql/operators/mysql.py
@@ -17,13 +17,21 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
+
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 
+@deprecated(
+    reason=(
+        "Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`."
+        "Also, you can provide `hook_params={'schema': <database>}`."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class MySqlOperator(SQLExecuteQueryOperator):
     """
     Executes sql code in a specific MySQL database.
@@ -65,10 +73,3 @@ class MySqlOperator(SQLExecuteQueryOperator):
             kwargs["hook_params"] = {"schema": database, **hook_params}
 
         super().__init__(conn_id=mysql_conn_id, **kwargs)
-        warnings.warn(
-            """This class is deprecated.
-            Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.
-            Also, you can provide `hook_params={'schema': <database>}`.""",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )

--- a/airflow/providers/oracle/operators/oracle.py
+++ b/airflow/providers/oracle/operators/oracle.py
@@ -18,10 +18,10 @@
 from __future__ import annotations
 
 import re
-import warnings
 from typing import TYPE_CHECKING, Sequence
 
 import oracledb
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
@@ -32,6 +32,10 @@ if TYPE_CHECKING:
     from airflow.utils.context import Context
 
 
+@deprecated(
+    reason="Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.",
+    category=AirflowProviderDeprecationWarning,
+)
 class OracleOperator(SQLExecuteQueryOperator):
     """
     Executes sql code in a specific Oracle database.
@@ -61,12 +65,6 @@ class OracleOperator(SQLExecuteQueryOperator):
 
     def __init__(self, *, oracle_conn_id: str = "oracle_default", **kwargs) -> None:
         super().__init__(conn_id=oracle_conn_id, **kwargs)
-        warnings.warn(
-            """This class is deprecated.
-            Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.""",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
 
 
 class OracleStoredProcedureOperator(BaseOperator):

--- a/airflow/providers/pagerduty/hooks/pagerduty.py
+++ b/airflow/providers/pagerduty/hooks/pagerduty.py
@@ -18,10 +18,10 @@
 """Hook for sending or receiving data from PagerDuty as well as creating PagerDuty incidents."""
 from __future__ import annotations
 
-import warnings
 from typing import Any
 
 import pdpyras
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
@@ -109,6 +109,13 @@ class PagerdutyHook(BaseHook):
         self._session = pdpyras.APISession(self.token)
         return self._session
 
+    @deprecated(
+        reason=(
+            "This method will be deprecated. Please use the "
+            "`airflow.providers.pagerduty.hooks.PagerdutyEventsHook` to interact with the Events API"
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def create_event(
         self,
         summary: str,
@@ -154,13 +161,6 @@ class PagerdutyHook(BaseHook):
             link's text.
         :return: PagerDuty Events API v2 response.
         """
-        warnings.warn(
-            "This method will be deprecated. Please use the "
-            "`airflow.providers.pagerduty.hooks.PagerdutyEventsHook` to interact with the Events API",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
-
         routing_key = routing_key or self.routing_key
 
         return PagerdutyEventsHook(integration_key=routing_key).create_event(

--- a/airflow/providers/pagerduty/hooks/pagerduty_events.py
+++ b/airflow/providers/pagerduty/hooks/pagerduty_events.py
@@ -18,10 +18,10 @@
 """Hook for sending or receiving data from PagerDuty as well as creating PagerDuty incidents."""
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any
 
 import pdpyras
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
@@ -76,6 +76,13 @@ class PagerdutyEventsHook(BaseHook):
                 "Cannot get token: No valid integration key nor pagerduty_events_conn_id supplied."
             )
 
+    @deprecated(
+        reason=(
+            "This method will be deprecated. Please use the "
+            "`PagerdutyEventsHook.send_event` to interact with the Events API"
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def create_event(
         self,
         summary: str,
@@ -118,13 +125,6 @@ class PagerdutyEventsHook(BaseHook):
             link's text.
         :return: PagerDuty Events API v2 response.
         """
-        warnings.warn(
-            "This method will be deprecated. Please use the "
-            "`PagerdutyEventsHook.send_event` to interact with the Events API",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
-
         data = PagerdutyEventsHook.prepare_event_data(
             summary=summary,
             severity=severity,

--- a/airflow/providers/postgres/hooks/postgres.py
+++ b/airflow/providers/postgres/hooks/postgres.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Union
 import psycopg2
 import psycopg2.extensions
 import psycopg2.extras
+from deprecated import deprecated
 from psycopg2.extras import DictCursor, NamedTupleCursor, RealDictCursor
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
@@ -90,23 +91,25 @@ class PostgresHook(DbApiHook):
         self.options = options
 
     @property
-    def schema(self):
-        warnings.warn(
+    @deprecated(
+        reason=(
             'The "schema" variable has been renamed to "database" as it contained the database name.'
-            'Please use "database" to get the database name.',
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
+            'Please use "database" to get the database name.'
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
+    def schema(self):
         return self.database
 
     @schema.setter
-    def schema(self, value):
-        warnings.warn(
+    @deprecated(
+        reason=(
             'The "schema" variable has been renamed to "database" as it contained the database name.'
-            'Please use "database" to set the database name.',
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
+            'Please use "database" to set the database name.'
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
+    def schema(self, value):
         self.database = value
 
     def _get_cursor(self, raw_cursor: str) -> CursorType:

--- a/airflow/providers/postgres/operators/postgres.py
+++ b/airflow/providers/postgres/operators/postgres.py
@@ -20,10 +20,19 @@ from __future__ import annotations
 import warnings
 from typing import Mapping
 
+from deprecated import deprecated
+
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 
+@deprecated(
+    reason=(
+        "Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`."
+        "Also, you can provide `hook_params={'schema': <database>}`."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class PostgresOperator(SQLExecuteQueryOperator):
     """
     Executes sql code in a specific Postgres database.
@@ -73,10 +82,3 @@ class PostgresOperator(SQLExecuteQueryOperator):
             kwargs["hook_params"] = {"options": options, **hook_params}
 
         super().__init__(conn_id=postgres_conn_id, **kwargs)
-        warnings.warn(
-            """This class is deprecated.
-            Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.
-            Also, you can provide `hook_params={'schema': <database>}`.""",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )

--- a/airflow/providers/slack/transfers/sql_to_slack.py
+++ b/airflow/providers/slack/transfers/sql_to_slack.py
@@ -16,11 +16,11 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from functools import cached_property
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
+from deprecated import deprecated
 from typing_extensions import Literal
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
@@ -154,6 +154,14 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
             )
 
 
+@deprecated(
+    reason=(
+        "`airflow.providers.slack.transfers.sql_to_slack.SqlToSlackOperator` has been renamed "
+        "and moved `airflow.providers.slack.transfers.sql_to_slack_webhook.SqlToSlackWebhookOperator` "
+        "this operator deprecated and will be removed in future"
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class SqlToSlackOperator(SqlToSlackWebhookOperator):
     """
     Executes an SQL statement in a given SQL connection and sends the results to Slack Incoming Webhook.
@@ -162,11 +170,4 @@ class SqlToSlackOperator(SqlToSlackWebhookOperator):
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "`airflow.providers.slack.transfers.sql_to_slack.SqlToSlackOperator` has been renamed "
-            "and moved `airflow.providers.slack.transfers.sql_to_slack_webhook.SqlToSlackWebhookOperator` "
-            "this operator deprecated and will be removed in future",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(*args, **kwargs)

--- a/airflow/providers/slack/transfers/sql_to_slack_webhook.py
+++ b/airflow/providers/slack/transfers/sql_to_slack_webhook.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence
 
+from deprecated import deprecated
 from tabulate import tabulate
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
@@ -162,11 +163,12 @@ class SqlToSlackWebhookOperator(BaseSqlToSlackOperator):
         self.log.debug("Finished sending SQL data to Slack")
 
     @property
+    @deprecated(
+        reason=(
+            "`SqlToSlackWebhookOperator.slack_conn_id` property deprecated and will be removed in a future. "
+            "Please use `slack_webhook_conn_id` instead."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def slack_conn_id(self):
-        warnings.warn(
-            f"`{type(self).__name__}.slack_conn_id` property deprecated and will be removed in a future. "
-            "Please use `slack_webhook_conn_id` instead.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         return self.slack_webhook_conn_id

--- a/airflow/providers/snowflake/operators/snowflake.py
+++ b/airflow/providers/snowflake/operators/snowflake.py
@@ -18,9 +18,10 @@
 from __future__ import annotations
 
 import time
-import warnings
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, Sequence, SupportsAbs, cast
+
+from deprecated import deprecated
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
@@ -37,6 +38,16 @@ if TYPE_CHECKING:
     from airflow.utils.context import Context
 
 
+@deprecated(
+    reason=(
+        "This class is deprecated. Please use "
+        "`airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`. "
+        "Also, you can provide `hook_params={'warehouse': <warehouse>, 'database': <database>, "
+        "'role': <role>, 'schema': <schema>, 'authenticator': <authenticator>,"
+        "'session_parameters': <session_parameters>}`."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class SnowflakeOperator(SQLExecuteQueryOperator):
     """
     Executes SQL code in a Snowflake database.
@@ -104,15 +115,6 @@ class SnowflakeOperator(SQLExecuteQueryOperator):
                 **hook_params,
             }
         super().__init__(conn_id=snowflake_conn_id, **kwargs)
-        warnings.warn(
-            """This class is deprecated.
-            Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.
-            Also, you can provide `hook_params={'warehouse': <warehouse>, 'database': <database>,
-            'role': <role>, 'schema': <schema>, 'authenticator': <authenticator>,
-            'session_parameters': <session_parameters>}`.""",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
 
     def _process_output(self, results: list[Any], descriptions: list[Sequence[Sequence] | None]) -> list[Any]:
         validated_descriptions: list[Sequence[Sequence]] = []

--- a/airflow/providers/sqlite/operators/sqlite.py
+++ b/airflow/providers/sqlite/operators/sqlite.py
@@ -17,13 +17,18 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import Sequence
+
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 
+@deprecated(
+    reason="Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.",
+    category=AirflowProviderDeprecationWarning,
+)
 class SqliteOperator(SQLExecuteQueryOperator):
     """
     Executes sql code in a specific Sqlite database.
@@ -51,9 +56,3 @@ class SqliteOperator(SQLExecuteQueryOperator):
 
     def __init__(self, *, sqlite_conn_id: str = "sqlite_default", **kwargs) -> None:
         super().__init__(conn_id=sqlite_conn_id, **kwargs)
-        warnings.warn(
-            """This class is deprecated.
-            Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.""",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -27,6 +27,7 @@ from select import select
 from typing import Any, Sequence
 
 import paramiko
+from deprecated import deprecated
 from paramiko.config import SSH_PORT
 from sshtunnel import SSHTunnelForwarder
 from tenacity import Retrying, stop_after_attempt, wait_fixed, wait_random
@@ -365,14 +366,15 @@ class SSHHook(BaseHook):
         self.client = client
         return client
 
-    def __enter__(self) -> SSHHook:
-        warnings.warn(
+    @deprecated(
+        reason=(
             "The contextmanager of SSHHook is deprecated."
             "Please use get_conn() as a contextmanager instead."
-            "This method will be removed in Airflow 2.0",
-            category=AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
+            "This method will be removed in Airflow 2.0"
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
+    def __enter__(self) -> SSHHook:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -422,6 +424,15 @@ class SSHHook(BaseHook):
 
         return client
 
+    @deprecated(
+        reason=(
+            "SSHHook.create_tunnel is deprecated, Please "
+            "use get_tunnel() instead. But please note that the "
+            "order of the parameters have changed. "
+            "This method will be removed in Airflow 2.0"
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def create_tunnel(
         self, local_port: int, remote_port: int, remote_host: str = "localhost"
     ) -> SSHTunnelForwarder:
@@ -431,15 +442,6 @@ class SSHHook(BaseHook):
         :param remote_port: remote port number
         :param remote_host: remote host
         """
-        warnings.warn(
-            "SSHHook.create_tunnel is deprecated, Please"
-            "use get_tunnel() instead. But please note that the"
-            "order of the parameters have changed"
-            "This method will be removed in Airflow 2.0",
-            category=AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
-
         return self.get_tunnel(remote_port, remote_host, local_port)
 
     def _pkey_from_private_key(self, private_key: str, passphrase: str | None = None) -> paramiko.PKey:

--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from base64 import b64encode
 from functools import cached_property
 from typing import TYPE_CHECKING, Container, Sequence
@@ -152,13 +151,14 @@ class SSHOperator(BaseOperator):
         self.log.info("Creating ssh_client")
         return self.hook.get_conn()
 
-    def exec_ssh_client_command(self, ssh_client: SSHClient, command: str) -> tuple[int, bytes, bytes]:
-        warnings.warn(
+    @deprecated(
+        reason=(
             "exec_ssh_client_command method on SSHOperator is deprecated, call "
-            "`ssh_hook.exec_ssh_client_command` instead",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
+            "`ssh_hook.exec_ssh_client_command` instead"
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
+    def exec_ssh_client_command(self, ssh_client: SSHClient, command: str) -> tuple[int, bytes, bytes]:
         return self.hook.exec_ssh_client_command(
             ssh_client, command, timeout=self.cmd_timeout, environment=self.environment, get_pty=self.get_pty
         )

--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -17,10 +17,10 @@
 from __future__ import annotations
 
 import time
-import warnings
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
+from deprecated import deprecated
 from tableauserverclient import Pager, PersonalAccessTokenAuth, Server, TableauAuth
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
@@ -121,14 +121,15 @@ class TableauHook(BaseHook):
         )
         return self.server.auth.sign_in(tableau_auth)
 
+    @deprecated(
+        reason=(
+            "Authentication via personal access token is deprecated. "
+            "Please, use the password authentication to avoid inconsistencies."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def _auth_via_token(self) -> Auth.contextmgr:
         """The method is deprecated. Please, use the authentication via password instead."""
-        warnings.warn(
-            "Authentication via personal access token is deprecated. "
-            "Please, use the password authentication to avoid inconsistencies.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         tableau_auth = PersonalAccessTokenAuth(
             token_name=self.conn.extra_dejson["token_name"],
             personal_access_token=self.conn.extra_dejson["personal_access_token"],

--- a/airflow/providers/trino/operators/trino.py
+++ b/airflow/providers/trino/operators/trino.py
@@ -18,9 +18,9 @@
 """This module contains the Trino operator."""
 from __future__ import annotations
 
-import warnings
 from typing import Any, Sequence
 
+from deprecated import deprecated
 from trino.exceptions import TrinoQueryError
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
@@ -28,6 +28,10 @@ from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.providers.trino.hooks.trino import TrinoHook
 
 
+@deprecated(
+    reason="Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.",
+    category=AirflowProviderDeprecationWarning,
+)
 class TrinoOperator(SQLExecuteQueryOperator):
     """
     Executes sql code using a specific Trino query Engine.
@@ -57,12 +61,6 @@ class TrinoOperator(SQLExecuteQueryOperator):
 
     def __init__(self, *, trino_conn_id: str = "trino_default", **kwargs: Any) -> None:
         super().__init__(conn_id=trino_conn_id, **kwargs)
-        warnings.warn(
-            """This class is deprecated.
-            Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.""",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
 
     def on_kill(self) -> None:
         if self._hook is not None and isinstance(self._hook, TrinoHook):  # type: ignore[attr-defined]

--- a/airflow/providers/vertica/operators/vertica.py
+++ b/airflow/providers/vertica/operators/vertica.py
@@ -17,13 +17,18 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import Any, Sequence
+
+from deprecated import deprecated
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 
+@deprecated(
+    reason="Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.",
+    category=AirflowProviderDeprecationWarning,
+)
 class VerticaOperator(SQLExecuteQueryOperator):
     """
     Executes sql code in a specific Vertica database.
@@ -45,9 +50,3 @@ class VerticaOperator(SQLExecuteQueryOperator):
 
     def __init__(self, *, vertica_conn_id: str = "vertica_default", **kwargs: Any) -> None:
         super().__init__(conn_id=vertica_conn_id, **kwargs)
-        warnings.warn(
-            """This class is deprecated.
-            Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.""",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )

--- a/airflow/providers/weaviate/hooks/weaviate.py
+++ b/airflow/providers/weaviate/hooks/weaviate.py
@@ -19,12 +19,12 @@ from __future__ import annotations
 
 import contextlib
 import json
-import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Dict, List, Sequence, cast
 
 import requests
 import weaviate.exceptions
+from deprecated import deprecated
 from tenacity import Retrying, retry, retry_if_exception, retry_if_exception_type, stop_after_attempt
 from weaviate import Client as WeaviateClient
 from weaviate.auth import AuthApiKey, AuthBearerToken, AuthClientCredentials, AuthClientPassword
@@ -139,14 +139,13 @@ class WeaviateHook(BaseHook):
         """Returns a Weaviate client."""
         return self.get_conn()
 
+    @deprecated(
+        reason="The `get_client` method has been renamed to `get_conn`",
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_client(self) -> WeaviateClient:
         """Returns a Weaviate client."""
         # Keeping this for backwards compatibility
-        warnings.warn(
-            "The `get_client` method has been renamed to `get_conn`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
         return self.conn
 
     def test_connection(self) -> tuple[bool, str]:

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -2062,7 +2062,7 @@ class TestBigQueryBaseCursorMethodsDeprecationWarning:
     def test_deprecation_warning(self, mock_bq_hook, func_name):
         args, kwargs = [1], {"param1": "val1"}
         new_path = re.escape(f"airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.{func_name}")
-        message_pattern = rf"This method is deprecated\.\s+Please use `{new_path}`"
+        message_pattern = rf"Call to deprecated method {func_name}\.\s+\(Please use `{new_path}`\)"
         message_regex = re.compile(message_pattern, re.MULTILINE)
 
         mocked_func = getattr(mock_bq_hook, func_name)

--- a/tests/providers/google/cloud/hooks/test_cloud_build.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_build.py
@@ -101,7 +101,7 @@ class TestCloudBuildHook:
 
         wait_time.return_value = 0
 
-        with pytest.warns(AirflowProviderDeprecationWarning, match="This method is deprecated"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="Call to deprecated"):
             self.hook.create_build(build=BUILD, project_id=PROJECT_ID)
 
         get_conn.return_value.create_build.assert_called_once_with(
@@ -122,7 +122,7 @@ class TestCloudBuildHook:
         get_conn.return_value.run_build_trigger.return_value = mock.MagicMock()
         mock_get_id_from_operation.return_value = BUILD_ID
 
-        with pytest.warns(AirflowProviderDeprecationWarning, match="This method is deprecated"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="Call to deprecated"):
             self.hook.create_build(build=BUILD, project_id=PROJECT_ID, wait=False)
 
         mock_operation = get_conn.return_value.create_build

--- a/tests/providers/oracle/operators/test_oracle.py
+++ b/tests/providers/oracle/operators/test_oracle.py
@@ -40,7 +40,7 @@ class TestOracleOperator:
         context = "test_context"
         task_id = "test_task_id"
 
-        with pytest.warns(AirflowProviderDeprecationWarning, match="This class is deprecated.*"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="Call to deprecated class *"):
             operator = OracleOperator(
                 sql=sql,
                 oracle_conn_id=oracle_conn_id,

--- a/tests/providers/trino/operators/test_trino.py
+++ b/tests/providers/trino/operators/test_trino.py
@@ -37,7 +37,7 @@ class TestTrinoOperator:
     def test_execute(self, mock_get_db_hook):
         """Asserts that the run method is called when a TrinoOperator task is executed"""
 
-        with pytest.warns(AirflowProviderDeprecationWarning, match="This class is deprecated.*"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="Call to deprecated class *"):
             op = TrinoOperator(
                 task_id=TASK_ID,
                 sql="SELECT 1;",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
## TLDR;
I propose standardizing our approach to deprecating elements in the Airflow codebase, aiming for improved readability and easier automated parsing. I propose adopting a structured approach, potentially enforceable through the CI process, for handling deprecations in Airflow. This would involve primarily using decorators for the deprecation process. This PR serves as an introduction and first step. The whole process will probably take couple of PR's.

I encourage everyone to share their thoughts and feedback on this proposal. 

## Genesis
The genesis of this proposal stems from my attempt to compile a comprehensive documentation of all deprecations in Airflow. The lack of a standardized process for deprecation made it challenging to track and document these changes effectively.

## Problem
Currently, deprecation in Airflow relies mainly on the content of warning messages, making it less accessible for automated discovery. The typical process includes:

- Modules: Raising a DeprecationWarning at the top, suggesting full module deprecation as indicated by the message.
- Classes: Issuing a DeprecationWarning within `__init__`, detailing the deprecation. The @deprecated decorator is rarely applied to the class.
- Functions/Methods: Emitting a DeprecationWarning within the function/method, with a description of the deprecation. The @deprecated decorator is more common here than in classes, but still rare.
- Specific Arguments: Announcing deprecation of an argument with a DeprecationWarning and a descriptive message within the function/method.
- Argument Values: For changes or deprecations in argument values (e.g., changing `schedule` from "@once" to "@single"), a DeprecationWarning is raised with a detailed message in the function/method.

The current practice of raising a DeprecationWarning in the `__init__` or a function in Airflow makes it unclear what exactly is being deprecated, whether it's the class, function, a specific argument, or a particular argument value.

## Proposed solution
I propose adopting a structured approach, potentially enforceable through the CI process, for handling deprecations in Airflow. This would involve primarily using decorators for the deprecation process. We could develop new decorators or utilize existing ones, similar to those in the TensorFlow [codebase](https://github.com/tensorflow/tensorflow/blob/dec8e0b11f4f87693b67e125e67dfbc68d26c205/tensorflow/python/util/deprecation.py#L274). These could be housed in a dedicated module, such as `airflow/deprecation.py`.

By implementing our own decorators, we can standardize the information provided during deprecation, allowing us to specify details using separate keyword arguments instead of embedding everything within a message.

## Demo 

- For modules, we would probably use the current solution.
- For classes, instead of raising a Warning in init, we would decorate a class (as in change files to this PR).
- For functions and methods, instead of raising a Warning in the body, we would decorate the class or method. Now, depending on the deprecated thing, we would either use @deprecated, @deprecated_args, @deprecated_arg_values etc.

Instead of this:
```
def __init__(self, *args, **kwargs) -> None:
    super().__init__(*args, **kwargs)
    if kwargs.get("sleep_time") is not None:
        warnings.warn(
            "The `sleep_time` parameter is deprecated, use sleep instead.",
            AirflowProviderDeprecationWarning,
            stacklevel=2,
        )
    if kwargs.get("run_type") == "defferable":
        warnings.warn(
            "Providing 'defferable' as `run_type` is deprecated, use `defferable=True`.",
            AirflowProviderDeprecationWarning,
            stacklevel=2,
        )
```

We could have:
```
@deprecated_args_value(old_name="run_type", old_value="defferable", new_name="defferable", new_value=True)
@deprecated_args("sleep_time", new_value_name="sleep")
def __init__(self, *args, **kwargs) -> None:
    super().__init__(*args, **kwargs)
```

## Challenges
I'm uncertain if we can entirely remove explicit calls to `warnings.warn`. For instance, in cases where complex logic determines if a provided argument value is deprecated, especially with complex objects or nested structures, using `warnings.warn` directly might still be the most effective method of notification. It remains to be seen if a decorator can neatly handle such scenarios. 

Please share any potential drawbacks of this approach in the comments.

## Future possibilities / work plan

We adopt the following steps for deprecating components in Airflow:

1. Utilize decorators for deprecating entire classes, functions, and methods, as improved through discussions in this PR.
2. Move all deprecation related Warnings and decorators to a separate module and extend their functionality by providing some additional arguments and formatting the Deprecation message.
3. Create a documentation site listing all deprecations, which simple static analysis should adequately maintain.
4. Develop additional decorators, such as `arg`, `arg_values` etc., to replace current warnings within function bodies and include these in the documentation.
5. Implement a CI check to ensure decorators are consistently used for deprecation.

Further considerations for future development:

- Utilizing decorators allows for automatic modification of docstrings for each entity (class, function, etc.), enabling the addition of comprehensive deprecation information (including details about deprecated arguments and argument values).
- If we have specific removal timelines (i.e., versions by which components should be removed from the provider or core Airflow), we can verify their removal in the pre-release CI process.

Feel free to suggest additional ideas or improvements.

Mentioning @potiuk , as we talked about it on the Slack. Feel free to tag others who might be interested in contributing their thoughts.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
