### PR TITLE
Enable "airflow tasks test" to run deferrable operator

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -636,7 +636,7 @@ def task_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> N
             else:
                 ti.run(ignore_task_deps=True, ignore_ti_state=True, test_mode=True, raise_on_defer=True)
     except TaskDeferred as defer:
-        ti._defer_task(defer=defer, session=session)
+        ti.defer_task(defer=defer, session=session)
         log.info("[TASK TEST] running trigger in line")
 
         event = _run_inline_trigger(defer.trigger)

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -41,7 +41,7 @@ from airflow.jobs.job import Job, run_job
 from airflow.jobs.local_task_job_runner import LocalTaskJobRunner
 from airflow.listeners.listener import get_listener_manager
 from airflow.models import DagPickle, TaskInstance
-from airflow.models.dag import DAG, _run_trigger
+from airflow.models.dag import DAG, _run_inline_trigger
 from airflow.models.dagrun import DagRun
 from airflow.models.operator import needs_expansion
 from airflow.models.param import ParamsDict
@@ -639,7 +639,7 @@ def task_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> N
         ti._defer_task(defer=defer, session=session)
         log.info("[TASK TEST] running trigger in line")
 
-        event = _run_trigger(defer.trigger)
+        event = _run_inline_trigger(defer.trigger)
         ti.next_method = defer.method_name
         ti.next_kwargs = {"event": event.payload} if event else defer.kwargs
 

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -18,6 +18,7 @@
 """Task sub-commands."""
 from __future__ import annotations
 
+import functools
 import importlib
 import json
 import logging
@@ -34,13 +35,13 @@ from sqlalchemy import select
 from airflow import settings
 from airflow.cli.simple_table import AirflowConsole
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException, DagRunNotFound, TaskInstanceNotFound
+from airflow.exceptions import AirflowException, DagRunNotFound, TaskDeferred, TaskInstanceNotFound
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.job import Job, run_job
 from airflow.jobs.local_task_job_runner import LocalTaskJobRunner
 from airflow.listeners.listener import get_listener_manager
 from airflow.models import DagPickle, TaskInstance
-from airflow.models.dag import DAG
+from airflow.models.dag import DAG, _run_trigger
 from airflow.models.dagrun import DagRun
 from airflow.models.operator import needs_expansion
 from airflow.models.param import ParamsDict
@@ -588,7 +589,8 @@ def task_states_for_dag_run(args, session: Session = NEW_SESSION) -> None:
 
 
 @cli_utils.action_cli(check_db=False)
-def task_test(args, dag: DAG | None = None) -> None:
+@provide_session
+def task_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> None:
     """Test task for a given dag_id."""
     # We want to log output from operators etc to show up here. Normally
     # airflow.task would redirect to a file, but here we want it to propagate
@@ -632,7 +634,22 @@ def task_test(args, dag: DAG | None = None) -> None:
             if args.dry_run:
                 ti.dry_run()
             else:
-                ti.run(ignore_task_deps=True, ignore_ti_state=True, test_mode=True)
+                ti.run(ignore_task_deps=True, ignore_ti_state=True, test_mode=True, raise_on_defer=True)
+    except TaskDeferred as defer:
+        ti._defer_task(defer=defer, session=session)
+        log.info("[TASK TEST] running trigger in line")
+
+        event = _run_trigger(defer.trigger)
+        ti.next_method = defer.method_name
+        ti.next_kwargs = {"event": event.payload} if event else defer.kwargs
+
+        execute_callable = getattr(task, ti.next_method)
+        if ti.next_kwargs:
+            execute_callable = functools.partial(execute_callable, **ti.next_kwargs)
+        context = ti.get_template_context(ignore_param_exceptions=False)
+        execute_callable(context)
+
+        log.info("[TASK TEST] Trigger completed")
     except Exception:
         if args.post_mortem:
             debugger = _guess_debugger()

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -40,7 +40,7 @@ from airflow.jobs.job import Job, run_job
 from airflow.jobs.local_task_job_runner import LocalTaskJobRunner
 from airflow.listeners.listener import get_listener_manager
 from airflow.models import DagPickle, TaskInstance
-from airflow.models.dag import DAG, _run_task, _triggerer_is_healthy
+from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
 from airflow.models.operator import needs_expansion
 from airflow.models.param import ParamsDict
@@ -66,7 +66,7 @@ from airflow.utils.log.secrets_masker import RedactedIO
 from airflow.utils.net import get_hostname
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
-from airflow.utils.state import DagRunState, TaskInstanceState
+from airflow.utils.state import DagRunState
 from airflow.utils.task_instance_session import set_current_task_instance_session
 
 if TYPE_CHECKING:
@@ -511,7 +511,8 @@ def task_list(args, dag: DAG | None = None) -> None:
 
 
 class _SupportedDebugger(Protocol):
