### PR TITLE
ECS Executor - Add backoff on failed task retry

### DIFF
--- a/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
+++ b/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
@@ -42,10 +42,14 @@ from airflow.providers.amazon.aws.executors.ecs.utils import (
     EcsQueuedTask,
     EcsTaskCollection,
 )
-from airflow.providers.amazon.aws.executors.utils.exponential_backoff_retry import exponential_backoff_retry
+from airflow.providers.amazon.aws.executors.utils.exponential_backoff_retry import (
+    calculate_next_attempt_delay,
+    exponential_backoff_retry,
+)
 from airflow.providers.amazon.aws.hooks.ecs import EcsHook
 from airflow.utils import timezone
 from airflow.utils.state import State
+from airflow.utils.timezone import utcnow
 
 if TYPE_CHECKING:
     from airflow.models.taskinstance import TaskInstanceKey
@@ -300,7 +304,14 @@ class AwsEcsExecutor(BaseExecutor):
             )
             self.active_workers.increment_failure_count(task_key)
             self.pending_tasks.appendleft(
-                EcsQueuedTask(task_key, task_cmd, queue, exec_info, failure_count + 1)
+                EcsQueuedTask(
+                    task_key,
+                    task_cmd,
+                    queue,
+                    exec_info,
+                    failure_count + 1,
+                    utcnow() + calculate_next_attempt_delay(failure_count),
+                )
             )
         else:
             self.log.error(
@@ -331,6 +342,8 @@ class AwsEcsExecutor(BaseExecutor):
             exec_config = ecs_task.executor_config
             attempt_number = ecs_task.attempt_number
             _failure_reasons = []
+            if utcnow() < ecs_task.next_attempt_time:
+                continue
             try:
                 run_task_response = self._run_task(task_key, cmd, queue, exec_config)
             except NoCredentialsError:
@@ -361,6 +374,7 @@ class AwsEcsExecutor(BaseExecutor):
                 # Make sure the number of attempts does not exceed MAX_RUN_TASK_ATTEMPTS
                 if int(attempt_number) <= int(self.__class__.MAX_RUN_TASK_ATTEMPTS):
                     ecs_task.attempt_number += 1
+                    ecs_task.next_attempt_time = utcnow() + calculate_next_attempt_delay(attempt_number)
                     self.pending_tasks.appendleft(ecs_task)
                 else:
                     self.log.error(
@@ -422,7 +436,7 @@ class AwsEcsExecutor(BaseExecutor):
         """Save the task to be executed in the next sync by inserting the commands into a queue."""
         if executor_config and ("name" in executor_config or "command" in executor_config):
             raise ValueError('Executor Config should never override "name" or "command"')
-        self.pending_tasks.append(EcsQueuedTask(key, command, queue, executor_config or {}, 1))
+        self.pending_tasks.append(EcsQueuedTask(key, command, queue, executor_config or {}, 1, utcnow()))
 
     def end(self, heartbeat_interval=10):
         """Waits for all currently running tasks to end, and doesn't launch any tasks."""

--- a/airflow/providers/amazon/aws/executors/ecs/utils.py
+++ b/airflow/providers/amazon/aws/executors/ecs/utils.py
@@ -23,6 +23,7 @@ Data classes and utility functions used by the ECS executor.
 
 from __future__ import annotations
 
+import datetime
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, List
@@ -58,6 +59,7 @@ class EcsQueuedTask:
     queue: str
     executor_config: ExecutorConfigType
     attempt_number: int
+    next_attempt_time: datetime.datetime
 
 
 @dataclass


### PR DESCRIPTION
Adds an exponential backoff to the retry times on failed ECS Executor tasks.  

Includes minor tweak to the existing exponential-backoff logic to make it more modular/reusable and a unit test.