### PR TITLE
Add excluded/included events to get_event_logs api

### DIFF
--- a/airflow/api_connexion/endpoints/event_log_endpoint.py
+++ b/airflow/api_connexion/endpoints/event_log_endpoint.py
@@ -58,6 +58,8 @@ def get_event_logs(
     task_id: str | None = None,
     owner: str | None = None,
     event: str | None = None,
+    excluded_events: str | None = None,
+    included_events: str | None = None,
     before: str | None = None,
     after: str | None = None,
     limit: int,
@@ -88,6 +90,12 @@ def get_event_logs(
         query = query.where(Log.owner == owner)
     if event:
         query = query.where(Log.event == event)
+    if included_events:
+        included_events_list = included_events.split(",")
+        query = query.where(Log.event.in_(included_events_list))
+    if excluded_events:
+        excluded_events_list = excluded_events.split(",")
+        query = query.where(Log.event.notin_(excluded_events_list))
     if before:
         query = query.where(Log.dttm < timezone.parse(before))
     if after:

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1160,6 +1160,22 @@ paths:
         - $ref: "#/components/parameters/Owner"
         - $ref: "#/components/parameters/Before"
         - $ref: "#/components/parameters/After"
+        - name: included_events
+          in: query
+          schema:
+            type: string
+          required: false
+          description: |
+            One or more event names separated by commas. If set, only return event logs with events matching this pattern.
+            *New in version 2.9.0*
+        - name: excluded_events
+          in: query
+          schema:
+            type: string
+          required: false
+          description: |
+            One or more event names separated by commas. If set, only return event logs with events that do not match this pattern.
+            *New in version 2.9.0*
       responses:
         "200":
           description: Success.

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -3510,6 +3510,16 @@ export interface operations {
         before?: components["parameters"]["Before"];
         /** Timestamp to select event logs occurring after. */
         after?: components["parameters"]["After"];
+        /**
+         * One or more event names separated by commas. If set, only return event logs with events matching this pattern.
+         * *New in version 2.9.0*
+         */
+        included_events?: string;
+        /**
+         * One or more event names separated by commas. If set, only return event logs with events that do not match this pattern.
+         * *New in version 2.9.0*
+         */
+        excluded_events?: string;
       };
     };
     responses: {

--- a/tests/api_connexion/endpoints/test_event_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_event_log_endpoint.py
@@ -291,14 +291,9 @@ class TestGetEventLogs(TestEventLogEndpoint):
             assert response.status_code == 200
             assert {eventlog["event"] for eventlog in response.json["event_logs"]} == expected_eventlogs
 
-    def test_should_filter_eventlogs_by_included_events(self, create_log_model, session):
-        create_log_model(event="TEST_EVENT_1", when=self.default_time)
-        create_log_model(event="TEST_EVENT_2", when=self.default_time_2)
-        log_model_3 = Log(event="cli_scheduler", owner="root", extra='{"host_name": "e24b454f002a"}')
-        log_model_3.dttm = self.default_time_2
-
-        session.add(log_model_3)
-        session.flush()
+    def test_should_filter_eventlogs_by_included_events(self, create_log_model):
+        for event in ["TEST_EVENT_1", "TEST_EVENT_2", "cli_scheduler"]:
+            create_log_model(event=event, when=self.default_time)
         response = self.client.get(
             "/api/v1/eventLogs?included_events=TEST_EVENT_1,TEST_EVENT_2",
             environ_overrides={"REMOTE_USER": "test_granular"},
@@ -307,14 +302,9 @@ class TestGetEventLogs(TestEventLogEndpoint):
         response_data = response.json
         assert len(response_data["event_logs"]) == 2
 
-    def test_should_filter_eventlogs_by_excluded_events(self, create_log_model, session):
-        create_log_model(event="TEST_EVENT_1", when=self.default_time)
-        create_log_model(event="TEST_EVENT_2", when=self.default_time_2)
-        log_model_3 = Log(event="cli_scheduler", owner="root", extra='{"host_name": "e24b454f002a"}')
-        log_model_3.dttm = self.default_time_2
-
-        session.add(log_model_3)
-        session.flush()
+    def test_should_filter_eventlogs_by_excluded_events(self, create_log_model):
+        for event in ["TEST_EVENT_1", "TEST_EVENT_2", "cli_scheduler"]:
+            create_log_model(event=event, when=self.default_time)
         response = self.client.get(
             "/api/v1/eventLogs?excluded_events=TEST_EVENT_1,TEST_EVENT_2",
             environ_overrides={"REMOTE_USER": "test_granular"},
@@ -322,6 +312,7 @@ class TestGetEventLogs(TestEventLogEndpoint):
         assert response.status_code == 200
         response_data = response.json
         assert len(response_data["event_logs"]) == 1
+        assert {"cli_scheduler"} == {x["event"] for x in response_data["event_logs"]}
 
 
 class TestGetEventLogPagination(TestEventLogEndpoint):

--- a/tests/api_connexion/endpoints/test_event_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_event_log_endpoint.py
@@ -301,6 +301,7 @@ class TestGetEventLogs(TestEventLogEndpoint):
         assert response.status_code == 200
         response_data = response.json
         assert len(response_data["event_logs"]) == 2
+        assert {"TEST_EVENT_1", "TEST_EVENT_2"} == {x["event"] for x in response_data["event_logs"]}
 
     def test_should_filter_eventlogs_by_excluded_events(self, create_log_model):
         for event in ["TEST_EVENT_1", "TEST_EVENT_2", "cli_scheduler"]:


### PR DESCRIPTION
Allow API users to specify what events to include or exclude when listing event logs

closes https://github.com/apache/airflow/issues/37582


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
