### PR TITLE
Avoid use of `assert` outside of the tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1104,7 +1104,7 @@ repos:
           airflow/example_dags/.*
         args:
           - "--skip"
-          - "B301,B324,B403,B404,B603"
+          - "B101,B301,B324,B403,B404,B603"
           - "--severity-level"
           - "high"  # TODO: remove this line when we fix all the issues
       - id: pylint

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -212,7 +212,8 @@ def _run_task_by_selected_method(
     - as raw task
     - by executor
     """
-    assert not isinstance(ti, TaskInstancePydantic), "Wait for AIP-44 implementation to complete"
+    if isinstance(ti, TaskInstancePydantic):
+        raise NotImplementedError("Wait for AIP-44 implementation to complete")
     if args.local:
         return _run_task_by_local_task_job(args, ti)
     if args.raw:

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -212,8 +212,8 @@ def _run_task_by_selected_method(
     - as raw task
     - by executor
     """
-    if isinstance(ti, TaskInstancePydantic):
-        raise NotImplementedError("Wait for AIP-44 implementation to complete")
+    if TYPE_CHECKING:
+        assert not isinstance(ti, TaskInstancePydantic)  # Wait for AIP-44 implementation to complete
     if args.local:
         return _run_task_by_local_task_job(args, ti)
     if args.raw:

--- a/airflow/models/skipmixin.py
+++ b/airflow/models/skipmixin.py
@@ -23,7 +23,6 @@ from typing import TYPE_CHECKING, Iterable, Sequence
 from sqlalchemy import select, update
 
 from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
-from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils import timezone
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -35,6 +34,7 @@ if TYPE_CHECKING:
     from pendulum import DateTime
     from sqlalchemy import Session
 
+    from airflow.models.dagrun import DagRun
     from airflow.models.operator import Operator
     from airflow.models.taskmixin import DAGNode
     from airflow.serialization.pydantic.dag_run import DagRunPydantic
@@ -197,7 +197,8 @@ class SkipMixin(LoggingMixin):
             )
 
         dag_run = ti.get_dagrun()
