### PR TITLE
Fix remote installation from git

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -52,6 +52,7 @@
 !.github
 !empty
 !Dockerfile
+!hatch_build.py
 
 # This folder is for you if you want to add any packages to the docker context when you build your own
 # docker image. most of other files and any new folder you add will be excluded by default

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1180,7 +1180,7 @@ COPY generated/* ${AIRFLOW_SOURCES}/generated/
 COPY constraints/* ${AIRFLOW_SOURCES}/constraints/
 COPY LICENSE ${AIRFLOW_SOURCES}/LICENSE
 COPY dev/airflow_pre_installed_providers.txt ${AIRFLOW_SOURCES}/dev/airflow_pre_installed_providers.txt
-COPY dev/hatch_build.py ${AIRFLOW_SOURCES}/dev/hatch_build.py
+COPY hatch_build.py ${AIRFLOW_SOURCES}/
 COPY --from=scripts install_airflow.sh /scripts/docker/
 
 # The goal of this line is to install the dependencies from the most current pyproject.toml from sources

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 log_level = logging.getLevelName(os.getenv("CUSTOM_AIRFLOW_BUILD_LOG_LEVEL", "INFO"))
 log.setLevel(log_level)
 
-AIRFLOW_ROOT_PATH = Path(__file__).parent.parent.resolve()
+AIRFLOW_ROOT_PATH = Path(__file__).parent.resolve()
 GENERATED_PROVIDERS_DEPENDENCIES_FILE = AIRFLOW_ROOT_PATH / "generated" / "provider_dependencies.json"
 DEV_DIR_PATH = AIRFLOW_ROOT_PATH / "dev"
 PREINSTALLED_PROVIDERS_FILE = DEV_DIR_PATH / "airflow_pre_installed_providers.txt"
@@ -84,7 +84,7 @@ class CustomBuild(BuilderInterface[BuilderConfig, PluginManager]):
             run(cmd, cwd=work_dir.as_posix(), check=True, shell=True)
 
     def get_version_api(self) -> dict[str, Callable[..., str]]:
-        """Custom build target for standard package preparation."""
+        """Get custom build target for standard package preparation."""
         return {"standard": self.build_standard}
 
     def build_standard(self, directory: str, artifacts: Any, **build_data: Any) -> str:
@@ -149,7 +149,7 @@ class CustomBuildHook(BuildHookInterface[BuilderConfig]):
 
     def initialize(self, version: str, build_data: dict[str, Any]) -> None:
         """
-        This occurs immediately before each build.
+        Initialize hook immediately before each build.
 
         Any modifications to the build data will be seen by the build target.
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1221,13 +1221,13 @@ features = []
 path = "airflow/__init__.py"
 
 [tool.hatch.build.targets.wheel.hooks.custom]
-path = "./dev/hatch_build.py"
+path = "./hatch_build.py"
 
 [tool.hatch.build.hooks.custom]
-path = "./dev/hatch_build.py"
+path = "./hatch_build.py"
 
 [tool.hatch.build.targets.custom]
-path = "./dev/hatch_build.py"
+path = "./hatch_build.py"
 
 [tool.hatch.build.targets.sdist]
 include = [


### PR DESCRIPTION
Having hatch_build.py in dev is not a good idea because hatch_build is removed from the archive produced by git archive and effectively it means that when you install Airflow from git URL it cannot find hatch_build.py

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
