### PR TITLE
Avoid `pendulum.from_timestamp` usage

### DIFF
--- a/airflow/providers/elasticsearch/log/es_json_formatter.py
+++ b/airflow/providers/elasticsearch/log/es_json_formatter.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+from datetime import datetime
+
 import pendulum
 
 from airflow.utils.log.json_formatter import JSONFormatter
@@ -30,7 +32,9 @@ class ElasticsearchJSONFormatter(JSONFormatter):
 
     def formatTime(self, record, datefmt=None):
         """Return the creation time of the LogRecord in ISO 8601 date/time format in the local time zone."""
-        dt = pendulum.from_timestamp(record.created, tz=pendulum.local_timezone())
+        # TODO: Use airflow.utils.timezone.from_timestamp(record.created, tz="local")
+        #  as soon as min Airflow 2.9.0
+        dt = datetime.fromtimestamp(record.created, tz=pendulum.local_timezone())
         s = dt.strftime(datefmt or self.default_time_format)
         if self.default_msec_format:
             s = self.default_msec_format % (s, record.msecs)

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -30,7 +30,6 @@ from typing import TYPE_CHECKING, Any, Collection, Iterable, Mapping, NamedTuple
 
 import attrs
 import lazy_object_proxy
-import pendulum
 from dateutil import relativedelta
 from pendulum.tz.timezone import FixedTimezone, Timezone
 
@@ -65,7 +64,7 @@ from airflow.utils.docs import get_docs_url
 from airflow.utils.module_loading import import_string, qualname
 from airflow.utils.operator_resources import Resources
 from airflow.utils.task_group import MappedTaskGroup, TaskGroup
-from airflow.utils.timezone import parse_timezone
+from airflow.utils.timezone import from_timestamp, parse_timezone
 from airflow.utils.types import NOTSET, ArgNotSet
 
 if TYPE_CHECKING:
@@ -567,7 +566,7 @@ class BaseSerialization:
         elif type_ == DAT.OP:
             return SerializedBaseOperator.deserialize_operator(var)
         elif type_ == DAT.DATETIME:
-            return pendulum.from_timestamp(var)
+            return from_timestamp(var)
         elif type_ == DAT.POD:
             if not _has_kubernetes():
                 raise RuntimeError("Cannot deserialize POD objects without kubernetes libraries installed!")
@@ -611,7 +610,7 @@ class BaseSerialization:
         else:
             raise TypeError(f"Invalid type {type_!s} in deserialization.")
 
-    _deserialize_datetime = pendulum.from_timestamp
+    _deserialize_datetime = from_timestamp
     _deserialize_timezone = parse_timezone
 
     @classmethod

--- a/airflow/utils/log/timezone_aware.py
+++ b/airflow/utils/log/timezone_aware.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 
-import pendulum
+from airflow.utils import timezone
 
 
 class TimezoneAware(logging.Formatter):
@@ -39,7 +39,7 @@ class TimezoneAware(logging.Formatter):
         This returns the creation time of the specified LogRecord in ISO 8601
         date and time format in the local time zone.
         """
-        dt = pendulum.from_timestamp(record.created, tz=pendulum.local_timezone())
+        dt = timezone.from_timestamp(record.created, tz="local")
         s = dt.strftime(datefmt or self.default_time_format)
         if self.default_msec_format:
             s = self.default_msec_format % (s, record.msecs)

--- a/airflow/utils/timezone.py
+++ b/airflow/utils/timezone.py
@@ -27,6 +27,8 @@ from pendulum.datetime import DateTime
 if TYPE_CHECKING:
     from pendulum.tz.timezone import FixedTimezone, Timezone
 
+    from airflow.typing_compat import Literal
+
 _PENDULUM3 = pendulum.__version__.startswith("3")
 # UTC Timezone as a tzinfo instance. Actual value depends on pendulum version:
 # - Timezone("UTC") in pendulum 3
@@ -299,3 +301,23 @@ def local_timezone() -> FixedTimezone | Timezone:
     :meta private:
     """
     return pendulum.tz.local_timezone()
