### PR TITLE
Small improvements in package preparation output

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -435,13 +435,13 @@ def _check_sdist_to_wheel_dists(dists_info: tuple[DistributionPackageInfo, ...])
             if not venv_created:
                 venv_path = (Path(tmp_dir_name) / ".venv").resolve().absolute()
                 venv_command_result = run_command(
-                    [sys.executable, "-m", "venv", venv_path.__fspath__()],
+                    [sys.executable, "-m", "venv", venv_path.as_posix()],
                     check=False,
                     capture_output=True,
                 )
                 if venv_command_result.returncode != 0:
                     get_console().print(
-                        f"[error]Error when initializing virtualenv in {venv_path.__fspath__()}:[/]\n"
+                        f"[error]Error when initializing virtualenv in {venv_path.as_posix()}:[/]\n"
                         f"{venv_command_result.stdout}\n{venv_command_result.stderr}"
                     )
                 python_path = venv_path / "bin" / "python"
@@ -450,8 +450,19 @@ def _check_sdist_to_wheel_dists(dists_info: tuple[DistributionPackageInfo, ...])
                         f"\n[errors]Python interpreter is not exist in path {python_path}. Exiting!\n"
                     )
                     sys.exit(1)
-                pip_command = (python_path.__fspath__(), "-m", "pip")
-                run_command([*pip_command, "install", f"pip=={AIRFLOW_PIP_VERSION}"], check=True)
+                pip_command = (python_path.as_posix(), "-m", "pip")
+                result = run_command(
+                    [*pip_command, "install", f"pip=={AIRFLOW_PIP_VERSION}"],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                if result.returncode != 0:
+                    get_console().print(
+                        f"[error]Error when installing pip in {venv_path.as_posix()}[/]\n"
+                        f"{result.stdout}\n{result.stderr}"
+                    )
+                    sys.exit(1)
                 venv_created = True
 
             returncode = _check_sdist_to_wheel(di, pip_command, str(tmp_dir_name))
@@ -485,6 +496,8 @@ def _check_sdist_to_wheel(dist_info: DistributionPackageInfo, pip_command: tuple
         # We should run `pip wheel` outside of Project directory for avoid the case
         # when some files presented into the project directory, but not included in sdist.
         cwd=cwd,
+        capture_output=True,
+        text=True,
     )
     if (returncode := result_pip_wheel.returncode) == 0:
         get_console().print(
@@ -492,7 +505,8 @@ def _check_sdist_to_wheel(dist_info: DistributionPackageInfo, pip_command: tuple
         )
     else:
         get_console().print(
-            f"[error]Unable to build wheel from sdist distribution for package {dist_info.package!r}.[/]"
+            f"[error]Unable to build wheel from sdist distribution for package {dist_info.package!r}.[/]\n"
+            f"{result_pip_wheel.stdout}\n{result_pip_wheel.stderr}"
         )
     return returncode
 
@@ -526,17 +540,19 @@ def prepare_airflow_packages(
         packages = DistributionPackageInfo.dist_packages(
             package_format=package_format, dist_directory=DIST_DIR, build_type="airflow"
         )
+        get_console().print()
+        _check_sdist_to_wheel_dists(packages)
+        get_console().print("\n[info]Packages available in dist:[/]\n")
         for dist_info in packages:
             get_console().print(str(dist_info))
         get_console().print()
-        _check_sdist_to_wheel_dists(packages)
     else:
         _build_airflow_packages_with_docker(
             package_format=package_format,
             source_date_epoch=source_date_epoch,
             version_suffix_for_pypi=version_suffix_for_pypi,
         )
-    get_console().print("[success]Successfully prepared Airflow packages:")
+    get_console().print("[success]Successfully prepared Airflow packages")
 
 
 def provider_action_summary(description: str, message_type: MessageType, packages: list[str]):
@@ -859,14 +875,15 @@ def prepare_provider_packages(
         get_console().print("\n[warning]No packages prepared!\n")
         sys.exit(0)
     get_console().print("\n[success]Successfully built packages!\n\n")
-    get_console().print("\n[info]Packages available in dist:\n")
     packages = DistributionPackageInfo.dist_packages(
         package_format=package_format, dist_directory=DIST_DIR, build_type="providers"
     )
+    get_console().print()
+    _check_sdist_to_wheel_dists(packages)
+    get_console().print("\n[info]Packages available in dist:\n")
     for dist_info in packages:
         get_console().print(str(dist_info))
     get_console().print()
-    _check_sdist_to_wheel_dists(packages)
 
 
 def run_generate_constraints(


### PR DESCRIPTION
Recent change (#37476) added a bit of clutter to the output of the release commands and made it a little difficult to see what is going on. This PR Fixes those issues:

* stdout from venv creation, pip installation, pip wheel is hidden
* stderr is still visible
* check = False is used and retcode check for pip installation which gives (potentially) a bit more readable error output
* list of packages in sdist is displayed after validation for packages happen - not before - this way they are nicely summarizing what is preparaed.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
