### PR TITLE
Merge all ECS executor configs following recursive python dict update

### DIFF
--- a/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
+++ b/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
@@ -41,7 +41,6 @@ from airflow.providers.amazon.aws.executors.ecs.utils import (
     EcsExecutorException,
     EcsQueuedTask,
     EcsTaskCollection,
-    _deep_update,
 )
 from airflow.providers.amazon.aws.executors.utils.exponential_backoff_retry import (
     calculate_next_attempt_delay,
@@ -49,6 +48,7 @@ from airflow.providers.amazon.aws.executors.utils.exponential_backoff_retry impo
 )
 from airflow.providers.amazon.aws.hooks.ecs import EcsHook
 from airflow.utils import timezone
+from airflow.utils.helpers import merge_dicts
 from airflow.utils.state import State
 
 if TYPE_CHECKING:
@@ -423,7 +423,7 @@ class AwsEcsExecutor(BaseExecutor):
         One last chance to modify Boto3's "run_task" kwarg params before it gets passed into the Boto3 client.
         """
         run_task_kwargs = deepcopy(self.run_task_kwargs)
-        run_task_kwargs = _deep_update(run_task_kwargs, exec_config)
+        run_task_kwargs = merge_dicts(run_task_kwargs, exec_config)
         container_override = self.get_container(run_task_kwargs["overrides"]["containerOverrides"])
         container_override["command"] = cmd
 

--- a/airflow/providers/amazon/aws/executors/ecs/utils.py
+++ b/airflow/providers/amazon/aws/executors/ecs/utils.py
@@ -266,16 +266,3 @@ def camelize_dict_keys(nested_dict) -> dict:
         else:
             result[new_key] = nested_dict[key]
     return result
-
-
-def _deep_update(dest_dict: dict, source_dict: dict) -> dict:
-    """Deep updates dest_dict with the values from source_dict."""
-    for key, value in source_dict.items():
-        if key in dest_dict and isinstance(dest_dict[key], dict) and isinstance(value, dict):
-            # Recursively update nested dictionaries
-            _deep_update(dest_dict[key], value)
-        else:
-            # Update or add key-value pairs
-            dest_dict[key] = value
-
-    return dest_dict

--- a/airflow/providers/amazon/aws/executors/ecs/utils.py
+++ b/airflow/providers/amazon/aws/executors/ecs/utils.py
@@ -266,3 +266,16 @@ def camelize_dict_keys(nested_dict) -> dict:
         else:
             result[new_key] = nested_dict[key]
     return result
+
+
+def _deep_update(dest_dict: dict, source_dict: dict) -> dict:
+    """Deep updates dest_dict with the values from source_dict."""
+    for key, value in source_dict.items():
+        if key in dest_dict and isinstance(dest_dict[key], dict) and isinstance(value, dict):
+            # Recursively update nested dictionaries
+            _deep_update(dest_dict[key], value)
+        else:
+            # Update or add key-value pairs
+            dest_dict[key] = value
+
+    return dest_dict

--- a/docs/apache-airflow-providers-amazon/executors/ecs-executor.rst
+++ b/docs/apache-airflow-providers-amazon/executors/ecs-executor.rst
@@ -113,6 +113,9 @@ For a more detailed description of available options, including type
 hints and examples, see the ``config_templates`` folder in the Amazon
 provider package.
 
+.. note::
+   ``exec_config`` is an optional parameter that can be provided to operators. It is a dictionary type and in the context of the ECS Executor it represents a ``run_task_kwargs`` configuration which is then updated over-top of the ``run_task_kwargs`` specified in Airflow config above (if present). It is a recursive update which essentially applies Python update to each nested dictionary in the configuration. Loosely approximated as: ``run_task_kwargs.update(exec_config)``
+
 .. _dockerfile_for_ecs_executor:
 
 Dockerfile for ECS Executor

--- a/docs/apache-airflow-providers-amazon/executors/ecs-executor.rst
+++ b/docs/apache-airflow-providers-amazon/executors/ecs-executor.rst
@@ -73,6 +73,9 @@ In the case of conflicts, the order of precedence from lowest to highest is:
 3. Load any values provided in the RUN_TASK_KWARGS option if one is
    provided.
 
+.. note::
+   ``exec_config`` is an optional parameter that can be provided to operators. It is a dictionary type and in the context of the ECS Executor it represents a ``run_task_kwargs`` configuration which is then updated over-top of the ``run_task_kwargs`` specified in Airflow config above (if present). It is a recursive update which essentially applies Python update to each nested dictionary in the configuration. Loosely approximated as: ``run_task_kwargs.update(exec_config)``
+
 Required config options:
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -88,7 +91,7 @@ Optional config options:
 
 -  ASSIGN_PUBLIC_IP - Whether to assign a public IP address to the
    containers launched by the ECS executor. Defaults to "False".
--  CONN_ID - The Airflow connection (i.e. credentials) used by the ECS
+-  AWS_CONN_ID - The Airflow connection (i.e. credentials) used by the ECS
    executor to make API calls to AWS ECS. Defaults to "aws_default".
 -  LAUNCH_TYPE - Launch type can either be 'FARGATE' OR 'EC2'. Defaults
    to "FARGATE".


### PR DESCRIPTION
This PR changes how `exec_config` works for the ECS executor. Previously the `exec_config` was only applied to item zero of the `containerOverrides` list (the container that receives the Airflow task command). This made it impossible for folks to override any configuration at the base or `overrides` level of the runTask kwargs (see docs for possible configuration [here](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs/client/run_task.html)).

The new strategy is to treat the `exec_config` as an entire run task kwargs config and do a recursive dict update. This allows folks to set any value from a task or DAG.

This behaviour change is allowed due to the feature still being experimental.

fixes #35490

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
