### PR TITLE
Fallback to locally installed k9s on ARM architecture

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -1242,7 +1242,7 @@ def k9s(python: str, kubernetes_version: str, k9s_args: tuple[str, ...]):
                 "K9S_EDITOR",
                 "-v",
                 f"{kubeconfig_file}:/root/.kube/config",
-                "quay.io/derailed/k9s",
+                "derailed/k9s",
                 "--namespace",
                 HELM_AIRFLOW_NAMESPACE,
                 *k9s_args,

--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -46,6 +46,7 @@ from airflow_breeze.utils.ci_group import ci_group
 from airflow_breeze.utils.click_utils import BreezeGroup
 from airflow_breeze.utils.console import Output, get_console
 from airflow_breeze.utils.custom_param_types import CacheableChoice, CacheableDefault
+from airflow_breeze.utils.host_info_utils import Architecture, get_host_architecture
 from airflow_breeze.utils.kubernetes_utils import (
     CHART_PATH,
     K8S_CLUSTERS_PATH,
@@ -1223,30 +1224,53 @@ def k9s(python: str, kubernetes_version: str, k9s_args: tuple[str, ...]):
     if not k9s_editor:
         env["K9S_EDITOR"] = env["EDITOR"]
     kubeconfig_file = get_kubeconfig_file(python=python, kubernetes_version=kubernetes_version)
-    result = run_command(
-        [
-            "docker",
-            "run",
-            "--rm",
-            "-it",
-            "--network",
-            "host",
-            "-e",
-            "EDITOR",
-            "-e",
-            "K9S_EDITOR",
-            "-v",
-            f"{kubeconfig_file}:/root/.kube/config",
-            "quay.io/derailed/k9s",
-            "--namespace",
-            HELM_AIRFLOW_NAMESPACE,
-            *k9s_args,
-        ],
-        env=env,
-        check=False,
-    )
-    if result.returncode != 0:
-        sys.exit(result.returncode)
+    # Until https://github.com/kubernetes-sigs/kind/pull/3511 is merged and released, running AMD images
+    # on ARM is broken with kind cluster running, so we need to run k9s directly on the host
+    arch, _ = get_host_architecture()
+    if arch != Architecture.ARM:
+        result = run_command(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "-it",
+                "--network",
+                "host",
+                "-e",
+                "EDITOR",
+                "-e",
+                "K9S_EDITOR",
+                "-v",
+                f"{kubeconfig_file}:/root/.kube/config",
+                "quay.io/derailed/k9s",
+                "--namespace",
+                HELM_AIRFLOW_NAMESPACE,
+                *k9s_args,
+            ],
+            env=env,
+            check=False,
+        )
+        if result.returncode != 0:
+            sys.exit(result.returncode)
+    else:
+        if shutil.which("k9s") is None:
+            get_console().print(
+                "[error]k9s is not installed. Please install it first "
+                "(for example with `brew install k9s`)."
+            )
+            sys.exit(1)
+        result = run_command(
+            [
+                "k9s",
+                "--namespace",
+                HELM_AIRFLOW_NAMESPACE,
+                *k9s_args,
+            ],
+            env=env,
+            check=False,
+        )
+        if result.returncode != 0:
+            sys.exit(result.returncode)
 
 
 def _logs(python: str, kubernetes_version: str):


### PR DESCRIPTION
The docker image for k9s available from creator does not support ARM architecture so we used to use emulated version. Hoever recently for some reason when kind cluster is running, rosetta is disabled and the AMD images cannot be run. Therefore on MacOS / ARM we fallback to k9s locally installed (for example with brew).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
