### PR TITLE
Fix KPO docs argument precedence 

### DIFF
--- a/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
@@ -78,7 +78,7 @@ Argument precedence
 ^^^^^^^^^^^^^^^^^^^
 
 When KPO defines the pod object, there may be overlap between the :class:`~airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator` arguments.
-In general, the order of precedence is ``full_pod_spec``, ``pod_template_file``, or otherwise the ``V1Pod`` default.
+In general, the order of precedence is ``full_pod_spec``, ``pod_template_file``, followed by ``V1Pod``, by default.
 
 For ``namespace``, if namespace is not provided via any of these methods, then we'll first try to
 get the current namespace (if the task is already running in kubernetes) and failing that we'll use

--- a/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
@@ -78,7 +78,7 @@ Argument precedence
 ^^^^^^^^^^^^^^^^^^^
 
 When KPO defines the pod object, there may be overlap between the :class:`~airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator` arguments.
-In general, the order of precedence is KPO field-specific arguments (e.g., `secrets`, `cmds`, `affinity`), more general templates``full_pod_spec``, ``pod_template_file``, ``pod_template_dict``,  and followed by ``V1Pod``, by default.
+In general, the order of precedence is KPO field-specific arguments (e.g., ``secrets``, ``cmds``, ``affinity``), more general templates ``full_pod_spec``, ``pod_template_file``, ``pod_template_dict``,  and followed by ``V1Pod``, by default.
 
 For ``namespace``, if namespace is not provided via any of these methods, then we'll first try to
 get the current namespace (if the task is already running in kubernetes) and failing that we'll use

--- a/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
@@ -78,7 +78,7 @@ Argument precedence
 ^^^^^^^^^^^^^^^^^^^
 
 When KPO defines the pod object, there may be overlap between the :class:`~airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator` arguments.
-In general, the order of precedence is ``full_pod_spec``, ``pod_template_file``, followed by ``V1Pod``, by default.
+In general, the order of precedence is ``pod_template_file``, ``pod_template_dict``, ``full_pod_spec``, and followed by ``V1Pod``, by default.
 
 For ``namespace``, if namespace is not provided via any of these methods, then we'll first try to
 get the current namespace (if the task is already running in kubernetes) and failing that we'll use

--- a/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
@@ -78,7 +78,7 @@ Argument precedence
 ^^^^^^^^^^^^^^^^^^^
 
 When KPO defines the pod object, there may be overlap between the :class:`~airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator` arguments.
-In general, the order of precedence is ``pod_template_file``, ``pod_template_dict``, ``full_pod_spec``, and followed by ``V1Pod``, by default.
+In general, the order of precedence is KPO field-specific arguments (e.g., `secrets`, `cmds`, `affinity`), more general templates``full_pod_spec``, ``pod_template_file``, ``pod_template_dict``,  and followed by ``V1Pod``, by default.
 
 For ``namespace``, if namespace is not provided via any of these methods, then we'll first try to
 get the current namespace (if the task is already running in kubernetes) and failing that we'll use

--- a/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
@@ -77,8 +77,8 @@ You can print out the Kubernetes manifest for the pod that would be created at r
 Argument precedence
 ^^^^^^^^^^^^^^^^^^^
 
-When building the pod object, there may be overlap between KPO params, pod spec, template and airflow connection.
-In general, the order of precedence is KPO argument > full pod spec > pod template file > airflow connection.
+When KPO defines the pod object, there may be overlap between the :class:`~airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator` arguments.
+In general, the order of precedence is ``full_pod_spec``, ``pod_template_file``, or otherwise the `V1Pod` default.
 
 For ``namespace``, if namespace is not provided via any of these methods, then we'll first try to
 get the current namespace (if the task is already running in kubernetes) and failing that we'll use

--- a/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
@@ -78,7 +78,7 @@ Argument precedence
 ^^^^^^^^^^^^^^^^^^^
 
 When KPO defines the pod object, there may be overlap between the :class:`~airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator` arguments.
-In general, the order of precedence is ``full_pod_spec``, ``pod_template_file``, or otherwise the `V1Pod` default.
+In general, the order of precedence is ``full_pod_spec``, ``pod_template_file``, or otherwise the ``V1Pod`` default.
 
 For ``namespace``, if namespace is not provided via any of these methods, then we'll first try to
 get the current namespace (if the task is already running in kubernetes) and failing that we'll use


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
@amoghrajesh 
closes: #35509


<!-- Please keep an empty line above the dashes. -->
---

Fixes the Argument precedence section of KPO docs. Removed incorrect mention of KPO creates pods based off the Airflow connection. It should be pod_template_file, pod_template_dict, full_pod_spec, then a default `V1Pod(metadata=k8s.V1ObjectMeta())`.

The complexity that `full_pod_spec` and `pod_template_*` can be reconciled by the order of precedence is ignored in the docs.