### PR TITLE
Fix `example_emr` system test

### DIFF
--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -723,15 +723,14 @@ class EmrCreateJobFlowOperator(BaseOperator):
         job_flow_overrides: str | dict[str, Any] | None = None,
         region_name: str | None = None,
         wait_for_completion: bool = False,
-        # TODO: waiter_max_attempts and waiter_delay should default to None when the other two are deprecated.
-        waiter_max_attempts: int | None | ArgNotSet = NOTSET,
-        waiter_delay: int | None | ArgNotSet = NOTSET,
+        waiter_max_attempts: int | None = None,
+        waiter_delay: int | None = None,
         waiter_countdown: int | None = None,
         waiter_check_interval_seconds: int = 60,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         **kwargs: Any,
     ):
-        if waiter_max_attempts is NOTSET:
+        if waiter_countdown:
             warnings.warn(
                 "The parameter waiter_countdown has been deprecated to standardize "
                 "naming conventions.  Please use waiter_max_attempts instead.  In the "
@@ -742,7 +741,7 @@ class EmrCreateJobFlowOperator(BaseOperator):
             # waiter_countdown defaults to never timing out, which is not supported
             # by boto waiters, so we will set it here to "a very long time" for now.
             waiter_max_attempts = (waiter_countdown or 999) // waiter_check_interval_seconds
-        if waiter_delay is NOTSET:
+        if waiter_check_interval_seconds:
             warnings.warn(
                 "The parameter waiter_check_interval_seconds has been deprecated to "
                 "standardize naming conventions.  Please use waiter_delay instead.  In the "
@@ -757,8 +756,8 @@ class EmrCreateJobFlowOperator(BaseOperator):
         self.job_flow_overrides = job_flow_overrides or {}
         self.region_name = region_name
         self.wait_for_completion = wait_for_completion
-        self.waiter_max_attempts = int(waiter_max_attempts)  # type: ignore[arg-type]
-        self.waiter_delay = int(waiter_delay)  # type: ignore[arg-type]
+        self.waiter_max_attempts = waiter_max_attempts or 60
+        self.waiter_delay = waiter_delay or 30
         self.deferrable = deferrable
 
     @cached_property

--- a/airflow/providers/amazon/aws/waiters/emr.json
+++ b/airflow/providers/amazon/aws/waiters/emr.json
@@ -65,6 +65,12 @@
                 {
                     "matcher": "path",
                     "argument": "Cluster.Status.State",
+                    "expected": "RUNNING",
+                    "state": "success"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "Cluster.Status.State",
                     "expected": "TERMINATED",
                     "state": "success"
                 },

--- a/tests/system/providers/amazon/aws/example_emr.py
+++ b/tests/system/providers/amazon/aws/example_emr.py
@@ -27,7 +27,6 @@ import boto3
 from airflow.decorators import task
 from airflow.models.baseoperator import chain
 from airflow.models.dag import DAG
-from airflow.providers.amazon.aws.hooks.ssm import SsmHook
 from airflow.providers.amazon.aws.operators.emr import (
     EmrAddStepsOperator,
     EmrCreateJobFlowOperator,
@@ -72,7 +71,7 @@ SPARK_STEPS = [
 
 JOB_FLOW_OVERRIDES: dict[str, Any] = {
     "Name": "PiCalc",
-    "ReleaseLabel": "emr-6.7.0",
+    "ReleaseLabel": "emr-7.0.0",
     "Applications": [{"Name": "Spark"}],
     "Instances": {
         "InstanceGroups": [
@@ -92,16 +91,6 @@ JOB_FLOW_OVERRIDES: dict[str, Any] = {
     "ServiceRole": "EMR_DefaultRole",
 }
 # [END howto_operator_emr_steps_config]
-
-
-@task
-def get_ami_id():
-    """
-    Returns an AL2 AMI compatible with EMR
-    """
-    return SsmHook(aws_conn_id=None).get_parameter_value(
-        "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-ebs"
-    )
 
 
 @task
@@ -147,7 +136,6 @@ with DAG(
 
     JOB_FLOW_OVERRIDES["LogUri"] = f"s3://{s3_bucket}/"
     JOB_FLOW_OVERRIDES["SecurityConfiguration"] = config_name
-    JOB_FLOW_OVERRIDES["Instances"]["InstanceGroups"][0]["CustomAmiId"] = get_ami_id()
 
     create_security_configuration = configure_security_config(config_name)
 
@@ -173,9 +161,6 @@ with DAG(
     )
     # [END howto_operator_emr_add_steps]
     add_steps.wait_for_completion = True
-    # On rare occasion (1 in 50ish?) this system test times out.  Extending the
-    # max_attempts from the default 60 to attempt to mitigate the flaky test.
-    add_steps.waiter_max_attempts = 90
 
     # [START howto_sensor_emr_step]
     wait_for_step = EmrStepSensor(


### PR DESCRIPTION
The system `example_emr` is failing in AWS CI for multiple reasons. The main reason being the AMI id used became somewhat less stable with EMR.

In this PR I also fix the deprecation warnings sent in `EmrCreateJobFlowOperator`. The current logic does not make sense and as a consequence, send by default deprecation warnings (even though the parameters are not specified).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
