### PR TITLE
Add a cross reference to security policy

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -57,6 +57,10 @@ Report bugs through `GitHub <https://github.com/apache/airflow/issues>`__.
 Please report relevant information and preferably code that exhibits the
 problem.
 
+.. note::
+   If you want to report a security finding, please consider
+   https://github.com/apache/airflow/security/policy
+
 Fix Bugs
 --------
 


### PR DESCRIPTION
As I was trying to seek for the link of the Airflow security team I had a hard time finding the policy and process... this PR adds a cross reference so that I hope in future it is better to be located (even if Github has a special UI element for this... I was blind)