### PR TITLE
Filter datasets graph by dag_id

### DIFF
--- a/airflow/www/static/js/api/useDatasetDependencies.ts
+++ b/airflow/www/static/js/api/useDatasetDependencies.ts
@@ -91,8 +91,8 @@ const findDownstreamGraph = ({
   const mergedGraphs = graphs
     .reduce((newGraphs, graph) => {
       // Find all overlapping graphs where at least one edge in each graph has the same target node
-      const otherGroups = newGraphs.filter((otherGroup) =>
-        otherGroup.edges.some((otherEdge, i) => {
+      const otherGroups = newGraphs.filter((otherGroup, i) =>
+        otherGroup.edges.some((otherEdge) => {
           if (graph.edges.some((edge) => edge.target === otherEdge.target)) {
             otherIndexes.push(i);
             return true;

--- a/airflow/www/static/js/datasets/DagFilter.tsx
+++ b/airflow/www/static/js/datasets/DagFilter.tsx
@@ -18,10 +18,12 @@
  */
 
 import React from "react";
+import { HStack } from "@chakra-ui/react";
 import { Size, useChakraSelectProps } from "chakra-react-select";
 
 import type { DatasetDependencies } from "src/api/useDatasetDependencies";
 import MultiSelect from "src/components/MultiSelect";
+import InfoTooltip from "src/components/InfoTooltip";
 
 interface Props {
   datasetDependencies?: DatasetDependencies;
@@ -58,6 +60,10 @@ const DagFilter = ({
     isClearable: false,
     selectedOptionStyle: "check",
     chakraStyles: {
+      container: (p) => ({
+        ...p,
+        width: "100%",
+      }),
       placeholder: (p) => ({
         ...p,
         color: "gray.700",
@@ -87,21 +93,24 @@ const DagFilter = ({
   });
 
   return (
-    <MultiSelect
-      {...multiSelectStyles}
-      isDisabled={!datasetDependencies}
-      value={transformArrayToMultiSelectOptions(filteredDagIds)}
-      onChange={(dagOptions) => {
-        if (
-          Array.isArray(dagOptions) &&
-          dagOptions.every((dagOption) => "value" in dagOption)
-        ) {
-          onFilterDags(dagOptions.map((option) => option.value));
-        }
-      }}
-      options={options}
-      placeholder="Filter by DAG ID"
-    />
+    <HStack width="100%">
+      <MultiSelect
+        {...multiSelectStyles}
+        isDisabled={!datasetDependencies}
+        value={transformArrayToMultiSelectOptions(filteredDagIds)}
+        onChange={(dagOptions) => {
+          if (
+            Array.isArray(dagOptions) &&
+            dagOptions.every((dagOption) => "value" in dagOption)
+          ) {
+            onFilterDags(dagOptions.map((option) => option.value));
+          }
+        }}
+        options={options}
+        placeholder="Filter graph by DAG ID"
+      />
+      <InfoTooltip label="Filter Datasets graph by anything that may be connected to one or more DAGs. Does not filter the datasets list." />
+    </HStack>
   );
 };
 

--- a/airflow/www/static/js/datasets/DagFilter.tsx
+++ b/airflow/www/static/js/datasets/DagFilter.tsx
@@ -1,0 +1,108 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+import { Size, useChakraSelectProps } from "chakra-react-select";
+
+import type { DatasetDependencies } from "src/api/useDatasetDependencies";
+import MultiSelect from "src/components/MultiSelect";
+
+interface Props {
+  datasetDependencies?: DatasetDependencies;
+  filteredDagIds: string[];
+  onFilterDags: (dagIds: string[]) => void;
+}
+
+const transformArrayToMultiSelectOptions = (
+  options: string[] | null
+): { label: string; value: string }[] =>
+  options === null
+    ? []
+    : options.map((option) => ({ label: option, value: option }));
+
+const DagFilter = ({
+  datasetDependencies,
+  filteredDagIds,
+  onFilterDags,
+}: Props) => {
+  const dagIds = (datasetDependencies?.nodes || [])
+    .filter((node) => node.value.class === "dag")
+    .map((dag) => dag.value.label);
+  const options = dagIds.map((dagId) => ({ label: dagId, value: dagId }));
+
+  const inputStyles: { backgroundColor: string; size: Size } = {
+    backgroundColor: "white",
+    size: "lg",
+  };
+  const multiSelectStyles = useChakraSelectProps({
+    ...inputStyles,
+    isMulti: true,
+    tagVariant: "solid",
+    hideSelectedOptions: false,
+    isClearable: false,
+    selectedOptionStyle: "check",
+    chakraStyles: {
+      placeholder: (p) => ({
+        ...p,
+        color: "gray.700",
+        fontSize: "md",
+      }),
+      inputContainer: (p) => ({
+        ...p,
+        color: "gray.700",
+        fontSize: "md",
+      }),
+      downChevron: (p) => ({
+        ...p,
+        fontSize: "lg",
+      }),
+      control: (p) => ({
+        ...p,
+        cursor: "pointer",
+      }),
+      option: (p) => ({
+        ...p,
+        transition: "background-color 0.2s",
+        _hover: {
+          bg: "gray.100",
+        },
+      }),
+    },
+  });
+
+  return (
+    <MultiSelect
+      {...multiSelectStyles}
+      isDisabled={!datasetDependencies}
+      value={transformArrayToMultiSelectOptions(filteredDagIds)}
+      onChange={(dagOptions) => {
+        if (
+          Array.isArray(dagOptions) &&
+          dagOptions.every((dagOption) => "value" in dagOption)
+        ) {
+          onFilterDags(dagOptions.map((option) => option.value));
+        }
+      }}
+      options={options}
+      placeholder="Filter by DAG ID"
+    />
+  );
+};
+
+export default DagFilter;

--- a/airflow/www/static/js/datasets/Graph/DagNode.tsx
+++ b/airflow/www/static/js/datasets/Graph/DagNode.tsx
@@ -19,13 +19,14 @@
 
 import React from "react";
 import {
+  Button,
   Flex,
   Link,
   Popover,
   PopoverArrow,
-  PopoverBody,
   PopoverCloseButton,
   PopoverContent,
+  PopoverFooter,
   PopoverHeader,
   PopoverTrigger,
   Portal,
@@ -40,9 +41,13 @@ import { getMetaValue } from "src/utils";
 const DagNode = ({
   dagId,
   isHighlighted,
+  isSelected,
+  onSelect,
 }: {
   dagId: string;
   isHighlighted?: boolean;
+  isSelected?: boolean;
+  onSelect?: (dagId: string, type: string) => void;
 }) => {
   const { colors } = useTheme();
   const containerRef = useContainerRef();
@@ -52,9 +57,12 @@ const DagNode = ({
     <Popover>
       <PopoverTrigger>
         <Flex
-          borderWidth={2}
-          borderColor={isHighlighted ? colors.blue[400] : undefined}
+          borderColor={
+            isHighlighted || isSelected ? colors.blue[400] : undefined
+          }
           borderRadius={5}
+          borderWidth={isSelected ? 4 : 2}
+          fontWeight={isSelected ? "bold" : "normal"}
           p={2}
           height="100%"
           width="100%"
@@ -72,11 +80,26 @@ const DagNode = ({
           <PopoverArrow bg="gray.100" />
           <PopoverCloseButton />
           <PopoverHeader>{dagId}</PopoverHeader>
-          <PopoverBody>
-            <Link color="blue" href={gridUrl}>
+          <PopoverFooter as={Flex} justifyContent="space-between">
+            <Button
+              variant="outline"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (onSelect) onSelect(dagId, "dag");
+              }}
+            >
+              Filter by DAG
+            </Button>
+            <Button
+              as={Link}
+              href={gridUrl}
+              variant="outline"
+              colorScheme="blue"
+            >
               View DAG
-            </Link>
-          </PopoverBody>
+            </Button>
+          </PopoverFooter>
         </PopoverContent>
       </Portal>
     </Popover>

--- a/airflow/www/static/js/datasets/Graph/Node.tsx
+++ b/airflow/www/static/js/datasets/Graph/Node.tsx
@@ -32,7 +32,7 @@ export interface CustomNodeProps {
   width?: number;
   isSelected?: boolean;
   isHighlighted?: boolean;
-  onSelect: (datasetUri: string) => void;
+  onSelect: (datasetUri: string, type: string) => void;
   isOpen?: boolean;
   isActive?: boolean;
 }
@@ -45,7 +45,12 @@ const BaseNode = ({
   return (
     <Box bg="white">
       {type === "dag" && (
-        <DagNode dagId={label} isHighlighted={isHighlighted} />
+        <DagNode
+          dagId={label}
+          isHighlighted={isHighlighted}
+          isSelected={isSelected}
+          onSelect={onSelect}
+        />
       )}
       {type !== "dag" && (
         <Flex
@@ -57,7 +62,7 @@ const BaseNode = ({
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
-            if (type === "dataset") onSelect(label);
+            onSelect(label, "dataset");
           }}
           cursor="pointer"
           fontSize={16}

--- a/airflow/www/static/js/datasets/List.test.tsx
+++ b/airflow/www/static/js/datasets/List.test.tsx
@@ -87,7 +87,11 @@ describe("Test Datasets List", () => {
       .mockImplementation(() => returnValue);
 
     const { getByText, queryAllByTestId } = render(
-      <DatasetsList onSelect={() => {}} />,
+      <DatasetsList
+        onSelect={() => {}}
+        filteredDagIds={[]}
+        onFilterDags={() => {}}
+      />,
       { wrapper: Wrapper }
     );
 
@@ -111,7 +115,11 @@ describe("Test Datasets List", () => {
       .mockImplementation(() => emptyReturnValue);
 
     const { getByText, queryAllByTestId, getByTestId } = render(
-      <DatasetsList onSelect={() => {}} />,
+      <DatasetsList
+        onSelect={() => {}}
+        filteredDagIds={[]}
+        onFilterDags={() => {}}
+      />,
       { wrapper: Wrapper }
     );
 
@@ -130,7 +138,11 @@ describe("Test Datasets List", () => {
 
     const { getByDisplayValue } = render(
       <Wrapper initialEntries={["/datasets?search=s3%253A%252F%252F"]}>
-        <DatasetsList onSelect={() => {}} />
+        <DatasetsList
+          onSelect={() => {}}
+          filteredDagIds={[]}
+          onFilterDags={() => {}}
+        />
       </Wrapper>
     );
 

--- a/airflow/www/static/js/datasets/List.tsx
+++ b/airflow/www/static/js/datasets/List.tsx
@@ -42,9 +42,14 @@ import { Table, TimeCell } from "src/components/Table";
 import type { API } from "src/types";
 import { getMetaValue } from "src/utils";
 import type { DateOption } from "src/api/useDatasetsSummary";
+import type { DatasetDependencies } from "src/api/useDatasetDependencies";
+import DagFilter from "./DagFilter";
 
 interface Props {
   onSelect: (datasetId: string) => void;
+  datasetDependencies?: DatasetDependencies;
+  filteredDagIds: string[];
+  onFilterDags: (dagIds: string[]) => void;
 }
 
 interface CellProps {
@@ -80,7 +85,12 @@ const dateOptions: Record<string, DateOption> = {
   hour: { count: 1, unit: "hour" },
 };
 
-const DatasetsList = ({ onSelect }: Props) => {
+const DatasetsList = ({
+  onSelect,
+  datasetDependencies,
+  onFilterDags,
+  filteredDagIds,
+}: Props) => {
   const limit = 25;
   const [offset, setOffset] = useState(0);
 
@@ -133,7 +143,11 @@ const DatasetsList = ({ onSelect }: Props) => {
   const docsUrl = getMetaValue("datasets_docs");
 
   const onSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
-    searchParams.set(SEARCH_PARAM, encodeURIComponent(e.target.value));
+    if (e.target.value) {
+      searchParams.set(SEARCH_PARAM, encodeURIComponent(e.target.value));
+    } else {
+      searchParams.delete(SEARCH_PARAM);
+    }
     setSearchParams(searchParams);
   };
 
@@ -158,7 +172,7 @@ const DatasetsList = ({ onSelect }: Props) => {
           to learn how to create a dataset.
         </Text>
       )}
-      <Flex wrap="wrap">
+      <Flex wrap="wrap" mb={2}>
         <Text mr={2}>Filter datasets with updates in the past:</Text>
         <ButtonGroup size="sm" isAttached variant="outline">
           <Button
@@ -194,7 +208,7 @@ const DatasetsList = ({ onSelect }: Props) => {
           })}
         </ButtonGroup>
       </Flex>
-      <InputGroup my={2} px={1}>
+      <InputGroup my={2}>
         <InputLeftElement pointerEvents="none">
           <MdSearch />
         </InputLeftElement>
@@ -215,7 +229,12 @@ const DatasetsList = ({ onSelect }: Props) => {
           </InputRightElement>
         )}
       </InputGroup>
-      <Box borderWidth={1}>
+      <DagFilter
+        datasetDependencies={datasetDependencies}
+        filteredDagIds={filteredDagIds}
+        onFilterDags={onFilterDags}
+      />
+      <Box borderWidth={1} mt={2}>
         <Table
           data={data}
           columns={columns}


### PR DESCRIPTION
Read in all the dag_ids from the dataset dependencies endpoint and allow filtering the datasets graph by dag_id
A user can filter via the multi-select or from a tooltip when clicking on a Dag

Also fixed a bug where we didn't always create the sub graphs correctly.

![Feb-15-2024 17-06-35](https://github.com/apache/airflow/assets/4600967/488935b3-229d-4068-87e0-6bd7d9f53bfd)

<img width="312" alt="Screenshot 2024-02-15 at 5 07 02 PM" src="https://github.com/apache/airflow/assets/4600967/e7a640d9-93a3-4060-9ea2-d15c2524b2d6">

<img width="596" alt="Screenshot 2024-02-15 at 5 06 52 PM" src="https://github.com/apache/airflow/assets/4600967/5d32c319-9a6c-4100-8e5b-e72833a4a821">

This only filters the graph, not the datasets list for now. It would be ideal to do this logic on the backend (see https://github.com/apache/airflow/issues/37423) to better couple them but this gets us some functionality.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
