### PR TITLE
fix: Signature of "insert_rows" incompatible with supertype "DbApiHook"

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -232,6 +232,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         target_fields: Any = None,
         commit_every: Any = 1000,
         replace: Any = False,
+        *,
+        executemany=False,
         **kwargs,
     ) -> None:
         """Insert rows.


### PR DESCRIPTION
This PR fixes the following mypy check failure for the google provider.

```
airflow/providers/google/cloud/hooks/bigquery.py:228: error: Signature of
"insert_rows" incompatible with supertype "DbApiHook"  [override]
        def insert_rows(
        ^
airflow/providers/google/cloud/hooks/bigquery.py:228: note:      Superclass:
airflow/providers/google/cloud/hooks/bigquery.py:228: note:          def insert_rows(self, table: Any, rows: Any, target_fields: Any = ..., commit_every: Any = ..., replace: Any = ..., executemany: Any = ..., **kwargs: Any) -> Any
airflow/providers/google/cloud/hooks/bigquery.py:228: note:      Subclass:
airflow/providers/google/cloud/hooks/bigquery.py:228: note:          def insert_rows(self, table: Any, rows: Any, target_fields: Any = ..., commit_every: Any = ..., replace: Any = ..., **kwargs: Any) -> None
```

in DbApiHook--> insert_rows  [method](https://github.com/dabla/airflow/blob/d3e89f82faae157c9c1b9ffd97d1934852f76071/airflow/providers/common/sql/hooks/sql.py#L519)  was recently updated to include executemany parameter.  But,  Google provider --> BigQueryHook  inherits the DbApiHook. Is it necessary that insert_rows ([link](https://github.com/apache/airflow/blob/c020fbd360663607463083cae8528dd1c8dc4281/airflow/providers/google/cloud/hooks/bigquery.py#L228) to the def) defined in an inherited class to have same signature? I've been seeing the following error locally and am wondering if BigQueryHook also needs to include the newly added executemany parameter

Related slack chat: https://apache-airflow.slack.com/archives/CCPRP7943/p1707836093751379