### PR TITLE
Add a task instance dependency for mapped dependencies

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -84,6 +84,7 @@ from airflow.models.taskinstance import TaskInstance, clear_task_instances
 from airflow.models.taskmixin import DependencyMixin
 from airflow.serialization.enums import DagAttributeTypes
 from airflow.task.priority_strategy import PriorityWeightStrategy, validate_and_load_priority_weight_strategy
+from airflow.ti_deps.deps.mapped_task_upstream_dep import MappedTaskUpstreamDep
 from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
 from airflow.ti_deps.deps.not_previously_skipped_dep import NotPreviouslySkippedDep
 from airflow.ti_deps.deps.prev_dagrun_dep import PrevDagrunDep
@@ -868,8 +869,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         **kwargs,
     ):
         from airflow.models.dag import DagContext
-        from airflow.ti_deps.deps.mapped_task_upstream_dep import MappedTaskUpstreamDep
-        from airflow.utils.task_group import MappedTaskGroup, TaskGroupContext
+        from airflow.utils.task_group import TaskGroupContext
 
         self.__init_kwargs = {}
 
@@ -897,8 +897,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self.task_id = task_group.child_id(task_id) if task_group else task_id
         if not self.__from_mapped and task_group:
             task_group.add(self)
-        if isinstance(task_group, MappedTaskGroup):
-            self.deps = self.deps | {MappedTaskUpstreamDep()}
 
         self.owner = owner
         self.email = email
@@ -1213,6 +1211,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
             PrevDagrunDep(),
             TriggerRuleDep(),
             NotPreviouslySkippedDep(),
