### PR TITLE
Link to release notes in the upgrade docs

### DIFF
--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -25,6 +25,11 @@ Newer Airflow versions can contain database migrations so you must run ``airflow
 to migrate your database with the schema changes in the Airflow version you are upgrading to.
 Don't worry, it's safe to run even if there are no migrations to perform.
 
+What are the changes between Airflow version x and y?
+=====================================================
+
+The :doc:`release notes <../release_notes>` lists the changes that were included in any given Airflow release.
+
 Upgrade preparation - make a backup of DB
 =========================================
 


### PR DESCRIPTION
We seems to get asked "whats new between Airflow x and y?" a lot, and I noticed that our upgrade docs don't point folks to the release notes. That's at least how I always answer, so at least now I can send a link :)