### PR TITLE
Fix upgrade docs to reflect true cli flags available

### DIFF
--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -68,7 +68,7 @@ to get the SQL statements that would be executed. You may also specify the start
 from Airflow 2.0.0 onward.
 
 Sample usage for Airflow version 2.7.0 or greater:
-   ``airflow db migrate -s --from-version "2.4.3" --to-version "2.7.3"``
+   ``airflow db migrate -s --from-version "2.4.3" -n "2.7.3"``
    ``airflow db migrate --show-sql-only --from-version "2.4.3" --to-version "2.7.3"``
 
 .. note::

--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -63,17 +63,13 @@ you access to Airflow ``CLI`` :doc:`/howto/usage-cli` and the database.
 
 Offline SQL migration scripts
 =============================
-If you want to run the upgrade script offline, you can use the ``-r`` or ``--revision-range`` flag
-to get the SQL statements that would be executed. This feature is supported in Postgres and MySQL
+If you want to run the upgrade script offline, you can use the ``-s`` or ``--show-sql-only`` flag
+to get the SQL statements that would be executed. You may also specify the starting airflow version with the ``--from-version`` flag. This feature is supported in Postgres and MySQL
 from Airflow 2.0.0 onward.
 
-Sample usage:
-   ``airflow db migrate -r "2.0.0:2.2.0"``
-   ``airflow db migrate --revision-range "e959f08ac86c:142555e44c17"``
-
-But for Airflow version 2.7.0 or greater, please use
-    ``airflow db migrate -r "2.0.0:2.2.0"``
-    ``airflow db migrate --revision-range "e959f08ac86c:142555e44c17"``
+Sample usage for Airflow version 2.7.0 or greater:
+   ``airflow db migrate -s --from-version "2.4.3"``
+   ``airflow db migrate --show-sql-only --from-version "2.4.3"``
 
 .. note::
     ``airflow db upgrade`` has been replaced by ``airflow db migrate`` since Airflow version 2.7.0

--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -64,12 +64,12 @@ you access to Airflow ``CLI`` :doc:`/howto/usage-cli` and the database.
 Offline SQL migration scripts
 =============================
 If you want to run the upgrade script offline, you can use the ``-s`` or ``--show-sql-only`` flag
-to get the SQL statements that would be executed. You may also specify the starting airflow version with the ``--from-version`` flag. This feature is supported in Postgres and MySQL
+to get the SQL statements that would be executed. You may also specify the starting airflow version with the ``--from-version`` flag and the ending airflow version with the ``-n`` or ``--to-version`` flag. This feature is supported in Postgres and MySQL
 from Airflow 2.0.0 onward.
 
 Sample usage for Airflow version 2.7.0 or greater:
-   ``airflow db migrate -s --from-version "2.4.3"``
-   ``airflow db migrate --show-sql-only --from-version "2.4.3"``
+   ``airflow db migrate -s --from-version "2.4.3" --to-version "2.7.3"``
+   ``airflow db migrate --show-sql-only --from-version "2.4.3" --to-version "2.7.3"``
 
 .. note::
     ``airflow db upgrade`` has been replaced by ``airflow db migrate`` since Airflow version 2.7.0


### PR DESCRIPTION
The upgrade docs section concerning [Offline SQL migration scripts](https://airflow.apache.org/docs/apache-airflow/stable/installation/upgrading.html#offline-sql-migration-scripts) are incorrect and reference cli flags which are not supported by the latest release of airflow -

<img width="1139" alt="Screenshot 2024-02-07 at 1 12 31 PM" src="https://github.com/apache/airflow/assets/9872693/1313aa99-b803-4036-bf88-198a3619197d">

The flags `-r` and `--revision-range` are [dead code with no references](https://github.com/apache/airflow/blob/2.8.1/airflow/cli/cli_config.py#L216-L227) (to be cleaned up in a subsequent PR). These flags are not used by the `airflow db migrate` command. The [true set of flags are these](https://github.com/apache/airflow/blob/2.8.1/airflow/cli/cli_config.py#L1539-L1545).

I have updated the documentation to reflect that users should actually be using the flags `--show-sql-only` and `--from-version`.