### PR TITLE
Add smtp provider to prod_image_installed_providers.txt

### DIFF
--- a/prod_image_installed_providers.txt
+++ b/prod_image_installed_providers.txt
@@ -22,6 +22,7 @@ redis
 sendgrid
 sftp
 slack
+smtp
 snowflake
 sqlite
 ssh


### PR DESCRIPTION
Looking into the prod image tests failing in #37733

FAILED docker_tests/test_prod_image.py::TestPythonPackages::test_required_providers_are_installed 

  E       AssertionError: List of expected installed packages and image content mismatch. Check /home/runner/work/airflow/airflow/prod_image_installed_providers.txt file.
....
  E         Extra items in the right set:
  E         'apache-airflow-providers-smtp'

Based on #37701 it seems that the smtp provider is now preinstalled on the prod image.

Tested locally with breeze prod-image build and breeze prod-image verify