### PR TITLE
Fix pyhive hive_pure_sasl extra name

### DIFF
--- a/airflow/providers/apache/hive/provider.yaml
+++ b/airflow/providers/apache/hive/provider.yaml
@@ -69,7 +69,7 @@ dependencies:
   - apache-airflow-providers-common-sql>=1.3.1
   - hmsclient>=0.1.0
   - pandas>=1.2.5
-  - pyhive[hive-pure-sasl]>=0.7.0
+  - pyhive[hive_pure_sasl]>=0.7.0
   - thrift>=0.9.2
 
 integrations:

--- a/docs/apache-airflow-providers-apache-hive/index.rst
+++ b/docs/apache-airflow-providers-apache-hive/index.rst
@@ -106,7 +106,7 @@ PIP package                              Version required
 ``apache-airflow-providers-common-sql``  ``>=1.3.1``
 ``hmsclient``                            ``>=0.1.0``
 ``pandas``                               ``>=1.2.5``
-``pyhive[hive-pure-sasl]``               ``>=0.7.0``
+``pyhive[hive_pure_sasl]``               ``>=0.7.0``
 ``thrift``                               ``>=0.9.2``
 =======================================  ==================
 

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -145,7 +145,7 @@
       "apache-airflow>=2.6.0",
       "hmsclient>=0.1.0",
       "pandas>=1.2.5",
-      "pyhive[hive-pure-sasl]>=0.7.0",
+      "pyhive[hive_pure_sasl]>=0.7.0",
       "thrift>=0.9.2"
     ],
     "devel-deps": [],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -579,7 +579,7 @@ apache-hive = [ # source: airflow/providers/apache/hive/provider.yaml
   "apache-airflow[common_sql]",
   "hmsclient>=0.1.0",
   "pandas>=1.2.5",
-  "pyhive[hive-pure-sasl]>=0.7.0",
+  "pyhive[hive_pure_sasl]>=0.7.0",
   "thrift>=0.9.2",
 ]
 apache-impala = [ # source: airflow/providers/apache/impala/provider.yaml


### PR DESCRIPTION
I noticed this warning in the build ci image job:
```
WARNING: pyhive 0.7.0 does not provide the extra 'hive-pure-sasl'
```
After checking, found that the correct name of this extra was always `hive_pure_sasl`: https://github.com/dropbox/PyHive/pull/454