### PR TITLE
Distribute CI/PROD regular builds among multiple workers

### DIFF
--- a/.github/actions/build-ci-images/action.yml
+++ b/.github/actions/build-ci-images/action.yml
@@ -18,6 +18,10 @@
 ---
 name: 'Build CI images'
 description: 'Build CI images'
+inputs:
+  python-version:
+    description: 'Python version to use'
+    required: true
 runs:
   using: "composite"
   steps:
@@ -29,18 +33,20 @@ runs:
         pip install rich>=12.4.4 pyyaml
         python scripts/ci/pre_commit/pre_commit_update_providers_dependencies.py
       if: env.UPGRADE_TO_NEWER_DEPENDENCIES != 'false'
-    - name: "Build & Push AMD64 CI images ${{ env.IMAGE_TAG }} ${{ env.PYTHON_VERSIONS }}"
-      shell: bash
-      run: breeze ci-image build --push --tag-as-latest --run-in-parallel --upgrade-on-failure
-    - name: "Source constraints"
+    - name: "Build & Push AMD64 CI images ${{ env.IMAGE_TAG }} ${{ inputs.python-version }}"
       shell: bash
       run: >
-        breeze release-management generate-constraints --run-in-parallel
+        breeze ci-image build --push --tag-as-latest --upgrade-on-failure
+        --python "${{ inputs.python-version }}"
+    - name: "Source constraints: ${{ inputs.python-version }}"
+      shell: bash
+      run: >
+        breeze release-management generate-constraints --python "${{ inputs.python-version }}"
         --airflow-constraints-mode constraints-source-providers
     - name: "Upload constraint artifacts"
       uses: actions/upload-artifact@v4
       with:
-        name: source-constraints
-        path: ./files/constraints-*/constraints-*.txt
+        name: source-constraints-${{ inputs.python-version }}
+        path: ./files/constraints-*/constraints-source-providers-*.txt
         retention-days: 7
         if-no-files-found: error

--- a/.github/actions/build-prod-images/action.yml
+++ b/.github/actions/build-prod-images/action.yml
@@ -19,6 +19,9 @@
 name: 'Build PROD images'
 description: 'Build PROD images'
 inputs:
+  python-version:
+    description: 'Python versions to use'
+    required: true
   build-provider-packages:
     description: 'Whether to build provider packages from sources'
     required: true
@@ -64,7 +67,7 @@ runs:
     - name: "Download constraints from the CI build"
       uses: actions/download-artifact@v4
       with:
-        name: source-constraints
+        name: source-constraints-${{ inputs.python-version }}
         path: ./docker-context-files
       if: ${{ inputs.build-provider-packages == 'true' }}
     - name: "Download constraints from the Generate & Verify build"
@@ -73,21 +76,21 @@ runs:
         name: constraints
         path: ./docker-context-files
       if: ${{ inputs.build-provider-packages != 'true' }}
-    - name: "Build & Push PROD images with source providers ${{ env.IMAGE_TAG }}:${{ env.PYTHON_VERSIONS }}"
+    - name: "Build & Push PROD images w/ source providers ${{ inputs.python-version }}:${{ env.IMAGE_TAG }}"
       shell: bash
       run: >
-        breeze prod-image build --tag-as-latest --run-in-parallel --push
+        breeze prod-image build --tag-as-latest --push
         --install-packages-from-context --airflow-constraints-mode constraints-source-providers
-        --use-constraints-for-context-packages
+        --use-constraints-for-context-packages --python "${{ inputs.python-version }}"
       env:
         COMMIT_SHA: ${{ github.sha }}
       if: ${{ inputs.build-provider-packages == 'true' }}
-    - name: "Build & Push PROD images with PyPi providers ${{ env.IMAGE_TAG }}:${{ env.PYTHON_VERSIONS }}"
+    - name: "Build & Push PROD images with PyPi providers ${{ inputs.python-version }}:${{ env.IMAGE_TAG }}"
       shell: bash
       run: >
-        breeze prod-image build --tag-as-latest --run-in-parallel --push
+        breeze prod-image build --tag-as-latest --push
         --install-packages-from-context --airflow-constraints-mode constraints
