### PR TITLE
Added JOB_STATE_CANCELLED and pool_sleep GCP Dataflow Operators

### DIFF
--- a/airflow/providers/google/cloud/operators/dataflow.py
+++ b/airflow/providers/google/cloud/operators/dataflow.py
@@ -801,6 +801,9 @@ class DataflowStartFlexTemplateOperator(GoogleCloudBaseOperator):
     :param expected_terminal_state: The expected final status of the operator on which the corresponding
         Airflow task succeeds. When not specified, it will be determined by the hook.
     :param append_job_name: True if unique suffix has to be appended to job name.
+    :param poll_sleep: The time in seconds to sleep between polling Google
+        Cloud Platform for the dataflow job status while the job is in the
+        JOB_STATE_RUNNING state.
     """
 
     template_fields: Sequence[str] = ("body", "location", "project_id", "gcp_conn_id")

--- a/airflow/providers/google/cloud/triggers/dataflow.py
+++ b/airflow/providers/google/cloud/triggers/dataflow.py
@@ -126,6 +126,14 @@ class TemplateJobStartTrigger(BaseTrigger):
                         }
                     )
                     return
+                elif status == JobState.JOB_STATE_CANCELLED:
+                    yield TriggerEvent(
+                        {
+                            "status": "cancelled",
+                            "message": f"Dataflow job with id {self.job_id} was cancelled",
+                        }
+                    )
+                    return
                 else:
                     self.log.info("Job is still running...")
                     self.log.info("Current job status is: %s", status)

--- a/tests/providers/google/cloud/operators/test_dataflow.py
+++ b/tests/providers/google/cloud/operators/test_dataflow.py
@@ -584,7 +584,7 @@ class TestDataflowTemplatedJobStartOperator:
             ("error", f"Dataflow job with id {JOB_ID} has failed its execution"),
             ("stopped", f"Dataflow job with id {JOB_ID} was stopped"),
             ("cancelled", f"Dataflow job with id {JOB_ID} was cancelled"),
-        ]
+        ],
     )
     def test_execute_complete_exception(self, deferrable_operator, status, message):
         event = {

--- a/tests/providers/google/cloud/triggers/test_dataflow.py
+++ b/tests/providers/google/cloud/triggers/test_dataflow.py
@@ -125,6 +125,20 @@ class TestTemplateJobStartTrigger:
         actual_event = await trigger.run().asend(None)
 
         assert actual_event == expected_event
+    
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.google.cloud.hooks.dataflow.AsyncDataflowHook.get_job_status")
+    async def test_run_loop_return_cancelled_event(self, mock_job_status, trigger):
+        mock_job_status.return_value = JobState.JOB_STATE_CANCELLED
+        expected_event = TriggerEvent(
+            {
+                "status": "cancelled",
+                "message": f"Dataflow job with id {JOB_ID} was cancelled",
+            }
+        )
+        actual_event = await trigger.run().asend(None)
+
+        assert actual_event == expected_event
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.dataflow.AsyncDataflowHook.get_job_status")

--- a/tests/providers/google/cloud/triggers/test_dataflow.py
+++ b/tests/providers/google/cloud/triggers/test_dataflow.py
@@ -125,7 +125,6 @@ class TestTemplateJobStartTrigger:
         actual_event = await trigger.run().asend(None)
 
         assert actual_event == expected_event
-    
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.dataflow.AsyncDataflowHook.get_job_status")
     async def test_run_loop_return_cancelled_event(self, mock_job_status, trigger):


### PR DESCRIPTION
Added an 'elif' block in the 'async def run(self)' method of 'TemplateJobStartTrigger', which captures 'JOB_STATE_CANCELLED'. This prevents the triggerer from looping indefinitely when a dataflow is cancelled. This also required updating the 'execute_complete' method of both 'DataflowStartFlexTemplateOperator' and 'DataflowTemplatedJobStartOperator', which now raise an 'AirflowException(event["message"])' when the job has the status "cancelled". So, if you cancel the job in the Google console, this will be reflected in the Airflow task execution.

Added 'pool_sleep' as an optional argument to the constructor of 'DataflowStartFlexTemplateOperator', preserving its default value of 10 seconds. This argument is passed to the 'TemplateJobStartTrigger' constructor when the 'self.defer' method is called in 'execute'.

Added tests to TemplateJobStartTrigger, DataflowStartFlexTemplateOperator and DataflowTemplatedJobStartOperator.