### PR TITLE
Bump aiohttp min version to avoid CVE-2024-23829 and CVE-2024-23334

### DIFF
--- a/airflow/providers/apache/livy/provider.yaml
+++ b/airflow/providers/apache/livy/provider.yaml
@@ -50,7 +50,7 @@ versions:
 dependencies:
   - apache-airflow>=2.6.0
   - apache-airflow-providers-http
-  - aiohttp
+  - aiohttp>=3.9.2
   - asgiref
 
 integrations:

--- a/airflow/providers/databricks/provider.yaml
+++ b/airflow/providers/databricks/provider.yaml
@@ -66,7 +66,7 @@ dependencies:
   # it needs to be excluded. See https://github.com/databricks/databricks-sql-python/issues/190
   # The 2.9.1 (to be released soon) already contains the fix
   - databricks-sql-connector>=2.0.0, <3.0.0, !=2.9.0
-  - aiohttp>=3.6.3, <4
+  - aiohttp>=3.9.2, <4
 
 additional-extras:
   # pip install apache-airflow-providers-databricks[sdk]

--- a/airflow/providers/dbt/cloud/provider.yaml
+++ b/airflow/providers/dbt/cloud/provider.yaml
@@ -50,7 +50,7 @@ dependencies:
   - apache-airflow>=2.6.0
   - apache-airflow-providers-http
   - asgiref
-  - aiohttp
+  - aiohttp>=3.9.2
 
 integrations:
   - integration-name: dbt Cloud

--- a/airflow/providers/http/provider.yaml
+++ b/airflow/providers/http/provider.yaml
@@ -57,7 +57,7 @@ dependencies:
   # release it as a requirement for airflow
   - requests>=2.26.0
   - requests_toolbelt
-  - aiohttp
+  - aiohttp>=3.9.2
   - asgiref
 
 integrations:

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -196,7 +196,7 @@
   },
   "apache.livy": {
     "deps": [
-      "aiohttp",
+      "aiohttp>=3.9.2",
       "apache-airflow-providers-http",
       "apache-airflow>=2.6.0",
       "asgiref"
@@ -358,7 +358,7 @@
   },
   "databricks": {
     "deps": [
-      "aiohttp>=3.6.3, <4",
+      "aiohttp>=3.9.2, <4",
       "apache-airflow-providers-common-sql>=1.10.0",
       "apache-airflow>=2.6.0",
       "databricks-sql-connector>=2.0.0, <3.0.0, !=2.9.0",
@@ -385,7 +385,7 @@
   },
   "dbt.cloud": {
     "deps": [
-      "aiohttp",
+      "aiohttp>=3.9.2",
       "apache-airflow-providers-http",
       "apache-airflow>=2.6.0",
       "asgiref"
@@ -615,7 +615,7 @@
   },
   "http": {
     "deps": [
-      "aiohttp",
+      "aiohttp>=3.9.2",
       "apache-airflow>=2.6.0",
       "asgiref",
       "requests>=2.26.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -524,7 +524,7 @@ winrm = [
 # If you want to modify these - modify the corresponding provider.yaml instead.
 #############################################################################################################
 # START OF GENERATED DEPENDENCIES
-# Hash of dependencies: b724779455591b6a7542cf2d456e5366
+# Hash of dependencies: 5041869464e6475fea61bee848306a8c
 airbyte = [ # source: airflow/providers/airbyte/provider.yaml
   "apache-airflow[http]",
 ]
@@ -595,7 +595,7 @@ apache-kylin = [ # source: airflow/providers/apache/kylin/provider.yaml
   "kylinpy>=2.6",
 ]
 apache-livy = [ # source: airflow/providers/apache/livy/provider.yaml
-  "aiohttp",
+  "aiohttp>=3.9.2",
   "apache-airflow[http]",
   "asgiref",
 ]
@@ -647,7 +647,7 @@ common-sql = [ # source: airflow/providers/common/sql/provider.yaml
   "sqlparse>=0.4.2",
 ]
 databricks = [ # source: airflow/providers/databricks/provider.yaml
-  "aiohttp>=3.6.3, <4",
+  "aiohttp>=3.9.2, <4",
   "apache-airflow[common_sql]",
   "databricks-sql-connector>=2.0.0, <3.0.0, !=2.9.0",
   "requests>=2.27,<3",
@@ -658,7 +658,7 @@ datadog = [ # source: airflow/providers/datadog/provider.yaml
   "datadog>=0.14.0",
 ]
 dbt-cloud = [ # source: airflow/providers/dbt/cloud/provider.yaml
-  "aiohttp",
+  "aiohttp>=3.9.2",
   "apache-airflow[http]",
   "asgiref",
 ]
@@ -764,7 +764,7 @@ hashicorp = [ # source: airflow/providers/hashicorp/provider.yaml
   "hvac>=1.1.0",
 ]
 http = [ # source: airflow/providers/http/provider.yaml
-  "aiohttp",
+  "aiohttp>=3.9.2",
   "asgiref",
   "requests>=2.26.0",
   "requests_toolbelt",


### PR DESCRIPTION
I don't know if it's possible to re-create the constraints or if this could be incompatible with older versions of Airflow.

cc: @potiuk 