### PR TITLE
Bump min versions of openapi validators

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -365,7 +365,7 @@ repos:
         name: Lint OpenAPI using openapi-spec-validator
         entry: openapi-spec-validator --schema 3.0.0
         language: python
-        additional_dependencies: ['openapi-spec-validator>=0.6.0']
+        additional_dependencies: ['openapi-spec-validator>=0.7.1', 'openapi-schema-validator>=0.6.2']
         files: ^airflow/api_connexion/openapi/
       - id: lint-dockerfile
         name: Lint Dockerfile

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -126,6 +126,8 @@ devel-dependencies:
   - mypy-boto3-redshift-data>=1.33.0
   - mypy-boto3-s3>=1.33.0
   - s3fs>=2023.10.0
+  - openapi-schema-validator>=0.6.2
+  - openapi-spec-validator>=0.7.1
 
 integrations:
   - integration-name: Amazon Athena

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -46,7 +46,9 @@
       "mypy-boto3-rds>=1.33.0",
       "mypy-boto3-redshift-data>=1.33.0",
       "mypy-boto3-s3>=1.33.0",
-      "s3fs>=2023.10.0"
+      "s3fs>=2023.10.0",
+      "openapi-schema-validator>=0.6.2",
+      "openapi-spec-validator>=0.7.1"
     ],
     "cross-providers-deps": [
       "apache.hive",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -565,6 +565,8 @@ amazon = [ # source: airflow/providers/amazon/provider.yaml
   "mypy-boto3-redshift-data>=1.33.0",
   "mypy-boto3-s3>=1.33.0",
   "s3fs>=2023.10.0",
+  "openapi-schema-validator>=0.6.2",
+  "openapi-spec-validator>=0.7.1",
 ]
 apache-beam = [ # source: airflow/providers/apache/beam/provider.yaml
   "apache-beam>=2.53.0;python_version != \"3.12\"",


### PR DESCRIPTION
The openapi validators in older versions do not work well for some moto tests which use the validators. Bumping specifically the min versions of those validators should help with better dependency resolving (wheb using uv and lowest transitive versions strategy it will downgrade the validators and will cause the tests to fail as seen in #37683.

Those are only test and development dependencies and we already use the min version specified in our CI, so it should have no impact on production airflow (but should help wiht CI/dependency resolution)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
