### PR TITLE
Remove usage of deprecated `flask._request_ctx_stack`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1479,6 +1479,12 @@ banned-module-level-imports = ["numpy", "pandas"]
 "typing.Sized".msg = "Use collections.abc.Sized"
 # Uses deprecated in Python 3.12 `datetime.datetime.utcfromtimestamp`
 "pendulum.from_timestamp".msg = "Use airflow.utils.timezone.from_timestamp"
+# Flask deprecations, worthwhile to keep it until we migrate to Flask 3.0+
+"flask._app_ctx_stack".msg = "Deprecated in Flask 2.2, removed in Flask 3.0"
+"flask._request_ctx_stack".msg = "Deprecated in Flask 2.2, removed in Flask 3.0"
+"flask.escape".msg = "Use markupsafe.escape instead. Deprecated in Flask 2.3, removed in Flask 3.0"
+"flask.Markup".msg = "Use markupsafe.Markup instead. Deprecated in Flask 2.3, removed in Flask 3.0"
+"flask.signals_available".msg = "Signals are always available. Deprecated in Flask 2.3, removed in Flask 3.0"
 
 [tool.ruff.lint.flake8-type-checking]
 exempt-modules = ["typing", "typing_extensions"]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This one was removed into the Flask 3.0. We only use in in [vendored kerberos auth backend](https://github.com/deshaw/flask-kerberos/blob/master/flask_kerberos.py).

> [!WARNING]  
> During the test I've found that we only test this module against Experimental API, however I can't make it work against REST API and FAB provider API. I've always got 403 error even if validation in kerberos finish successfully. 
> So I have an assumption that this backend might not work with Airflow REST API.

In addition I've added other deprecated stuff from Flask into our `pyproject.toml`, just in case.

And final good news, almost everything in our dependencies "support" Flask 3.

```console
Flask==2.2.5
├── apache-airflow==2.9.0.dev0 [requires: Flask>=2.2,<2.3]
├── connexion==2.14.2 [requires: Flask>=1.0.4,<2.3]
│   └── apache-airflow==2.9.0.dev0 [requires: connexion>=2.10.0,<3.0]
├── Flask-AppBuilder==4.3.11 [requires: Flask>=2,<2.3.0]
├── Flask-Babel==2.0.0 [requires: Flask]
│   └── Flask-AppBuilder==4.3.11 [requires: Flask-Babel>=1,<3]
├── Flask-Bcrypt==1.0.1 [requires: Flask]
├── Flask-Caching==2.1.0 [requires: Flask]
│   └── apache-airflow==2.9.0.dev0 [requires: Flask-Caching>=1.5.0]
├── Flask-JWT-Extended==4.6.0 [requires: Flask>=2.0,<4.0]
│   └── Flask-AppBuilder==4.3.11 [requires: Flask-JWT-Extended>=4.0.0,<5.0.0]
├── Flask-Limiter==3.5.1 [requires: Flask>=2]
│   └── Flask-AppBuilder==4.3.11 [requires: Flask-Limiter>3,<4]
├── Flask-Login==0.6.3 [requires: Flask>=1.0.4]
│   └── Flask-AppBuilder==4.3.11 [requires: Flask-Login>=0.3,<0.7]
├── flask-session==0.5.0 [requires: Flask>=2.2]
│   └── apache-airflow==2.9.0.dev0 [requires: flask-session>=0.4.0,<0.6]
├── Flask-SQLAlchemy==2.5.1 [requires: Flask>=0.10]
│   └── Flask-AppBuilder==4.3.11 [requires: Flask-SQLAlchemy>=2.4,<3]
└── flask-wtf==1.2.1 [requires: Flask]
    ├── apache-airflow==2.9.0.dev0 [requires: flask-wtf>=0.15]
    └── Flask-AppBuilder==4.3.11 [requires: flask-wtf>=0.14.2,<2]
```

- `Connexion`: Support from v3, https://github.com/apache/airflow/pull/36052
- `Flask-AppBuilder`:  https://github.com/dpgaspar/Flask-AppBuilder/pull/2196 merged into the master, so I hope next version of FAB should either support ~Flask 3~ (i was blind) Flask 2.3

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
