### PR TITLE
Fix assignment of template field in `__init__` in `hive-stats`

### DIFF
--- a/airflow/providers/apache/hive/operators/hive_stats.py
+++ b/airflow/providers/apache/hive/operators/hive_stats.py
@@ -77,7 +77,7 @@ class HiveStatsCollectionOperator(BaseOperator):
         presto_conn_id: str = "presto_default",
         mysql_conn_id: str = "airflow_db",
         ds: str = "{{ ds }}",
-        dttm: str = "{{ execution_date.isoformat() }}",
+        dttm: str = "{{ logical_date.isoformat() }}",
         **kwargs: Any,
     ) -> None:
         if "col_blacklist" in kwargs:

--- a/airflow/providers/apache/hive/operators/hive_stats.py
+++ b/airflow/providers/apache/hive/operators/hive_stats.py
@@ -76,6 +76,8 @@ class HiveStatsCollectionOperator(BaseOperator):
         metastore_conn_id: str = "metastore_default",
         presto_conn_id: str = "presto_default",
         mysql_conn_id: str = "airflow_db",
+        ds: str = "{{ ds }}",
+        dttm: str = "{{ execution_date.isoformat() }}",
         **kwargs: Any,
     ) -> None:
         if "col_blacklist" in kwargs:
@@ -96,8 +98,8 @@ class HiveStatsCollectionOperator(BaseOperator):
         self.presto_conn_id = presto_conn_id
         self.mysql_conn_id = mysql_conn_id
         self.assignment_func = assignment_func
-        self.ds = "{{ ds }}"
-        self.dttm = "{{ execution_date.isoformat() }}"
+        self.ds = ds
+        self.dttm = dttm
 
     def get_default_exprs(self, col: str, col_type: str) -> dict[Any, Any]:
         """Get default expressions."""


### PR DESCRIPTION
related: https://github.com/apache/airflow/issues/36484

fix:
```
HiveStatsCollectionOperator's constructor lacks direct assignments for instance members corresponding to the following template fields (i.e., self.field_name = field_name or 
super.__init__(field_name=field_name, ...) ):
['dttm', 'ds']
HiveStatsCollectionOperator's constructor contains invalid assignments to the following instance members that should be corresponding to template fields (i.e., self.field_name = field_name):
['self.ds', 'self.dttm']
```

cc: @shahar1 
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
