### PR TITLE
Make ImapHook mail body encoding configurable

### DIFF
--- a/airflow/providers/imap/hooks/imap.py
+++ b/airflow/providers/imap/hooks/imap.py
@@ -117,7 +117,13 @@ class ImapHook(BaseHook):
         return mail_client
 
     def has_mail_attachment(
-        self, name: str, *, check_regex: bool = False, mail_folder: str = "INBOX", mail_filter: str = "All", encoding: str = "utf-8"
+        self,
+        name: str,
+        *,
+        check_regex: bool = False,
+        mail_folder: str = "INBOX",
+        mail_filter: str = "All",
+        encoding: str = "utf-8",
     ) -> bool:
         """
         Check the mail folder for mails containing attachments with the given name.
@@ -127,6 +133,7 @@ class ImapHook(BaseHook):
         :param mail_folder: The mail folder where to look at.
         :param mail_filter: If set other than 'All' only specific mails will be checked.
             See :py:meth:`imaplib.IMAP4.search` for details.
+        :param encoding: The encoding used to parse mail body.
         :returns: True if there is an attachment with the given name and False if not.
         """
         mail_attachments = self._retrieve_mails_attachments_by_name(
@@ -143,7 +150,7 @@ class ImapHook(BaseHook):
         mail_folder: str = "INBOX",
         mail_filter: str = "All",
         not_found_mode: str = "raise",
-        encoding: str = "utf-8"
+        encoding: str = "utf-8",
     ) -> list[tuple]:
         """
         Retrieve mail's attachments in the mail folder by its name.
@@ -159,6 +166,7 @@ class ImapHook(BaseHook):
             If it is set to 'raise' it will raise an exception,
             if set to 'warn' it will only print a warning and
             if set to 'ignore' it won't notify you at all.
+        :param encoding: The encoding used to parse mail body.
         :returns: a list of tuple each containing the attachment filename and its payload.
         """
         mail_attachments = self._retrieve_mails_attachments_by_name(
@@ -180,7 +188,7 @@ class ImapHook(BaseHook):
         mail_folder: str = "INBOX",
         mail_filter: str = "All",
         not_found_mode: str = "raise",
-        encoding: str = "utf-8"
+        encoding: str = "utf-8",
     ) -> None:
         """
         Download mail's attachments in the mail folder by its name to the local directory.
@@ -198,6 +206,7 @@ class ImapHook(BaseHook):
             If it is set to 'raise' it will raise an exception,
             if set to 'warn' it will only print a warning and
             if set to 'ignore' it won't notify you at all.
+        :param encoding: The encoding used to parse mail body.
         """
         mail_attachments = self._retrieve_mails_attachments_by_name(
             name, check_regex, latest_only, mail_folder, mail_filter, encoding
@@ -217,7 +226,13 @@ class ImapHook(BaseHook):
             self.log.warning("No mail attachments found!")
 
     def _retrieve_mails_attachments_by_name(
-        self, name: str, check_regex: bool, latest_only: bool, mail_folder: str, mail_filter: str, encoding: str = "utf-8"
+        self,
+        name: str,
+        check_regex: bool,
+        latest_only: bool,
+        mail_folder: str,
+        mail_filter: str,
+        encoding: str = "utf-8",
     ) -> list:
         if not self.mail_client:
             raise Exception("The 'mail_client' should be initialized before!")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**Airflow IMAP Hook only decodes with UTF-8**
I use the airflow imap hook, which internally only parses mail body with UTF-8 encoding.
I have a mail with some German characters such as `ü` in text, so what is a way to be able to parse that mails as well?
```
69        with ImapHook(imap_conn_id="imap") as conn:
70            attachments = conn.retrieve_mail_attachments(
71                name="(.*).PDF",
72                check_regex=True,
73                mail_folder="INBOX",
74                mail_filter="(UNSEEN)",
75                not_found_mode="warn"
76            )
```

Fails with:

```
[...]
    mail_body_str = mail_body.decode("utf-8")  # type: ignore
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xfc in position 8269: invalid start byte
```

https://airflow.apache.org/docs/apache-airflow-providers-imap/stable/_modules/airflow/providers/imap/hooks/imap.html#ImapHook.retrieve_mail_attachments

```
    def _fetch_mail_body(self, mail_id: str) -> str:
        if not self.mail_client:
            raise Exception("The 'mail_client' should be initialized before!")
        _, data = self.mail_client.fetch(mail_id, "(RFC822)")
        mail_body = data[0][1]  # type: ignore # The mail body is always in this specific location
        mail_body_str = mail_body.decode("utf-8")  # type: ignore
        return mail_body_str
```

This PR makes the encoding configurable.

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
