### PR TITLE
Get rid of pytest-httpx as dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1406,7 +1406,7 @@ COPY --from=scripts install_from_docker_context_files.sh install_airflow.sh \
 # an incorrect architecture.
 ARG TARGETARCH
 # Value to be able to easily change cache id and therefore use a bare new cache
-ARG PIP_CACHE_EPOCH="0"
+ARG PIP_CACHE_EPOCH="9"
 
 # hadolint ignore=SC2086, SC2010, DL3042
 RUN --mount=type=cache,id=$PYTHON_BASE_IMAGE-$AIRFLOW_PIP_VERSION-$TARGETARCH-$PIP_CACHE_EPOCH,target=/tmp/.cache/pip,uid=${AIRFLOW_UID} \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1072,7 +1072,7 @@ ARG AIRFLOW_CONSTRAINTS_LOCATION=""
 ARG DEFAULT_CONSTRAINTS_BRANCH="constraints-main"
 # By changing the epoch we can force reinstalling Airflow and pip all dependencies
 # It can also be overwritten manually by setting the AIRFLOW_CI_BUILD_EPOCH environment variable.
-ARG AIRFLOW_CI_BUILD_EPOCH="6"
+ARG AIRFLOW_CI_BUILD_EPOCH="7"
 ARG AIRFLOW_PRE_CACHED_PIP_PACKAGES="true"
 ARG AIRFLOW_PIP_VERSION=24.0
 # Setup PIP

--- a/airflow/providers/databricks/provider.yaml
+++ b/airflow/providers/databricks/provider.yaml
@@ -61,7 +61,7 @@ versions:
 dependencies:
   - apache-airflow>=2.6.0
   - apache-airflow-providers-common-sql>=1.10.0
-  - requests>=2.27,<3
+  - requests>=2.27.0,<3
   # The connector 2.9.0 released on Aug 10, 2023 has a bug that it does not properly declare urllib3 and
   # it needs to be excluded. See https://github.com/databricks/databricks-sql-python/issues/190
   # The 2.9.1 (to be released soon) already contains the fix

--- a/airflow/providers/http/provider.yaml
+++ b/airflow/providers/http/provider.yaml
@@ -55,7 +55,7 @@ dependencies:
   - apache-airflow>=2.6.0
   # The 2.26.0 release of requests got rid of the chardet LGPL mandatory dependency, allowing us to
   # release it as a requirement for airflow
-  - requests>=2.26.0
+  - requests>=2.27.0,<3
   - requests_toolbelt
   - aiohttp>=3.9.2
   - asgiref

--- a/airflow/providers/influxdb/provider.yaml
+++ b/airflow/providers/influxdb/provider.yaml
@@ -26,7 +26,7 @@ description: |
 dependencies:
   - apache-airflow>=2.6.0
   - influxdb-client>=1.19.0
-  - requests>=2.26.0
+  - requests>=2.27.0,<3
 
 state: ready
 source-date-epoch: 1703288143

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -362,7 +362,7 @@
       "apache-airflow-providers-common-sql>=1.10.0",
       "apache-airflow>=2.6.0",
       "databricks-sql-connector>=2.0.0, <3.0.0, !=2.9.0",
-      "requests>=2.27,<3"
+      "requests>=2.27.0,<3"
     ],
     "devel-deps": [
       "deltalake>=0.12.0"
@@ -618,7 +618,7 @@
       "aiohttp>=3.9.2",
       "apache-airflow>=2.6.0",
       "asgiref",
-      "requests>=2.26.0",
+      "requests>=2.27.0,<3",
       "requests_toolbelt"
     ],
     "devel-deps": [],
@@ -639,7 +639,7 @@
     "deps": [
       "apache-airflow>=2.6.0",
       "influxdb-client>=1.19.0",
-      "requests>=2.26.0"
+      "requests>=2.27.0,<3"
     ],
     "devel-deps": [],
     "cross-providers-deps": [],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,8 @@ dependencies = [
     "python-dateutil>=2.3",
     "python-nvd3>=0.15.0",
     "python-slugify>=5.0",
+    # Requests 3 if it will be released, will be heavily breaking.
+    "requests>=2.27.0,<3",
     "rfc3339-validator>=0.1.4",
     "rich-argparse>=1.0.0",
     "rich>=12.4.4",
@@ -185,7 +187,7 @@ cgroups = [
     "cgroupspy>=0.2.2",
 ]
 deprecated-api = [
-    "requests>=2.26.0",
+    "requests>=2.27.0,<3",
 ]
 github-enterprise = [
     "apache-airflow[fab]",
@@ -340,7 +342,6 @@ devel-tests = [
     "coverage>=7.2",
     "pytest-asyncio>=0.23.3",
     "pytest-cov>=4.1.0",
-    "pytest-httpx>=0.21.3",
     "pytest-icdiff>=0.9",
     "pytest-instafail>=0.5.0",
     "pytest-mock>=3.12.0",
@@ -654,7 +655,7 @@ databricks = [ # source: airflow/providers/databricks/provider.yaml
   "aiohttp>=3.9.2, <4",
   "apache-airflow[common_sql]",
   "databricks-sql-connector>=2.0.0, <3.0.0, !=2.9.0",
-  "requests>=2.27,<3",
+  "requests>=2.27.0,<3",
   # Devel dependencies for the databricks provider
   "deltalake>=0.12.0",
 ]
@@ -769,13 +770,13 @@ hashicorp = [ # source: airflow/providers/hashicorp/provider.yaml
 http = [ # source: airflow/providers/http/provider.yaml
   "aiohttp>=3.9.2",
   "asgiref",
-  "requests>=2.26.0",
+  "requests>=2.27.0,<3",
   "requests_toolbelt",
 ]
 imap = [] # source: airflow/providers/imap/provider.yaml
 influxdb = [ # source: airflow/providers/influxdb/provider.yaml
   "influxdb-client>=1.19.0",
-  "requests>=2.26.0",
+  "requests>=2.27.0,<3",
 ]
 jdbc = [ # source: airflow/providers/jdbc/provider.yaml
   "apache-airflow[common_sql]",


### PR DESCRIPTION
We were using it in one test case only that can be easily mocked manually. Pytest-httpx blocks us from upgrading to pytest 8 because the newer versions of it that support Pytest 8 have Python >= 3.9.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
