### PR TITLE
Add Run Duration in React

### DIFF
--- a/airflow/www/static/js/dag/details/dag/Dag.tsx
+++ b/airflow/www/static/js/dag/details/dag/Dag.tsx
@@ -50,7 +50,7 @@ import type { TaskState } from "src/types";
 
 import type { DAG, DAGDetail } from "src/types/api-generated";
 import URLSearchParamsWrapper from "src/utils/URLSearchParamWrapper";
-import { SimpleStatus } from "../StatusBox";
+import { SimpleStatus } from "../../StatusBox";
 
 const dagId = getMetaValue("dag_id");
 const tagIndexUrl = getMetaValue("tag_index_url");

--- a/airflow/www/static/js/dag/details/dag/RunDuration.tsx
+++ b/airflow/www/static/js/dag/details/dag/RunDuration.tsx
@@ -1,0 +1,54 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useState } from "react";
+import { Box, Checkbox, Flex } from "@chakra-ui/react";
+
+import InfoTooltip from "src/components/InfoTooltip";
+import RunDurationChart from "./RunDurationChart";
+
+const LANDING_TIME_KEY = "showLandingTimes";
+
+const RunDuration = () => {
+  const storedValue = localStorage.getItem(LANDING_TIME_KEY);
+  const [showLandingTimes, setShowLandingTimes] = useState(
+    storedValue ? JSON.parse(storedValue) : true
+  );
+  const onChange = () => {
+    localStorage.setItem(LANDING_TIME_KEY, (!showLandingTimes).toString());
+    setShowLandingTimes(!showLandingTimes);
+  };
+
+  return (
+    <Box height="50%">
+      <Flex justifyContent="right" pr="30px">
+        <Checkbox isChecked={showLandingTimes} onChange={onChange} size="lg">
+          Show Landing Times
+        </Checkbox>
+        <InfoTooltip
+          label="Landing Time is the difference between the Data Interval End and the
+        start of the Dag Run"
+          size={16}
+        />
+      </Flex>
+      <RunDurationChart showLandingTimes={showLandingTimes} />
+    </Box>
+  );
+};
+export default RunDuration;

