### PR TITLE
Remove SCHEDULED_DEPS which is no longer used anywhere since 2.0.0

### DIFF
--- a/airflow/ti_deps/dependencies_deps.py
+++ b/airflow/ti_deps/dependencies_deps.py
@@ -20,7 +20,6 @@ from airflow.ti_deps.dependencies_states import (
     BACKFILL_QUEUEABLE_STATES,
     QUEUEABLE_STATES,
     RUNNABLE_STATES,
-    SCHEDULEABLE_STATES,
 )
 from airflow.ti_deps.deps.dag_ti_slots_available_dep import DagTISlotsAvailableDep
 from airflow.ti_deps.deps.dag_unpaused_dep import DagUnpausedDep

--- a/airflow/ti_deps/dependencies_deps.py
+++ b/airflow/ti_deps/dependencies_deps.py
@@ -33,14 +33,6 @@ from airflow.ti_deps.deps.task_concurrency_dep import TaskConcurrencyDep
 from airflow.ti_deps.deps.task_not_running_dep import TaskNotRunningDep
 from airflow.ti_deps.deps.valid_state_dep import ValidStateDep
 
-# Context to get the dependencies that need to be met in order for a task instance to be
-# set to 'scheduled' state.
-SCHEDULED_DEPS = {
-    RunnableExecDateDep(),
-    ValidStateDep(SCHEDULEABLE_STATES),
-    TaskNotRunningDep(),
-}
-
 # Dependencies that if met, task instance should be re-queued.
 REQUEUEABLE_DEPS = {
     DagTISlotsAvailableDep(),


### PR DESCRIPTION
`SCHEDULED_DEPS` is no longer used anywhere in the codebase, since `2.0.0` (the last version where it was used is `1.10.15`)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
