### PR TITLE
Readme Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,14 +181,14 @@ them to the appropriate format and workflow that your tool requires.
 
 ```bash
 pip install 'apache-airflow==2.8.2'
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
+--constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
 ```
 
 2. Installing with extras (i.e., postgres, google)
 
 ```bash
-pip install 'apache-airflow[postgres,google]==2.8.2'
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
+pip install 'apache-airflow==2.8.2'
+--constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
 ```
 
 For information on installing provider packages, check

--- a/README.md
+++ b/README.md
@@ -180,14 +180,14 @@ them to the appropriate format and workflow that your tool requires.
 
 
 ```bash
-pip install 'apache-airflow==2.8.2' \
+pip install 'apache-airflow==2.8.2'
  --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
 ```
 
 2. Installing with extras (i.e., postgres, google)
 
 ```bash
-pip install 'apache-airflow[postgres,google]==2.8.2' \
+pip install 'apache-airflow[postgres,google]==2.8.2'
  --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
 ```
 

--- a/README.md
+++ b/README.md
@@ -180,15 +180,13 @@ them to the appropriate format and workflow that your tool requires.
 
 
 ```bash
-pip install 'apache-airflow==2.8.2'
---constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
+pip install 'apache-airflow==2.8.2' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
 ```
 
 2. Installing with extras (i.e., postgres, google)
 
 ```bash
-pip install 'apache-airflow==2.8.2'
---constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
+pip install 'apache-airflow==2.8.2' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
 ```
 
 For information on installing provider packages, check


### PR DESCRIPTION
The PyPI installation command was not working when I tried to install Apache Airflow on my local machine with the given bash command. 

## Error Message
```bash
At line:2 char:4
+  --constraint "https://raw.githubusercontent.com/apache/airflow/const ...
+    ~
Missing expression after unary operator '--'.
At line:2 char:4
+  --constraint "https://raw.githubusercontent.com/apache/airflow/const ...
+    ~~~~~~~~~~
Unexpected token 'constraint' in expression or statement.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : MissingExpressionAfterOperator
```

## Solution
Updated the bash command to be executed in a single line.

### Old
 
```bash
pip install 'apache-airflow==2.8.2' \
>>  --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
```

### New
 
```bash
pip install 'apache-airflow==2.8.2' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
```