### PR TITLE
Convert Kubernetes ApiException status code to string to ensure it's correctly checked

### DIFF
--- a/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -442,7 +442,7 @@ class KubernetesExecutor(BaseExecutor):
                     retries = self.task_publish_retries[key]
                     # In case of exceeded quota errors, requeue the task as per the task_publish_max_retries
                     if (
-                        e.status == 403
+                        str(e.status) == "403"
                         and "exceeded quota" in body["message"]
                         and (self.task_publish_max_retries == -1 or retries < self.task_publish_max_retries)
                     ):

--- a/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
+++ b/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
@@ -136,7 +136,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
             else:
                 return watcher.stream(kube_client.list_namespaced_pod, self.namespace, **query_kwargs)
         except ApiException as e:
-            if e.status == 410:  # Resource version is too old
+            if str(e.status) == "410":  # Resource version is too old
                 if self.namespace == ALL_NAMESPACES:
                     pods = kube_client.list_pod_for_all_namespaces(watch=False)
                 else:
@@ -425,7 +425,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
             )
         except ApiException as e:
             # If the pod is already deleted
-            if e.status != 404:
+            if str(e.status) != "404":
                 raise
 
     def patch_pod_executor_done(self, *, pod_name: str, namespace: str):

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -584,7 +584,7 @@ class AsyncKubernetesHook(KubernetesHook):
                 )
             except async_client.ApiException as e:
                 # If the pod is already deleted
-                if e.status != 404:
+                if str(e.status) != "404":
                     raise
 
     async def read_logs(self, name: str, namespace: str):

--- a/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py
+++ b/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py
@@ -43,7 +43,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 def should_retry_start_spark_job(exception: BaseException) -> bool:
     """Check if an Exception indicates a transient error and warrants retrying."""
     if isinstance(exception, ApiException):
-        return exception.status == 409
+        return str(exception.status) == "409"
     return False
 
 
@@ -363,5 +363,5 @@ class CustomObjectLauncher(LoggingMixin):
             )
         except ApiException as e:
             # If the pod is already deleted
-            if e.status != 404:
+            if str(e.status) != "404":
                 raise

--- a/airflow/providers/cncf/kubernetes/pod_launcher_deprecated.py
+++ b/airflow/providers/cncf/kubernetes/pod_launcher_deprecated.py
@@ -119,7 +119,7 @@ class PodLauncher(LoggingMixin):
             )
         except ApiException as e:
             # If the pod is already deleted
-            if e.status != 404:
+            if str(e.status) != "404":
                 raise
 
     def start_pod(self, pod: V1Pod, startup_timeout: int = 120):

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -67,7 +67,7 @@ class PodLaunchFailedException(AirflowException):
 def should_retry_start_pod(exception: BaseException) -> bool:
     """Check if an Exception indicates a transient error and warrants retrying."""
     if isinstance(exception, ApiException):
-        return exception.status == 409
+        return str(exception.status) == "409"
     return False
 
 
@@ -340,7 +340,7 @@ class PodManager(LoggingMixin):
             )
         except ApiException as e:
             # If the pod is already deleted
-            if e.status != 404:
+            if str(e.status) != "404":
                 raise
 
     @tenacity.retry(


### PR DESCRIPTION
closes: #37369

According to the documentation, the status code should be an integer, but by checking the source code, we find that it's parsed from the API response without any check/validation. In case there is a bug in one of the Kubernetes versions/distributions, we may have this status code as a string, and this is the only explanation I found for #37369.

To ensure that our checks work without any issues, I just converted all the loaded status codes to str and I compared them with the string version of the status code to check. This operation is not costly and should be safe.