### PR TITLE
Run Trigger Page: Configurable number of recent configs

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1875,7 +1875,7 @@ webserver:
       type: boolean
       example: ~
       default: "False"
-    num_recent_confs_for_trigger:
+    num_recent_configurations_for_trigger:
       description: |
         Number of recent DAG run configurations in the selector on the trigger web form.
       version_added: 2.9.0

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1875,6 +1875,13 @@ webserver:
       type: boolean
       example: ~
       default: "False"
+    num_recent_confs_for_trigger:
+      description: |
+        Number of recent DAG run configurations in the selector on the trigger web form.
+      version_added: 2.9.0
+      type: integer
+      example: "10"
+      default: "5"
     allow_raw_html_descriptions:
       description: |
         A DAG author is able to provide any raw HTML into ``doc_md`` or params description in

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2029,6 +2029,7 @@ class Airflow(AirflowBaseView):
             flash(f"Cannot create dagruns because the dag {dag_id} has import errors", "error")
             return redirect(origin)
 
+        num_recent_confs = conf.getint("webserver", "num_recent_confs_for_trigger")
         recent_runs = session.execute(
             select(DagRun.conf, func.max(DagRun.run_id).label("run_id"), func.max(DagRun.execution_date))
             .where(
@@ -2038,7 +2039,7 @@ class Airflow(AirflowBaseView):
             )
             .group_by(DagRun.conf)
             .order_by(func.max(DagRun.execution_date).desc())
-            .limit(5)
+            .limit(num_recent_confs)
         )
         recent_confs = {
             run_id: json.dumps(run_conf)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2029,7 +2029,7 @@ class Airflow(AirflowBaseView):
             flash(f"Cannot create dagruns because the dag {dag_id} has import errors", "error")
             return redirect(origin)
 
-        num_recent_confs = conf.getint("webserver", "num_recent_confs_for_trigger")
+        num_recent_confs = conf.getint("webserver", "num_recent_configurations_for_trigger")
         recent_runs = session.execute(
             select(DagRun.conf, func.max(DagRun.run_id).label("run_id"), func.max(DagRun.execution_date))
             .where(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Some users are heavily relying on running DAGs manually by altering or repeating previous configurations.
The number (more precisely limit) of previous runs sent to the `trigger.html` selector is 5 and quite low for this use-case.

This PR makes the number of recent DAG run configurations configurable.

Questions:
* Are there any unit tests required here?
* I (speaking for the in house users) would love that feature sooner than later, I've put version 2.9.0 into the configuration YML, I believe that's the earliest when sticking to semantic versioning... and the change is liked by the airflow community...

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
