### PR TITLE
Fix 'implicitly coercing SELECT object to scalar subquery' in latest dag run statement

### DIFF
--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -24,6 +24,7 @@ import os
 import pickle
 import re
 import sys
+import warnings
 import weakref
 from contextlib import redirect_stdout
 from datetime import timedelta
@@ -39,6 +40,7 @@ import time_machine
 from dateutil.relativedelta import relativedelta
 from pendulum.tz.timezone import Timezone
 from sqlalchemy import inspect
+from sqlalchemy.exc import SAWarning
 
 from airflow import settings
 from airflow.configuration import conf
@@ -4148,34 +4150,40 @@ class TestTaskClearingSetupTeardownBehavior:
                 dag.validate_setup_teardown()
 
 
-def test_get_latest_runs_query_one_dag(dag_maker, session):
-    with dag_maker(dag_id="dag1") as dag1:
-        ...
-    query = DAG._get_latest_runs_query(dags=[dag1.dag_id])
-    actual = [x.strip() for x in str(query.compile()).splitlines()]
-    expected = [
-        "SELECT dag_run.id, dag_run.dag_id, dag_run.execution_date, dag_run.data_interval_start, dag_run.data_interval_end",
-        "FROM dag_run",
-        "WHERE dag_run.dag_id = :dag_id_1 AND dag_run.execution_date = (SELECT max(dag_run.execution_date) AS max_execution_date",
-        "FROM dag_run",
-        "WHERE dag_run.dag_id = :dag_id_2 AND dag_run.run_type IN (__[POSTCOMPILE_run_type_1]))",
-    ]
-    assert actual == expected
+def test_statement_latest_runs_one_dag(dag_maker, session):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=SAWarning)
+
+        with dag_maker(dag_id="dag1") as dag1:
+            ...
+        query = DAG._get_latest_runs_stmt(dags=[dag1.dag_id])
+        actual = [x.strip() for x in str(query.compile()).splitlines()]
+        expected = [
+            "SELECT dag_run.id, dag_run.dag_id, dag_run.execution_date, dag_run.data_interval_start, dag_run.data_interval_end",
+            "FROM dag_run",
+            "WHERE dag_run.dag_id = :dag_id_1 AND dag_run.execution_date = (SELECT max(dag_run.execution_date) AS max_execution_date",
+            "FROM dag_run",
+            "WHERE dag_run.dag_id = :dag_id_2 AND dag_run.run_type IN (__[POSTCOMPILE_run_type_1]))",
+        ]
+        assert actual == expected
 
 
-def test_get_latest_runs_query_two_dags(dag_maker, session):
-    with dag_maker(dag_id="dag1") as dag1:
-        ...
-    with dag_maker(dag_id="dag2") as dag2:
-        ...
-    query = DAG._get_latest_runs_query(dags=[dag1.dag_id, dag2.dag_id])
-    actual = [x.strip() for x in str(query.compile()).splitlines()]
-    print("\n".join(actual))
-    expected = [
-        "SELECT dag_run.id, dag_run.dag_id, dag_run.execution_date, dag_run.data_interval_start, dag_run.data_interval_end",
-        "FROM dag_run, (SELECT dag_run.dag_id AS dag_id, max(dag_run.execution_date) AS max_execution_date",
-        "FROM dag_run",
-        "WHERE dag_run.dag_id IN (__[POSTCOMPILE_dag_id_1]) AND dag_run.run_type IN (__[POSTCOMPILE_run_type_1]) GROUP BY dag_run.dag_id) AS anon_1",
-        "WHERE dag_run.dag_id = anon_1.dag_id AND dag_run.execution_date = anon_1.max_execution_date",
-    ]
-    assert actual == expected
+def test_statement_latest_runs_many_dag(dag_maker, session):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=SAWarning)
+
+        with dag_maker(dag_id="dag1") as dag1:
+            ...
+        with dag_maker(dag_id="dag2") as dag2:
+            ...
+        query = DAG._get_latest_runs_stmt(dags=[dag1.dag_id, dag2.dag_id])
+        actual = [x.strip() for x in str(query.compile()).splitlines()]
+        print("\n".join(actual))
+        expected = [
+            "SELECT dag_run.id, dag_run.dag_id, dag_run.execution_date, dag_run.data_interval_start, dag_run.data_interval_end",
+            "FROM dag_run, (SELECT dag_run.dag_id AS dag_id, max(dag_run.execution_date) AS max_execution_date",
+            "FROM dag_run",
+            "WHERE dag_run.dag_id IN (__[POSTCOMPILE_dag_id_1]) AND dag_run.run_type IN (__[POSTCOMPILE_run_type_1]) GROUP BY dag_run.dag_id) AS anon_1",
+            "WHERE dag_run.dag_id = anon_1.dag_id AND dag_run.execution_date = anon_1.max_execution_date",
+        ]
+        assert actual == expected

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -4178,7 +4178,6 @@ def test_statement_latest_runs_many_dag(dag_maker, session):
             ...
         query = DAG._get_latest_runs_stmt(dags=[dag1.dag_id, dag2.dag_id])
         actual = [x.strip() for x in str(query.compile()).splitlines()]
