### PR TITLE
Bugfix Triggering DAG with parameters is mandatory when show_trigger_form_if_no_params is enabled

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -231,6 +231,7 @@
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                   <input type="hidden" name="dag_id" value="{{ dag.dag_id }}">
                   <input type="hidden" name="unpause" value="True">
+                  <input type="hidden" name="conf" value="{}">
                   <!-- for task instance detail pages, dag_id is still a query param -->
                   {% if 'dag_id' in request.args %}
                     <input type="hidden" name="origin" value="{{ url_for(request.endpoint, **request.args) }}">

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -377,6 +377,7 @@
                           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                           <input type="hidden" name="dag_id" value="{{ dag.dag_id }}">
                           <input type="hidden" name="unpause" value="True">
+                          <input type="hidden" name="conf" value="{}">
                           <button type="submit" class="dropdown-form-btn">Trigger DAG</button>
                         </form>
                       </li>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2189,7 +2189,8 @@ class Airflow(AirflowBaseView):
             form = DateTimeForm(data={"execution_date": execution_date})
             # Take over "bad" submitted fields for new form display
             for k, v in form_fields.items():
-                form_fields[k]["value"] = run_conf[k]
+                if k in run_conf:
+                    form_fields[k]["value"] = run_conf[k]
             return self.render_template(
                 "airflow/trigger.html",
                 form_fields=form_fields,


### PR DESCRIPTION
After the last rework of the trigger form to prevent a XSS we did not fully test the UI when the configuration `show_trigger_form_if_no_params` is set to True.

This PR fixes the reported problem as reported in #36843 by submitting a virtual empty form.
Alongside I found that there is a key error if some required fields are not set, which still is validated. In such cases an Exception was produced earlier, now it is correctly forwarding and forcing the user to enter data into the form.

How to test (needs to be made manually :-( ):
- Run Airflow and trigger a DAG with params (e.g. example_params_ui_tutorial) and one without (e.g. example_bash_decorator) and see like before form is displayed depending on params defined on the DAG.
- Start webserver with `AIRFLOW__WEBSERVER__SHOW_TRIGGER_FORM_IF_NO_PARAMS=True` and try to start the two DAGs above with and without params. Shuod fix the bug reported.

closes: #36843 
