### PR TITLE
Add missing `v2-8` branches to codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -86,6 +86,8 @@ coverage:
           - v2-6-test
           - v2-7-stable
           - v2-7-test
+          - v2-8-stable
+          - v2-8-test
         if_no_uploads: error
         if_not_found: success
         if_ci_failed: error


### PR DESCRIPTION
The entries in this file should be two but only one part was filled during the last release. This fixes it

