### PR TITLE
Show dataset events above task/run details in grid view

### DIFF
--- a/airflow/www/static/js/api/useUpstreamDatasetEvents.ts
+++ b/airflow/www/static/js/api/useUpstreamDatasetEvents.ts
@@ -33,7 +33,7 @@ export default function useUpstreamDatasetEvents({ runId }: Props) {
     const upstreamEventsUrl = (
       getMetaValue("upstream_dataset_events_api") ||
       `api/v1/dags/${dagId}/dagRuns/_DAG_RUN_ID_/upstreamDatasetEvents`
-    ).replace("_DAG_RUN_ID_", runId);
+    ).replace("_DAG_RUN_ID_", encodeURIComponent(runId));
     return axios.get<AxiosResponse, API.DatasetEventCollection>(
       upstreamEventsUrl
     );

--- a/airflow/www/static/js/dag/details/dagRun/DatasetTriggerEvents.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/DatasetTriggerEvents.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useMemo } from "react";
-import { Box, Heading, Text } from "@chakra-ui/react";
+import { Box, Text } from "@chakra-ui/react";
 
 import {
   DatasetLink,
@@ -63,7 +63,9 @@ const DatasetTriggerEvents = ({ runId }: Props) => {
 
   return (
     <Box mt={3} flexGrow={1}>
-      <Heading size="md">Dataset Events</Heading>
+      <Text as="strong" mb={3}>
+        Dataset Events
+      </Text>
       <Text>Dataset updates that triggered this DAG run.</Text>
       <Table data={data} columns={columns} isLoading={isLoading} />
     </Box>

--- a/airflow/www/static/js/dag/details/dagRun/DatasetTriggerEvents.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/DatasetTriggerEvents.tsx
@@ -20,6 +20,7 @@ import React, { useMemo } from "react";
 import { Box, Text } from "@chakra-ui/react";
 
 import {
+  CodeCell,
   DatasetLink,
   Table,
   TaskInstanceLink,
@@ -54,6 +55,12 @@ const DatasetTriggerEvents = ({ runId }: Props) => {
         Header: "When",
         accessor: "timestamp",
         Cell: TimeCell,
+      },
+      {
+        Header: "Extra",
+        accessor: "extra",
+        Cell: CodeCell,
+        disableSortBy: true,
       },
     ],
     []

--- a/airflow/www/static/js/dag/details/dagRun/Details.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/Details.tsx
@@ -1,0 +1,193 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useEffect } from "react";
+import {
+  Flex,
+  Box,
+  Button,
+  Spacer,
+  Table,
+  Tbody,
+  Tr,
+  Td,
+  useClipboard,
+  Text,
+} from "@chakra-ui/react";
+
+import ReactJson from "react-json-view";
+
+import type { DagRun as DagRunType } from "src/types";
+import { SimpleStatus } from "src/dag/StatusBox";
+import { ClipboardText } from "src/components/Clipboard";
+import { formatDuration, getDuration } from "src/datetime_utils";
+import Time from "src/components/Time";
+import RunTypeIcon from "src/components/RunTypeIcon";
+
+interface Props {
+  run: DagRunType;
+}
+
+const formatConf = (conf: string | null | undefined): string => {
+  if (!conf) {
+    return "";
+  }
+  return JSON.stringify(JSON.parse(conf), null, 4);
+};
+
+const DagRunDetails = ({ run }: Props) => {
+  const { onCopy, setValue, hasCopied } = useClipboard(formatConf(run?.conf));
+
+  useEffect(() => {
+    setValue(formatConf(run?.conf));
+  }, [run, setValue]);
+
+  if (!run) return null;
+  const {
+    state,
+    runType,
+    lastSchedulingDecision,
+    dataIntervalStart,
+    dataIntervalEnd,
+    startDate,
+    endDate,
+    queuedAt,
+    externalTrigger,
+    conf,
+    confIsJson,
+  } = run;
+
+  return (
+    <Box mt={3} flexGrow={1}>
+      <Text as="strong" mb={3}>
+        Dag Run Details
+      </Text>
+      <Table variant="striped">
+        <Tbody>
+          <Tr>
+            <Td>Status</Td>
+            <Td>
+              <Flex>
+                <SimpleStatus state={state} mx={2} />
+                {state || "no status"}
+              </Flex>
+            </Td>
+          </Tr>
+          <Tr>
+            <Td>Run ID</Td>
+            <Td>
+              <ClipboardText value={run.runId} />
+            </Td>
+          </Tr>
+          <Tr>
+            <Td>Run type</Td>
+            <Td>
+              <RunTypeIcon runType={runType} />
+              {runType}
+            </Td>
+          </Tr>
+          {startDate && (
+            <Tr>
+              <Td>Run duration</Td>
+              <Td>{formatDuration(getDuration(startDate, endDate))}</Td>
+            </Tr>
+          )}
+          {lastSchedulingDecision && (
+            <Tr>
+              <Td>Last scheduling decision</Td>
+              <Td>
+                <Time dateTime={lastSchedulingDecision} />
+              </Td>
+            </Tr>
+          )}
+          {queuedAt && (
+            <Tr>
+              <Td>Queued at</Td>
+              <Td>
+                <Time dateTime={queuedAt} />
+              </Td>
+            </Tr>
+          )}
+          {startDate && (
+            <Tr>
+              <Td>Started</Td>
+              <Td>
+                <Time dateTime={startDate} />
+              </Td>
+            </Tr>
+          )}
+          {endDate && (
+            <Tr>
+              <Td>Ended</Td>
+              <Td>
+                <Time dateTime={endDate} />
+              </Td>
+            </Tr>
+          )}
+          {dataIntervalStart && dataIntervalEnd && (
+            <>
+              <Tr>
+                <Td>Data interval start</Td>
+                <Td>
+                  <Time dateTime={dataIntervalStart} />
+                </Td>
+              </Tr>
+              <Tr>
+                <Td>Data interval end</Td>
+                <Td>
+                  <Time dateTime={dataIntervalEnd} />
+                </Td>
+              </Tr>
+            </>
+          )}
+          <Tr>
+            <Td>Externally triggered</Td>
+            <Td>{externalTrigger ? "True" : "False"}</Td>
+          </Tr>
+          <Tr>
+            <Td>Run config</Td>
+            {confIsJson ? (
+              <Td>
+                <Flex>
+                  <ReactJson
+                    src={JSON.parse(conf ?? "")}
+                    name={false}
+                    theme="rjv-default"
+                    iconStyle="triangle"
+                    indentWidth={2}
+                    displayDataTypes={false}
+                    enableClipboard={false}
+                    style={{ backgroundColor: "inherit" }}
+                  />
+                  <Spacer />
+                  <Button aria-label="Copy" onClick={onCopy}>
+                    {hasCopied ? "Copied!" : "Copy"}
+                  </Button>
+                </Flex>
+              </Td>
+            ) : (
+              <Td>{conf ?? "None"}</Td>
+            )}
+          </Tr>
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default DagRunDetails;

--- a/airflow/www/static/js/dag/details/dagRun/index.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/index.tsx
@@ -16,46 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useEffect, useRef } from "react";
-import {
-  Flex,
-  Box,
-  Button,
-  Divider,
-  Spacer,
-  Table,
-  Tbody,
-  Tr,
-  Td,
-  useClipboard,
-} from "@chakra-ui/react";
-
-import ReactJson from "react-json-view";
+import React, { useRef } from "react";
+import { Box } from "@chakra-ui/react";
 
 import { useGridData } from "src/api";
 import { getMetaValue, useOffsetTop } from "src/utils";
 import type { DagRun as DagRunType } from "src/types";
-import { SimpleStatus } from "src/dag/StatusBox";
-import { ClipboardText } from "src/components/Clipboard";
-import { formatDuration, getDuration } from "src/datetime_utils";
-import Time from "src/components/Time";
-import RunTypeIcon from "src/components/RunTypeIcon";
 import NotesAccordion from "src/dag/details/NotesAccordion";
 
 import DatasetTriggerEvents from "./DatasetTriggerEvents";
+import DagRunDetails from "./Details";
 
 const dagId = getMetaValue("dag_id");
 
 interface Props {
   runId: DagRunType["runId"];
 }
-
-const formatConf = (conf: string | null | undefined): string => {
-  if (!conf) {
-    return "";
-  }
-  return JSON.stringify(JSON.parse(conf), null, 4);
-};
 
 const DagRun = ({ runId }: Props) => {
   const {
@@ -65,27 +41,9 @@ const DagRun = ({ runId }: Props) => {
   const offsetTop = useOffsetTop(detailsRef);
 
   const run = dagRuns.find((dr) => dr.runId === runId);
-  const { onCopy, setValue, hasCopied } = useClipboard(formatConf(run?.conf));
-
-  useEffect(() => {
-    setValue(formatConf(run?.conf));
-  }, [run, setValue]);
 
   if (!run) return null;
-  const {
-    state,
-    runType,
-    lastSchedulingDecision,
-    dataIntervalStart,
-    dataIntervalEnd,
-    startDate,
-    endDate,
-    queuedAt,
-    externalTrigger,
-    conf,
-    confIsJson,
-    note,
-  } = run;
+  const { runType, note } = run;
 
   return (
     <Box
@@ -94,127 +52,16 @@ const DagRun = ({ runId }: Props) => {
       overflowY="auto"
       pb={4}
     >
-      <Box px={4}>
-        <NotesAccordion
-          dagId={dagId}
-          runId={runId}
-          initialValue={note}
-          key={dagId + runId}
-        />
-      </Box>
-      <Divider my={0} />
-      <Table variant="striped">
-        <Tbody>
-          <Tr>
-            <Td>Status</Td>
-            <Td>
-              <Flex>
-                <SimpleStatus state={state} mx={2} />
-                {state || "no status"}
-              </Flex>
-            </Td>
-          </Tr>
-          <Tr>
-            <Td>Run ID</Td>
-            <Td>
-              <ClipboardText value={runId} />
-            </Td>
-          </Tr>
-          <Tr>
-            <Td>Run type</Td>
-            <Td>
-              <RunTypeIcon runType={runType} />
-              {runType}
-            </Td>
-          </Tr>
-          {startDate && (
-            <Tr>
-              <Td>Run duration</Td>
-              <Td>{formatDuration(getDuration(startDate, endDate))}</Td>
-            </Tr>
-          )}
-          {lastSchedulingDecision && (
-            <Tr>
-              <Td>Last scheduling decision</Td>
-              <Td>
-                <Time dateTime={lastSchedulingDecision} />
-              </Td>
-            </Tr>
-          )}
-          {queuedAt && (
-            <Tr>
-              <Td>Queued at</Td>
-              <Td>
-                <Time dateTime={queuedAt} />
-              </Td>
-            </Tr>
-          )}
-          {startDate && (
-            <Tr>
-              <Td>Started</Td>
-              <Td>
-                <Time dateTime={startDate} />
-              </Td>
-            </Tr>
-          )}
-          {endDate && (
-            <Tr>
-              <Td>Ended</Td>
-              <Td>
-                <Time dateTime={endDate} />
-              </Td>
-            </Tr>
-          )}
-          {dataIntervalStart && dataIntervalEnd && (
-            <>
-              <Tr>
-                <Td>Data interval start</Td>
-                <Td>
-                  <Time dateTime={dataIntervalStart} />
-                </Td>
-              </Tr>
-              <Tr>
-                <Td>Data interval end</Td>
-                <Td>
-                  <Time dateTime={dataIntervalEnd} />
-                </Td>
-              </Tr>
-            </>
-          )}
-          <Tr>
-            <Td>Externally triggered</Td>
-            <Td>{externalTrigger ? "True" : "False"}</Td>
-          </Tr>
-          <Tr>
-            <Td>Run config</Td>
-            {confIsJson ? (
-              <Td>
-                <Flex>
-                  <ReactJson
-                    src={JSON.parse(conf ?? "")}
-                    name={false}
-                    theme="rjv-default"
-                    iconStyle="triangle"
-                    indentWidth={2}
-                    displayDataTypes={false}
-                    enableClipboard={false}
-                    style={{ backgroundColor: "inherit" }}
-                  />
-                  <Spacer />
-                  <Button aria-label="Copy" onClick={onCopy}>
-                    {hasCopied ? "Copied!" : "Copy"}
-                  </Button>
-                </Flex>
-              </Td>
-            ) : (
-              <Td>{conf ?? "None"}</Td>
-            )}
-          </Tr>
-        </Tbody>
-      </Table>
+      <NotesAccordion
+        dagId={dagId}
+        runId={runId}
+        initialValue={note}
+        key={dagId + runId}
+      />
       {runType === "dataset_triggered" && (
         <DatasetTriggerEvents runId={runId} />
       )}
+      <DagRunDetails run={run} />
     </Box>
   );
 };

--- a/airflow/www/static/js/dag/details/taskInstance/DatasetUpdateEvents.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/DatasetUpdateEvents.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useMemo } from "react";
-import { Box, Heading, Text } from "@chakra-ui/react";
+import { Box, Text } from "@chakra-ui/react";
 
 import {
   DatasetLink,
@@ -70,8 +70,10 @@ const DatasetUpdateEvents = ({ runId, taskId }: Props) => {
   const data = useMemo(() => datasetEvents, [datasetEvents]);
 
   return (
-    <Box mt={3} flexGrow={1}>
-      <Heading size="md">Dataset Events</Heading>
+    <Box my={3} flexGrow={1}>
+      <Text as="strong" mb={3}>
+        Dataset Events
+      </Text>
       <Text>Dataset updates caused by this task instance</Text>
       <Table data={data} columns={columns} isLoading={isLoading} />
     </Box>

--- a/airflow/www/static/js/dag/details/taskInstance/DatasetUpdateEvents.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/DatasetUpdateEvents.tsx
@@ -20,6 +20,7 @@ import React, { useMemo } from "react";
 import { Box, Text } from "@chakra-ui/react";
 
 import {
+  CodeCell,
   DatasetLink,
   Table,
   TimeCell,
@@ -62,6 +63,12 @@ const DatasetUpdateEvents = ({ runId, taskId }: Props) => {
         Header: "Triggered Runs",
         accessor: "createdDagruns",
         Cell: TriggeredRuns,
+      },
+      {
+        Header: "Extra",
+        accessor: "extra",
+        Cell: CodeCell,
+        disableSortBy: true,
       },
     ],
     []

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -18,7 +18,7 @@
  */
 
 import React from "react";
-import { Text, Flex, Table, Tbody, Tr, Td, Code } from "@chakra-ui/react";
+import { Text, Flex, Table, Tbody, Tr, Td, Code, Box } from "@chakra-ui/react";
 import { snakeCase } from "lodash";
 
 import { getGroupAndMapSummary } from "src/utils";
@@ -32,7 +32,6 @@ import type {
   TaskInstance as GridTaskInstance,
   TaskState,
 } from "src/types";
-import DatasetUpdateEvents from "./DatasetUpdateEvents";
 
 interface Props {
   gridInstance: GridTaskInstance;
@@ -48,7 +47,7 @@ const Details = ({ gridInstance, taskInstance, group }: Props) => {
 
   const mappedStates = !taskInstance ? gridInstance.mappedStates : undefined;
 
-  const { isMapped, tooltip, operator, hasOutletDatasets, triggerRule } = group;
+  const { isMapped, tooltip, operator, triggerRule } = group;
 
   const { totalTasks, childTaskMap } = getGroupAndMapSummary({
     group,
@@ -82,39 +81,7 @@ const Details = ({ gridInstance, taskInstance, group }: Props) => {
   const isOverall = (isMapped || isGroup) && "Overall ";
 
   return (
-    <Flex flexWrap="wrap" justifyContent="space-between">
-      {!!taskInstance?.trigger && !!taskInstance?.triggererJob && (
-        <>
-          <Text as="strong" mb={3}>
-            Triggerer info
-          </Text>
-          <Table variant="striped" mb={3}>
-            <Tbody>
-              <Tr>
-                <Td>Trigger class</Td>
-                <Td>{`${taskInstance?.trigger?.classpath}`}</Td>
-              </Tr>
-              <Tr>
-                <Td>Trigger ID</Td>
-                <Td>{`${taskInstance?.trigger?.id}`}</Td>
-              </Tr>
-              <Tr>
-                <Td>Trigger creation time</Td>
-                <Td>{`${taskInstance?.trigger?.createdDate}`}</Td>
-              </Tr>
-              <Tr>
-                <Td>Assigned triggerer</Td>
-                <Td>{`${taskInstance?.triggererJob?.hostname}`}</Td>
-              </Tr>
-              <Tr>
-                <Td>Latest triggerer heartbeat</Td>
-                <Td>{`${taskInstance?.triggererJob?.latestHeartbeat}`}</Td>
-              </Tr>
-            </Tbody>
-          </Table>
-        </>
-      )}
-
+    <Box mt={3} flexGrow={1}>
       <Text as="strong" mb={3}>
         Task Instance Details
       </Text>
@@ -305,10 +272,7 @@ const Details = ({ gridInstance, taskInstance, group }: Props) => {
           )}
         </Tbody>
       </Table>
-      {hasOutletDatasets && (
-        <DatasetUpdateEvents taskId={taskId} runId={runId} />
-      )}
-    </Flex>
+    </Box>
   );
 };
 

--- a/airflow/www/static/js/dag/details/taskInstance/TriggererInfo.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/TriggererInfo.tsx
@@ -1,0 +1,65 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+import { Text, Table, Tbody, Tr, Td, Box } from "@chakra-ui/react";
+
+import type { API } from "src/types";
+
+interface Props {
+  taskInstance?: API.TaskInstance;
+}
+
+const TriggererInfo = ({ taskInstance }: Props) => {
+  if (!taskInstance?.trigger || !taskInstance?.triggererJob) return null;
+
+  return (
+    <Box mt={3} flexGrow={1}>
+      <Text as="strong" mb={3}>
+        Triggerer info
+      </Text>
+      <Table variant="striped" mb={3}>
+        <Tbody>
+          <Tr>
+            <Td>Trigger class</Td>
+            <Td>{`${taskInstance?.trigger?.classpath}`}</Td>
+          </Tr>
+          <Tr>
+            <Td>Trigger ID</Td>
+            <Td>{`${taskInstance?.trigger?.id}`}</Td>
+          </Tr>
+          <Tr>
+            <Td>Trigger creation time</Td>
+            <Td>{`${taskInstance?.trigger?.createdDate}`}</Td>
+          </Tr>
+          <Tr>
+            <Td>Assigned triggerer</Td>
+            <Td>{`${taskInstance?.triggererJob?.hostname}`}</Td>
+          </Tr>
+          <Tr>
+            <Td>Latest triggerer heartbeat</Td>
+            <Td>{`${taskInstance?.triggererJob?.latestHeartbeat}`}</Td>
+          </Tr>
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default TriggererInfo;

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -28,6 +28,8 @@ import NotesAccordion from "src/dag/details/NotesAccordion";
 import TaskNav from "./Nav";
 import ExtraLinks from "./ExtraLinks";
 import Details from "./Details";
+import DatasetUpdateEvents from "./DatasetUpdateEvents";
+import TriggererInfo from "./TriggererInfo";
 
 const dagId = getMetaValue("dag_id")!;
 
@@ -106,6 +108,10 @@ const TaskInstance = ({ taskId, runId, mapIndex }: Props) => {
           tryNumber={taskInstance?.tryNumber || gridInstance.tryNumber}
         />
       )}
+      {group.hasOutletDatasets && (
+        <DatasetUpdateEvents taskId={taskId} runId={runId} />
+      )}
+      <TriggererInfo taskInstance={taskInstance} />
       <Details
         gridInstance={gridInstance}
         taskInstance={taskInstance}

--- a/airflow/www/static/js/datasets/DatasetEvents.tsx
+++ b/airflow/www/static/js/datasets/DatasetEvents.tsx
@@ -27,6 +27,7 @@ import {
   TimeCell,
   TaskInstanceLink,
   TriggeredRuns,
+  CodeCell,
 } from "src/components/Table";
 
 const Events = ({ datasetId }: { datasetId: number }) => {
@@ -65,6 +66,12 @@ const Events = ({ datasetId }: { datasetId: number }) => {
         Header: "Triggered Runs",
         accessor: "createdDagruns",
         Cell: TriggeredRuns,
+      },
+      {
+        Header: "Extra",
+        accessor: "extra",
+        Cell: CodeCell,
+        disableSortBy: true,
       },
     ],
     []


### PR DESCRIPTION
Before, we had dataset events linked to a task instance or dag run below all of the details. It is too easy to miss that information, especially since those details contain a lot more information. Now all datasets are above all of the task/run metadata.

Also, broke up each section into its own component to keep our files smaller.


Before (scrolled to the bottom of the page):
<img width="756" alt="Screenshot 2024-02-21 at 2 45 39 PM" src="https://github.com/apache/airflow/assets/4600967/a85ae1f2-ac7e-4e00-ba3c-fcd16d6c7c9a">
<img width="753" alt="Screenshot 2024-02-21 at 2 45 34 PM" src="https://github.com/apache/airflow/assets/4600967/8e27aff7-89e2-4f9e-b645-0ca01bf3a49c">



After:
<img width="807" alt="Screenshot 2024-02-21 at 2 45 12 PM" src="https://github.com/apache/airflow/assets/4600967/87dc9245-6660-4973-8103-e8815283fd01">
<img width="786" alt="Screenshot 2024-02-21 at 2 45 15 PM" src="https://github.com/apache/airflow/assets/4600967/bcafbc3f-7231-4c1c-983b-8814d742c2f3">



I think we can still improve the extra link and notes UI so they take up less vertical space.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
