### PR TITLE
Make Datasets hashable

### DIFF
--- a/airflow/datasets/__init__.py
+++ b/airflow/datasets/__init__.py
@@ -46,3 +46,12 @@ class Dataset(os.PathLike):
 
     def __fspath__(self):
         return self.uri
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.uri == other.uri
+        else:
+            return NotImplemented
+
+    def __hash__(self):
+        return hash(self.uri)

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -70,6 +70,25 @@ def test_fspath():
     assert os.fspath(dataset) == uri
 
 
+def test_equal_when_same_uri():
+    uri = "s3://example_dataset"
+    dataset1 = Dataset(uri=uri)
+    dataset2 = Dataset(uri=uri)
+    assert dataset1 == dataset2
+
+
+def test_not_equal_when_different_uri():
+    dataset1 = Dataset(uri="s3://example_dataset")
+    dataset2 = Dataset(uri="s3://other_dataset")
+    assert dataset1 != dataset2
+
+
+def test_hash():
+    uri = "s3://example_dataset"
+    dataset = Dataset(uri=uri)
+    hash(dataset)
+
+
 @pytest.mark.parametrize(
     "inputs, scenario, expected",
     [


### PR DESCRIPTION
Currently DAGs accept a [`Collection["Dataset"]`](https://github.com/apache/airflow/blob/0c02ead4d8a527cbf0a916b6344f255c520e637f/airflow/models/dag.py#L171) as an option for the `schedule`, but that collection cannot be a `set` because Datasets are not a hashable type. The interesting thing is that [the `DatasetModel` is actually already hashable](https://github.com/apache/airflow/blob/dec78ab3f140f35e507de825327652ec24d03522/airflow/models/dataset.py#L93-L100), so this introduces a bit of duplication since it's mostly the same implementation. However, Airflow users are primarily interfacing with `Dataset`, not `DatasetModel` so I think it makes sense for `Dataset` to be hashable. I'm not sure how to square the duplication or what `__eq__` and `__hash__` provide for `DatasetModel` though.

There was discussion on the original PR that created the `Dataset` (https://github.com/apache/airflow/pull/24613) about whether to create two classes or one. In that discussion @kaxil mentioned:

> I would slightly favour a separate `DatasetModel` and `Dataset` so `Dataset` becomes an extensible class, and `DatasetModel` just stores the info about the class. So users don't need to care about SQLAlchmey stuff when extending it.

That first PR created the `Dataset` model as both SQLAlchemy and user space class though. It wasn't until later on (https://github.com/apache/airflow/pull/25727) that the `DatasetModel` got broken out from `Dataset` and one became two. That provides a bit of background on why they both exist for anyone reading this who is curious.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
