### PR TITLE
Fix bug introduced by replacing spaces by + in run_id

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1944,7 +1944,7 @@ class Airflow(AirflowBaseView):
     @provide_session
     def trigger(self, dag_id: str, session: Session = NEW_SESSION):
         """Triggers DAG Run."""
-        run_id = request.values.get("run_id", "").replace(" ", "+")
+        run_id = request.values.get("run_id", "")
         origin = get_safe_url(request.values.get("origin"))
         unpause = request.values.get("unpause")
         request_conf = request.values.get("conf")

--- a/tests/www/views/test_views_trigger_dag.py
+++ b/tests/www/views/test_views_trigger_dag.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import datetime
 import json
+from urllib.parse import quote
 
 import pytest
 
@@ -369,6 +370,7 @@ def test_trigger_dag_params_array_value_none_render(admin_client, dag_maker, ses
 def test_dag_run_id_pattern(session, admin_client, pattern, run_id, result):
     with conf_vars({("scheduler", "allowed_run_id_pattern"): pattern}):
         test_dag_id = "example_bash_operator"
+        run_id = quote(run_id)
         admin_client.post(f"dags/{test_dag_id}/trigger?run_id={run_id}", data={"conf": "{}"})
         run = session.query(DagRun).filter(DagRun.dag_id == test_dag_id).first()
         if result:


### PR DESCRIPTION
While working on sanitizing the run_id(#32293), I replaced spaces with + which is not an ideal way to quote a URL. This led to issues when users use spaces in their DAG run_id.
This commit fixes the issue by using urllib.parse.quote to properly quote the URL.

