### PR TITLE
Remove duplicated definitions of random volumes

### DIFF
--- a/scripts/ci/docker-compose/backend-mysql.yml
+++ b/scripts/ci/docker-compose/backend-mysql.yml
@@ -32,7 +32,6 @@ services:
       - MYSQL_DATABASE=airflow
     volumes:
       - ../mysql/conf.d:/etc/mysql/conf.d:ro
-      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
       - mysql-db-volume:/var/lib/mysql
     healthcheck:
       test: ["CMD", "mysql", "-h", "localhost", "-P", "3306", "-u", "root", "-e", "SELECT 1"]

--- a/scripts/ci/docker-compose/backend-none.yml
+++ b/scripts/ci/docker-compose/backend-none.yml
@@ -20,5 +20,3 @@ services:
     environment:
       - BACKEND=none
       - AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=none-backend://
-    volumes:
-      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source

--- a/scripts/ci/docker-compose/backend-postgres.yml
+++ b/scripts/ci/docker-compose/backend-postgres.yml
@@ -33,7 +33,6 @@ services:
       - POSTGRES_DB=airflow
       - POSTGRES_HOST_AUTH_METHOD=password
     volumes:
-      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
       - postgres-db-volume:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD", "psql", "-h", "localhost", "-U", "postgres", "-c", "select 1", "airflow"]

--- a/scripts/ci/docker-compose/backend-sqlite-no-volume.yml
+++ b/scripts/ci/docker-compose/backend-sqlite-no-volume.yml
@@ -20,5 +20,3 @@ services:
     environment:
       - BACKEND=sqlite
       - AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=${SQLITE_URL}
-    volumes:
-      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source

--- a/scripts/ci/docker-compose/backend-sqlite.yml
+++ b/scripts/ci/docker-compose/backend-sqlite.yml
@@ -21,7 +21,6 @@ services:
       - BACKEND=sqlite
       - AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=${SQLITE_URL}
     volumes:
-      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
       - sqlite-db-volume:/root/airflow/sqlite
 volumes:
   sqlite-db-volume:

--- a/scripts/ci/docker-compose/integration-cassandra.yml
+++ b/scripts/ci/docker-compose/integration-cassandra.yml
@@ -25,7 +25,6 @@ services:
       HEAP_NEWSIZE: 128M
       MAX_HEAP_SIZE: 256M
     volumes:
-      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
       - cassandra-db-volume:/var/lib/cassandra
     healthcheck:
       # We use IPv6 variant of the check to workaround the problem with 3.0.26 version

--- a/scripts/ci/docker-compose/integration-celery.yml
+++ b/scripts/ci/docker-compose/integration-celery.yml
@@ -22,7 +22,6 @@ services:
     labels:
       breeze.description: "Integration required for Celery executor tests."
     volumes:
-      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
       - rabbitmq-db-volume:/var/lib/rabbitmq
     healthcheck:
       test: rabbitmq-diagnostics -q ping
@@ -33,7 +32,6 @@ services:
   redis:
     image: redis:5.0.1
     volumes:
-      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
       - redis-db-volume:/data/redis
     ports:
       - "${REDIS_HOST_PORT}:6379"

--- a/scripts/ci/docker-compose/integration-kerberos.yml
+++ b/scripts/ci/docker-compose/integration-kerberos.yml
@@ -29,7 +29,6 @@ services:
 
     volumes:
       - kerberos-keytabs:/root/kerberos-keytabs
-      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
 
     environment:
       - KRB5_TRACE=/dev/stderr

--- a/scripts/ci/docker-compose/integration-mongo.yml
+++ b/scripts/ci/docker-compose/integration-mongo.yml
@@ -22,7 +22,6 @@ services:
     labels:
       breeze.description: "Integration required for MongoDB hooks."
     volumes:
-      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
       - mongo-db-volume:/data/db
     healthcheck:
       test: echo 'db.runCommand("ping").ok' | mongo localhost:27017/test --quiet

--- a/scripts/ci/docker-compose/integration-pinot.yml
+++ b/scripts/ci/docker-compose/integration-pinot.yml
@@ -23,8 +23,6 @@ services:
       breeze.description: "Integration required for Apache Pinot hooks."
     ports:
       - "9080:9080"
-    volumes:
-      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
     command: QuickStart -type batch
     healthcheck:
       test: curl -f http://localhost:8000/health

--- a/scripts/ci/docker-compose/integration-trino.yml
+++ b/scripts/ci/docker-compose/integration-trino.yml
@@ -42,7 +42,6 @@ services:
       - "37778-37786:7778"
 
     volumes:
-      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
       - ../dockerfiles/krb5-kdc-server/krb5.conf:/etc/krb5.conf:ro
       - trino-db-volume:/data/trino
       - kerberos-keytabs:/home/trino/kerberos-keytabs


### PR DESCRIPTION
Docker Compose 2.24 started to error out on duplicated (but otherwise identical) volume definitions coming from multiple docker compose files. We had urandom volume defined not only in base yaml but also in all the backend and integration yaml files which new docker compose does not like (and I agree with it).

That resulted with error:

``services.airflow.volumes array items[0,2] must be unique``

This PR removes the duplicated volume definitions, as side effect it makes our docker compose files cleaner.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
