### PR TITLE
Add capability of testing canary CI runs by apache/airflow PR

### DIFF
--- a/dev/breeze/doc/ci/04_selective_checks.md
+++ b/dev/breeze/doc/ci/04_selective_checks.md
@@ -272,11 +272,12 @@ am overview of possible labels and their meaning:
 
 | Label                         | Affected outputs              | Meaning                                                                                               |
 |-------------------------------|-------------------------------|-------------------------------------------------------------------------------------------------------|
-| full tests needed             | full-tests-needed             | Run complete set of tests, including all Python all DB versions, and all test types.                  |
+| canary                        | is-canary-run                 | If set, the PR run from apache/airflow repo behaves as `canary` run (can only be run by maintainer).  |
 | debug ci resources            | debug-ci-resources            | If set, then debugging resources is enabled during parallel tests and you can see them in the output. |
-| use public runners            | runs-on                       | Force using public runners even for Committer runs.                                                   |
+| full tests needed             | full-tests-needed             | Run complete set of tests, including all Python all DB versions, and all test types.                  |
 | non committer build           | is-committer-build            | If set then even for non-committer builds, the scripts used for images are used from target branch.   |
 | upgrade to newer dependencies | upgrade-to-newer-dependencies | If set then dependencies in the CI image build are upgraded to the newer ones.                        |
+| use public runners            | runs-on                       | Force using public runners even for Committer runs.                                                   |
 
 
 -----

--- a/dev/breeze/doc/ci/07_debugging.md
+++ b/dev/breeze/doc/ci/07_debugging.md
@@ -57,6 +57,14 @@ maintainer.
   should push your branch as `main` branch in your local fork. This will
   run changed `build-images.yml` workflow as it will be in `main` branch
   of your fork
+- When you are a committer and you change build images workflow, together
+  with build scripts, your build might fail because your scripts are used
+  in `build-images.yml` workflow, but the workflow is run using the `main`
+  version. Setting `non committer build` label will make your PR run using
+  the main version of the scripts and the workflow
+- When you want to test how changes in your workflow affect `canary` run,
+  as maintainer, you should push your PR to `apache` repository not to your
+  fork and set `canary` label to the PR
 
 -----
 

--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -323,6 +323,8 @@ class WorkflowInfo(NamedTuple):
             and (self.ref_name == "main" or TEST_BRANCH_MATCHER.match(self.ref_name))
         ):
             return "true"
+        if "canary" in self.pull_request_labels and self.head_repo == "apache/airflow":
+            return "true"
         return "false"
 
     def run_coverage(self) -> str:


### PR DESCRIPTION
It's been impossible to test canary runs as they are only run when you push to `main` or one of the `v2-*-test` branch in apache/airlfow repo. This PR adds capability to run special PR with `canary` label to test canary run workflow in a PR from committer run in the apache/airflow repo.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