-    def post_mortem(self) -> None: ...
+    def post_mortem(self) -> None:
+        ...
 
 
 SUPPORTED_DEBUGGER_MODULES = [
@@ -587,8 +588,7 @@ def task_states_for_dag_run(args, session: Session = NEW_SESSION) -> None:
 
 
 @cli_utils.action_cli(check_db=False)
-@provide_session
-def task_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> None:
+def task_test(args, dag: DAG | None = None) -> None:
     """Test task for a given dag_id."""
     # We want to log output from operators etc to show up here. Normally
     # airflow.task would redirect to a file, but here we want it to propagate
@@ -632,16 +632,7 @@ def task_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> N
             if args.dry_run:
                 ti.dry_run()
             else:
-                triggerer_running = _triggerer_is_healthy()
-                _run_task(
-                    ti=ti, inline_trigger=not triggerer_running, session=session, log_prefix="[Task test]"
-                )
-
-                while ti.state == TaskInstanceState.DEFERRED:
-                    _run_task(
-                        ti=ti, inline_trigger=not triggerer_running, session=session, log_prefix="[Task test]"
-                    )
-
+                ti.run(ignore_task_deps=True, ignore_ti_state=True, test_mode=True)
     except Exception:
         if args.post_mortem:
             debugger = _guess_debugger()

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -4065,9 +4065,7 @@ def _run_trigger(trigger):
     return asyncio.run(_run_trigger_main())
 
 
-def _run_task(
-    *, ti: TaskInstance, inline_trigger: bool = False, session: Session, log_prefix: str = "[DAG TEST] "
-):
+def _run_task(*, ti: TaskInstance, inline_trigger: bool = False, session: Session):
     """
     Run a single task instance, and push result to Xcom for downstream tasks.
 
@@ -4077,21 +4075,21 @@ def _run_task(
     Args:
         ti: TaskInstance to run
     """
-    log.info("%s starting task_id=%s map_index=%s", log_prefix, ti.task_id, ti.map_index)
+    log.info("[DAG TEST] starting task_id=%s map_index=%s", ti.task_id, ti.map_index)
     while True:
         try:
-            log.info("%s running task %s", log_prefix, ti)
+            log.info("[DAG TEST] running task %s", ti)
             ti._run_raw_task(session=session, raise_on_defer=inline_trigger)
             break
         except TaskDeferred as e:
-            log.info("%s running trigger in line", log_prefix)
+            log.info("[DAG TEST] running trigger in line")
             event = _run_trigger(e.trigger)
             ti.next_method = e.method_name
             ti.next_kwargs = {"event": event.payload} if event else e.kwargs
-            log.info("%s Trigger completed", log_prefix)
+            log.info("[DAG TEST] Trigger completed")
         session.merge(ti)
         session.commit()
-    log.info("%s end task task_id=%s map_index=%s", log_prefix, ti.task_id, ti.map_index)
+    log.info("[DAG TEST] end task task_id=%s map_index=%s", ti.task_id, ti.map_index)
 
 
 def _get_or_create_dagrun(

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -4065,7 +4065,9 @@ def _run_trigger(trigger):
     return asyncio.run(_run_trigger_main())
 
 
-def _run_task(*, ti: TaskInstance, inline_trigger: bool = False, session: Session):
+def _run_task(
+    *, ti: TaskInstance, inline_trigger: bool = False, session: Session, log_prefix: str = "[DAG TEST] "
+):
     """
     Run a single task instance, and push result to Xcom for downstream tasks.
 
@@ -4075,21 +4077,21 @@ def _run_task(*, ti: TaskInstance, inline_trigger: bool = False, session: Sessio
     Args:
         ti: TaskInstance to run
     """
-    log.info("[DAG TEST] starting task_id=%s map_index=%s", ti.task_id, ti.map_index)
+    log.info("%s starting task_id=%s map_index=%s", log_prefix, ti.task_id, ti.map_index)
     while True:
         try:
-            log.info("[DAG TEST] running task %s", ti)
+            log.info("%s running task %s", log_prefix, ti)
             ti._run_raw_task(session=session, raise_on_defer=inline_trigger)
             break
         except TaskDeferred as e:
-            log.info("[DAG TEST] running trigger in line")
+            log.info("%s running trigger in line", log_prefix)
             event = _run_trigger(e.trigger)
             ti.next_method = e.method_name
             ti.next_kwargs = {"event": event.payload} if event else e.kwargs
-            log.info("[DAG TEST] Trigger completed")
+            log.info("%s Trigger completed", log_prefix)
         session.merge(ti)
         session.commit()
-    log.info("[DAG TEST] end task task_id=%s map_index=%s", ti.task_id, ti.map_index)
+    log.info("%s end task task_id=%s map_index=%s", log_prefix, ti.task_id, ti.map_index)
 
 
 def _get_or_create_dagrun(

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -4057,12 +4057,12 @@ class DagContext:
             return None
 
 
-def _run_trigger(trigger):
-    async def _run_trigger_main():
+def _run_inline_trigger(trigger):
+    async def _run_inline_trigger_main():
         async for event in trigger.run():
             return event
 
-    return asyncio.run(_run_trigger_main())
+    return asyncio.run(_run_inline_trigger_main())
 
 
 def _run_task(*, ti: TaskInstance, inline_trigger: bool = False, session: Session):
@@ -4083,7 +4083,7 @@ def _run_task(*, ti: TaskInstance, inline_trigger: bool = False, session: Sessio
             break
         except TaskDeferred as e:
             log.info("[DAG TEST] running trigger in line")
-            event = _run_trigger(e.trigger)
+            event = _run_inline_trigger(e.trigger)
             ti.next_method = e.method_name
             ti.next_kwargs = {"event": event.payload} if event else e.kwargs
             log.info("[DAG TEST] Trigger completed")

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2378,7 +2378,7 @@ class TaskInstance(Base, LoggingMixin):
                 # a trigger.
                 if raise_on_defer:
                     raise
-                self._defer_task(defer=defer, session=session)
+                self.defer_task(defer=defer, session=session)
                 self.log.info(
                     "Pausing task as DEFERRED. dag_id=%s, task_id=%s, execution_date=%s, start_date=%s",
                     self.dag_id,
@@ -2565,8 +2565,11 @@ class TaskInstance(Base, LoggingMixin):
         return _execute_task(self, context, task_orig)
 
     @provide_session
-    def _defer_task(self, session: Session, defer: TaskDeferred) -> None:
-        """Mark the task as deferred and sets up the trigger that is needed to resume it."""
+    def defer_task(self, session: Session, defer: TaskDeferred) -> None:
+        """Mark the task as deferred and sets up the trigger that is needed to resume it.
+
+        :meta: private
+        """
         from airflow.models.trigger import Trigger
 
         # First, make the trigger entry

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2625,6 +2625,7 @@ class TaskInstance(Base, LoggingMixin):
         job_id: str | None = None,
         pool: str | None = None,
         session: Session = NEW_SESSION,
+        raise_on_defer: bool = False,
     ) -> None:
         """Run TaskInstance."""
         res = self.check_and_change_state_before_execution(
@@ -2644,7 +2645,12 @@ class TaskInstance(Base, LoggingMixin):
             return
 
         self._run_raw_task(
-            mark_success=mark_success, test_mode=test_mode, job_id=job_id, pool=pool, session=session
+            mark_success=mark_success,
+            test_mode=test_mode,
+            job_id=job_id,
+            pool=pool,
+            session=session,
+            raise_on_defer=raise_on_defer,
         )
 
     def dry_run(self) -> None:

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -37,7 +37,7 @@ from airflow.decorators import task
 from airflow.exceptions import AirflowException
 from airflow.models import DagBag, DagModel, DagRun
 from airflow.models.baseoperator import BaseOperator
-from airflow.models.dag import _run_trigger
+from airflow.models.dag import _run_inline_trigger
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.triggers.base import TriggerEvent
 from airflow.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
@@ -878,15 +878,15 @@ class TestCliDags:
         dag_command.dag_test(cli_args)
         assert "data_interval" in mock__get_or_create_dagrun.call_args.kwargs
 
-    def test_dag_test_run_trigger(self, dag_maker):
+    def test_dag_test_run_inline_trigger(self, dag_maker):
         now = timezone.utcnow()
         trigger = DateTimeTrigger(moment=now)
-        e = _run_trigger(trigger)
+        e = _run_inline_trigger(trigger)
         assert isinstance(e, TriggerEvent)
         assert e.payload == now
 
     def test_dag_test_no_triggerer_running(self, dag_maker):
-        with mock.patch("airflow.models.dag._run_trigger", wraps=_run_trigger) as mock_run:
+        with mock.patch("airflow.models.dag._run_inline_trigger", wraps=_run_inline_trigger) as mock_run:
             with dag_maker() as dag:
 
                 @task

--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -266,7 +266,7 @@ def test_trigger_lifecycle(session):
 class TestTriggerRunner:
     @pytest.mark.asyncio
     @patch("airflow.jobs.triggerer_job_runner.TriggerRunner.set_individual_trigger_logging")
-    async def test_run_trigger_canceled(self, session) -> None:
+    async def test_run_inline_trigger_canceled(self, session) -> None:
         trigger_runner = TriggerRunner()
         trigger_runner.triggers = {1: {"task": MagicMock(), "name": "mock_name", "events": 0}}
         mock_trigger = MagicMock()
@@ -278,7 +278,7 @@ class TestTriggerRunner:
 
     @pytest.mark.asyncio
     @patch("airflow.jobs.triggerer_job_runner.TriggerRunner.set_individual_trigger_logging")
-    async def test_run_trigger_timeout(self, session, caplog) -> None:
+    async def test_run_inline_trigger_timeout(self, session, caplog) -> None:
         trigger_runner = TriggerRunner()
         trigger_runner.triggers = {1: {"task": MagicMock(), "name": "mock_name", "events": 0}}
         mock_trigger = MagicMock()


### PR DESCRIPTION
## Why

Currently, `airflow tasks test [DAG] [TASK]` cannot test tasks in deferrable mode; it just ends when `TaskDeferred` is raised.


## What
This PR adds the functionality to run inline triggerer when if `TaskDeferred` is raised when running `airflow tasks test [DAG] [TASK]`


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
