### PR TITLE
Add test cases for ObjectStoragePath relative_to/is_relative_to methods

### DIFF
--- a/tests/io/test_path.py
+++ b/tests/io/test_path.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import sys
 import uuid
 from stat import S_ISDIR, S_ISREG
 from tempfile import NamedTemporaryFile
@@ -199,6 +200,26 @@ class TestFs:
         assert e.size() == len(txt)
 
         e.unlink()
+
+    @pytest.mark.skipif(sys.version_info < (3, 9), reason="`is_relative_to` new in version 3.9")
+    def test_is_relative_to(self):
+        uuid_dir = f"/tmp/{str(uuid.uuid4())}"
+        o1 = ObjectStoragePath(f"file://{uuid_dir}/aaa")
+        o2 = ObjectStoragePath(f"file://{uuid_dir}")
+        o3 = ObjectStoragePath(f"file://{str(uuid.uuid4())}")
+        assert o1.is_relative_to(o2)
+        assert not o1.is_relative_to(o3)
+
+    def test_relative_to(self):
+        uuid_dir = f"/tmp/{str(uuid.uuid4())}"
+        o1 = ObjectStoragePath(f"file://{uuid_dir}/aaa")
+        o2 = ObjectStoragePath(f"file://{uuid_dir}")
+        o3 = ObjectStoragePath(f"file://{str(uuid.uuid4())}")
+
+        _ = o1.relative_to(o2)  # Should not raise any error
+
+        with pytest.raises(ValueError):
+            o1.relative_to(o3)
 
     def test_move_local(self):
         _from = ObjectStoragePath(f"file:///tmp/{str(uuid.uuid4())}")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: #37568

This just a test cases, we know about the problem, this one just for prevent regression

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
