### PR TITLE
Fix regression on trigger form error display on form validation

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2152,6 +2152,7 @@ class Airflow(AirflowBaseView):
                 form_fields=form_fields,
                 **render_params,
                 conf=request_conf,
+                form=form,
             )
 
         flash(f"Triggered {dag_id}, it should start any moment now.")


### PR DESCRIPTION
During release tests of 2.8.2rc2 I realized a small regression on Trigger form UI in special conditions:

If the trigger form is submitted with invalid values, the rendering of the re-display of the form generates a stack trace display with "UndefinedError" - "jinja2.exceptions.UndefinedError: 'form' is undefined".

This can be caused by the user by:

1. Open a trigger form and adjust the generated JSON manually to be invalid (e.g. use example_params_ui_tutorial, set `required_field: null`) and try to submit
2. If the user tries to trigger a form w/o config and the option `AIRFLOW__WEBSERVER__SHOW_TRIGGER_FORM_IF_NO_PARAMS=True` is set, the DAG has required fields which are generating an invalid DAG run.

Root cause is missing to supply the "form" value from a rework in PR #37497 where 1 line was deleted accidentially:

https://github.com/apache/airflow/pull/37497/files#diff-917b70d2661fae8322c538a4f60b9d4ba755556036fe0c527eb0411a6ac60f2eL2155

This PR adds the line such that the form can be rendered again.
Double checked and this is the only path where the `form` parameter was missing for rendering.