### PR TITLE
Include `airflow_pre_installed_providers.txt` into sdist distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1248,7 +1248,8 @@ exclude = [
 artifacts = [
     "/airflow/www/static/dist/",
     "/airflow/git_version",
-    "/generated/"
+    "/generated/",
+    "airflow_pre_installed_providers.txt",
 ]
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Found that is not possible to build wheel or install airflow from the `sdist` distribution.

How to reproduce (manual steps)

1. Build sdist from the `main`
```console
❯ hatch build -t sdist
───────────────────────────────────────────────────────── sdist ─────────────────────────────────────────────────────────
dist/apache_airflow-2.9.0.dev0.tar.gz

# Save path for the future
❯ export SDIST_PATH=$(realpath dist/apache_airflow-2.9.0.dev0.tar.gz)

```

2. Create new fresh virtual environment, activate and change directory outside of the project, e.g. into the venv directory 
```console
❯ TMP_DIR=$(mktemp -d)

❯ python -m venv "${TMP_DIR}/venv"

❯ cd "${TMP_DIR}"

❯ source venv/bin/activate

❯ python -m pip install pip -U
```

3. Try to install airflow from sdist or build wheel
```console
❯ pip wheel "${SDIST_PATH}" --no-deps

Processing /Users/taragolis/Projects/common/airflow/dist/apache_airflow-2.9.0.dev0.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [28 lines of output]
      Traceback (most recent call last):
        File "/var/folders/g7/vy97v5m51_v9hdpf_qxqzqvr0000gn/T/tmp.0kwAImfbZo/venv/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/var/folders/g7/vy97v5m51_v9hdpf_qxqzqvr0000gn/T/tmp.0kwAImfbZo/venv/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/var/folders/g7/vy97v5m51_v9hdpf_qxqzqvr0000gn/T/tmp.0kwAImfbZo/venv/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 152, in prepare_metadata_for_build_wheel
          whl_basename = backend.build_wheel(metadata_directory, config_settings)
        File "/private/var/folders/g7/vy97v5m51_v9hdpf_qxqzqvr0000gn/T/pip-build-env-8e6ny3uk/overlay/lib/python3.9/site-packages/hatchling/build.py", line 58, in build_wheel
          return os.path.basename(next(builder.build(directory=wheel_directory, versions=['standard'])))
        File "/private/var/folders/g7/vy97v5m51_v9hdpf_qxqzqvr0000gn/T/pip-build-env-8e6ny3uk/overlay/lib/python3.9/site-packages/hatchling/builders/plugin/interface.py", line 116, in build
          configured_build_hooks = self.get_build_hooks(directory)
        File "/private/var/folders/g7/vy97v5m51_v9hdpf_qxqzqvr0000gn/T/pip-build-env-8e6ny3uk/overlay/lib/python3.9/site-packages/hatchling/builders/plugin/interface.py", line 379, in get_build_hooks
          configured_build_hooks[hook_name] = build_hook(
        File "/private/var/folders/g7/vy97v5m51_v9hdpf_qxqzqvr0000gn/T/pip-build-env-8e6ny3uk/overlay/lib/python3.9/site-packages/hatchling/builders/hooks/custom.py", line 35, in __new__
          hook_class = load_plugin_from_script(path, build_script, BuildHookInterface, 'build_hook')
        File "/private/var/folders/g7/vy97v5m51_v9hdpf_qxqzqvr0000gn/T/pip-build-env-8e6ny3uk/overlay/lib/python3.9/site-packages/hatchling/plugin/utils.py", line 18, in load_plugin_from_script
          spec.loader.exec_module(module)  # type: ignore
        File "<frozen importlib._bootstrap_external>", line 850, in exec_module
        File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
        File "/private/var/folders/g7/vy97v5m51_v9hdpf_qxqzqvr0000gn/T/pip-req-build-d5qqql97/hatch_build.py", line 41, in <module>
          for package in PREINSTALLED_PROVIDERS_FILE.read_text().splitlines()
        File "/Users/taragolis/.pyenv/versions/3.9.10/lib/python3.9/pathlib.py", line 1266, in read_text
          with self.open(mode='r', encoding=encoding, errors=errors) as f:
        File "/Users/taragolis/.pyenv/versions/3.9.10/lib/python3.9/pathlib.py", line 1252, in open
          return io.open(self, mode, buffering, encoding, errors, newline,
        File "/Users/taragolis/.pyenv/versions/3.9.10/lib/python3.9/pathlib.py", line 1120, in _opener
          return self._accessor.open(self, flags, mode)
      FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/g7/vy97v5m51_v9hdpf_qxqzqvr0000gn/T/pip-req-build-d5qqql97/airflow_pre_installed_providers.txt'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
