### PR TITLE
feat(hashicorp): Add `VAULT_TOKEN` support

### DIFF
--- a/airflow/providers/hashicorp/_internal_client/vault_client.py
+++ b/airflow/providers/hashicorp/_internal_client/vault_client.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import os
 from functools import cached_property
 
 import hvac
@@ -125,7 +126,7 @@ class _VaultClient(LoggingMixin):
             raise VaultError(
                 f"The auth_type is not supported: {auth_type}. It should be one of {VALID_AUTH_TYPES}"
             )
-        if auth_type == "token" and not token and not token_path:
+        if auth_type == "token" and not token and not token_path and "VAULT_TOKEN" not in os.environ:
             raise VaultError("The 'token' authentication type requires 'token' or 'token_path'")
         if auth_type == "github" and not token and not token_path:
             raise VaultError("The 'github' authentication type requires 'token' or 'token_path'")
@@ -151,7 +152,7 @@ class _VaultClient(LoggingMixin):
         self.url = url
         self.auth_type = auth_type
         self.kwargs = kwargs
-        self.token = token
+        self.token = token or os.getenv("VAULT_TOKEN", None)
         self.token_path = token_path
         self.auth_mount_point = auth_mount_point
         self.mount_point = mount_point

--- a/tests/providers/hashicorp/_internal_client/test_vault_client.py
+++ b/tests/providers/hashicorp/_internal_client/test_vault_client.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import os
 from unittest import mock
 from unittest.mock import mock_open, patch
 
@@ -544,6 +545,19 @@ class TestVaultClient:
         vault_client = _VaultClient(
             auth_type="token", token="s.7AU0I51yv1Q1lxOIg1F3ZRAS", url="http://localhost:8180", session=None
         )
+        client = vault_client.client
+        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
+        client.is_authenticated.assert_called_with()
+        assert "s.7AU0I51yv1Q1lxOIg1F3ZRAS" == client.token
+        assert 2 == vault_client.kv_engine_version
+        assert "secret" == vault_client.mount_point
+
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_token_in_env(self, mock_hvac):
+        mock_client = mock.MagicMock()
+        mock_hvac.Client.return_value = mock_client
+        os.environ["VAULT_TOKEN"] = "s.7AU0I51yv1Q1lxOIg1F3ZRAS"
+        vault_client = _VaultClient(auth_type="token", url="http://localhost:8180", session=None)
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.is_authenticated.assert_called_with()

--- a/tests/providers/hashicorp/_internal_client/test_vault_client.py
+++ b/tests/providers/hashicorp/_internal_client/test_vault_client.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import os
 from unittest import mock
 from unittest.mock import mock_open, patch
 
@@ -553,10 +552,10 @@ class TestVaultClient:
         assert "secret" == vault_client.mount_point
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
-    def test_token_in_env(self, mock_hvac):
+    def test_token_in_env(self, mock_hvac, monkeypatch):
+        monkeypatch.setenv("VAULT_TOKEN", "s.7AU0I51yv1Q1lxOIg1F3ZRAS")
         mock_client = mock.MagicMock()
         mock_hvac.Client.return_value = mock_client
-        os.environ["VAULT_TOKEN"] = "s.7AU0I51yv1Q1lxOIg1F3ZRAS"
         vault_client = _VaultClient(auth_type="token", url="http://localhost:8180", session=None)
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)


### PR DESCRIPTION
`VAULT_TOKEN` wasn't checked upon `VaultClient`construction. Added a check to ingest it if present in os.environ. See #37336 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
