### PR TITLE
Protect against the case where Airflow is checked out in AIRFLOW_HOME

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/path_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/path_utils.py
@@ -263,7 +263,17 @@ def find_airflow_sources_root_to_operate_on() -> Path:
         # only print warning and sleep if not producing complete results
         reinstall_if_different_sources(airflow_sources)
         reinstall_if_setup_changed()
-    os.chdir(str(airflow_sources))
+    os.chdir(airflow_sources.as_posix())
+    airflow_home_dir = Path(os.environ.get("AIRFLOW_HOME", (Path.home() / "airflow").resolve().as_posix()))
+    if airflow_sources.resolve() == airflow_home_dir.resolve():
+        get_console().print(
+            f"\n[error]Your Airflow sources are checked out in {airflow_home_dir} which "
+            f"is your also your AIRFLOW_HOME where airflow writes logs and database. \n"
+            f"This is a bad idea because Airflow might override and cleanup your checked out "
+            f"sources and .git repository.[/]\n"
+        )
+        get_console().print("\nPlease check out your Airflow code elsewhere.\n")
+        sys.exit(1)
     return airflow_sources
 
 


### PR DESCRIPTION
When airflow is checked out in the same directory as AIRFLOW_HOME, cleanup might remove everythig including .git folder. And this might happen because people might check out airflow in their HOME directory - and default AIRFLOW_HOME is ${HOME}/airflow.

THis PR will detect if Airflow is checked out AIRFLOW_HOME and will error out in this case.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
