### PR TITLE
Fix assignment of template field in `__init__` in `KubernetesPodOperator`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -313,7 +313,6 @@ repos:
               ^airflow\/providers\/amazon\/aws\/transfers\/redshift_to_s3\.py$|
               ^airflow\/providers\/google\/cloud\/operators\/compute\.py$|
               ^airflow\/providers\/google\/cloud\/operators\/vertex_ai\/custom_job\.py$|
-              ^airflow\/providers\/cncf\/kubernetes\/operators\/pod\.py$|
               ^airflow\/providers\/amazon\/aws\/operators\/emr\.py$|
               ^airflow\/providers\/amazon\/aws\/operators\/eks\.py$
           )$

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -245,9 +245,9 @@ class KubernetesPodOperator(BaseOperator):
         cmds: list[str] | None = None,
         arguments: list[str] | None = None,
         ports: list[k8s.V1ContainerPort] | None = None,
-        volume_mounts_param: list[k8s.V1VolumeMount] | None = None,
-        volumes_param: list[k8s.V1Volume] | None = None,
-        env_vars_param: list[k8s.V1EnvVar] | dict[str, str] | None = None,
+        volume_mounts: list[k8s.V1VolumeMount] | None = None,
+        volumes: list[k8s.V1Volume] | None = None,
+        env_vars: list[k8s.V1EnvVar] | dict[str, str] | None = None,
         env_from: list[k8s.V1EnvFromSource] | None = None,
         secrets: list[Secret] | None = None,
         in_cluster: bool | None = None,
@@ -309,7 +309,7 @@ class KubernetesPodOperator(BaseOperator):
         self.labels = labels or {}
         self.startup_timeout_seconds = startup_timeout_seconds
         self.startup_check_interval_seconds = startup_check_interval_seconds
-        env_vars = convert_env_vars(env_vars_param) if env_vars_param else []
+        env_vars = convert_env_vars(env_vars) if env_vars else []
         self.env_vars = env_vars
         if pod_runtime_info_envs:
             self.env_vars.extend([convert_pod_runtime_info_env(p) for p in pod_runtime_info_envs])
@@ -318,9 +318,9 @@ class KubernetesPodOperator(BaseOperator):
         if self.configmaps:
             self.env_from.extend([convert_configmap(c) for c in self.configmaps])
         self.ports = [convert_port(p) for p in ports] if ports else []
-        volume_mounts = [convert_volume_mount(v) for v in volume_mounts_param] if volume_mounts_param else []
+        volume_mounts = [convert_volume_mount(v) for v in volume_mounts] if volume_mounts else []
         self.volume_mounts = volume_mounts
-        volumes = [convert_volume(volume) for volume in volumes_param] if volumes_param else []
+        volumes = [convert_volume(volume) for volume in volumes] if volumes else []
         self.volumes = volumes
         self.secrets = secrets or []
         self.in_cluster = in_cluster

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -245,9 +245,9 @@ class KubernetesPodOperator(BaseOperator):
         cmds: list[str] | None = None,
         arguments: list[str] | None = None,
         ports: list[k8s.V1ContainerPort] | None = None,
-        volume_mounts: list[k8s.V1VolumeMount] | None = None,
-        volumes: list[k8s.V1Volume] | None = None,
-        env_vars: list[k8s.V1EnvVar] | dict[str, str] | None = None,
+        volume_mounts_param: list[k8s.V1VolumeMount] | None = None,
+        volumes_param: list[k8s.V1Volume] | None = None,
+        env_vars_param: list[k8s.V1EnvVar] | dict[str, str] | None = None,
         env_from: list[k8s.V1EnvFromSource] | None = None,
         secrets: list[Secret] | None = None,
         in_cluster: bool | None = None,
@@ -309,7 +309,8 @@ class KubernetesPodOperator(BaseOperator):
         self.labels = labels or {}
         self.startup_timeout_seconds = startup_timeout_seconds
         self.startup_check_interval_seconds = startup_check_interval_seconds
-        self.env_vars = convert_env_vars(env_vars) if env_vars else []
+        env_vars = convert_env_vars(env_vars_param) if env_vars_param else []
+        self.env_vars = env_vars
         if pod_runtime_info_envs:
             self.env_vars.extend([convert_pod_runtime_info_env(p) for p in pod_runtime_info_envs])
         self.env_from = env_from or []
@@ -317,8 +318,10 @@ class KubernetesPodOperator(BaseOperator):
         if self.configmaps:
             self.env_from.extend([convert_configmap(c) for c in self.configmaps])
         self.ports = [convert_port(p) for p in ports] if ports else []
-        self.volume_mounts = [convert_volume_mount(v) for v in volume_mounts] if volume_mounts else []
-        self.volumes = [convert_volume(volume) for volume in volumes] if volumes else []
+        volume_mounts = [convert_volume_mount(v) for v in volume_mounts_param] if volume_mounts_param else []
+        self.volume_mounts = volume_mounts
+        volumes = [convert_volume(volume) for volume in volumes_param] if volumes_param else []
+        self.volumes = volumes
         self.secrets = secrets or []
         self.in_cluster = in_cluster
         self.cluster_context = cluster_context


### PR DESCRIPTION
related: #36484
fix:
```
KubernetesPodOperator's constructor lacks direct assignments for instance members corresponding to the following template fields (i.e., self.field_name = field_name or 
super.__init__(field_name=field_name, ...) ):
['volume_mounts', 'env_vars', 'volumes']
KubernetesPodOperator's constructor contains invalid assignments to the following instance members that should be corresponding to template fields (i.e., self.field_name = field_name):
['self.env_vars', 'self.volume_mounts', 'self.volumes']
```

cc: @shahar1 
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
