### PR TITLE
Improve AIRFLOW__WEBSERVER__BASE_URL docs

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1388,9 +1388,9 @@ webserver:
       default: "{AIRFLOW_HOME}/webserver_config.py"
     base_url:
       description: |
-        The base url of your website as airflow cannot guess what domain or
-        cname you are using. This is used in automated emails that
-        airflow sends to point links to the right web server
+        The base url of your website: Airflow cannot guess what domain or CNAME you are using.
+        This is used to create links in the Log Url column in the Browse - Task Instances menu,
+        as well as in any automated emails sent by Airflow that contain links to your webserver.
       version_added: ~
       type: string
       example: ~


### PR DESCRIPTION
The fact that the Log Url column gets its base URL from AIRFLOW__WEBSERVER__BASE_URL was undocumented, hence this addition.