--- a/airflow/www/static/js/dag/details/dag/RunDurationChart.tsx
+++ b/airflow/www/static/js/dag/details/dag/RunDurationChart.tsx
@@ -1,0 +1,266 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* global moment */
+
+import React from "react";
+import { startCase } from "lodash";
+import type { SeriesOption } from "echarts";
+
+import useSelection from "src/dag/useSelection";
+import { useGridData } from "src/api";
+import { getDuration, formatDateTime, defaultFormat } from "src/datetime_utils";
+import ReactECharts, { ReactEChartsProps } from "src/components/ReactECharts";
+import type { DagRun } from "src/types";
+import { getTask } from "src/utils";
+
+interface RunDuration extends DagRun {
+  landingDuration: moment.Duration;
+  landingDurationUnit: number;
+  queuedDuration: moment.Duration;
+  queuedDurationUnit: number;
+  runDuration: moment.Duration;
+  runDurationUnit: number;
+}
+
+interface Props {
+  showLandingTimes?: boolean;
+}
+
+const RunDurationChart = ({ showLandingTimes }: Props) => {
+  const {
+    selected: { taskId },
+    onSelect,
+  } = useSelection();
+
+  const {
+    data: { dagRuns, groups, ordering },
+  } = useGridData();
+
+  let maxDuration = 0;
+  let unit = "seconds";
+
+  const task = getTask({ taskId, task: groups });
+
+  if (!task) return null;
+  const orderingLabel = ordering[0] || ordering[1] || "startDate";
+
+  const durations: (RunDuration | {})[] = dagRuns.map((dagRun) => {
+    // @ts-ignore
+    const landingDuration = moment.duration(
+      getDuration(dagRun.dataIntervalEnd, dagRun.queuedAt || dagRun.startDate)
+    );
+
+    // @ts-ignore
+    const runDuration = moment.duration(
+      dagRun.startDate && dagRun.endDate
+        ? getDuration(dagRun.startDate, dagRun?.endDate)
+        : 0
+    );
+
+    // @ts-ignore
+    const queuedDuration = moment.duration(
+      dagRun.queuedAt && dagRun.startDate && dagRun.startDate > dagRun.queuedAt
+        ? getDuration(dagRun.queuedAt, dagRun.startDate)
+        : 0
+    );
+
+    if (showLandingTimes) {
+      if (landingDuration.asSeconds() > maxDuration) {
+        maxDuration = landingDuration.asSeconds();
+      }
+    } else if (runDuration.asSeconds() > maxDuration) {
+      maxDuration = runDuration.asSeconds();
+    }
+
+    if (maxDuration <= 60 * 2) {
+      unit = "seconds";
+    } else if (maxDuration <= 60 * 60 * 2) {
+      unit = "minutes";
+    } else if (maxDuration <= 24 * 60 * 60 * 2) {
+      unit = "hours";
+    } else {
+      unit = "days";
+    }
+
+    let landingDurationUnit;
+    let queuedDurationUnit;
+    let runDurationUnit;
+
+    if (unit === "seconds") {
+      landingDurationUnit = landingDuration.asSeconds();
+      queuedDurationUnit = queuedDuration.asSeconds();
+      runDurationUnit = runDuration.asSeconds();
+    } else if (unit === "minutes") {
+      landingDurationUnit = landingDuration.asMinutes();
+      queuedDurationUnit = queuedDuration.asMinutes();
+      runDurationUnit = runDuration.asMinutes();
+    } else if (unit === "hours") {
+      landingDurationUnit = landingDuration.asHours();
+      queuedDurationUnit = queuedDuration.asHours();
+      runDurationUnit = runDuration.asHours();
+    } else {
+      landingDurationUnit = landingDuration.asDays();
+      queuedDurationUnit = queuedDuration.asDays();
+      runDurationUnit = runDuration.asDays();
+    }
+
+    return {
+      ...dagRun,
+      landingDuration,
+      runDuration,
+      queuedDuration,
+      landingDurationUnit,
+      runDurationUnit,
+      queuedDurationUnit,
+    };
+  });
+
+  // @ts-ignore
+  function formatTooltip(args) {
+    const { data } = args[0];
+    const {
+      runId,
+      queuedAt,
+      startDate,
+      logicalDate,
+      dataIntervalStart,
+      dataIntervalEnd,
+      state,
+      endDate,
+      queuedDurationUnit,
+      runDurationUnit,
+      landingDurationUnit,
+    } = data;
+
+    return `
+      Run Id: ${runId} <br>
+      State: ${state} <br>
+      Logical Date: ${formatDateTime(logicalDate)} <br>
+      Data Interval Start: ${formatDateTime(dataIntervalStart)} <br>
+      Data Interval End: ${formatDateTime(dataIntervalEnd)} <br>
+      ${queuedAt ? `Queued: ${formatDateTime(queuedAt)} <br>` : ""}
+      Started: ${startDate && formatDateTime(startDate)} <br>
+      Ended: ${endDate && formatDateTime(endDate || undefined)} <br>
+      Landing Time: ${landingDurationUnit.toFixed(2)} ${unit}<br>
+      ${
+        queuedAt
+          ? `Queued duration: ${queuedDurationUnit.toFixed(2)} ${unit}<br>`
+          : ""
+      }
+      Run duration: ${runDurationUnit.toFixed(2)} ${unit}<br>
+      Total duration: ${(
+        landingDurationUnit +
+        queuedDurationUnit +
+        runDurationUnit
+      ).toFixed(2)} ${unit}<br>
+    `;
+  }
+
+  const option: ReactEChartsProps["option"] = {
+    series: [
+      ...(showLandingTimes
+        ? [
+            {
+              type: "bar",
+              barMinHeight: 0.1,
+              itemStyle: {
+                color: stateColors.scheduled,
+                opacity: 0.6,
+              },
+              stack: "x",
+            } as SeriesOption,
+          ]
+        : []),
+      {
+        type: "bar",
+        barMinHeight: 0.1,
+        itemStyle: {
+          color: stateColors.queued,
+          opacity: 0.6,
+        },
+        stack: "x",
+      },
+      {
+        type: "bar",
+        barMinHeight: 1,
+        itemStyle: {
+          // @ts-ignore
+          color: (params) => stateColors[params.data.state],
+        },
+        stack: "x",
+      },
+    ],
+    // @ts-ignore
+    dataset: {
+      dimensions: [
+        "runId",
+        ...(showLandingTimes ? ["landingDurationUnit"] : []),
+        "queuedDurationUnit",
+        "runDurationUnit",
+      ],
+      source: durations,
+    },
+    tooltip: {
+      trigger: "axis",
+      formatter: formatTooltip,
+      axisPointer: {
+        type: "shadow",
+      },
+    },
+    xAxis: {
+      type: "category",
+      show: true,
+      axisLabel: {
+        formatter: (runId: string) => {
+          const dagRun = dagRuns.find((dr) => dr.runId === runId);
+          if (!dagRun || !dagRun[orderingLabel]) return runId;
+          // @ts-ignore
+          return moment(dagRun[orderingLabel]).format(defaultFormat);
+        },
+      },
+      name: startCase(orderingLabel),
+      nameLocation: "end",
+      nameGap: 0,
+      nameTextStyle: {
+        align: "right",
+        verticalAlign: "top",
+        padding: [30, 0, 0, 0],
+      },
+    },
+    yAxis: {
+      type: "value",
+      name: `Duration (${unit})`,
+    },
+  };
+
+  const events = {
+    // @ts-ignore
+    click(params) {
+      onSelect({
+        taskId: params.data.taskId,
+        runId: params.data.runId,
+      });
+    },
+  };
+
+  return <ReactECharts option={option} events={events} />;
+};
+
+export default RunDurationChart;

