### PR TITLE
Fix SQLThresholdCheckOperator error on falsey vals

### DIFF
--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -1061,10 +1061,11 @@ class SQLThresholdCheckOperator(BaseSQLOperator):
         result = hook.get_first(self.sql)
 
         # if the query returns 0 rows result will be None so cannot be indexed into
-        if result is None:
-            self._raise_exception(f"The following query returned zero rows: {self.sql}")
-        else:
+        # also covers indexing out of bounds on empty list, tuple etc. if returned
+        try:
             result = result[0]
+        except (TypeError, IndexError):
+            self._raise_exception(f"The following query returned zero rows: {self.sql}")
 
         min_threshold = _convert_to_float_if_possible(self.min_threshold)
         max_threshold = _convert_to_float_if_possible(self.max_threshold)

--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -1058,9 +1058,13 @@ class SQLThresholdCheckOperator(BaseSQLOperator):
 
     def execute(self, context: Context):
         hook = self.get_db_hook()
-        result = hook.get_first(self.sql)[0]
-        if not result:
+        result = hook.get_first(self.sql)
+
+        # if the query returns 0 rows result will be None so cannot be indexed into
+        if result is None:
             self._raise_exception(f"The following query returned zero rows: {self.sql}")
+        else:
+            result = result[0]
 
         min_threshold = _convert_to_float_if_possible(self.min_threshold)
         max_threshold = _convert_to_float_if_possible(self.max_threshold)

--- a/tests/providers/common/sql/operators/test_sql.py
+++ b/tests/providers/common/sql/operators/test_sql.py
@@ -901,12 +901,21 @@ class TestThresholdCheckOperator:
             operator.execute(context=MagicMock())
 
     @mock.patch.object(SQLThresholdCheckOperator, "get_db_hook")
-    def test_pass_min_value_max_sql(self, mock_get_db_hook):
+    @pytest.mark.parametrize(
+        ("sql", "min_threshold", "max_threshold"),
+        (
+            ("Select 75", 45, "Select 100"),
+            # check corner-case if result of query is "falsey" does not raise error
+            ("Select 0", 0, 1),
+            ("Select 1", 0, 1),
+        ),
+    )
+    def test_pass_min_value_max_sql(self, mock_get_db_hook, sql, min_threshold, max_threshold):
         mock_hook = mock.Mock()
         mock_hook.get_first.side_effect = lambda x: (int(x.split()[1]),)
         mock_get_db_hook.return_value = mock_hook
 
-        operator = self._construct_operator("Select 75", 45, "Select 100")
+        operator = self._construct_operator(sql, min_threshold, max_threshold)
 
         operator.execute(context=MagicMock())
 
@@ -919,6 +928,18 @@ class TestThresholdCheckOperator:
         operator = self._construct_operator("Select 155", "Select 45", 100)
 
         with pytest.raises(AirflowException, match="155.*45.*100.0"):
+            operator.execute(context=MagicMock())
+
+    @mock.patch.object(SQLThresholdCheckOperator, "get_db_hook")
+    def test_fail_if_query_returns_no_rows(self, mock_get_db_hook):
+        mock_hook = mock.Mock()
+        mock_hook.get_first.return_value = None
+        mock_get_db_hook.return_value = mock_hook
+
+        sql = "Select val from table1 where val = 'val not in table'"
+        operator = self._construct_operator(sql, 20, 100)
+
+        with pytest.raises(AirflowException, match=f"The following query returned zero rows: {sql}"):
             operator.execute(context=MagicMock())
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #37089
related: #37089

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

# Summary
As documented in #37089 the SQLThresholdCheckOperator will currently fail if a "falsey" value is returned from the query (e.g. 0 or "").
This is a fix to change the error check a bit and as side effect make the exception for `The following query returned zero rows:...`
Whereas before, if no rows really were returned, the user would see the following:
```
result = hook.get_first(self.sql)[0]
TypeError: 'NoneType' object is not subscriptable
```

For testing, I used a parameterized test on an existing test and added a new test to cover the "no rows returned" case.
But please let me know if something else would be preferable.

closes: https://github.com/apache/airflow/issues/37089