### PR TITLE
[OpenLineage] Check for disabled operators in DefaultExtractor.extract_on_complete

### DIFF
--- a/tests/providers/openlineage/extractors/test_base.py
+++ b/tests/providers/openlineage/extractors/test_base.py
@@ -285,3 +285,17 @@ def test_default_extractor_uses_wrong_operatorlineage_class():
     assert (
         ExtractorManager().extract_metadata(mock.MagicMock(), operator, complete=False) == OperatorLineage()
     )
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "AIRFLOW__OPENLINEAGE__DISABLED_FOR_OPERATORS": "tests.providers.openlineage.extractors.test_base.ExampleOperator"
+    },
+)
+def test_default_extraction_disabled_operator():
+    extractor = DefaultExtractor(ExampleOperator(task_id="test"))
+    metadata = extractor.extract()
+    assert metadata is None
+    metadata = extractor.extract_on_complete(None)
+    assert metadata is None

--- a/tests/providers/openlineage/extractors/test_bash.py
+++ b/tests/providers/openlineage/extractors/test_bash.py
@@ -117,3 +117,16 @@ def test_extract_dag_bash_command_env_does_not_disable_on_random_string():
 def test_extract_dag_bash_command_conf_does_not_disable_on_random_string():
     extractor = BashExtractor(bash_task)
     assert extractor.extract().job_facets["sourceCode"] == SourceCodeJobFacet("bash", "ls -halt && exit 0")
+
+
+@patch.dict(
+    os.environ,
+    {"AIRFLOW__OPENLINEAGE__DISABLED_FOR_OPERATORS": "airflow.operators.bash.BashOperator"},
+)
+def test_bash_extraction_disabled_operator():
+    operator = BashOperator(task_id="taskid", bash_command="echo 1;")
+    extractor = BashExtractor(operator)
+    metadata = extractor.extract()
+    assert metadata is None
+    metadata = extractor.extract_on_complete(None)
+    assert metadata is None

--- a/tests/providers/openlineage/extractors/test_python.py
+++ b/tests/providers/openlineage/extractors/test_python.py
@@ -87,6 +87,8 @@ def test_python_extraction_disabled_operator():
     extractor = PythonExtractor(operator)
     metadata = extractor.extract()
     assert metadata is None
+    metadata = extractor.extract_on_complete(None)
+    assert metadata is None
 
 
 @patch.dict(os.environ, {"OPENLINEAGE_AIRFLOW_DISABLE_SOURCE_CODE": "False"})


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In `BaseExtractor.extract()` we check if operator is disabled but in `DefaultExtractor.extract_on_complete()` we missed this check. This PR adds this check and some tests to make sure everything works as expected.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