+
+
+def from_timestamp(
+    timestamp: int | float, tz: str | FixedTimezone | Timezone | Literal["local"] = utc
+) -> DateTime:
+    """
+    Parse timestamp and return DateTime in a given time zone.
+
+    :param timestamp: epoch time in seconds.
+    :param tz: In which timezone should return a resulting object.
+        Could be either one of pendulum timezone, IANA timezone or `local` literal.
+
+    :meta private:
+    """
+    result = coerce_datetime(dt.datetime.fromtimestamp(timestamp, tz=utc))
+    if tz != utc or tz != "UTC":
+        if isinstance(tz, str) and tz.lower() == "local":
+            tz = local_timezone()
+        result = result.in_timezone(tz)
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1372,6 +1372,8 @@ combine-as-imports = true
 "airflow.AirflowException".msg = "Use airflow.exceptions.AirflowException instead."
 "airflow.Dataset".msg = "Use airflow.datasets.Dataset instead."
 "airflow.models.baseoperator.BaseOperatorLink".msg = "Use airflow.models.baseoperatorlink.BaseOperatorLink"
+# Uses deprecated in Python 3.12 `datetime.datetime.utcfromtimestamp`
+"pendulum.from_timestamp".msg = "Use airflow.utils.timezone.from_timestamp"
 
 [tool.ruff.flake8-tidy-imports]
 # Ban certain modules from being imported at module level, instead requiring

--- a/tests/utils/test_timezone.py
+++ b/tests/utils/test_timezone.py
@@ -21,7 +21,7 @@ import datetime
 
 import pendulum
 import pytest
-from pendulum.tz.timezone import Timezone
+from pendulum.tz.timezone import FixedTimezone, Timezone
 
 from airflow.utils import timezone
 from airflow.utils.timezone import coerce_datetime, parse_timezone
@@ -156,3 +156,47 @@ def test_parse_timezone_offset(tz_offset: int, expected_offset, expected_name):
     assert tz.offset == expected_offset
     assert tz.name == expected_name
     assert parse_timezone(tz_offset) is tz
+
+
+@pytest.mark.parametrize(
+    "tz",
+    [
+        pytest.param(None, id="implicit"),
+        pytest.param(timezone.utc, id="explicit"),
+        pytest.param("UTC", id="utc-literal"),
+    ],
+)
+def test_from_timestamp_utc(tz):
+    from_ts = timezone.from_timestamp(0) if tz is None else timezone.from_timestamp(0, tz=tz)
+    assert from_ts == pendulum.DateTime(1970, 1, 1, tzinfo=timezone.utc)
+    assert from_ts.tzinfo == timezone.utc
+
+
+@pytest.mark.parametrize("tz", ["local", "LOCAL"])
+def test_from_timestamp_local(tz):
+    local_tz = timezone.local_timezone()
+    from_ts = timezone.from_timestamp(0, tz=tz)
+    assert from_ts == pendulum.DateTime(1970, 1, 1, tzinfo=timezone.utc)
+    assert from_ts.tzinfo == local_tz
+
+
+@pytest.mark.parametrize(
+    "tz, iana_timezone",
+    [
+        pytest.param(Timezone("Europe/Paris"), "Europe/Paris", id="pendulum-timezone"),
+        pytest.param("America/New_York", "America/New_York", id="IANA-timezone"),
+    ],
+)
+def test_from_timestamp_iana_timezones(tz, iana_timezone):
+    from_ts = timezone.from_timestamp(0, tz=tz)
+    assert from_ts == pendulum.DateTime(1970, 1, 1, tzinfo=timezone.utc)
+    # In pendulum 2 there is a problem with compare tzinfo object (caching?), so we check the name
+    assert from_ts.tzinfo.name == iana_timezone
+    assert isinstance(from_ts.tzinfo, Timezone)
+
+
+@pytest.mark.parametrize("utc_offset", [3600, -7200])
+def test_from_timestamp_fixed_timezone(utc_offset):
+    from_ts = timezone.from_timestamp(0, tz=FixedTimezone(utc_offset))
+    assert from_ts == pendulum.DateTime(1970, 1, 1, tzinfo=timezone.utc)
+    assert from_ts.utcoffset() == datetime.timedelta(seconds=utc_offset)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This function use deprecated in Python 3.12 `datetime.datetime.utcfromtimestamp` https://github.com/sdispater/pendulum/pull/803 as result it might cause recursion error into the Airflow logger in Python 3.12

