### PR TITLE
Fix Airflow serialization for namedtuple

### DIFF
--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -345,8 +345,12 @@ def _is_pydantic(cls: Any) -> bool:
 
 
 def _is_namedtuple(cls: Any) -> bool:
-    """Return True if the class is a namedtuple."""
-    return isinstance(cls, tuple) and hasattr(cls, "_asdict") and hasattr(cls, "_fields")
+    """Return True if the class is a namedtuple.
+
+    Checking is done by attributes as it is significantly faster than
+    using isinstance.
+    """
+    return hasattr(cls, "_asdict") and hasattr(cls, "_fields") and hasattr(cls, "_field_defaults")
 
 
 def _register():

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -346,11 +346,7 @@ def _is_pydantic(cls: Any) -> bool:
 
 def _is_namedtuple(cls: Any) -> bool:
     """Return True if the class is a namedtuple."""
-    return (
-        isinstance(cls, tuple) and
-        hasattr(cls, '_asdict') and
-        hasattr(cls, '_fields')
-    )
+    return isinstance(cls, tuple) and hasattr(cls, "_asdict") and hasattr(cls, "_fields")
 
 
 def _register():

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -141,17 +141,17 @@ def serialize(o: object, depth: int = 0) -> U | None:
         qn = "builtins.tuple"
         classname = qn
 
-    # custom serializers
-    dct = {
-        CLASSNAME: qn,
-        VERSION: getattr(cls, "__version__", DEFAULT_VERSION),
-    }
-
     # if there is a builtin serializer available use that
     if qn in _serializers:
         data, serialized_classname, version, is_serialized = _serializers[qn].serialize(o)
         if is_serialized:
             return encode(classname or serialized_classname, version, serialize(data, depth + 1))
+
+    # custom serializers
+    dct = {
+        CLASSNAME: qn,
+        VERSION: getattr(cls, "__version__", DEFAULT_VERSION),
+    }
 
     # object / class brings their own
     if hasattr(o, "serialize"):

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -134,7 +134,7 @@ def serialize(o: object, depth: int = 0) -> U | None:
 
     cls = type(o)
     qn = qualname(o)
-
+    
     # serialize namedtuple like tuples
     if _is_namedtuple(o):
         qn = "builtins.tuple"
@@ -144,12 +144,12 @@ def serialize(o: object, depth: int = 0) -> U | None:
         CLASSNAME: qn,
         VERSION: getattr(cls, "__version__", DEFAULT_VERSION),
     }
-
+    
     # if there is a builtin serializer available use that
     if qn in _serializers:
         data, serialized_classname, version, is_serialized = _serializers[qn].serialize(o)
         if is_serialized:
-            return encode(serialized_classname, version, serialize(data, depth + 1))
+            return encode(classname or serialized_classname, version, serialize(data, depth + 1))
 
     # object / class brings their own
     if hasattr(o, "serialize"):

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -134,22 +134,24 @@ def serialize(o: object, depth: int = 0) -> U | None:
 
     cls = type(o)
     qn = qualname(o)
-    
+    classname = None
+
     # serialize namedtuple like tuples
     if _is_namedtuple(o):
         qn = "builtins.tuple"
+        classname = qn
+
+    # if there is a builtin serializer available use that
+    if qn in _serializers:
+        data, serialized_classname, version, is_serialized = _serializers[qn].serialize(o)
+        if is_serialized:
+            return encode(classname or serialized_classname, version, serialize(data, depth + 1))
 
     # custom serializers
     dct = {
         CLASSNAME: qn,
         VERSION: getattr(cls, "__version__", DEFAULT_VERSION),
     }
-    
-    # if there is a builtin serializer available use that
-    if qn in _serializers:
-        data, serialized_classname, version, is_serialized = _serializers[qn].serialize(o)
-        if is_serialized:
-            return encode(classname or serialized_classname, version, serialize(data, depth + 1))
 
     # object / class brings their own
     if hasattr(o, "serialize"):

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -134,24 +134,22 @@ def serialize(o: object, depth: int = 0) -> U | None:
 
     cls = type(o)
     qn = qualname(o)
-    classname = None
-
+    
     # serialize namedtuple like tuples
     if _is_namedtuple(o):
         qn = "builtins.tuple"
