### PR TITLE
Limit moto to version below 5.0.0

### DIFF
--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -118,7 +118,10 @@ additional-extras:
 devel-dependencies:
   - aiobotocore>=2.7.0
   - aws_xray_sdk>=2.12.0
-  - moto[cloudformation,glue]>=4.2.12
+  # Moto 5 replaced all decorators with single mock_aws decorator and we need to
+  # Replace the usage of mock decorators in our tests to be able to use moto 5
+  # See https://github.com/apache/airflow/issues/37053
+  - moto[cloudformation,glue]>=4.2.12,<5.0.0
   - mypy-boto3-appflow>=1.33.0
   - mypy-boto3-rds>=1.33.0
   - mypy-boto3-redshift-data>=1.33.0

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -41,7 +41,7 @@
     "devel-deps": [
       "aiobotocore>=2.7.0",
       "aws_xray_sdk>=2.12.0",
-      "moto[cloudformation,glue]>=4.2.12",
+      "moto[cloudformation,glue]>=4.2.12,<5.0.0",
       "mypy-boto3-appflow>=1.33.0",
       "mypy-boto3-rds>=1.33.0",
       "mypy-boto3-redshift-data>=1.33.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -533,6 +533,7 @@ alibaba = [
   "oss2>=2.14.0",
 ]
 amazon = [
+  "PyAthena>=3.0.10",
   "apache-airflow[common_sql]",
   "apache-airflow[http]",
   "asgiref",
@@ -546,13 +547,12 @@ amazon = [
   # Devel dependencies for the amazon provider
   "aiobotocore>=2.7.0",
   "aws_xray_sdk>=2.12.0",
-  "moto[cloudformation,glue]>=4.2.12",
+  "moto[cloudformation,glue]>=4.2.12,<5.0.0",
   "mypy-boto3-appflow>=1.33.0",
   "mypy-boto3-rds>=1.33.0",
   "mypy-boto3-redshift-data>=1.33.0",
   "mypy-boto3-s3>=1.33.0",
   "s3fs>=2023.10.0",
-  "PyAthena>=3.0.10",
 ]
 apache-beam = [
   "apache-beam>=2.53.0",


### PR DESCRIPTION
Moto 5 replaced all decorators with single mock_aws decorator and we need to Replace the usage of mock decorators in our tests to be able to use moto 5 Related: #37053

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