-        print("\n".join(actual))
         expected = [
             "SELECT dag_run.id, dag_run.dag_id, dag_run.execution_date, dag_run.data_interval_start, dag_run.data_interval_end",
             "FROM dag_run, (SELECT dag_run.dag_id AS dag_id, max(dag_run.execution_date) AS max_execution_date",

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -4154,8 +4154,9 @@ def test_statement_latest_runs_one_dag():
     with warnings.catch_warnings():
         warnings.simplefilter("error", category=SAWarning)
 
-        query = DAG._get_latest_runs_stmt(dags=["fake-dag"])
-        actual = [x.strip() for x in str(query.compile()).splitlines()]
+        stmt = DAG._get_latest_runs_stmt(dags=["fake-dag"])
+        compiled_stmt = str(stmt.compile())
+        actual = [x.strip() for x in compiled_stmt.splitlines()]
         expected = [
             "SELECT dag_run.id, dag_run.dag_id, dag_run.execution_date, dag_run.data_interval_start, dag_run.data_interval_end",
             "FROM dag_run",
@@ -4163,15 +4164,16 @@ def test_statement_latest_runs_one_dag():
             "FROM dag_run",
             "WHERE dag_run.dag_id = :dag_id_2 AND dag_run.run_type IN (__[POSTCOMPILE_run_type_1]))",
         ]
-        assert actual == expected
+        assert actual == expected, compiled_stmt
 
 
 def test_statement_latest_runs_many_dag():
     with warnings.catch_warnings():
         warnings.simplefilter("error", category=SAWarning)
 
-        query = DAG._get_latest_runs_stmt(dags=["fake-dag-1", "fake-dag-2"])
-        actual = [x.strip() for x in str(query.compile()).splitlines()]
+        stmt = DAG._get_latest_runs_stmt(dags=["fake-dag-1", "fake-dag-2"])
+        compiled_stmt = str(stmt.compile())
+        actual = [x.strip() for x in compiled_stmt.splitlines()]
         expected = [
             "SELECT dag_run.id, dag_run.dag_id, dag_run.execution_date, dag_run.data_interval_start, dag_run.data_interval_end",
             "FROM dag_run, (SELECT dag_run.dag_id AS dag_id, max(dag_run.execution_date) AS max_execution_date",
@@ -4179,4 +4181,4 @@ def test_statement_latest_runs_many_dag():
             "WHERE dag_run.dag_id IN (__[POSTCOMPILE_dag_id_1]) AND dag_run.run_type IN (__[POSTCOMPILE_run_type_1]) GROUP BY dag_run.dag_id) AS anon_1",
             "WHERE dag_run.dag_id = anon_1.dag_id AND dag_run.execution_date = anon_1.max_execution_date",
         ]
-        assert actual == expected
+        assert actual == expected, compiled_stmt

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -4150,13 +4150,11 @@ class TestTaskClearingSetupTeardownBehavior:
                 dag.validate_setup_teardown()
 
 
-def test_statement_latest_runs_one_dag(dag_maker, session):
+def test_statement_latest_runs_one_dag():
     with warnings.catch_warnings():
         warnings.simplefilter("error", category=SAWarning)
 
-        with dag_maker(dag_id="dag1") as dag1:
-            ...
-        query = DAG._get_latest_runs_stmt(dags=[dag1.dag_id])
+        query = DAG._get_latest_runs_stmt(dags=["fake-dag"])
         actual = [x.strip() for x in str(query.compile()).splitlines()]
         expected = [
             "SELECT dag_run.id, dag_run.dag_id, dag_run.execution_date, dag_run.data_interval_start, dag_run.data_interval_end",
@@ -4168,15 +4166,11 @@ def test_statement_latest_runs_one_dag(dag_maker, session):
         assert actual == expected
 
 
-def test_statement_latest_runs_many_dag(dag_maker, session):
+def test_statement_latest_runs_many_dag():
     with warnings.catch_warnings():
         warnings.simplefilter("error", category=SAWarning)
 
-        with dag_maker(dag_id="dag1") as dag1:
-            ...
-        with dag_maker(dag_id="dag2") as dag2:
-            ...
-        query = DAG._get_latest_runs_stmt(dags=[dag1.dag_id, dag2.dag_id])
+        query = DAG._get_latest_runs_stmt(dags=["fake-dag-1", "fake-dag-2"])
         actual = [x.strip() for x in str(query.compile()).splitlines()]
         expected = [
             "SELECT dag_run.id, dag_run.dag_id, dag_run.execution_date, dag_run.data_interval_start, dag_run.data_interval_end",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Resolve SQAlchemy warning in case if statement generated for the single dag_id
 
```console
sqlalchemy.exc.SAWarning: implicitly coercing SELECT object to scalar subquery; please use the .scalar_subquery() method to produce a scalar subquery.
```

In addition change type annotation from `Query` to the `Select` which provided and rename method from query to stmt (statement). Legacy Query API provide a bit different interface rather than statement-based

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
