### PR TITLE
Revert protection against back-compatibilty issue with google-core-api

### DIFF
--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -93,7 +93,8 @@ dependencies:
   - gcsfs>=2023.10.0
   - google-ads>=22.1.0
   - google-analytics-admin
-  - google-api-core>=2.11.0
+  # Google-api-core 2.16.0 back-compat issue: https://github.com/googleapis/python-api-core/issues/576
+  - google-api-core>=2.11.0,!=2.16.0
   - google-api-python-client>=1.6.0
   - google-auth>=1.0.0
   - google-auth-httplib2>=0.0.1

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -516,7 +516,7 @@
       "gcsfs>=2023.10.0",
       "google-ads>=22.1.0",
       "google-analytics-admin",
-      "google-api-core>=2.11.0",
+      "google-api-core>=2.11.0,!=2.16.0",
       "google-api-python-client>=1.6.0",
       "google-auth-httplib2>=0.0.1",
       "google-auth>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -524,7 +524,7 @@ winrm = [
 # If you want to modify these - modify the corresponding provider.yaml instead.
 #############################################################################################################
 # START OF GENERATED DEPENDENCIES
-# Hash of dependencies: 5041869464e6475fea61bee848306a8c
+# Hash of dependencies: ad91a0758ca9b408679bd3ea3ec22c66
 airbyte = [ # source: airflow/providers/airbyte/provider.yaml
   "apache-airflow[http]",
 ]
@@ -705,7 +705,7 @@ google = [ # source: airflow/providers/google/provider.yaml
   "gcsfs>=2023.10.0",
   "google-ads>=22.1.0",
   "google-analytics-admin",
-  "google-api-core>=2.11.0",
+  "google-api-core>=2.11.0,!=2.16.0",
   "google-api-python-client>=1.6.0",
   "google-auth-httplib2>=0.0.1",
   "google-auth>=1.0.0",

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_batch.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_batch.py
@@ -22,17 +22,7 @@ from __future__ import annotations
 import os
 from datetime import datetime
 
-try:
-    from google.api_core.retry import AsyncRetry  # type: ignore[attr-defined]
-    # There is a backwards-incompatible change in google.api_core.retry.AsyncRetry imports
-    # In 2.16.0 version of google-api-core, AsyncRetry was moved to google.api_core.retry_unary_async
-    # and backwards compatibility impots were not haandling the case of
-    # `from google.api_core.retry_async import AsyncRetry`
-    # The issue is tracked in https://github.com/googleapis/python-api-core/issues/586
-    # Until it is solved, we need to handle both cases, because one works before and one after 2.16.0
-    # But there is no import that works for both.
-except ImportError:
-    from google.api_core.retry_async import AsyncRetry  # type: ignore[attr-defined]
+from google.api_core.retry_async import AsyncRetry
 
 from airflow.models.dag import DAG
 from airflow.providers.google.cloud.operators.dataproc import (


### PR DESCRIPTION
The bug we reported for google-core-api 2.16.0 has been fixed in 2.16.1 and we can revert the workaround now

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
