### PR TITLE
Limit `flask-session` to <0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,9 @@ dependencies = [
     "deprecated>=1.2.13",
     "dill>=0.2.2",
     "flask-caching>=1.5.0",
-    "flask-session>=0.4.0",
+    # Flask-Session 0.6 add new arguments into the SqlAlchemySessionInterface constructor as well as
+    # all parameters now are mandatory which make AirflowDatabaseSessionInterface incopatible with this version.
+    "flask-session>=0.4.0,<0.6",
     "flask-wtf>=0.15",
     # Flask 2.3 is scheduled to introduce a number of deprecation removals - some of them might be breaking
     # for our dependencies - notably `_app_ctx_stack` and `_request_ctx_stack` removals.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

New version of [`Flask-Session`](https://pypi.org/project/Flask-Session/) breaks our [`AirflowDatabaseSessionInterface`](https://github.com/apache/airflow/blob/dae2d44695e0bf6eb87c184767cac26ebc5dadd8/airflow/www/session.py#L36) by add new arguments into the constructor `sid_length`, `sequence`, `schema` and `bind_key` and make all arguments are mandatory include previously optional `use_signer` and `permanent`

[Test OpenAPI client](https://github.com/apache/airflow/actions/runs/7582079179/job/20650960654?pr=36893#logs)
---
```console
Run airflow db init
/home/runner/actions-runner/_work/airflow/airflow/airflow/cli/commands/db_command.py:47 DeprecationWarning: `db init` is deprecated.  Use `db migrate` instead to migrate the db and/or airflow connections create-default-connections to create the default connections
DB: sqlite:////home/runner/airflow/airflow.db
[2024-01-19T09:50:[35](https://github.com/apache/airflow/actions/runs/7582079179/job/20650960654?pr=36893#step:12:36).350+0000] {migration.py:216} INFO - Context impl SQLiteImpl.
[2024-01-19T09:50:35.352+0000] {migration.py:219} INFO - Will assume non-transactional DDL.
Traceback (most recent call last):
  File "/home/runner/actions-runner/_work/_tool/Python/3.8.18/x64/bin/airflow", line 8, in <module>
    sys.exit(main())
  File "/home/runner/actions-runner/_work/airflow/airflow/airflow/__main__.py", line 57, in main
    args.func(args)
  File "/home/runner/actions-runner/_work/airflow/airflow/airflow/cli/cli_config.py", line 49, in command
    return func(*args, **kwargs)
  File "/home/runner/actions-runner/_work/airflow/airflow/airflow/utils/providers_configuration_loader.py", line 55, in wrapped_function
    return func(*args, **kwargs)
  File "/home/runner/actions-runner/_work/airflow/airflow/airflow/cli/commands/db_command.py", line 53, in initdb
    db.initdb()
  File "/home/runner/actions-runner/_work/airflow/airflow/airflow/utils/session.py", line 79, in wrapper
    return func(*args, session=session, **kwargs)
  File "/home/runner/actions-runner/_work/airflow/airflow/airflow/utils/db.py", line 732, in initdb
    _create_db_from_orm(session=session)
  File "/home/runner/actions-runner/_work/airflow/airflow/airflow/utils/db.py", line 717, in _create_db_from_orm
    _create_flask_session_tbl(engine.url)
  File "/home/runner/actions-runner/_work/airflow/airflow/airflow/utils/db.py", line 710, in _create_flask_session_tbl
    db = _get_flask_db(sql_database_uri)
  File "/home/runner/actions-runner/_work/airflow/airflow/airflow/utils/db.py", line 699, in _get_flask_db
    AirflowDatabaseSessionInterface(app=flask_app, db=db, table="session", key_prefix="")
TypeError: __init__() missing 6 required positional arguments: 'sequence', 'schema', 'bind_key', 'use_signer', 'permanent', and 'sid_length'
Error: Process completed with exit code 1.
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
