### PR TITLE
Fix signature check into the `test_expected_thin_hooks` test

### DIFF
--- a/tests/providers/amazon/aws/hooks/test_hooks_signature.py
+++ b/tests/providers/amazon/aws/hooks/test_hooks_signature.py
@@ -72,7 +72,7 @@ def get_aws_hooks_modules():
     elif not hooks_dir.is_dir():
         raise NotADirectoryError(hooks_dir.__fspath__())
 
-    for module in hooks_dir.glob("*.py"):
+    for module in sorted(hooks_dir.glob("*.py")):
         name = module.stem
         if name.startswith("_"):
             continue
@@ -99,7 +99,7 @@ def get_aws_hooks_from_module(hook_module: str) -> list[tuple[type[AwsGenericHoo
 
 def validate_hook(hook: type[AwsGenericHook], hook_name: str, hook_module: str) -> tuple[bool, str | None]:
     hook_extra_parameters = set()
-    for k, v in inspect.signature(hook).parameters.items():
+    for k, v in inspect.signature(hook.__init__).parameters.items():
         if v.kind == inspect.Parameter.VAR_POSITIONAL:
             k = "*args"
         elif v.kind == inspect.Parameter.VAR_KEYWORD:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Follow-up: https://github.com/apache/airflow/pull/37199#issuecomment-1930704459

Seems like `inspect.signature(CLASS)` works a different in python 3.8 and 3.9+.
If directly pass class then it always returns params signature as
```console
mappingproxy(OrderedDict([('args', <Parameter "*args">), ('kwds', <Parameter "**kwds">)]))
```
Which is always pass in current test case.

If compare to Python 3.9+ it returns 
```console
mappingproxy(OrderedDict([('s3_bucket', <Parameter "s3_bucket: 'str | None' = None">), ('job_name', <Parameter "job_name: 'str | None' = None">), ('desc', <Parameter "desc: 'str | None' = None">), ('concurrent_run_limit', <Parameter "concurrent_run_limit: 'int' = 1">), ('script_location', <Parameter "script_location: 'str | None' = None">), ('retry_limit', <Parameter "retry_limit: 'int' = 0">), ('num_of_dpus', <Parameter "num_of_dpus: 'int | float | None' = None">), ('iam_role_name', <Parameter "iam_role_name: 'str | None' = None">), ('iam_role_arn', <Parameter "iam_role_arn: 'str | None' = None">), ('create_job_kwargs', <Parameter "create_job_kwargs: 'dict | None' = None">), ('update_config', <Parameter "update_config: 'bool' = False">), ('job_poll_interval', <Parameter "job_poll_interval: 'int | float' = 6">), ('args', <Parameter "*args">), ('kwargs', <Parameter "**kwargs">)]))
```

This PR intend to use signature of `__init__` constructor, and result will be same regardless of python interpreter version
```console
mappingproxy(OrderedDict([('self', <Parameter "self">), ('s3_bucket', <Parameter "s3_bucket: 'str | None' = None">), ('job_name', <Parameter "job_name: 'str | None' = None">), ('desc', <Parameter "desc: 'str | None' = None">), ('concurrent_run_limit', <Parameter "concurrent_run_limit: 'int' = 1">), ('script_location', <Parameter "script_location: 'str | None' = None">), ('retry_limit', <Parameter "retry_limit: 'int' = 0">), ('num_of_dpus', <Parameter "num_of_dpus: 'int | float | None' = None">), ('iam_role_name', <Parameter "iam_role_name: 'str | None' = None">), ('iam_role_arn', <Parameter "iam_role_arn: 'str | None' = None">), ('create_job_kwargs', <Parameter "create_job_kwargs: 'dict | None' = None">), ('update_config', <Parameter "update_config: 'bool' = False">), ('job_poll_interval', <Parameter "job_poll_interval: 'int | float' = 6">), ('args', <Parameter "*args">), ('kwargs', <Parameter "**kwargs">)]))
```

Also check if comment out `"AthenaSQLHook": {"athena_conn_id"},` then it raise an error into the Python 3.8 (as well as Python 3.9)

```console
❯ pytest "tests/providers/amazon/aws/hooks/test_hooks_signature.py::test_expected_thin_hooks[athena_sql]"
====================================================================================================== test session starts ======================================================================================================
platform linux -- Python 3.8.18, pytest-7.4.4, pluggy-1.4.0 -- /home/taragolis/.local/share/hatch/env/virtual/apache-airflow/5ZPEbf5v/apache-airflow/bin/python
cachedir: .pytest_cache
rootdir: /home/taragolis/Projects/common/airflow
configfile: pyproject.toml
plugins: icdiff-0.9, asyncio-0.23.4, timeouts-1.2.1, mock-3.12.0, time-machine-2.13.0, httpx-0.22.0, rerunfailures-13.0, instafail-0.5.0, cov-4.1.0, requests-mock-1.11.0, xdist-3.5.0, anyio-4.2.0
asyncio: mode=strict
setup timeout: 0.0s, execution timeout: 0.0s, teardown timeout: 0.0s
collected 1 item                                                                                                                                                                                                                

tests/providers/amazon/aws/hooks/test_hooks_signature.py::test_expected_thin_hooks[athena_sql] FAILED                                                                                                                     [100%]

=========================================================================================================== FAILURES ============================================================================================================
_____________________________________________________________________________________________ test_expected_thin_hooks[athena_sql] ______________________________________________________________________________________________

...
    
        if errors:
            errors_msg = "\n * ".join(errors)
>           pytest.fail(reason=f"Found errors in {hook_module}:\n * {errors_msg}")
E           Failed: Found errors in airflow.providers.amazon.aws.hooks.athena_sql:
E            * 'airflow.providers.amazon.aws.hooks.athena_sql.AthenaSQLHook' has additional attributes 'athena_conn_id'. Expected that all `boto3` related hooks (based on `AwsGenericHook` or `AwsBaseHook`) should not use additional attributes in class constructor, please move them to method signatures. Make sure that 'AthenaSQLHook' constructor has signature `def __init__(self, *args, **kwargs):`

tests/providers/amazon/aws/hooks/test_hooks_signature.py:199: Failed
----------------------------------------------------------------------------------------------------- Captured stdout setup -----------------------------------------------------------------------------------------------------
========================= AIRFLOW ==========================
Home of the user: /home/taragolis
Airflow home /home/taragolis/airflow
Skipping initializing of the DB as it was initialized already.
You can re-initialize the database by adding --with-db-init flag when running tests.
======================================================================================================= warnings summary ========================================================================================================
tests/providers/amazon/aws/hooks/test_hooks_signature.py::test_expected_thin_hooks[athena_sql]
  /home/taragolis/.local/share/hatch/env/virtual/apache-airflow/5ZPEbf5v/apache-airflow/lib/python3.8/site-packages/flask_appbuilder/models/sqla/__init__.py:105: MovedIn20Warning: Deprecated API features detected! These feature(s) are not compatible with SQLAlchemy 2.0. To prevent incompatible upgrades prior to updating applications, ensure requirements files are pinned to "sqlalchemy<2.0". Set environment variable SQLALCHEMY_WARN_20=1 to show all deprecation warnings.  Set environment variable SQLALCHEMY_SILENCE_UBER_WARNING=1 to silence this message. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    @as_declarative(name="Model", metaclass=ModelDeclarativeMeta)

tests/providers/amazon/aws/hooks/test_hooks_signature.py::test_expected_thin_hooks[athena_sql]
tests/providers/amazon/aws/hooks/test_hooks_signature.py::test_expected_thin_hooks[athena_sql]
  /home/taragolis/.local/share/hatch/env/virtual/apache-airflow/5ZPEbf5v/apache-airflow/lib/python3.8/site-packages/marshmallow_sqlalchemy/convert.py:17: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _META_KWARGS_DEPRECATED = LooseVersion(ma.__version__) >= LooseVersion("3.10.0")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================================================== short test summary info ====================================================================================================
FAILED tests/providers/amazon/aws/hooks/test_hooks_signature.py::test_expected_thin_hooks[athena_sql] - Failed: Found errors in airflow.providers.amazon.aws.hooks.athena_sql:
================================================================================================= 1 failed, 3 warnings in 1.05s =================================================================================================

```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
