### PR TITLE
Chart: Fix cluster-wide RBAC naming clash when using multiple multiNamespace releases with the same name

### DIFF
--- a/chart/newsfragments/37197.fix.rst
+++ b/chart/newsfragments/37197.fix.rst
@@ -1,6 +1,0 @@
-Fixed name clashes when using multiple Airflow deployments in `multiNamespaceMode` across several namespaces. `ClusterRole`s and `ClusterRoleBinding`s created when `multiNamespaceMode` is enabled now have unique names:
-* `{{ include "airflow.fullname" . }}-pod-launcher-role` has been renamed to `{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-launcher-role`
-* `{{ include "airflow.fullname" . }}-pod-launcher-rolebinding` has been renamed to `{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-launcher-rolebinding`
-* `{{ include "airflow.fullname" . }}-pod-log-reader-role` has been renamed to `{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-log-reader-role`
-* `{{ include "airflow.fullname" . }}-pod-log-reader-rolebinding` has been renamed to `{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-log-reader-rolebinding`
-* `{{ include "airflow.fullname" . }}-scc-rolebinding` has been renamed to `{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-scc-rolebinding`

--- a/chart/newsfragments/37197.fix.rst
+++ b/chart/newsfragments/37197.fix.rst
@@ -1,0 +1,6 @@
+Fixed name clashes when using multiple Airflow deployments in `multiNamespaceMode` across several namespaces. `ClusterRole`s and `ClusterRoleBinding`s created when `multiNamespaceMode` is enabled now have unique names:
+* `{{ include "airflow.fullname" . }}-pod-launcher-role` has been renamed to `{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-launcher-role`
+* `{{ include "airflow.fullname" . }}-pod-launcher-rolebinding` has been renamed to `{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-launcher-rolebinding`
+* `{{ include "airflow.fullname" . }}-pod-log-reader-role` has been renamed to `{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-log-reader-role`
+* `{{ include "airflow.fullname" . }}-pod-log-reader-rolebinding` has been renamed to `{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-log-reader-rolebinding`
+* `{{ include "airflow.fullname" . }}-scc-rolebinding` has been renamed to `{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-scc-rolebinding`

--- a/chart/newsfragments/37197.significant.rst
+++ b/chart/newsfragments/37197.significant.rst
@@ -1,8 +1,8 @@
 Fixed name clashes when using multiple Airflow deployments in ``multiNamespaceMode`` across several namespaces.
 
 ``ClusterRole``s and ``ClusterRoleBinding``s created when ``multiNamespaceMode`` is enabled have been renamed to ensure unique names:
