### PR TITLE
Deprecate PY* constants into the airflow module

### DIFF
--- a/airflow/utils/hashlib_wrapper.py
+++ b/airflow/utils/hashlib_wrapper.py
@@ -18,12 +18,11 @@
 from __future__ import annotations
 
 import hashlib
+import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from _typeshed import ReadableBuffer
-
-from airflow import PY39
 
 
 def md5(__string: ReadableBuffer = b"") -> hashlib._Hash:
@@ -33,6 +32,6 @@ def md5(__string: ReadableBuffer = b"") -> hashlib._Hash:
     :param __string: The data to hash. Default to empty str byte.
     :return: The hashed value.
     """
-    if PY39:
+    if sys.version_info >= (3, 9):
         return hashlib.md5(__string, usedforsecurity=False)  # type: ignore
     return hashlib.md5(__string)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1462,8 +1462,17 @@ combine-as-imports = true
 banned-module-level-imports = ["numpy", "pandas"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
+# Direct import from the airflow package modules and constraints
 "airflow.AirflowException".msg = "Use airflow.exceptions.AirflowException instead."
 "airflow.Dataset".msg = "Use airflow.datasets.Dataset instead."
+"airflow.PY36".msg = "Use sys.version_info >= (3, 6) instead."
+"airflow.PY37".msg = "Use sys.version_info >= (3, 7) instead."
+"airflow.PY38".msg = "Use sys.version_info >= (3, 8) instead."
+"airflow.PY39".msg = "Use sys.version_info >= (3, 9) instead."
+"airflow.PY310".msg = "Use sys.version_info >= (3, 10) instead."
+"airflow.PY311".msg = "Use sys.version_info >= (3, 11) instead."
+"airflow.PY312".msg = "Use sys.version_info >= (3, 12) instead."
+# Deprecated imports
 "airflow.models.baseoperator.BaseOperatorLink".msg = "Use airflow.models.baseoperatorlink.BaseOperatorLink"
 # Deprecated in Python 3.11, Pending Removal in Python 3.15: https://github.com/python/cpython/issues/90817
 # Deprecation warning in Python 3.11 also recommends using locale.getencoding but it available in Python 3.11

--- a/tests/core/test_airflow_module.py
+++ b/tests/core/test_airflow_module.py
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+import airflow
+from airflow.exceptions import AirflowException
+
+TEST_CASES = {
+    "PY36": sys.version_info >= (3, 6),
+    "PY37": sys.version_info >= (3, 7),
+    "PY38": sys.version_info >= (3, 8),
+    "PY39": sys.version_info >= (3, 9),
+    "PY310": sys.version_info >= (3, 10),
+    "PY311": sys.version_info >= (3, 11),
+    "PY312": sys.version_info >= (3, 12),
+}
+
+
+@pytest.mark.parametrize("py_attr, expected", TEST_CASES.items())
+def test_lazy_load_py_versions(py_attr, expected):
+    with pytest.warns(DeprecationWarning, match=f"Python version constraint '{py_attr}' is deprecated"):
+        # If there is no warning, then most possible it imported somewhere else.
+        assert getattr(airflow, py_attr) is expected
+
+
+@pytest.mark.parametrize("py_attr", ["PY35", "PY313"])
+def test_wrong_py_version(py_attr):
+    with pytest.raises(AttributeError, match=f"'airflow' has no attribute '{py_attr}'"):
+        getattr(airflow, py_attr)
+
+
+def test_deprecated_exception():
+    warning_pattern = "Import 'AirflowException' directly from the airflow module is deprecated"
+    with pytest.warns(DeprecationWarning, match=warning_pattern):
+        # If there is no warning, then most possible it imported somewhere else.
+        assert getattr(airflow, "AirflowException") is AirflowException

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -19,13 +19,14 @@ from __future__ import annotations
 
 import datetime
 import os
+import sys
 from unittest import mock
 from unittest.mock import MagicMock, patch
 from zipfile import ZipFile
 
 import pytest
 
-from airflow import PY311, settings
+from airflow import settings
 from airflow.callbacks.callback_requests import TaskCallbackRequest
 from airflow.configuration import TEST_DAGS_FOLDER, conf
 from airflow.dag_processing.manager import DagFileProcessorAgent
@@ -53,6 +54,7 @@ from tests.test_utils.mock_executor import MockExecutor
 pytestmark = pytest.mark.db_test
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
+PY311 = sys.version_info >= (3, 11)
 
 # Include the words "airflow" and "dag" in the file contents,
 # tricking airflow into thinking these

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -22,7 +22,6 @@ from typing import TYPE_CHECKING, Dict, Tuple, Union
 
 import pytest
 
-from airflow import PY38, PY311
 from airflow.decorators import setup, task as task_decorator, teardown
 from airflow.decorators.base import DecoratedMappedOperator
 from airflow.exceptions import AirflowException, XComNotFound
@@ -49,6 +48,8 @@ if TYPE_CHECKING:
     from airflow.models.dagrun import DagRun
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
+PY38 = sys.version_info >= (3, 8)
+PY311 = sys.version_info >= (3, 11)
 
 
 class TestAirflowTaskDecorator(BasePythonTest):

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -37,7 +37,6 @@ from unittest.mock import MagicMock
 import pytest
 from slugify import slugify
 
-from airflow import PY311
 from airflow.decorators import task_group
 from airflow.exceptions import AirflowException, DeserializingResultError, RemovedInAirflow3Warning
 from airflow.models.baseoperator import BaseOperator
@@ -75,6 +74,7 @@ DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 TEMPLATE_SEARCHPATH = os.path.join(AIRFLOW_MAIN_FOLDER, "tests", "config_templates")
 LOGGER_NAME = "airflow.task.operators"
 DEFAULT_PYTHON_VERSION = f"{sys.version_info[0]}.{sys.version_info[1]}"
+PY311 = sys.version_info >= (3, 11)
 
 
 class BasePythonTest:

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -17,22 +17,13 @@
 # under the License.
 from __future__ import annotations
 
-import pytest
-
-from airflow import PY311
-
-if PY311:
-    pytest.skip(
-        "The tests are skipped because Apache Hive provider is not supported on Python 3.11",
-        allow_module_level=True,
-    )
-
 import datetime
 import itertools
 from collections import namedtuple
 from unittest import mock
 
 import pandas as pd
+import pytest
 from hmsclient import HMSClient
 
 from airflow.exceptions import AirflowException

--- a/tests/serialization/serializers/test_serializers.py
+++ b/tests/serialization/serializers/test_serializers.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import datetime
 import decimal
+import sys
 from importlib import metadata
 from unittest.mock import patch
 
@@ -31,11 +32,10 @@ from packaging import version
 from pendulum import DateTime
 from pendulum.tz.timezone import FixedTimezone, Timezone
 
-from airflow import PY39
 from airflow.models.param import Param, ParamsDict
 from airflow.serialization.serde import DATA, deserialize, serialize
 
-if PY39:
+if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo
 else:
     from backports.zoneinfo import ZoneInfo


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

First constant was added in https://github.com/apache/airflow/pull/7517 for validate is Airflow run on Python >= 3.7 and if not use backport support of [PEP-562](https://peps.python.org/pep-0562/).

It is not widely use in Airflow Core, at that moment there is only one reference. However it might be not safe to use it in core, because it might create cyclic error in case if it imported somewhere else during first load, e.g. into the `airflow.configurations` or `airflow.settings` or their imports. In providers it is not practical to use it, you have to wait approx one year for allow to use it, and it also might be a reason for cyclic errors, e.g. if it use in secrets backends and their imports.

For avoid usage in project it disabled by `TID251` - Banned API
All current usage, most in tests, replaced by `sys.version_info`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
