### PR TITLE
Fix KeyError when KPO exits too soon

### DIFF
--- a/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -245,7 +245,12 @@ class KubernetesPodTrigger(BaseTrigger):
                 )
             elif container_state == ContainerState.FAILED:
                 return TriggerEvent(
-                    {"status": "failed", "namespace": self.pod_namespace, "name": self.pod_name}
+                    {
+                        "status": "failed",
+                        "namespace": self.pod_namespace,
+                        "name": self.pod_name,
+                        "message": "Container state failed",
+                    }
                 )
             if time_get_more_logs and datetime.datetime.now(tz=datetime.timezone.utc) > time_get_more_logs:
                 return TriggerEvent(

--- a/tests/providers/cncf/kubernetes/triggers/test_pod.py
+++ b/tests/providers/cncf/kubernetes/triggers/test_pod.py
@@ -182,7 +182,14 @@ class TestKubernetesPodTrigger:
         )
         mock_method.return_value = ContainerState.FAILED
 
-        expected_event = TriggerEvent({"status": "failed", "namespace": "default", "name": "test-pod-name"})
+        expected_event = TriggerEvent(
+            {
+                "status": "failed",
+                "namespace": "default",
+                "name": "test-pod-name",
+                "message": "Container state failed",
+            }
+        )
         actual_event = await trigger.run().asend(None)
 
         assert actual_event == expected_event


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

On occasions where the pod terminates quickly on pod failure, instead of an AirflowException being raised, we see a KeyError exception:

```
2024-02-17, 08:35:59 EST] {base.py:83} INFO - Using connection ID 'google_cloud_default' for task execution.
[2024-02-17, 08:35:59 EST] {credentials_provider.py:353} INFO - Getting connection using `google.auth.default()` since no explicit credentials are provided.
[2024-02-17, 08:36:00 EST] {pod_manager.py:798} INFO - Running command... if [ -s /***/xcom/return.json ]; then cat /***/xcom/return.json; else echo __***_xcom_result_empty__; fi
[2024-02-17, 08:36:00 EST] {pod_manager.py:798} INFO - Running command... kill -s SIGINT 1
[2024-02-17, 08:36:00 EST] {pod.py:559} INFO - xcom result file is empty.
[2024-02-17, 08:36:00 EST] {pod.py:709} INFO - Got event: {'status': 'failed', 'namespace': '***-default', 'name': 'fail-quzr387j'}
[2024-02-17, 08:36:00 EST] {pod.py:773} INFO - Container logs: + sleep 2
[2024-02-17, 08:36:00 EST] {pod.py:773} INFO - Container logs: + exit 1
[2024-02-17, 08:36:00 EST] {pod.py:773} INFO - Container logs: 
[2024-02-17, 08:36:00 EST] {pod_manager.py:616} INFO - Pod fail-quzr387j has phase Running
[2024-02-17, 08:36:03 EST] {pod.py:907} INFO - Skipping deleting pod: fail-quzr387j
[2024-02-17, 08:36:03 EST] {taskinstance.py:2751} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/opt/airflow/airflow/providers/cncf/kubernetes/operators/pod.py", line 711, in trigger_reentry
    message = event.get("stack_trace", event["message"])
KeyError: 'message'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/opt/airflow/airflow/models/taskinstance.py", line 446, in _execute_task
    result = _execute_callable(context=context, **execute_callable_kwargs)
  File "/opt/airflow/airflow/models/taskinstance.py", line 416, in _execute_callable
    return execute_callable(context=context, **execute_callable_kwargs)
  File "/opt/airflow/airflow/models/baseoperator.py", line 1623, in resume_execution
    return execute_callable(context)
  File "/opt/airflow/airflow/providers/google/cloud/operators/kubernetes_engine.py", line 789, in execute_complete
    return super().execute_complete(context, event, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/deprecated/classic.py", line 285, in wrapper_function
    return wrapped_(*args_, **kwargs_)
  File "/opt/airflow/airflow/providers/cncf/kubernetes/operators/pod.py", line 762, in execute_complete
    self.trigger_reentry(context=context, event=event)
  File "/opt/airflow/airflow/providers/cncf/kubernetes/operators/pod.py", line 740, in trigger_reentry
    self._clean(event)
  File "/opt/airflow/airflow/providers/cncf/kubernetes/operators/pod.py", line 755, in _clean
    self.post_complete_action(
  File "/opt/airflow/airflow/providers/cncf/kubernetes/operators/pod.py", line 783, in post_complete_action
    self.cleanup(
  File "/opt/airflow/airflow/providers/cncf/kubernetes/operators/pod.py", line 834, in cleanup
    raise AirflowException(
airflow.exceptions.AirflowException: Pod fail-quzr387j returned a failure.
```

The reason for this is because this [TriggerEvent payload does not pass a `message` field](https://github.com/apache/airflow/blob/e9730daeee557838bb3029d00c17699afa3e95bb/airflow/providers/cncf/kubernetes/triggers/pod.py#L246-L249) which is expected [here](https://github.com/apache/airflow/blob/e9730daeee557838bb3029d00c17699afa3e95bb/airflow/providers/cncf/kubernetes/operators/pod.py#L710). 

Granted, this is not really a big problem. The [next line](https://github.com/apache/airflow/blob/e9730daeee557838bb3029d00c17699afa3e95bb/airflow/providers/cncf/kubernetes/operators/pod.py#L710-L711) is the raise anyways. It's just a bit confusing to the user.

This fixes the missing message KeyError so that we see the proper exception getting raised:

<img width="1126" alt="image" src="https://github.com/apache/airflow/assets/9200263/e15d4af5-6797-4d7c-bc20-106b767c3abe">


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
