### PR TITLE
Fix spelling of `airflow`

### DIFF
--- a/dev/README_RELEASE_PYTHON_CLIENT.md
+++ b/dev/README_RELEASE_PYTHON_CLIENT.md
@@ -161,7 +161,7 @@ cd airflow-dev/clients/python
 svn mkdir ${VERSION}${VERSION_SUFFIX}
 
 # Move the artifacts to svn folder & commit
-mv ${AIRLFOW_REPO_ROOT}/dist/apache_airflow_client-* ${VERSION}${VERSION_SUFFIX}/
+mv ${AIRFLOW_REPO_ROOT}/dist/apache_airflow_client-* ${VERSION}${VERSION_SUFFIX}/
 cd ${VERSION}${VERSION_SUFFIX}
 svn add *
 svn commit -m "Add artifacts for Apache Airflow Python Client ${VERSION}${VERSION_SUFFIX}"

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -153,11 +153,11 @@ class CustomBuildHook(BuildHookInterface[BuilderConfig]):
         Any modifications to the build data will be seen by the build target.
         """
         if version == "standard":
-            all_possible_non_airlfow_dependencies = []
+            all_possible_non_airflow_dependencies = []
             for extra, deps in self.metadata.core.optional_dependencies.items():
                 for dep in deps:
                     if not dep.startswith("apache-airflow"):
-                        all_possible_non_airlfow_dependencies.append(dep)
+                        all_possible_non_airflow_dependencies.append(dep)
             # remove devel dependencies from optional dependencies for standard packages
             self.metadata.core._optional_dependencies = {
                 key: value
@@ -167,7 +167,7 @@ class CustomBuildHook(BuildHookInterface[BuilderConfig]):
             # This is the special dependency in wheel package that is used to install all possible
             # 3rd-party dependencies for airflow for the CI image. It is exposed in the wheel package
             # because we want to use for building the image cache from GitHub URL.
-            self.metadata.core._optional_dependencies["devel-ci"] = all_possible_non_airlfow_dependencies
+            self.metadata.core._optional_dependencies["devel-ci"] = all_possible_non_airflow_dependencies
             # Replace editable dependencies with provider dependencies for provider packages
             for dependency_id in DEPENDENCIES.keys():
                 if DEPENDENCIES[dependency_id]["state"] != "ready":


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
