### PR TITLE
Fix hash caching in `ObjectStoragePath`

### DIFF
--- a/airflow/io/path.py
+++ b/airflow/io/path.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import contextlib
-import functools
 import os
 import shutil
 import typing
@@ -152,9 +151,10 @@ class ObjectStoragePath(CloudPath):
 
         return cls._from_parts(args_list, url=parsed_url, conn_id=conn_id, **kwargs)  # type: ignore
 
-    @functools.lru_cache
     def __hash__(self) -> int:
-        return hash(str(self))
+        if not (_hash := getattr(self, "_hash", None)):
+            self._hash = _hash = hash(str(self))
+        return _hash
 
     def __eq__(self, other: typing.Any) -> bool:
         return self.samestore(other) and str(self) == str(other)

--- a/tests/io/test_path.py
+++ b/tests/io/test_path.py
@@ -318,3 +318,12 @@ class TestFs:
         o = ObjectStoragePath(i)
         assert o.protocol == p
         assert o.path == f
+
+    def test_hash(self):
+        file_uri_1 = f"file:///tmp/{str(uuid.uuid4())}"
+        file_uri_2 = f"file:///tmp/{str(uuid.uuid4())}"
+        s = set()
+        for _ in range(10):
+            s.add(ObjectStoragePath(file_uri_1))
+            s.add(ObjectStoragePath(file_uri_2))
+        assert len(s) == 2


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This fix is taken from the https://github.com/apache/airflow/pull/37757#discussion_r1505123675

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
