### PR TITLE
Use new AirflowTaskTerminated exception inheriting BaseException for SIGTERMs

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -86,6 +86,10 @@ class AirflowTaskTimeout(BaseException):
     """Raise when the task execution times-out."""
 
 
+class AirflowTaskTerminated(BaseException):
+    """Raise when the task execution is terminated."""
+
+
 class AirflowWebServerTimeout(AirflowException):
     """Raise when the web server times out."""
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -76,6 +76,7 @@ from airflow.exceptions import (
     AirflowRescheduleException,
     AirflowSensorTimeout,
     AirflowSkipException,
+    AirflowTaskTerminated,
     AirflowTaskTimeout,
     DagRunNotFound,
     RemovedInAirflow3Warning,
@@ -2411,7 +2412,7 @@ class TaskInstance(Base, LoggingMixin):
                 self.handle_failure(e, test_mode, context, force_fail=True, session=session)
                 session.commit()
                 raise
-            except (AirflowTaskTimeout, AirflowException) as e:
+            except (AirflowTaskTimeout, AirflowException, AirflowTaskTerminated) as e:
                 if not test_mode:
                     self.refresh_from_db(lock_for_update=True, session=session)
                 # for case when task is marked as success/failed externally
@@ -2496,7 +2497,7 @@ class TaskInstance(Base, LoggingMixin):
                 return
             self.log.error("Received SIGTERM. Terminating subprocesses.")
             self.task.on_kill()
-            raise AirflowException("Task received SIGTERM signal")
+            raise AirflowTaskTerminated("Task received SIGTERM signal")
 
         signal.signal(signal.SIGTERM, signal_handler)
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -45,6 +45,7 @@ from airflow.exceptions import (
     AirflowRescheduleException,
     AirflowSensorTimeout,
     AirflowSkipException,
+    AirflowTaskTerminated,
     UnmappableXComLengthPushed,
     UnmappableXComTypePushed,
     XComForMappingNotPushed,
@@ -496,7 +497,7 @@ class TestTaskInstance:
         dr = dag_maker.create_dagrun()
         ti = dr.task_instances[0]
         ti.task = task_
-        with pytest.raises(AirflowException):
+        with pytest.raises(AirflowTaskTerminated):
             ti.run()
         assert "on_failure_callback called" in caplog.text
 
@@ -519,7 +520,7 @@ class TestTaskInstance:
         dr = dag_maker.create_dagrun()
         ti = dr.task_instances[0]
         ti.task = task
-        with pytest.raises(AirflowException):
+        with pytest.raises(AirflowTaskTerminated):
             ti.run()
         ti.refresh_from_db()
         assert ti.state == State.UP_FOR_RETRY


### PR DESCRIPTION
When a task is terminated, it get sent a SIGTERM signal, (through standard_task_runner.terminate).
This signal is picked up by taskinstance.py, where it injects an AirflowException into the current running task.

The exception raised there is now changed into a new AirflowTaskTerminated exception.
This new exception inherits BaseException, so that it is not caught and ignored accidentally by code that tries to perform ordinary error handling. Because termination requests should not be ignored.

This will improve reliability of cancelling tasks and will make error logs and error categorization more clear about the reason for failure.

(The terminate function does eventually send SIGKILL if the
 SIGTERM is ignored, but waiting for that should not be necessary)