### PR TITLE
Fix naming validation in `check_files.py` after switch to the hatch builds

### DIFF
--- a/dev/check_files.py
+++ b/dev/check_files.py
@@ -131,7 +131,7 @@ def check_release(files: list[str], version: str):
 
     expected_files = expand_name_variations(
         [
-            f"apache-airflow-{version}.tar.gz",
+            f"apache_airflow-{version}.tar.gz",
             f"apache-airflow-{version}-source.tar.gz",
             f"apache_airflow-{version}-py3-none-any.whl",
         ]
@@ -247,31 +247,31 @@ if __name__ == "__main__":
 def test_check_release_pass():
     """Passes if all present"""
     files = [
-        "apache_airflow-2.2.1-py3-none-any.whl",
-        "apache_airflow-2.2.1-py3-none-any.whl.asc",
-        "apache_airflow-2.2.1-py3-none-any.whl.sha512",
-        "apache-airflow-2.2.1-source.tar.gz",
-        "apache-airflow-2.2.1-source.tar.gz.asc",
-        "apache-airflow-2.2.1-source.tar.gz.sha512",
-        "apache-airflow-2.2.1.tar.gz",
-        "apache-airflow-2.2.1.tar.gz.asc",
-        "apache-airflow-2.2.1.tar.gz.sha512",
+        "apache_airflow-2.8.1-py3-none-any.whl",
+        "apache_airflow-2.8.1-py3-none-any.whl.asc",
+        "apache_airflow-2.8.1-py3-none-any.whl.sha512",
+        "apache-airflow-2.8.1-source.tar.gz",
+        "apache-airflow-2.8.1-source.tar.gz.asc",
+        "apache-airflow-2.8.1-source.tar.gz.sha512",
+        "apache_airflow-2.8.1.tar.gz",
+        "apache_airflow-2.8.1.tar.gz.asc",
+        "apache_airflow-2.8.1.tar.gz.sha512",
     ]
-    assert check_release(files, version="2.2.1rc2") == []
+    assert check_release(files, version="2.8.1rc2") == []
 
 
 def test_check_release_fail():
     """Fails if missing one"""
     files = [
-        "apache_airflow-2.2.1-py3-none-any.whl",
-        "apache_airflow-2.2.1-py3-none-any.whl.asc",
-        "apache_airflow-2.2.1-py3-none-any.whl.sha512",
-        "apache-airflow-2.2.1-source.tar.gz",
-        "apache-airflow-2.2.1-source.tar.gz.asc",
-        "apache-airflow-2.2.1-source.tar.gz.sha512",
-        "apache-airflow-2.2.1.tar.gz.asc",
-        "apache-airflow-2.2.1.tar.gz.sha512",
+        "apache_airflow-2.8.1-py3-none-any.whl",
+        "apache_airflow-2.8.1-py3-none-any.whl.asc",
+        "apache_airflow-2.8.1-py3-none-any.whl.sha512",
+        "apache-airflow-2.8.1-source.tar.gz",
+        "apache-airflow-2.8.1-source.tar.gz.asc",
+        "apache-airflow-2.8.1-source.tar.gz.sha512",
+        "apache_airflow-2.8.1.tar.gz.asc",
+        "apache_airflow-2.8.1.tar.gz.sha512",
     ]
 
-    missing_files = check_release(files, version="2.2.1rc2")
-    assert missing_files == ["apache-airflow-2.2.1.tar.gz"]
+    missing_files = check_release(files, version="2.8.1rc2")
+    assert missing_files == ["apache_airflow-2.8.1.tar.gz"]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

After we switch to hatch builds the naming of `sdist` packages changed from apache`-`airflow-{version}.tar.gz to   apache`_`airflow-{version}.tar.gz. This PR reflects this changes

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
