### PR TITLE
Move some` FAB related tests to provider

### DIFF
--- a/tests/providers/fab/auth_manager/test_security.py
+++ b/tests/providers/fab/auth_manager/test_security.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import contextlib
 import datetime
+import json
 import logging
 import os
 from unittest import mock
@@ -1139,3 +1140,66 @@ def test_custom_access_denied_message():
     ):
         initialize_config()
         assert get_access_denied_message() == "My custom access denied message"
+
+
+@pytest.mark.db_test
+class TestHasAccessDagDecorator:
+    @pytest.mark.parametrize(
+        "dag_id_args, dag_id_kwargs, dag_id_form, dag_id_json, fail",
+        [
+            ("a", None, None, None, False),
+            (None, "b", None, None, False),
+            (None, None, "c", None, False),
+            (None, None, None, "d", False),
+            ("a", "a", None, None, False),
+            ("a", "a", "a", None, False),
+            ("a", "a", "a", "a", False),
+            (None, "a", "a", "a", False),
+            (None, None, "a", "a", False),
+            ("a", None, None, "a", False),
+            ("a", None, "a", None, False),
+            ("a", None, "c", None, True),
+            (None, "b", "c", None, True),
+            (None, None, "c", "d", True),
+            ("a", "b", "c", "d", True),
+        ],
+    )
+    def test_dag_id_consistency(
+        self,
+        app,
+        dag_id_args: str | None,
+        dag_id_kwargs: str | None,
+        dag_id_form: str | None,
+        dag_id_json: str | None,
+        fail: bool,
+    ):
+        with app.test_request_context() as mock_context:
+            from airflow.www.auth import has_access_dag
+
+            mock_context.request.args = {"dag_id": dag_id_args} if dag_id_args else {}
+            kwargs = {"dag_id": dag_id_kwargs} if dag_id_kwargs else {}
+            mock_context.request.form = {"dag_id": dag_id_form} if dag_id_form else {}
+            if dag_id_json:
+                mock_context.request._cached_data = json.dumps({"dag_id": dag_id_json})
+                mock_context.request._parsed_content_type = ["application/json"]
+
+            with create_user_scope(
+                app,
+                username="test-user",
+                role_name="limited-role",
+                permissions=[(permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG)],
+            ) as user:
+                with patch(
+                    "airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager.get_user"
+                ) as mock_get_user:
+                    mock_get_user.return_value = user
+
+                    @has_access_dag("GET")
+                    def test_func(**kwargs):
+                        return True
+
+                    result = test_func(**kwargs)
+                    if fail:
+                        assert result[1] == 403
+                    else:
+                        assert result is True


### PR DESCRIPTION
There are still some tests that are really FAB provider Auth Manager tests but they were left in the core (which is kind-of expected remnant of the past. We will eventually find and move all of them but for now let's just move some of them we are aware of.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
