### PR TITLE
Revert "Update statsd-mapping.yml to support Airflow 2.X pool metrics (#36305)

### DIFF
--- a/chart/files/statsd-mappings.yml
+++ b/chart/files/statsd-mappings.yml
@@ -76,18 +76,8 @@ mappings:
     labels:
       pool: "$1"
 
-  - match: airflow.pool.queued_slots.*
-    name: "airflow_pool_queued_slots"
-    labels:
-      pool: "$1"
-
-  - match: airflow.pool.running_slots.*
-    name: "airflow_pool_running_slots"
-    labels:
-      pool: "$1"
-
-  - match: airflow.pool.deferred_slots.*
-    name: "airflow_pool_deferred_slots"
+  - match: airflow.pool.used_slots.*
+    name: "airflow_pool_used_slots"
     labels:
       pool: "$1"
 


### PR DESCRIPTION
This reverts commit 3e6d69dfc64957b70d749ec57f80d3dc023cb535. This is a breaking change in the way metrics are exported.

See https://github.com/apache/airflow/pull/36305#issuecomment-1905003845 for more context.