### PR TITLE
Add post endpoint for dataset events

### DIFF
--- a/airflow/api_connexion/endpoints/dataset_endpoint.py
+++ b/airflow/api_connexion/endpoints/dataset_endpoint.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-from datetime import datetime
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 
@@ -24,7 +23,7 @@ from connexion import NoContent
 from marshmallow import ValidationError
 from sqlalchemy import delete, func, select
 from sqlalchemy.orm import joinedload, subqueryload
-from airflow.utils import timezone
+
 from airflow.api_connexion import security
 from airflow.api_connexion.endpoints.request_dict import get_json_request_dict
 from airflow.api_connexion.exceptions import BadRequest, NotFound
@@ -48,6 +47,7 @@ from airflow.datasets import Dataset
 from airflow.datasets.manager import dataset_manager
 from airflow.models.dataset import DatasetDagRunQueue, DatasetEvent, DatasetModel
 from airflow.security import permissions
+from airflow.utils import timezone
 from airflow.utils.db import get_query_count
 from airflow.utils.log.action_logger import action_event_from_permission
 from airflow.utils.session import NEW_SESSION, provide_session

--- a/airflow/api_connexion/endpoints/dataset_endpoint.py
+++ b/airflow/api_connexion/endpoints/dataset_endpoint.py
@@ -339,11 +339,10 @@ def post_dataset_event(session: Session = NEW_SESSION) -> APIResponse:
     except ValidationError as err:
         raise BadRequest(detail=str(err))
     uri = json_body["dataset_uri"]
-    dm = session.scalar(select(DatasetModel).where(DatasetModel.uri == uri).limit(1))
-    if not dm:
+    dataset = session.scalar(select(DatasetModel).where(DatasetModel.uri == uri).limit(1))
+    if not dataset:
         raise NotFound(title="Dataset not found", detail=f"Dataset with uri: '{uri}' not found")