+            MappedTaskUpstreamDep(),
         }
     )
     """

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -868,7 +868,8 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         **kwargs,
     ):
         from airflow.models.dag import DagContext
-        from airflow.utils.task_group import TaskGroupContext
+        from airflow.ti_deps.deps.mapped_task_upstream_dep import MappedTaskUpstreamDep
+        from airflow.utils.task_group import MappedTaskGroup, TaskGroupContext
 
         self.__init_kwargs = {}
 
@@ -896,6 +897,8 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self.task_id = task_group.child_id(task_id) if task_group else task_id
         if not self.__from_mapped and task_group:
             task_group.add(self)
+        if isinstance(task_group, MappedTaskGroup):
+            self.deps = self.deps | {MappedTaskUpstreamDep()}
 
         self.owner = owner
         self.email = email

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -50,7 +50,6 @@ from airflow.models.pool import Pool
 from airflow.serialization.enums import DagAttributeTypes
 from airflow.task.priority_strategy import PriorityWeightStrategy, validate_and_load_priority_weight_strategy
 from airflow.ti_deps.deps.mapped_task_expanded import MappedTaskIsExpanded
-from airflow.ti_deps.deps.mapped_task_upstream_dep import MappedTaskUpstreamDep
 from airflow.typing_compat import Literal
 from airflow.utils.context import context_update_for_unmapped
 from airflow.utils.helpers import is_container, prevent_duplicates
@@ -361,7 +360,7 @@ class MappedOperator(AbstractOperator):
                 f"'deps' must be a set defined as a class-level variable on {operator_class.__name__}, "
                 f"not a {type(operator_deps).__name__}"
             )
-        return operator_deps | {MappedTaskIsExpanded(), MappedTaskUpstreamDep()}
+        return operator_deps | {MappedTaskIsExpanded()}
 
     @property
     def task_type(self) -> str:

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -50,6 +50,7 @@ from airflow.models.pool import Pool
 from airflow.serialization.enums import DagAttributeTypes
 from airflow.task.priority_strategy import PriorityWeightStrategy, validate_and_load_priority_weight_strategy
 from airflow.ti_deps.deps.mapped_task_expanded import MappedTaskIsExpanded
+from airflow.ti_deps.deps.mapped_task_upstream_dep import MappedTaskUpstreamDep
 from airflow.typing_compat import Literal
 from airflow.utils.context import context_update_for_unmapped
 from airflow.utils.helpers import is_container, prevent_duplicates
@@ -360,7 +361,7 @@ class MappedOperator(AbstractOperator):
                 f"'deps' must be a set defined as a class-level variable on {operator_class.__name__}, "
                 f"not a {type(operator_deps).__name__}"
             )
-        return operator_deps | {MappedTaskIsExpanded()}
+        return operator_deps | {MappedTaskIsExpanded(), MappedTaskUpstreamDep()}
 
     @property
     def task_type(self) -> str:

--- a/airflow/ti_deps/deps/mapped_task_upstream_dep.py
+++ b/airflow/ti_deps/deps/mapped_task_upstream_dep.py
@@ -1,0 +1,92 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.utils.state import State, TaskInstanceState
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from airflow.models.taskinstance import TaskInstance
+    from airflow.ti_deps.dep_context import DepContext
+    from airflow.ti_deps.deps.base_ti_dep import TIDepStatus
+
+
+class MappedTaskUpstreamDep(BaseTIDep):
+    """
+    Determines if a mapped task's upstream tasks that provide XComs used by this task for task mapping are in
+    a state that allows a given task instance to run.
+    """
+
+    NAME = "Mapped dependencies have succeeded"
+    IGNORABLE = True
+    IS_TASK_DEP = True
+
+    def _get_dep_statuses(
+        self,
+        ti: TaskInstance,
+        session: Session,
+        dep_context: DepContext,
+    ) -> Iterator[TIDepStatus]:
+        from airflow.models.mappedoperator import MappedOperator
+
+        if isinstance(ti.task, MappedOperator):
+            mapped_dependencies = ti.task.iter_mapped_dependencies()
+        elif (task_group := ti.task.get_closest_mapped_task_group()) is not None:
+            mapped_dependencies = task_group.iter_mapped_dependencies()
+        else:
+            return
+
+        mapped_dependency_tis = [
+            ti.get_dagrun(session).get_task_instance(operator.task_id, session=session)
+            for operator in mapped_dependencies
+        ]
+        if not mapped_dependency_tis:
+            yield self._passing_status(reason="There are no mapped dependencies!")
+            return
+        # ti can be None if the mapped dependency is a mapped operator, and it has already been expanded. In
+        # this case, we don't need to check it any further as it didn't fail or was skipped altogether
+        finished_tis = [ti for ti in mapped_dependency_tis if ti is not None and ti.state in State.finished]
+        if not finished_tis:
+            return
+
+        finished_states = {finished_ti.state for finished_ti in finished_tis}
+        if finished_states == {TaskInstanceState.SUCCESS}:
+            # Mapped dependencies are at least partially done and only feature successes
+            return
+
+        # At least one mapped dependency was not successful
+        # - If another dependency (such as the trigger rule dependency) has not already marked the task as
+        # FAILED or UPSTREAM_FAILED then we update the state
+        if ti.state not in {TaskInstanceState.FAILED, TaskInstanceState.UPSTREAM_FAILED}:
+            new_state = None
+            if (
+                TaskInstanceState.FAILED in finished_states
+                or TaskInstanceState.UPSTREAM_FAILED in finished_states
+            ):
+                new_state = TaskInstanceState.UPSTREAM_FAILED
+            elif TaskInstanceState.SKIPPED in finished_states:
+                new_state = TaskInstanceState.SKIPPED
+            if new_state is not None and ti.set_state(new_state, session):
+                dep_context.have_changed_ti_states = True
+        # - Return a failing status
+        yield self._failing_status(reason="At least one of task's mapped dependencies has not succeeded!")

--- a/airflow/ti_deps/deps/mapped_task_upstream_dep.py
+++ b/airflow/ti_deps/deps/mapped_task_upstream_dep.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
-from sqlalchemy import and_, select
+from sqlalchemy import select
 
 from airflow.models.taskinstance import TaskInstance
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep

--- a/airflow/ti_deps/deps/mapped_task_upstream_dep.py
+++ b/airflow/ti_deps/deps/mapped_task_upstream_dep.py
@@ -33,8 +33,8 @@ if TYPE_CHECKING:
 
 class MappedTaskUpstreamDep(BaseTIDep):
     """
