### PR TITLE
Set job labels for traceability in BigQuery jobs

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -2779,7 +2779,7 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator, _BigQueryOpenLineageMix
                 self.configuration["labels"]["airflow-dag"] = self.dag_id
                 self.configuration["labels"]["airflow-task"] = self.task_id
         else:
-            self.configuration["labels"] = { "airflow-dag": self.dag_id, "airflow-task": self.task_id }
+            self.configuration["labels"] = {"airflow-dag": self.dag_id, "airflow-task": self.task_id}
 
         # Submit a new job without waiting for it to complete.
         return hook.insert_job(

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -68,6 +68,7 @@ BIGQUERY_JOB_DETAILS_LINK_FMT = "https://console.cloud.google.com/bigquery?j={jo
 LABEL_REGEX = re.compile(r"^[a-z][\w-]+$")
 LABEL_SIZE_LIMIT = 64
 
+
 class BigQueryUIColors(enum.Enum):
     """Hex colors for BigQuery operators."""
 

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -2777,10 +2777,9 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator, _BigQueryOpenLineageMix
 
         if LABEL_REGEX.match(dag_label) and LABEL_REGEX.match(task_label):
             automatic_labels = {"airflow-dag": dag_label, "airflow-task": task_label}
-            if "labels" in self.configuration:
-                if isinstance(self.configuration["labels"], dict):
-                    self.configuration["labels"].update(automatic_labels)
-            else:
+            if isinstance(self.configuration.get("labels"), dict):
+                self.configuration["labels"].update(automatic_labels)
+            elif "labels" not in self.configuration:
                 self.configuration["labels"] = automatic_labels
 
     def _submit_job(

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -2773,6 +2773,14 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator, _BigQueryOpenLineageMix
         hook: BigQueryHook,
         job_id: str,
     ) -> BigQueryJob:
+        # Annotate the job with dag and task id labels
+        if "labels" in self.configuration:
+            if isinstance(self.configuration["labels"], dict):
+                self.configuration["labels"]["airflow-dag"] = self.dag_id
+                self.configuration["labels"]["airflow-task"] = self.task_id
+        else:
+            self.configuration["labels"] = { "airflow-dag": self.dag_id, "airflow-task": self.task_id }
+
         # Submit a new job without waiting for it to complete.
         return hook.insert_job(
             configuration=self.configuration,

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -1834,7 +1834,7 @@ class TestBigQueryInsertJobOperator:
                 "useLegacySql": False,
             },
         }
-        with dag_maker("adhoc_airflow_except_this_task_id_is_really_really_really_really_long") as dag:
+        with dag_maker("adhoc_airflow_except_this_task_id_is_really_really_really_really_long"):
             op = BigQueryInsertJobOperator(
                 task_id="insert_query_job",
                 configuration=configuration,
@@ -1851,7 +1851,7 @@ class TestBigQueryInsertJobOperator:
                 "useLegacySql": False,
             },
         }
-        with dag_maker("YELLING_DAG_NAME") as dag:
+        with dag_maker("YELLING_DAG_NAME"):
             op = BigQueryInsertJobOperator(
                 task_id="YELLING_TASK_ID",
                 configuration=configuration,

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -1102,7 +1102,7 @@ class TestBigQueryInsertJobOperator:
             project_id=TEST_GCP_PROJECT_ID,
         )
         result = op.execute(context=MagicMock())
-        assert configuration["labels"] == { "airflow-dag": "adhoc_airflow", "airflow-task": "insert_query_job" }
+        assert configuration["labels"] == {"airflow-dag": "adhoc_airflow", "airflow-task": "insert_query_job"}
 
         mock_hook.return_value.insert_job.assert_called_once_with(
             configuration=configuration,
@@ -1144,7 +1144,7 @@ class TestBigQueryInsertJobOperator:
             project_id=TEST_GCP_PROJECT_ID,
         )
         result = op.execute(context=MagicMock())
-        assert configuration["labels"] == { "airflow-dag": "adhoc_airflow", "airflow-task": "copy_query_job" }
+        assert configuration["labels"] == {"airflow-dag": "adhoc_airflow", "airflow-task": "copy_query_job"}
 
         mock_hook.return_value.insert_job.assert_called_once_with(
             configuration=configuration,
@@ -1766,9 +1766,7 @@ class TestBigQueryInsertJobOperator:
                 "query": "SELECT * FROM any",
                 "useLegacySql": False,
             },
-            "labels": {
-                "foo": "bar"
-            }
+            "labels": {"foo": "bar"},
         }
         mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
         mock_hook.return_value.generate_job_id.return_value = real_job_id
@@ -1780,11 +1778,11 @@ class TestBigQueryInsertJobOperator:
             job_id=job_id,
             project_id=TEST_GCP_PROJECT_ID,
         )
-        result = op.execute(context=MagicMock())
+        op.execute(context=MagicMock())
         assert configuration["labels"] == {
             "foo": "bar",
             "airflow-dag": "adhoc_airflow",
-            "airflow-task": "insert_query_job"
+            "airflow-task": "insert_query_job",
         }
 
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
@@ -1798,7 +1796,7 @@ class TestBigQueryInsertJobOperator:
                 "query": "SELECT * FROM any",
                 "useLegacySql": False,
             },
-            "labels": None
+            "labels": None,
         }
         mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
         mock_hook.return_value.generate_job_id.return_value = real_job_id
@@ -1810,8 +1808,8 @@ class TestBigQueryInsertJobOperator:
             job_id=job_id,
             project_id=TEST_GCP_PROJECT_ID,
         )
-        result = op.execute(context=MagicMock())
-        assert configuration["labels"] == None
+        op.execute(context=MagicMock())
+        assert configuration["labels"] is None
 
 
 class TestBigQueryIntervalCheckOperator:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This adds the airflow dag ID and task ID as labels to BigQuery jobs.  This helps trace the jobs back to their corresponding DAG from audit logs and job history.  I personally use this to track BigQuery costs at a DAG/task granularity over time.

Let me know if there is a better place to put this than the `_submit_job` call.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