-    timestamp = datetime.now()
-    timestamp = timestamp.astimezone(timezone.utc)
+    timestamp = datetime.now(timezone.utc)
     extra = json_body.get("extra", {})
     dataset_event = dataset_manager.register_dataset_change(
         dataset=Dataset(uri),

--- a/airflow/api_connexion/endpoints/dataset_endpoint.py
+++ b/airflow/api_connexion/endpoints/dataset_endpoint.py
@@ -347,6 +347,7 @@ def create_dataset_event(session: Session = NEW_SESSION) -> APIResponse:
         raise NotFound(title="Dataset not found", detail=f"Dataset with uri: '{uri}' not found")
     timestamp = timezone.utcnow()
     extra = json_body.get("extra", {})
+    extra["from_rest_api"] = True
     dataset_event = dataset_manager.register_dataset_change(
         dataset=Dataset(uri),
         timestamp=timestamp,

--- a/airflow/api_connexion/endpoints/dataset_endpoint.py
+++ b/airflow/api_connexion/endpoints/dataset_endpoint.py
@@ -333,8 +333,8 @@ def delete_dataset_queued_events(
         permission=permissions.ACTION_CAN_CREATE,
     ),
 )
-def post_dataset_event(session: Session = NEW_SESSION) -> APIResponse:
-    """Post dataset event."""
+def create_dataset_event(session: Session = NEW_SESSION) -> APIResponse:
+    """Create dataset event."""
     body = get_json_request_dict()
     try:
         json_body = create_dataset_event_schema.load(body)

--- a/airflow/api_connexion/endpoints/dataset_endpoint.py
+++ b/airflow/api_connexion/endpoints/dataset_endpoint.py
@@ -36,6 +36,7 @@ from airflow.api_connexion.schemas.dataset_schema import (
     QueuedEvent,
     QueuedEventCollection,
     TaskOutletDatasetReference,
+    create_dataset_event_schema,
     dataset_collection_schema,
     dataset_event_collection_schema,
     dataset_event_schema,
@@ -334,10 +335,12 @@ def delete_dataset_queued_events(
 )
 def post_dataset_event(session: Session = NEW_SESSION) -> APIResponse:
     """Post dataset event."""
+    body = get_json_request_dict()
     try:
-        json_body = dataset_event_schema.load(get_json_request_dict(), session=session)
+        json_body = create_dataset_event_schema.load(body)
     except ValidationError as err:
         raise BadRequest(detail=str(err))
+
     uri = json_body["dataset_uri"]
     dataset = session.scalar(select(DatasetModel).where(DatasetModel.uri == uri).limit(1))
     if not dataset:

--- a/airflow/api_connexion/endpoints/dataset_endpoint.py
+++ b/airflow/api_connexion/endpoints/dataset_endpoint.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 
@@ -24,7 +24,7 @@ from connexion import NoContent
 from marshmallow import ValidationError
 from sqlalchemy import delete, func, select
 from sqlalchemy.orm import joinedload, subqueryload
-
+from airflow.utils import timezone
 from airflow.api_connexion import security
 from airflow.api_connexion.endpoints.request_dict import get_json_request_dict
 from airflow.api_connexion.exceptions import BadRequest, NotFound
@@ -345,7 +345,7 @@ def post_dataset_event(session: Session = NEW_SESSION) -> APIResponse:
     dataset = session.scalar(select(DatasetModel).where(DatasetModel.uri == uri).limit(1))
     if not dataset:
         raise NotFound(title="Dataset not found", detail=f"Dataset with uri: '{uri}' not found")
-    timestamp = datetime.now(timezone.utc)
+    timestamp = timezone.utcnow()
     extra = json_body.get("extra", {})
     dataset_event = dataset_manager.register_dataset_change(
         dataset=Dataset(uri),

--- a/airflow/api_connexion/endpoints/dataset_endpoint.py
+++ b/airflow/api_connexion/endpoints/dataset_endpoint.py
@@ -356,5 +356,4 @@ def post_dataset_event(session: Session = NEW_SESSION) -> APIResponse:
     if not dataset_event:
         raise NotFound(title="Dataset not found", detail=f"Dataset with uri: '{uri}' not found")
     event = dataset_event_schema.dump(dataset_event)
-    event.pop("created_dagruns")
     return event

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2161,7 +2161,7 @@ paths:
       summary: Create dataset event
       description: Create dataset event
       x-openapi-router-controller: airflow.api_connexion.endpoints.dataset_endpoint
-      operationId: post_dataset_event
+      operationId: create_dataset_event
       tags: [Dataset]
       requestBody:
         required: true

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2129,21 +2129,21 @@ paths:
           $ref: "#/components/responses/NotFound"
 
   /datasets/events:
-    parameters:
-      - $ref: "#/components/parameters/PageLimit"
-      - $ref: "#/components/parameters/PageOffset"
-      - $ref: "#/components/parameters/OrderBy"
-      - $ref: "#/components/parameters/FilterDatasetID"
-      - $ref: "#/components/parameters/FilterSourceDAGID"
-      - $ref: "#/components/parameters/FilterSourceTaskID"
-      - $ref: "#/components/parameters/FilterSourceRunID"
-      - $ref: "#/components/parameters/FilterSourceMapIndex"
     get:
       summary: Get dataset events
       description: Get dataset events
       x-openapi-router-controller: airflow.api_connexion.endpoints.dataset_endpoint
       operationId: get_dataset_events
       tags: [Dataset]
+      parameters:
+        - $ref: "#/components/parameters/PageLimit"
+        - $ref: "#/components/parameters/PageOffset"
+        - $ref: "#/components/parameters/OrderBy"
+        - $ref: "#/components/parameters/FilterDatasetID"
+        - $ref: "#/components/parameters/FilterSourceDAGID"
+        - $ref: "#/components/parameters/FilterSourceTaskID"
+        - $ref: "#/components/parameters/FilterSourceRunID"
+        - $ref: "#/components/parameters/FilterSourceMapIndex"
       responses:
         "200":
           description: Success.
@@ -2157,6 +2157,33 @@ paths:
           $ref: "#/components/responses/PermissionDenied"
         "404":
           $ref: "#/components/responses/NotFound"
+    post:
+      summary: Create dataset event
+      description: Create dataset event
+      x-openapi-router-controller: airflow.api_connexion.endpoints.dataset_endpoint
+      operationId: post_dataset_event
+      tags: [Dataset]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDatasetEvent'
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DatasetEvent'
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
   /config:
     get:
@@ -4289,6 +4316,20 @@ components:
           type: string
           description: The dataset event creation time
           nullable: false
+
+    CreateDatasetEvent:
+      type: object
+      required:
+        - dataset_uri
+      properties:
+        dataset_uri:
+          type: string
+          description: The URI of the dataset
+          nullable: false
+        extra:
+          type: object
+          description: The dataset event extra
+          nullable: true
 
     QueuedEvent:
       type: object

--- a/airflow/api_connexion/schemas/dataset_schema.py
+++ b/airflow/api_connexion/schemas/dataset_schema.py
@@ -147,8 +147,16 @@ class DatasetEventCollectionSchema(Schema):
     total_entries = fields.Int()
 
 
+class CreateDatasetEventSchema(Schema):
+    """Create Dataset Event Schema."""
+
+    dataset_uri = fields.String()
+    extra = JsonObjectField()
+
+
 dataset_event_schema = DatasetEventSchema()
 dataset_event_collection_schema = DatasetEventCollectionSchema()
+create_dataset_event_schema = CreateDatasetEventSchema()
 
 
 class QueuedEvent(NamedTuple):

--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -63,7 +63,7 @@ class DatasetManager(LoggingMixin):
         extra=None,
         session: Session,
         **kwargs,
-    ) -> DatasetEvent | None:
+    ) -> None:
         """
         Register dataset related changes.
 
@@ -77,7 +77,7 @@ class DatasetManager(LoggingMixin):
         )
         if not dataset_model:
             self.log.warning("DatasetModel %s not found", dataset)
-            return None
+            return
 
         event_kwargs = {
             "dataset_id": dataset_model.id,

--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -56,7 +56,13 @@ class DatasetManager(LoggingMixin):
             self.notify_dataset_created(dataset=Dataset(uri=dataset_model.uri, extra=dataset_model.extra))
 
     def register_dataset_change(
-        self, *, task_instance: TaskInstance = None, dataset: Dataset, extra=None, session: Session, **kwargs
+        self,
+        *,
+        task_instance: TaskInstance | None = None,
+        dataset: Dataset,
+        extra=None,
+        session: Session,
+        **kwargs,
     ) -> DatasetEvent | None:
         """
         Register dataset related changes.
@@ -71,7 +77,8 @@ class DatasetManager(LoggingMixin):
         )
         if not dataset_model:
             self.log.warning("DatasetModel %s not found", dataset)
