### PR TITLE
Avoid log-groomer container failures when log persistence is enabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1181,14 +1181,10 @@ echo "Cleaning logs every $EVERY seconds"
 
 while true; do
   echo "Trimming airflow logs to ${RETENTION} days."
- 
-  files=$(find "${DIRECTORY}"/logs \
+  find "${DIRECTORY}"/logs \
     -type d -name 'lost+found' -prune -o \
-    -type f -mtime +"${RETENTION}" -name '*.log' || true)
- 
-  for file in ${files}; do
-    rm -f ${file} || true
-  done
+    -type f -mtime +"${RETENTION}" -name '*.log' -print0 | \
+    xargs -0 rm -f || true
 
   find "${DIRECTORY}"/logs -type d -empty -delete || true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1181,10 +1181,14 @@ echo "Cleaning logs every $EVERY seconds"
 
 while true; do
   echo "Trimming airflow logs to ${RETENTION} days."
-  find "${DIRECTORY}"/logs \
+ 
+  files=$(find "${DIRECTORY}"/logs \
     -type d -name 'lost+found' -prune -o \
-    -type f -mtime +"${RETENTION}" -name '*.log' -print0 | \
-    xargs -0 rm -f
+    -type f -mtime +"${RETENTION}" -name '*.log' || true)
+ 
+  for file in ${files}; do
+    rm -f ${file} || true
+  done
 
   find "${DIRECTORY}"/logs -type d -empty -delete || true
 

--- a/scripts/docker/clean-logs.sh
+++ b/scripts/docker/clean-logs.sh
@@ -30,14 +30,10 @@ echo "Cleaning logs every $EVERY seconds"
 
 while true; do
   echo "Trimming airflow logs to ${RETENTION} days."
-
-  files=$(find "${DIRECTORY}"/logs \
+  find "${DIRECTORY}"/logs \
     -type d -name 'lost+found' -prune -o \
-    -type f -mtime +"${RETENTION}" -name '*.log' || true)
-
-  for file in ${files}; do
-    rm -f ${file} || true
-  done
+    -type f -mtime +"${RETENTION}" -name '*.log' -print0 | \
+    xargs -0 rm -f || true
 
   find "${DIRECTORY}"/logs -type d -empty -delete || true
 

--- a/scripts/docker/clean-logs.sh
+++ b/scripts/docker/clean-logs.sh
@@ -30,10 +30,14 @@ echo "Cleaning logs every $EVERY seconds"
 
 while true; do
   echo "Trimming airflow logs to ${RETENTION} days."
-  find "${DIRECTORY}"/logs \
+
+  files=$(find "${DIRECTORY}"/logs \
     -type d -name 'lost+found' -prune -o \
-    -type f -mtime +"${RETENTION}" -name '*.log' -print0 | \
-    xargs -0 rm -f
+    -type f -mtime +"${RETENTION}" -name '*.log' || true)
+
+  for file in ${files}; do
+    rm -f ${file} || true
+  done
 
   find "${DIRECTORY}"/logs -type d -empty -delete || true
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #37220
related: #33162

With this PR, failures on find or rm command on logs folder will be ignored (still will be shown on the container logs)

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #37220
related: #33162

With this PR, failures on find or rm command on logs folder will be ignored (still will be shown on the container logs)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
