### PR TITLE
Deprecate smtp configs in airflow settings / local_settings

### DIFF
--- a/airflow/providers/smtp/notifications/smtp.py
+++ b/airflow/providers/smtp/notifications/smtp.py
@@ -25,23 +25,16 @@ from airflow.configuration import conf
 from airflow.notifications.basenotifier import BaseNotifier
 from airflow.providers.smtp.hooks.smtp import SmtpHook
 
-try:
-    from airflow.settings import SMTP_DEFAULT_TEMPLATED_HTML_CONTENT_PATH, SMTP_DEFAULT_TEMPLATED_SUBJECT
-except ImportError:
-    # This is a fallback for when the settings are not available - they were only added in 2.8.1,
-    # so we should be able to remove it when min airflow version for the SMTP provider is 2.9.0
-    # we do not raise deprecation warning here, because the user might be using 2.8.0 and the new provider
-    # deliberately, and we do not want to upgrade to newer version of Airflow so we should not raise the
-    # deprecation warning here. If the user will modify the settings in local_settings even for earlier
-    # versions of Airflow, they will be properly used as they will be imported above
-    SMTP_DEFAULT_TEMPLATED_HTML_CONTENT_PATH = (Path(__file__).parent / "templates" / "email.html").as_posix()
-    SMTP_DEFAULT_TEMPLATED_SUBJECT = """
-{% if ti is defined %}
-DAG {{ ti.dag_id }} - Task {{ ti.task_id }} - Run ID {{ ti.run_id }} in State {{ ti.state }}
-{% elif slas is defined %}
-SLA Missed for DAG {{ dag.dag_id }} - Task {{ slas[0].task_id }}
-{% endif %}
-"""
+SMTP_DEFAULT_TEMPLATED_HTML_CONTENT_PATH = conf.get(
+    "smtp",
+    "templated_html_content_path",
+    fallback=(Path(__file__).parent / "templates" / "email.html").as_posix(),
+)
+SMTP_DEFAULT_TEMPLATED_SUBJECT_PATH = conf.get(
+    "smtp",
+    "templated_email_subject_path",
+    fallback=(Path(__file__).parent / "templates" / "email_subject.jinja").as_posix(),
+)
 
 
 class SmtpNotifier(BaseNotifier):
@@ -63,7 +56,10 @@ class SmtpNotifier(BaseNotifier):
             ),
         )
 
-    Default template is defined in airflow.settings but can be overridden in local_settings.py
+    Default template can be overridden via the following provider configuration data:
+        - templated_email_subject_path
+        - templated_html_content_path
+
 
     :param smtp_conn_id: The :ref:`smtp connection id <howto/connection:smtp>`
         that contains the information used to authenticate the client.
@@ -104,7 +100,9 @@ class SmtpNotifier(BaseNotifier):
         self.smtp_conn_id = smtp_conn_id
         self.from_email = from_email or conf.get("smtp", "smtp_mail_from")
         self.to = to
-        self.subject = subject or SMTP_DEFAULT_TEMPLATED_SUBJECT.replace("\n", "").strip()
+        self.subject = (
+            subject or Path(SMTP_DEFAULT_TEMPLATED_SUBJECT_PATH).read_text().replace("\n", "").strip()
+        )
         self.files = files
         self.cc = cc
         self.bcc = bcc

