### PR TITLE
Fix collapsed grid width and match selected row between grid/gantt

### DIFF
--- a/airflow/www/static/js/dag/Main.tsx
+++ b/airflow/www/static/js/dag/Main.tsx
@@ -38,7 +38,7 @@ import keyboardShortcutIdentifier from "./keyboardShortcutIdentifier";
 
 const detailsPanelKey = "hideDetailsPanel";
 const minPanelWidth = 300;
-const collapsedWidth = "28px";
+const collapsedWidth = "32px";
 
 const gridWidthKey = "grid-width";
 const saveWidth = debounce(

--- a/airflow/www/static/js/dag/details/Header.tsx
+++ b/airflow/www/static/js/dag/details/Header.tsx
@@ -87,7 +87,7 @@ const Header = () => {
   const isMappedTaskDetails = runId && taskId && mapIndex !== undefined;
 
   return (
-    <Breadcrumb separator={<Text color="gray.300">/</Text>}>
+    <Breadcrumb ml={3} separator={<Text color="gray.300">/</Text>}>
       <BreadcrumbItem isCurrentPage={isDagDetails} mt={4}>
         <BreadcrumbLink
           onClick={clearSelection}

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -197,7 +197,7 @@ const Details = ({
       : group?.instances.find((ti) => ti.runId === runId);
 
   return (
-    <Flex flexDirection="column" pl={3} height="100%">
+    <Flex flexDirection="column" height="100%">
       <Flex
         alignItems="center"
         justifyContent="space-between"

--- a/airflow/www/static/js/dag/grid/dagRuns/index.tsx
+++ b/airflow/www/static/js/dag/grid/dagRuns/index.tsx
@@ -147,11 +147,21 @@ const DagRuns = ({
           </Flex>
         </Th>
       )}
-      <Th align="right" verticalAlign="bottom">
+      <Th
+        align="right"
+        verticalAlign="bottom"
+        borderRightWidth="16px"
+        borderRightColor="white"
+      >
         <Flex
           justifyContent="flex-end"
           borderBottomWidth={3}
           position="relative"
+          borderRightWidth="16px"
+          borderRightColor="white"
+          marginRight="-16px"
+          borderTopWidth="50px"
+          borderTopColor="white"
         >
           {runs.map((run: RunWithDuration, index) => (
             <DagRunBar

--- a/airflow/www/static/js/dag/grid/index.tsx
+++ b/airflow/www/static/js/dag/grid/index.tsx
@@ -165,11 +165,10 @@ const Grid = ({
         ref={gridScrollRef}
         overflow="auto"
         position="relative"
-        pr={4}
         mt={8}
         overscrollBehavior="auto"
       >
-        <Table pr="10px" borderRightWidth="14px" borderColor="transparent">
+        <Table borderRightWidth="16px" borderColor="transparent">
           <Thead>
             <DagRuns
               groups={groups}

--- a/airflow/www/static/js/dag/grid/renderTaskRows.tsx
+++ b/airflow/www/static/js/dag/grid/renderTaskRows.tsx
@@ -146,6 +146,8 @@ const Row = (props: RowProps) => {
         bg={isSelected ? "blue.100" : "inherit"}
         borderBottomWidth={1}
         borderBottomColor={isGroup && isOpen ? "gray.400" : "gray.200"}
+        borderRightWidth="16px"
+        borderRightColor={isSelected ? "blue.100" : "transparent"}
         role="group"
         _hover={!isSelected ? { bg: hoverBlue } : undefined}
         transition="background-color 0.2s"


### PR DESCRIPTION
The collapsed grid view was broken in https://github.com/apache/airflow/pull/35346. This PR fixes it.

Also, has the selected row of the grid continue into the gantt chart instead of having a whitespace.

Before:
<img width="291" alt="Screenshot 2024-02-06 at 2 00 37 PM" src="https://github.com/apache/airflow/assets/4600967/c04e0222-8205-46ad-9ee2-5938a32188eb">
<img width="512" alt="Screenshot 2024-02-06 at 2 00 32 PM" src="https://github.com/apache/airflow/assets/4600967/d6537f85-7634-4c18-afe7-0d88a68ee07d">

After:
<img width="588" alt="Screenshot 2024-02-06 at 1 59 32 PM" src="https://github.com/apache/airflow/assets/4600967/9bcdb229-541b-45d0-8f88-7f3d0fea7ab2">
<img width="806" alt="Screenshot 2024-02-06 at 1 59 41 PM" src="https://github.com/apache/airflow/assets/4600967/350c9b75-5a44-4bae-a59f-8b439f16e4ab">


---


**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
