### PR TITLE
Fix execution data validation error in `/get_logs_with_metadata` endpoint

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1552,7 +1552,7 @@ class Airflow(AirflowBaseView):
             execution_date = timezone.parse(execution_date_str, strict=True)
         except ValueError:
             error_message = (
-                f"Given execution date, {execution_date}, could not be identified as a date. "
+                f"Given execution date {execution_date_str!r} could not be identified as a date. "
                 "Example date format: 2015-11-16T14:34:15+00:00"
             )
             return {"error": error_message}, 400

--- a/tests/www/views/test_views_log.py
+++ b/tests/www/views/test_views_log.py
@@ -468,6 +468,30 @@ def test_get_logs_with_json_response_format(log_admin_client, create_expected_lo
     assert "Log for testing." in response.json["message"][0][1]
 
 
+def test_get_logs_invalid_execution_data_format(log_admin_client):
+    url_template = (
+        "get_logs_with_metadata?dag_id={}&"
+        "task_id={}&execution_date={}&"
+        "try_number={}&metadata={}&format=file"
+    )
+    try_number = 1
+    url = url_template.format(
+        DAG_ID,
+        TASK_ID,
+        urllib.parse.quote_plus("Tuesday February 27, 2024"),
+        try_number,
+        "{}",
+    )
+    response = log_admin_client.get(url)
+    assert response.status_code == 400
+    assert response.json == {
+        "error": (
+            "Given execution date 'Tuesday February 27, 2024' could not be identified as a date. "
+            "Example date format: 2015-11-16T14:34:15+00:00"
+        )
+    }
+
+
 @unittest.mock.patch("airflow.www.views.TaskLogReader")
 def test_get_logs_for_handler_without_read_method(mock_reader, log_admin_client):
     type(mock_reader.return_value).supports_read = unittest.mock.PropertyMock(return_value=False)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

`execution_date` referenced before assigned so in case of invalid date (rare scenario) it return 500 error instead of 400 error

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
