### PR TITLE
Remove flakiness introduced by cleanup in configuration test

### DIFF
--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -1654,6 +1654,9 @@ def test_error_when_contributing_to_existing_section():
         assert conf.get("celery", "celery_app_name") == "test"
 
 
+# Technically it's not a DB test, but we want to make sure it's not interfering with xdist non-db tests
+# Because the `_cleanup` method might cause side-effect for parallel-run tests
+@pytest.mark.db_test
 class TestWriteDefaultAirflowConfigurationIfNeeded:
     @pytest.fixture(autouse=True)
     def setup_test_cases(self, tmp_path_factory):


### PR DESCRIPTION
The changes in #37320 introduced flakiness while removing side-effect of configuration test. Cleanup of ProvidersManager might interfere with other tests using it at the same time. This caused some Non-DB test failures with missing keys in ProvidersManager.

The fix is to mark the configuration test as DB-test - then it will never be run by NonDB xdist and it will always run sequentially to other tests (and still it will not introduce side-effect as cleanup will always be done between tests.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
