### PR TITLE
Fix invalid deprecation of `DataFusionPipelineLinkHelper`

### DIFF
--- a/airflow/providers/google/cloud/operators/datafusion.py
+++ b/airflow/providers/google/cloud/operators/datafusion.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING, Any, Sequence
 
+from deprecated import deprecated
 from google.api_core.retry import exponential_sleep_generator
 from googleapiclient.errors import HttpError
 
@@ -49,10 +50,14 @@ class DataFusionPipelineLinkHelper:
     """
 
     @staticmethod
+    @deprecated(
+        reason=(
+            "Consider using "
+            "``airflow.providers.google.cloud.utils.helpers.resource_path_to_dict`` instead."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def get_project_id(instance):
-        raise AirflowProviderDeprecationWarning(
-            "DataFusionPipelineLinkHelper is deprecated. Consider using resource_path_to_dict() instead."
-        )
         instance = instance["name"]
         project_id = next(x for x in instance.split("/") if x.startswith("airflow"))
         return project_id

--- a/airflow/providers/google/cloud/operators/datafusion.py
+++ b/airflow/providers/google/cloud/operators/datafusion.py
@@ -51,10 +51,7 @@ class DataFusionPipelineLinkHelper:
 
     @staticmethod
     @deprecated(
-        reason=(
-            "Consider using "
-            "``airflow.providers.google.cloud.utils.helpers.resource_path_to_dict`` instead."
-        ),
+        reason="Please use `airflow.providers.google.cloud.utils.helpers.resource_path_to_dict` instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def get_project_id(instance):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

`get_project_id` just raise an error instead of warning, so this method is unreachable. This part broken since Google Provider v10.10.0


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
