### PR TITLE
Fix occasional attr-undefined for the python_kubernetes_script

### DIFF
--- a/airflow/providers/cncf/kubernetes/python_kubernetes_script.py
+++ b/airflow/providers/cncf/kubernetes/python_kubernetes_script.py
@@ -21,8 +21,8 @@ from __future__ import annotations
 import os
 from collections import deque
 
-import jinja2
-from jinja2 import select_autoescape
+from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
+from jinja2.nativetypes import NativeEnvironment
 
 
 def _balance_parens(after_decorator):
@@ -77,16 +77,14 @@ def write_python_script(
     :param render_template_as_native_obj: If ``True``, rendered Jinja template would be converted
         to a native Python object
     """
-    template_loader = jinja2.FileSystemLoader(searchpath=os.path.dirname(__file__))
-    template_env: jinja2.Environment
+    template_loader = FileSystemLoader(searchpath=os.path.dirname(__file__))
+    template_env: Environment
     if render_template_as_native_obj:
-        template_env = jinja2.nativetypes.NativeEnvironment(
-            loader=template_loader, undefined=jinja2.StrictUndefined
-        )
+        template_env = NativeEnvironment(loader=template_loader, undefined=StrictUndefined)
     else:
-        template_env = jinja2.Environment(
+        template_env = Environment(
             loader=template_loader,
-            undefined=jinja2.StrictUndefined,
+            undefined=StrictUndefined,
             autoescape=select_autoescape(["html", "xml"]),
         )
     template = template_env.get_template("python_kubernetes_script.jinja2")


### PR DESCRIPTION
Mypy **sometimes** finds out that nativetypes is not defined in the `__init__.py` of jinja2 and complaints. But only sometimes.

This PR changes import scheme in the script to use directly module imports.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