--- a/airflow/providers/smtp/notifications/smtp.py
+++ b/airflow/providers/smtp/notifications/smtp.py
@@ -33,7 +33,7 @@ SMTP_DEFAULT_TEMPLATED_HTML_CONTENT_PATH = conf.get(
 SMTP_DEFAULT_TEMPLATED_SUBJECT_PATH = conf.get(
     "smtp",
     "templated_email_subject_path",
-    fallback=(Path(__file__).parent / "templates" / "email_subject.jinja").as_posix(),
+    fallback=(Path(__file__).parent / "templates" / "email_subject.jinja2").as_posix(),
 )
 
 

--- a/airflow/providers/smtp/notifications/templates/email_subject.jinja
+++ b/airflow/providers/smtp/notifications/templates/email_subject.jinja
@@ -1,5 +1,0 @@
-{% if ti is defined %}
-DAG {{ ti.dag_id }} - Task {{ ti.task_id }} - Run ID {{ ti.run_id }} in State {{ ti.state }}
-{% elif slas is defined %}
-SLA Missed for DAG {{ dag.dag_id }} - Task {{ slas[0].task_id }}
-{% endif %}

--- a/airflow/providers/smtp/notifications/templates/email_subject.jinja
+++ b/airflow/providers/smtp/notifications/templates/email_subject.jinja
@@ -1,0 +1,5 @@
+{% if ti is defined %}
+DAG {{ ti.dag_id }} - Task {{ ti.task_id }} - Run ID {{ ti.run_id }} in State {{ ti.state }}
+{% elif slas is defined %}
+SLA Missed for DAG {{ dag.dag_id }} - Task {{ slas[0].task_id }}
+{% endif %}

--- a/airflow/providers/smtp/notifications/templates/email_subject.jinja2
+++ b/airflow/providers/smtp/notifications/templates/email_subject.jinja2
@@ -1,0 +1,23 @@
+{#
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+#}
+{% if ti is defined %}
+DAG {{ ti.dag_id }} - Task {{ ti.task_id }} - Run ID {{ ti.run_id }} in State {{ ti.state }}
+{% elif slas is defined %}
+SLA Missed for DAG {{ dag.dag_id }} - Task {{ slas[0].task_id }}
+{% endif %}

--- a/airflow/providers/smtp/provider.yaml
+++ b/airflow/providers/smtp/provider.yaml
@@ -87,19 +87,19 @@ config:
         version_added: 1.3.0
         example: "default"
         default: ~
-      default_templated_email_subject_path:
+      templated_email_subject_path:
         description: |
           Allows overriding of the standard templated email subject line when the SmtpNotifier is used.
-          Must provide a path.
+          Must provide a path to the template.
         type: string
-        version_added: 2.9.0
+        version_added: 1.6.1
         example: "path/to/override/email_subject.html"
         default: ~
-      default_templated_html_content_path:
+      templated_html_content_path:
         description: |
           Allows overriding of the standard templated email path when the SmtpNotifier is used. Must provide
-          a path.
+          a path to the template.
         type: string
-        version_added: 2.9.0
+        version_added: 1.6.1
         example: "path/to/override/email.html"
         default: ~

--- a/airflow/providers/smtp/provider.yaml
+++ b/airflow/providers/smtp/provider.yaml
@@ -87,3 +87,19 @@ config:
         version_added: 1.3.0
         example: "default"
         default: ~
+      default_templated_email_subject_path:
+        description: |
+          Allows overriding of the standard templated email subject line when the SmtpNotifier is used.
+          Must provide a path.
+        type: string
+        version_added: 2.9.0
+        example: "path/to/override/email_subject.html"
+        default: ~
+      default_templated_html_content_path:
+        description: |
+          Allows overriding of the standard templated email path when the SmtpNotifier is used. Must provide
+          a path.
+        type: string
+        version_added: 2.9.0
+        example: "path/to/override/email.html"
+        default: ~

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -33,7 +33,7 @@ from sqlalchemy.pool import NullPool
 
 from airflow import policies
 from airflow.configuration import AIRFLOW_HOME, WEBSERVER_CONFIG, conf  # NOQA F401
-from airflow.exceptions import AirflowProviderDeprecationWarning, RemovedInAirflow3Warning
+from airflow.exceptions import RemovedInAirflow3Warning
 from airflow.executors import executor_constants
 from airflow.logging_config import configure_logging
 from airflow.utils.orm_event_handlers import setup_event_handlers
@@ -502,15 +502,6 @@ def import_local_settings():
             )
             setattr(airflow_local_settings, "task_policy", airflow_local_settings.policy)
             names.remove("policy")
-
-        if "SMTP_DEFAULT_TEMPLATED_SUBJECT" in names or "SMTP_DEFAULT_TEMPLATED_HTML_CONTENT_PATH" in names:
-            warnings.warn(
-                "Configuring non-default `SMTP_DEFAULT_TEMPLATED_SUBJECT` and "
-                "`SMTP_DEFAULT_TEMPLATED_HTML_CONTENT_PATH` is deprecated. Please upgrade to "
-                "the new version of the SMTP provider and use provider configurations instead.",
-                AirflowProviderDeprecationWarning,
-                stacklevel=2,
-            )
 
         plugin_functions = policies.make_plugin_from_local_settings(
             POLICY_PLUGIN_MANAGER, airflow_local_settings, names


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: [#37703](https://github.com/apache/airflow/issues/37703)

This removes the usage of `airflow/settings.py` | `airflow_local_settings.py` from the templated SmtpNotifier. 

Ensure emails still come through as expected:

<img width="898" alt="Screenshot 2024-02-26 at 5 47 07 PM" src="https://github.com/apache/airflow/assets/9200263/e85f57bd-2815-4101-bdd8-fd570310d942">

<img width="997" alt="Screenshot 2024-02-26 at 5 46 59 PM" src="https://github.com/apache/airflow/assets/9200263/b29f65b8-d4df-43e2-942d-8abbfe49ddcd">

<img width="578" alt="Screenshot 2024-02-26 at 6 02 28 PM" src="https://github.com/apache/airflow/assets/9200263/870b23f0-94fc-4a98-a2dc-fd87ad9490f0">


Using this test dag:

```py
import datetime

from airflow import DAG
from airflow.operators.bash import BashOperator
from airflow.providers.smtp.notifications.smtp import SmtpNotifier
from datetime import timedelta


with DAG(
    dag_id="my_dag",
    start_date=datetime.datetime(2021, 1, 1),
    schedule="*/5 * * * *",
    catchup=False,
    max_active_tasks=1,
    max_active_runs=1,
    sla_miss_callback=SmtpNotifier(from_email=None, to="xyz@gmail.com"),
):
    BashOperator(
        task_id="task",
        bash_command="sleep 5 && exit 1",
        retries=1,
        sla=timedelta(seconds=30),
        on_success_callback=SmtpNotifier(from_email=None, to="xyz@gmail.com"),
        on_failure_callback=SmtpNotifier(from_email=None, to="xyz@gmail.com"),
        on_retry_callback=SmtpNotifier(from_email=None, to="xyz@gmail.com"),
    )

```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
