### PR TITLE
Adding certificate validation for ssl in mongo hook

### DIFF
--- a/airflow/providers/mongo/CHANGELOG.rst
+++ b/airflow/providers/mongo/CHANGELOG.rst
@@ -27,6 +27,17 @@
 Changelog
 ---------
 
+3.7.0
+......
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+Introduced the allow_insecure flag in the extras field of for the MongoDB connection. This flag allows users to control
+whether insecure connections are permitted when using SSL encryption. By default, the allow_insecure flag is
+set to False. This means that when SSL encryption is enabled (ssl=True), insecure connections are not allowed unless
+explicitly specified by the user.
+
 3.6.0
 .....
 

--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -19,7 +19,7 @@
 from __future__ import annotations
 
 import warnings
-from ssl import CERT_NONE
+from ssl import CERT_NONE, CERT_REQUIRED
 from typing import TYPE_CHECKING, Any, overload
 from urllib.parse import quote_plus, urlunsplit
 
@@ -107,7 +107,7 @@ class MongoHook(BaseHook):
                 options["tlsAllowInvalidCertificates"] = allow_insecure
             else:
                 # For older pymongo versions, use 'ssl_cert_reqs'
-                options["ssl_cert_reqs"] = None if allow_insecure else CERT_NONE
+                options["ssl_cert_reqs"] = CERT_NONE if allow_insecure else CERT_REQUIRED
 
         self.client = MongoClient(self.uri, **options)
         return self.client

--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -55,15 +55,15 @@ class MongoHook(BaseHook):
     The `allow_insecure` only makes sense in ssl context and is configurable and can be used in one of
     the following scenarios:
 
-    * HTTP (ssl = False)
+    HTTP (ssl = False)
     Here, `ssl` is disabled and using `allow_insecure` doesn't make sense.
     Example connection extra: {"ssl": false}
 
-    * HTTPS, but insecure (ssl = True, allow_insecure = True)
+    HTTPS, but insecure (ssl = True, allow_insecure = True)
     Here, `ssl` is enabled, and the connection allows insecure connections.
     Example connection extra: {"ssl": true, "allow_insecure": true}
 
-    * HTTPS, but secure (ssl = True, allow_insecure = False - default when SSL enabled):
+    HTTPS, but secure (ssl = True, allow_insecure = False - default when SSL enabled):
     Here, `ssl` is enabled, and the connection does not allow insecure connections (default behavior when
     SSL is enabled). Example connection extra: {"ssl": true} or {"ssl": true, "allow_insecure": false}
 

--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -48,6 +48,28 @@ class MongoHook(BaseHook):
     ex.
         {"srv": true, "replicaSet": "test", "ssl": true, "connectTimeoutMS": 30000}
 
+    For enabling SSL, the `"ssl": true` option can be used within the connection string options, under extra.
+    In scenarios where SSL is enabled, `allow_insecure` option is not included by default in the connection
+    unless specified. This is so that we ensure a secure medium while handling connections to MongoDB.
+
+    The `allow_insecure` only makes sense in ssl context and is configurable and can be used in one of
+    the following scenarios:
+
+    * HTTP (ssl = False)
+    Here, `ssl` is disabled and using `allow_insecure` doesn't make sense.
+    Example connection extra: {"ssl": false}
+
+    * HTTPS, but insecure (ssl = True, allow_insecure = True)
+    Here, `ssl` is enabled, and the connection allows insecure connections.
+    Example connection extra: {"ssl": true, "allow_insecure": true}
+
+    * HTTPS, but secure (ssl = True, allow_insecure = False - default when SSL enabled):
+    Here, `ssl` is enabled, and the connection does not allow insecure connections (default behavior when
+    SSL is enabled). Example connection extra: {"ssl": true} or {"ssl": true, "allow_insecure": false}
+
+    Note: `tls` is an alias to `ssl` and can be used in place of `ssl`. Example: {"ssl": false} or
+    {"tls": false}.
+
     :param mongo_conn_id: The :ref:`Mongo connection id <howto/connection:mongo>` to use
         when connecting to MongoDB.
     """
@@ -75,7 +97,10 @@ class MongoHook(BaseHook):
         self.uri = self._create_uri()
 
         self.allow_insecure = self.extras.pop("allow_insecure", "false").lower() == "true"
-        self.ssl_enabled = self.extras.get("ssl", "false").lower() == "true"
+        self.ssl_enabled = (
+            self.extras.get("ssl", "false").lower() == "true"
+            or self.extras.get("tls", "false").lower() == "true"
+        )
 
         if self.ssl_enabled and not self.allow_insecure:
             # Case: HTTPS
@@ -86,6 +111,7 @@ class MongoHook(BaseHook):
             self.extras.pop("ssl", None)
         elif not self.ssl_enabled and "allow_insecure" in self.extras:
             # Case: HTTP (ssl=False) with allow_insecure specified
+            self.log.warning("allow_insecure is only applicable when ssl is set")
             self.extras.pop("allow_insecure", None)
         elif not self.ssl_enabled:
             # Case: HTTP (ssl=False) with allow_insecure not specified


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Currently, we are skipping tls certificate validation in mongo hook even if ssl is set to true. This needs to be handled better

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
