### PR TITLE
Add secret caching for Airflow CLI

### DIFF
--- a/airflow/__main__.py
+++ b/airflow/__main__.py
@@ -35,6 +35,7 @@ import argcomplete
 from airflow import configuration
 from airflow.cli import cli_parser
 from airflow.configuration import write_webserver_configuration_if_needed
+from airflow.secrets.cache import SecretCache
 
 
 def main():
@@ -54,6 +55,11 @@ def main():
         conf = write_default_airflow_configuration_if_needed()
         if args.subcommand in ["webserver", "internal-api", "worker"]:
             write_webserver_configuration_if_needed(conf)
+
+    # Some tasks require parsing DAG files, so we enable secret caching for improved performance.
+    # If the user did not configure secret caching, this action is a no-op.
+    SecretCache.init()
+
     args.func(args)
 
 

--- a/airflow/__main__.py
+++ b/airflow/__main__.py
@@ -56,8 +56,12 @@ def main():
         if args.subcommand in ["webserver", "internal-api", "worker"]:
             write_webserver_configuration_if_needed(conf)
 
-    # Some tasks require parsing DAG files, so we enable secret caching for improved performance.
-    # If the user did not configure secret caching, this action is a no-op.
+    # DAGs that access variables and connections in top-level code can slow down the DAG parsing due
+    # to additional requests to the secret backend. The parsing can be sped up by caching secrets once
+    # they have been accessed once. This is supported by the `secrets.use_cache` configuration option
+    # and implemented in the secret cache.
+    # If caching is enabled, the below line will set up the cache and enable caching for all further
+    # variable access. If caching is not explicitly enabled, the below line is a no-op.
     SecretCache.init()
 
     args.func(args)


### PR DESCRIPTION
This PR adds secret caching for the Airflow CLI. [Secret caching](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#use-cache) current only works for the DAG-processing job, but is ignored when parsing the files through the CLI. This currently causes slow response times from the Airflow CLI for DAGs that use top-level variables.

By initializing the cache as part of the CLI startup, we make sure the cache is enabled properly for parsing. If the user did not configure caching explicitly, the added cache initialization is a no-op and the behavior is the same as before.

closes: #37543 

I did not add a test case yet because I did not find an existing one for `__main__.main()` yet. I am open for suggestions on how to properly test the added caching, however since this is a very small change that does not change behavior until explicitly configured we may be good without one.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
