### PR TITLE
Avoid side-effects for providers-manager related tests

### DIFF
--- a/tests/always/test_providers_manager.py
+++ b/tests/always/test_providers_manager.py
@@ -39,13 +39,8 @@ from airflow.providers_manager import (
 
 class TestProviderManager:
     @pytest.fixture(autouse=True)
-    def inject_fixtures(self, caplog):
+    def inject_fixtures(self, caplog, cleanup_providers_manager):
         self._caplog = caplog
-
-    @pytest.fixture(autouse=True, scope="function")
-    def clean(self):
-        """The tests depend on a clean state of a ProvidersManager."""
-        ProvidersManager().__init__()
 
     def test_providers_are_loaded(self):
         with self._caplog.at_level(logging.WARNING):
@@ -93,8 +88,9 @@ class TestProviderManager:
         assert [] == [w.message for w in warning_records.list if "hook-class-names" in str(w.message)]
 
     def test_warning_logs_generated(self):
+        providers_manager = ProvidersManager()
+        providers_manager._hooks_lazy_dict = LazyDictWithCache()
         with self._caplog.at_level(logging.WARNING):
-            providers_manager = ProvidersManager()
             providers_manager._provider_dict["apache-airflow-providers-sftp"] = ProviderInfo(
                 version="0.0.1",
                 data={
@@ -165,6 +161,7 @@ class TestProviderManager:
 
     def test_providers_manager_register_plugins(self):
         providers_manager = ProvidersManager()
+        providers_manager._provider_dict = LazyDictWithCache()
         providers_manager._provider_dict["apache-airflow-providers-apache-hive"] = ProviderInfo(
             version="0.0.1",
             data={

--- a/tests/api_connexion/endpoints/test_provider_endpoint.py
+++ b/tests/api_connexion/endpoints/test_provider_endpoint.py
@@ -69,7 +69,7 @@ def configured_app(minimal_app_for_api):
 
 class TestBaseProviderEndpoint:
     @pytest.fixture(autouse=True)
-    def setup_attrs(self, configured_app) -> None:
+    def setup_attrs(self, configured_app, cleanup_providers_manager) -> None:
         self.app = configured_app
         self.client = self.app.test_client()  # type:ignore
 

--- a/tests/cli/commands/test_info_command.py
+++ b/tests/cli/commands/test_info_command.py
@@ -183,7 +183,7 @@ class TestInfoCommandMockHttpx:
             ("database", "sql_alchemy_conn"): "postgresql+psycopg2://postgres:airflow@postgres/airflow",
         }
     )
-    def test_show_info_anonymize_fileio(self, setup_parser):
+    def test_show_info_anonymize_fileio(self, setup_parser, cleanup_providers_manager):
         with mock.patch("airflow.cli.commands.info_command.httpx.post") as post:
             post.return_value = httpx.Response(
                 status_code=200,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1120,6 +1120,18 @@ def close_all_sqlalchemy_sessions():
     close_all_sessions()
 
 
+@pytest.fixture()
+def cleanup_providers_manager():
+    from airflow.providers_manager import ProvidersManager
+
+    ProvidersManager()._cleanup()
+    ProvidersManager().initialize_providers_configuration()
+    try:
+        yield
+    finally:
+        ProvidersManager()._cleanup()
+
+
 # The code below is a modified version of capture-warning code from
 # https://github.com/athinkingape/pytest-capture-warnings
 


### PR DESCRIPTION
When running tests in v2-8-tests some of the tests failed with package-name key not found in providers manager. This was because some other tests modified dictionaries stored in ProvidersManager and added there entries that missed the keys.

This PR adds a a new fixture `cleanup_providers_manager` - that will reinitialize the ProvidersManager before the test and - more importantly will clean it up after. This way all the entries added manually should be removed for other tests and all the tests that do not explicitly initialize providers manager should fail if they need it.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