-    Determines if a mapped task's upstream tasks that provide XComs used by this task for task mapping are in
-    a state that allows a given task instance to run.
+    Determines if the task, if mapped, has upstream tasks that provide XComs used by
+    this task for task mapping, and are in states that allow the task instance to run.
     """
 
     NAME = "Mapped dependencies have succeeded"

--- a/airflow/ti_deps/deps/mapped_task_upstream_dep.py
+++ b/airflow/ti_deps/deps/mapped_task_upstream_dep.py
@@ -67,12 +67,10 @@ class MappedTaskUpstreamDep(BaseTIDep):
         mapped_dependency_tis = (
             session.scalars(
                 select(TaskInstance).where(
-                    and_(
-                        TaskInstance.task_id.in_([operator.task_id for operator in mapped_dependencies]),
-                        TaskInstance.dag_id == ti.dag_id,
-                        TaskInstance.run_id == ti.run_id,
-                        TaskInstance.map_index == -1,
-                    )
+                    TaskInstance.task_id.in_(operator.task_id for operator in mapped_dependencies),
+                    TaskInstance.dag_id == ti.dag_id,
+                    TaskInstance.run_id == ti.run_id,
+                    TaskInstance.map_index == -1,
                 )
             ).all()
             if mapped_dependencies

--- a/airflow/ti_deps/deps/mapped_task_upstream_dep.py
+++ b/airflow/ti_deps/deps/mapped_task_upstream_dep.py
@@ -33,8 +33,10 @@ if TYPE_CHECKING:
 
 class MappedTaskUpstreamDep(BaseTIDep):
     """
