### PR TITLE
fix: update  broken hyperlink in contributing docs.

### DIFF
--- a/contributing-docs/06_development_environments.rst
+++ b/contributing-docs/06_development_environments.rst
@@ -32,7 +32,7 @@ in `07_local_virtualenv.rst <07_local_virtualenv.rst>`__.
 Benefits:
 
 -   Packages are installed locally. No container environment is required.
--   You can benefit from local debugging within your IDE. You can follow the `Contributors quick start <contributor.rst#quick-start>`__
+-   You can benefit from local debugging within your IDE. You can follow the `Local and remote debugging in IDE <07_local_virtualenv.rst#local-and-remote-debugging-in-ide>`__
     to set up your local virtualenv and connect your IDE with the environment.
 -   With the virtualenv in your IDE, you can benefit from auto completion and running tests directly from the IDE.
 


### PR DESCRIPTION
Hyperlink to the [Contributors quick start](https://github.com/apache/airflow/blob/main/contributing-docs/contributor.rst#quick-start) in the [06_development_environments](https://github.com/apache/airflow/blob/main/contributing-docs/06_development_environments.rst) is broken. Also, the wording needs to be improved as the contributing doc is split into multiple files.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->


