### PR TITLE
Add a note to also update committers list in airflow-site repo

### DIFF
--- a/COMMITTERS.rst
+++ b/COMMITTERS.rst
@@ -200,3 +200,5 @@ To be able to merge PRs, committers have to integrate their GitHub ID with Apach
     * ``dev/breeze/src/airflow_breeze/global_constants.py`` (COMMITTERS variable)
     * name and GitHub ID in `project.rst <https://github.com/apache/airflow/blob/main/docs/apache-airflow/project.rst>`__.
     * If you had been a collaborator role before getting committer, remove your Github ID from ``.asf.yaml``.
+7.  To be listed on airflow main entry web site, also raise a PR in
+    `Airflow-Site committers.json <https://github.com/apache/airflow-site/blob/main/landing-pages/site/data/committers.json>`__.


### PR DESCRIPTION
As I was missing to update airflow-site repo after getting a comitter and nobody else did this... adding a note such that it is not forgotten for new committers.