### PR TITLE
Avoid side-effects in `conf_vars` testing helper

### DIFF
--- a/tests/test_utils/config.py
+++ b/tests/test_utils/config.py
@@ -42,16 +42,20 @@ def conf_vars(overrides):
                 conf.add_section(section)
             conf.set(section, key, value)
         else:
-            conf.remove_option(section, key)
+            if conf.has_section(section):
+                conf.remove_option(section, key)
     settings.configure_vars()
     try:
         yield
     finally:
         for (section, key), value in original.items():
             if value is not None:
+                if not conf.has_section(section):
+                    conf.add_section(section)
                 conf.set(section, key, value)
             else:
-                conf.remove_option(section, key)
+                if conf.has_section(section):
+                    conf.remove_option(section, key)
         for env, value in original_env_vars.items():
             os.environ[env] = value
         settings.configure_vars()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In pytest 8.0.0 the order of tests cases from @pytest.mark.parametrize executed in reversed order. This would be fixed in 8.0.1 (or whatewer version would be next):
- https://github.com/pytest-dev/pytest/issues/11937

This regression in pytest shows that we have some side effects in `conf_vars` helper, 
e.g. if run `tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py::TestCloudwatchTaskHandler::test_write_json_logs` in pytest 8.0.0
or run it individually it would fail

```console
❯ pytest "tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py::TestCloudwatchTaskHandler::test_write_json_logs[not-set]"


======================================================================================================== test session starts ========================================================================================================
platform darwin -- Python 3.9.10, pytest-8.0.0, pluggy-1.3.0 -- /Users/taragolis/.pyenv/versions/3.9.10/envs/airflow-dev-env-39/bin/python
cachedir: .pytest_cache
rootdir: /Users/taragolis/Projects/common/airflow
configfile: pyproject.toml
plugins: anyio-4.0.0, instafail-0.5.0, forked-1.4.0, httpx-0.21.3, rerunfailures-12.0, timeouts-1.2.1, time-machine-2.13.0, cov-4.1.0, asyncio-0.21.1, mock-3.12.0, aiohttp-1.0.5, requests-mock-1.11.0, xdist-3.3.1, capture-warnings-0.0.4, icdiff-0.8
asyncio: mode=strict
setup timeout: 0.0s, execution timeout: 0.0s, teardown timeout: 0.0s
collected 1 item                                                                                                                                                                                                                    

tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py::TestCloudwatchTaskHandler::test_write_json_logs[not-set] FAILED                                                                                               [100%]

============================================================================================================= FAILURES ==============================================================================================================
______________________________________________________________________________________ TestCloudwatchTaskHandler.test_write_json_logs[not-set] ______________________________________________________________________________________

self = <tests.providers.amazon.aws.log.test_cloudwatch_task_handler.TestCloudwatchTaskHandler object at 0x116b632e0>, mock_get_log_events = <MagicMock name='get_log_events' id='4843681872'>, conf_json_serialize = None
expected_serialized_output = '{"datetime": "2023-01-01T00:00:00+00:00", "customObject": null}'

    @pytest.mark.parametrize(
        "conf_json_serialize, expected_serialized_output",
        [
            pytest.param(
                "airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize_legacy",
                '{"datetime": "2023-01-01T00:00:00+00:00", "customObject": null}',
                id="json-serialize-legacy",
            ),
            pytest.param(
                "airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize",
                '{"datetime": "2023-01-01T00:00:00+00:00", "customObject": "SomeCustomSerialization(...)"}',
                id="json-serialize",
            ),
            pytest.param(
                None, '{"datetime": "2023-01-01T00:00:00+00:00", "customObject": null}', id="not-set"
            ),
        ],
    )
    @mock.patch.object(AwsLogsHook, "get_log_events")
    def test_write_json_logs(self, mock_get_log_events, conf_json_serialize, expected_serialized_output):
        class ToSerialize:
            def __init__(self):
                pass
    
            def __repr__(self):
                return "SomeCustomSerialization(...)"
    
        with conf_vars({("aws", "cloudwatch_task_handler_json_serializer"): conf_json_serialize}):
            handler = self.cloudwatch_task_handler
            handler.set_context(self.ti)
            message = logging.LogRecord(
                name="test_log_record",
                level=logging.DEBUG,
                pathname="fake.path",
                lineno=42,
                args=None,
                exc_info=None,
                msg={
                    "datetime": datetime(2023, 1, 1),
                    "customObject": ToSerialize(),
                },
            )
            with mock.patch("watchtower.threading.Thread"), mock.patch("watchtower.queue.Queue") as mq:
                mock_queue = Mock()
                mq.return_value = mock_queue
                handler.handle(message)
>               mock_queue.put.assert_called_once_with(
                    {"message": expected_serialized_output, "timestamp": ANY}
                )

tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py:220: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../../.pyenv/versions/3.9.10/lib/python3.9/contextlib.py:126: in __exit__
    next(self.gen)
tests/test_utils/config.py:52: in conf_vars
    conf.set(section, key, value)
airflow/configuration.py:1304: in set
    super().set(section, option, value)
../../../.pyenv/versions/3.9.10/lib/python3.9/configparser.py:1204: in set
    super().set(section, option, value)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <airflow.configuration.AirflowConfigParser object at 0x110067f10>, section = 'aws', option = 'cloudwatch_task_handler_json_serializer'
value = 'airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize_legacy'

    def set(self, section, option, value=None):
        """Set an option."""
        if value:
            value = self._interpolation.before_set(self, section, option,
                                                   value)
        if not section or section == self.default_section:
            sectdict = self._defaults
        else:
            try:
                sectdict = self._sections[section]
            except KeyError:
>               raise NoSectionError(section) from None
E               configparser.NoSectionError: No section: 'aws'

```

It might not reproduced in CI, because some other tests adds some side effects `¯\_(ツ)_/¯` as result this and maybe others tests completed succesefully

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
