### PR TITLE
Handle SystemExit raised in the task.

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2393,6 +2393,12 @@ class TaskInstance(Base, LoggingMixin):
                 self.handle_failure(e, test_mode, context, session=session)
                 session.commit()
                 raise
+            except SystemExit as code:
+                self.handle_failure(
+                    f"Task failed due to SystemExit({code})", test_mode, context, session=session
+                )
+                session.commit()
+                raise
             finally:
                 Stats.incr(f"ti.finish.{self.dag_id}.{self.task_id}.{self.state}", tags=self.stats_tags)
                 # Same metric with tagging

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -410,6 +410,17 @@ def _execute_task(task_instance: TaskInstance | TaskInstancePydantic, context: C
             execute_callable_kwargs["next_kwargs"] = task_instance.next_kwargs
     else:
         execute_callable = task_to_execute.execute
+
+    def _execute_callable(context, **execute_callable_kwargs):
+        try:
+            return execute_callable(context=context, **execute_callable_kwargs)
+        except SystemExit as e:
+            # Handle only successful cases here. Failure cases will be handled upper
+            # in the exception chain.
+            if e.code is not None and e.code != 0:
+                raise
+            return None
+
     # If a timeout is specified for the task, make it fail
     # if it goes beyond
     if task_to_execute.execution_timeout:
@@ -427,12 +438,12 @@ def _execute_task(task_instance: TaskInstance | TaskInstancePydantic, context: C
                 raise AirflowTaskTimeout()
             # Run task in timeout wrapper
             with timeout(timeout_seconds):
-                result = execute_callable(context=context, **execute_callable_kwargs)
+                result = _execute_callable(context=context, **execute_callable_kwargs)
         except AirflowTaskTimeout:
             task_to_execute.on_kill()
             raise
     else:
-        result = execute_callable(context=context, **execute_callable_kwargs)
+        result = _execute_callable(context=context, **execute_callable_kwargs)
     with create_session() as session:
         if task_to_execute.do_xcom_push:
             xcom_value = result
@@ -2393,12 +2404,13 @@ class TaskInstance(Base, LoggingMixin):
                 self.handle_failure(e, test_mode, context, session=session)
                 session.commit()
                 raise
-            except SystemExit as code:
-                self.handle_failure(
-                    f"Task failed due to SystemExit({code})", test_mode, context, session=session
-                )
+            except SystemExit as e:
+                # We have already handled SystemExit with success codes (0 and None) in the `_execute_task`.
+                # Therefore, here we must handle only error codes.
+                msg = f"Task failed due to SystemExit({e.code})"
+                self.handle_failure(msg, test_mode, context, session=session)
                 session.commit()
-                raise
+                raise Exception(msg)
             finally:
                 Stats.incr(f"ti.finish.{self.dag_id}.{self.task_id}.{self.state}", tags=self.stats_tags)
                 # Same metric with tagging


### PR DESCRIPTION
Closes: #36809

Currently, we don't handle system exit events in tasks (e.g. `sys.exit()`). Due to this, tasks remain in the running state, which can lead to undesired behavior in cases like #36809.