### PR TITLE
Make airflow package preparation in docker work with all builders

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -239,6 +239,9 @@ airflow/www/node_modules
 # Exclude link to docs
 airflow/www/static/docs
 
+# Exclude out directory
+out/
+
 # Exclude python generated files
 **/__pycache__/
 **/*.py[cod]
@@ -351,7 +354,6 @@ def _build_local_build_image():
     run_command(
         [
             "docker",
-            "buildx",
             "build",
             ".",
             "-f",


### PR DESCRIPTION
The Airflow package preparation using docker, worked nicely in CI and in most cases it worked locally, however in some cases, if you had custom docker builder configured it could stop working because you could have builder configured that would not load the images built locally (this is when you earlier run buildx for caching.

This is now fixed - instead of using `buildx` plugin we use regular `docker build` plugin to build airflow packages, also we ignore `out` directory which was not ignored before and could unnecesarily increase time and size of the image build for airflow package preparation.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
