### PR TITLE
Change the URL building in HttpHookAsync to match the behavior of HttpHook

### DIFF
--- a/airflow/datasets/__init__.py
+++ b/airflow/datasets/__init__.py
@@ -114,6 +114,18 @@ class Dataset(os.PathLike, BaseDatasetEventInput):
 
     __version__: ClassVar[int] = 1
 
+    @uri.validator
+    def _check_uri(self, attr, uri: str) -> None:
+        if uri.isspace():
+            raise ValueError(f"{attr.name} cannot be just whitespace")
+        try:
+            uri.encode("ascii")
+        except UnicodeEncodeError:
+            raise ValueError(f"{attr.name!r} must be ascii")
+        parsed = urlsplit(uri)
+        if parsed.scheme and parsed.scheme.lower() == "airflow":
+            raise ValueError(f"{attr.name!r} scheme `airflow` is reserved")
+
     def __fspath__(self) -> str:
         return self.uri
 

--- a/airflow/datasets/__init__.py
+++ b/airflow/datasets/__init__.py
@@ -114,18 +114,6 @@ class Dataset(os.PathLike, BaseDatasetEventInput):
 
     __version__: ClassVar[int] = 1
 
-    @uri.validator
-    def _check_uri(self, attr, uri: str) -> None:
-        if uri.isspace():
-            raise ValueError(f"{attr.name} cannot be just whitespace")
-        try:
-            uri.encode("ascii")
-        except UnicodeEncodeError:
-            raise ValueError(f"{attr.name!r} must be ascii")
-        parsed = urlsplit(uri)
-        if parsed.scheme and parsed.scheme.lower() == "airflow":
-            raise ValueError(f"{attr.name!r} scheme `airflow` is reserved")
-
     def __fspath__(self) -> str:
         return self.uri
 

--- a/airflow/providers/http/hooks/http.py
+++ b/airflow/providers/http/hooks/http.py
@@ -40,8 +40,9 @@ if TYPE_CHECKING:
 
 def _url_from_endpoint(base_url: str | None, endpoint: str | None) -> str:
     """Combine base url with endpoint."""
+    print(f"base_url: {base_url}, endpoint: {endpoint}")
     if base_url and not base_url.endswith("/") and endpoint and not endpoint.startswith("/"):
-        return f"{base_url}/{endpoint}"
+        return base_url + "/" + endpoint
     return (base_url or "") + (endpoint or "")
 
 

--- a/airflow/providers/http/hooks/http.py
+++ b/airflow/providers/http/hooks/http.py
@@ -38,6 +38,14 @@ if TYPE_CHECKING:
     from airflow.models import Connection
 
 
+def _url_from_endpoint(base_url: str | None, endpoint: str | None) -> str:
+    """Combine base url with endpoint."""
+    print(f"base_url: {base_url}, endpoint: {endpoint}")
+    if base_url and not base_url.endswith("/") and endpoint and not endpoint.startswith("/"):
+        return base_url + "/" + endpoint
+    return (base_url or "") + (endpoint or "")
+
+
 class HttpHook(BaseHook):
     """Interact with HTTP servers.
 
@@ -158,7 +166,7 @@ class HttpHook(BaseHook):
 
         session = self.get_conn(headers)
 
-        url = self.url_from_endpoint(endpoint)
+        url = _url_from_endpoint(self.base_url, endpoint)
 
         if self.tcp_keep_alive:
             keep_alive_adapter = TCPKeepAliveAdapter(
@@ -261,12 +269,6 @@ class HttpHook(BaseHook):
         # TODO: remove ignore type when https://github.com/jd/tenacity/issues/428 is resolved
         return self._retry_obj(self.run, *args, **kwargs)  # type: ignore
 
-    def url_from_endpoint(self, endpoint: str | None) -> str:
-        """Combine base url with endpoint."""
-        if self.base_url and not self.base_url.endswith("/") and endpoint and not endpoint.startswith("/"):
-            return self.base_url + "/" + endpoint
-        return (self.base_url or "") + (endpoint or "")
-
     def test_connection(self):
         """Test HTTP Connection."""
         try:
@@ -357,9 +359,7 @@ class HttpAsyncHook(BaseHook):
         if headers:
             _headers.update(headers)
 
-        base_url = (self.base_url or "").rstrip("/")
-        endpoint = (endpoint or "").lstrip("/")
-        url = f"{base_url}/{endpoint}"
+        url = _url_from_endpoint(self.base_url, endpoint)
 
         async with aiohttp.ClientSession() as session:
             if self.method == "GET":

--- a/airflow/providers/http/hooks/http.py
+++ b/airflow/providers/http/hooks/http.py
@@ -40,9 +40,8 @@ if TYPE_CHECKING:
 
 def _url_from_endpoint(base_url: str | None, endpoint: str | None) -> str:
     """Combine base url with endpoint."""
-    print(f"base_url: {base_url}, endpoint: {endpoint}")
     if base_url and not base_url.endswith("/") and endpoint and not endpoint.startswith("/"):
-        return base_url + "/" + endpoint
+        return f"{base_url}/{endpoint}"
     return (base_url or "") + (endpoint or "")
 
 

--- a/tests/providers/http/hooks/test_http.py
+++ b/tests/providers/http/hooks/test_http.py
@@ -657,7 +657,7 @@ class TestHttpAsyncHook:
             hook = HttpAsyncHook()
             with mock.patch("aiohttp.ClientSession.post", new_callable=mock.AsyncMock) as mocked_function:
                 await hook.run("v1/test")
-                assert mocked_function.call_args.args[0] == schema + "://" + conn.host + "v1/test"
+                assert mocked_function.call_args.args[0] == f"{schema}://{conn.host}v1/test"
 
     @pytest.mark.asyncio
     async def test_build_request_url_from_endpoint_param(self):

--- a/tests/providers/http/hooks/test_http.py
+++ b/tests/providers/http/hooks/test_http.py
@@ -657,7 +657,7 @@ class TestHttpAsyncHook:
             hook = HttpAsyncHook()
             with mock.patch("aiohttp.ClientSession.post", new_callable=mock.AsyncMock) as mocked_function:
                 await hook.run("v1/test")
-                assert mocked_function.call_args.args[0] == f"{schema}://{conn.host}v1/test"
+                assert mocked_function.call_args.args[0] == schema + "://" + conn.host + "v1/test"
 
     @pytest.mark.asyncio
     async def test_build_request_url_from_endpoint_param(self):


### PR DESCRIPTION
As mentioned in #37664 `HttpHookAsync` asumes that `base_url` is passed to the hook or can be extracted from connection, whereas `HttpHook` handles correctly when no `base_url` is passed and `endpoint` is a complete url. 

This PR aims to set the same behavior to both hooks.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
