### PR TITLE
Type Check for retries: Add tests

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -124,7 +124,7 @@ logger = logging.getLogger("airflow.models.baseoperator.BaseOperator")
 
 
 def parse_retries(retries: Any) -> int | None:
-    if retries is None or isinstance(retries, int):
+    if retries is None or type(retries) == int:  # noqa: E721
         return retries
     try:
         parsed_retries = int(retries)

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -101,6 +101,11 @@ class MockNamedTuple(NamedTuple):
     var2: str
 
 
+class CustomInt(int):
+    def __int__(self):
+        raise ValueError("Cannot cast to int")
+
+
 class TestBaseOperator:
     def test_expand(self):
         dummy = DummyClass(test_param=True)
@@ -828,11 +833,18 @@ def test_init_subclass_args():
 
 
 @pytest.mark.db_test
-def test_operator_retries_invalid(dag_maker):
+@pytest.mark.parametrize(
+    ("retries", "expected"),
+    [
+        pytest.param("foo", "'retries' type must be int, not str", id="string"),
+        pytest.param(CustomInt(10), "'retries' type must be int, not CustomInt", id="custom int"),
+    ],
+)
+def test_operator_retries_invalid(dag_maker, retries, expected):
     with pytest.raises(AirflowException) as ctx:
         with dag_maker():
-            BaseOperator(task_id="test_illegal_args", retries="foo")
-    assert str(ctx.value) == "'retries' type must be int, not str"
+            BaseOperator(task_id="test_illegal_args", retries=retries)
+    assert str(ctx.value) == expected
 
 
 @pytest.mark.db_test


### PR DESCRIPTION
I saw that tests were required for this PR - https://github.com/apache/airflow/pull/34914 . So, I added them. 

Had to create a custom Int class which can't be converted to int. 

Honestly, this added test does feel like a imaginary made up problem. I don't completely agree with myself that this PR should be merged.