### PR TITLE
Clean up webserver endpoints adding to audit log

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1837,8 +1837,8 @@ webserver:
         The audit logs in the db will not be affected by this parameter.
       version_added: 2.3.0
       type: string
-      example: ~
-      default: "gantt,landing_times,tries,duration,calendar,graph,grid,tree"
+      example: "cli_task_run,running,success"
+      default: ~
     audit_view_included_events:
       description: |
         Comma separated string of view events to include in dag audit view.

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1838,7 +1838,7 @@ webserver:
       version_added: 2.3.0
       type: string
       example: ~
-      default: "gantt,landing_times,tries,duration,calendar,graph,grid,tree,tree_data"
+      default: "gantt,landing_times,tries,duration,calendar,graph,grid,tree"
     audit_view_included_events:
       description: |
         Comma separated string of view events to include in dag audit view.

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1360,7 +1360,7 @@ class Airflow(AirflowBaseView):
 
         logging.info("Retrieving rendered templates.")
         dag: DAG = get_airflow_app().dag_bag.get_dag(dag_id)
-        dag_run = dag.get_dagrun(execution_date=dttm, session=session)
+        dag_run = dag.get_dagrun(execution_date=dttm)
         raw_task = dag.get_task(task_id).prepare_for_execution()
 
         no_dagrun = False

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1347,7 +1347,6 @@ class Airflow(AirflowBaseView):
 
     @expose("/rendered-templates")
     @auth.has_access_dag("GET", DagAccessEntity.TASK_INSTANCE)
-    @action_logging
     @provide_session
     def rendered_templates(self, session):
         """Get rendered Dag."""
@@ -1466,7 +1465,6 @@ class Airflow(AirflowBaseView):
 
     @expose("/rendered-k8s")
     @auth.has_access_dag("GET", DagAccessEntity.TASK_INSTANCE)
-    @action_logging
     @provide_session
     def rendered_k8s(self, *, session: Session = NEW_SESSION):
         """Get rendered k8s yaml."""
@@ -1532,7 +1530,6 @@ class Airflow(AirflowBaseView):
     @expose("/get_logs_with_metadata")
     @auth.has_access_dag("GET", DagAccessEntity.TASK_INSTANCE)
     @auth.has_access_dag("GET", DagAccessEntity.TASK_LOGS)
-    @action_logging
     @provide_session
     def get_logs_with_metadata(self, session: Session = NEW_SESSION):
         """Retrieve logs including metadata."""
@@ -1613,7 +1610,6 @@ class Airflow(AirflowBaseView):
 
     @expose("/log")
     @auth.has_access_dag("GET", DagAccessEntity.TASK_LOGS)
-    @action_logging
     @provide_session
     def log(self, session: Session = NEW_SESSION):
         """Retrieve log."""
@@ -1658,7 +1654,6 @@ class Airflow(AirflowBaseView):
 
     @expose("/redirect_to_external_log")
     @auth.has_access_dag("GET", DagAccessEntity.TASK_LOGS)
-    @action_logging
     @provide_session
     def redirect_to_external_log(self, session: Session = NEW_SESSION):
         """Redirects to external log."""
@@ -1690,7 +1685,6 @@ class Airflow(AirflowBaseView):
 
     @expose("/task")
     @auth.has_access_dag("GET", DagAccessEntity.TASK_INSTANCE)
-    @action_logging
     @provide_session
     def task(self, session: Session = NEW_SESSION):
         """Retrieve task."""
@@ -1816,7 +1810,6 @@ class Airflow(AirflowBaseView):
 
     @expose("/xcom")
     @auth.has_access_dag("GET", DagAccessEntity.XCOM)
-    @action_logging
     @provide_session
     def xcom(self, session: Session = NEW_SESSION):
         """Retrieve XCOM."""
@@ -2345,6 +2338,7 @@ class Airflow(AirflowBaseView):
 
     @expose("/blocked", methods=["POST"])
     @auth.has_access_dag("GET", DagAccessEntity.RUN)
+    @action_logging
     @provide_session
     def blocked(self, session: Session = NEW_SESSION):
         """Mark Dag Blocked."""
@@ -2980,7 +2974,6 @@ class Airflow(AirflowBaseView):
 
     @expose("/dags/<string:dag_id>/duration")
     @auth.has_access_dag("GET", DagAccessEntity.TASK_INSTANCE)
-    @action_logging
     @provide_session
     def duration(self, dag_id: str, session: Session = NEW_SESSION):
         """Get Dag as duration graph."""
@@ -3132,7 +3125,6 @@ class Airflow(AirflowBaseView):
 
     @expose("/dags/<string:dag_id>/tries")
     @auth.has_access_dag("GET", DagAccessEntity.TASK_INSTANCE)
