### PR TITLE
Fix bug with clicking url-unsafe tags

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -262,7 +262,7 @@
               <div>
                 {% for tag in dag.tags | sort(attribute='name') %}
                   <a class="label label-info"
-                     href="?tags={{ tag.name }}"
+                     href="?tags={{ tag.name | urlencode }}"
                      style="margin: 6px 6px 0 0;">
                     {{ tag.name }}
                   </a>


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
When using the text input box, filtering DAGs on a tag with url-unsafe characters (for example, `#slack-channel`) replaces the url-unsafe characters with their url encoded equivalents: `/home?tags=%23slack-channel`

However when you click on a tag to filter, the tag is not urlencoded, which leads to an error: the url is translated to `/home#slack-channel` with the return message `No matching DAG tags found.` (as the browser does not know how to interpret `#` and `?` together, I assume).

This fix ensures that clicking tags also url encodes them which causes `#hash-tags` and other special characters to work correctly when clicking tags to filter.