-        classname = qn
-
-    # if there is a builtin serializer available use that
-    if qn in _serializers:
-        data, serialized_classname, version, is_serialized = _serializers[qn].serialize(o)
-        if is_serialized:
-            return encode(classname or serialized_classname, version, serialize(data, depth + 1))
 
     # custom serializers
     dct = {
         CLASSNAME: qn,
         VERSION: getattr(cls, "__version__", DEFAULT_VERSION),
     }
+    
+    # if there is a builtin serializer available use that
+    if qn in _serializers:
+        data, serialized_classname, version, is_serialized = _serializers[qn].serialize(o)
+        if is_serialized:
+            return encode(classname or serialized_classname, version, serialize(data, depth + 1))
 
     # object / class brings their own
     if hasattr(o, "serialize"):

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -136,7 +136,9 @@ def serialize(o: object, depth: int = 0) -> U | None:
     qn = qualname(o)
     classname = None
 
-    # serialize namedtuple like tuples
+    # Serialize namedtuple like tuples
+    # We also override the classname returned by the builtin.py serializer. The classname
+    # has to be "builtins.tuple", so that the deserializer can deserialize the object into tuple.
     if _is_namedtuple(o):
         qn = "builtins.tuple"
         classname = qn

--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -134,7 +134,7 @@ def serialize(o: object, depth: int = 0) -> U | None:
 
     cls = type(o)
     qn = qualname(o)
-    
+
     # serialize namedtuple like tuples
     if _is_namedtuple(o):
         qn = "builtins.tuple"
@@ -144,12 +144,12 @@ def serialize(o: object, depth: int = 0) -> U | None:
         CLASSNAME: qn,
         VERSION: getattr(cls, "__version__", DEFAULT_VERSION),
     }
-    
+
     # if there is a builtin serializer available use that
     if qn in _serializers:
         data, serialized_classname, version, is_serialized = _serializers[qn].serialize(o)
         if is_serialized:
-            return encode(classname or serialized_classname, version, serialize(data, depth + 1))
+            return encode(serialized_classname, version, serialize(data, depth + 1))
 
     # object / class brings their own
     if hasattr(o, "serialize"):

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import datetime
 import enum
+from collections import namedtuple
 from dataclasses import dataclass
 from importlib import import_module
 from typing import ClassVar
@@ -184,6 +185,14 @@ class TestSerDe:
         with pytest.raises(AttributeError, match="^reserved"):
             i = {SCHEMA_ID: "cannot"}
             serialize(i)
+
+    def test_ser_namedtuple(self):
+        CustomTuple = namedtuple("CustomTuple", ['id', 'value'])
+        data = CustomTuple(id=1, value="something")
+
+        i = deserialize(serialize(data))
+        e = (1, "something")
+        assert i == e
 
     def test_no_serializer(self):
         with pytest.raises(TypeError, match="^cannot serialize"):

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -187,7 +187,7 @@ class TestSerDe:
             serialize(i)
 
     def test_ser_namedtuple(self):
-        CustomTuple = namedtuple("CustomTuple", ['id', 'value'])
+        CustomTuple = namedtuple("CustomTuple", ["id", "value"])
         data = CustomTuple(id=1, value="something")
 
         i = deserialize(serialize(data))


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR fixes: #36839
In some cases, the namedtuple was not recognized as tuple and failed to serialize.


<br>

__Side note__:
When we return a tuple from a task, the tuple reach the XComEncoder and get serialized as a dict - thanks to [this line](https://github.com/apache/airflow/blob/46470aba68e5ebeee24a03dc22d012a50ee287ad/airflow/utils/json.py#L101). However, when we return a list of tuples, the tuples get serialized as lists. The [above condition is false](https://github.com/apache/airflow/blob/46470aba68e5ebeee24a03dc22d012a50ee287ad/airflow/utils/json.py#L101), and we fallback to the default json encoding behavior. Thus, the way namedtuple / tuple are handled is inconsistent.

This causes some queries of the Databricks Hook and Operator to fail right now, depending on how the Hook / Operator are parameterized.

This PR fix the namedtuple for such queries, but it doesn't fix the inconsistency: sometimes namedtuple will be encoded as dict, sometimes as list. IMO a definitive fix involve another strategy than [`qualname()`](https://github.com/apache/airflow/blob/46470aba68e5ebeee24a03dc22d012a50ee287ad/airflow/utils/module_loading.py#L47). Because namedtuples have dynamic qualnames, wich will never be "builtins.tuple".

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
