### PR TITLE
Add Dag Audit Log to React

### DIFF
--- a/airflow/www/static/js/api/index.ts
+++ b/airflow/www/static/js/api/index.ts
@@ -50,6 +50,7 @@ import useDags from "./useDags";
 import useDagRuns from "./useDagRuns";
 import useHistoricalMetricsData from "./useHistoricalMetricsData";
 import { useTaskXcomEntry, useTaskXcomCollection } from "./useTaskXcom";
+import useEventLogs from "./useEventLogs";
 
 axios.interceptors.request.use((config) => {
   config.paramsSerializer = {
@@ -96,4 +97,5 @@ export {
   useHistoricalMetricsData,
   useTaskXcomEntry,
   useTaskXcomCollection,
+  useEventLogs,
 };

--- a/airflow/www/static/js/api/useEventLogs.tsx
+++ b/airflow/www/static/js/api/useEventLogs.tsx
@@ -1,0 +1,59 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import axios, { AxiosResponse } from "axios";
+import { useQuery } from "react-query";
+
+import { getMetaValue } from "src/utils";
+import type { API } from "src/types";
+import { useAutoRefresh } from "src/context/autorefresh";
+
+export default function useEventLogs({
+  dagId,
+  taskId,
+  limit,
+  offset,
+  orderBy,
+  after,
+  before,
+  owner,
+}: API.GetEventLogsVariables) {
+  const { isRefreshOn } = useAutoRefresh();
+  return useQuery(
+    ["eventLogs", dagId, taskId, limit, offset, orderBy, after, before, owner],
+    () => {
+      const eventsLogUrl = getMetaValue("event_logs_api");
+      const orderParam = orderBy ? { order_by: orderBy } : {};
+      return axios.get<AxiosResponse, API.EventLogCollection>(eventsLogUrl, {
+        params: {
+          offset,
+          limit,
+          ...{ dag_id: dagId },
+          ...{ task_id: taskId },
+          ...orderParam,
+          after,
+          before,
+        },
+      });
+    },
+    {
+      refetchInterval: isRefreshOn && (autoRefreshInterval || 1) * 1000,
+    }
+  );
+}

--- a/airflow/www/static/js/dag/details/AuditLog.tsx
+++ b/airflow/www/static/js/dag/details/AuditLog.tsx
@@ -16,16 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+/* global moment */
+
 import React, { useMemo, useRef, useState } from "react";
-import { Box, Text } from "@chakra-ui/react";
+import {
+  Box,
+  Flex,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Input,
+  HStack,
+} from "@chakra-ui/react";
+import type { SortingRule } from "react-table";
+import { snakeCase } from "lodash";
 
 import { CodeCell, Table, TimeCell } from "src/components/Table";
 import { useEventLogs } from "src/api";
 import { getMetaValue, useOffsetTop } from "src/utils";
 import type { DagRun } from "src/types";
-import Time from "src/components/Time";
-import type { SortingRule } from "react-table";
-import { snakeCase } from "lodash";
+import LinkButton from "src/components/LinkButton";
 
 interface Props {
   taskId?: string;
@@ -94,13 +105,48 @@ const AuditLog = ({ taskId, run }: Props) => {
       ref={logRef}
       overflowY="auto"
     >
-      {!!run && (
-        <Text>
-          Showing logs between Dag Run Queued at (
-          <Time dateTime={run.queuedAt} />) and Last Scheduling Decision (
-          <Time dateTime={run.lastSchedulingDecision} />)
-        </Text>
-      )}
+      <Flex justifyContent="right">
+        <LinkButton href={getMetaValue("audit_log_url")}>
+          View full cluster Audit Log
+        </LinkButton>
+      </Flex>
+      <HStack spacing={2} alignItems="flex-start">
+        <FormControl>
+          <FormLabel>Show Logs After</FormLabel>
+          <Input
+            type="datetime"
+            // @ts-ignore
+            placeholder={run?.queuedAt ? moment(run?.queuedAt).format() : ""}
+            isDisabled
+          />
+          {!!run && run?.queuedAt && (
+            <FormHelperText>After selected DAG Run Queued At</FormHelperText>
+          )}
+        </FormControl>
+        <FormControl>
+          <FormLabel>Show Logs Before</FormLabel>
+          <Input
+            type="datetime"
+            placeholder={
+              run?.lastSchedulingDecision
+                ? // @ts-ignore
+                  moment(run?.lastSchedulingDecision).format()
+                : ""
+            }
+            isDisabled
+          />
+          {!!run && run?.lastSchedulingDecision && (
+            <FormHelperText>
+              Before selected DAG Run Last Scheduling Decision
+            </FormHelperText>
+          )}
+        </FormControl>
+        <FormControl>
+          <FormLabel>Filter by Task ID</FormLabel>
+          <Input placeholder={taskId} isDisabled />
+          <FormHelperText />
+        </FormControl>
+      </HStack>
       <Table
         data={memoData || []}
         columns={columns}

--- a/airflow/www/static/js/dag/details/AuditLog.tsx
+++ b/airflow/www/static/js/dag/details/AuditLog.tsx
@@ -1,0 +1,124 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useMemo, useRef, useState } from "react";
+import { Box, Text } from "@chakra-ui/react";
+
+import { CodeCell, Table, TimeCell } from "src/components/Table";
+import { useEventLogs } from "src/api";
+import { getMetaValue, useOffsetTop } from "src/utils";
+import type { DagRun } from "src/types";
+import Time from "src/components/Time";
+import type { SortingRule } from "react-table";
+import { snakeCase } from "lodash";
+
+interface Props {
+  taskId?: string;
+  run?: DagRun;
+}
+
+const dagId = getMetaValue("dag_id") || undefined;
+
+const AuditLog = ({ taskId, run }: Props) => {
+  const logRef = useRef<HTMLDivElement>(null);
+  const offsetTop = useOffsetTop(logRef);
+  const limit = 25;
+  const [offset, setOffset] = useState(0);
+  const [sortBy, setSortBy] = useState<SortingRule<object>[]>([
+    { id: "when", desc: true },
+  ]);
+
+  const sort = sortBy[0];
+  const orderBy = sort ? `${sort.desc ? "-" : ""}${snakeCase(sort.id)}` : "";
+
+  const { data, isLoading } = useEventLogs({
+    dagId,
+    taskId,
+    before: run?.lastSchedulingDecision || undefined,
+    after: run?.queuedAt || undefined,
+    orderBy,
+    limit,
+    offset,
+  });
+
+  const columns = useMemo(() => {
+    const when = {
+      Header: "When",
+      accessor: "when",
+      Cell: TimeCell,
+    };
+    const task = {
+      Header: "Task ID",
+      accessor: "taskId",
+    };
+    const rest = [
+      {
+        Header: "Event",
+        accessor: "event",
+      },
+      {
+        Header: "Owner",
+        accessor: "owner",
+      },
+      {
+        Header: "Extra",
+        accessor: "extra",
+        Cell: CodeCell,
+      },
+    ];
+    return !taskId ? [when, task, ...rest] : [when, ...rest];
+  }, [taskId]);
+
+  const memoData = useMemo(() => data?.eventLogs, [data?.eventLogs]);
+  const memoSort = useMemo(() => sortBy, [sortBy]);
+
+  return (
+    <Box
+      height="100%"
+      maxHeight={`calc(100% - ${offsetTop}px)`}
+      ref={logRef}
+      overflowY="auto"
+    >
+      {!!run && (
+        <Text>
+          Showing logs between Dag Run Queued at (
+          <Time dateTime={run.queuedAt} />) and Last Scheduling Decision (
+          <Time dateTime={run.lastSchedulingDecision} />)
+        </Text>
+      )}
+      <Table
+        data={memoData || []}
+        columns={columns}
+        isLoading={isLoading}
+        manualPagination={{
+          offset,
+          setOffset,
+          totalEntries: data?.totalEntries || 0,
+        }}
+        manualSort={{
+          setSortBy,
+          sortBy,
+          initialSortBy: memoSort,
+        }}
+        pageSize={limit}
+      />
+    </Box>
+  );
+};
+
+export default AuditLog;

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -42,6 +42,7 @@ import {
   MdOutlineViewTimeline,
   MdSyncAlt,
   MdHourglassBottom,
+  MdPlagiarism,
 } from "react-icons/md";
 import { BiBracket } from "react-icons/bi";
 import URLSearchParamsWrapper from "src/utils/URLSearchParamWrapper";
@@ -63,6 +64,7 @@ import ClearInstance from "./taskInstance/taskActions/ClearInstance";
 import MarkInstanceAs from "./taskInstance/taskActions/MarkInstanceAs";
 import XcomCollection from "./taskInstance/Xcom";
 import TaskDetails from "./task";
+import AuditLog from "./AuditLog";
 
 const dagId = getMetaValue("dag_id")!;
 
@@ -82,11 +84,13 @@ const tabToIndex = (tab?: string) => {
       return 2;
     case "code":
       return 3;
+    case "audit_logs":
+      return 4;
     case "logs":
     case "mapped_tasks":
-      return 4;
-    case "xcom":
       return 5;
+    case "xcom":
+      return 6;
     case "details":
     default:
       return 0;
@@ -106,10 +110,12 @@ const indexToTab = (
     case 3:
       return "code";
     case 4:
+      return "audit_logs";
+    case 5:
       if (isMappedTaskSummary) return "mapped_tasks";
       if (isTaskInstance) return "logs";
       return undefined;
-    case 5:
+    case 6:
       if (isTaskInstance) return "xcom";
       return undefined;
     case 0:
@@ -173,9 +179,9 @@ const Details = ({
   );
 
   useEffect(() => {
-    // Default to graph tab when navigating from a task instance to a group/dag/dagrun
-    const tabCount = runId && taskId && !isGroup ? 5 : 4;
-    if (tabCount === 4 && tabIndex > 3) {
+    // Default to graph tab when navigating from a task instance to a dagrun
+    const tabCount = runId && taskId && !isGroup ? 6 : 4;
+    if (tabCount === 6 && tabIndex > 5) {
       if (!runId && taskId) onChangeTab(0);
       else onChangeTab(1);
     }
@@ -275,6 +281,14 @@ const Details = ({
               Code
             </Text>
           </Tab>
+          {(!isGroup || !taskId) && (
+            <Tab>
+              <MdPlagiarism size={16} />
+              <Text as="strong" ml={1}>
+                Audit Log
+              </Text>
+            </Tab>
+          )}
           {isTaskInstance && (
             <Tab>
               <MdReorder size={16} />
@@ -359,6 +373,11 @@ const Details = ({
           <TabPanel height="100%">
             <DagCode />
           </TabPanel>
+          {(!isGroup || !taskId) && (
+            <TabPanel height="100%">
+              <AuditLog taskId={taskId || undefined} run={run} />
+            </TabPanel>
+          )}
           {isTaskInstance && run && (
             <TabPanel
               pt={mapIndex !== undefined ? "0px" : undefined}

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -81,6 +81,7 @@
   <meta name="dag_details_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_dag_endpoint_get_dag_details', dag_id=dag.dag_id) }}">
   <meta name="datasets_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_dataset_endpoint_get_datasets') }}">
   <meta name="event_logs_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_event_log_endpoint_get_event_logs') }}">
+  <meta name="audit_log_url" content="{{ url_for('LogModelView.list') }}">
 
   <!-- End Urls -->
   <meta name="is_paused" content="{{ dag_is_paused }}">

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -80,6 +80,7 @@
   <meta name="dag_source_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_dag_source_endpoint_get_dag_source', file_token='_FILE_TOKEN_') }}">
   <meta name="dag_details_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_dag_endpoint_get_dag_details', dag_id=dag.dag_id) }}">
   <meta name="datasets_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_dataset_endpoint_get_datasets') }}">
+  <meta name="event_logs_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_event_log_endpoint_get_event_logs') }}">
 
   <!-- End Urls -->
   <meta name="is_paused" content="{{ dag_is_paused }}">


### PR DESCRIPTION
Continue modernizing the UI. Use the REST API show the Audit Log for a DAG in react.

The Audit Log shows up as a tab for every selection (dag, dag run, task, task instance). And we try to filter the Audit Log accordingly, within the limitations we have at least.

Run ID isn't recorded and execution date is not currently a parameter (nor do we always record the execution date or map index anyway). So instead when there is a dag run, we filter the before/after dates to the queued at and last scheduling decision dates.

Also cleaned up the logic of what tabs to default to when changing selection.

Task Instance Selected (filtered by before, after and task id)
<img width="1191" alt="Screenshot 2024-02-24 at 5 09 30 PM" src="https://github.com/apache/airflow/assets/4600967/38861c8f-17e0-4ee0-96fc-2603311e4f6e">

Task is selected (filtered by task id)
<img width="1204" alt="Screenshot 2024-02-24 at 5 09 51 PM" src="https://github.com/apache/airflow/assets/4600967/1c637335-8d05-4824-80c2-544506c25f31">

Nothing selected (only filtered by dag id)
<img width="1192" alt="Screenshot 2024-02-24 at 5 09 42 PM" src="https://github.com/apache/airflow/assets/4600967/68ee2c40-3baa-44f1-a233-ee321b32906a">

Dag Run selected (filtered by before and after)
<img width="1193" alt="Screenshot 2024-02-24 at 5 09 37 PM" src="https://github.com/apache/airflow/assets/4600967/f7ad0b2f-7adf-4df2-bcdc-8695a08ea3a4">


ToDo in later PRs:
- Remove old DAG Audit Log page
- Allow user to edit filters directly instead of via task selection and add more filters
- Allow multiple task ids as a parameter (can filter by task group)

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
