### PR TITLE
Fix `log_query` to format SQL statement correctly in `AthenaOperator`

### DIFF
--- a/airflow/providers/amazon/aws/hooks/athena.py
+++ b/airflow/providers/amazon/aws/hooks/athena.py
@@ -34,13 +34,16 @@ from airflow.providers.amazon.aws.utils.waiter_with_logging import wait
 if TYPE_CHECKING:
     from botocore.paginate import PageIterator
 
+MULTI_LINE_QUERY_LOG_PREFIX = "\n\t\t"
+
 
 def query_params_to_string(params: dict[str, str | Collection[str]]) -> str:
-    line_prefix = "\n\t\t"
     result = ""
     for key, value in params.items():
         if key == "QueryString":
-            value = line_prefix + str(value).replace("\n", line_prefix).rstrip()
+            value = (
+                MULTI_LINE_QUERY_LOG_PREFIX + str(value).replace("\n", MULTI_LINE_QUERY_LOG_PREFIX).rstrip()
+            )
         result += f"\t{key}: {value}\n"
     return result.rstrip()
 

--- a/airflow/providers/amazon/aws/hooks/athena.py
+++ b/airflow/providers/amazon/aws/hooks/athena.py
@@ -25,7 +25,7 @@ This module contains AWS Athena hook.
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Collection
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
@@ -35,12 +35,12 @@ if TYPE_CHECKING:
     from botocore.paginate import PageIterator
 
 
-def query_params_to_string(params: dict[str, str]) -> str:
+def query_params_to_string(params: dict[str, str | Collection[str]]) -> str:
     line_prefix = "\n\t\t"
     result = ""
     for key, value in params.items():
         if key == "QueryString":
-            value = line_prefix + value.replace("\n", line_prefix).rstrip()
+            value = line_prefix + str(value).replace("\n", line_prefix).rstrip()
         result += f"\t{key}: {value}\n"
     return result.rstrip()
 

--- a/airflow/providers/amazon/aws/hooks/athena.py
+++ b/airflow/providers/amazon/aws/hooks/athena.py
@@ -35,6 +35,16 @@ if TYPE_CHECKING:
     from botocore.paginate import PageIterator
 
 
+def query_params_to_string(params: dict[str, str]) -> str:
+    line_prefix = "\n\t\t"
+    result = ""
+    for key, value in params.items():
+        if key == "QueryString":
+            value = line_prefix + value.replace("\n", line_prefix).rstrip()
+        result += f"\t{key}: {value}\n"
+    return result.rstrip()
+
+
 class AthenaHook(AwsBaseHook):
     """Interact with Amazon Athena.
 
@@ -115,7 +125,7 @@ class AthenaHook(AwsBaseHook):
         if client_request_token:
             params["ClientRequestToken"] = client_request_token
         if self.log_query:
-            self.log.info("Running Query with params: %s", params)
+            self.log.info("Running Query with params:\n%s", query_params_to_string(params))
         response = self.get_conn().start_query_execution(**params)
         query_execution_id = response["QueryExecutionId"]
         self.log.info("Query execution id: %s", query_execution_id)


### PR DESCRIPTION
Just some whitespace changes to make the Athena query log messages look more readable in the logs.

Before:
![image](https://github.com/apache/airflow/assets/1920178/7f653135-076e-4c5b-8329-6b31038a82b7)

After:
![image](https://github.com/apache/airflow/assets/1920178/34e433ee-2f75-4704-b260-c7436d0d5a87)

closes: https://github.com/apache/airflow/issues/34189
