### PR TITLE
Pass project_id to get_job in CloudRunExecuteJobOperator

### DIFF
--- a/tests/providers/google/cloud/operators/test_cloud_run.py
+++ b/tests/providers/google/cloud/operators/test_cloud_run.py
@@ -21,6 +21,7 @@ This module contains various unit tests for GCP Cloud Build Operators
 from __future__ import annotations
 
 from unittest import mock
+from unittest.mock import ANY
 
 import pytest
 from google.cloud.run_v2 import Job
@@ -108,6 +109,9 @@ class TestCloudRunExecuteJobOperator:
 
         hook_mock.return_value.execute_job.assert_called_once_with(
             job_name=JOB_NAME, region=REGION, project_id=PROJECT_ID, overrides=None
+        )
+        hook_mock.return_value.get_job.assert_called_once_with(
+            job_name=ANY, region=REGION, project_id=PROJECT_ID
         )
 
     @mock.patch(CLOUD_RUN_HOOK_PATH)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
The project id is passed pretty much everywhere except here. From my understanding it causes the hook to fallback to the account's project id only for `get_job` method. It seemed like an oversight to me.

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
