### PR TITLE
Standardize use of get_app with flask appbuilder

### DIFF
--- a/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -339,7 +339,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
 
     def register_views(self):
         """Register FAB auth manager related views."""
-        if not self.appbuilder.app.config.get("FAB_ADD_SECURITY_VIEWS", True):
+        if not self.appbuilder.get_app.config.get("FAB_ADD_SECURITY_VIEWS", True):
             return
 
         if self.auth_user_registration:
@@ -416,7 +416,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
                 category="Security",
             )
         self.appbuilder.menu.add_separator("Security")
-        if self.appbuilder.app.config.get("FAB_ADD_SECURITY_PERMISSION_VIEW", True):
+        if self.appbuilder.get_app.config.get("FAB_ADD_SECURITY_PERMISSION_VIEW", True):
             self.appbuilder.add_view(
                 self.actionmodelview,
                 "Actions",
@@ -424,7 +424,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
                 label=lazy_gettext("Actions"),
                 category="Security",
             )
-        if self.appbuilder.app.config.get("FAB_ADD_SECURITY_VIEW_MENU_VIEW", True):
+        if self.appbuilder.get_app.config.get("FAB_ADD_SECURITY_VIEW_MENU_VIEW", True):
             self.appbuilder.add_view(
                 self.resourcemodelview,
                 "Resources",
@@ -432,7 +432,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
                 label=lazy_gettext("Resources"),
                 category="Security",
             )
-        if self.appbuilder.app.config.get("FAB_ADD_SECURITY_PERMISSION_VIEWS_VIEW", True):
+        if self.appbuilder.get_app.config.get("FAB_ADD_SECURITY_PERMISSION_VIEWS_VIEW", True):
             self.appbuilder.add_view(
                 self.permissionmodelview,
                 "Permission Pairs",
@@ -517,27 +517,27 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
     @property
     def auth_type(self):
         """Get the auth type."""
-        return self.appbuilder.app.config["AUTH_TYPE"]
+        return self.appbuilder.get_app.config["AUTH_TYPE"]
 
     @property
     def is_auth_limited(self) -> bool:
         """Is the auth rate limited."""
-        return self.appbuilder.app.config["AUTH_RATE_LIMITED"]
+        return self.appbuilder.get_app.config["AUTH_RATE_LIMITED"]
 
     @property
     def auth_rate_limit(self) -> str:
         """Get the auth rate limit."""
-        return self.appbuilder.app.config["AUTH_RATE_LIMIT"]
+        return self.appbuilder.get_app.config["AUTH_RATE_LIMIT"]
 
     @property
     def auth_role_public(self):
         """Get the public role."""
-        return self.appbuilder.app.config["AUTH_ROLE_PUBLIC"]
+        return self.appbuilder.get_app.config["AUTH_ROLE_PUBLIC"]
 
     @property
     def oauth_providers(self):
         """Oauth providers."""
-        return self.appbuilder.app.config["OAUTH_PROVIDERS"]
+        return self.appbuilder.get_app.config["OAUTH_PROVIDERS"]
 
     @property
     def auth_ldap_tls_cacertdir(self):
@@ -698,7 +698,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
 
     def create_builtin_roles(self):
         """Return FAB builtin roles."""
-        return self.appbuilder.app.config.get("FAB_ROLES", {})
+        return self.appbuilder.get_app.config.get("FAB_ROLES", {})
 
     @property
     def builtin_roles(self):
@@ -859,7 +859,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
                 Base.metadata.create_all(engine)
                 log.info(const.LOGMSG_INF_SEC_ADD_DB)
 
-            roles_mapping = self.appbuilder.app.config.get("FAB_ROLES_MAPPING", {})
+            roles_mapping = self.appbuilder.get_app.config.get("FAB_ROLES_MAPPING", {})
             for pk, name in roles_mapping.items():
                 self.update_role(pk, name)
             for role_name in self._builtin_roles:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Standardizes the use of get_app within the FabAirflowSecurityManagerOverride. 
This makes mocking the appbuilder object simpler for testing, and matches how this was done in the previous security manager.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
