### PR TITLE
Check if Python 3.12 is used for release management commands as well

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
@@ -26,7 +26,7 @@ from airflow_breeze.commands.release_management_group import release_management
 from airflow_breeze.utils.confirm import confirm_action
 from airflow_breeze.utils.console import console_print
 from airflow_breeze.utils.path_utils import AIRFLOW_SOURCES_ROOT, DIST_DIR, OUT_DIR
-from airflow_breeze.utils.python_versions import check_python_3_9_or_above
+from airflow_breeze.utils.python_versions import check_python_version
 from airflow_breeze.utils.reproducible import get_source_date_epoch, repack_deterministically
 from airflow_breeze.utils.run_utils import run_command
 
@@ -311,7 +311,7 @@ def remove_old_releases(version, repo_root):
     "--version", required=True, help="The release candidate version e.g. 2.4.3rc1", envvar="VERSION"
 )
 def prepare_airflow_tarball(version: str):
-    check_python_3_9_or_above()
+    check_python_version()
     from packaging.version import Version
 
     airflow_version = Version(version)
@@ -337,7 +337,7 @@ def prepare_airflow_tarball(version: str):
 )
 @option_answer
 def publish_release_candidate(version, previous_version, github_token):
-    check_python_3_9_or_above()
+    check_python_version()
     from packaging.version import Version
 
     airflow_version = Version(version)

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -144,7 +144,7 @@ from airflow_breeze.utils.provider_dependencies import (
     generate_providers_metadata_for_package,
     get_related_providers,
 )
-from airflow_breeze.utils.python_versions import check_python_3_9_or_above, get_python_version_list
+from airflow_breeze.utils.python_versions import check_python_version, get_python_version_list
 from airflow_breeze.utils.reproducible import get_source_date_epoch, repack_deterministically
 from airflow_breeze.utils.run_utils import (
     run_command,
@@ -511,7 +511,7 @@ def prepare_airflow_packages(
     version_suffix_for_pypi: str,
     use_local_hatch: bool,
 ):
-    check_python_3_9_or_above()
+    check_python_version()
     perform_environment_checks()
     fix_ownership_using_docker()
     cleanup_python_generated_files()
@@ -760,7 +760,7 @@ def prepare_provider_packages(
     skip_tag_check: bool,
     version_suffix_for_pypi: str,
 ):
-    check_python_3_9_or_above()
+    check_python_version()
     perform_environment_checks()
     fix_ownership_using_docker()
     cleanup_python_generated_files()
@@ -2619,7 +2619,7 @@ def prepare_helm_chart_tarball(
 ) -> None:
     import yaml
 
-    check_python_3_9_or_above()
+    check_python_version()
     chart_yaml_file_content = CHART_YAML_FILE.read_text()
     chart_yaml_dict = yaml.safe_load(chart_yaml_file_content)
     version_in_chart = chart_yaml_dict["version"]
@@ -2761,7 +2761,7 @@ def prepare_helm_chart_tarball(
 @option_dry_run
 @option_verbose
 def prepare_helm_chart_package(sign_email: str):
-    check_python_3_9_or_above()
+    check_python_version()
 
     import yaml
 

--- a/dev/breeze/src/airflow_breeze/utils/python_versions.py
+++ b/dev/breeze/src/airflow_breeze/utils/python_versions.py
@@ -45,12 +45,19 @@ def get_python_version_list(python_versions: str) -> list[str]:
     return python_version_list
 
 
-def check_python_3_9_or_above():
+def check_python_version():
+    error = False
     if not sys.version_info >= (3, 9):
-        get_console().print("[error]Python 3.9 or later is required to prepare reproducible archives.\n")
+        get_console().print("[error]At least Python 3.9 is required to prepare reproducible archives.\n")
+        error = True
+    elif not sys.version_info < (3, 12):
+        get_console().print("[error]Python 3.12 is not supported.\n")
+        error = True
+    if error:
         get_console().print(
-            "[warning]Please reinstall Breeze in Python3.9+ environment. For example:[/]\n\n"
-            "pipx uninstall apache-airflow-breeze\n\n"
+            "[warning]Please reinstall Breeze using Python 3.9 - 3.11 environment.[/]\n\n"
+            "For example:\n\n"
+            "pipx uninstall apache-airflow-breeze\n"
             "pipx install --python $(which python3.9) -e ./dev/breeze --force\n"
         )
         sys.exit(1)

--- a/dev/breeze/src/airflow_breeze/utils/reproducible.py
+++ b/dev/breeze/src/airflow_breeze/utils/reproducible.py
@@ -43,7 +43,7 @@ from pathlib import Path
 from subprocess import CalledProcessError, CompletedProcess
 
 from airflow_breeze.utils.path_utils import AIRFLOW_SOURCES_ROOT, OUT_DIR, REPRODUCIBLE_DIR
-from airflow_breeze.utils.python_versions import check_python_3_9_or_above
+from airflow_breeze.utils.python_versions import check_python_version
 from airflow_breeze.utils.run_utils import run_command
 
 
@@ -91,7 +91,7 @@ def repack_deterministically(
         tarinfo.mtime = timestamp
         return tarinfo
 
-    check_python_3_9_or_above()
+    check_python_version()
     OUT_DIR.mkdir(exist_ok=True)
     shutil.rmtree(REPRODUCIBLE_DIR, ignore_errors=True)
     REPRODUCIBLE_DIR.mkdir(exist_ok=True)
@@ -149,7 +149,7 @@ def repack_deterministically(
 
 
 def main():
-    check_python_3_9_or_above()
+    check_python_version()
     parser = ArgumentParser()
     parser.add_argument("-a", "--archive", help="archive to repack")
     parser.add_argument("-o", "--out", help="archive destination")


### PR DESCRIPTION
We've been checking - for reproducibility - if python version used is Python 3.9 or above, but since we are also rebuilding sdist packages, we need to check if sdist packages can be converted to wheel packages as well so we need to check python version used.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
