### PR TITLE
fix how GKEPodAsyncHook.service_file_as_context is used

### DIFF
--- a/airflow/providers/google/cloud/hooks/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/hooks/kubernetes_engine.py
@@ -508,7 +508,7 @@ class GKEPodAsyncHook(GoogleBaseAsyncHook):
         :param name: Name of the pod.
         :param namespace: Name of the pod's namespace.
         """
-        async with self.service_file_as_context() as service_file:  # type: ignore[attr-defined]
+        with await self.service_file_as_context() as service_file:  # type: ignore[attr-defined]
             async with Token(scopes=self.scopes, service_file=service_file) as token:
                 async with self.get_conn(token) as connection:
                     v1_api = async_client.CoreV1Api(connection)
@@ -524,7 +524,7 @@ class GKEPodAsyncHook(GoogleBaseAsyncHook):
         :param name: Name of the pod.
         :param namespace: Name of the pod's namespace.
         """
-        async with self.service_file_as_context() as service_file:  # type: ignore[attr-defined]
+        with await self.service_file_as_context() as service_file:  # type: ignore[attr-defined]
             async with Token(scopes=self.scopes, service_file=service_file) as token, self.get_conn(
                 token
             ) as connection:
@@ -551,7 +551,7 @@ class GKEPodAsyncHook(GoogleBaseAsyncHook):
         :param name: Name of the pod.
         :param namespace: Name of the pod's namespace.
         """
-        async with self.service_file_as_context() as service_file:  # type: ignore[attr-defined]
+        with await self.service_file_as_context() as service_file:  # type: ignore[attr-defined]
             async with Token(scopes=self.scopes, service_file=service_file) as token, self.get_conn(
                 token
             ) as connection:

--- a/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
@@ -324,8 +324,8 @@ class TestGKEPodAsyncHook:
     async def test_get_pod(
         self, read_namespace_pod_mock, get_conn_mock, mock_token, async_hook, mock_service_file
     ):
-        async_hook.service_file_as_context = mock.MagicMock()
-        async_hook.service_file_as_context.return_value.__aenter__.return_value = mock_service_file
+        async_hook.service_file_as_context = mock.AsyncMock()
+        async_hook.service_file_as_context.return_value.__enter__.return_value = mock_service_file
 
         self.make_mock_awaitable(read_namespace_pod_mock)
 
@@ -347,8 +347,8 @@ class TestGKEPodAsyncHook:
     async def test_delete_pod(
         self, delete_namespaced_pod, get_conn_mock, mock_token, async_hook, mock_service_file
     ):
-        async_hook.service_file_as_context = mock.MagicMock()
-        async_hook.service_file_as_context.return_value.__aenter__.return_value = mock_service_file
+        async_hook.service_file_as_context = mock.AsyncMock()
+        async_hook.service_file_as_context.return_value.__enter__.return_value = mock_service_file
 
         self.make_mock_awaitable(delete_namespaced_pod)
 
@@ -372,8 +372,8 @@ class TestGKEPodAsyncHook:
     async def test_read_logs(
         self, read_namespaced_pod_log, get_conn_mock, mock_token, async_hook, mock_service_file, caplog
     ):
-        async_hook.service_file_as_context = mock.MagicMock()
-        async_hook.service_file_as_context.return_value.__aenter__.return_value = mock_service_file
+        async_hook.service_file_as_context = mock.AsyncMock()
+        async_hook.service_file_as_context.return_value.__enter__.return_value = mock_service_file
 
         self.make_mock_awaitable(read_namespaced_pod_log, result="Test string #1\nTest string #2\n")
 


### PR DESCRIPTION
address https://github.com/apache/airflow/pull/37081#issuecomment-1936803815

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
