### PR TITLE
Return back removed public HttpHook's method

### DIFF
--- a/airflow/providers/http/hooks/http.py
+++ b/airflow/providers/http/hooks/http.py
@@ -268,6 +268,10 @@ class HttpHook(BaseHook):
         # TODO: remove ignore type when https://github.com/jd/tenacity/issues/428 is resolved
         return self._retry_obj(self.run, *args, **kwargs)  # type: ignore
 
+    def url_from_endpoint(self, endpoint: str | None) -> str:
+        """Combine base url with endpoint."""
+        return _url_from_endpoint(base_url=self.base_url, endpoint=endpoint)
+
     def test_connection(self):
         """Test HTTP Connection."""
         try:

--- a/tests/providers/http/hooks/test_http.py
+++ b/tests/providers/http/hooks/test_http.py
@@ -497,6 +497,18 @@ class TestHttpHook:
             tcp_keep_alive_send.assert_not_called()
             http_send.assert_called()
 
+    @pytest.mark.parametrize(
+        "base_url, endpoint, expected_url",
+        [
+            pytest.param("https://example.org", "/v1/test", "https://example.org/v1/test", id="both-set"),
+            pytest.param("", "http://foo/bar/v1/test", "http://foo/bar/v1/test", id="only-endpoint"),
+        ],
+    )
+    def test_url_from_endpoint(self, base_url: str, endpoint: str, expected_url: str):
+        hook = HttpHook()
+        hook.base_url = base_url
+        assert hook.url_from_endpoint(endpoint) == expected_url
+
 
 class TestHttpAsyncHook:
     @pytest.mark.asyncio


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

During #37696 method `HttpHook.url_from_endpoint` was removed.
For avoid any breaking changes return it back

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
