### PR TITLE
Add Python 3.12 exclusions in providers/pyproject.toml

### DIFF
--- a/airflow/providers/apache/beam/provider.yaml
+++ b/airflow/providers/apache/beam/provider.yaml
@@ -63,6 +63,10 @@ additional-extras:
     dependencies:
       - apache-beam[gcp]
 
+# Apache Beam currently does not support Python 3.12
+# There is an issue tracking it https://github.com/apache/beam/issues/29149
+excluded-python-versions: ['3.12']
+
 integrations:
   - integration-name: Apache Beam
     external-doc-url: https://beam.apache.org/

--- a/airflow/providers/papermill/provider.yaml
+++ b/airflow/providers/papermill/provider.yaml
@@ -21,6 +21,11 @@ name: Papermill
 description: |
     `Papermill <https://github.com/nteract/papermill>`__
 
+# Papermill is technically compliant with 3.12, but it's 2.5.0 version that is compliant, requires pinned
+# version of aiohttp which conflicts with other providers. The fix for that is implemented extra-links:
+# https://github.com/nteract/papermill/pull/771 and waits for new Papermill release
+excluded-python-versions: ['3.12']
+
 state: ready
 source-date-epoch: 1705912216
 versions:

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -76,7 +76,9 @@
     "cross-providers-deps": [
       "google"
     ],
-    "excluded-python-versions": [],
+    "excluded-python-versions": [
+      "3.12"
+    ],
     "state": "ready"
   },
   "apache.cassandra": {
@@ -880,7 +882,9 @@
     ],
     "devel-deps": [],
     "cross-providers-deps": [],
-    "excluded-python-versions": [],
+    "excluded-python-versions": [
+      "3.12"
+    ],
     "state": "ready"
   },
   "pgvector": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -567,8 +567,8 @@ amazon = [ # source: airflow/providers/amazon/provider.yaml
   "s3fs>=2023.10.0",
 ]
 apache-beam = [ # source: airflow/providers/apache/beam/provider.yaml
-  "apache-beam>=2.53.0",
-  "pyarrow>=14.0.1",
+  "apache-beam>=2.53.0;python_version != \"3.12\"",
+  "pyarrow>=14.0.1;python_version != \"3.12\"",
 ]
 apache-cassandra = [ # source: airflow/providers/apache/cassandra/provider.yaml
   "cassandra-driver>=3.13.0",
@@ -867,9 +867,9 @@ pagerduty = [ # source: airflow/providers/pagerduty/provider.yaml
   "pdpyras>=4.1.2",
 ]
 papermill = [ # source: airflow/providers/papermill/provider.yaml
-  "ipykernel",
-  "papermill[all]>=2.4.0",
-  "scrapbook[all]",
+  "ipykernel;python_version != \"3.12\"",
+  "papermill[all]>=2.4.0;python_version != \"3.12\"",
+  "scrapbook[all];python_version != \"3.12\"",
 ]
 pgvector = [ # source: airflow/providers/pgvector/provider.yaml
   "apache-airflow[postgres]",


### PR DESCRIPTION
Some of the providers need to be currently excluded from Python 3.12 because they have conflicting dependencies. While we are working on Python 3.12 support in #36755, in order to install airflow (for caching purposes) from GitHub URL, we need to separately merge the exclusions to main - this will help to build Python 3.12 CI image with all necessary dependencies cached.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