-            return
+            return None
+
         event_kwargs = {
             "dataset_id": dataset_model.id,
             "extra": extra,

--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -63,7 +63,7 @@ class DatasetManager(LoggingMixin):
         extra=None,
         session: Session,
         **kwargs,
-    ) -> None:
+    ) -> DatasetEvent | None:
         """
         Register dataset related changes.
 
@@ -92,7 +92,8 @@ class DatasetManager(LoggingMixin):
                     "source_map_index": task_instance.map_index,
                 }
             )
-        session.add(DatasetEvent(**event_kwargs))
+        dataset_event = DatasetEvent(**event_kwargs)
+        session.add(dataset_event)
         session.flush()
 
         self.notify_dataset_changed(dataset=dataset)
@@ -101,6 +102,7 @@ class DatasetManager(LoggingMixin):
         if dataset_model.consuming_dags:
             self._queue_dagruns(dataset_model, session)
         session.flush()
+        return dataset_event
 
     def notify_dataset_created(self, dataset: Dataset):
         """Run applicable notification actions when a dataset is created."""

--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -77,7 +77,7 @@ class DatasetManager(LoggingMixin):
         )
         if not dataset_model:
             self.log.warning("DatasetModel %s not found", dataset)
-            return
+            return None
 
         event_kwargs = {
             "dataset_id": dataset_model.id,

--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -56,8 +56,8 @@ class DatasetManager(LoggingMixin):
             self.notify_dataset_created(dataset=Dataset(uri=dataset_model.uri, extra=dataset_model.extra))
 
     def register_dataset_change(
-        self, *, task_instance: TaskInstance, dataset: Dataset, extra=None, session: Session, **kwargs
-    ) -> None:
+        self, *, task_instance: TaskInstance = None, dataset: Dataset, extra=None, session: Session, **kwargs
+    ) -> DatasetEvent | None:
         """
         Register dataset related changes.
 