--- a/airflow/www/static/js/dag/details/dag/RunDurationChart.tsx
+++ b/airflow/www/static/js/dag/details/dag/RunDurationChart.tsx
@@ -28,7 +28,6 @@ import { useGridData } from "src/api";
 import { getDuration, formatDateTime, defaultFormat } from "src/datetime_utils";
 import ReactECharts, { ReactEChartsProps } from "src/components/ReactECharts";
 import type { DagRun } from "src/types";
-import { getTask } from "src/utils";
 
 interface RunDuration extends DagRun {
   landingDuration: moment.Duration;
@@ -44,21 +43,15 @@ interface Props {
 }
 
 const RunDurationChart = ({ showLandingTimes }: Props) => {
-  const {
-    selected: { taskId },
-    onSelect,
-  } = useSelection();
+  const { onSelect } = useSelection();
 
   const {
-    data: { dagRuns, groups, ordering },
+    data: { dagRuns, ordering },
   } = useGridData();
 
   let maxDuration = 0;
   let unit = "seconds";
 
-  const task = getTask({ taskId, task: groups });
-
-  if (!task) return null;
   const orderingLabel = ordering[0] || ordering[1] || "startDate";
 
   const durations: (RunDuration | {})[] = dagRuns.map((dagRun) => {
@@ -201,6 +194,7 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
         type: "bar",
         barMinHeight: 1,
         itemStyle: {
+          opacity: 1,
           // @ts-ignore
           color: (params) => stateColors[params.data.state],
         },
@@ -254,7 +248,6 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
     // @ts-ignore
     click(params) {
       onSelect({
-        taskId: params.data.taskId,
         runId: params.data.runId,
       });
     },

--- a/airflow/www/yarn.lock
+++ b/airflow/www/yarn.lock
@@ -4474,9 +4474,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001349:
-  version "1.0.30001516"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001516.tgz#621b1be7d85a8843ee7d210fd9d87b52e3daab3a"
-  integrity sha512-Wmec9pCBY8CWbmI4HsjBeQLqDTqV91nFVR83DnZpYyRnPI1wePDsTg0bGLPC5VU/3OIZV1fmxEea1b+tFKe86g==
+  version "1.0.30001589"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001589.tgz"
+  integrity sha512-vNQWS6kI+q6sBlHbh71IIeC+sRwK2N3EDySc/updIGhIee2x5z00J4c1242/5/d6EpEMdOnk/m+6tuk4/tcsqg==
 
 ccount@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Similar to task duration but for dag runs. At first this was to replace the Landing Time chart, which made more sense at a dag run level vs a task instance level. But instead decided to make it a full view and allow users to toggle Landing Times on/off.

<img width="289" alt="Screenshot 2024-02-26 at 11 05 40 PM" src="https://github.com/apache/airflow/assets/4600967/2b2fe401-22d8-46cc-bd54-0354cfc9506e">

![Feb-26-2024 23-05-27](https://github.com/apache/airflow/assets/4600967/ffc9da41-b4a7-49c3-8bb8-23e709d1775a)

(This is a daily dag with an old start_date and catchup is true)
<img width="1182" alt="Screenshot 2024-02-26 at 11 04 32 PM" src="https://github.com/apache/airflow/assets/4600967/6662b481-393b-45a3-b224-3df6f4e289e2">

You can also see queued time for a dag run:
<img width="652" alt="Screenshot 2024-02-29 at 10 01 55 AM" src="https://github.com/apache/airflow/assets/4600967/f1cecb21-37a1-4229-93d9-07f813041a6c">


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