-    Determines if the task, if mapped, has upstream tasks that provide XComs used by
-    this task for task mapping, and are in states that allow the task instance to run.
+    Determines if the task, if mapped, is allowed to run based on its mapped dependencies.
+
+    In particular, check if upstream tasks that provide XComs used by this task for task mapping are in
+    states that allow the task instance to run.
     """
 
     NAME = "Mapped dependencies have succeeded"

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1526,6 +1526,7 @@ class TestStringifiedDAGs:
 
         deps = serialize_op["deps"]
         assert deps == [
+            "airflow.ti_deps.deps.mapped_task_upstream_dep.MappedTaskUpstreamDep",
             "airflow.ti_deps.deps.not_in_retry_period_dep.NotInRetryPeriodDep",
             "airflow.ti_deps.deps.not_previously_skipped_dep.NotPreviouslySkippedDep",
             "airflow.ti_deps.deps.prev_dagrun_dep.PrevDagrunDep",
@@ -1576,6 +1577,7 @@ class TestStringifiedDAGs:
         serialize_op = SerializedBaseOperator.serialize_operator(dag.task_dict["task1"])
 
         assert serialize_op["deps"] == [
+            "airflow.ti_deps.deps.mapped_task_upstream_dep.MappedTaskUpstreamDep",
             "airflow.ti_deps.deps.not_in_retry_period_dep.NotInRetryPeriodDep",
             "airflow.ti_deps.deps.not_previously_skipped_dep.NotPreviouslySkippedDep",
             "airflow.ti_deps.deps.prev_dagrun_dep.PrevDagrunDep",
@@ -1586,6 +1588,7 @@ class TestStringifiedDAGs:
         op = SerializedBaseOperator.deserialize_operator(serialize_op)
         assert sorted(str(dep) for dep in op.deps) == [
             "<TIDep(CustomTestTriggerRule)>",
+            "<TIDep(Mapped dependencies have succeeded)>",
             "<TIDep(Not In Retry Period)>",
             "<TIDep(Not Previously Skipped)>",
             "<TIDep(Previous Dagrun State)>",

--- a/tests/ti_deps/deps/test_mapped_task_upstream_dep.py
+++ b/tests/ti_deps/deps/test_mapped_task_upstream_dep.py
@@ -149,7 +149,8 @@ def test_mapped_task_upstream_dep(
     )
     assert get_dep_statuses(dr, mapped_task, session) == expected_statuses
     ti = dr.get_task_instance(session=session, task_id=mapped_task)
-    assert ti is not None and ti.state == expected_state
+    assert ti is not None
+    assert ti.state == expected_state
 
 
 @pytest.mark.parametrize("failure_mode", [None, FAILED, UPSTREAM_FAILED])

--- a/tests/ti_deps/deps/test_mapped_task_upstream_dep.py
+++ b/tests/ti_deps/deps/test_mapped_task_upstream_dep.py
@@ -1,0 +1,350 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from airflow.exceptions import AirflowFailException, AirflowSkipException
+from airflow.ti_deps.dep_context import DepContext
+from airflow.ti_deps.deps.base_ti_dep import TIDepStatus
+from airflow.ti_deps.deps.mapped_task_upstream_dep import MappedTaskUpstreamDep
+from airflow.utils.state import TaskInstanceState
+
+pytestmark = pytest.mark.db_test
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm.session import Session
+
+    from airflow.models.dagrun import DagRun
+    from airflow.models.taskinstance import TaskInstance
+
+FAILED = TaskInstanceState.FAILED
+REMOVED = TaskInstanceState.REMOVED
+SKIPPED = TaskInstanceState.SKIPPED
+SUCCESS = TaskInstanceState.SUCCESS
+UPSTREAM_FAILED = TaskInstanceState.UPSTREAM_FAILED
+
+
+@pytest.mark.parametrize(
+    ["task_state", "upstream_states", "expected_state", "expect_failed_dep"],
+    [
+        # finished mapped dependencies with state != success result in failed dep and a modified state
+        (None, [None, None], None, False),
+        (None, [SUCCESS, None], None, False),
+        (None, [SKIPPED, None], SKIPPED, True),
+        (None, [FAILED, None], UPSTREAM_FAILED, True),
+        (None, [UPSTREAM_FAILED, None], UPSTREAM_FAILED, True),
+        (None, [REMOVED, None], None, True),
+        # success does not cancel out failed finished mapped dependencies
+        (None, [SKIPPED, SUCCESS], SKIPPED, True),
+        (None, [FAILED, SUCCESS], UPSTREAM_FAILED, True),
+        (None, [UPSTREAM_FAILED, SUCCESS], UPSTREAM_FAILED, True),
+        (None, [REMOVED, SUCCESS], None, True),
+        # skipped and failed/upstream_failed result in upstream_failed
+        (None, [SKIPPED, FAILED], UPSTREAM_FAILED, True),
+        (None, [SKIPPED, UPSTREAM_FAILED], UPSTREAM_FAILED, True),
+        (None, [SKIPPED, REMOVED], SKIPPED, True),
+        # if state of the mapped task is already set (e.g., by another ti dep), then failed and
+        # upstream_failed are not overwritten but failed deps are still reported
+        (SKIPPED, [None, None], SKIPPED, False),
+        (SKIPPED, [SUCCESS, None], SKIPPED, False),
+        (SKIPPED, [SKIPPED, None], SKIPPED, True),
+        (SKIPPED, [FAILED, None], UPSTREAM_FAILED, True),
+        (SKIPPED, [UPSTREAM_FAILED, None], UPSTREAM_FAILED, True),
+        (SKIPPED, [REMOVED, None], SKIPPED, True),
+        (FAILED, [None, None], FAILED, False),
+        (FAILED, [SUCCESS, None], FAILED, False),
+        (FAILED, [SKIPPED, None], FAILED, True),
+        (FAILED, [FAILED, None], FAILED, True),
+        (FAILED, [UPSTREAM_FAILED, None], FAILED, True),
+        (FAILED, [REMOVED, None], FAILED, True),
+        (UPSTREAM_FAILED, [None, None], UPSTREAM_FAILED, False),
+        (UPSTREAM_FAILED, [SUCCESS, None], UPSTREAM_FAILED, False),
+        (UPSTREAM_FAILED, [SKIPPED, None], UPSTREAM_FAILED, True),
+        (UPSTREAM_FAILED, [FAILED, None], UPSTREAM_FAILED, True),
+        (UPSTREAM_FAILED, [UPSTREAM_FAILED, None], UPSTREAM_FAILED, True),
+        (UPSTREAM_FAILED, [REMOVED, None], UPSTREAM_FAILED, True),
+        (REMOVED, [None, None], REMOVED, False),
+        (REMOVED, [SUCCESS, None], REMOVED, False),
+        (REMOVED, [SKIPPED, None], SKIPPED, True),
+        (REMOVED, [FAILED, None], UPSTREAM_FAILED, True),
+        (REMOVED, [UPSTREAM_FAILED, None], UPSTREAM_FAILED, True),
+        (REMOVED, [REMOVED, None], REMOVED, True),
+    ],
+)
+@pytest.mark.parametrize("testcase", ["task", "group"])
+def test_mapped_task_upstream_dep(
+    dag_maker,
+    session: Session,
+    task_state: TaskInstanceState | None,
+    upstream_states: list[TaskInstanceState | None],
+    expected_state: TaskInstanceState | None,
+    expect_failed_dep: bool,
+    testcase: str,
+):
+    from airflow.decorators import task, task_group
+
+    with dag_maker(session=session):
+
+        @task
+        def t():
+            return [1, 2]
+
+        @task
+        def m(x, y):
+            return x + y
+
+        @task_group
+        def g(x, y):
+            return m(x, y)
+
+        if testcase == "task":
+            m.expand(x=t.override(task_id="t1")(), y=t.override(task_id="t2")())
+        else:
+            g.expand(x=t.override(task_id="t1")(), y=t.override(task_id="t2")())
+
+    mapped_task = "m" if testcase == "task" else "g.m"
+
+    dr: DagRun = dag_maker.create_dagrun()
+    tis = {ti.task_id: ti for ti in dr.get_task_instances(session=session)}
+    if task_state is not None:
+        tis[mapped_task].set_state(task_state, session=session)
+    if upstream_states[0] is not None:
+        tis["t1"].set_state(upstream_states[0], session=session)
+    if upstream_states[1] is not None:
+        tis["t2"].set_state(upstream_states[1], session=session)
+
+    expected_statuses = (
+        []
+        if not expect_failed_dep
+        else [
+            TIDepStatus(
+                dep_name="Mapped dependencies have succeeded",
+                passed=False,
+                reason="At least one of task's mapped dependencies has not succeeded!",
+            )
+        ]
+    )
+    assert get_dep_statuses(dr, mapped_task, session) == expected_statuses
+    ti = dr.get_task_instance(session=session, task_id=mapped_task)
+    assert ti is not None and ti.state == expected_state
+
+
+@pytest.mark.parametrize("failure_mode", [None, FAILED, UPSTREAM_FAILED])
+@pytest.mark.parametrize("skip_upstream", [True, False])
+@pytest.mark.parametrize("testcase", ["task", "group"])
+def test_step_by_step(
+    dag_maker, session: Session, failure_mode: TaskInstanceState | None, skip_upstream: bool, testcase: str
+):
+    from airflow.decorators import task, task_group
+
+    with dag_maker(session=session):
+
+        @task
+        def t1():
+            return [0]
+
+        @task
+        def t2_a():
+            if failure_mode == UPSTREAM_FAILED:
+                raise AirflowFailException()
+            return [1, 2]
+
+        @task
+        def t2_b(x):
+            if failure_mode == FAILED:
+                raise AirflowFailException()
+            return x
+
+        @task
+        def t3():
+            if skip_upstream:
+                raise AirflowSkipException()
+            return [3, 4]
+
+        @task
+        def t4():
+            return 17
+
+        @task(trigger_rule="all_done")
+        def m1(a, x, y, z):
+            return a + x + y + z
+
+        @task(trigger_rule="all_done")
+        def m2(x, y):
+            return x + y
+
+        @task_group
+        def tg(a, x, y, z):
+            return m2(a, m1(a, x, y, z))
+
+        vals = t1()
+        if testcase == "task":
+            m2.expand(x=vals, y=m1.partial(a=t4()).expand(x=vals, y=t2_b(t2_a()), z=t3()))
+        else:
+            tg.partial(a=t4()).expand(x=vals, y=t2_b(t2_a()), z=t3())
+
+    dr: DagRun = dag_maker.create_dagrun()
+
+    mapped_task_1 = "m1" if testcase == "task" else "tg.m1"
+    mapped_task_2 = "m2" if testcase == "task" else "tg.m2"
+
+    # Initial decision, t1, t2 and t3 can be scheduled
+    schedulable_tis, finished_tis_states = _one_scheduling_decision_iteration(dr, session)
+    assert sorted(schedulable_tis) == ["t1", "t2_a", "t3", "t4"]
+    assert not finished_tis_states
+
+    # Run first schedulable task - expect no dep statuses for m1 as only one of its 3 mapped dependencies is
+    # finished
+    schedulable_tis["t1"].run()
+    _one_scheduling_decision_iteration(dr, session)
+    assert not get_dep_statuses(dr, mapped_task_1, session)
+
+    # Run remaining schedulable tasks
+    if failure_mode == UPSTREAM_FAILED:
+        with pytest.raises(AirflowFailException):
+            schedulable_tis["t2_a"].run()
+    else:
+        schedulable_tis["t2_a"].run()
+        schedulable_tis, finished_tis_states = _one_scheduling_decision_iteration(dr, session)
+        if not failure_mode:
+            schedulable_tis["t2_b"].run()
+        else:
+            with pytest.raises(AirflowFailException):
+                schedulable_tis["t2_b"].run()
+    schedulable_tis["t3"].run()
+    schedulable_tis["t4"].run()
+
+    # Decision after running all tasks
+    _one_scheduling_decision_iteration(dr, session)
+
+    # Standalone test of the mapped task upstream dependency status
+    expect_passed = not failure_mode and not skip_upstream
+    expected_statuses = (
+        []
+        if expect_passed
+        else [
+            TIDepStatus(
+                dep_name="Mapped dependencies have succeeded",
+                passed=expect_passed,
+                reason=(
+                    "The task's mapped dependencies have all succeeded!"
+                    if expect_passed
+                    else "At least one of task's mapped dependencies has not succeeded!"
+                ),
+            )
+        ]
+    )
+    assert get_dep_statuses(dr, mapped_task_1, session) == expected_statuses
+    if not expect_passed:
+        assert get_dep_statuses(dr, mapped_task_2, session) == expected_statuses
+
+    # Full test of the mapped task upstream dependency status
+    schedulable_tis, finished_tis_states = _one_scheduling_decision_iteration(dr, session)
+    expected_finished_tis_states = {
+        "t1": SUCCESS,
+        "t2_a": FAILED if failure_mode == UPSTREAM_FAILED else SUCCESS,
+        "t2_b": failure_mode if failure_mode else SUCCESS,
+        "t3": SKIPPED if skip_upstream else SUCCESS,
+        "t4": SUCCESS,
+    }
+    if not expect_passed:
+        expected_finished_tis_states[mapped_task_1] = UPSTREAM_FAILED if failure_mode else SKIPPED
+        expected_finished_tis_states[mapped_task_2] = UPSTREAM_FAILED if failure_mode else SKIPPED
+    assert finished_tis_states == expected_finished_tis_states
+
+    if expect_passed:
+        # Run the m1 tasks
+        for i in range(4):
+            schedulable_tis[f"{mapped_task_1}_{i}"].run()
+            expected_finished_tis_states[f"{mapped_task_1}_{i}"] = SUCCESS
+        schedulable_tis, finished_tis_states = _one_scheduling_decision_iteration(dr, session)
+        # Since m1 was expanded successfully, the upstream dep check does not do anything
+        assert not get_dep_statuses(dr, mapped_task_2, session)
+        # Run the m2 tasks
+        for i in range(4):
+            schedulable_tis[f"{mapped_task_2}_{i}"].run()
+            expected_finished_tis_states[f"{mapped_task_2}_{i}"] = SUCCESS
+        schedulable_tis, finished_tis_states = _one_scheduling_decision_iteration(dr, session)
+        assert finished_tis_states == expected_finished_tis_states
+
+
+@pytest.mark.parametrize("testcase", ["task", "group"])
+def test_no_mapped_dependencies(dag_maker, session: Session, testcase: str):
+    from airflow.decorators import task, task_group
+
+    with dag_maker(session=session):
+
+        @task
+        def m(x):
+            return x
+
+        @task_group
+        def tg(x):
+            return m(x)
+
+        if testcase == "task":
+            m.expand(x=[1, 2, 3])
+        else:
+            tg.expand(x=[1, 2, 3])
+
+    dr: DagRun = dag_maker.create_dagrun()
+
+    mapped_task = "m" if testcase == "task" else "tg.m"
+
+    # Initial decision, t can be scheduled
+    schedulable_tis, finished_tis_states = _one_scheduling_decision_iteration(dr, session)
+    assert sorted(schedulable_tis) == [f"{mapped_task}_{i}" for i in range(3)]
+    assert not finished_tis_states
+
+    # Expect passed dep status for t as it does not have any mapped dependencies
+    expected_statuses = TIDepStatus(
+        dep_name="Mapped dependencies have succeeded",
+        passed=True,
+        reason="There are no mapped dependencies!",
+    )
+    assert get_dep_statuses(dr, mapped_task, session) == [expected_statuses]
+
+
+def _one_scheduling_decision_iteration(
+    dr: DagRun, session: Session
+) -> tuple[dict[str, TaskInstance], dict[str, str]]:
+    def _key(ti) -> str:
+        return ti.task_id if ti.map_index == -1 else f"{ti.task_id}_{ti.map_index}"
+
+    decision = dr.task_instance_scheduling_decisions(session=session)
+    return (
+        {_key(ti): ti for ti in decision.schedulable_tis},
+        {_key(ti): ti.state for ti in decision.finished_tis},
+    )
+
+
+def get_dep_statuses(dr: DagRun, task_id: str, session: Session) -> list[TIDepStatus]:
+    return list(
+        MappedTaskUpstreamDep()._get_dep_statuses(
+            ti=_get_ti(dr, task_id),
+            dep_context=DepContext(),
+            session=session,
+        )
+    )
+
+
+def _get_ti(dr: DagRun, task_id: str) -> TaskInstance:
+    return next(ti for ti in dr.task_instances if ti.task_id == task_id)

--- a/tests/ti_deps/deps/test_mapped_task_upstream_dep.py
+++ b/tests/ti_deps/deps/test_mapped_task_upstream_dep.py
@@ -377,7 +377,7 @@ def test_no_mapped_dependencies(dag_maker, session: Session, testcase: str):
     expected_statuses = TIDepStatus(
         dep_name="Mapped dependencies have succeeded",
         passed=True,
-        reason="There are no mapped dependencies!",
+        reason="There are no (unexpanded) mapped dependencies!",
     )
     assert get_dep_statuses(dr, mapped_task, session) == [expected_statuses]
 

--- a/tests/ti_deps/deps/test_mapped_task_upstream_dep.py
+++ b/tests/ti_deps/deps/test_mapped_task_upstream_dep.py
@@ -340,7 +340,7 @@ def test_mapped_in_mapped_task_group(dag_maker, session: Session):
         # Add a test once mapped tasks within mapped task groups become supported
         with pytest.raises(NotImplementedError) as ctx:
             g.expand(x=t())
-            assert str(ctx.value) == "operator expansion in an expanded task group is not yet supported"
+        assert str(ctx.value) == "operator expansion in an expanded task group is not yet supported"
 
 
 @pytest.mark.parametrize("testcase", ["task", "group"])

--- a/tests/ti_deps/deps/test_mapped_task_upstream_dep.py
+++ b/tests/ti_deps/deps/test_mapped_task_upstream_dep.py
@@ -229,9 +229,10 @@ def test_step_by_step(
     if failure_mode == UPSTREAM_FAILED:
         with pytest.raises(AirflowFailException):
             schedulable_tis["t2_a"].run()
+        _one_scheduling_decision_iteration(dr, session)
     else:
         schedulable_tis["t2_a"].run()
-        schedulable_tis, finished_tis_states = _one_scheduling_decision_iteration(dr, session)
+        schedulable_tis, _ = _one_scheduling_decision_iteration(dr, session)
         if not failure_mode:
             schedulable_tis["t2_b"].run()
         else:
@@ -239,11 +240,9 @@ def test_step_by_step(
                 schedulable_tis["t2_b"].run()
     schedulable_tis["t3"].run()
     schedulable_tis["t4"].run()
-
-    # Decision after running all tasks
     _one_scheduling_decision_iteration(dr, session)
 
-    # Test the mapped task upstream dependency status
+    # Test the mapped task upstream dependency checks
     schedulable_tis, finished_tis_states = _one_scheduling_decision_iteration(dr, session)
     expected_finished_tis_states = {
         "t1": SUCCESS,

--- a/tests/ti_deps/deps/test_mapped_task_upstream_dep.py
+++ b/tests/ti_deps/deps/test_mapped_task_upstream_dep.py
@@ -113,15 +113,19 @@ def test_mapped_task_upstream_dep(
             return x + y
 
         @task_group
-        def g(x, y):
-            return m(x, y)
+        def g1(x, y):
+            @task_group
+            def g2():
+                return m(x, y)
+
+            return g2()
 
         if testcase == "task":
             m.expand(x=t.override(task_id="t1")(), y=t.override(task_id="t2")())
         else:
-            g.expand(x=t.override(task_id="t1")(), y=t.override(task_id="t2")())
+            g1.expand(x=t.override(task_id="t1")(), y=t.override(task_id="t2")())
 
-    mapped_task = "m" if testcase == "task" else "g.m"
+    mapped_task = "m" if testcase == "task" else "g1.g2.m"
 
     dr: DagRun = dag_maker.create_dagrun()
     tis = {ti.task_id: ti for ti in dr.get_task_instances(session=session)}

--- a/tests/ti_deps/deps/test_mapped_task_upstream_dep.py
+++ b/tests/ti_deps/deps/test_mapped_task_upstream_dep.py
@@ -317,7 +317,7 @@ def test_nested_mapped_task_groups(dag_maker, session: Session):
     # Add a test once nested mapped task groups become supported
     with pytest.raises(NotImplementedError) as ctx:
         dag_maker.create_dagrun()
-    assert str(ctx.value) == "operator expansion in an expanded task group is not yet supported"
+    assert str(ctx.value) == ""
 
 
 def test_mapped_in_mapped_task_group(dag_maker, session: Session):


### PR DESCRIPTION
This closes #37091.

In particular, dynamically mapped tasks currently show as `failed_upstream` instead of `skipped` if some of the tasks that generate the mapping are skipped and the trigger rule is `none_failed`, `all_done` or similar.

This is because when trying to expand the mapped task, a failed and skipped mapped dependency behave identically and both result in a NotFullyPopulated being raised.

This PR introduces a new task instance dependency that sets a dynamically mapped task to `skipped` if any of the mapped dependencies are skipped (but not failed) and to `upstream_failed` if any of the mapped dependencies are failed. As such, an expansion of the mapped task is never attempted.

Before (from #37091):
![image](https://github.com/apache/airflow/assets/53116297/64db4f98-9661-452f-8fac-11dc3e90f8e8)

After:
![image](https://github.com/apache/airflow/assets/53116297/194d8cd2-c323-4c40-b58f-7c45502ca7bc)
