### PR TITLE
Fix providers validation in `check_files.py` after switch to the hatch builds

### DIFF
--- a/dev/check_files.py
+++ b/dev/check_files.py
@@ -96,7 +96,7 @@ def check_providers(files: list[str]):
         version = strip_rc_suffix(version)
         expected_files = expand_name_variations(
             [
-                f"{name}-{version}.tar.gz",
+                f"{name.replace('-', '_')}-{version}.tar.gz",
                 f"{name.replace('-', '_')}-{version}-py3-none-any.whl",
             ]
         )
@@ -275,3 +275,47 @@ def test_check_release_fail():
 
     missing_files = check_release(files, version="2.8.1rc2")
     assert missing_files == ["apache_airflow-2.8.1.tar.gz"]
+
+
+def test_check_providers_pass(monkeypatch, tmp_path):
+    """Passes if all present"""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "packages.txt").write_text(
+        "https://pypi.org/project/apache-airflow-providers-airbyte/3.1.0rc1/\n"
+        "https://pypi.org/project/apache-airflow-providers-foo-bar/9.6.42rc2/\n"
+    )
+
+    files = [
+        "apache_airflow_providers_airbyte-3.1.0.tar.gz",
+        "apache_airflow_providers_airbyte-3.1.0.tar.gz.asc",
+        "apache_airflow_providers_airbyte-3.1.0.tar.gz.sha512",
+        "apache_airflow_providers_airbyte-3.1.0-py3-none-any.whl",
+        "apache_airflow_providers_airbyte-3.1.0-py3-none-any.whl.asc",
+        "apache_airflow_providers_airbyte-3.1.0-py3-none-any.whl.sha512",
+        "apache_airflow_providers_foo_bar-9.6.42.tar.gz",
+        "apache_airflow_providers_foo_bar-9.6.42.tar.gz.asc",
+        "apache_airflow_providers_foo_bar-9.6.42.tar.gz.sha512",
+        "apache_airflow_providers_foo_bar-9.6.42-py3-none-any.whl",
+        "apache_airflow_providers_foo_bar-9.6.42-py3-none-any.whl.asc",
+        "apache_airflow_providers_foo_bar-9.6.42-py3-none-any.whl.sha512",
+    ]
+    assert check_providers(files) == []
+
+
+def test_check_providers_failure(monkeypatch, tmp_path):
+    """Passes if all present"""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "packages.txt").write_text(
+        "https://pypi.org/project/apache-airflow-providers-spam-egg/1.2.3rc4/\n"
+    )
+
+    files = [
+        "apache_airflow_providers_spam_egg-1.2.3.tar.gz",
+        "apache_airflow_providers_spam_egg-1.2.3.tar.gz.sha512",
+        "apache_airflow_providers_spam_egg-1.2.3-py3-none-any.whl",
+        "apache_airflow_providers_spam_egg-1.2.3-py3-none-any.whl.asc",
+    ]
+    assert sorted(check_providers(files)) == [
+        "apache_airflow_providers_spam_egg-1.2.3-py3-none-any.whl.sha512",
+        "apache_airflow_providers_spam_egg-1.2.3.tar.gz.asc",
+    ]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: https://github.com/apache/airflow/pull/36902

Just figure out that naming also affected to providers packages

```console
❯ breeze release-management prepare-provider-packages microsoft.azure google amazon --version-suffix-for-pypi dev0 --package-format both
Good version of Docker: 24.0.7.
Good version of docker-compose: 2.23.3
...

Successfully built packages!


Packages available in dist:

apache_airflow_providers_amazon-8.16.0.dev0-py3-none-any.whl
apache_airflow_providers_amazon-8.16.0.dev0.tar.gz
apache_airflow_providers_google-10.13.1.dev0-py3-none-any.whl
apache_airflow_providers_google-10.13.1.dev0.tar.gz
apache_airflow_providers_microsoft_azure-8.5.1.dev0-py3-none-any.whl
apache_airflow_providers_microsoft_azure-8.5.1.dev0.tar.gz
```

I think that it not required to change `check_upgrade_check` and maybe even better to remove this option from the file

https://github.com/apache/airflow/blob/98fb11b6502efad034492b16acd73a059e82baff/dev/check_files.py#L146-L157

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
