### PR TITLE
feat: Fall back to datasets' "extra" if arg extra is empty

### DIFF
--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -64,6 +64,9 @@ class DatasetManager(LoggingMixin):
         For local datasets, look them up, record the dataset event, queue dagruns, and broadcast
         the dataset event
         """
+        if extra is None and dataset.extra:
+            extra = dataset.extra
+
         dataset_model = session.scalar(
             select(DatasetModel)
             .where(DatasetModel.uri == dataset.uri)

--- a/tests/datasets/test_manager.py
+++ b/tests/datasets/test_manager.py
@@ -66,7 +66,7 @@ class TestDatasetManager:
         mock_session.add.assert_not_called()
         mock_session.merge.assert_not_called()
 
-    def test_register_dataset_change(self, session, dag_maker, mock_task_instance):
+    def register_dataset_change_without_extra(self, session, dag_maker, mock_task_instance):
         dsem = DatasetManager()
 
         ds = Dataset(uri="test_dataset_uri")
@@ -80,6 +80,44 @@ class TestDatasetManager:
         session.flush()
 
         dsem.register_dataset_change(task_instance=mock_task_instance, dataset=ds, session=session)
+
+        # Ensure we've created a dataset
+        assert session.query(DatasetEvent).filter_by(dataset_id=dsm.id).count() == 1
+        assert session.query(DatasetDagRunQueue).count() == 2
+
+    def test_register_dataset_change_with_dataset_extra(self, session, dag_maker, mock_task_instance):
+        dsem = DatasetManager()
+
+        ds = Dataset(uri="test_dataset_uri", extra={"hi": "bye"})
+        dag1 = DagModel(dag_id="dag1")
+        dag2 = DagModel(dag_id="dag2")
+        session.add_all([dag1, dag2])
+
+        dsm = DatasetModel(uri="test_dataset_uri")
+        session.add(dsm)
+        dsm.consuming_dags = [DagScheduleDatasetReference(dag_id=dag.dag_id) for dag in (dag1, dag2)]
+        session.flush()
+
+        dsem.register_dataset_change(task_instance=mock_task_instance, dataset=ds, session=session)
+
+        # Ensure we've created a dataset
+        assert session.query(DatasetEvent).filter_by(dataset_id=dsm.id).count() == 1
+        assert session.query(DatasetDagRunQueue).count() == 2
+
+    def test_register_dataset_change_with_extra(self, session, dag_maker, mock_task_instance):
+        dsem = DatasetManager()
+
+        ds = Dataset(uri="test_dataset_uri")
+        dag1 = DagModel(dag_id="dag1")
+        dag2 = DagModel(dag_id="dag2")
+        session.add_all([dag1, dag2])
+
+        dsm = DatasetModel(uri="test_dataset_uri")
+        session.add(dsm)
+        dsm.consuming_dags = [DagScheduleDatasetReference(dag_id=dag.dag_id) for dag in (dag1, dag2)]
+        session.flush()
+
+        dsem.register_dataset_change(task_instance=mock_task_instance, dataset=ds, session=session, extra={"hi": "bye"})
 
         # Ensure we've created a dataset
         assert session.query(DatasetEvent).filter_by(dataset_id=dsm.id).count() == 1

--- a/tests/datasets/test_manager.py
+++ b/tests/datasets/test_manager.py
@@ -117,7 +117,9 @@ class TestDatasetManager:
         dsm.consuming_dags = [DagScheduleDatasetReference(dag_id=dag.dag_id) for dag in (dag1, dag2)]
         session.flush()
 
-        dsem.register_dataset_change(task_instance=mock_task_instance, dataset=ds, session=session, extra={"hi": "bye"})
+        dsem.register_dataset_change(
+            task_instance=mock_task_instance, dataset=ds, session=session, extra={"hi": "bye"}
+        )
 
         # Ensure we've created a dataset
         assert session.query(DatasetEvent).filter_by(dataset_id=dsm.id).count() == 1


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

fix: https://github.com/apache/airflow/issues/37006

Fall back to datasets' "extra" if arg extra is empty

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
