### PR TITLE
Wrap AIRFLOW_HOME env var lookup in Path

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/path_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/path_utils.py
@@ -318,7 +318,7 @@ DOCKER_CONTEXT_DIR = AIRFLOW_SOURCES_ROOT / "docker-context-files"
 CACHE_TMP_FILE_DIR = tempfile.TemporaryDirectory()
 OUTPUT_LOG = Path(CACHE_TMP_FILE_DIR.name, "out.log")
 BREEZE_SOURCES_ROOT = AIRFLOW_SOURCES_ROOT / "dev" / "breeze"
-AIRFLOW_HOME_DIR = os.environ.get("AIRFLOW_HOME", Path.home() / "airflow")
+AIRFLOW_HOME_DIR = Path(os.environ.get("AIRFLOW_HOME", Path.home() / "airflow"))
 
 
 def create_volume_if_missing(volume_name: str):


### PR DESCRIPTION
When testing the change with AIRFLOW_HOME env var set.
related: #37697 

❯ breeze cleanup                        
Removing cache of parameters, and cleans up docker cache
Removing unused networks

Are you sure with the removal of unused docker networks? 
Press y/N/q: 
Pruning docker images

Are you sure with the removal of docker images? 
Press y/N/q: 
Removing build cache dir /home/dylanr/code/airflow/.build

Are you sure with the removal? 
Press y/N/q: 
Uninstalling airflow and removing configuration

Are you sure with the uninstall / remove? 
Press y/N/q: y
Traceback (most recent call last):
  File "/home/dylanr/.local/bin/breeze", line 8, in <module>
    sys.exit(main())
  File "/home/dylanr/.local/share/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/dylanr/.local/share/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/rich_click/rich_command.py", line 126, in main
    rv = self.invoke(ctx)
  File "/home/dylanr/.local/share/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/dylanr/.local/share/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/dylanr/.local/share/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/dylanr/code/airflow/dev/breeze/src/airflow_breeze/commands/main_command.py", line 296, in cleanup
    AIRFLOW_HOME_DIR.mkdir(exist_ok=True, parents=True)
AttributeError: 'str' object has no attribute 'mkdir'



