### PR TITLE
Remove superfluous `@Sentry.enrich_errors` 

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -3227,7 +3227,6 @@ class TaskInstance(Base, LoggingMixin):
 
     @classmethod
     @internal_api_call
-    @Sentry.enrich_errors
     @provide_session
     def _schedule_downstream_tasks(
         cls,

--- a/airflow/sentry.py
+++ b/airflow/sentry.py
@@ -161,8 +161,7 @@ if conf.getboolean("sentry", "sentry_on", fallback=False):
             """
             Decorate errors.
 
-            Wrap TaskInstance._run_raw_task and LocalTaskJob._run_mini_scheduler_on_child_tasks
-            to support task specific tags and breadcrumbs.
+            Wrap TaskInstance._run_raw_task to support task specific tags and breadcrumbs.
             """
             session_args_idx = find_session_idx(func)
 

--- a/airflow/serialization/pydantic/taskinstance.py
+++ b/airflow/serialization/pydantic/taskinstance.py
@@ -390,7 +390,7 @@ class TaskInstancePydantic(BaseModelPydantic, LoggingMixin):
         :meta: private
         """
         return TaskInstance._schedule_downstream_tasks(
-            ti=self, sessions=session, max_tis_per_query=max_tis_per_query
+            ti=self, session=session, max_tis_per_query=max_tis_per_query
         )
 
     def command_as_list(


### PR DESCRIPTION
Remove superfluous `@Sentry.enrich_errors` from `TaskInstance._schedule_downstream_tasks`

A recent refactoring broke the contract `enrich_errors` expect. This decorator is being removed because it's not desired to log Sentry errors for scheduling issues.

Closes: #36957
Closes: #36968 [this PR is an alternate implementation]

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

