### PR TITLE
Implement a way to forward warnings to db

### DIFF
--- a/airflow/datasets/__init__.py
+++ b/airflow/datasets/__init__.py
@@ -24,6 +24,8 @@ from typing import TYPE_CHECKING, Any, Callable, ClassVar, Iterable, Iterator, P
 
 import attr
 
+from airflow.exceptions import DagUserCodeWarning
+
 if TYPE_CHECKING:
     from urllib.parse import SplitResult
 
@@ -63,7 +65,7 @@ def _sanitize_uri(uri: str) -> str:
         warnings.warn(
             "A dataset URI should not contain auth info (e.g. username or "
             "password). It has been automatically dropped.",
-            UserWarning,
+            DagUserCodeWarning,
             stacklevel=3,
         )
     if parsed.query:

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -424,6 +424,13 @@ class AirflowProviderDeprecationWarning(DeprecationWarning):
     "Indicates the provider version that started raising this deprecation warning"
 
 
+class DagUserCodeWarning(UserWarning):
+    """Issued for user code in DAG file that should be warned about.
+
+    This will be collected by the DAG processor converted into a DagWarning entry.
+    """
+
+
 class DeserializingResultError(ValueError):
     """Raised when an error is encountered while a pickling library deserializes a pickle file."""
 

--- a/tests/api_connexion/endpoints/test_dag_warning_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_warning_endpoint.py
@@ -88,8 +88,8 @@ class TestGetDagWarningEndpoint(TestBaseDagWarning):
             session.add(DagModel(dag_id="dag1"))
             session.add(DagModel(dag_id="dag2"))
             session.add(DagModel(dag_id="dag3"))
-            session.add(DagWarning("dag1", "non-existent pool", "test message"))
-            session.add(DagWarning("dag2", "non-existent pool", "test message"))
+            session.add(DagWarning(dag_id="dag1", warning_type="non-existent pool", message="test message"))
+            session.add(DagWarning(dag_id="dag2", warning_type="non-existent pool", message="test message"))
             session.commit()
 
     def test_response_one(self):

--- a/tests/models/test_dagwarning.py
+++ b/tests/models/test_dagwarning.py
@@ -44,8 +44,8 @@ class TestDagWarning:
         session.commit()
 
         dag_warnings = [
-            DagWarning("dag_1", "non-existent pool", "non-existent pool"),
-            DagWarning("dag_2", "non-existent pool", "non-existent pool"),
+            DagWarning(dag_id="dag_1", warning_type="non-existent pool", message="non-existent pool"),
+            DagWarning(dag_id="dag_2", warning_type="non-existent pool", message="non-existent pool"),
         ]
         session.add_all(dag_warnings)
         session.commit()


### PR DESCRIPTION
This implements a mechanism to catch DagUserCodeWarning messages emitted from a DAG file, and convert them into DagWarning entries to show in the web UI. This way, both Airflow core and DAG authors can use the stdlib `warnings` mechanism to emit warnings, and the DAG processor makes them visible to Airflow users.

Still a work in progress. Todo:

1. Add migration for DagWarning schema changes
2. Add tests for https://github.com/apache/airflow/pull/37005#discussion_r1500259622

Close #37699
Close #29275