-        assert isinstance(dag_run, DagRun)
+        if TYPE_CHECKING:
+            assert isinstance(dag_run, DagRun)
 
         # TODO(potiuk): Handle TaskInstancePydantic case differently - we need to figure out the way to
         # pass task that has been set in LocalTaskJob but in the way that TaskInstancePydantic definition

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1025,7 +1025,8 @@ def _email_alert(
     :meta private:
     """
     subject, html_content, html_content_err = task_instance.get_email_subject_content(exception, task=task)
-    assert task.email
+    if TYPE_CHECKING:
+        assert task.email
     try:
         send_email(task.email, subject, html_content)
     except Exception:

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -406,7 +406,8 @@ class PlainXComArg(XComArg):
         from airflow.models.taskinstance import TaskInstance
 
         ti = context["ti"]
-        assert isinstance(ti, TaskInstance), "Wait for AIP-44 implementation to complete"
+        if not isinstance(ti, TaskInstance):
+            raise NotImplementedError("Wait for AIP-44 implementation to complete")
 
         task_id = self.operator.task_id
         map_indexes = ti.get_relevant_upstream_map_indexes(

--- a/airflow/providers/alibaba/cloud/hooks/analyticdb_spark.py
+++ b/airflow/providers/alibaba/cloud/hooks/analyticdb_spark.py
@@ -80,7 +80,7 @@ class AnalyticDBSparkHook(BaseHook, LoggingMixin):
     ) -> None:
         self.adb_spark_conn_id = adb_spark_conn_id
         self.adb_spark_conn = self.get_connection(adb_spark_conn_id)
-        self.region = self.get_default_region() if region is None else region
+        self.region = region or self.get_default_region()
         super().__init__(*args, **kwargs)
 
     def submit_spark_app(
@@ -327,8 +327,6 @@ class AnalyticDBSparkHook(BaseHook, LoggingMixin):
 
     def get_adb_spark_client(self) -> Client:
         """Get valid AnalyticDB MySQL Spark client."""
-        assert self.region is not None
-
         extra_config = self.adb_spark_conn.extra_dejson
         auth_type = extra_config.get("auth_type", None)
         if not auth_type:
@@ -352,7 +350,7 @@ class AnalyticDBSparkHook(BaseHook, LoggingMixin):
             )
         )
 
-    def get_default_region(self) -> str | None:
+    def get_default_region(self) -> str:
         """Get default region from connection."""
         extra_config = self.adb_spark_conn.extra_dejson
         auth_type = extra_config.get("auth_type", None)

--- a/airflow/providers/alibaba/cloud/hooks/oss.py
+++ b/airflow/providers/alibaba/cloud/hooks/oss.py
@@ -87,7 +87,7 @@ class OSSHook(BaseHook):
     def __init__(self, region: str | None = None, oss_conn_id="oss_default", *args, **kwargs) -> None:
         self.oss_conn_id = oss_conn_id
         self.oss_conn = self.get_connection(oss_conn_id)
-        self.region = self.get_default_region() if region is None else region
+        self.region = region or self.get_default_region()
         super().__init__(*args, **kwargs)
 
     def get_conn(self) -> Connection:
@@ -137,7 +137,6 @@ class OSSHook(BaseHook):
         :return: the bucket object to the bucket name.
         """
         auth = self.get_credential()
-        assert self.region is not None
         return oss2.Bucket(auth, f"https://oss-{self.region}.aliyuncs.com", bucket_name)
 
     @provide_bucket_name
@@ -353,7 +352,7 @@ class OSSHook(BaseHook):
 
         return oss2.Auth(oss_access_key_id, oss_access_key_secret)
 
-    def get_default_region(self) -> str | None:
+    def get_default_region(self) -> str:
         extra_config = self.oss_conn.extra_dejson
         auth_type = extra_config.get("auth_type", None)
         if not auth_type:

--- a/airflow/providers/amazon/aws/executors/batch/batch_executor_config.py
+++ b/airflow/providers/amazon/aws/executors/batch/batch_executor_config.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import json
 from json import JSONDecodeError
+from typing import TYPE_CHECKING
 
 from airflow.configuration import conf
 from airflow.providers.amazon.aws.executors.batch.utils import (
@@ -68,8 +69,9 @@ def build_submit_kwargs() -> dict:
     if "eksPropertiesOverride" in job_kwargs:
         raise KeyError("Eks jobs are not currently supported.")
 
+    if TYPE_CHECKING:
+        assert isinstance(job_kwargs, dict)
     # some checks with some helpful errors
-    assert isinstance(job_kwargs, dict)
     if "containerOverrides" not in job_kwargs or "command" not in job_kwargs["containerOverrides"]:
         raise KeyError(
             'SubmitJob API needs kwargs["containerOverrides"]["command"] field,'

--- a/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -727,9 +727,8 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         # If the user does not exist, make a random password and make it
         if not user_exists:
             print(f"FlaskAppBuilder Authentication Manager: Creating {user_name} user")
-            role = self.find_role("Admin")
-            if TYPE_CHECKING:
-                assert role is not None
+            if (role := self.find_role("Admin")) is None:
+                raise AirflowException("Unable to find role 'Admin'")
             # password does not contain visually similar characters: ijlIJL1oO0
             password = "".join(random.choices("abcdefghkmnpqrstuvwxyzABCDEFGHKMNPQRSTUVWXYZ23456789", k=16))
             with open(password_path, "w") as file:

--- a/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -728,7 +728,8 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         if not user_exists:
             print(f"FlaskAppBuilder Authentication Manager: Creating {user_name} user")
             role = self.find_role("Admin")
-            assert role is not None
+            if TYPE_CHECKING:
+                assert role is not None
             # password does not contain visually similar characters: ijlIJL1oO0
             password = "".join(random.choices("abcdefghkmnpqrstuvwxyzABCDEFGHKMNPQRSTUVWXYZ23456789", k=16))
             with open(password_path, "w") as file:
@@ -2445,8 +2446,9 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         :param ldap: The ldap module reference
         :param con: The ldap connection
         """
-        # always check AUTH_LDAP_BIND_USER is set before calling this method
-        assert self.auth_ldap_bind_user, "AUTH_LDAP_BIND_USER must be set"
+        if not self.auth_ldap_bind_user:
+            # always check AUTH_LDAP_BIND_USER is set before calling this method
+            raise ValueError("AUTH_LDAP_BIND_USER must be set")
 
         try:
             log.debug("LDAP bind indirect TRY with username: %r", self.auth_ldap_bind_user)
@@ -2465,8 +2467,9 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         :param username: username to match with AUTH_LDAP_UID_FIELD
         :return: ldap object array
         """
-        # always check AUTH_LDAP_SEARCH is set before calling this method
-        assert self.auth_ldap_search, "AUTH_LDAP_SEARCH must be set"
+        if not self.auth_ldap_search:
+            # always check AUTH_LDAP_SEARCH is set before calling this method
+            raise ValueError("AUTH_LDAP_SEARCH must be set")
 
         # build the filter string for the LDAP search
         if self.auth_ldap_search_filter:

--- a/airflow/providers/microsoft/psrp/hooks/psrp.py
+++ b/airflow/providers/microsoft/psrp/hooks/psrp.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 from copy import copy
 from logging import DEBUG, ERROR, INFO, WARNING
-from typing import Any, Callable, Generator
+from typing import TYPE_CHECKING, Any, Callable, Generator
 from warnings import warn
 from weakref import WeakKeyDictionary
 
@@ -173,7 +173,8 @@ class PsrpHook(BaseHook):
         if local_context:
             self.__enter__()
         try:
-            assert self._conn is not None
+            if TYPE_CHECKING:
+                assert self._conn is not None
             ps = PowerShell(self._conn)
             yield ps
             ps.begin_invoke()

--- a/airflow/providers/openlineage/extractors/base.py
+++ b/airflow/providers/openlineage/extractors/base.py
@@ -77,11 +77,6 @@ class BaseExtractor(ABC, LoggingMixin):
         )
         return fully_qualified_class_name in self.disabled_operators
 
-    def validate(self):
-        if self.operator.task_type not in self.get_operator_classnames():
-            msg = f"Operator Type {self.operator.task_type} is not supported."
-            raise AssertionError(msg)
-
     @abstractmethod
     def _execute_extraction(self) -> OperatorLineage | None:
         ...

--- a/airflow/providers/openlineage/extractors/base.py
+++ b/airflow/providers/openlineage/extractors/base.py
@@ -78,7 +78,9 @@ class BaseExtractor(ABC, LoggingMixin):
         return fully_qualified_class_name in self.disabled_operators
 
     def validate(self):
-        assert self.operator.task_type in self.get_operator_classnames()
+        if self.operator.task_type not in self.get_operator_classnames():
+            msg = f"Operator Type {self.operator.task_type} is not supported."
+            raise AssertionError(msg)
 
     @abstractmethod
     def _execute_extraction(self) -> OperatorLineage | None:

--- a/airflow/providers/yandex/secrets/lockbox.py
+++ b/airflow/providers/yandex/secrets/lockbox.py
@@ -128,10 +128,8 @@ class LockboxSecretBackend(BaseSecretsBackend, LoggingMixin):
         self.yc_connection_id = None
         if not any([yc_oauth_token, yc_sa_key_json, yc_sa_key_json_path]):
             self.yc_connection_id = yc_connection_id or default_conn_name
-        else:
-            assert (
-                yc_connection_id is None
-            ), "yc_connection_id should not be used if other credentials are specified"
+        elif yc_connection_id is not None:
+            raise ValueError("`yc_connection_id` should not be used if other credentials are specified")
 
         self.folder_id = folder_id
         self.connections_prefix = connections_prefix.rstrip(sep) if connections_prefix is not None else None

--- a/airflow/serialization/pydantic/job.py
+++ b/airflow/serialization/pydantic/job.py
@@ -16,7 +16,7 @@
 # under the License.
 import datetime
 from functools import cached_property
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job_runner import BaseJobRunner
@@ -53,7 +53,8 @@ class JobPydantic(BaseModelPydantic):
     def heartrate(self) -> float:
         from airflow.jobs.job import Job
 
-        assert self.job_type is not None
+        if TYPE_CHECKING:
+            assert self.job_type is not None
         return Job._heartrate(self.job_type)
 
     def is_alive(self, grace_multiplier=2.1) -> bool:

--- a/dev/breeze/src/airflow_breeze/commands/minor_release_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/minor_release_command.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import os
+import sys
 
 import click
 
@@ -158,7 +159,18 @@ def create_constraints(version_branch):
 @option_answer
 def create_minor_version_branch(version_branch):
     for obj in version_branch.split("-"):
-        assert isinstance(int(obj), int)
+        if not obj.isdigit():
+            console_print(f"[error]Failed `version_branch` part {obj!r} not a digit.")
+            sys.exit(1)
+        elif len(obj) > 1 and obj.startswith("0"):
+            # `01` is a valid digit string, as well as it could be converted to the integer,
+            # however, it might be considered as typo (e.g. 10) so better stop here
+            console_print(
+                f"[error]Found leading zero into the `version_branch` part {obj!r} ",
+                f"if it is not a typo consider to use {int(obj)} instead.",
+            )
+            sys.exit(1)
+
     os.chdir(AIRFLOW_SOURCES_ROOT)
     repo_root = os.getcwd()
     console_print()

--- a/dev/perf/dags/elastic_dag.py
+++ b/dev/perf/dags/elastic_dag.py
@@ -39,12 +39,12 @@ def parse_time_delta(time_str: str):
     :param time_str: A string identifying a duration.  (eg. 2h13m)
     :return datetime.timedelta: A datetime.timedelta object or "@once"
     """
-    parts = RE_TIME_DELTA.match(time_str)
-
-    assert parts is not None, (
-        f"Could not parse any time information from '{time_str}'. "
-        f"Examples of valid strings: '8h', '2d8h5m20s', '2m4s'"
-    )
+    if (parts := RE_TIME_DELTA.match(time_str)) is None:
+        msg = (
+            f"Could not parse any time information from '{time_str}'. "
+            f"Examples of valid strings: '8h', '2d8h5m20s', '2m4s'"
+        )
+        raise ValueError(msg)
 
     time_params = {name: float(param) for name, param in parts.groupdict().items() if param}
     return timedelta(**time_params)  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1337,6 +1337,7 @@ extend-select = [
     "PGH004",  # Use specific rule codes when using noqa
     "PGH005", # Invalid unittest.mock.Mock methods/attributes/properties
     "B006", # Checks for uses of mutable objects as function argument defaults.
+    "S101", # Checks use `assert` outside the test cases, test cases should be added into the exclusions
 ]
 ignore = [
     "D203",
@@ -1391,13 +1392,14 @@ combine-as-imports = true
 "*/example_dags/*" = ["D"]
 "chart/*" = ["D"]
 "dev/*" = ["D"]
-# In addition ignore top level imports, e.g. pandas, numpy in tests
+# In addition, ignore top level imports, e.g. pandas, numpy (TID253) and use of assert (S101) in tests
 "dev/perf/*" = ["TID253"]
-"dev/breeze/tests/*" = ["TID253"]
-"tests/*" = ["D", "TID253"]
-"docker_tests/*" = ["D", "TID253"]
-"kubernetes_tests/*" = ["D", "TID253"]
-"helm_tests/*" = ["D", "TID253"]
+"dev/check_files.py" = ["S101"]
+"dev/breeze/tests/*" = ["TID253", "S101"]
+"tests/*" = ["D", "TID253", "S101"]
+"docker_tests/*" = ["D", "TID253", "S101"]
+"kubernetes_tests/*" = ["D", "TID253", "S101"]
+"helm_tests/*" = ["D", "TID253", "S101"]
 
 # All of the modules which have an extra license header (i.e. that we copy from another project) need to
 # ignore E402 -- module level import not at top level

--- a/scripts/ci/pre_commit/pre_commit_sync_init_decorator.py
+++ b/scripts/ci/pre_commit/pre_commit_sync_init_decorator.py
@@ -24,6 +24,7 @@ import collections.abc
 import itertools
 import pathlib
 import sys
+from typing import TYPE_CHECKING
 
 PACKAGE_ROOT = pathlib.Path(__file__).resolve().parents[3].joinpath("airflow")
 DAG_PY = PACKAGE_ROOT.joinpath("models", "dag.py")
@@ -93,7 +94,9 @@ def _match_arguments(
         if dec is None and ini is not None:
             yield f"Argument present in {init_name} but missing from @{deco_name}: {ini.arg}"
             return
-        assert ini is not None and dec is not None  # Because None is only possible as fillvalue.
+
+        if TYPE_CHECKING:
+            assert ini is not None and dec is not None  # Because None is only possible as fillvalue.
 
         if ini.arg != dec.arg:
             yield f"Argument {i + 1} mismatch: {init_name} has {ini.arg} but @{deco_name} has {dec.arg}"

--- a/scripts/in_container/run_migration_reference.py
+++ b/scripts/in_container/run_migration_reference.py
@@ -107,7 +107,8 @@ def revision_suffix(rev: Script):
 
 def ensure_airflow_version(revisions: Iterable[Script]):
     for rev in revisions:
-        assert rev.module.__file__ is not None  # For Mypy.
+        if TYPE_CHECKING:  # For mypy
+            assert rev.module.__file__ is not None
         file = Path(rev.module.__file__)
         content = file.read_text()
         if not has_version(content):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Enable [`S101`](https://docs.astral.sh/ruff/rules/assert/) for make sure that we follow https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#dont-use-asserts-outside-tests

This exact the same rule which use by bandit `B101`, however ruff have some significant benefit - it ignore this rule inside of `TYPE_CHECKING` which might use for make `mypy` happy and do not executed in runtime.

```console
❯ pre-commit run ruff --all-files
Run 'ruff' for extremely fast Python linting.............................Failed
- hook id: ruff
- exit code: 1

airflow/cli/commands/task_command.py:215:5: S101 Use of `assert` detected
airflow/models/skipmixin.py:200:9: S101 Use of `assert` detected
airflow/models/taskinstance.py:1028:5: S101 Use of `assert` detected
airflow/models/xcom_arg.py:409:9: S101 Use of `assert` detected
airflow/providers/alibaba/cloud/hooks/analyticdb_spark.py:330:9: S101 Use of `assert` detected
airflow/providers/alibaba/cloud/hooks/oss.py:140:9: S101 Use of `assert` detected
airflow/providers/fab/auth_manager/security_manager/override.py:731:13: S101 Use of `assert` detected
airflow/providers/fab/auth_manager/security_manager/override.py:2449:9: S101 Use of `assert` detected
airflow/providers/fab/auth_manager/security_manager/override.py:2469:9: S101 Use of `assert` detected
airflow/providers/microsoft/psrp/hooks/psrp.py:176:13: S101 Use of `assert` detected
airflow/providers/openlineage/extractors/base.py:81:9: S101 Use of `assert` detected
airflow/providers/yandex/secrets/lockbox.py:132:13: S101 Use of `assert` detected
airflow/serialization/pydantic/job.py:56:9: S101 Use of `assert` detected
dev/breeze/src/airflow_breeze/commands/minor_release_command.py:161:9: S101 Use of `assert` detected
dev/perf/dags/elastic_dag.py:44:5: S101 Use of `assert` detected
scripts/ci/pre_commit/pre_commit_sync_init_decorator.py:96:9: S101 Use of `assert` detected
scripts/in_container/run_migration_reference.py:110:9: S101 Use of `assert` detected
Found 17 errors.
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
