### PR TITLE
Fix the otel config descriptions

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1077,22 +1077,23 @@ metrics:
       example: ~
       default: "False"
     otel_host:
-      description: ~
+      description: |
+        Specifies the hostname or IP address of the OpenTelemetry Collector to which Airflow sends
+        metrics and traces.
       version_added: 2.6.0
       type: string
       example: ~
       default: "localhost"
     otel_port:
       description: |
-        Specifies the hostname or IP address of the OpenTelemetry Collector to which Airflow sends
-        metrics and traces
+        Specifies the port of the OpenTelemetry Collector that is listening to.
       version_added: 2.6.0
       type: string
       example: ~
       default: "8889"
     otel_prefix:
       description: |
-        Specifies the port of the OpenTelemetry Collector that is listening to
+        The prefix for the Airflow metrics.
       version_added: 2.6.0
       type: string
       example: ~
@@ -1100,14 +1101,14 @@ metrics:
     otel_interval_milliseconds:
       description: |
         Defines the interval, in milliseconds, at which Airflow sends batches of metrics and traces
-        to the configured OpenTelemetry Collector
+        to the configured OpenTelemetry Collector.
       version_added: 2.6.0
       type: integer
       example: ~
       default: "60000"
     otel_debugging_on:
       description: |
-        If True, all metrics are also emitted to the console.  Defaults to False.
+        If True, all metrics are also emitted to the console. Defaults to False.
       version_added: 2.7.0
       type: string
       example: ~


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The descriptions of the otel config variables are incorrect. This is being addressed in this PR.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
