### PR TITLE
Order XCom entries by map index in API

### DIFF
--- a/airflow/api_connexion/endpoints/xcom_endpoint.py
+++ b/airflow/api_connexion/endpoints/xcom_endpoint.py
@@ -71,7 +71,8 @@ def get_xcom_entries(
         query = query.where(XCom.map_index == map_index)
     if xcom_key is not None:
         query = query.where(XCom.key == xcom_key)
-    query = query.order_by(DR.execution_date, XCom.task_id, XCom.map_index, XCom.dag_id, XCom.key)
+    # Match idx_xcom_task_instance + idx_xcom_key for performance.
+    query = query.order_by(XCom.dag_id, XCom.task_id, XCom.run_id, XCom.map_index, XCom.key)
     total_entries = get_query_count(query, session=session)
     query = session.scalars(query.offset(offset).limit(limit))
     return xcom_collection_schema.dump(XComCollection(xcom_entries=query, total_entries=total_entries))

--- a/airflow/api_connexion/endpoints/xcom_endpoint.py
+++ b/airflow/api_connexion/endpoints/xcom_endpoint.py
@@ -71,7 +71,7 @@ def get_xcom_entries(
         query = query.where(XCom.map_index == map_index)
     if xcom_key is not None:
         query = query.where(XCom.key == xcom_key)
-    query = query.order_by(DR.execution_date, XCom.task_id, XCom.dag_id, XCom.key)
+    query = query.order_by(DR.execution_date, XCom.task_id, XCom.map_index, XCom.dag_id, XCom.key)
     total_entries = get_query_count(query, session=session)
     query = session.scalars(query.offset(offset).limit(limit))
     return xcom_collection_schema.dump(XComCollection(xcom_entries=query, total_entries=total_entries))


### PR DESCRIPTION
This makes the resulting list more stable.

I found this in a failed CI run: https://github.com/apache/airflow/actions/runs/7698956149/job/20980348665

While it is technically possible to just fix this in the tests, I feel it is better to make the list returned by the API have a stable ordering since this is useful in general anyway.
