### PR TITLE
Limit docs publishing tests to canary run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -767,25 +767,25 @@ jobs:
         run: >
           git clone https://github.com/apache/airflow-site.git ${GITHUB_WORKSPACE}/airflow-site &&
           echo "AIRFLOW_SITE_DIRECTORY=${GITHUB_WORKSPACE}/airflow-site" >> "$GITHUB_ENV"
-        if: needs.build-info.outputs.full-tests-needed == 'true'
+        if: needs.build-info.outputs.canary-run == 'true'
       - name: "Publish docs"
         run: >
           breeze release-management publish-docs
           --override-versioned --run-in-parallel
           ${{ needs.build-info.outputs.docs-list-as-string }}
-        if: needs.build-info.outputs.full-tests-needed == 'true'
+        if: needs.build-info.outputs.canary-run == 'true'
       - name: "Generate back references for providers"
         run: breeze release-management add-back-references all-providers
-        if: needs.build-info.outputs.full-tests-needed == 'true'
+        if: needs.build-info.outputs.canary-run == 'true'
       - name: "Generate back references for apache-airflow"
         run: breeze release-management add-back-references apache-airflow
-        if: needs.build-info.outputs.full-tests-needed == 'true'
+        if: needs.build-info.outputs.canary-run == 'true'
       - name: "Generate back references for docker-stack"
         run: breeze release-management add-back-references docker-stack
-        if: needs.build-info.outputs.full-tests-needed == 'true'
+        if: needs.build-info.outputs.canary-run == 'true'
       - name: "Generate back references for helm-chart"
         run: breeze release-management add-back-references helm-chart
-        if: needs.build-info.outputs.full-tests-needed == 'true'
+        if: needs.build-info.outputs.canary-run == 'true'
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a  # v4.0.1
         if: needs.build-info.outputs.canary-run == 'true' && needs.build-info.outputs.default-branch == 'main'

--- a/dev/breeze/doc/ci/05_workflows.md
+++ b/dev/breeze/doc/ci/05_workflows.md
@@ -237,7 +237,7 @@ code.
 | Upgrade checks                  | Performs checks if there are some pending upgrades       |          | Yes      | Yes        | Yes              |
 | Static checks                   | Performs full static checks                              | Yes (6)  | Yes      | Yes        | Yes (7)          |
 | Basic static checks             | Performs basic static checks (no image)                  | Yes (6)  |          |            |                  |
-| Build docs                      | Builds and tests publishing of the documentation         | Yes      | Yes      | Yes        | Yes              |
+| Build docs                      | Builds and tests publishing of the documentation         | Yes      | Yes (11) | Yes        | Yes              |
 | Spellcheck docs                 | Spellcheck docs                                          | Yes      | Yes      | Yes        | Yes              |
 | Tests wheel provider packages   | Tests if provider packages can be built and released     | Yes      | Yes      | Yes        |                  |
 | Tests Airflow compatibility     | Compatibility of provider packages with older Airflow    | Yes      | Yes      | Yes        |                  |
@@ -292,6 +292,9 @@ via `skip-provider-tests` selective check output.
 
 `(10)` Only run the builds in case PR is run by a committer from
 "apache" repository and in scheduled build.
+
+`(11)` Docs publishing is only done in Canary run, to handle the case where
+cloning whole airflow site on Public Runner cannot complete due to the size of the repository.
 
 ## CodeQL scan
 


### PR DESCRIPTION
Docs publishing step takes a lot of disk space and time to complete, due to size of the airflow-site repo. We should limit it to only run for canary runs on self-hosted runners.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
