### PR TITLE
Implement token refresh on BigQuery dts run operator to handle the heavy migration jobs over 1 hour

### DIFF
--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -307,6 +307,12 @@ class GoogleBaseHook(BaseHook):
         credentials, _ = self.get_credentials_and_project_id()
         return credentials
 
+    def refresh_credentials(self) -> google.auth.credentials.Credentials:
+        """Refresh the Credentials object for Google API."""
+        credentials = self.get_credentials()
+        credentials.refresh(google.auth.transport.requests.Request())
+        return credentials
+
     def _get_access_token(self) -> str:
         """Return a valid access token from Google API Credentials."""
         credentials = self.get_credentials()
@@ -706,3 +712,8 @@ class GoogleBaseAsyncHook(BaseHook):
         """
         sync_hook = await self.get_sync_hook()
         return await sync_to_async(sync_hook.provide_gcp_credential_file_as_context)()
+
+    async def refresh_credentials(self) -> google.auth.credentials.Credentials:
+        """Refresh the Credentials object for Google API."""
+        sync_hook = await self.get_sync_hook()
+        return await sync_to_async(sync_hook.refresh_credentials)()


### PR DESCRIPTION
related issue:
- https://github.com/apache/airflow/issues/31648

releated PR:
- https://github.com/apache/airflow/pull/31651
- https://github.com/apache/airflow/pull/32673

Currently, when BigQuery Data Transfer job triggered by Airflow operator, exceeds one hour, it fails due to the expiration of the credential (default lifespan = 1 hour).

```
Access Denied: Table projectid:table_name: Permission bigquery.tables.get denied on table projectid:datasetid.table_name (or it may not exist).
```

So, I add the token refresh logic on DTS run operator. (additionally, add fallback logic to `timeout` parameter based on `execution_timeout` of Operator)