### PR TITLE
fix: using endpoint from connection if not specified

### DIFF
--- a/airflow/providers/yandex/secrets/lockbox.py
+++ b/airflow/providers/yandex/secrets/lockbox.py
@@ -253,6 +253,9 @@ class LockboxSecretBackend(BaseSecretsBackend, LoggingMixin):
         return sorted(entries.values())[0]
 
     def _get_secrets(self) -> list[secret_pb.Secret]:
+        # generate client if not exists, to load folder_id from connections
+        _ = self._client
+
         response = self._list_secrets(folder_id=self.folder_id)
 
         secrets: list[secret_pb.Secret] = response.secrets[:]

--- a/airflow/providers/yandex/secrets/lockbox.py
+++ b/airflow/providers/yandex/secrets/lockbox.py
@@ -103,7 +103,8 @@ class LockboxSecretBackend(BaseSecretsBackend, LoggingMixin):
     :param sep: Specifies the separator used to concatenate secret_prefix and secret_id.
         Default: "/"
     :param endpoint: Specifies an API endpoint.
-        Leave blank to use default.
+        If set to None (null in JSON), requests will use the connection endpoint, if specified,
+        or the default endpoint.
     """
 
     def __init__(
@@ -191,6 +192,7 @@ class LockboxSecretBackend(BaseSecretsBackend, LoggingMixin):
             self.yc_sa_key_json = self._get_field("service_account_json")
             self.yc_sa_key_json_path = self._get_field("service_account_json_path")
             self.folder_id = self.folder_id or self._get_field("folder_id")
+            self.endpoint = self.endpoint or self._get_field("endpoint")
 
         credentials = get_credentials(
             oauth_token=self.yc_oauth_token,

--- a/docs/apache-airflow-providers-yandex/secrets-backends/yandex-cloud-lockbox-secret-backend.rst
+++ b/docs/apache-airflow-providers-yandex/secrets-backends/yandex-cloud-lockbox-secret-backend.rst
@@ -73,7 +73,7 @@ You can pass the following parameters:
 * ``variables_prefix``: Specifies the prefix of the secret to read to get Variables. If set to None (null in JSON), requests for variables will not be sent to Yandex Lockbox. Default: "airflow/variables"
 * ``config_prefix``: Specifies the prefix of the secret to read to get Configurations. If set to None (null in JSON), requests for variables will not be sent to Yandex Lockbox. Default: "airflow/config"
 * ``sep``: Specifies the separator used to concatenate secret_prefix and secret_id. Default: "/"
-* ``endpoint``: Specifies an API endpoint. Leave blank to use default.
+* ``endpoint``: Specifies an API endpoint. If set to None (null in JSON), requests will use the connection endpoint, if specified, or the default endpoint.
 
 All options should be passed as a JSON dictionary.
 

--- a/tests/providers/yandex/secrets/test_lockbox.py
+++ b/tests/providers/yandex/secrets/test_lockbox.py
@@ -176,6 +176,37 @@ class TestLockboxSecretBackend:
 
         assert sm._client is not None
 
+    @patch("airflow.providers.yandex.secrets.lockbox.LockboxSecretBackend._get_field")
+    def test_yandex_lockbox_secret_backend__client_credentials_received_from_connection(self, mock_get_field):
+        yc_oauth_token = "y3_Vdheub7w9bIut67GHeL345gfb5GAnd3dZnf08FRbvjeUFvetYiohGvc"
+        yc_sa_key_json = "sa_key_json"
+        yc_sa_key_json_path = "sa_key_json_path"
+        folder_id = "folder_id123"
+        endpoint = "some-custom-api-endpoint.cloud.yandex.net"
+        yc_connection_id = "connection_id"
+
+        fields = {
+            "oauth": yc_oauth_token,
+            "service_account_json": yc_sa_key_json,
+            "service_account_json_path": yc_sa_key_json_path,
+            "folder_id": folder_id,
+            "endpoint": endpoint,
+        }
+        mock_get_field.side_effect = lambda key: fields[key]
+
+        sm = LockboxSecretBackend(
+            yc_connection_id=yc_connection_id,
+        )
+        client = sm._client
+
+        assert client is not None
+        assert sm.yc_oauth_token == yc_oauth_token
+        assert sm.yc_sa_key_json == yc_sa_key_json
+        assert sm.yc_sa_key_json_path == yc_sa_key_json_path
+        assert sm.folder_id == folder_id
+        assert sm.endpoint == endpoint
+        assert sm.yc_connection_id == yc_connection_id
+
     def test_yandex_lockbox_secret_backedn__get_endpoint(self):
         endpoint = "api.cloud.yandex.net"
         expected = {

--- a/tests/providers/yandex/secrets/test_lockbox.py
+++ b/tests/providers/yandex/secrets/test_lockbox.py
@@ -346,8 +346,9 @@ class TestLockboxSecretBackend:
 
         assert res is None
 
+    @patch("airflow.providers.yandex.secrets.lockbox.LockboxSecretBackend._client")
     @patch("airflow.providers.yandex.secrets.lockbox.LockboxSecretBackend._list_secrets")
-    def test_yandex_lockbox_secret_backend__get_secrets(self, mock_list_secrets):
+    def test_yandex_lockbox_secret_backend__get_secrets(self, mock_list_secrets, mock_client):
         secrets = secret_service_pb.ListSecretsResponse(
             secrets=[
                 secret_pb.Secret(
@@ -360,6 +361,7 @@ class TestLockboxSecretBackend:
         )
 
         mock_list_secrets.return_value = secrets
+        mock_client.return_value = None
 
         res = LockboxSecretBackend(
             folder_id="someid",
@@ -367,8 +369,9 @@ class TestLockboxSecretBackend:
 
         assert res == secrets.secrets
 
+    @patch("airflow.providers.yandex.secrets.lockbox.LockboxSecretBackend._client")
     @patch("airflow.providers.yandex.secrets.lockbox.LockboxSecretBackend._list_secrets")
-    def test_yandex_lockbox_secret_backend__get_secrets_page_token(self, mock_list_secrets):
+    def test_yandex_lockbox_secret_backend__get_secrets_page_token(self, mock_list_secrets, mock_client):
         first_secrets = secret_service_pb.ListSecretsResponse(
             secrets=[
                 secret_pb.Secret(
@@ -396,6 +399,7 @@ class TestLockboxSecretBackend:
             first_secrets,
             second_secrets,
         ]
+        mock_client.return_value = None
 
         res = LockboxSecretBackend(
             folder_id="someid",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

try to use endpoint from connection if it not specified in `backend_kwargs`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
