### PR TITLE
Increase timeout for kill-switch on ARM instances.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2406,7 +2406,7 @@ jobs:
   # It rebuilds all images using just-pushed constraints using buildx and pushes them to registry
   # It will automatically check if a new python image was released and will pull the latest one if needed
   push-buildx-cache-to-github-registry:
-    timeout-minutes: 120
+    timeout-minutes: 110
     name: "Push Image Cache"
     runs-on: ${{fromJSON(needs.build-info.outputs.runs-on)}}
     needs:
@@ -2500,7 +2500,7 @@ jobs:
   # There is no point in running this one in "canary" run, because the above step is doing the
   # same build anyway.
   build-ci-arm-images:
-    timeout-minutes: 50
+    timeout-minutes: 110
     name: >
       Build CI ARM images
       ${{needs.build-info.outputs.all-python-versions-list-as-string}}

--- a/scripts/ci/images/initialize.sh
+++ b/scripts/ci/images/initialize.sh
@@ -30,4 +30,4 @@ sudo service docker start
 # This instance will run for maximum 40 minutes and
 # It will terminate itself after that (it can also
 # be terminated immediately when the job finishes)
-echo "sudo shutdown -h now" | at now +40 min
+echo "sudo shutdown -h now" | at now +90 min


### PR DESCRIPTION
In order to conserve cost, our ARM instances have kill switch that causes self-termination after some time. Currently when we rebuild cache for PROD images and the cache is not warmed up, it takes longer than 40 minutes that was specified as timeout. Increasing it to 90 minutes gives us more time to complete it.

The kill-switch is only there "in case" so that if the CI job is cancelled, the machine still will shut-down predictably.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
