### PR TITLE
Fix dynamic configmaps as environment variable in `KubernetesPodOperator`

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -230,7 +230,7 @@ class KubernetesPodOperator(BaseOperator):
         "volumes",
         "volume_mounts",
         "cluster_context",
-        "configmaps",
+        "env_from",
     )
     template_fields_renderers = {"env_vars": "py"}
 
@@ -313,9 +313,8 @@ class KubernetesPodOperator(BaseOperator):
         if pod_runtime_info_envs:
             self.env_vars.extend([convert_pod_runtime_info_env(p) for p in pod_runtime_info_envs])
         self.env_from = env_from or []
-        self.configmaps = configmaps
-        if self.configmaps:
-            self.env_from.extend([convert_configmap(c) for c in self.configmaps])
+        if configmaps:
+            self.env_from.extend([convert_configmap(c) for c in configmaps])
         self.ports = [convert_port(p) for p in ports] if ports else []
         self.volume_mounts = [convert_volume_mount(v) for v in volume_mounts] if volume_mounts else []
         self.volumes = [convert_volume(volume) for volume in volumes] if volumes else []
@@ -419,6 +418,10 @@ class KubernetesPodOperator(BaseOperator):
             elif isinstance(content, k8s.V1PersistentVolumeClaimVolumeSource):
                 template_fields = ("claim_name",)
             elif isinstance(content, k8s.V1ConfigMapVolumeSource):
+                template_fields = ("name",)
+            elif isinstance(content, k8s.V1EnvFromSource):
+                template_fields = ("config_map_ref",)
+            elif isinstance(content, k8s.V1ConfigMapEnvSource):
                 template_fields = ("name",)
             else:
                 template_fields = None

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -179,7 +179,7 @@ class TestKubernetesPodOperator:
         assert dag_id == ti.task.arguments
         assert dag_id == ti.task.env_vars[0]
         assert dag_id == rendered.annotations["dag-id"]
-        assert dag_id == ti.task.configmaps[0]
+        assert dag_id == ti.task.env_from[0].config_map_ref.name
         assert dag_id == rendered.volumes[0].name
         assert dag_id == rendered.volumes[0].config_map.name
 


### PR DESCRIPTION
This change is to fix issue from [Provider cncf.kubernetes: 7.14.0rc1](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/7.14.0rc1) testing for the PR #36922. After troubleshooting the issue, I have found that to allow dynamic configmaps as environment variable, it will require to add template support for the attribute 'env_from', not the 'configmaps' 
