### PR TITLE
Adding optional SSL verification for druid operator

### DIFF
--- a/airflow/providers/apache/druid/hooks/druid.py
+++ b/airflow/providers/apache/druid/hooks/druid.py
@@ -53,9 +53,9 @@ class DruidHook(BaseHook):
                     the Druid job for the status of the ingestion job.
                     Must be greater than or equal to 1
     :param max_ingestion_time: The maximum ingestion time before assuming the job failed
-    :parm verify_ssl: Either a boolean, in which case it controls whether we verify the server's TLS
+    :param verify_ssl: Either a boolean, in which case it controls whether we verify the server's TLS
                       certificate, or a string, in which case it must be a path to a CA bundle to use.
-                      Defaults to True.
+                      Defaults to True
     """
 
     def __init__(
@@ -108,8 +108,9 @@ class DruidHook(BaseHook):
         url = self.get_conn_url(ingestion_type)
 
         self.log.info("Druid ingestion spec: %s", json_index_spec)
-        req_index = requests.post(url, data=json_index_spec, headers=self.header, auth=self.get_auth(),
-                                  verify=self.verify_ssl)
+        req_index = requests.post(
+            url, data=json_index_spec, headers=self.header, auth=self.get_auth(), verify=self.verify_ssl
+        )
 
         code = req_index.status_code
         not_accepted = not (200 <= code < 300)

--- a/airflow/providers/apache/druid/hooks/druid.py
+++ b/airflow/providers/apache/druid/hooks/druid.py
@@ -53,6 +53,9 @@ class DruidHook(BaseHook):
                     the Druid job for the status of the ingestion job.
                     Must be greater than or equal to 1
     :param max_ingestion_time: The maximum ingestion time before assuming the job failed
+    :parm verify_ssl: Either a boolean, in which case it controls whether we verify the server's TLS
+                      certificate, or a string, in which case it must be a path to a CA bundle to use.
+                      Defaults to True.
     """
 
     def __init__(
@@ -60,12 +63,14 @@ class DruidHook(BaseHook):
         druid_ingest_conn_id: str = "druid_ingest_default",
         timeout: int = 1,
         max_ingestion_time: int | None = None,
+        verify_ssl: bool | str = True,
     ) -> None:
         super().__init__()
         self.druid_ingest_conn_id = druid_ingest_conn_id
         self.timeout = timeout
         self.max_ingestion_time = max_ingestion_time
         self.header = {"content-type": "application/json"}
+        self.verify_ssl = verify_ssl
 
         if self.timeout < 1:
             raise ValueError("Druid timeout should be equal or greater than 1")
@@ -103,7 +108,8 @@ class DruidHook(BaseHook):
         url = self.get_conn_url(ingestion_type)
 
         self.log.info("Druid ingestion spec: %s", json_index_spec)
-        req_index = requests.post(url, data=json_index_spec, headers=self.header, auth=self.get_auth())
+        req_index = requests.post(url, data=json_index_spec, headers=self.header, auth=self.get_auth(),
+                                  verify=self.verify_ssl)
 
         code = req_index.status_code
         not_accepted = not (200 <= code < 300)

--- a/airflow/providers/apache/druid/operators/druid.py
+++ b/airflow/providers/apache/druid/operators/druid.py
@@ -37,6 +37,9 @@ class DruidOperator(BaseOperator):
         of the ingestion job. Must be greater than or equal to 1
     :param max_ingestion_time: The maximum ingestion time before assuming the job failed
     :param ingestion_type: The ingestion type of the job. Could be IngestionType.Batch or IngestionType.MSQ
+    :parm verify_ssl: Either a boolean, in which case it controls whether we verify the server's TLS
+                      certificate, or a string, in which case it must be a path to a CA bundle to use.
+                      Defaults to True.
     """
 
     template_fields: Sequence[str] = ("json_index_file",)
@@ -51,6 +54,7 @@ class DruidOperator(BaseOperator):
         timeout: int = 1,
         max_ingestion_time: int | None = None,
         ingestion_type: IngestionType = IngestionType.BATCH,
+        verify_ssl: bool | str = True,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -59,12 +63,14 @@ class DruidOperator(BaseOperator):
         self.timeout = timeout
         self.max_ingestion_time = max_ingestion_time
         self.ingestion_type = ingestion_type
+        self.verify_ssl = verify_ssl
 
     def execute(self, context: Context) -> None:
         hook = DruidHook(
             druid_ingest_conn_id=self.conn_id,
             timeout=self.timeout,
             max_ingestion_time=self.max_ingestion_time,
+            verify_ssl=self.verify_ssl
         )
         self.log.info("Submitting %s", self.json_index_file)
         hook.submit_indexing_job(self.json_index_file, self.ingestion_type)

--- a/airflow/providers/apache/druid/operators/druid.py
+++ b/airflow/providers/apache/druid/operators/druid.py
@@ -37,7 +37,7 @@ class DruidOperator(BaseOperator):
         of the ingestion job. Must be greater than or equal to 1
     :param max_ingestion_time: The maximum ingestion time before assuming the job failed
     :param ingestion_type: The ingestion type of the job. Could be IngestionType.Batch or IngestionType.MSQ
-    :parm verify_ssl: Either a boolean, in which case it controls whether we verify the server's TLS
+    :param verify_ssl: Either a boolean, in which case it controls whether we verify the server's TLS
                       certificate, or a string, in which case it must be a path to a CA bundle to use.
                       Defaults to True.
     """