-    @action_logging
     @provide_session
     def tries(self, dag_id: str, session: Session = NEW_SESSION):
         """Show all tries."""
@@ -3214,7 +3206,6 @@ class Airflow(AirflowBaseView):
 
     @expose("/dags/<string:dag_id>/landing-times")
     @auth.has_access_dag("GET", DagAccessEntity.TASK_INSTANCE)
-    @action_logging
     @provide_session
     def landing_times(self, dag_id: str, session: Session = NEW_SESSION):
         """Show landing times."""
@@ -3334,7 +3325,6 @@ class Airflow(AirflowBaseView):
 
     @expose("/extra_links")
     @auth.has_access_dag("GET", DagAccessEntity.TASK_INSTANCE)
-    @action_logging
     @provide_session
     def extra_links(self, *, session: Session = NEW_SESSION):
         """
@@ -3745,7 +3735,6 @@ class Airflow(AirflowBaseView):
             )
 
     @expose("/robots.txt")
-    @action_logging
     def robots(self):
         """
         Return a robots.txt file for blocking certain search engine crawlers.
@@ -5780,7 +5769,6 @@ class DagDependenciesView(AirflowBaseView):
     @expose("/dag-dependencies")
     @auth.has_access_dag("GET", DagAccessEntity.DEPENDENCIES)
     @gzipped
-    @action_logging
     def list(self):
         """Display DAG dependencies."""
         title = "DAG Dependencies"

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1325,8 +1325,7 @@ class Airflow(AirflowBaseView):
 
     @expose("/dags/<string:dag_id>/code")
     @auth.has_access_dag("GET", DagAccessEntity.CODE)
-    @provide_session
-    def code(self, dag_id, session: Session = NEW_SESSION):
+    def code(self, dag_id):
         """Dag Code."""
         kwargs = {
             **sanitize_args(request.args),
@@ -2491,7 +2490,7 @@ class Airflow(AirflowBaseView):
 
     @expose("/dagrun_details")
     def dagrun_details(self):
-        """Redirect to the GRID DAGRun page. This is avoids breaking links."""
+        """Redirect to the Grid DagRun page. This is avoids breaking links."""
         dag_id = request.args.get("dag_id")
         run_id = request.args.get("run_id")
         return redirect(url_for("Airflow.grid", dag_id=dag_id, dag_run_id=run_id))
@@ -2762,16 +2761,12 @@ class Airflow(AirflowBaseView):
             )
 
     @expose("/dags/<string:dag_id>")
-    @gzipped
-    @action_logging
     def dag(self, dag_id):
         """Redirect to default DAG view."""
         kwargs = {**sanitize_args(request.args), "dag_id": dag_id}
         return redirect(url_for("Airflow.grid", **kwargs))
 
     @expose("/tree")
-    @gzipped
-    @action_logging
     def legacy_tree(self):
         """Redirect to the replacement - grid view. Kept for backwards compatibility."""
         return redirect(url_for("Airflow.grid", **sanitize_args(request.args)))
@@ -2838,8 +2833,6 @@ class Airflow(AirflowBaseView):
         )
 
     @expose("/calendar")
-    @gzipped
-    @action_logging
     def legacy_calendar(self):
         """Redirect from url param."""
         return redirect(url_for("Airflow.calendar", **sanitize_args(request.args)))
@@ -2953,15 +2946,12 @@ class Airflow(AirflowBaseView):
         )
 
     @expose("/graph")
-    @gzipped
-    @action_logging
     def legacy_graph(self):
         """Redirect from url param."""
         return redirect(url_for("Airflow.graph", **sanitize_args(request.args)))
 
     @expose("/dags/<string:dag_id>/graph")
     @gzipped
-    @action_logging
     @provide_session
     def graph(self, dag_id: str, session: Session = NEW_SESSION):
         """Redirect to the replacement - grid + graph. Kept for backwards compatibility."""
@@ -2984,7 +2974,6 @@ class Airflow(AirflowBaseView):
         return redirect(url_for("Airflow.grid", **kwargs))
 
     @expose("/duration")
-    @action_logging
     def legacy_duration(self):
         """Redirect from url param."""
         return redirect(url_for("Airflow.duration", **sanitize_args(request.args)))
@@ -3137,7 +3126,6 @@ class Airflow(AirflowBaseView):
         )
 
     @expose("/tries")
-    @action_logging
     def legacy_tries(self):
         """Redirect from url param."""
         return redirect(url_for("Airflow.tries", **sanitize_args(request.args)))
@@ -3220,7 +3208,6 @@ class Airflow(AirflowBaseView):
         )
 
     @expose("/landing_times")
-    @action_logging
     def legacy_landing_times(self):
         """Redirect from url param."""
         return redirect(url_for("Airflow.landing_times", **sanitize_args(request.args)))
