### PR TITLE
Add operator to collect diagnostic tarball for Dataproc cluster

### DIFF
--- a/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/airflow/providers/google/cloud/hooks/dataproc.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import time
 import uuid
+from collections.abc import MutableSequence
 from typing import TYPE_CHECKING, Any, Sequence
 
 from google.api_core.client_options import ClientOptions
@@ -54,6 +55,7 @@ if TYPE_CHECKING:
     from google.api_core.retry_async import AsyncRetry
     from google.protobuf.duration_pb2 import Duration
     from google.protobuf.field_mask_pb2 import FieldMask
+    from google.type.interval_pb2 import Interval
 
 
 class DataProcJobBuilder:
@@ -386,17 +388,25 @@ class DataprocHook(GoogleBaseHook):
         region: str,
         cluster_name: str,
         project_id: str,
+        tarball_gcs_dir: str | None = None,
+        diagnosis_interval: dict | Interval | None = None,
+        jobs: MutableSequence[str] | None = None,
+        yarn_application_ids: MutableSequence[str] | None = None,
         retry: Retry | _MethodDefault = DEFAULT,
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
-    ) -> str:
+    ) -> Operation:
         """Get cluster diagnostic information.
 
-        After the operation completes, the GCS URI to diagnose is returned.
+        After the operation completes, the response contains the Cloud Storage URI of the diagnostic output report containing a summary of collected diagnostics.
 
         :param project_id: Google Cloud project ID that the cluster belongs to.
         :param region: Cloud Dataproc region in which to handle the request.
         :param cluster_name: Name of the cluster.
+        :param tarball_gcs_dir:  The output Cloud Storage directory for the diagnostic tarball. If not specified, a task-specific directory in the cluster's staging bucket will be used.
+        :param diagnosis_interval: Time interval in which diagnosis should be carried out on the cluster.
+        :param jobs: Specifies a list of jobs on which diagnosis is to be performed. Format: `projects/{project}/regions/{region}/jobs/{job}`
+        :param yarn_application_ids: Specifies a list of yarn applications on which diagnosis is to be performed.
         :param retry: A retry object used to retry requests. If *None*, requests
             will not be retried.
         :param timeout: The amount of time, in seconds, to wait for the request
@@ -405,15 +415,21 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         """
         client = self.get_cluster_client(region=region)
-        operation = client.diagnose_cluster(
-            request={"project_id": project_id, "region": region, "cluster_name": cluster_name},
+        result = client.diagnose_cluster(
+            request={
+                "project_id": project_id,
+                "region": region,
+                "cluster_name": cluster_name,
+                "tarball_gcs_dir": tarball_gcs_dir,
+                "diagnosis_interval": diagnosis_interval,
+                "jobs": jobs,
+                "yarn_application_ids": yarn_application_ids,
+            },
             retry=retry,
             timeout=timeout,
             metadata=metadata,
         )
-        operation.result()
-        gcs_uri = str(operation.operation.response.value)
-        return gcs_uri
+        return result
 
     @GoogleBaseHook.fallback_to_default_project_id
     def get_cluster(
@@ -1243,17 +1259,25 @@ class DataprocAsyncHook(GoogleBaseHook):
         region: str,
         cluster_name: str,
         project_id: str,
+        tarball_gcs_dir: str | None = None,
+        diagnosis_interval: dict | Interval | None = None,
+        jobs: MutableSequence[str] | None = None,
+        yarn_application_ids: MutableSequence[str] | None = None,
         retry: AsyncRetry | _MethodDefault = DEFAULT,
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
-    ) -> str:
+    ) -> AsyncOperation:
         """Get cluster diagnostic information.
 
-        After the operation completes, the GCS URI to diagnose is returned.
+        After the operation completes, the response contains the Cloud Storage URI of the diagnostic output report containing a summary of collected diagnostics.
 
         :param project_id: Google Cloud project ID that the cluster belongs to.
         :param region: Cloud Dataproc region in which to handle the request.
         :param cluster_name: Name of the cluster.
+        :param tarball_gcs_dir:  The output Cloud Storage directory for the diagnostic tarball. If not specified, a task-specific directory in the cluster's staging bucket will be used.
+        :param diagnosis_interval: Time interval in which diagnosis should be carried out on the cluster.
+        :param jobs: Specifies a list of jobs on which diagnosis is to be performed. Format: `projects/{project}/regions/{region}/jobs/{job}`
+        :param yarn_application_ids: Specifies a list of yarn applications on which diagnosis is to be performed.
         :param retry: A retry object used to retry requests. If *None*, requests
             will not be retried.
         :param timeout: The amount of time, in seconds, to wait for the request
@@ -1262,15 +1286,21 @@ class DataprocAsyncHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         """
         client = self.get_cluster_client(region=region)