@@ -72,16 +72,20 @@ class DatasetManager(LoggingMixin):
         if not dataset_model:
             self.log.warning("DatasetModel %s not found", dataset)
             return
-        session.add(
-            DatasetEvent(
-                dataset_id=dataset_model.id,
-                source_task_id=task_instance.task_id,
-                source_dag_id=task_instance.dag_id,
-                source_run_id=task_instance.run_id,
-                source_map_index=task_instance.map_index,
-                extra=extra,
+        event_kwargs = {
+            "dataset_id": dataset_model.id,
+            "extra": extra,
+        }
+        if task_instance:
+            event_kwargs.update(
+                {
+                    "source_task_id": task_instance.task_id,
+                    "source_dag_id": task_instance.dag_id,
+                    "source_run_id": task_instance.run_id,
+                    "source_map_index": task_instance.map_index,
+                }
             )
-        )
+        session.add(DatasetEvent(**event_kwargs))
         session.flush()
 
         self.notify_dataset_changed(dataset=dataset)

--- a/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -248,6 +248,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         (permissions.ACTION_CAN_CREATE, permissions.RESOURCE_DAG_RUN),
         (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG_RUN),
         (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_DAG_RUN),
+        (permissions.ACTION_CAN_CREATE, permissions.RESOURCE_DATASET),
     ]
     # [END security_user_perms]
 
@@ -275,6 +276,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_VARIABLE),
         (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_XCOM),
         (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_DATASET),
+        (permissions.ACTION_CAN_CREATE, permissions.RESOURCE_DATASET),
     ]
     # [END security_op_perms]
 

