### PR TITLE
Fix unexpected keyword argument 'secret_path' in secrets.kv.v2

### DIFF
--- a/airflow/providers/hashicorp/_internal_client/vault_client.py
+++ b/airflow/providers/hashicorp/_internal_client/vault_client.py
@@ -472,6 +472,6 @@ class _VaultClient(LoggingMixin):
             )
         else:
             response = self.client.secrets.kv.v2.create_or_update_secret(
-                secret_path=secret_path, secret=secret, mount_point=mount_point, cas=cas
+                path=secret_path, secret=secret, mount_point=mount_point, cas=cas
             )
         return response

--- a/airflow/providers/hashicorp/_internal_client/vault_client.py
+++ b/airflow/providers/hashicorp/_internal_client/vault_client.py
@@ -468,7 +468,7 @@ class _VaultClient(LoggingMixin):
         mount_point, secret_path = self._parse_secret_path(secret_path)
         if self.kv_engine_version == 1:
             response = self.client.secrets.kv.v1.create_or_update_secret(
-                secret_path=secret_path, secret=secret, mount_point=mount_point, method=method
+                path=secret_path, secret=secret, mount_point=mount_point, method=method
             )
         else:
             response = self.client.secrets.kv.v2.create_or_update_secret(

--- a/tests/providers/hashicorp/_internal_client/test_vault_client.py
+++ b/tests/providers/hashicorp/_internal_client/test_vault_client.py
@@ -1111,7 +1111,7 @@ class TestVaultClient:
         )
         vault_client.create_or_update_secret(secret_path="path", secret={"key": "value"})
         mock_client.secrets.kv.v1.create_or_update_secret.assert_called_once_with(
-            mount_point="secret", secret_path="path", secret={"key": "value"}, method=None
+            mount_point="secret", path="path", secret={"key": "value"}, method=None
         )
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -1145,7 +1145,7 @@ class TestVaultClient:
         )
         vault_client.create_or_update_secret(secret_path="path", secret={"key": "value"}, method="post")
         mock_client.secrets.kv.v1.create_or_update_secret.assert_called_once_with(
-            mount_point="secret", secret_path="path", secret={"key": "value"}, method="post"
+            mount_point="secret", path="path", secret={"key": "value"}, method="post"
         )
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")

--- a/tests/providers/hashicorp/_internal_client/test_vault_client.py
+++ b/tests/providers/hashicorp/_internal_client/test_vault_client.py
@@ -1061,7 +1061,7 @@ class TestVaultClient:
         )
         vault_client.create_or_update_secret(secret_path="path", secret={"key": "value"})
         mock_client.secrets.kv.v2.create_or_update_secret.assert_called_once_with(
-            mount_point="secret", secret_path="path", secret={"key": "value"}, cas=None
+            mount_point="secret", path="path", secret={"key": "value"}, cas=None
         )
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -1093,7 +1093,7 @@ class TestVaultClient:
         )
         vault_client.create_or_update_secret(secret_path="path", secret={"key": "value"}, cas=10)
         mock_client.secrets.kv.v2.create_or_update_secret.assert_called_once_with(
-            mount_point="secret", secret_path="path", secret={"key": "value"}, cas=10
+            mount_point="secret", path="path", secret={"key": "value"}, cas=10
         )
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")

--- a/tests/providers/hashicorp/hooks/test_vault.py
+++ b/tests/providers/hashicorp/hooks/test_vault.py
@@ -1253,7 +1253,7 @@ class TestVaultHook:
         test_hook = VaultHook(**kwargs)
         test_hook.create_or_update_secret(secret_path="path", secret={"key": "value"}, method=method)
         mock_client.secrets.kv.v1.create_or_update_secret.assert_called_once_with(
-            mount_point="secret", secret_path="path", secret={"key": "value"}, method=expected_method
+            mount_point="secret", path="path", secret={"key": "value"}, method=expected_method
         )
 
 

--- a/tests/providers/hashicorp/hooks/test_vault.py
+++ b/tests/providers/hashicorp/hooks/test_vault.py
@@ -1208,7 +1208,7 @@ class TestVaultHook:
         test_hook = VaultHook(**kwargs)
         test_hook.create_or_update_secret(secret_path="path", secret={"key": "value"})
         mock_client.secrets.kv.v2.create_or_update_secret.assert_called_once_with(
-            mount_point="secret", secret_path="path", secret={"key": "value"}, cas=None
+            mount_point="secret", path="path", secret={"key": "value"}, cas=None
         )
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -1227,7 +1227,7 @@ class TestVaultHook:
         test_hook = VaultHook(**kwargs)
         test_hook.create_or_update_secret(secret_path="path", secret={"key": "value"}, cas=10)
         mock_client.secrets.kv.v2.create_or_update_secret.assert_called_once_with(
-            mount_point="secret", secret_path="path", secret={"key": "value"}, cas=10
+            mount_point="secret", path="path", secret={"key": "value"}, cas=10
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #37619 
related: #37619 

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Closes: #37619 
Fix unexpected keyword argument 'secret_path' in secrets.kv.v2
Called `self.client.secrets.kv.v2.create_or_update_secret()` function with `path` argument instead
Document: https://hvac.readthedocs.io/en/stable/usage/secrets_engines/kv_v2.html#create-update-secret

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