```console
2024-02-01T00:16:09.5682821Z /usr/local/lib/python3.12/site-packages/pendulum/__init__.py:295 DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
2024-02-01T00:16:09.5683171Z Process DagFileProcessor109-Process:
2024-02-01T00:16:09.5683635Z Traceback (most recent call last):
2024-02-01T00:16:09.5684622Z   File "/usr/local/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
2024-02-01T00:16:09.5684847Z     self.run()
2024-02-01T00:16:09.5685455Z   File "/usr/local/lib/python3.12/multiprocessing/process.py", line 108, in run
2024-02-01T00:16:09.5685746Z     self._target(*self._args, **self._kwargs)
2024-02-01T00:16:09.5686591Z   File "/opt/airflow/airflow/dag_processing/processor.py", line 182, in _run_file_processor
2024-02-01T00:16:09.5686850Z     _handle_dag_file_processing()
2024-02-01T00:16:09.5687635Z   File "/opt/airflow/airflow/dag_processing/processor.py", line 161, in _handle_dag_file_processing
2024-02-01T00:16:09.5688168Z     log.info("Started process (PID=%s) to work on %s", os.getpid(), file_path)
2024-02-01T00:16:09.5688718Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 1539, in info
2024-02-01T00:16:09.5688970Z     self._log(INFO, msg, args, **kwargs)
2024-02-01T00:16:09.5689526Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 1684, in _log
2024-02-01T00:16:09.5689738Z     self.handle(record)
2024-02-01T00:16:09.5690307Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 1700, in handle
2024-02-01T00:16:09.5690536Z     self.callHandlers(record)
2024-02-01T00:16:09.5691167Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 1762, in callHandlers
2024-02-01T00:16:09.5691378Z     hdlr.handle(record)
2024-02-01T00:16:09.5691947Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 1028, in handle
2024-02-01T00:16:09.5692169Z     self.emit(record)
2024-02-01T00:16:09.5692799Z   File "/opt/airflow/airflow/utils/log/file_processor_handler.py", line 74, in emit
2024-02-01T00:16:09.5693038Z     self.handler.emit(record)
2024-02-01T00:16:09.5693571Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 1280, in emit
2024-02-01T00:16:09.5693830Z     StreamHandler.emit(self, record)
2024-02-01T00:16:09.5694362Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 1160, in emit
2024-02-01T00:16:09.5694614Z     msg = self.format(record)
2024-02-01T00:16:09.5694811Z           ^^^^^^^^^^^^^^^^^^^
2024-02-01T00:16:09.5695368Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 999, in format
2024-02-01T00:16:09.5695598Z     return fmt.format(record)
2024-02-01T00:16:09.5695803Z            ^^^^^^^^^^^^^^^^^^
2024-02-01T00:16:09.5696632Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 705, in format
2024-02-01T00:16:09.5697033Z     record.asctime = self.formatTime(record, self.datefmt)
2024-02-01T00:16:09.5697291Z                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-02-01T00:16:09.5697925Z   File "/opt/airflow/airflow/utils/log/timezone_aware.py", line 42, in formatTime
2024-02-01T00:16:09.5698456Z     dt = pendulum.from_timestamp(record.created, tz=pendulum.local_timezone())
2024-02-01T00:16:09.5698748Z          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-02-01T00:16:09.5700066Z   File "/usr/local/lib/python3.12/site-packages/pendulum/__init__.py", line 295, in from_timestamp
2024-02-01T00:16:09.5700446Z     dt = _datetime.datetime.utcfromtimestamp(timestamp)
2024-02-01T00:16:09.5700702Z          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-02-01T00:16:09.5701257Z   File "/usr/local/lib/python3.12/warnings.py", line 109, in _showwarnmsg
2024-02-01T00:16:09.5701655Z     sw(msg.message, msg.category, msg.filename, msg.lineno,
2024-02-01T00:16:09.5702224Z   File "/opt/airflow/airflow/settings.py", line 126, in custom_show_warning
2024-02-01T00:16:09.5702530Z     write_console.print(msg, soft_wrap=True)
2024-02-01T00:16:09.5703346Z   File "/usr/local/lib/python3.12/site-packages/rich/console.py", line 1673, in print
2024-02-01T00:16:09.5703554Z     with self:
2024-02-01T00:16:09.5704351Z   File "/usr/local/lib/python3.12/site-packages/rich/console.py", line 865, in __exit__
2024-02-01T00:16:09.5704578Z     self._exit_buffer()
2024-02-01T00:16:09.5705422Z   File "/usr/local/lib/python3.12/site-packages/rich/console.py", line 823, in _exit_buffer
2024-02-01T00:16:09.5705887Z     self._check_buffer()
2024-02-01T00:16:09.5706785Z   File "/usr/local/lib/python3.12/site-packages/rich/console.py", line 2060, in _check_buffer
2024-02-01T00:16:09.5707003Z     self.file.write(text)
2024-02-01T00:16:09.5707585Z   File "/opt/airflow/airflow/utils/log/logging_mixin.py", line 200, in write
2024-02-01T00:16:09.5707934Z     self.flush()
2024-02-01T00:16:09.5708527Z   File "/opt/airflow/airflow/utils/log/logging_mixin.py", line 207, in flush
2024-02-01T00:16:09.5708752Z     self._propagate_log(buf)
2024-02-01T00:16:09.5709415Z   File "/opt/airflow/airflow/utils/log/logging_mixin.py", line 188, in _propagate_log
2024-02-01T00:16:09.5709816Z     self.logger.log(self.level, remove_escape_codes(message))
2024-02-01T00:16:09.5710466Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 1609, in log
2024-02-01T00:16:09.5710730Z     self._log(level, msg, args, **kwargs)
2024-02-01T00:16:09.5711279Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 1684, in _log
2024-02-01T00:16:09.5711498Z     self.handle(record)
2024-02-01T00:16:09.5712065Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 1700, in handle
2024-02-01T00:16:09.5712306Z     self.callHandlers(record)
2024-02-01T00:16:09.5712912Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 1762, in callHandlers
2024-02-01T00:16:09.5713142Z     hdlr.handle(record)
2024-02-01T00:16:09.5713697Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 1028, in handle
2024-02-01T00:16:09.5713912Z     self.emit(record)
2024-02-01T00:16:09.5714543Z   File "/opt/airflow/airflow/utils/log/file_processor_handler.py", line 74, in emit
2024-02-01T00:16:09.5714777Z     self.handler.emit(record)
2024-02-01T00:16:09.5715311Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 1280, in emit
2024-02-01T00:16:09.5715574Z     StreamHandler.emit(self, record)
2024-02-01T00:16:09.5716103Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 1160, in emit
2024-02-01T00:16:09.5716346Z     msg = self.format(record)
2024-02-01T00:16:09.5716539Z           ^^^^^^^^^^^^^^^^^^^
2024-02-01T00:16:09.5717093Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 999, in format
2024-02-01T00:16:09.5717319Z     return fmt.format(record)
2024-02-01T00:16:09.5717525Z            ^^^^^^^^^^^^^^^^^^
2024-02-01T00:16:09.5718074Z   File "/usr/local/lib/python3.12/logging/__init__.py", line 705, in format
2024-02-01T00:16:09.5718464Z     record.asctime = self.formatTime(record, self.datefmt)
2024-02-01T00:16:09.5718719Z                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-02-01T00:16:09.5719349Z   File "/opt/airflow/airflow/utils/log/timezone_aware.py", line 42, in formatTime
2024-02-01T00:16:09.5719890Z     dt = pendulum.from_timestamp(record.created, tz=pendulum.local_timezone())
2024-02-01T00:16:09.5720173Z          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-02-01T00:16:09.5721122Z   File "/usr/local/lib/python3.12/site-packages/pendulum/__init__.py", line 295, in from_timestamp

... truncated 2000+ lines of traceback

2024-02-01T00:16:09.6686905Z     self.logger.log(self.level, remove_escape_codes(message))
2024-02-01T00:16:09.6687301Z                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-02-01T00:16:09.6688023Z   File "/opt/airflow/airflow/utils/log/logging_mixin.py", line 61, in remove_escape_codes
2024-02-01T00:16:09.6688266Z     return ANSI_ESCAPE.sub("", text)
2024-02-01T00:16:09.6688481Z            ^^^^^^^^^^^^^^^^^^^^^^^^^
2024-02-01T00:16:09.6689163Z   File "/usr/local/lib/python3.12/site-packages/re2.py", line 291, in sub
2024-02-01T00:16:09.6689496Z     joined_pieces, _ = self.subn(repl, text, count)
2024-02-01T00:16:09.6689733Z                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-02-01T00:16:09.6690066Z RecursionError: maximum recursion depth exceeded
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