@@ -70,7 +70,7 @@ class DruidOperator(BaseOperator):
             druid_ingest_conn_id=self.conn_id,
             timeout=self.timeout,
             max_ingestion_time=self.max_ingestion_time,
-            verify_ssl=self.verify_ssl
+            verify_ssl=self.verify_ssl,
         )
         self.log.info("Submitting %s", self.json_index_file)
         hook.submit_indexing_job(self.json_index_file, self.ingestion_type)

--- a/tests/providers/apache/druid/hooks/test_druid.py
+++ b/tests/providers/apache/druid/hooks/test_druid.py
@@ -96,6 +96,25 @@ class TestDruidSubmitHook:
         assert task_post.called_once
         assert status_check.called_once
 
+    def test_submit_with_correct_ssl_arg(self, requests_mock):
+        self.db_hook.verify_ssl = "/path/to/ca.crt"
+        task_post = requests_mock.post(
+            "http://druid-overlord:8081/druid/indexer/v1/task",
+            text='{"task":"9f8a7359-77d4-4612-b0cd-cc2f6a3c28de"}',
+        )
+        status_check = requests_mock.get(
+            "http://druid-overlord:8081/druid/indexer/v1/task/9f8a7359-77d4-4612-b0cd-cc2f6a3c28de/status",
+            text='{"status":{"status": "SUCCESS"}}',
+        )
+
+        self.db_hook.submit_indexing_job("Long json file")
+
+        assert task_post.called_once
+        assert status_check.called_once
+        if task_post.called_once:
+            verify_ssl = task_post.request_history[0].verify
+            assert "/path/to/ca.crt" == verify_ssl
+
     def test_submit_correct_json_body(self, requests_mock):
         task_post = requests_mock.post(
             "http://druid-overlord:8081/druid/indexer/v1/task",

--- a/tests/providers/apache/druid/operators/test_druid.py
+++ b/tests/providers/apache/druid/operators/test_druid.py
@@ -102,14 +102,22 @@ def test_init_with_timeout_and_max_ingestion_time():
     assert expected_values["max_ingestion_time"] == operator.max_ingestion_time
 
 
-def test_init_default_timeout():
+def test_init_defaults():
     operator = DruidOperator(
         task_id="spark_submit_job",
         json_index_file=JSON_INDEX_STR,
         params={"index_type": "index_hadoop", "datasource": "datasource_prd"},
     )
+    expected_default_druid_ingest_conn_id = "druid_ingest_default"
     expected_default_timeout = 1
+    expected_default_max_ingestion_time = None
+    expected_default_ingestion_type = IngestionType.BATCH
+    expected_default_verify_ssl = True
+    assert expected_default_druid_ingest_conn_id == operator.conn_id
     assert expected_default_timeout == operator.timeout
+    assert expected_default_max_ingestion_time == operator.max_ingestion_time
+    assert expected_default_ingestion_type == operator.ingestion_type
+    assert expected_default_verify_ssl == operator.verify_ssl
 
 
 @patch("airflow.providers.apache.druid.operators.druid.DruidHook")
@@ -120,6 +128,7 @@ def test_execute_calls_druid_hook_with_the_right_parameters(mock_druid_hook):
     druid_ingest_conn_id = "druid_ingest_default"
     max_ingestion_time = 5
     timeout = 5
+    verify_ssl = "/path/to/ca.crt"
     operator = DruidOperator(
         task_id="spark_submit_job",
         json_index_file=json_index_file,
@@ -127,11 +136,13 @@ def test_execute_calls_druid_hook_with_the_right_parameters(mock_druid_hook):
         timeout=timeout,
         ingestion_type=IngestionType.MSQ,
         max_ingestion_time=max_ingestion_time,
+        verify_ssl=verify_ssl,
     )
     operator.execute(context={})
     mock_druid_hook.assert_called_once_with(
         druid_ingest_conn_id=druid_ingest_conn_id,
         timeout=timeout,
         max_ingestion_time=max_ingestion_time,
+        verify_ssl=verify_ssl,
     )
     mock_druid_hook_instance.submit_indexing_job.assert_called_once_with(json_index_file, IngestionType.MSQ)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Adding ability for druid operator to specify path to ca bundle when submitting Druid ingestion job.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
