### PR TITLE
Fix rendering `LivyOperator.spark_params`

### DIFF
--- a/airflow/providers/apache/livy/operators/livy.py
+++ b/airflow/providers/apache/livy/operators/livy.py
@@ -64,6 +64,9 @@ class LivyOperator(BaseOperator):
             See Tenacity documentation at https://github.com/jd/tenacity
     """
 
+    template_fields: Sequence[str] = ("spark_params",)
+    template_fields_renderers = {"spark_params": "json"}
+
     def __init__(
         self,
         *,
@@ -94,7 +97,8 @@ class LivyOperator(BaseOperator):
     ) -> None:
         super().__init__(**kwargs)
 
-        self.spark_params = {
+        spark_params = {
+            # Prepare spark parameters, it will be templated later.
             "file": file,
             "class_name": class_name,
             "args": args,
@@ -112,7 +116,7 @@ class LivyOperator(BaseOperator):
             "conf": conf,
             "proxy_user": proxy_user,
         }
-
+        self.spark_params = spark_params
         self._livy_conn_id = livy_conn_id
         self._livy_conn_auth_type = livy_conn_auth_type
         self._polling_interval = polling_interval

--- a/tests/providers/apache/livy/operators/test_livy.py
+++ b/tests/providers/apache/livy/operators/test_livy.py
@@ -379,3 +379,51 @@ class TestLivyOperator:
                 },
             )
         self.mock_context["ti"].xcom_push.assert_not_called()
+
+
+@pytest.mark.db_test
+def test_spark_params_templating(create_task_instance_of_operator):
+    ti = create_task_instance_of_operator(
+        LivyOperator,
+        # Templated fields
+        file="{{ 'literal-file' }}",
+        class_name="{{ 'literal-class-name' }}",
+        args="{{ 'literal-args' }}",
+        jars="{{ 'literal-jars' }}",
+        py_files="{{ 'literal-py-files' }}",
+        files="{{ 'literal-files' }}",
+        driver_memory="{{ 'literal-driver-memory' }}",
+        driver_cores="{{ 'literal-driver-cores' }}",
+        executor_memory="{{ 'literal-executor-memory' }}",
+        executor_cores="{{ 'literal-executor-cores' }}",
+        num_executors="{{ 'literal-num-executors' }}",
+        archives="{{ 'literal-archives' }}",
+        queue="{{ 'literal-queue' }}",
+        name="{{ 'literal-name' }}",
+        conf="{{ 'literal-conf' }}",
+        proxy_user="{{ 'literal-proxy-user' }}",
+        # Other parameters
+        dag_id="test_template_body_templating_dag",
+        task_id="test_template_body_templating_task",
+        execution_date=timezone.datetime(2024, 2, 1, tzinfo=timezone.utc),
+    )
+    ti.render_templates()
+    task: LivyOperator = ti.task
+    assert task.spark_params == {
+        "archives": "literal-archives",
+        "args": "literal-args",
+        "class_name": "literal-class-name",
+        "conf": "literal-conf",
+        "driver_cores": "literal-driver-cores",
+        "driver_memory": "literal-driver-memory",
+        "executor_cores": "literal-executor-cores",
+        "executor_memory": "literal-executor-memory",
+        "file": "literal-file",
+        "files": "literal-files",
+        "jars": "literal-jars",
+        "name": "literal-name",
+        "num_executors": "literal-num-executors",
+        "proxy_user": "literal-proxy-user",
+        "py_files": "literal-py-files",
+        "queue": "literal-queue",
+    }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #37357
related: #36484, #36490


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
