### PR TITLE
fix task_instance can not get task attribute correctly when turning on sentry

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -3231,6 +3231,7 @@ class TaskInstance(Base, LoggingMixin):
     @provide_session
     def _schedule_downstream_tasks(
         cls,
+        *,
         ti: TaskInstance | TaskInstancePydantic,
         session: Session = NEW_SESSION,
         max_tis_per_query: int | None = None,

--- a/airflow/sentry.py
+++ b/airflow/sentry.py
@@ -161,14 +161,15 @@ if conf.getboolean("sentry", "sentry_on", fallback=False):
             """
             Decorate errors.
 
-            Wrap TaskInstance._run_raw_task and LocalTaskJob._run_mini_scheduler_on_child_tasks
-            to support task specific tags and breadcrumbs.
+            Wrap TaskInstance._run_raw_task, TaskInstnace._schedule_downstream_tasks and
+            LocalTaskJob._run_mini_scheduler_on_child_tasks to support task specific tags and breadcrumbs.
             """
             session_args_idx = find_session_idx(func)
 
             @wraps(func)
             def wrapper(_self, *args, **kwargs):
-                # Wrapping the _run_raw_task function with push_scope to contain
+                # Wrapping the TaskInstance._run_raw_task, TaskInstnace._schedule_downstream_tasks and
+                # LocalTaskJob._run_mini_scheduler_on_child_tasks with push_scope to contain
                 # tags and breadcrumbs to a specific Task Instance
 
                 try:
@@ -180,6 +181,7 @@ if conf.getboolean("sentry", "sentry_on", fallback=False):
                     try:
                         ti_from_kwargs = kwargs.get("ti", None)
                         if ti_from_kwargs:
+                            # Get taskinstnace from TaskInstnace._schedule_downstream_tasks
                             task_instance = ti_from_kwargs
                         elif hasattr(_self, "task_instance"):
                             # Is a LocalTaskJob get the task instance

--- a/airflow/sentry.py
+++ b/airflow/sentry.py
@@ -178,8 +178,11 @@ if conf.getboolean("sentry", "sentry_on", fallback=False):
 
                 with sentry_sdk.push_scope():
                     try:
-                        # Is a LocalTaskJob get the task instance
-                        if hasattr(_self, "task_instance"):
+                        ti_from_kwargs = kwargs.get("ti", None)
+                        if ti_from_kwargs:
+                            task_instance = ti_from_kwargs
+                        elif hasattr(_self, "task_instance"):
+                            # Is a LocalTaskJob get the task instance
                             task_instance = _self.task_instance
                         else:
                             task_instance = _self

--- a/airflow/sentry.py
+++ b/airflow/sentry.py
@@ -181,7 +181,7 @@ if conf.getboolean("sentry", "sentry_on", fallback=False):
                     try:
                         ti_from_kwargs = kwargs.get("ti", None)
                         if ti_from_kwargs:
-                            # Get taskinstnace from TaskInstnace._schedule_downstream_tasks
+                            # Get taskinstance from TaskInstance._schedule_downstream_tasks
                             task_instance = ti_from_kwargs
                         elif hasattr(_self, "task_instance"):
                             # Is a LocalTaskJob get the task instance

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -3192,37 +3192,6 @@ class TestTaskInstance:
         assert State.SKIPPED == ti.state
         assert callback_function.called
 
-    @mock.patch("sentry_sdk.push_scope")
-    def test__run_raw_task_decorated_with_sentry_enrich_errors(self, mock_push_scope, create_task_instance):
-        """
-        Test TaskInstance._run_raw_task is decorated with encountering error.
-        """
-
-        with conf_vars(
-            {
-                ("sentry", "sentry_on"): "True"
-            }
-        ):
-            ti = create_task_instance()
-            ti._run_raw_task()
-            assert mock_push_scope.called
-
-    @mock.patch("sentry_sdk.push_scope")
-    def test__schedule_downstream_tasks_decorated_with_sentry_enrich_errors(
-        self, mock_push_scope, create_task_instance, session
-    ):
-        """
-        Test TaskInstance._schedule_downstream_tasks is decorated with encountering error.
-        """
-        with conf_vars(
-            {
-                ("sentry", "sentry_on"): "True"
-            }
-        ):
-            ti = create_task_instance()
-            TaskInstance._schedule_downstream_tasks(ti=ti, session=session)
-            assert mock_push_scope.called
-
 
 @pytest.mark.parametrize("pool_override", [None, "test_pool2"])
 def test_refresh_from_task(pool_override):

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -3192,6 +3192,37 @@ class TestTaskInstance:
         assert State.SKIPPED == ti.state
         assert callback_function.called
 
+    @mock.patch("sentry_sdk.push_scope")
+    def test__run_raw_task_decorated_with_sentry_enrich_errors(self, mock_push_scope, create_task_instance):
+        """
+        Test TaskInstance._run_raw_task is decorated with encountering error.
+        """
+
+        with conf_vars(
+            {
+                ("sentry", "sentry_on"): "True"
+            }
+        ):
+            ti = create_task_instance()
+            ti._run_raw_task()
+            assert mock_push_scope.called
+
+    @mock.patch("sentry_sdk.push_scope")
+    def test__schedule_downstream_tasks_decorated_with_sentry_enrich_errors(
+        self, mock_push_scope, create_task_instance, session
+    ):
+        """
+        Test TaskInstance._schedule_downstream_tasks is decorated with encountering error.
+        """
+        with conf_vars(
+            {
+                ("sentry", "sentry_on"): "True"
+            }
+        ):
+            ti = create_task_instance()
+            TaskInstance._schedule_downstream_tasks(ti=ti, session=session)
+            assert mock_push_scope.called
+
 
 @pytest.mark.parametrize("pool_override", [None, "test_pool2"])
 def test_refresh_from_task(pool_override):


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/36957

As reported by @jkramer-ginkgo, we also encountered a similar issue, and I'm able to reproduce it with the steps provided. Among the suggested solutions by @jkramer-ginkgo , I think it might make more sense to get `ti` from `kwargs` instead of removing this decorator. The  root cause is that https://github.com/apache/airflow/blob/db2b75c233e3e3c59ec9d0563b93ddbe733ad0bf/airflow/models/taskinstance.py#L3225 cannot get `task` attribute https://github.com/apache/airflow/blob/db2b75c233e3e3c59ec9d0563b93ddbe733ad0bf/airflow/sentry.py#L127. But this decorator is also used in https://github.com/apache/airflow/blob/2.8.0/airflow/models/taskinstance.py#L2280, so the original logic would still be needed. I also change `_schedule_downstream_tasks` arguments to be keyword-lonly so that we can ensure that we can get ti from kwargs in `enrich_error`.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
