### PR TITLE
Fix lazy loading of ObjectStoragePath fs backends

### DIFF
--- a/airflow/io/path.py
+++ b/airflow/io/path.py
@@ -95,23 +95,6 @@ class ObjectStoragePath(CloudPath):
     def __eq__(self, other: typing.Any) -> bool:
         return self.samestore(other) and str(self) == str(other)
 
-    def __str__(self):
-        """Return the string representation of the path.
-
-        This is a workaround for the fact that upath does not honor the _protocol_dispatch flag when
-        creating a string representation
-        """
-        conn_id = self.storage_options.get("conn_id")
-        parts = list(self._parts)
-
-        # remove trailing slash from the bucket
-        parts[0] = parts[0].rstrip("/")
-
-        if conn_id:
-            return f"{self._protocol}://{conn_id}@{'/'.join(parts)}"
-        else:
-            return f"{self._protocol}://{'/'.join(parts)}"
-
     def samestore(self, other: typing.Any) -> bool:
         return (
             isinstance(other, ObjectStoragePath)

--- a/airflow/io/path.py
+++ b/airflow/io/path.py
@@ -95,6 +95,21 @@ class ObjectStoragePath(CloudPath):
     def __eq__(self, other: typing.Any) -> bool:
         return self.samestore(other) and str(self) == str(other)
 
+    def __str__(self):
+        """Return the string representation of the path. This is a workaround for the fact that
+        upath does not honor the _protocol_dispatch flag when creating a string representation"""
+
+        conn_id = self.storage_options.get("conn_id")
+        parts = list(self._parts)
+
+        # remove trailing slash from the bucket
+        parts[0] = parts[0].rstrip("/")
+
+        if conn_id:
+            return f"{self._protocol}://{conn_id}@{'/'.join(parts)}"
+        else:
+            return f"{self._protocol}://{'/'.join(parts)}"
+
     def samestore(self, other: typing.Any) -> bool:
         return (
             isinstance(other, ObjectStoragePath)

--- a/airflow/io/path.py
+++ b/airflow/io/path.py
@@ -96,9 +96,11 @@ class ObjectStoragePath(CloudPath):
         return self.samestore(other) and str(self) == str(other)
 
     def __str__(self):
-        """Return the string representation of the path. This is a workaround for the fact that
-        upath does not honor the _protocol_dispatch flag when creating a string representation"""
+        """Return the string representation of the path.
 
+        This is a workaround for the fact that upath does not honor the _protocol_dispatch flag when
+        creating a string representation
+        """
         conn_id = self.storage_options.get("conn_id")
         parts = list(self._parts)
 

--- a/airflow/io/path.py
+++ b/airflow/io/path.py
@@ -74,9 +74,9 @@ class ObjectStoragePath(CloudPath):
     def _parse_storage_options(
         cls, urlpath: str, protocol: str, storage_options: Mapping[str, Any]
     ) -> dict[str, Any]:
-        fs = attach(protocol or "file", conn_id=storage_options.get("conn_id")).fs
-        pth_storage_options = type(fs)._get_kwargs_from_urls(urlpath)
-        return {**pth_storage_options, **storage_options}
+        # we will not use the fs here, so we can avoid the dispatch
+        # it might be that we will not parse the storage options correctly
+        return {**storage_options}
 
     @classmethod
     def _fs_factory(

--- a/airflow/io/path.py
+++ b/airflow/io/path.py
@@ -95,6 +95,24 @@ class ObjectStoragePath(CloudPath):
     def __eq__(self, other: typing.Any) -> bool:
         return self.samestore(other) and str(self) == str(other)
 
+    def __str__(self):
+        """Return the string representation of the path.
+
+        This is a workaround for the fact that upath does not honor the _protocol_dispatch flag when
+        creating a string representation
+        """
+        conn_id = self.storage_options.get("conn_id")
+        parts = list(self._parts)
+
+        # remove trailing slash from the bucket
+        if len(parts) > 0:
+            parts[0] = parts[0].rstrip("/")
+
+        if conn_id:
+            return f"{self._protocol}://{conn_id}@{'/'.join(parts)}"
+        else:
+            return f"{self._protocol}://{'/'.join(parts)}"
+
     def samestore(self, other: typing.Any) -> bool:
         return (
             isinstance(other, ObjectStoragePath)

--- a/tests/io/test_path.py
+++ b/tests/io/test_path.py
@@ -99,6 +99,14 @@ class TestFs:
         _fsspec_registry.clear()
         _fsspec_registry.update(self._fsspec_registry)
 
+    def test_lazy_load(self):
+        o = ObjectStoragePath("file:///tmp/foo")
+        with pytest.raises(AttributeError):
+            assert o._fs_cached
+
+        assert o.fs is not None
+        assert o._fs_cached
+
     def test_alias(self):
         store = attach("file", alias="local")
         assert isinstance(store.fs, LocalFileSystem)

--- a/tests/providers/common/io/operators/test_file_transfer.py
+++ b/tests/providers/common/io/operators/test_file_transfer.py
@@ -55,13 +55,13 @@ def test_get_openlineage_facets_on_start():
     dst_bucket = "dst-bucket"
     dst_key = "dst-key"
 
-    expected_input = Dataset(namespace=f"s3://{src_bucket}", name=src_key)
-    expected_output = Dataset(namespace=f"s3://{dst_bucket}", name=dst_key)
+    expected_input = Dataset(namespace=f"gs://{src_bucket}", name=src_key)
+    expected_output = Dataset(namespace=f"gs://{dst_bucket}", name=dst_key)
 
     op = FileTransferOperator(
         task_id="test",
-        src=f"s3://{src_bucket}/{src_key}",
-        dst=f"s3://{dst_bucket}/{dst_key}",
+        src=f"gs://{src_bucket}/{src_key}",
+        dst=f"gs://{dst_bucket}/{dst_key}",
     )
 
     lineage = op.get_openlineage_facets_on_start()


### PR DESCRIPTION
The new structure introduces eager loading,
which we don't want. This re-instates lazy loading at the expense of that storage_options might not be fully parsed.

@potiuk @ap-- @Taragolis 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
