### PR TITLE
Make sure all unique run_ids render a task duration bar

### DIFF
--- a/airflow/www/static/js/dag/details/task/TaskDuration.tsx
+++ b/airflow/www/static/js/dag/details/task/TaskDuration.tsx
@@ -178,7 +178,7 @@ const TaskDuration = () => {
     ],
     // @ts-ignore
     dataset: {
-      dimensions: [orderingLabel, "queuedDurationUnit", "runDurationUnit"],
+      dimensions: ["runId", "queuedDurationUnit", "runDurationUnit"],
       source: durations,
     },
     tooltip: {
@@ -192,9 +192,12 @@ const TaskDuration = () => {
       type: "category",
       show: true,
       axisLabel: {
-        formatter: (value: string) =>
+        formatter: (runId: string) => {
+          const dagRun = dagRuns.find((dr) => dr.runId === runId);
+          if (!dagRun || !dagRun[orderingLabel]) return runId;
           // @ts-ignore
-          value ? moment(value).format(defaultFormat) : "",
+          return moment(dagRun[orderingLabel]).format(defaultFormat);
+        },
       },
       name: startCase(orderingLabel),
       nameLocation: "end",


### PR DESCRIPTION
Before, we were only rendering each bar of the bar graph of task durations based on unique `ordering` but manual dag runs can have the same data interval start/end. Instead, we should show a duration bar for every runId.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
