### PR TITLE
Enable the 'Is Active?' flag by default in user view

### DIFF
--- a/airflow/providers/fab/auth_manager/models/__init__.py
+++ b/airflow/providers/fab/auth_manager/models/__init__.py
@@ -152,7 +152,7 @@ class User(Model, BaseUser):
         String(512).with_variant(String(512, collation="NOCASE"), "sqlite"), unique=True, nullable=False
     )
     password = Column(String(256))
-    active = Column(Boolean)
+    active = Column(Boolean, default=True)
     email = Column(String(512), unique=True, nullable=False)
     last_login = Column(DateTime)
     login_count = Column(Integer)

--- a/tests/providers/fab/auth_manager/api_endpoints/test_user_endpoint.py
+++ b/tests/providers/fab/auth_manager/api_endpoints/test_user_endpoint.py
@@ -83,6 +83,7 @@ class TestUserEndpoint:
                 roles=roles or [],
                 created_on=timezone.parse(DEFAULT_TIME),
                 changed_on=timezone.parse(DEFAULT_TIME),
+                active=True,
             )
             for i in range(1, count + 1)
         ]
@@ -96,7 +97,7 @@ class TestGetUser(TestUserEndpoint):
         response = self.client.get("/auth/fab/v1/users/TEST_USER1", environ_overrides={"REMOTE_USER": "test"})
         assert response.status_code == 200
         assert response.json == {
-            "active": None,
+            "active": True,
             "changed_on": DEFAULT_TIME,
             "created_on": DEFAULT_TIME,
             "email": "mytest@test1.org",
@@ -124,7 +125,7 @@ class TestGetUser(TestUserEndpoint):
         response = self.client.get("/auth/fab/v1/users/prince", environ_overrides={"REMOTE_USER": "test"})
         assert response.status_code == 200
         assert response.json == {
-            "active": None,
+            "active": True,
             "changed_on": DEFAULT_TIME,
             "created_on": DEFAULT_TIME,
             "email": "prince@example.org",
@@ -152,7 +153,7 @@ class TestGetUser(TestUserEndpoint):
         response = self.client.get("/auth/fab/v1/users/liberace", environ_overrides={"REMOTE_USER": "test"})
         assert response.status_code == 200
         assert response.json == {
-            "active": None,
+            "active": True,
             "changed_on": DEFAULT_TIME,
             "created_on": DEFAULT_TIME,
             "email": "liberace@example.org",
@@ -180,7 +181,7 @@ class TestGetUser(TestUserEndpoint):
         response = self.client.get("/auth/fab/v1/users/nameless", environ_overrides={"REMOTE_USER": "test"})
         assert response.status_code == 200
         assert response.json == {
-            "active": None,
+            "active": True,
             "changed_on": DEFAULT_TIME,
             "created_on": DEFAULT_TIME,
             "email": "nameless@example.org",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

While personally creating an user from the UI, I personally find it inconvenient to tick the checkbox for `Is Active?`
It would be nice to have this enabled by default so that users do not run into cases where they miss it


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