--- a/airflow/www/static/js/components/Table/Cells.tsx
+++ b/airflow/www/static/js/components/Table/Cells.tsx
@@ -150,6 +150,9 @@ export const TaskInstanceLink = ({ cell: { value, row } }: CellProps) => {
   const { sourceRunId, sourceDagId, sourceMapIndex } = row.original;
   const gridUrl = getMetaValue("grid_url");
   const dagId = getMetaValue("dag_id");
+  if (!value || !sourceRunId || !sourceDagId || !gridUrl) {
+    return null;
+  }
   const stringToReplace = dagId || "__DAG_ID__";
   const url = `${gridUrl?.replace(
     stringToReplace,

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1802,6 +1802,12 @@ export interface components {
       /** @description The dataset event creation time */
       timestamp?: string;
     };
+    CreateDatasetEvent: {
+      /** @description The URI of the dataset */
+      dataset_uri: string;
+      /** @description The dataset event extra */
+      extra?: { [key: string]: unknown } | null;
+    };
     QueuedEvent: {
       /** @description The datata uri. */
       uri?: string;
@@ -1821,12 +1827,6 @@ export interface components {
     QueuedEventCollection: {
       datasets?: components["schemas"]["QueuedEvent"][];
     } & components["schemas"]["CollectionInfo"];
-    CreateDatasetEvent: {
-      /** @description The URI of the dataset */
-      dataset_uri: string;
-      /** @description The dataset event extra */
-      extra?: { [key: string]: unknown } | null;
-    };
     BasicDAGRun: {
       /** @description Run ID. */
       run_id?: string;
@@ -5170,14 +5170,14 @@ export type DatasetCollection = CamelCasedPropertiesDeep<
 export type DatasetEvent = CamelCasedPropertiesDeep<
   components["schemas"]["DatasetEvent"]
 >;
+export type CreateDatasetEvent = CamelCasedPropertiesDeep<
+  components["schemas"]["CreateDatasetEvent"]
+>;
 export type QueuedEvent = CamelCasedPropertiesDeep<
   components["schemas"]["QueuedEvent"]
 >;
 export type QueuedEventCollection = CamelCasedPropertiesDeep<
   components["schemas"]["QueuedEventCollection"]
->;
-export type CreateDatasetEvent = CamelCasedPropertiesDeep<
-  components["schemas"]["CreateDatasetEvent"]
 >;
 export type BasicDAGRun = CamelCasedPropertiesDeep<
   components["schemas"]["BasicDAGRun"]

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -685,7 +685,7 @@ export interface paths {
     /** Get dataset events */
     get: operations["get_dataset_events"];
     /** Create dataset event */
-    post: operations["post_dataset_event"];
+    post: operations["create_dataset_event"];
   };
   "/config": {
     get: operations["get_config"];
@@ -4582,7 +4582,7 @@ export interface operations {
     };
   };
   /** Create dataset event */
-  post_dataset_event: {
+  create_dataset_event: {
     responses: {
       /** Success. */
       200: {
@@ -5488,7 +5488,7 @@ export type GetDatasetEventsVariables = CamelCasedPropertiesDeep<
   operations["get_dataset_events"]["parameters"]["query"]
 >;
 export type PostDatasetEventVariables = CamelCasedPropertiesDeep<
-  operations["post_dataset_event"]["requestBody"]["content"]["application/json"]
+  operations["create_dataset_event"]["requestBody"]["content"]["application/json"]
 >;
 export type GetConfigVariables = CamelCasedPropertiesDeep<
   operations["get_config"]["parameters"]["query"]

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -684,31 +684,8 @@ export interface paths {
   "/datasets/events": {
     /** Get dataset events */
     get: operations["get_dataset_events"];
-    parameters: {
-      query: {
-        /** The numbers of items to return. */
-        limit?: components["parameters"]["PageLimit"];
-        /** The number of items to skip before starting to collect the result set. */
-        offset?: components["parameters"]["PageOffset"];
-        /**
-         * The name of the field to order the results by.
-         * Prefix a field name with `-` to reverse the sort order.
-         *
-         * *New in version 2.1.0*
-         */
-        order_by?: components["parameters"]["OrderBy"];
-        /** The Dataset ID that updated the dataset. */
-        dataset_id?: components["parameters"]["FilterDatasetID"];
-        /** The DAG ID that updated the dataset. */
-        source_dag_id?: components["parameters"]["FilterSourceDAGID"];
-        /** The task ID that updated the dataset. */
-        source_task_id?: components["parameters"]["FilterSourceTaskID"];
-        /** The DAG run ID that updated the dataset. */
-        source_run_id?: components["parameters"]["FilterSourceRunID"];
-        /** The map index that updated the dataset. */
-        source_map_index?: components["parameters"]["FilterSourceMapIndex"];
-      };
-    };
+    /** Create dataset event */
+    post: operations["post_dataset_event"];
   };
   "/config": {
     get: operations["get_config"];
@@ -1844,6 +1821,12 @@ export interface components {
     QueuedEventCollection: {
       datasets?: components["schemas"]["QueuedEvent"][];
     } & components["schemas"]["CollectionInfo"];
+    CreateDatasetEvent: {
+      /** @description The URI of the dataset */
+      dataset_uri: string;
+      /** @description The dataset event extra */
+      extra?: { [key: string]: unknown } | null;
+    };
     BasicDAGRun: {
       /** @description Run ID. */
       run_id?: string;
@@ -4598,6 +4581,26 @@ export interface operations {
       404: components["responses"]["NotFound"];
     };
   };
+  /** Create dataset event */
+  post_dataset_event: {
+    responses: {
+      /** Success. */
+      200: {
+        content: {
+          "application/json": components["schemas"]["DatasetEvent"];
+        };
+      };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthenticated"];
+      403: components["responses"]["PermissionDenied"];
+      404: components["responses"]["NotFound"];
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CreateDatasetEvent"];
+      };
+    };
+  };
   get_config: {
     parameters: {
       query: {
@@ -5173,6 +5176,9 @@ export type QueuedEvent = CamelCasedPropertiesDeep<
 export type QueuedEventCollection = CamelCasedPropertiesDeep<
   components["schemas"]["QueuedEventCollection"]
 >;
+export type CreateDatasetEvent = CamelCasedPropertiesDeep<
+  components["schemas"]["CreateDatasetEvent"]
+>;
 export type BasicDAGRun = CamelCasedPropertiesDeep<
   components["schemas"]["BasicDAGRun"]
 >;
@@ -5480,6 +5486,9 @@ export type GetDatasetVariables = CamelCasedPropertiesDeep<
 >;
 export type GetDatasetEventsVariables = CamelCasedPropertiesDeep<
   operations["get_dataset_events"]["parameters"]["query"]
+>;
+export type PostDatasetEventVariables = CamelCasedPropertiesDeep<
+  operations["post_dataset_event"]["requestBody"]["content"]["application/json"]
 >;
 export type GetConfigVariables = CamelCasedPropertiesDeep<
   operations["get_config"]["parameters"]["query"]

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -5487,7 +5487,7 @@ export type GetDatasetVariables = CamelCasedPropertiesDeep<
 export type GetDatasetEventsVariables = CamelCasedPropertiesDeep<
   operations["get_dataset_events"]["parameters"]["query"]
 >;
-export type PostDatasetEventVariables = CamelCasedPropertiesDeep<
+export type CreateDatasetEventVariables = CamelCasedPropertiesDeep<
   operations["create_dataset_event"]["requestBody"]["content"]["application/json"]
 >;
 export type GetConfigVariables = CamelCasedPropertiesDeep<

--- a/tests/api_connexion/endpoints/test_dataset_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dataset_endpoint.py
@@ -604,7 +604,7 @@ class TestPostDatasetEvents(TestDatasetEndpoint):
             "created_dagruns": [],
             "dataset_uri": event_payload["dataset_uri"],
             "dataset_id": ANY,
-            "extra": {"foo": "bar"},
+            "extra": {"foo": "bar", "from_rest_api": True},
             "source_dag_id": None,
             "source_task_id": None,
             "source_run_id": None,

--- a/tests/api_connexion/endpoints/test_dataset_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dataset_endpoint.py
@@ -597,7 +597,7 @@ class TestPostDatasetEvents(TestDatasetEndpoint):
             "source_dag_id": None,
             "source_task_id": None,
             "source_run_id": None,
-            "source_map_index": -1,
+            "source_map_index": None,
             "timestamp": self.default_time,
         }
 

--- a/tests/api_connexion/endpoints/test_dataset_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dataset_endpoint.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import urllib
 from typing import Generator
+from unittest.mock import ANY
 
 import pytest
 import time_machine
@@ -53,6 +54,7 @@ def configured_app(minimal_app_for_api):
         role_name="Test",
         permissions=[
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_DATASET),
+            (permissions.ACTION_CAN_CREATE, permissions.RESOURCE_DATASET),
         ],
     )
     create_user(app, username="test_no_permissions", role_name="TestNoPermissions")  # type: ignore
@@ -575,6 +577,42 @@ class TestGetDatasetEvents(TestDatasetEndpoint):
             ],
             "total_entries": 1,
         }
+
+
+class TestPostDatasetEvents(TestDatasetEndpoint):
+    def test_should_respond_200(self, session):
+        self._create_dataset(session)
+        event_payload = {"dataset_uri": "TEST_DATASET_URI", "extra": {"foo": "bar"}}
+        response = self.client.post(
+            "/api/v1/datasets/events", json=event_payload, environ_overrides={"REMOTE_USER": "test"}
+        )
+
+        assert response.status_code == 200
+        response_data = response.json
+        assert response_data == {
+            "id": ANY,
+            "dataset_uri": event_payload["dataset_uri"],
+            "dataset_id": ANY,
+            "extra": {"foo": "bar"},
+            "source_dag_id": None,
+            "source_task_id": None,
+            "source_run_id": None,
+            "source_map_index": -1,
+            "timestamp": self.default_time,
+        }
+
+    def test_order_by_raises_400_for_invalid_attr(self, session):
+        self._create_dataset(session)
+        event_invalid_payload = {"dataset_uri": "TEST_DATASET_URI", "extra": {"foo": "bar"}, "fake": {}}
+        response = self.client.post(
+            "/api/v1/datasets/events", json=event_invalid_payload, environ_overrides={"REMOTE_USER": "test"}
+        )
+        assert response.status_code == 400
+
+    def test_should_raises_401_unauthenticated(self, session):
+        self._create_dataset(session)
+        response = self.client.post("/api/v1/datasets/events", json={"dataset_uri": "TEST_DATASET_URI"})
+        assert_401(response)
 
 
 class TestGetDatasetEventsEndpointPagination(TestDatasetEndpoint):

--- a/tests/api_connexion/schemas/test_dataset_schema.py
+++ b/tests/api_connexion/schemas/test_dataset_schema.py
@@ -162,6 +162,37 @@ class TestDatasetEventSchema(TestDatasetSchemaBase):
         }
 
 
+class TestDatasetEventCreateSchema(TestDatasetSchemaBase):
+    def test_serialize(self, session):
+        d = DatasetModel("s3://abc")
+        session.add(d)
+        session.commit()
+        event = DatasetEvent(
+            id=1,
+            dataset_id=d.id,
+            extra={"foo": "bar"},
+            source_dag_id=None,
+            source_task_id=None,
+            source_run_id=None,
+            source_map_index=-1,
+        )
+        session.add(event)
+        session.flush()
+        serialized_data = dataset_event_schema.dump(event)
+        assert serialized_data == {
+            "id": 1,
+            "dataset_id": d.id,
+            "dataset_uri": "s3://abc",
+            "extra": {"foo": "bar"},
+            "source_dag_id": None,
+            "source_task_id": None,
+            "source_run_id": None,
+            "source_map_index": -1,
+            "timestamp": self.timestamp,
+            "created_dagruns": [],
+        }
+
+
 class TestDatasetEventCollectionSchema(TestDatasetSchemaBase):
     def test_serialize(self, session):
         common = {


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

related: #36723



<!-- Please keep an empty line above the dashes. -->
---
This PR introduces a new POST endpoint for dataset events in Apache Airflow. It allows for the registration of dataset events, enabling more dynamic tracking and management of datasets within Airflow workflows. The changes include modifications to API endpoints, schema definitions, dataset managers, security permissions, and corresponding unit tests to ensure functionality and security compliance.

Changes
- API Endpoints: Added a new post endpoint (post_dataset_event) to dataset_endpoint.py for creating dataset events, along with necessary security checks and action logging.
- OpenAPI Specification: Updated the openapi/v1.yaml file to include the new post endpoint under /datasets/events, including request and response schema definitions.
- Dataset Manager: Modified manager.py to support registering dataset changes without a task instance and to return a DatasetEvent object.
- Security Permissions: Updated security_manager/override.py to include create permissions for the dataset resource.
- UI and Types: Adjusted JavaScript components and API-generated types to accommodate the new changes.
- Unit Tests: Added comprehensive tests in test_dataset_endpoint.py and test_dataset_schema.py to cover the new endpoint functionality and schema validation.

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
