### PR TITLE
add reuse_existing_run for allowing DbtCloudRunJobOperator to reuse existing run

### DIFF
--- a/airflow/providers/dbt/cloud/hooks/dbt.py
+++ b/airflow/providers/dbt/cloud/hooks/dbt.py
@@ -109,6 +109,7 @@ class DbtCloudJobRunStatus(Enum):
     SUCCESS = 10
     ERROR = 20
     CANCELLED = 30
+    NON_TERMINAL_STATUSES = (QUEUED, STARTING, RUNNING)
     TERMINAL_STATUSES = (SUCCESS, ERROR, CANCELLED)
 
     @classmethod
@@ -458,6 +459,20 @@ class DbtCloudHook(HttpHook):
                 "order_by": order_by,
             },
             paginate=True,
+        )
+
+    @fallback_to_default_account
+    def get_job_runs(self, account_id: int | None = None, payload: dict[str, Any] | None = None) -> Response:
+        """
+        Retrieve metadata for a specific run of a dbt Cloud job.
+
+        :param account_id: Optional. The ID of a dbt Cloud account.
+        :param paylod: Optional. Query Parameters
+        :return: The request response.
+        """
+        return self._run_and_get_response(
+            endpoint=f"{account_id}/runs/",
+            payload=payload,
         )
 
     @fallback_to_default_account

--- a/tests/providers/dbt/cloud/hooks/test_dbt.py
+++ b/tests/providers/dbt/cloud/hooks/test_dbt.py
@@ -445,6 +445,21 @@ class TestDbtCloudHook:
         ids=["default_account", "explicit_account"],
     )
     @patch.object(DbtCloudHook, "run")
+    def test_get_job_runs(self, mock_http_run, conn_id, account_id):
+        hook = DbtCloudHook(conn_id)
+        hook.get_job_runs(account_id=account_id)
+
+        assert hook.method == "GET"
+
+        _account_id = account_id or DEFAULT_ACCOUNT_ID
+        hook.run.assert_called_once_with(endpoint=f"{_account_id}/runs/", data=None)
+
+    @pytest.mark.parametrize(
+        argnames="conn_id, account_id",
+        argvalues=[(ACCOUNT_ID_CONN, None), (NO_ACCOUNT_ID_CONN, ACCOUNT_ID)],
+        ids=["default_account", "explicit_account"],
+    )
+    @patch.object(DbtCloudHook, "run")
     @patch.object(DbtCloudHook, "_paginate")
     def test_get_job_run(self, mock_http_run, mock_paginate, conn_id, account_id):
         hook = DbtCloudHook(conn_id)
@@ -493,9 +508,11 @@ class TestDbtCloudHook:
         argnames=("job_run_status", "expected_status", "expected_output"),
         argvalues=wait_for_job_run_status_test_args,
         ids=[
-            f"run_status_{argval[0]}_expected_{argval[1]}"
-            if isinstance(argval[1], int)
-            else f"run_status_{argval[0]}_expected_AnyTerminalStatus"
+            (
+                f"run_status_{argval[0]}_expected_{argval[1]}"
+                if isinstance(argval[1], int)
+                else f"run_status_{argval[0]}_expected_AnyTerminalStatus"
+            )
             for argval in wait_for_job_run_status_test_args
         ],
     )


### PR DESCRIPTION
Allow DbtCloudRunJobOperator to reuse existing non-terminal job run without needing to trigger the job again

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
