### PR TITLE
Add "airflow users reset-password" command

### DIFF
--- a/airflow/providers/fab/auth_manager/cli_commands/definition.py
+++ b/airflow/providers/fab/auth_manager/cli_commands/definition.py
@@ -137,6 +137,27 @@ USERS_COMMANDS = (
         ),
     ),
     ActionCommand(
+        name="reset-password",
+        help="Reset a user's password",
+        func=lazy_load_command(
+            "airflow.providers.fab.auth_manager.cli_commands.user_command.user_reset_password"
+        ),
+        args=(
+            ARG_USERNAME_OPTIONAL,
+            ARG_EMAIL_OPTIONAL,
+            ARG_PASSWORD,
+            ARG_USE_RANDOM_PASSWORD,
+            ARG_VERBOSE,
+        ),
+        epilog=(
+            "examples:\n"
+            'To reset an user with username equals to "admin", run:\n'
+            "\n"
+            "    $ airflow users reset-password \\\n"
+            "          --username admin"
+        ),
+    ),
+    ActionCommand(
         name="delete",
         help="Delete a user",
         func=lazy_load_command("airflow.providers.fab.auth_manager.cli_commands.user_command.users_delete"),

--- a/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -458,7 +458,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         jwt_manager.init_app(self.appbuilder.app)
         jwt_manager.user_lookup_loader(self.load_user_jwt)
 
-    def reset_password(self, userid, password):
+    def reset_password(self, userid: int, password: str) -> bool:
         """
         Change/Reset a user's password for auth db.
 
@@ -470,7 +470,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         user = self.get_user_by_id(userid)
         user.password = generate_password_hash(password)
         self.reset_user_sessions(user)
-        self.update_user(user)
+        return self.update_user(user)
 
     def reset_user_sessions(self, user: User) -> None:
         if isinstance(self.appbuilder.get_app.session_interface, AirflowDatabaseSessionInterface):
@@ -1536,7 +1536,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             .limit(1)
         )
 
-    def update_user(self, user):
+    def update_user(self, user: User) -> bool:
         try:
             self.get_session.merge(user)
             self.get_session.commit()
@@ -1545,6 +1545,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             log.error(const.LOGMSG_ERR_SEC_UPD_USER, e)
             self.get_session.rollback()
             return False
+        return True
 
     def del_register_user(self, register_user):
         """

--- a/tests/providers/fab/auth_manager/cli_commands/test_definition.py
+++ b/tests/providers/fab/auth_manager/cli_commands/test_definition.py
@@ -25,7 +25,7 @@ from airflow.providers.fab.auth_manager.cli_commands.definition import (
 
 class TestCliDefinition:
     def test_users_commands(self):
-        assert len(USERS_COMMANDS) == 7
+        assert len(USERS_COMMANDS) == 8
 
     def test_roles_commands(self):
         assert len(ROLES_COMMANDS) == 7

--- a/tests/providers/fab/auth_manager/cli_commands/test_user_command.py
+++ b/tests/providers/fab/auth_manager/cli_commands/test_user_command.py
@@ -472,3 +472,55 @@ class TestCliUsers:
     def test_cli_import_users_exceptions(self, user, message):
         with pytest.raises(SystemExit, match=re.escape(message)):
             self._import_users_from_file([user])
+
+    def test_cli_reset_user_password(self):
+        args = self.parser.parse_args(
+            [
+                "users",
+                "create",
+                "--username",
+                "test3",
+                "--lastname",
+                "doe",
+                "--firstname",
+                "jon",
+                "--email",
+                "jdoe@example.com",
+                "--role",
+                "Viewer",
+                "--use-random-password",
+            ]
+        )
+        user_command.users_create(args)
+        args = self.parser.parse_args(
+            ["users", "reset-password", "--username", "test3", "--use-random-password"]
+        )
+        with redirect_stdout(StringIO()) as stdout:
+            user_command.user_reset_password(args)
+        assert 'User "test3" password reset successfully' in stdout.getvalue()
+
+    def test_cli_reset_user_password_with_email(self):
+        args = self.parser.parse_args(
+            [
+                "users",
+                "create",
+                "--username",
+                "test3",
+                "--lastname",
+                "doe",
+                "--firstname",
+                "jon",
+                "--email",
+                "jdoe@example.com",
+                "--role",
+                "Viewer",
+                "--use-random-password",
+            ]
+        )
+        user_command.users_create(args)
+        args = self.parser.parse_args(
+            ["users", "reset-password", "--email", "jdoe@example.com", "--password", "s3cr3t"]
+        )
+        with redirect_stdout(StringIO()) as stdout:
+            user_command.user_reset_password(args)
+        assert 'User "test3" password reset successfully' in stdout.getvalue()


### PR DESCRIPTION
closes: #37009 

Added support for reset-password command which
can either randomly generate a password, or
take a password from user.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