-        operation = await client.diagnose_cluster(
-            request={"project_id": project_id, "region": region, "cluster_name": cluster_name},
+        result = await client.diagnose_cluster(
+            request={
+                "project_id": project_id,
+                "region": region,
+                "cluster_name": cluster_name,
+                "tarball_gcs_dir": tarball_gcs_dir,
+                "diagnosis_interval": diagnosis_interval,
+                "jobs": jobs,
+                "yarn_application_ids": yarn_application_ids,
+            },
             retry=retry,
             timeout=timeout,
             metadata=metadata,
         )
-        operation.result()
-        gcs_uri = str(operation.operation.response.value)
-        return gcs_uri
+        return result
 
     @GoogleBaseHook.fallback_to_default_project_id
     async def get_cluster(

--- a/airflow/providers/google/cloud/triggers/dataproc.py
+++ b/airflow/providers/google/cloud/triggers/dataproc.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 import time
 from typing import Any, AsyncIterator, Sequence
 
@@ -26,6 +27,7 @@ from google.api_core.exceptions import NotFound
 from google.cloud.dataproc_v1 import Batch, ClusterStatus, JobStatus
 
 from airflow.providers.google.cloud.hooks.dataproc import DataprocAsyncHook
+from airflow.providers.google.cloud.utils.dataproc import DataprocOperationType
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 
@@ -281,22 +283,24 @@ class DataprocDeleteClusterTrigger(DataprocBaseTrigger):
             yield TriggerEvent({"status": "error", "message": "Timeout"})
 
 
-class DataprocWorkflowTrigger(DataprocBaseTrigger):
+class DataprocOperationTrigger(DataprocBaseTrigger):
     """
-    Trigger that periodically polls information from Dataproc API to verify status.
+    Trigger that periodically polls information on a long running operation from Dataproc API to verify status.
 
     Implementation leverages asynchronous transport.
     """
 
-    def __init__(self, name: str, **kwargs: Any):
+    def __init__(self, name: str, operation_type: str | None = None, **kwargs: Any):
         super().__init__(**kwargs)
         self.name = name
+        self.operation_type = operation_type
 
     def serialize(self):
         return (
-            "airflow.providers.google.cloud.triggers.dataproc.DataprocWorkflowTrigger",
+            "airflow.providers.google.cloud.triggers.dataproc.DataprocOperationTrigger",
             {
                 "name": self.name,
+                "operation_type": self.operation_type,
                 "project_id": self.project_id,
                 "region": self.region,
                 "gcp_conn_id": self.gcp_conn_id,
@@ -317,14 +321,30 @@ class DataprocWorkflowTrigger(DataprocBaseTrigger):
                     else:
                         status = "success"
                         message = "Operation is successfully ended."
-                    yield TriggerEvent(
-                        {
-                            "operation_name": operation.name,
-                            "operation_done": operation.done,
-                            "status": status,
-                            "message": message,
-                        }
-                    )
+                    if self.operation_type == DataprocOperationType.DIAGNOSE.value:
+                        gcs_regex = rb"gs:\/\/[a-z0-9][a-z0-9_-]{1,61}[a-z0-9_\-\/]*"
+                        gcs_uri_value = operation.response.value
+                        match = re.search(gcs_regex, gcs_uri_value)
+                        if match:
+                            output_uri = match.group(0).decode("utf-8", "ignore")
+                        else:
+                            output_uri = gcs_uri_value
+                        yield TriggerEvent(
+                            {
+                                "status": status,
+                                "message": message,
+                                "output_uri": output_uri,
+                            }
+                        )
+                    else:
+                        yield TriggerEvent(
+                            {
+                                "operation_name": operation.name,
+                                "operation_done": operation.done,
+                                "status": status,
+                                "message": message,
+                            }
+                        )
                     return
                 else:
                     self.log.info("Sleeping for %s seconds.", self.polling_interval_seconds)

--- a/airflow/providers/google/cloud/utils/dataproc.py
+++ b/airflow/providers/google/cloud/utils/dataproc.py
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from enum import Enum
+
+
+class DataprocOperationType(Enum):
+    """Contains types of long running operations."""
+
+    DIAGNOSE = "DIAGNOSE"

--- a/docs/apache-airflow-providers-google/operators/cloud/dataproc.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/dataproc.rst
@@ -145,6 +145,31 @@ You can generate and use config as followed:
     :start-after: [START how_to_cloud_dataproc_create_cluster_generate_cluster_config]
     :end-before: [END how_to_cloud_dataproc_create_cluster_generate_cluster_config]
 
+Diagnose a cluster
+------------------
+Dataproc supports the collection of `cluster diagnostic information <https://cloud.google.com/dataproc/docs/support/diagnose-cluster-command#diagnostic_summary_and_archive_contents>`_
+like system, Spark, Hadoop, and Dataproc logs, cluster configuration files that can be used to troubleshoot a Dataproc cluster or job.
+It is important to note that this information can only be collected before the cluster is deleted.
+For more information about the available fields to pass when diagnosing a cluster, visit
+`Dataproc diagnose cluster API. <https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters/diagnose>`_
+
+To diagnose a Dataproc cluster use:
+:class:`~airflow.providers.google.cloud.operators.dataproc.DataprocDiagnoseClusterOperator.``
+
+.. exampleinclude:: /../../tests/system/providers/google/cloud/dataproc/example_dataproc_cluster_diagnose.py
+    :language: python
+    :dedent: 0
+    :start-after: [START how_to_cloud_dataproc_diagnose_cluster]
+    :end-before: [END how_to_cloud_dataproc_diagnose_cluster]
+
+You can also use deferrable mode in order to run the operator asynchronously:
+
+.. exampleinclude:: /../../tests/system/providers/google/cloud/dataproc/example_dataproc_cluster_diagnose.py
+    :language: python
+    :dedent: 0
+    :start-after: [START how_to_cloud_dataproc_diagnose_cluster_deferrable]
+    :end-before: [END how_to_cloud_dataproc_diagnose_cluster_deferrable]
+
 Update a cluster
 ----------------
 You can scale the cluster up or down by providing a cluster config and a updateMask.

--- a/docs/apache-airflow/img/airflow_erd.svg
+++ b/docs/apache-airflow/img/airflow_erd.svg
@@ -1363,7 +1363,7 @@
 <g id="edge44" class="edge">
 <title>task_instance&#45;&#45;xcom</title>
 <path fill="none" stroke="#7f7f7f" stroke-dasharray="5,2" d="M1166.1,-816.29C1196.72,-811.66 1228.55,-806.13 1258.36,-800.24"/>
-<text text-anchor="start" x="1248.36" y="-804.04" font-family="Times,serif" font-size="14.00">1</text>
+<text text-anchor="start" x="1227.36" y="-804.04" font-family="Times,serif" font-size="14.00">0..N</text>
 <text text-anchor="start" x="1166.1" y="-820.09" font-family="Times,serif" font-size="14.00">1</text>
 </g>
 <!-- rendered_task_instance_fields -->

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -387,6 +387,7 @@ datapoint
 Dataprep
 Dataproc
 dataproc
+DataprocDiagnoseClusterOperator
 DataScan
 dataScans
 Dataset

--- a/tests/providers/google/cloud/hooks/test_dataproc.py
+++ b/tests/providers/google/cloud/hooks/test_dataproc.py
@@ -197,19 +197,26 @@ class TestDataprocHook:
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_cluster_client"))
     def test_diagnose_cluster(self, mock_client):
-        self.hook.diagnose_cluster(project_id=GCP_PROJECT, region=GCP_LOCATION, cluster_name=CLUSTER_NAME)
+        self.hook.diagnose_cluster(
+            project_id=GCP_PROJECT,
+            region=GCP_LOCATION,
+            cluster_name=CLUSTER_NAME,
+        )
         mock_client.assert_called_once_with(region=GCP_LOCATION)
         mock_client.return_value.diagnose_cluster.assert_called_once_with(
             request=dict(
                 project_id=GCP_PROJECT,
                 region=GCP_LOCATION,
                 cluster_name=CLUSTER_NAME,
+                tarball_gcs_dir=None,
+                jobs=None,
+                yarn_application_ids=None,
+                diagnosis_interval=None,
             ),
             metadata=(),
             retry=DEFAULT,
             timeout=None,
         )
-        mock_client.return_value.diagnose_cluster.return_value.result.assert_called_once_with()
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_cluster_client"))
     def test_get_cluster(self, mock_client):
@@ -646,12 +653,15 @@ class TestDataprocAsyncHook:
                 project_id=GCP_PROJECT,
                 region=GCP_LOCATION,
                 cluster_name=CLUSTER_NAME,
+                tarball_gcs_dir=None,
+                jobs=None,
+                yarn_application_ids=None,
+                diagnosis_interval=None,
             ),
             metadata=(),
             retry=DEFAULT,
             timeout=None,
         )
-        mock_client.return_value.diagnose_cluster.return_value.result.assert_called_once_with()
 
     @pytest.mark.asyncio
     @mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_cluster_client"))

--- a/tests/providers/google/cloud/utils/test_dataproc.py
+++ b/tests/providers/google/cloud/utils/test_dataproc.py
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.providers.google.cloud.utils.dataproc import DataprocOperationType
+
+
+class TestDataprocOperationType:
+    @pytest.mark.parametrize(
+        "str_value, expected_item",
+        [
+            ("DIAGNOSE", DataprocOperationType.DIAGNOSE.value),
+        ],
+    )
+    def test_diagnose_operation(self, str_value, expected_item):
+        assert str_value == expected_item

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_cluster_diagnose.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_cluster_diagnose.py
@@ -1,0 +1,118 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Example Airflow DAG for DataprocDiagnoseClusterOperator.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+from airflow.models.dag import DAG
+from airflow.providers.google.cloud.operators.dataproc import (
+    DataprocCreateClusterOperator,
+    DataprocDeleteClusterOperator,
+    DataprocDiagnoseClusterOperator,
+)
+from airflow.utils.trigger_rule import TriggerRule
+
+ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
+DAG_ID = "dataproc_diagnose_cluster"
+PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT")
+
+CLUSTER_NAME = f"cluster-{ENV_ID}-{DAG_ID}".replace("_", "-")
+REGION = "europe-west1"
+
+
+# Cluster definition
+CLUSTER_CONFIG = {
+    "master_config": {
+        "num_instances": 1,
+        "machine_type_uri": "n1-standard-4",
+        "disk_config": {"boot_disk_type": "pd-standard", "boot_disk_size_gb": 32},
+    },
+    "worker_config": {
+        "num_instances": 2,
+        "machine_type_uri": "n1-standard-4",
+        "disk_config": {"boot_disk_type": "pd-standard", "boot_disk_size_gb": 32},
+    },
+}
+
+
+with DAG(
+    DAG_ID,
+    schedule="@once",
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
+    tags=["example", "dataproc", "diagnose", "cluster"],
+) as dag:
+    create_cluster = DataprocCreateClusterOperator(
+        task_id="create_cluster",
+        project_id=PROJECT_ID,
+        cluster_config=CLUSTER_CONFIG,
+        region=REGION,
+        cluster_name=CLUSTER_NAME,
+    )
+
+    # [START how_to_cloud_dataproc_diagnose_cluster]
+    diagnose_cluster = DataprocDiagnoseClusterOperator(
+        task_id="diagnose_cluster",
+        region=REGION,
+        project_id=PROJECT_ID,
+        cluster_name=CLUSTER_NAME,
+    )
+    # [END how_to_cloud_dataproc_diagnose_cluster]
+
+    # [START how_to_cloud_dataproc_diagnose_cluster_deferrable]
+    diagnose_cluster_deferrable = DataprocDiagnoseClusterOperator(
+        task_id="diagnose_cluster_deferrable",
+        region=REGION,
+        project_id=PROJECT_ID,
+        cluster_name=CLUSTER_NAME,
+        deferrable=True,
+    )
+    # [END how_to_cloud_dataproc_diagnose_cluster_deferrable]
+
+    delete_cluster = DataprocDeleteClusterOperator(
+        task_id="delete_cluster",
+        project_id=PROJECT_ID,
+        cluster_name=CLUSTER_NAME,
+        region=REGION,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
+    (
+        # TEST SETUP
+        create_cluster
+        # TEST BODY
+        >> diagnose_cluster
+        # TEST TEARDOWN
+        >> delete_cluster
+    )
+
+    from tests.system.utils.watcher import watcher
+
+    # This test needs watcher in order to properly mark success/failure
+    # when "teardown" task with trigger rule is part of the DAG
+    list(dag.tasks) >> watcher()
+
+
+from tests.system.utils import get_test_run  # noqa: E402
+
+# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+test_run = get_test_run(dag)


### PR DESCRIPTION
1. Make diagnose_cluster hook return Operation object just like the rest of the hooks.
2. Rename DataprocWorkflowTrigger to DataprocOperationTrigger handle all types of operations for get_operation.
3. Add new operator to capture diagnostic tarball for Dataproc clusters.

closes: #36173 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:



How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
