### PR TITLE
Workaround backwards-incompatibility in google-core-api 2.16.0

### DIFF
--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_batch.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_batch.py
@@ -22,7 +22,17 @@ from __future__ import annotations
 import os
 from datetime import datetime
 
-from google.api_core.retry_async import AsyncRetry
+try:
+    from google.api_core.retry import AsyncRetry  # type: ignore[attr-defined]
+    # There is a backwards-incompatible change in google.api_core.retry.AsyncRetry imports
+    # In 2.16.0 version of google-api-core, AsyncRetry was moved to google.api_core.retry_unary_async
+    # and backwards compatibility impots were not haandling the case of
+    # `from google.api_core.retry_async import AsyncRetry`
+    # The issue is tracked in https://github.com/googleapis/python-api-core/issues/586
+    # Until it is solved, we need to handle both cases, because one works before and one after 2.16.0
+    # But there is no import that works for both.
+except ImportError:
+    from google.api_core.retry_async import AsyncRetry  # type: ignore[attr-defined]
 
 from airflow.models.dag import DAG
 from airflow.providers.google.cloud.operators.dataproc import (


### PR DESCRIPTION
There is a backwards-incompatible change in
google.api_core.retry.AsyncRetry imports.

In 2.16.0 version of google-api-core, AsyncRetry was moved to google.api_core.retry_unary_async and backwards compatibility impots were not haandling the case of:
`from google.api_core.retry_async imprt AsyncRetry`

The issue is tracked in https://github.com/googleapis/python-api-core/issues/586

Until it is solved, we need to handle both cases, because one works before and one after 2.16.0.

But there is no import that works for both.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
