### PR TITLE
Add test for google cloud run delete job

### DIFF
--- a/tests/providers/google/cloud/hooks/test_cloud_run.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_run.py
@@ -22,6 +22,7 @@ from unittest import mock
 import pytest
 from google.cloud.run_v2 import (
     CreateJobRequest,
+    DeleteJobRequest,
     GetJobRequest,
     Job,
     ListJobsRequest,
@@ -70,7 +71,7 @@ class TestCloudRunHook:
         region = "region1"
         project_id = "projectid"
         job = Job()
-        job.name = job.name = f"projects/{project_id}/locations/{region}/jobs/{job_name}"
+        job.name = f"projects/{project_id}/locations/{region}/jobs/{job_name}"
 
         update_request = UpdateJobRequest()
         update_request.job = job
@@ -246,6 +247,17 @@ class TestCloudRunHook:
 
         with pytest.raises(expected_exception=AirflowException):
             cloud_run_hook.list_jobs(region=region, project_id=project_id, limit=limit)
+
+    @mock.patch("airflow.providers.google.cloud.hooks.cloud_run.JobsClient")
+    def test_delete_job(self, mock_batch_service_client, cloud_run_hook):
+        job_name = "job1"
+        region = "region1"
+        project_id = "projectid"
+
+        delete_request = DeleteJobRequest(name=f"projects/{project_id}/locations/{region}/jobs/{job_name}")
+
+        cloud_run_hook.delete_job(job_name=job_name, region=region, project_id=project_id)
+        cloud_run_hook._client.delete_job.assert_called_once_with(delete_request)
 
     def _mock_pager(self, number_of_jobs):
         mock_pager = []


### PR DESCRIPTION
I have added a test for googe cloud run delete_job which was missing before. Also job.name was repeated twice in the same line which is unnecssary.

Please let me know your thoughts.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
