### PR TITLE
Add more task details from rest api

### DIFF
--- a/airflow/www/static/js/api/useTaskInstance.ts
+++ b/airflow/www/static/js/api/useTaskInstance.ts
@@ -18,25 +18,18 @@
  */
 
 import axios, { AxiosResponse } from "axios";
-import type { API, TaskInstance } from "src/types";
+import type { API } from "src/types";
 import { useQuery } from "react-query";
 import { useAutoRefresh } from "src/context/autorefresh";
 
 import { getMetaValue } from "src/utils";
 import type { SetOptional } from "type-fest";
 
-/* GridData.TaskInstance and API.TaskInstance are not compatible at the moment.
- * Remove this function when changing the api response for grid_data_url to comply
- * with API.TaskInstance.
- */
-const convertTaskInstance = (ti: API.TaskInstance) =>
-  ({ ...ti, runId: ti.dagRunId } as TaskInstance);
-
 const taskInstanceApi = getMetaValue("task_instance_api");
 
 interface Props
   extends SetOptional<API.GetMappedTaskInstanceVariables, "mapIndex"> {
-  enabled: boolean;
+  enabled?: boolean;
 }
 
 const useTaskInstance = ({
@@ -61,15 +54,10 @@ const useTaskInstance = ({
 
   return useQuery(
     ["taskInstance", dagId, dagRunId, taskId, mapIndex],
-    () =>
-      axios.get<AxiosResponse, API.TaskInstance>(url, {
-        headers: { Accept: "text/plain" },
-      }),
+    () => axios.get<AxiosResponse, API.TaskInstance>(url),
     {
-      placeholderData: {},
       refetchInterval: isRefreshOn && (autoRefreshInterval || 1) * 1000,
       enabled,
-      select: convertTaskInstance,
     }
   );
 };

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -227,7 +227,11 @@ const Details = ({
               <MarkInstanceAs
                 taskId={taskId}
                 runId={runId}
-                state={instance?.state}
+                state={
+                  !instance?.state || instance?.state === "none"
+                    ? undefined
+                    : instance.state
+                }
                 isGroup={isGroup}
                 isMapped={isMapped}
                 mapIndex={mapIndex}
@@ -348,7 +352,11 @@ const Details = ({
                 mapIndex={mapIndex}
                 executionDate={run?.executionDate}
                 tryNumber={instance?.tryNumber}
-                state={instance?.state}
+                state={
+                  !instance?.state || instance?.state === "none"
+                    ? undefined
+                    : instance.state
+                }
               />
             </TabPanel>
           )}

--- a/airflow/www/static/js/dag/details/taskInstance/ExtraLinks.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/ExtraLinks.tsx
@@ -54,10 +54,9 @@ const ExtraLinks = ({
     url && /^(?:[a-z]+:)?\/\//.test(url);
 
   return (
-    <Box mb={3}>
+    <Box my={3}>
       <Text as="strong">Extra Links</Text>
-      <Divider my={2} />
-      <Flex flexWrap="wrap">
+      <Flex flexWrap="wrap" mt={3}>
         {links.map(({ name, url }) => (
           <Button
             key={name}

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -22,7 +22,7 @@ import { Box } from "@chakra-ui/react";
 
 import { useGridData, useTaskInstance } from "src/api";
 import { getMetaValue, getTask, useOffsetTop } from "src/utils";
-import type { DagRun, TaskInstance as TaskInstanceType } from "src/types";
+import type { DagRun, TaskInstance as GridTaskInstance } from "src/types";
 import NotesAccordion from "src/dag/details/NotesAccordion";
 
 import TaskNav from "./Nav";
@@ -34,7 +34,7 @@ const dagId = getMetaValue("dag_id")!;
 interface Props {
   taskId: string;
   runId: DagRun["runId"];
-  mapIndex: TaskInstanceType["mapIndex"];
+  mapIndex: GridTaskInstance["mapIndex"];
 }
 
 const TaskInstance = ({ taskId, runId, mapIndex }: Props) => {
@@ -56,19 +56,16 @@ const TaskInstance = ({ taskId, runId, mapIndex }: Props) => {
   const isGroup = !!children;
   const isGroupOrMappedTaskSummary = isGroup || isMappedTaskSummary;
 
-  const { data: mappedTaskInstance } = useTaskInstance({
+  const { data: taskInstance } = useTaskInstance({
     dagId,
     dagRunId: runId,
     taskId,
     mapIndex,
-    enabled: isMapIndexDefined,
+    enabled: (!isGroup && !isMapped) || isMapIndexDefined,
   });
+  const gridInstance = group?.instances.find((ti) => ti.runId === runId);
 
-  const instance = isMapIndexDefined
-    ? mappedTaskInstance
-    : group?.instances.find((ti) => ti.runId === runId);
-
-  if (!group || !run || !instance) return null;
+  if (!group || !run || !gridInstance) return null;
 
   const { executionDate } = run;
 
@@ -94,31 +91,26 @@ const TaskInstance = ({ taskId, runId, mapIndex }: Props) => {
           dagId={dagId}
           runId={runId}
           taskId={taskId}
-          mapIndex={instance.mapIndex}
-          initialValue={instance.note}
-          key={dagId + runId + taskId + instance.mapIndex}
+          mapIndex={gridInstance.mapIndex}
+          initialValue={gridInstance.note}
+          key={dagId + runId + taskId + gridInstance.mapIndex}
         />
       )}
-      {isMapped && group.extraLinks && isMapIndexDefined && (
+      {!!group.extraLinks?.length && !isGroupOrMappedTaskSummary && (
         <ExtraLinks
           taskId={taskId}
           dagId={dagId}
-          mapIndex={mapIndex}
+          mapIndex={isMapped && isMapIndexDefined ? mapIndex : undefined}
           executionDate={executionDate}
           extraLinks={group?.extraLinks}
-          tryNumber={instance.tryNumber}
+          tryNumber={taskInstance?.tryNumber || gridInstance.tryNumber}
         />
       )}
-      {!isMapped && group.extraLinks && (
-        <ExtraLinks
-          taskId={taskId}
-          dagId={dagId}
-          executionDate={executionDate}
-          extraLinks={group?.extraLinks}
-          tryNumber={instance.tryNumber}
-        />
-      )}
-      <Details instance={instance} group={group} dagId={dagId} />
+      <Details
+        gridInstance={gridInstance}
+        taskInstance={taskInstance}
+        group={group}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
Use the getTaskInstance endpoint from the REST API to fill in more task details in the grid view.

<img width="641" alt="Screenshot 2024-02-13 at 12 08 33 PM" src="https://github.com/apache/airflow/assets/4600967/eb857c1c-21cf-4016-8f0f-aff6f49b40fc">


We were only using the API for mapped tasks or to check the triggerer before


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
