### PR TITLE
Update DatabricksSqlOperator to work with namedtuple

### DIFF
--- a/airflow/providers/databricks/operators/databricks_sql.py
+++ b/airflow/providers/databricks/operators/databricks_sql.py
@@ -146,14 +146,14 @@ class DatabricksSqlOperator(SQLExecuteQueryOperator):
                 if write_header:
                     writer.writeheader()
                 for row in last_results:
-                    writer.writerow(row.asDict())
+                    writer.writerow(row._asdict())
         elif self._output_format.lower() == "json":
             with open(self._output_path, "w") as file:
-                file.write(json.dumps([row.asDict() for row in last_results]))
+                file.write(json.dumps([row._asdict() for row in last_results]))
         elif self._output_format.lower() == "jsonl":
             with open(self._output_path, "w") as file:
                 for row in last_results:
-                    file.write(json.dumps(row.asDict()))
+                    file.write(json.dumps(row._asdict()))
                     file.write("\n")
         else:
             raise AirflowException(f"Unsupported output format: '{self._output_format}'")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Now, DatabricksSQLHook will return namedtuples as results. So we change "row.asDict()" to "row._asdict() to accommodate these changes. 

We also add test cases for json and jsonl output, which is uncovered in previous tests.

closes: #37007

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
