### PR TITLE
Limit universal-pathlib to < 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,15 @@ dependencies = [
     # See https://github.com/apache/airflow/pull/31693
     # We should also remove "licenses/LICENSE-unicodecsv.txt" file when we remove this dependency
     "unicodecsv>=0.14.1",
-    "universal-pathlib>=0.1.4",
+    # The Universal Pathlib provides  Pathlib-like interface for FSSPEC
+    # In 0.1. *It was not very well defined for extension, so the way how we use it for 0.1.*
+    # so we used a lot of private methods and attributes that were not defined in the interface
+    # an they are broken with version 0.2.0 which is much better suited for extension and supports
+    # Python 3.12. We should limit it, unti we migrate to 0.2.0
+    # See: https://github.com/fsspec/universal_pathlib/pull/173#issuecomment-1937090528
+    # This is prerequistite to make Airflow compatible with Python 3.12
+    # Tracked in https://github.com/apache/airflow/pull/36755
+    "universal-pathlib>=0.1.4,<0.2.0",
     # Werkzug 3 breaks Flask-Login 0.6.2, also connexion needs to be updated to >= 3.0
     # we should remove this limitation when FAB supports Flask 2.3 and we migrate connexion to 3+
     "werkzeug>=2.0,<3",


### PR DESCRIPTION
The Universal Pathlib provides  Pathlib-like interface for FSSPEC In 0.1. *It was not very well defined for extension, so the way how we use it for 0.1.* so we used a lot of private methods and attributes that were not defined in the interface an they are broken with version 0.2.0 which is much better suited for extension and supports Python 3.12. We should limit it, unti we migrate to 0.2.0 See: https://github.com/fsspec/universal_pathlib/pull/173#issuecomment-1937090528 This is prerequistite to make Airflow compatible with Python 3.12 Tracked in https://github.com/apache/airflow/pull/36755

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
