### PR TITLE
Fix permission check on DAGs when `access_entity` is specified

### DIFF
--- a/airflow/api_connexion/security.py
+++ b/airflow/api_connexion/security.py
@@ -145,10 +145,11 @@ def requires_access_dag(
             # ``access`` means here:
             # - if a DAG id is provided (``dag_id`` not None): is the user authorized to access this DAG
             # - if no DAG id is provided: is the user authorized to access all DAGs
-            if dag_id or access:
+            if dag_id or access or access_entity:
                 return access
 
-            # No DAG id is provided and the user is not authorized to access all DAGs
+            # No DAG id is provided, the user is not authorized to access all DAGs and authorization is done
+            # on DAG level
             # If method is "GET", return whether the user has read access to any DAGs
             # If method is "PUT", return whether the user has edit access to any DAGs
             return (method == "GET" and any(get_auth_manager().get_permitted_dag_ids(methods=["GET"]))) or (


### PR DESCRIPTION
When `requires_access_dag` is used with `access_entity` specified, it can lead to some inconsistencies. `requires_access_dag` should check whether the user is authorized to read/edit at least one DAG (line 155) only when no `access_entity` is specified. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
