### PR TITLE
Flower K8s Probe config

### DIFF
--- a/chart/templates/flower/flower-deployment.yaml
+++ b/chart/templates/flower/flower-deployment.yaml
@@ -116,7 +116,7 @@ spec:
             - name: flower-ui
               containerPort: {{ .Values.ports.flowerUI }}
           livenessProbe:
-            failureThreshold: 10
+            failureThreshold: {{ .Values.flower.livenessProbe.failureThreshold }}
             exec:
               command:
                 - curl
@@ -125,10 +125,10 @@ spec:
                 - $AIRFLOW__CELERY__FLOWER_BASIC_AUTH
                 {{- end }}
                 - {{ printf "localhost:%s" (.Values.ports.flowerUI | toString) }}
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.flower.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.flower.livenessProbe.periodSeconds }}
           readinessProbe:
-            failureThreshold: 10
+            failureThreshold: {{ .Values.flower.readinessProbe.failureThreshold }}
             exec:
               command:
                 - curl
@@ -137,8 +137,8 @@ spec:
                 - $AIRFLOW__CELERY__FLOWER_BASIC_AUTH
                 {{- end }}
                 - {{ printf "localhost:%s" (.Values.ports.flowerUI | toString) }}
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.flower.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.flower.readinessProbe.periodSeconds }}
           envFrom:
           {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env:

--- a/chart/templates/flower/flower-deployment.yaml
+++ b/chart/templates/flower/flower-deployment.yaml
@@ -127,6 +127,7 @@ spec:
                 - {{ printf "localhost:%s" (.Values.ports.flowerUI | toString) }}
             initialDelaySeconds: {{ .Values.flower.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.flower.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.flower.livenessProbe.timeoutSeconds }}
           readinessProbe:
             failureThreshold: {{ .Values.flower.readinessProbe.failureThreshold }}
             exec:
@@ -139,6 +140,7 @@ spec:
                 - {{ printf "localhost:%s" (.Values.ports.flowerUI | toString) }}
             initialDelaySeconds: {{ .Values.flower.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.flower.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.flower.readinessProbe.timeoutSeconds }}
           envFrom:
           {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4955,6 +4955,60 @@
                     "type": "boolean",
                     "default": false
                 },
+                "livenessProbe": {
+                    "description": "Liveness probe configuration.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "initialDelaySeconds": {
+                            "description": "Flower Liveness probe initial delay.",
+                            "type": "integer",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "description": "Flower Liveness probe timeout seconds.",
+                            "type": "integer",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "description": "Flower Liveness probe failure threshold.",
+                            "type": "integer",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "description": "Flower Liveness probe period seconds.",
+                            "type": "integer",
+                            "default": 5
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "description": "Readiness probe configuration.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "initialDelaySeconds": {
+                            "description": "Flower Readiness probe initial delay.",
+                            "type": "integer",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "description": "Flower Readiness probe timeout seconds.",
+                            "type": "integer",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "description": "Flower Readiness probe failure threshold.",
+                            "type": "integer",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "description": "Flower Readiness probe period seconds.",
+                            "type": "integer",
+                            "default": 5
+                        }
+                    }
+                },
                 "revisionHistoryLimit": {
                     "description": "Number of old replicasets to retain.",
                     "type": [

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1709,7 +1709,7 @@ flower:
   # If True, and using CeleryExecutor/CeleryKubernetesExecutor, will deploy flower app.
   enabled: false
 
-  ivenessProbe:
+  livenessProbe:
     initialDelaySeconds: 10
     timeoutSeconds: 5
     failureThreshold: 10

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1708,6 +1708,19 @@ flower:
   # Enable flower.
   # If True, and using CeleryExecutor/CeleryKubernetesExecutor, will deploy flower app.
   enabled: false
+
+  ivenessProbe:
+    initialDelaySeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 10
+    periodSeconds: 5
+
+  readinessProbe:
+    initialDelaySeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 10
+    periodSeconds: 5
+
   # Max number of old replicasets to retain
   revisionHistoryLimit: ~
 

--- a/helm_tests/other/test_flower.py
+++ b/helm_tests/other/test_flower.py
@@ -363,6 +363,34 @@ class TestFlowerDeployment:
         assert "annotations" in jmespath.search("metadata", docs[0])
         assert jmespath.search("metadata.annotations", docs[0])["test_annotation"] == "test_annotation_value"
 
+    @pytest.mark.parametrize("probe", ["livenessProbe", "readinessProbe"])
+    def test_probe_values_are_configurable(self, probe):
+        docs = render_chart(
+            values={
+                "flower": {
+                    "enabled": True,
+                    probe: {
+                        "initialDelaySeconds": 111,
+                        "timeoutSeconds": 222,
+                        "failureThreshold": 333,
+                        "periodSeconds": 444,
+                    },
+                },
+            },
+            show_only=["templates/flower/flower-deployment.yaml"],
+        )
+
+        assert 111 == jmespath.search(
+            f"spec.template.spec.containers[0].{probe}.initialDelaySeconds", docs[0]
+        )
+        assert 222 == jmespath.search(
+            f"spec.template.spec.containers[0].{probe}.timeoutSeconds", docs[0]
+        )
+        assert 333 == jmespath.search(
+            f"spec.template.spec.containers[0].{probe}.failureThreshold", docs[0]
+        )
+        assert 444 == jmespath.search(f"spec.template.spec.containers[0].{probe}.periodSeconds", docs[0])
+
 
 class TestFlowerService:
     """Tests flower service."""

--- a/helm_tests/other/test_flower.py
+++ b/helm_tests/other/test_flower.py
@@ -383,12 +383,8 @@ class TestFlowerDeployment:
         assert 111 == jmespath.search(
             f"spec.template.spec.containers[0].{probe}.initialDelaySeconds", docs[0]
         )
-        assert 222 == jmespath.search(
-            f"spec.template.spec.containers[0].{probe}.timeoutSeconds", docs[0]
-        )
-        assert 333 == jmespath.search(
-            f"spec.template.spec.containers[0].{probe}.failureThreshold", docs[0]
-        )
+        assert 222 == jmespath.search(f"spec.template.spec.containers[0].{probe}.timeoutSeconds", docs[0])
+        assert 333 == jmespath.search(f"spec.template.spec.containers[0].{probe}.failureThreshold", docs[0])
         assert 444 == jmespath.search(f"spec.template.spec.containers[0].{probe}.periodSeconds", docs[0])
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

I want to control flower probe configuration on helm values file.
Because, I think that the flower probe period is too often (`5s`), and I want to customize it 🙏 

Please, take a look at, and let me know if there's something I missed 😄 

reference kubernetes doc: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