-        --use-constraints-for-context-packages
+        --use-constraints-for-context-packages --python "${{ inputs.python-version }}"
       env:
         COMMIT_SHA: ${{ github.sha }}
       if: ${{ inputs.build-provider-packages != 'true' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -60,7 +60,7 @@ jobs:
     env:
       TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
     outputs:
-      python-versions: "${{ steps.selective-checks.python-versions }}"
+      python-versions: ${{ steps.selective-checks.outputs.python-versions }}
       upgrade-to-newer-dependencies: ${{ steps.selective-checks.outputs.upgrade-to-newer-dependencies }}
       all-python-versions-list-as-string: >-
         ${{ steps.selective-checks.outputs.all-python-versions-list-as-string }}
@@ -160,13 +160,16 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
   build-ci-images:
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ${{fromJson(needs.build-info.outputs.python-versions)}}
     permissions:
       contents: read
       packages: write
     timeout-minutes: 80
-    name: >
-      Build CI images ${{needs.build-info.outputs.all-python-versions-list-as-string}}
-    runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
+    name: Build CI image ${{ matrix.python-version }}
+    runs-on: ["ubuntu-22.04"]
     needs: [build-info]
     if: |
       needs.build-info.outputs.ci-image-build == 'true' &&
@@ -222,9 +225,10 @@ jobs:
       #  BE RUN SAFELY AS PART OF DOCKER BUILD. BECAUSE IT RUNS INSIDE THE DOCKER CONTAINER AND IT IS
       #  ISOLATED FROM THE RUNNER.
       ####################################################################################################
-      - name: >
-          Build CI Images ${{needs.build-info.outputs.all-python-versions-list-as-string}}:${{env.IMAGE_TAG}}
+      - name: Build CI Image ${{ matrix.python-version }}:${{env.IMAGE_TAG}}
         uses: ./.github/actions/build-ci-images
+        with:
+          python-version: ${{ matrix.python-version }}
         env:
           UPGRADE_TO_NEWER_DEPENDENCIES: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
           DOCKER_CACHE: ${{ needs.build-info.outputs.cache-directive }}
@@ -233,14 +237,16 @@ jobs:
           BUILD_TIMEOUT_MINUTES: 70
 
   build-prod-images:
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ${{fromJson(needs.build-info.outputs.python-versions)}}
     permissions:
       contents: read
       packages: write
     timeout-minutes: 80
-    name: >
-      Build PROD images
-      ${{needs.build-info.outputs.all-python-versions-list-as-string}}
-    runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
+    name: Build PROD image ${{ matrix.python-version }}
+    runs-on: ["ubuntu-22.04"]
     needs: [build-info, build-ci-images]
     if: |
       needs.build-info.outputs.prod-image-build == 'true' &&
@@ -301,13 +307,12 @@ jobs:
         uses: ./.github/actions/breeze
         with:
           python-version: ${{ env.REPRODUCIBLE_PYTHON_VERSION }}
-      - name: >
-          Build PROD Images
-          ${{needs.build-info.outputs.all-python-versions-list-as-string}}:${{env.IMAGE_TAG}}
+      - name: Build PROD Image ${{ matrix.python-version }}:${{env.IMAGE_TAG}}
         uses: ./.github/actions/build-prod-images
         with:
           build-provider-packages: ${{ needs.build-info.outputs.default-branch == 'main' }}
           chicken-egg-providers: ${{ needs.build-info.outputs.chicken-egg-providers }}
+          python-version: ${{ matrix.python-version }}
         env:
           UPGRADE_TO_NEWER_DEPENDENCIES: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
           DOCKER_CACHE: ${{ needs.build-info.outputs.cache-directive }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     # option but to specify a hard-coded list here. This is "safe", the
     # runner checks if the user is an owner or collaborator of the repo
     # before running the workflow.
-    runs-on: "ubuntu-22.04"
+    runs-on: ["ubuntu-22.04"]
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     outputs:
@@ -267,11 +267,13 @@ jobs:
         run: breeze shell --max-time 120
 
   build-ci-images:
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ${{fromJson(needs.build-info.outputs.python-versions)}}
     timeout-minutes: 80
-    name: >-
-      ${{needs.build-info.outputs.build-job-description}} CI images
-      ${{needs.build-info.outputs.all-python-versions-list-as-string}}
-    runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
+    name: ${{needs.build-info.outputs.build-job-description}} CI image ${{ matrix.python-version }}
+    runs-on: ["ubuntu-22.04"]
     needs: [build-info]
     env:
       DEFAULT_BRANCH: ${{ needs.build-info.outputs.default-branch }}
@@ -289,19 +291,19 @@ jobs:
           ref: ${{ needs.build-info.outputs.targetCommitSha }}
           persist-credentials: false
         if: needs.build-info.outputs.in-workflow-build == 'true'
-      - name: >
-          Build CI Images
-          ${{needs.build-info.outputs.all-python-versions-list-as-string}}:${{env.IMAGE_TAG}}
+      - name: Build CI Images ${{ matrix.python-version }}:${{env.IMAGE_TAG}}
         uses: ./.github/actions/build-ci-images
         if: needs.build-info.outputs.in-workflow-build == 'true'
+        with:
+          python-version: ${{ matrix.python-version }}
         env:
           UPGRADE_TO_NEWER_DEPENDENCIES: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
           DOCKER_CACHE: ${{ needs.build-info.outputs.cache-directive }}
           PYTHON_VERSIONS: ${{needs.build-info.outputs.all-python-versions-list-as-string}}
           DEBUG_RESOURCES: ${{needs.build-info.outputs.debug-resources}}
           BUILD_TIMEOUT_MINUTES: 70
-      - name: Verify CI images ${{ env.PYTHON_VERSIONS }}:${{ env.IMAGE_TAG }}
-        run: breeze ci-image verify --run-in-parallel
+      - name: Verify CI images ${{ matrix.python-version }}:${{ env.IMAGE_TAG }}
+        run: breeze ci-image verify --python ${{ matrix.python-version }}
         env:
           PYTHON_VERSIONS: ${{needs.build-info.outputs.all-python-versions-list-as-string}}
           DEBUG_RESOURCES: ${{needs.build-info.outputs.debug-resources}}
@@ -449,7 +451,7 @@ jobs:
   wait-for-ci-images:
     timeout-minutes: 120
     name: "Wait for CI images"
-    runs-on: "ubuntu-22.04"
+    runs-on: ["ubuntu-22.04"]
     needs: [build-info, build-ci-images]
     if: needs.build-info.outputs.ci-image-build == 'true'
     env:
@@ -1840,11 +1842,12 @@ jobs:
           echo Total number of unique warnings $(cat ./artifacts/test-warnings*/* | sort | uniq | wc -l)
 
   build-prod-images:
+    strategy:
+      matrix:
+        python-version: ${{fromJson(needs.build-info.outputs.python-versions)}}
     timeout-minutes: 80
-    name: >
-      ${{needs.build-info.outputs.build-job-description}} PROD images (main)
-      ${{needs.build-info.outputs.all-python-versions-list-as-string}}
-    runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
+    name: ${{needs.build-info.outputs.build-job-description}} PROD image (main) ${{matrix.python-version}}
+    runs-on: ["ubuntu-22.04"]
     needs: [build-info, build-ci-images]
     env:
       DEFAULT_BRANCH: ${{ needs.build-info.outputs.default-branch }}
@@ -1853,8 +1856,6 @@ jobs:
       BACKEND: sqlite
       VERSION_SUFFIX_FOR_PYPI: "dev0"
       DEBUG_RESOURCES: ${{needs.build-info.outputs.debug-resources}}
-      # Force more parallelism for build even on public images
-      PARALLELISM: 6
     steps:
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
@@ -1875,9 +1876,7 @@ jobs:
         if: >
           needs.build-info.outputs.in-workflow-build == 'true' &&
           needs.build-info.outputs.default-branch == 'main'
-      - name: >
-          Build PROD Images
-          ${{needs.build-info.outputs.all-python-versions-list-as-string}}:${{env.IMAGE_TAG}}
+      - name: Build PROD Image ${{ matrix.python-version }}:${{env.IMAGE_TAG}}
         uses: ./.github/actions/build-prod-images
         if: >
           needs.build-info.outputs.in-workflow-build == 'true' &&
@@ -1885,6 +1884,7 @@ jobs:
         with:
           build-provider-packages: ${{ needs.build-info.outputs.default-branch == 'main' }}
           chicken-egg-providers: ${{ needs.build-info.outputs.chicken-egg-providers }}
+          python-version: ${{ matrix.python-version }}
         env:
           UPGRADE_TO_NEWER_DEPENDENCIES: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
           DOCKER_CACHE: ${{ needs.build-info.outputs.cache-directive }}
@@ -1892,11 +1892,12 @@ jobs:
           DEBUG_RESOURCES: ${{ needs.build-info.outputs.debug-resources }}
 
   build-prod-images-bullseye:
+    strategy:
+      matrix:
+        python-version: ${{fromJson(needs.build-info.outputs.python-versions)}}
     timeout-minutes: 80
-    name: >
-      Build Bullseye PROD images (main)
-      ${{needs.build-info.outputs.all-python-versions-list-as-string}}
-    runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
+    name: Build Bullseye PROD image (main) ${{matrix.python-version}}
+    runs-on: ["ubuntu-22.04"]
     needs: [build-info, build-ci-images]
     if: needs.build-info.outputs.canary-run == 'true'
     env:
@@ -1906,8 +1907,6 @@ jobs:
       BACKEND: sqlite
       VERSION_SUFFIX_FOR_PYPI: "dev0"
       DEBUG_RESOURCES: ${{needs.build-info.outputs.debug-resources}}
-      # Force more parallelism for build even on public images
-      PARALLELISM: 6
     steps:
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
@@ -1929,9 +1928,7 @@ jobs:
         if: >
           needs.build-info.outputs.in-workflow-build == 'true' &&
           needs.build-info.outputs.default-branch == 'main'
-      - name: >
-          Build Bullseye PROD Images
-          ${{needs.build-info.outputs.all-python-versions-list-as-string}}:${{env.IMAGE_TAG}}
+      - name: Build Bullseye PROD Image ${{ matrix.python-version }}:${{env.IMAGE_TAG}}
         uses: ./.github/actions/build-prod-images
         if: >
           needs.build-info.outputs.in-workflow-build == 'true' &&
@@ -1939,6 +1936,7 @@ jobs:
         with:
           build-provider-packages: ${{ needs.build-info.outputs.default-branch == 'main' }}
           chicken-egg-providers: ${{ needs.build-info.outputs.chicken-egg-providers }}
+          python-version: ${{ matrix.python-version }}
         env:
           UPGRADE_TO_NEWER_DEPENDENCIES: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
           DOCKER_CACHE: ${{ needs.build-info.outputs.cache-directive }}
@@ -1950,11 +1948,12 @@ jobs:
           IMAGE_TAG: "bullseye-${{ github.event.pull_request.head.sha || github.sha }}"
 
   build-prod-images-mysql-client:
+    strategy:
+      matrix:
+        python-version: ${{fromJson(needs.build-info.outputs.python-versions)}}
     timeout-minutes: 80
-    name: >
-      Build MySQL Client PROD images (main)
-      ${{needs.build-info.outputs.all-python-versions-list-as-string}}
-    runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
+    name: Build MySQL Client PROD image (main) ${{ matrix.python-version}}
+    runs-on: ["ubuntu-22.04"]
     needs: [build-info, build-ci-images]
     if: needs.build-info.outputs.canary-run == 'true'
     env:
@@ -1964,8 +1963,6 @@ jobs:
       BACKEND: sqlite
       VERSION_SUFFIX_FOR_PYPI: "dev0"
       DEBUG_RESOURCES: ${{needs.build-info.outputs.debug-resources}}
-      # Force more parallelism for build even on public images
-      PARALLELISM: 6
     steps:
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
@@ -1987,9 +1984,7 @@ jobs:
         if: >
           needs.build-info.outputs.in-workflow-build == 'true' &&
           needs.build-info.outputs.default-branch == 'main'
-      - name: >
-          Build MySQL Client PROD Images
-          ${{needs.build-info.outputs.all-python-versions-list-as-string}}:${{env.IMAGE_TAG}}
+      - name: Build MySQL Client PROD Image ${{ matrix.python-version }}:${{env.IMAGE_TAG}}
         uses: ./.github/actions/build-prod-images
         if: >
           needs.build-info.outputs.in-workflow-build == 'true' &&
@@ -1997,6 +1992,7 @@ jobs:
         with:
           build-provider-packages: ${{ needs.build-info.outputs.default-branch == 'main' }}
           chicken-egg-providers: ${{ needs.build-info.outputs.chicken-egg-providers }}
+          python-version: ${{ matrix.python-version }}
         env:
           UPGRADE_TO_NEWER_DEPENDENCIES: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
           DOCKER_CACHE: ${{ needs.build-info.outputs.cache-directive }}
@@ -2009,11 +2005,13 @@ jobs:
 
 
   build-prod-images-release-branch:
+    strategy:
+      matrix:
+        python-version: ${{fromJson(needs.build-info.outputs.python-versions)}}
     timeout-minutes: 80
     name: >
-      ${{needs.build-info.outputs.build-job-description}} PROD images (v2_*_test)
-      ${{needs.build-info.outputs.all-python-versions-list-as-string}}
-    runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
+      ${{needs.build-info.outputs.build-job-description}} PROD image (v2_*_test) ${{matrix.python-version}}
+    runs-on: ["ubuntu-22.04"]
     needs: [build-info, generate-constraints]
     env:
       DEFAULT_BRANCH: ${{ needs.build-info.outputs.default-branch }}
@@ -2022,8 +2020,6 @@ jobs:
       BACKEND: sqlite
       VERSION_SUFFIX_FOR_PYPI: "dev0"
       DEBUG_RESOURCES: ${{needs.build-info.outputs.debug-resources}}
-      # Force more parallelism for build even on public images
-      PARALLELISM: 6
     steps:
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
@@ -2044,9 +2040,7 @@ jobs:
         if: >
           needs.build-info.outputs.in-workflow-build == 'true' &&
           needs.build-info.outputs.default-branch != 'main'
-      - name: >
-          Build PROD Images
-          ${{needs.build-info.outputs.all-python-versions-list-as-string}}:${{env.IMAGE_TAG}}
+      - name: Build Release PROD Image ${{ matrix.python-version }}:${{env.IMAGE_TAG}}
         uses: ./.github/actions/build-prod-images
         if: >
           needs.build-info.outputs.in-workflow-build == 'true' &&
@@ -2054,6 +2048,7 @@ jobs:
         with:
           build-provider-packages: ${{ needs.build-info.outputs.default-branch == 'main' }}
           chicken-egg-providers: ${{ needs.build-info.outputs.chicken-egg-providers }}
+          python-version: ${{ matrix.python-version }}
         env:
           UPGRADE_TO_NEWER_DEPENDENCIES: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
           DOCKER_CACHE: ${{ needs.build-info.outputs.cache-directive }}
@@ -2061,11 +2056,12 @@ jobs:
           DEBUG_RESOURCES: ${{ needs.build-info.outputs.debug-resources }}
 
   build-prod-images-bullseye-release-branch:
+    strategy:
+      matrix:
+        python-version: ${{fromJson(needs.build-info.outputs.python-versions)}}
     timeout-minutes: 80
-    name: >
-      Build Bullseye PROD images (v2_*_test)
-      ${{needs.build-info.outputs.all-python-versions-list-as-string}}
-    runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
+    name: Build Bullseye PROD image (v2_*_test) ${{matrix.python-version}}
+    runs-on: ["ubuntu-22.04"]
     needs: [build-info, generate-constraints]
     if: needs.build-info.outputs.canary-run == 'true'
     env:
@@ -2075,8 +2071,6 @@ jobs:
       BACKEND: sqlite
       VERSION_SUFFIX_FOR_PYPI: "dev0"
       DEBUG_RESOURCES: ${{needs.build-info.outputs.debug-resources}}
-      # Force more parallelism for build even on public images
-      PARALLELISM: 6
     steps:
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
@@ -2098,9 +2092,7 @@ jobs:
         if: >
           needs.build-info.outputs.in-workflow-build == 'true' &&
           needs.build-info.outputs.default-branch != 'main'
-      - name: >
-          Build Bullseye PROD Images
-          ${{needs.build-info.outputs.all-python-versions-list-as-string}}:${{env.IMAGE_TAG}}
+      - name: Build Bullseye Release PROD Image ${{ matrix.python-version }}:${{env.IMAGE_TAG}}
         uses: ./.github/actions/build-prod-images
         if: >
           needs.build-info.outputs.in-workflow-build == 'true' &&
@@ -2108,6 +2100,7 @@ jobs:
         with:
           build-provider-packages: ${{ needs.build-info.outputs.default-branch == 'main' }}
           chicken-egg-providers: ${{ needs.build-info.outputs.chicken-egg-providers }}
+          python-version: ${{ matrix.python-version }}
         env:
           UPGRADE_TO_NEWER_DEPENDENCIES: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
           DOCKER_CACHE: ${{ needs.build-info.outputs.cache-directive }}
@@ -2119,11 +2112,12 @@ jobs:
           IMAGE_TAG: "bullseye-${{ github.event.pull_request.head.sha || github.sha }}"
 
   build-prod-images-mysql-release-branch:
+    strategy:
+      matrix:
+        python-version: ${{fromJson(needs.build-info.outputs.python-versions)}}
     timeout-minutes: 80
-    name: >
-      Build MySQL PROD images (v2_*_test)
-      ${{needs.build-info.outputs.all-python-versions-list-as-string}}
-    runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
+    name: Build MySQL PROD image (v2_*_test) ${{matrix.python-version}}
+    runs-on: ["ubuntu-22.04"]
     needs: [build-info, generate-constraints]
     if: needs.build-info.outputs.canary-run == 'true'
     env:
@@ -2133,8 +2127,6 @@ jobs:
       BACKEND: sqlite
       VERSION_SUFFIX_FOR_PYPI: "dev0"
       DEBUG_RESOURCES: ${{needs.build-info.outputs.debug-resources}}
-      # Force more parallelism for build even on public images
-      PARALLELISM: 6
     steps:
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
@@ -2156,9 +2148,7 @@ jobs:
         if: >
           needs.build-info.outputs.in-workflow-build == 'true' &&
           needs.build-info.outputs.default-branch != 'main'
-      - name: >
-          Build Bullseye PROD Images
-          ${{needs.build-info.outputs.all-python-versions-list-as-string}}:${{env.IMAGE_TAG}}
+      - name: Build Mysql PROD Image ${{matrix.python-version}}:${{env.IMAGE_TAG}}
         uses: ./.github/actions/build-prod-images
         if: >
           needs.build-info.outputs.in-workflow-build == 'true' &&
@@ -2166,6 +2156,7 @@ jobs:
         with:
           build-provider-packages: ${{ needs.build-info.outputs.default-branch == 'main' }}
           chicken-egg-providers: ${{ needs.build-info.outputs.chicken-egg-providers }}
+          python-version: ${{ matrix.python-version }}
         env:
           UPGRADE_TO_NEWER_DEPENDENCIES: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
           DOCKER_CACHE: ${{ needs.build-info.outputs.cache-directive }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   selective-checks:
     name: Selective checks
-    runs-on: "ubuntu-22.04"
+    runs-on: ["ubuntu-22.04"]
     outputs:
       needs-python-scans: ${{ steps.selective-checks.outputs.needs-python-scans }}
       needs-javascript-scans: ${{ steps.selective-checks.outputs.needs-javascript-scans }}
@@ -54,7 +54,7 @@ jobs:
 
   analyze:
     name: Analyze
-    runs-on: "ubuntu-22.04"
+    runs-on: ["ubuntu-22.04"]
     needs: [selective-checks]
     strategy:
       fail-fast: false

--- a/.github/workflows/recheck-old-bug-report.yml
+++ b/.github/workflows/recheck-old-bug-report.yml
@@ -26,7 +26,7 @@ permissions:
   issues: write
 jobs:
   recheck-old-bug-report:
-    runs-on: "ubuntu-22.04"
+    runs-on: ["ubuntu-22.04"]
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,7 +27,7 @@ permissions:
   issues: write
 jobs:
   stale:
-    runs-on: "ubuntu-22.04"
+    runs-on: ["ubuntu-22.04"]
     steps:
       - uses: actions/stale@v9
         with:


### PR DESCRIPTION
Seems that Public GitHub runners started to run out of space for our parallell builds. Buid parallelisation has been done in order to make a good use of small number of runners available, However since we have many runners available from Apache Software Foundation, we can easily just have one image per worker now without risking unnecessary queuing because there is no worker available.

This way each build is separate and requires less disk space to complete the build.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