@@ -3326,14 +3313,12 @@ class Airflow(AirflowBaseView):
         return "OK"
 
     @expose("/gantt")
-    @action_logging
     def legacy_gantt(self):
         """Redirect from url param."""
         return redirect(url_for("Airflow.gantt", **sanitize_args(request.args)))
 
     @expose("/dags/<string:dag_id>/gantt")
     @auth.has_access_dag("GET", DagAccessEntity.TASK_INSTANCE)
-    @action_logging
     @provide_session
     def gantt(self, dag_id: str, session: Session = NEW_SESSION):
         """Redirect to the replacement - grid + gantt. Kept for backwards compatibility."""
@@ -3406,12 +3391,10 @@ class Airflow(AirflowBaseView):
     @expose("/object/graph_data")
     @auth.has_access_dag("GET", DagAccessEntity.TASK_INSTANCE)
     @gzipped
-    @action_logging
-    @provide_session
-    def graph_data(self, session: Session = NEW_SESSION):
+    def graph_data(self):
         """Get Graph Data."""
         dag_id = request.args.get("dag_id")
-        dag = get_airflow_app().dag_bag.get_dag(dag_id, session=session)
+        dag = get_airflow_app().dag_bag.get_dag(dag_id)
         root = request.args.get("root")
         if root:
             filter_upstream = request.args.get("filter_upstream") == "true"
@@ -3435,7 +3418,6 @@ class Airflow(AirflowBaseView):
 
     @expose("/object/task_instances")
     @auth.has_access_dag("GET", DagAccessEntity.TASK_INSTANCE)
-    @action_logging
     def task_instances(self):
         """Show task instances."""
         dag_id = request.args.get("dag_id")

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2768,7 +2768,6 @@ class Airflow(AirflowBaseView):
     @expose("/dags/<string:dag_id>/grid")
     @auth.has_access_dag("GET", DagAccessEntity.TASK_INSTANCE)
     @gzipped
-    @action_logging
     @provide_session
     def grid(self, dag_id: str, session: Session = NEW_SESSION):
         """Get Dag's grid view."""
@@ -2834,7 +2833,6 @@ class Airflow(AirflowBaseView):
     @expose("/dags/<string:dag_id>/calendar")
     @auth.has_access_dag("GET", DagAccessEntity.RUN)
     @gzipped
-    @action_logging
     @provide_session
     def calendar(self, dag_id: str, session: Session = NEW_SESSION):
         """Get DAG runs as calendar."""

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3735,6 +3735,7 @@ class Airflow(AirflowBaseView):
             )
 
     @expose("/robots.txt")
+    @action_logging
     def robots(self):
         """
         Return a robots.txt file for blocking certain search engine crawlers.

--- a/tests/www/views/test_views_decorators.py
+++ b/tests/www/views/test_views_decorators.py
@@ -17,8 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import urllib.parse
-
 import pytest
 
 from airflow.models import DagBag, Variable
@@ -92,39 +90,17 @@ def clean_db():
     clear_db_variables()
 
 
-def test_action_logging_get(session, admin_client):
-    url = (
-        f"dags/example_bash_operator/grid?"
-        f"execution_date={urllib.parse.quote_plus(str(EXAMPLE_DAG_DEFAULT_DATE))}"
-    )
-    resp = admin_client.get(url, follow_redirects=True)
-    check_content_in_response("success", resp)
+def test_action_logging_robots(session, admin_client):
+    url = "/robots.txt"
+    admin_client.get(url, follow_redirects=True)
 
     # In mysql backend, this commit() is needed to write down the logs
     session.commit()
     _check_last_log(
         session,
-        dag_id="example_bash_operator",
-        event="grid",
-        execution_date=EXAMPLE_DAG_DEFAULT_DATE,
-    )
-
-
-def test_action_logging_get_legacy_view(session, admin_client):
-    url = (
-        f"tree?dag_id=example_bash_operator&"
-        f"execution_date={urllib.parse.quote_plus(str(EXAMPLE_DAG_DEFAULT_DATE))}"
-    )
-    resp = admin_client.get(url, follow_redirects=True)
-    check_content_in_response("success", resp)
-
-    # In mysql backend, this commit() is needed to write down the logs
-    session.commit()
-    _check_last_log(
-        session,
-        dag_id="example_bash_operator",
-        event="legacy_tree",
-        execution_date=EXAMPLE_DAG_DEFAULT_DATE,
+        event="robots",
+        dag_id=None,
+        execution_date=None,
     )
 
 


### PR DESCRIPTION
Only log webserver events that are CRUD actions. View-only endpoints shouldn't be logged. Therefore we don't need any default excluded events.


Removed a few other unused decorators, mostly on on redirect functions.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
