### PR TITLE
Affixing exit summary to publish-docs command

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -1239,13 +1239,13 @@ def run_publish_docs_in_parallel(
                     skipped_entries.append(message)
 
     if include_success_outputs:
-        print("Success entries:")
+        get_console().print("[success]Packages those were published:")
         for entry in success_entries:
-            print(entry)
-        print("=================================================")
-    print("Skipped entries:")
+            get_console().print(f"[success]{entry}")
+        get_console().rule()
+    get_console().print("\n[warning]Packages those were skippeds:")
     for entry in skipped_entries:
-        print(entry)
+        get_console().print(f"[warning]{entry}")
 
 
 @release_management.command(
@@ -1326,13 +1326,13 @@ def publish_docs(
             else:
                 skipped_entries.append(message)
         if include_success_outputs:
-            print("Success entries:")
+            get_console().print("[success]Packages those were published:")
             for entry in success_entries:
-                print(entry)
-            print("=================================================")
-        print("Skipped entries:")
+                get_console().print(f"[success]{entry}")
+            get_console().rule()
+        get_console().print("\n[warning]Packages those were skipped:")
         for entry in skipped_entries:
-            print(entry)
+            get_console().print(f"[warning]{entry}")
 
 
 @release_management.command(

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -1243,7 +1243,7 @@ def run_publish_docs_in_parallel(
         for entry in success_entries:
             get_console().print(f"[success]{entry}")
         get_console().rule()
-    get_console().print("\n[warning]Packages those were skippeds:")
+    get_console().print("\n[warning]Packages skippeds:")
     for entry in skipped_entries:
         get_console().print(f"[warning]{entry}")
 

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -1239,7 +1239,7 @@ def run_publish_docs_in_parallel(
                     skipped_entries.append(message)
 
     if include_success_outputs:
-        get_console().print("[success]Packages those were published:")
+        get_console().print("[success]Packages published:")
         for entry in success_entries:
             get_console().print(f"[success]{entry}")
         get_console().rule()

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -1326,7 +1326,7 @@ def publish_docs(
             else:
                 skipped_entries.append(message)
         if include_success_outputs:
-            get_console().print("[success]Packages those were published:")
+            get_console().print("[success]Packages published:")
             for entry in success_entries:
                 get_console().print(f"[success]{entry}")
             get_console().rule()

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -1330,7 +1330,7 @@ def publish_docs(
             for entry in success_entries:
                 get_console().print(f"[success]{entry}")
             get_console().rule()
-        get_console().print("\n[warning]Packages those were skipped:")
+        get_console().print("\n[warning]Packages skipped:")
         for entry in skipped_entries:
             get_console().print(f"[warning]{entry}")
 

--- a/dev/breeze/src/airflow_breeze/utils/docs_publisher.py
+++ b/dev/breeze/src/airflow_breeze/utils/docs_publisher.py
@@ -92,10 +92,12 @@ class DocsPublisher:
                         f"Delete it manually if you want to regenerate it!"
                     )
                     get_console(output=self.output).print()
-                    return
+                    return 1, f"Skipping {self.package_name}: Previously existing directory"
+            # If output directory exists and is not versioned, delete it
             shutil.rmtree(output_dir)
         shutil.copytree(self._build_dir, output_dir)
         if self.is_versioned:
             with open(os.path.join(output_dir, "..", "stable.txt"), "w") as stable_file:
                 stable_file.write(self._current_version)
         get_console(output=self.output).print()
+        return 0, f"Docs published: {self.package_name}"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

It would be nice to have a summary of the action all provider docs underwent at the end of `breeze publish-docs` command as it is super easy to miss the notes while publishing in bulk

Sample output:
```
(new-env) ➜  airflow git:(summaryPublishDocs) ✗ breeze release-management publish-docs apache.pinot apache.beam apache.impala --include-success-outputs
Publishing docs for 3 package(s)
 - apache-airflow-providers-apache-beam
 - apache-airflow-providers-apache-impala
 - apache-airflow-providers-apache-pinot

Publishing docs for apache-airflow-providers-apache-beam
Copy directory: /Users/adesai/Documents/OSS/airflow/docs/_build/docs/apache-airflow-providers-apache-beam/stable => 
/Users/adesai/Documents/OSS/airflow-site/docs-archive/apache-airflow-providers-apache-beam/5.6.0
Skipping previously existing /Users/adesai/Documents/OSS/airflow-site/docs-archive/apache-airflow-providers-apache-beam/5.6.0! Delete it manually if you want to regenerate it!

Publishing docs for apache-airflow-providers-apache-impala
Copy directory: /Users/adesai/Documents/OSS/airflow/docs/_build/docs/apache-airflow-providers-apache-impala/stable => 
/Users/adesai/Documents/OSS/airflow-site/docs-archive/apache-airflow-providers-apache-impala/1.3.0
Skipping previously existing /Users/adesai/Documents/OSS/airflow-site/docs-archive/apache-airflow-providers-apache-impala/1.3.0! Delete it manually if you want to regenerate it!

Publishing docs for apache-airflow-providers-apache-pinot
Copy directory: /Users/adesai/Documents/OSS/airflow/docs/_build/docs/apache-airflow-providers-apache-pinot/stable => 
/Users/adesai/Documents/OSS/airflow-site/docs-archive/apache-airflow-providers-apache-pinot/4.3.0
Skipping previously existing /Users/adesai/Documents/OSS/airflow-site/docs-archive/apache-airflow-providers-apache-pinot/4.3.0! Delete it manually if you want to regenerate it!

Success entries:
Skipped entries:
Skipping apache-airflow-providers-apache-beam: Previously existing directory
Skipping apache-airflow-providers-apache-impala: Previously existing directory
Skipping apache-airflow-providers-apache-pinot: Previously existing directory
(new-env) ➜  airflow git:(summaryPublishDocs) ✗ breeze release-management publish-docs apache.pinot apache.beam apache.impala apache.spark  --include-success-outputs
(new-env) ➜  airflow git:(summaryPublishDocs) ✗ breeze release-management publish-docs apache.pinot apache.beam apache.impala apache.spark  --include-success-outputs
Publishing docs for 4 package(s)
 - apache-airflow-providers-apache-beam
 - apache-airflow-providers-apache-impala
 - apache-airflow-providers-apache-pinot
 - apache-airflow-providers-apache-spark

Publishing docs for apache-airflow-providers-apache-beam
Copy directory: /Users/adesai/Documents/OSS/airflow/docs/_build/docs/apache-airflow-providers-apache-beam/stable => 
/Users/adesai/Documents/OSS/airflow-site/docs-archive/apache-airflow-providers-apache-beam/5.6.0
Skipping previously existing /Users/adesai/Documents/OSS/airflow-site/docs-archive/apache-airflow-providers-apache-beam/5.6.0! Delete it manually if you want to regenerate it!

Publishing docs for apache-airflow-providers-apache-impala
Copy directory: /Users/adesai/Documents/OSS/airflow/docs/_build/docs/apache-airflow-providers-apache-impala/stable => 
/Users/adesai/Documents/OSS/airflow-site/docs-archive/apache-airflow-providers-apache-impala/1.3.0
Skipping previously existing /Users/adesai/Documents/OSS/airflow-site/docs-archive/apache-airflow-providers-apache-impala/1.3.0! Delete it manually if you want to regenerate it!

Publishing docs for apache-airflow-providers-apache-pinot
Copy directory: /Users/adesai/Documents/OSS/airflow/docs/_build/docs/apache-airflow-providers-apache-pinot/stable => 
/Users/adesai/Documents/OSS/airflow-site/docs-archive/apache-airflow-providers-apache-pinot/4.3.0
Skipping previously existing /Users/adesai/Documents/OSS/airflow-site/docs-archive/apache-airflow-providers-apache-pinot/4.3.0! Delete it manually if you want to regenerate it!

Publishing docs for apache-airflow-providers-apache-spark
Copy directory: /Users/adesai/Documents/OSS/airflow/docs/_build/docs/apache-airflow-providers-apache-spark/stable => 
/Users/adesai/Documents/OSS/airflow-site/docs-archive/apache-airflow-providers-apache-spark/4.7.1

Success entries:
Docs published: apache-airflow-providers-apache-spark
=================================================

Skipped entries:
Skipping apache-airflow-providers-apache-beam: Previously existing directory
Skipping apache-airflow-providers-apache-impala: Previously existing directory
Skipping apache-airflow-providers-apache-pinot: Previously existing directory
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
