### PR TITLE
Use execution_date= param as a backup to base date for grid view

### DIFF
--- a/airflow/www/static/js/dag/useFilters.tsx
+++ b/airflow/www/static/js/dag/useFilters.tsx
@@ -69,6 +69,7 @@ export interface FilterHookReturn extends UtilFunctions {
 
 // Params names
 export const BASE_DATE_PARAM = "base_date";
+export const EXECUTION_DATE_PARAM = "execution_date";
 export const NUM_RUNS_PARAM = "num_runs";
 export const RUN_TYPE_PARAM = "run_type";
 export const RUN_STATE_PARAM = "run_state";
@@ -93,7 +94,10 @@ const useFilters = (): FilterHookReturn => {
     ? searchParams.get(FILTER_DOWNSTREAM_PARAM) === "true"
     : undefined;
 
-  const baseDate = searchParams.get(BASE_DATE_PARAM) || now;
+  const baseDate =
+    searchParams.get(BASE_DATE_PARAM) ||
+    searchParams.get(EXECUTION_DATE_PARAM) ||
+    now;
   const numRuns =
     searchParams.get(NUM_RUNS_PARAM) || defaultDagRunDisplayNumber.toString();
 


### PR DESCRIPTION
Helps to fix https://github.com/apache/airflow/issues/34723 and can coexist with #34887

Use the execution_date param, already sent as a link in the browse -> dagruns / task instances, as a backup to the base_date param.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
