### PR TITLE
Fix task duration selection

### DIFF
--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -312,6 +312,7 @@ const Details = ({
               pr={4}
               mt="4px"
               onClick={() => {
+                onChangeTab(0);
                 onSelect({ taskId });
               }}
             >


### PR DESCRIPTION
When clicking on task duration, we also need to redirect to the details tab. Because really Task Duration is just the Task Details view.

I might refactor all of the tab logic. It's gotten a lot more complex

closes: https://github.com/apache/airflow/issues/37599

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
