### PR TITLE
Allow templating git-sync repo url

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -48,7 +48,7 @@ spec:
   {{- if or (and .Values.dags.gitSync.enabled (not .Values.dags.persistence.enabled)) .Values.workers.extraInitContainers }}
   initContainers:
     {{- if and .Values.dags.gitSync.enabled (not .Values.dags.persistence.enabled) }}
-      {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 4 }}
+      {{- include "git_sync_container" (merge . (dict "is_init" "true")) | nindent 4 }}
     {{- end }}
     {{- if .Values.workers.extraInitContainers }}
       {{- toYaml .Values.workers.extraInitContainers | nindent 4 }}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -252,9 +252,9 @@ If release name contains chart name it will be used as a full name.
     - name: GIT_SYNC_BRANCH
       value: {{ .Values.dags.gitSync.branch | quote }}
     - name: GIT_SYNC_REPO
-      value: {{ .Values.dags.gitSync.repo | quote }}
+      value: {{ tpl .Values.dags.gitSync.repo . | quote }}
     - name: GITSYNC_REPO
-      value: {{ .Values.dags.gitSync.repo | quote }}
+      value: {{ tpl .Values.dags.gitSync.repo . | quote }}
     - name: GIT_SYNC_DEPTH
       value: {{ .Values.dags.gitSync.depth | quote }}
     - name: GITSYNC_DEPTH

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -141,7 +141,7 @@ spec:
             {{- end }}
         {{- end }}
         {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
-          {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 8 }}
+          {{- include "git_sync_container" (merge . (dict "is_init" "true")) | nindent 8 }}
         {{- end }}
         {{- if .Values.dagProcessor.extraInitContainers }}
           {{- toYaml .Values.dagProcessor.extraInitContainers | nindent 8 }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -166,7 +166,7 @@ spec:
             {{- end }}
         {{- end }}
         {{- if and $localOrDagProcessorDisabled .Values.dags.gitSync.enabled }}
-          {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 8 }}
+          {{- include "git_sync_container" (merge . (dict "is_init" "true")) | nindent 8 }}
         {{- end }}
         {{- if .Values.scheduler.extraInitContainers }}
           {{- toYaml .Values.scheduler.extraInitContainers | nindent 8 }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -157,7 +157,7 @@ spec:
             {{- end }}
         {{- end }}
         {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
-          {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 8 }}
+          {{- include "git_sync_container" (merge . (dict "is_init" "true")) | nindent 8 }}
         {{- end }}
         {{- if .Values.triggerer.extraInitContainers }}
           {{- toYaml .Values.triggerer.extraInitContainers | nindent 8 }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -160,7 +160,7 @@ spec:
             {{- end }}
         {{- end }}
         {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) (semverCompare "<2.0.0" .Values.airflowVersion) }}
-          {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 8 }}
+          {{- include "git_sync_container" (merge . (dict "is_init" "true")) | nindent 8 }}
         {{- end }}
         {{- if .Values.webserver.extraInitContainers }}
           {{- toYaml .Values.webserver.extraInitContainers | nindent 8 }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -217,7 +217,7 @@ spec:
             {{- end }}
         {{- end }}
         {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
-          {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 8 }}
+          {{- include "git_sync_container" (merge . (dict "is_init" "true")) | nindent 8 }}
         {{- end }}
         {{- if .Values.workers.extraInitContainers }}
           {{- toYaml .Values.workers.extraInitContainers | nindent 8 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2451,7 +2451,7 @@ dags:
   gitSync:
     enabled: false
 
-    # git repo clone url
+    # git repo clone url (can be templated)
     # ssh example: git@github.com:apache/airflow.git
     # https example: https://github.com/apache/airflow.git
     repo: https://github.com/apache/airflow.git

--- a/helm_tests/other/test_git_sync_triggerer.py
+++ b/helm_tests/other/test_git_sync_triggerer.py
@@ -41,3 +41,30 @@ class TestGitSyncTriggerer:
             show_only=["templates/triggerer/triggerer-deployment.yaml"],
         )
         assert "git-sync-ssh-key" not in jmespath.search("spec.template.spec.volumes[].name", docs[0])
+
+    def test_can_repo_url_be_templated(self):
+        docs = render_chart(
+            values={
+                "testValues": {
+                    "dict": {
+                        "key": "aa",
+                    },
+                },
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "repo": "https://github.com/{{ .Values.testValues.dict.key }}/{{ .Release.Namespace }}.git",
+                    }
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+            namespace="bb",
+        )
+
+        assert {"name": "GIT_SYNC_REPO", "value": "https://github.com/aa/bb.git"} in jmespath.search(
+            "spec.template.spec.containers[1].env", docs[0]
+        )
+
+        assert {"name": "GITSYNC_REPO", "value": "https://github.com/aa/bb.git"} in jmespath.search(
+            "spec.template.spec.containers[1].env", docs[0]
+        )

--- a/helm_tests/other/test_git_sync_webserver.py
+++ b/helm_tests/other/test_git_sync_webserver.py
@@ -172,3 +172,30 @@ class TestGitSyncWebserver:
             show_only=["templates/webserver/webserver-deployment.yaml"],
         )
         assert "git-sync-ssh-key" not in jmespath.search("spec.template.spec.volumes[].name", docs[0])
+
+    def test_can_repo_url_be_templated(self):
+        docs = render_chart(
+            values={
+                "testValues": {
+                    "dict": {
+                        "key": "aa",
+                    },
+                },
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "repo": "https://github.com/{{ .Values.testValues.dict.key }}/{{ .Release.Namespace }}.git",
+                    }
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+            namespace="bb",
+        )
+
+        assert {"name": "GIT_SYNC_REPO", "value": "https://github.com/aa/bb.git"} in jmespath.search(
+            "spec.template.spec.containers[1].env", docs[0]
+        )
+
+        assert {"name": "GITSYNC_REPO", "value": "https://github.com/aa/bb.git"} in jmespath.search(
+            "spec.template.spec.containers[1].env", docs[0]
+        )

--- a/helm_tests/other/test_git_sync_worker.py
+++ b/helm_tests/other/test_git_sync_worker.py
@@ -132,3 +132,30 @@ class TestGitSyncWorker:
         )
 
         assert "git-sync-ssh-key" not in jmespath.search("spec.template.spec.volumes[].name", docs[0])
+
+    def test_can_repo_url_be_templated(self):
+        docs = render_chart(
+            values={
+                "testValues": {
+                    "dict": {
+                        "key": "aa",
+                    },
+                },
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "repo": "https://github.com/{{ .Values.testValues.dict.key }}/{{ .Release.Namespace }}.git",
+                    }
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+            namespace="bb",
+        )
+
+        assert {"name": "GIT_SYNC_REPO", "value": "https://github.com/aa/bb.git"} in jmespath.search(
+            "spec.template.spec.containers[1].env", docs[0]
+        )
+
+        assert {"name": "GITSYNC_REPO", "value": "https://github.com/aa/bb.git"} in jmespath.search(
+            "spec.template.spec.containers[1].env", docs[0]
+        )


### PR DESCRIPTION
I would like to propose allowing template values to git-sync repo url.

Why is it needed?
Let's assume that we're providing airflow service to multiple teams.
By creating git-sync repo urls using <code>{{ .Release.Namespace }}</code> or <code>{{ .Release.Name }}</code>,
there is no need to create multiple values ​​files to store different hostnames ​​for each team.

Usage
```yaml
dags:
  gitSync:
    enabled: true

    # git repo clone url (can be templated)
    repo: 'https://github.com/{{ .Release.Namespace }}/airflow-dags.git'
```