### PR TITLE
Remove the remaining references to use the token bypassing the Connection in the Slack provider.

### DIFF
--- a/airflow/providers/slack/hooks/slack.py
+++ b/airflow/providers/slack/hooks/slack.py
@@ -72,9 +72,6 @@ class SlackHook(BaseHook):
         This hook intend to use `Slack API` connection
         and might not work correctly with `Slack Incoming Webhook` and `HTTP` connections.
 
-    Takes both Slack API token directly and connection that has Slack API token. If both are
-    supplied, Slack API token will be used. Also exposes the rest of slack.WebClient args.
-
     Examples:
      .. code-block:: python
 
@@ -88,6 +85,9 @@ class SlackHook(BaseHook):
         # Call method from Slack SDK (you have to handle errors yourself)
         #  For more details check https://slack.dev/python-slack-sdk/web/index.html#messaging
         slack_hook.client.chat_postMessage(channel="#random", text="Hello world!")
+
+    Additional arguments which are not listed into parameters exposed
+    into the rest of ``slack.WebClient`` constructor args.
 
     :param slack_conn_id: :ref:`Slack connection id <howto/connection:slack>`
         that has Slack API token in the password field.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Ability to provide token directly into the hook arguments deprecated into the v7 version of provider and removed into the v8.
However information about it appear still exists into different places of provider it is not the first time when we remove such of info from the Slack provider and I hope this is the last time and finally we completely remove information  this past ability.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
