### PR TITLE
Make PRs changing pyproject.toml neutral for breeze tests

### DIFF
--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -38,6 +38,9 @@ ANSI_COLORS_MATCHER = re.compile(r"(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]")
 ALL_DOCS_SELECTED_FOR_BUILD = ""
 ALL_PROVIDERS_AFFECTED = ""
 
+# commit that is neutral - allows to keep pyproject.toml-changing PRS neutral for unit tests
+NEUTRAL_COMMIT = "938f0c1f3cc4cbe867123ee8aa9f290f9f18100a"
+
 
 def escape_ansi_colors(line):
     return ANSI_COLORS_MATCHER.sub("", line)
@@ -587,7 +590,7 @@ def test_expected_output_pull_request_main(
 ):
     stderr = SelectiveChecks(
         files=files,
-        commit_ref="HEAD",
+        commit_ref=NEUTRAL_COMMIT,
         github_event=GithubEvents.PULL_REQUEST,
         pr_labels=(),
         default_branch="main",
@@ -687,7 +690,7 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
     stderr = SelectiveChecks(
         files=files,
         github_event=GithubEvents.PULL_REQUEST,
-        commit_ref="HEAD",
+        commit_ref=NEUTRAL_COMMIT,
         default_branch="main",
     )
     assert_outputs_are_printed(expected_outputs, str(stderr))
@@ -819,7 +822,7 @@ def test_expected_output_full_tests_needed(
 ):
     stderr = SelectiveChecks(
         files=files,
-        commit_ref="HEAD",
+        commit_ref=NEUTRAL_COMMIT,
         github_event=GithubEvents.PULL_REQUEST,
         pr_labels=pr_labels,
         default_branch=default_branch,
@@ -942,7 +945,7 @@ def test_expected_output_pull_request_v2_7(
 ):
     stderr = SelectiveChecks(
         files=files,
-        commit_ref="HEAD",
+        commit_ref=NEUTRAL_COMMIT,
         github_event=GithubEvents.PULL_REQUEST,
         pr_labels=(),
         default_branch="v2-7-stable",
@@ -1110,7 +1113,7 @@ def test_expected_output_pull_request_target(
 ):
     stderr = SelectiveChecks(
         files=files,
-        commit_ref="HEAD",
+        commit_ref=NEUTRAL_COMMIT,
         github_event=GithubEvents.PULL_REQUEST_TARGET,
         pr_labels=(),
         default_branch="main",
@@ -1199,7 +1202,7 @@ def test_expected_output_push(
 ):
     stderr = SelectiveChecks(
         files=files,
-        commit_ref="HEAD",
+        commit_ref=NEUTRAL_COMMIT,
         github_event=GithubEvents.PUSH,
         pr_labels=pr_labels,
         default_branch=default_branch,
@@ -1436,7 +1439,7 @@ def test_upgrade_to_newer_dependencies(
 def test_docs_filter(files: tuple[str, ...], expected_outputs: dict[str, str]):
     stderr = SelectiveChecks(
         files=files,
-        commit_ref="HEAD",
+        commit_ref=NEUTRAL_COMMIT,
         github_event=GithubEvents.PULL_REQUEST,
         pr_labels=(),
         default_branch="main",
@@ -1461,7 +1464,7 @@ def test_docs_filter(files: tuple[str, ...], expected_outputs: dict[str, str]):
 def test_helm_tests_trigger_ci_build(files: tuple[str, ...], expected_outputs: dict[str, str]):
     stderr = SelectiveChecks(
         files=files,
-        commit_ref="HEAD",
+        commit_ref=NEUTRAL_COMMIT,
         github_event=GithubEvents.PULL_REQUEST,
         pr_labels=(),
         default_branch="main",
@@ -1708,7 +1711,7 @@ def test_has_migrations(files: tuple[str, ...], has_migrations: bool):
     stderr = str(
         SelectiveChecks(
             files=files,
-            commit_ref="HEAD",
+            commit_ref=NEUTRAL_COMMIT,
             github_event=GithubEvents.PULL_REQUEST,
             default_branch="main",
         )
@@ -1742,7 +1745,7 @@ def test_has_migrations(files: tuple[str, ...], has_migrations: bool):
 def test_provider_compatibility_checks(labels: tuple[str, ...], expected_outputs: dict[str, str]):
     stderr = SelectiveChecks(
         files=(),
-        commit_ref="HEAD",
+        commit_ref=NEUTRAL_COMMIT,
         github_event=GithubEvents.PULL_REQUEST,
         pr_labels=labels,
         default_branch="main",
@@ -1830,7 +1833,7 @@ def test_mypy_matches(
 ):
     stderr = SelectiveChecks(
         files=files,
-        commit_ref="HEAD",
+        commit_ref=NEUTRAL_COMMIT,
         default_branch=default_branch,
         github_event=GithubEvents.PULL_REQUEST,
         pr_labels=pr_labels,
@@ -1878,7 +1881,7 @@ def test_pr_labels(
 ):
     stderr = SelectiveChecks(
         files=files,
-        commit_ref="HEAD",
+        commit_ref=NEUTRAL_COMMIT,
         default_branch="main",
         github_actor=github_actor,
         github_event=GithubEvents.PULL_REQUEST,


### PR DESCRIPTION
The #37305 optimized CI jobs to limit tests run when pyproject.toml is changed without impacting dependencies, optional_dependencies and build-system. However it impacts results of other unit tests as they were using `HEAD` as commit in selective checks,

Instead of using HEAD, we are using neutral commit (one only changing INTHEWILD) for all such tests, so that we do not introduce side effects coming from the incoming PR.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
