### PR TITLE
Add more precise description on avoiding generic package/module names

### DIFF
--- a/docs/apache-airflow/administration-and-deployment/modules_management.rst
+++ b/docs/apache-airflow/administration-and-deployment/modules_management.rst
@@ -38,6 +38,7 @@ You can do it in one of those ways:
 The next chapter has a general description of how Python loads packages and modules, and dives
 deeper into the specifics of each of the three possibilities above.
 
+
 How package/modules loading in Python works
 -------------------------------------------
 
@@ -159,13 +160,32 @@ Airflow, when running dynamically adds three directories to the ``sys.path``:
    as safe because they are part of configuration of the Airflow installation and controlled by the
    people managing the installation.
 
-Best practices for module loading
----------------------------------
+Best practices for your code naming
+-----------------------------------
 
 There are a few gotchas you should be careful about when you import your code.
 
+Sometimes, you might see exceptions that ``module 'X' has no attribute 'Y'`` raised from Airflow or other
+library code that you use. This is usually caused by the fact that you have a module or packaged named 'X'
+in your ``PYTHONPATH`` at the top level and it is imported instead of the module that the original
+code expects.
+
+You should always use unique names for your packages and modules and there are ways how you can make
+sure that uniqueness is enforced described below.
+
+
 Use unique top package name
 ...........................
+
+Most importantly avoid using generic names for anything that you add directly at the top level of your
+``PYTHONPATH``. For example if you add ``airflow`` folder with ``__init__.py`` to your ``DAGS_FOLDER``,
+it will clash with the Airflow package and you will not be able to import anything from Airflow
+package. Similarly do not add ``airflow.py`` file directly there. Also common names used by standard
+library packages such as ``multiprocessing`` or ``logging`` etc. should not be used as top level - either
+as packages (i.e. folders with ``__init__.py``) or as modules (i.e. ``.py`` files).
+
+The same applies to ``config`` and ``plugins`` folders which are also at the ``PYTHONPATH`` and anything
+you add to your ``PYTHONPATH`` manually (see details in the following chapters).
 
 It is recommended that you always put your DAGs/common files in a subpackage which is unique to your
 deployment (``my_company`` in the example below). It is far too easy to use generic names for the


### PR DESCRIPTION
It's more and more happening recently that users start to put generic package and module names directly at ``PYTHONPATH`` which overrides the stdlib or airflow imports. Adding a more detailed description should help in just directing people to that page where they can learn how Python module loading works.

The chapter name is changed to "Best practices for your code namig", because the problem is whit naming, not loading.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