-* ``{{ include "airflow.fullname" . }}-pod-launcher-role`` has been renamed to ``{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-launcher-role``
-* ``{{ include "airflow.fullname" . }}-pod-launcher-rolebinding`` has been renamed to ``{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-launcher-rolebinding``
-* ``{{ include "airflow.fullname" . }}-pod-log-reader-role`` has been renamed to ``{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-log-reader-role``
-* ``{{ include "airflow.fullname" . }}-pod-log-reader-rolebinding`` has been renamed to ``{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-log-reader-rolebinding``
-* ``{{ include "airflow.fullname" . }}-scc-rolebinding`` has been renamed to ``{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-scc-rolebinding``
+* ``{{ include "airflow.fullname" . }}-pod-launcher-role`` has been renamed to ``{{ .Release.Namespace }}-{{ include "airflow.fullname" . }}-pod-launcher-role``
+* ``{{ include "airflow.fullname" . }}-pod-launcher-rolebinding`` has been renamed to ``{{ .Release.Namespace }}-{{ include "airflow.fullname" . }}-pod-launcher-rolebinding``
+* ``{{ include "airflow.fullname" . }}-pod-log-reader-role`` has been renamed to ``{{ .Release.Namespace }}-{{ include "airflow.fullname" . }}-pod-log-reader-role``
+* ``{{ include "airflow.fullname" . }}-pod-log-reader-rolebinding`` has been renamed to ``{{ .Release.Namespace }}-{{ include "airflow.fullname" . }}-pod-log-reader-rolebinding``
+* ``{{ include "airflow.fullname" . }}-scc-rolebinding`` has been renamed to ``{{ .Release.Namespace }}-{{ include "airflow.fullname" . }}-scc-rolebinding``

--- a/chart/newsfragments/37197.significant.rst
+++ b/chart/newsfragments/37197.significant.rst
@@ -1,0 +1,8 @@
+Fixed name clashes when using multiple Airflow deployments in ``multiNamespaceMode`` across several namespaces.
+
+``ClusterRole``s and ``ClusterRoleBinding``s created when ``multiNamespaceMode`` is enabled have been renamed to ensure unique names:
+* ``{{ include "airflow.fullname" . }}-pod-launcher-role`` has been renamed to ``{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-launcher-role``
+* ``{{ include "airflow.fullname" . }}-pod-launcher-rolebinding`` has been renamed to ``{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-launcher-rolebinding``
+* ``{{ include "airflow.fullname" . }}-pod-log-reader-role`` has been renamed to ``{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-log-reader-role``
+* ``{{ include "airflow.fullname" . }}-pod-log-reader-rolebinding`` has been renamed to ``{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-log-reader-rolebinding``
+* ``{{ include "airflow.fullname" . }}-scc-rolebinding`` has been renamed to ``{{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-scc-rolebinding``

--- a/chart/templates/rbac/pod-launcher-role.yaml
+++ b/chart/templates/rbac/pod-launcher-role.yaml
@@ -28,15 +28,20 @@ kind: ClusterRole
 kind: Role
 {{- end }}
 metadata:
-  name: {{ include "airflow.fullname" . }}-pod-launcher-role
   {{- if not .Values.multiNamespaceMode }}
+  name: {{ include "airflow.fullname" . }}-pod-launcher-role
   namespace: "{{ .Release.Namespace }}"
+  {{- else }}
+  name: {{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-launcher-role
   {{- end }}
   labels:
     tier: airflow
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+    {{- if .Values.multiNamespaceMode }}
+    namespace: "{{ .Release.Namespace }}"
+    {{- end }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/chart/templates/rbac/pod-launcher-role.yaml
+++ b/chart/templates/rbac/pod-launcher-role.yaml
@@ -32,7 +32,7 @@ metadata:
   name: {{ include "airflow.fullname" . }}-pod-launcher-role
   namespace: "{{ .Release.Namespace }}"
   {{- else }}
-  name: {{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-launcher-role
+  name: {{ .Release.Namespace }}-{{ include "airflow.fullname" . }}-pod-launcher-role
   {{- end }}
   labels:
     tier: airflow

--- a/chart/templates/rbac/pod-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/pod-launcher-rolebinding.yaml
@@ -34,7 +34,7 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
   name: {{ include "airflow.fullname" . }}-pod-launcher-rolebinding
   {{- else }}
-  name: {{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-launcher-rolebinding
+  name: {{ .Release.Namespace }}-{{ include "airflow.fullname" . }}-pod-launcher-rolebinding
   {{- end }}
   labels:
     tier: airflow
@@ -51,7 +51,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   {{- if .Values.multiNamespaceMode }}
   kind: ClusterRole
-  name: {{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-launcher-role
+  name: {{ .Release.Namespace }}-{{ include "airflow.fullname" . }}-pod-launcher-role
   {{- else }}
   kind: Role
   name: {{ include "airflow.fullname" . }}-pod-launcher-role

--- a/chart/templates/rbac/pod-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/pod-launcher-rolebinding.yaml
@@ -32,13 +32,18 @@ kind: RoleBinding
 metadata:
   {{- if not .Values.multiNamespaceMode }}
   namespace: "{{ .Release.Namespace }}"
-  {{- end }}
   name: {{ include "airflow.fullname" . }}-pod-launcher-rolebinding
+  {{- else }}
+  name: {{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-launcher-rolebinding
+  {{- end }}
   labels:
     tier: airflow
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+    {{- if .Values.multiNamespaceMode }}
+    namespace: "{{ .Release.Namespace }}"
+    {{- end }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -46,10 +51,11 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   {{- if .Values.multiNamespaceMode }}
   kind: ClusterRole
+  name: {{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-launcher-role
   {{- else }}
   kind: Role
-  {{- end }}
   name: {{ include "airflow.fullname" . }}-pod-launcher-role
+  {{- end }}
 subjects:
   {{- if has .Values.executor $schedulerLaunchExecutors }}
   - kind: ServiceAccount

--- a/chart/templates/rbac/pod-log-reader-role.yaml
+++ b/chart/templates/rbac/pod-log-reader-role.yaml
@@ -32,7 +32,7 @@ metadata:
   name: {{ include "airflow.fullname" . }}-pod-log-reader-role
   namespace: "{{ .Release.Namespace }}"
   {{- else }}
-  name: {{ include "airflow.fullname" . }}-{{ .Release.Namespace}}-pod-log-reader-role
+  name: {{ .Release.Namespace }}-{{ include "airflow.fullname" . }}-pod-log-reader-role
   {{- end }}
   labels:
     tier: airflow

--- a/chart/templates/rbac/pod-log-reader-role.yaml
+++ b/chart/templates/rbac/pod-log-reader-role.yaml
@@ -28,15 +28,20 @@ kind: ClusterRole
 kind: Role
 {{- end }}
 metadata:
-  name: {{ include "airflow.fullname" . }}-pod-log-reader-role
   {{- if not .Values.multiNamespaceMode }}
+  name: {{ include "airflow.fullname" . }}-pod-log-reader-role
   namespace: "{{ .Release.Namespace }}"
+  {{- else }}
+  name: {{ include "airflow.fullname" . }}-{{ .Release.Namespace}}-pod-log-reader-role
   {{- end }}
   labels:
     tier: airflow
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+    {{- if .Values.multiNamespaceMode }}
+    namespace: "{{ .Release.Namespace }}"
+    {{- end }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/chart/templates/rbac/pod-log-reader-rolebinding.yaml
+++ b/chart/templates/rbac/pod-log-reader-rolebinding.yaml
@@ -32,7 +32,7 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
   name: {{ include "airflow.fullname" . }}-pod-log-reader-rolebinding
   {{- else }}
-  name: {{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-log-reader-rolebinding
+  name: {{ .Release.Namespace }}-{{ include "airflow.fullname" . }}-pod-log-reader-rolebinding
   {{- end }}
   labels:
     tier: airflow
@@ -49,7 +49,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   {{- if .Values.multiNamespaceMode }}
   kind: ClusterRole
-  name: {{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-log-reader-role
+  name: {{ .Release.Namespace }}-{{ include "airflow.fullname" . }}-pod-log-reader-role
   {{- else }}
   kind: Role
   name: {{ include "airflow.fullname" . }}-pod-log-reader-role

--- a/chart/templates/rbac/pod-log-reader-rolebinding.yaml
+++ b/chart/templates/rbac/pod-log-reader-rolebinding.yaml
@@ -30,13 +30,18 @@ kind: RoleBinding
 metadata:
   {{- if not .Values.multiNamespaceMode }}
   namespace: "{{ .Release.Namespace }}"
-  {{- end }}
   name: {{ include "airflow.fullname" . }}-pod-log-reader-rolebinding
+  {{- else }}
+  name: {{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-log-reader-rolebinding
+  {{- end }}
   labels:
     tier: airflow
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+    {{- if .Values.multiNamespaceMode }}
+    namespace: "{{ .Release.Namespace }}"
+    {{- end }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -44,10 +49,11 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   {{- if .Values.multiNamespaceMode }}
   kind: ClusterRole
+  name: {{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-pod-log-reader-role
   {{- else }}
   kind: Role
-  {{- end }}
   name: {{ include "airflow.fullname" . }}-pod-log-reader-role
+  {{- end }}
 subjects:
   {{- if .Values.webserver.allowPodLogReading }}
   - kind: ServiceAccount

--- a/chart/templates/rbac/security-context-constraint-rolebinding.yaml
+++ b/chart/templates/rbac/security-context-constraint-rolebinding.yaml
@@ -33,7 +33,7 @@ metadata:
   name: {{ include "airflow.fullname" . }}-scc-rolebinding
   namespace: "{{ .Release.Namespace }}"
   {{- else }}
-  name: {{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-scc-rolebinding
+  name: {{ .Release.Namespace }}-{{ include "airflow.fullname" . }}-scc-rolebinding
   {{- end }}
   labels:
     tier: airflow

--- a/chart/templates/rbac/security-context-constraint-rolebinding.yaml
+++ b/chart/templates/rbac/security-context-constraint-rolebinding.yaml
@@ -30,14 +30,19 @@ kind: RoleBinding
 {{- end }}
 metadata:
   {{- if not .Values.multiNamespaceMode }}
-  namespace: "{{ .Release.Namespace }}"
-  {{- end }}
   name: {{ include "airflow.fullname" . }}-scc-rolebinding
+  namespace: "{{ .Release.Namespace }}"
+  {{- else }}
+  name: {{ include "airflow.fullname" . }}-{{ .Release.Namespace }}-scc-rolebinding
+  {{- end }}
   labels:
     tier: airflow
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+    {{- if .Values.multiNamespaceMode }}
+    namespace: "{{ .Release.Namespace }}"
+    {{- end }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/helm_tests/airflow_aux/test_pod_launcher_role.py
+++ b/helm_tests/airflow_aux/test_pod_launcher_role.py
@@ -53,18 +53,27 @@ class TestPodLauncher:
     @pytest.mark.parametrize(
         "multiNamespaceMode, namespace, expectedRole, expectedRoleBinding",
         [
-            (True, "namespace", "release-name-namespace-pod-launcher-role", "release-name-namespace-pod-launcher-rolebinding"),
-            (True, "other-ns", "release-name-other-ns-pod-launcher-role", "release-name-other-ns-pod-launcher-rolebinding"),
+            (
+                True,
+                "namespace",
+                "release-name-namespace-pod-launcher-role",
+                "release-name-namespace-pod-launcher-rolebinding",
+            ),
+            (
+                True,
+                "other-ns",
+                "release-name-other-ns-pod-launcher-role",
+                "release-name-other-ns-pod-launcher-rolebinding",
+            ),
             (False, "namespace", "release-name-pod-launcher-role", "release-name-pod-launcher-rolebinding"),
         ],
     )
-    def test_pod_launcher_rolebinding_multi_namespace(self, multiNamespaceMode, namespace, expectedRole, expectedRoleBinding):
+    def test_pod_launcher_rolebinding_multi_namespace(
+        self, multiNamespaceMode, namespace, expectedRole, expectedRoleBinding
+    ):
         docs = render_chart(
-            namespace = namespace,
-            values={
-                "webserver": {"allowPodLogReading": True},
-                "multiNamespaceMode": multiNamespaceMode
-            },
+            namespace=namespace,
+            values={"webserver": {"allowPodLogReading": True}, "multiNamespaceMode": multiNamespaceMode},
             show_only=["templates/rbac/pod-launcher-rolebinding.yaml"],
         )
 
@@ -93,11 +102,8 @@ class TestPodLauncher:
     )
     def test_pod_launcher_role_multi_namespace(self, multiNamespaceMode, namespace, expectedRole):
         docs = render_chart(
-            namespace = namespace,
-            values={
-                "webserver": {"allowPodLogReading": True},
-                "multiNamespaceMode": multiNamespaceMode
-            },
+            namespace=namespace,
+            values={"webserver": {"allowPodLogReading": True}, "multiNamespaceMode": multiNamespaceMode},
             show_only=["templates/rbac/pod-launcher-role.yaml"],
         )
 

--- a/helm_tests/airflow_aux/test_pod_launcher_role.py
+++ b/helm_tests/airflow_aux/test_pod_launcher_role.py
@@ -56,14 +56,14 @@ class TestPodLauncher:
             (
                 True,
                 "namespace",
-                "release-name-namespace-pod-launcher-role",
-                "release-name-namespace-pod-launcher-rolebinding",
+                "namespace-release-name-pod-launcher-role",
+                "namespace-release-name-pod-launcher-rolebinding",
             ),
             (
                 True,
                 "other-ns",
-                "release-name-other-ns-pod-launcher-role",
-                "release-name-other-ns-pod-launcher-rolebinding",
+                "other-ns-release-name-pod-launcher-role",
+                "other-ns-release-name-pod-launcher-rolebinding",
             ),
             (False, "namespace", "release-name-pod-launcher-role", "release-name-pod-launcher-rolebinding"),
         ],
@@ -95,8 +95,8 @@ class TestPodLauncher:
     @pytest.mark.parametrize(
         "multiNamespaceMode, namespace, expectedRole",
         [
-            (True, "namespace", "release-name-namespace-pod-launcher-role"),
-            (True, "other-ns", "release-name-other-ns-pod-launcher-role"),
+            (True, "namespace", "namespace-release-name-pod-launcher-role"),
+            (True, "other-ns", "other-ns-release-name-pod-launcher-role"),
             (False, "namespace", "release-name-pod-launcher-role"),
         ],
     )

--- a/helm_tests/airflow_aux/test_pod_launcher_role.py
+++ b/helm_tests/airflow_aux/test_pod_launcher_role.py
@@ -77,14 +77,14 @@ class TestPodLauncher:
             show_only=["templates/rbac/pod-launcher-rolebinding.yaml"],
         )
 
-        actualRoleBinding = jmespath.search("metadata.name", docs[0]) if docs else []
+        actualRoleBinding = jmespath.search("metadata.name", docs[0])
         assert actualRoleBinding == expectedRoleBinding
 
-        actualRoleRef = jmespath.search("roleRef.name", docs[0]) if docs else []
+        actualRoleRef = jmespath.search("roleRef.name", docs[0])
         assert actualRoleRef == expectedRole
 
-        actualKind = jmespath.search("kind", docs[0]) if docs else []
-        actualRoleRefKind = jmespath.search("roleRef.kind", docs[0]) if docs else []
+        actualKind = jmespath.search("kind", docs[0])
+        actualRoleRefKind = jmespath.search("roleRef.kind", docs[0])
         if multiNamespaceMode:
             assert actualKind == "ClusterRoleBinding"
             assert actualRoleRefKind == "ClusterRole"
@@ -107,10 +107,10 @@ class TestPodLauncher:
             show_only=["templates/rbac/pod-launcher-role.yaml"],
         )
 
-        actualRole = jmespath.search("metadata.name", docs[0]) if docs else []
+        actualRole = jmespath.search("metadata.name", docs[0])
         assert actualRole == expectedRole
 
-        actualKind = jmespath.search("kind", docs[0]) if docs else []
+        actualKind = jmespath.search("kind", docs[0])
         if multiNamespaceMode:
             assert actualKind == "ClusterRole"
         else:

--- a/helm_tests/security/test_rbac_pod_log_reader.py
+++ b/helm_tests/security/test_rbac_pod_log_reader.py
@@ -97,14 +97,14 @@ class TestPodReader:
             show_only=["templates/rbac/pod-log-reader-rolebinding.yaml"],
         )
 
-        actualRoleBinding = jmespath.search("metadata.name", docs[0]) if docs else []
+        actualRoleBinding = jmespath.search("metadata.name", docs[0])
         assert actualRoleBinding == expectedRoleBinding
 
-        actualRoleRef = jmespath.search("roleRef.name", docs[0]) if docs else []
+        actualRoleRef = jmespath.search("roleRef.name", docs[0])
         assert actualRoleRef == expectedRole
 
-        actualKind = jmespath.search("kind", docs[0]) if docs else []
-        actualRoleRefKind = jmespath.search("roleRef.kind", docs[0]) if docs else []
+        actualKind = jmespath.search("kind", docs[0])
+        actualRoleRefKind = jmespath.search("roleRef.kind", docs[0])
         if multiNamespaceMode:
             assert actualKind == "ClusterRoleBinding"
             assert actualRoleRefKind == "ClusterRole"
@@ -127,10 +127,10 @@ class TestPodReader:
             show_only=["templates/rbac/pod-log-reader-role.yaml"],
         )
 
-        actualRole = jmespath.search("metadata.name", docs[0]) if docs else []
+        actualRole = jmespath.search("metadata.name", docs[0])
         assert actualRole == expectedRole
 
-        actualKind = jmespath.search("kind", docs[0]) if docs else []
+        actualKind = jmespath.search("kind", docs[0])
         if multiNamespaceMode:
             assert actualKind == "ClusterRole"
         else:

--- a/helm_tests/security/test_rbac_pod_log_reader.py
+++ b/helm_tests/security/test_rbac_pod_log_reader.py
@@ -68,18 +68,32 @@ class TestPodReader:
     @pytest.mark.parametrize(
         "multiNamespaceMode, namespace, expectedRole, expectedRoleBinding",
         [
-            (True, "namespace", "release-name-namespace-pod-log-reader-role", "release-name-namespace-pod-log-reader-rolebinding"),
-            (True, "other-ns", "release-name-other-ns-pod-log-reader-role", "release-name-other-ns-pod-log-reader-rolebinding"),
-            (False, "namespace", "release-name-pod-log-reader-role", "release-name-pod-log-reader-rolebinding"),
+            (
+                True,
+                "namespace",
+                "release-name-namespace-pod-log-reader-role",
+                "release-name-namespace-pod-log-reader-rolebinding",
+            ),
+            (
+                True,
+                "other-ns",
+                "release-name-other-ns-pod-log-reader-role",
+                "release-name-other-ns-pod-log-reader-rolebinding",
+            ),
+            (
+                False,
+                "namespace",
+                "release-name-pod-log-reader-role",
+                "release-name-pod-log-reader-rolebinding",
+            ),
         ],
     )
-    def test_pod_log_reader_rolebinding_multi_namespace(self, multiNamespaceMode, namespace, expectedRole, expectedRoleBinding):
+    def test_pod_log_reader_rolebinding_multi_namespace(
+        self, multiNamespaceMode, namespace, expectedRole, expectedRoleBinding
+    ):
         docs = render_chart(
-            namespace = namespace,
-            values={
-                "webserver": {"allowPodLogReading": True},
-                "multiNamespaceMode": multiNamespaceMode
-            },
+            namespace=namespace,
+            values={"webserver": {"allowPodLogReading": True}, "multiNamespaceMode": multiNamespaceMode},
             show_only=["templates/rbac/pod-log-reader-rolebinding.yaml"],
         )
 
@@ -108,11 +122,8 @@ class TestPodReader:
     )
     def test_pod_log_reader_role_multi_namespace(self, multiNamespaceMode, namespace, expectedRole):
         docs = render_chart(
-            namespace = namespace,
-            values={
-                "webserver": {"allowPodLogReading": True},
-                "multiNamespaceMode": multiNamespaceMode
-            },
+            namespace=namespace,
+            values={"webserver": {"allowPodLogReading": True}, "multiNamespaceMode": multiNamespaceMode},
             show_only=["templates/rbac/pod-log-reader-role.yaml"],
         )
 

--- a/helm_tests/security/test_rbac_pod_log_reader.py
+++ b/helm_tests/security/test_rbac_pod_log_reader.py
@@ -71,14 +71,14 @@ class TestPodReader:
             (
                 True,
                 "namespace",
-                "release-name-namespace-pod-log-reader-role",
-                "release-name-namespace-pod-log-reader-rolebinding",
+                "namespace-release-name-pod-log-reader-role",
+                "namespace-release-name-pod-log-reader-rolebinding",
             ),
             (
                 True,
                 "other-ns",
-                "release-name-other-ns-pod-log-reader-role",
-                "release-name-other-ns-pod-log-reader-rolebinding",
+                "other-ns-release-name-pod-log-reader-role",
+                "other-ns-release-name-pod-log-reader-rolebinding",
             ),
             (
                 False,
@@ -115,8 +115,8 @@ class TestPodReader:
     @pytest.mark.parametrize(
         "multiNamespaceMode, namespace, expectedRole",
         [
-            (True, "namespace", "release-name-namespace-pod-log-reader-role"),
-            (True, "other-ns", "release-name-other-ns-pod-log-reader-role"),
+            (True, "namespace", "namespace-release-name-pod-log-reader-role"),
+            (True, "other-ns", "other-ns-release-name-pod-log-reader-role"),
             (False, "namespace", "release-name-pod-log-reader-role"),
         ],
     )

--- a/helm_tests/security/test_rbac_pod_log_reader.py
+++ b/helm_tests/security/test_rbac_pod_log_reader.py
@@ -64,3 +64,63 @@ class TestPodReader:
         )
         actual = jmespath.search("metadata.name", docs[0]) if docs else None
         assert actual == expected
+
+    @pytest.mark.parametrize(
+        "multiNamespaceMode, namespace, expectedRole, expectedRoleBinding",
+        [
+            (True, "namespace", "release-name-namespace-pod-log-reader-role", "release-name-namespace-pod-log-reader-rolebinding"),
+            (True, "other-ns", "release-name-other-ns-pod-log-reader-role", "release-name-other-ns-pod-log-reader-rolebinding"),
+            (False, "namespace", "release-name-pod-log-reader-role", "release-name-pod-log-reader-rolebinding"),
+        ],
+    )
+    def test_pod_log_reader_rolebinding_multi_namespace(self, multiNamespaceMode, namespace, expectedRole, expectedRoleBinding):
+        docs = render_chart(
+            namespace = namespace,
+            values={
+                "webserver": {"allowPodLogReading": True},
+                "multiNamespaceMode": multiNamespaceMode
+            },
+            show_only=["templates/rbac/pod-log-reader-rolebinding.yaml"],
+        )
+
+        actualRoleBinding = jmespath.search("metadata.name", docs[0]) if docs else []
+        assert actualRoleBinding == expectedRoleBinding
+
+        actualRoleRef = jmespath.search("roleRef.name", docs[0]) if docs else []
+        assert actualRoleRef == expectedRole
+
+        actualKind = jmespath.search("kind", docs[0]) if docs else []
+        actualRoleRefKind = jmespath.search("roleRef.kind", docs[0]) if docs else []
+        if multiNamespaceMode:
+            assert actualKind == "ClusterRoleBinding"
+            assert actualRoleRefKind == "ClusterRole"
+        else:
+            assert actualKind == "RoleBinding"
+            assert actualRoleRefKind == "Role"
+
+    @pytest.mark.parametrize(
+        "multiNamespaceMode, namespace, expectedRole",
+        [
+            (True, "namespace", "release-name-namespace-pod-log-reader-role"),
+            (True, "other-ns", "release-name-other-ns-pod-log-reader-role"),
+            (False, "namespace", "release-name-pod-log-reader-role"),
+        ],
+    )
+    def test_pod_log_reader_role_multi_namespace(self, multiNamespaceMode, namespace, expectedRole):
+        docs = render_chart(
+            namespace = namespace,
+            values={
+                "webserver": {"allowPodLogReading": True},
+                "multiNamespaceMode": multiNamespaceMode
+            },
+            show_only=["templates/rbac/pod-log-reader-role.yaml"],
+        )
+
+        actualRole = jmespath.search("metadata.name", docs[0]) if docs else []
+        assert actualRole == expectedRole
+
+        actualKind = jmespath.search("kind", docs[0]) if docs else []
+        if multiNamespaceMode:
+            assert actualKind == "ClusterRole"
+        else:
+            assert actualKind == "Role"

--- a/helm_tests/security/test_scc_rolebinding.py
+++ b/helm_tests/security/test_scc_rolebinding.py
@@ -65,8 +65,8 @@ class TestSCCActivation:
     @pytest.mark.parametrize(
         "rbac_enabled,scc_enabled,created,namespace,expected_name",
         [
-            (True, True, True, "default", "release-name-default-scc-rolebinding"),
-            (True, True, True, "other-ns", "release-name-other-ns-scc-rolebinding"),
+            (True, True, True, "default", "default-release-name-scc-rolebinding"),
+            (True, True, True, "other-ns", "other-ns-release-name-scc-rolebinding"),
         ],
     )
     def test_create_scc_multinamespace(self, rbac_enabled, scc_enabled, created, namespace, expected_name):

--- a/helm_tests/security/test_scc_rolebinding.py
+++ b/helm_tests/security/test_scc_rolebinding.py
@@ -63,13 +63,15 @@ class TestSCCActivation:
             assert "release-name-airflow-cleanup" == jmespath.search("subjects[8].name", docs[0])
 
     @pytest.mark.parametrize(
-        "rbac_enabled,scc_enabled,created",
+        "rbac_enabled,scc_enabled,created,namespace,expected_name",
         [
-            (True, True, True),
+            (True, True, True, "default", "release-name-default-scc-rolebinding"),
+            (True, True, True, "other-ns", "release-name-other-ns-scc-rolebinding"),
         ],
     )
-    def test_create_scc_multinamespace(self, rbac_enabled, scc_enabled, created):
+    def test_create_scc_multinamespace(self, rbac_enabled, scc_enabled, created, namespace, expected_name):
         docs = render_chart(
+            namespace=namespace,
             values={
                 "multiNamespaceMode": True,
                 "webserver": {"defaultUser": {"enabled": False}},
@@ -84,7 +86,7 @@ class TestSCCActivation:
         if created:
             assert "ClusterRoleBinding" == jmespath.search("kind", docs[0])
             assert "ClusterRole" == jmespath.search("roleRef.kind", docs[0])
-            assert "release-name-scc-rolebinding" == jmespath.search("metadata.name", docs[0])
+            assert expected_name == jmespath.search("metadata.name", docs[0])
             assert "system:openshift:scc:anyuid" == jmespath.search("roleRef.name", docs[0])
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Currently, when deploying multiple releases that share the same release name in **different** namespaces deployment is failing due to a naming clash of the cluster-scoped RBAC resources.

This PR introduces changes that make sure that `ClusterRole`s and `ClusterRoleBinding`s are uniquely named according to both the release name, as well as the release namespace, thus solving the naming clash.

---

Steps to reproduce current behavior:
1. Create namespace `airflow-a`
2. Install helm chart release named `airflow` into namespace `airflow-a` with `multiNamespaceMode: true`
3. Create namespace `airflow-b`
4. Install helm chart release named `airflow` into namespace `airflow-b` with `multiNamespaceMode: true`
5. Installing the helm chart will fail due to a naming clash of the cluster-wide RBAC resources

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---

Related: #31613 (closed, resubmitting with updated tests)

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
