### PR TITLE
SqlToS3Operator: feat/ add max_rows_per_file parameter

### DIFF
--- a/airflow/providers/amazon/aws/transfers/sql_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/sql_to_s3.py
@@ -135,6 +135,12 @@ class SqlToS3Operator(BaseOperator):
         if "path_or_buf" in self.pd_kwargs:
             raise AirflowException("The argument path_or_buf is not allowed, please remove it")
 
+        if self.max_rows_per_file and self.groupby_kwargs:
+            raise AirflowException(
+                "SqlToS3Operator arguments max_rows_per_file and groupby_kwargs "
+                "can not be both specified. Please choose one."
+            )
+
         try:
             self.file_format = FILE_FORMAT[file_format.upper()]
         except KeyError:

--- a/airflow/providers/amazon/aws/transfers/sql_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/sql_to_s3.py
@@ -83,7 +83,7 @@ class SqlToS3Operator(BaseOperator):
     :param file_format: the destination file format, only string 'csv', 'json' or 'parquet' is accepted.
     :param max_rows_per_file: (optional) argument to set destination file number of rows limit, if source data
         is larger than that, it will be dispatched into multiple files.
-        Will be ignored if groupby_kwargs argument is specified.
+        Will be ignored if ``groupby_kwargs`` argument is specified.
     :param pd_kwargs: arguments to include in DataFrame ``.to_parquet()``, ``.to_json()`` or ``.to_csv()``.
     :param groupby_kwargs: argument to include in DataFrame ``groupby()``.
     """

--- a/tests/providers/amazon/aws/transfers/test_sql_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_sql_to_s3.py
@@ -271,6 +271,58 @@ class TestSqlToS3Operator:
             )
         )
 
+    def test_with_max_rows_per_file(self):
+        """
+        Test operator when the max_rows_per_file is specified
+        """
+        query = "query"
+        s3_bucket = "bucket"
+        s3_key = "key"
+
+        op = SqlToS3Operator(
+            query=query,
+            s3_bucket=s3_bucket,
+            s3_key=s3_key,
+            sql_conn_id="mysql_conn_id",
+            aws_conn_id="aws_conn_id",
+            task_id="task_id",
+            replace=True,
+            pd_kwargs={"index": False, "header": False},
+            max_rows_per_file=3,
+            dag=None,
+        )
+        example = {
+            "Team": ["Australia", "Australia", "India", "India"],
+            "Player": ["Ricky", "David Warner", "Virat Kohli", "Rohit Sharma"],
+            "Runs": [345, 490, 672, 560],
+        }
+
+        df = pd.DataFrame(example)
+        data = []
+        for group_name, df in op._partition_dataframe(df):
+            data.append((group_name, df))
+        data.sort(key=lambda d: d[0])
+        team, df = data[0]
+        assert df.equals(
+            pd.DataFrame(
+                {
+                    "Team": ["Australia", "Australia", "India"],
+                    "Player": ["Ricky", "David Warner", "Virat Kohli"],
+                    "Runs": [345, 490, 672],
+                }
+            )
+        )
+        team, df = data[1]
+        assert df.equals(
+            pd.DataFrame(
+                {
+                    "Team": ["India"],
+                    "Player": ["Rohit Sharma"],
+                    "Runs": [560],
+                }
+            )
+        )
+
     @mock.patch("airflow.providers.common.sql.operators.sql.BaseHook.get_connection")
     def test_hook_params(self, mock_get_conn):
         mock_get_conn.return_value = Connection(conn_id="postgres_test", conn_type="postgres")


### PR DESCRIPTION
**Description**
`SqlToS3Operator` create an S3 object from the output of a sql qurey. Unless you specify a groupby_kwargs parameter, the entire data will be written in one object. This could results on data pipeline issues especially when output files are consumed by limited resources workers (like Kubernetes pods).
So I suggest adding a new paramter, `max_rows_per_file`, to limit the size of destination files and dispatch output data into multiple files.

**Use case/motivation**
I faced a lot of out-of-memory issues when trying to process SqlToS3Operator destination object. With such a feature, output will be standardized and next compute worker can easily has an adequate size and a predictable run time.

**Code of Conduct**
 I agree to follow this project's [Code of Conduct](https://github.com/apache/airflow/blob/main/CODE_OF_CONDUCT.md) 