### PR TITLE
Remove broken deprecated fallback into the Google provider operators

### DIFF
--- a/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
@@ -22,7 +22,7 @@ from copy import deepcopy
 from datetime import date, time
 from typing import TYPE_CHECKING, Sequence
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.google.cloud.hooks.cloud_storage_transfer_service import (
     ACCESS_KEY_ID,
@@ -537,37 +537,24 @@ class CloudDataTransferServiceListOperationsOperator(GoogleCloudBaseOperator):
 
     def __init__(
         self,
-        request_filter: dict | None = None,
+        request_filter: dict,
         project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
         api_version: str = "v1",
         google_impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
-        # To preserve backward compatibility
-        # TODO: remove one day
-        if request_filter is None:
-            if "filter" in kwargs:
-                request_filter = kwargs["filter"]
-                AirflowProviderDeprecationWarning(
-                    "Use 'request_filter' instead 'filter' to pass the argument."
-                )
-            else:
-                TypeError("__init__() missing 1 required positional argument: 'request_filter'")
-
         super().__init__(**kwargs)
         self.filter = request_filter
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
         self.google_impersonation_chain = google_impersonation_chain
-        self._validate_inputs()
 
-    def _validate_inputs(self) -> None:
+    def execute(self, context: Context) -> list[dict]:
         if not self.filter:
             raise AirflowException("The required parameter 'filter' is empty or None")
 
-    def execute(self, context: Context) -> list[dict]:
         hook = CloudDataTransferServiceHook(
             api_version=self.api_version,
             gcp_conn_id=self.gcp_conn_id,

--- a/airflow/providers/google/cloud/transfers/gcs_to_local.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_local.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Sequence
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.models.xcom import MAX_XCOM_SIZE
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
@@ -77,7 +77,7 @@ class GCSToLocalFilesystemOperator(BaseOperator):
         self,
         *,
         bucket: str,
-        object_name: str | None = None,
+        object_name: str,
         filename: str | None = None,
         store_to_xcom_key: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
@@ -85,19 +85,8 @@ class GCSToLocalFilesystemOperator(BaseOperator):
         file_encoding: str = "utf-8",
         **kwargs,
     ) -> None:
-        # To preserve backward compatibility
-        # TODO: Remove one day
-        if object_name is None:
-            object_name = kwargs.get("object")
-            if object_name is not None:
-                self.object_name = object_name
-                AirflowProviderDeprecationWarning("Use 'object_name' instead of 'object'.")
-            else:
-                TypeError("__init__() missing 1 required positional argument: 'object_name'")
-
         if filename is not None and store_to_xcom_key is not None:
             raise ValueError("Either filename or store_to_xcom_key can be set")
-
         super().__init__(**kwargs)
         self.bucket = bucket
         self.filename = filename


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fallback to the deprecated parameters broken for a very long time in `GCSToLocalFilesystemOperator` and `CloudDataTransferServiceListOperationsOperator`

```console
❯ docker run --platform=linux/amd64 -it --rm apache/airflow:2.0.2 bash

airflow@873858e9d559:/opt/airflow$ python
Python 3.6.15 (default, Sep  8 2021, 02:32:33) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.

>>> from airflow.providers.google.cloud.transfers.gcs_to_local import GCSToLocalFilesystemOperator
>>> from airflow.providers.google.cloud.operators.cloud_storage_transfer_service import CloudDataTransferServiceListOperationsOperator

>>> GCSToLocalFilesystemOperator(task_id="t1", bucket="foo", object="bar")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/models/baseoperator.py", line 89, in __call__
    obj: BaseOperator = type.__call__(cls, *args, **kwargs)
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/utils/decorators.py", line 94, in wrapper
    result = func(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/providers/google/cloud/transfers/gcs_to_local.py", line 120, in __init__
    super().__init__(**kwargs)
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/utils/decorators.py", line 94, in wrapper
    result = func(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/models/baseoperator.py", line 414, in __init__
    "arguments were:\n**kwargs: {k}".format(c=self.__class__.__name__, k=kwargs, t=task_id),
airflow.exceptions.AirflowException: Invalid arguments were passed to GCSToLocalFilesystemOperator (task_id: t1). Invalid arguments were:
**kwargs: {'object': 'bar'}

>>> GCSToLocalFilesystemOperator(task_id="t2", bucket="foo", object_name="bar", object="spam")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/models/baseoperator.py", line 89, in __call__
    obj: BaseOperator = type.__call__(cls, *args, **kwargs)
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/utils/decorators.py", line 94, in wrapper
    result = func(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/providers/google/cloud/transfers/gcs_to_local.py", line 120, in __init__
    super().__init__(**kwargs)
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/utils/decorators.py", line 94, in wrapper
    result = func(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/models/baseoperator.py", line 414, in __init__
    "arguments were:\n**kwargs: {k}".format(c=self.__class__.__name__, k=kwargs, t=task_id),
airflow.exceptions.AirflowException: Invalid arguments were passed to GCSToLocalFilesystemOperator (task_id: t2). Invalid arguments were:
**kwargs: {'object': 'spam'}

>>> CloudDataTransferServiceListOperationsOperator(task_id="t3", filter="foo")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/models/baseoperator.py", line 89, in __call__
    obj: BaseOperator = type.__call__(cls, *args, **kwargs)
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py", line 532, in __init__
    super().__init__(**kwargs)
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/utils/decorators.py", line 94, in wrapper
    result = func(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/models/baseoperator.py", line 414, in __init__
    "arguments were:\n**kwargs: {k}".format(c=self.__class__.__name__, k=kwargs, t=task_id),
airflow.exceptions.AirflowException: Invalid arguments were passed to CloudDataTransferServiceListOperationsOperator (task_id: t3). Invalid arguments were:
**kwargs: {'filter': 'foo'}

>>> CloudDataTransferServiceListOperationsOperator(task_id="t4", request_filter="foo", filter="bar")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/models/baseoperator.py", line 89, in __call__
    obj: BaseOperator = type.__call__(cls, *args, **kwargs)
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py", line 532, in __init__
    super().__init__(**kwargs)
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/utils/decorators.py", line 94, in wrapper
    result = func(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/models/baseoperator.py", line 414, in __init__
    "arguments were:\n**kwargs: {k}".format(c=self.__class__.__name__, k=kwargs, t=task_id),
airflow.exceptions.AirflowException: Invalid arguments were passed to CloudDataTransferServiceListOperationsOperator (task_id: t4). Invalid arguments were:
**kwargs: {'filter': 'bar'}
```

There is no reason to fix it after 10 major version of Google Provider

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
