### PR TITLE
Enable more `flake8-pytest-style` (PT) rules

### DIFF
--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -85,7 +85,7 @@ def test_label(request):
     return label[-63:]
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_get_connection():
     with mock.patch(f"{HOOK_CLASS}.get_connection", return_value=Connection(conn_id="kubernetes_default")):
         yield

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1326,7 +1326,15 @@ extend-select = [
     "TID253",  # Ban certain modules from being imported at module level
     "ISC",  # Checks for implicit literal string concatenation (auto-fixable)
     "B006", # Checks for uses of mutable objects as function argument defaults.
+    "PT001",
+    "PT003",
+    "PT009",
     "PT014", # Checks for duplicate test cases in pytest.mark.parametrize
+    "PT023",
+    "PT024",
+    "PT025",
+    "PT026",
+    "PT027",
 ]
 ignore = [
     "D203",
@@ -1497,9 +1505,15 @@ banned-module-level-imports = ["numpy", "pandas"]
 "flask.escape".msg = "Use markupsafe.escape instead. Deprecated in Flask 2.3, removed in Flask 3.0"
 "flask.Markup".msg = "Use markupsafe.Markup instead. Deprecated in Flask 2.3, removed in Flask 3.0"
 "flask.signals_available".msg = "Signals are always available. Deprecated in Flask 2.3, removed in Flask 3.0"
+# Some specific cases
+"unittest.TestCase".msg = "Use pytest compatible classes"
 
 [tool.ruff.lint.flake8-type-checking]
 exempt-modules = ["typing", "typing_extensions"]
+
+[tool.ruff.lint.flake8-pytest-style]
+mark-parentheses = false
+fixture-parentheses = false
 
 ## pytest settings ##
 [tool.pytest.ini_options]

--- a/tests/always/test_connection.py
+++ b/tests/always/test_connection.py
@@ -38,22 +38,22 @@ from tests.test_utils.config import conf_vars
 ConnectionParts = namedtuple("ConnectionParts", ["conn_type", "login", "password", "host", "port", "schema"])
 
 
-@pytest.fixture()
+@pytest.fixture
 def get_connection1():
     return Connection()
 
 
-@pytest.fixture()
+@pytest.fixture
 def get_connection2():
     return Connection(host="apache.org", extra={})
 
 
-@pytest.fixture()
+@pytest.fixture
 def get_connection3():
     return Connection(conn_type="foo", login="", password="p@$$")
 
 
-@pytest.fixture()
+@pytest.fixture
 def get_connection4():
     return Connection(
         conn_type="bar",
@@ -67,7 +67,7 @@ def get_connection4():
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def get_connection5():
     return Connection(uri="aws://")
 

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -38,7 +38,7 @@ from tests.test_utils.db import clear_db_dags, clear_db_runs, clear_db_serialize
 pytestmark = pytest.mark.db_test
 
 
-@pytest.fixture()
+@pytest.fixture
 def current_file_token(url_safe_serializer) -> str:
     return url_safe_serializer.dumps(__file__)
 

--- a/tests/api_connexion/endpoints/test_event_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_event_log_endpoint.py
@@ -71,7 +71,7 @@ def task_instance(session, create_task_instance, request):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def log_model(create_log_model, request):
     return create_log_model(
         event="TEST_EVENT",

--- a/tests/api_connexion/endpoints/test_forward_to_fab_endpoint.py
+++ b/tests/api_connexion/endpoints/test_forward_to_fab_endpoint.py
@@ -46,7 +46,7 @@ def _delete_user(**filters):
         session.delete(user)
 
 
-@pytest.fixture()
+@pytest.fixture
 def autoclean_user_payload(autoclean_username, autoclean_email):
     return {
         "username": autoclean_username,
@@ -57,7 +57,7 @@ def autoclean_user_payload(autoclean_username, autoclean_email):
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def autoclean_admin_user(configured_app, autoclean_user_payload):
     security_manager = configured_app.appbuilder.sm
     return security_manager.add_user(
@@ -66,14 +66,14 @@ def autoclean_admin_user(configured_app, autoclean_user_payload):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def autoclean_username():
     _delete_user(username=EXAMPLE_USER_NAME)
     yield EXAMPLE_USER_NAME
     _delete_user(username=EXAMPLE_USER_NAME)
 
 
-@pytest.fixture()
+@pytest.fixture
 def autoclean_email():
     _delete_user(email=EXAMPLE_USER_EMAIL)
     yield EXAMPLE_USER_EMAIL

--- a/tests/api_connexion/schemas/test_xcom_schema.py
+++ b/tests/api_connexion/schemas/test_xcom_schema.py
@@ -59,7 +59,7 @@ def _compare_xcom_collections(collection1: dict, collection_2: dict):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def create_xcom(create_task_instance, session):
     def maker(dag_id, task_id, execution_date, key, map_index=-1, value=None):
         ti = create_task_instance(

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -22,7 +22,7 @@ import json
 import os
 from datetime import datetime, timedelta
 from io import StringIO
-from unittest import TestCase, mock
+from unittest import mock
 from unittest.mock import MagicMock
 
 import pendulum
@@ -598,12 +598,12 @@ class TestCliDags:
         dag_path = os.path.join(TEST_DAGS_FOLDER, "test_invalid_cron.py")
         args = self.parser.parse_args(["dags", "list", "--output", "yaml", "--subdir", dag_path])
         with contextlib.redirect_stdout(StringIO()) as temp_stdout:
-            with TestCase.assertRaises(TestCase(), SystemExit) as context:
+            with pytest.raises(SystemExit) as err_ctx:
                 dag_command.dag_list_import_errors(args)
             out = temp_stdout.getvalue()
         assert "[0 100 * * *] is not acceptable, out of range" in out
         assert dag_path in out
-        assert context.exception.code == 1
+        assert err_ctx.value.code == 1
 
     def test_cli_list_dag_runs(self):
         dag_command.dag_trigger(

--- a/tests/cli/commands/test_info_command.py
+++ b/tests/cli/commands/test_info_command.py
@@ -172,7 +172,7 @@ class TestAirflowInfo:
         assert "postgresql+psycopg2://p...s:PASSWORD@postgres/airflow" in output
 
 
-@pytest.fixture()
+@pytest.fixture
 def setup_parser():
     yield cli_parser.get_parser()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,7 @@ collect_ignore = [
 ]
 
 
-@pytest.fixture()
+@pytest.fixture
 def reset_environment():
     """Resets env variables."""
     init_env = os.environ.copy()
@@ -105,7 +105,7 @@ def reset_environment():
             os.environ[key] = init_env[key]
 
 
-@pytest.fixture()
+@pytest.fixture
 def secret_key() -> str:
     """Return secret key configured."""
     from airflow.configuration import conf
@@ -119,12 +119,12 @@ def secret_key() -> str:
     return the_key
 
 
-@pytest.fixture()
+@pytest.fixture
 def url_safe_serializer(secret_key) -> URLSafeSerializer:
     return URLSafeSerializer(secret_key)
 
 
-@pytest.fixture()
+@pytest.fixture
 def reset_db():
     """Resets Airflow db."""
 
@@ -945,7 +945,7 @@ def create_task_instance(dag_maker, create_dummy_dag):
     return maker
 
 
-@pytest.fixture()
+@pytest.fixture
 def create_task_instance_of_operator(dag_maker):
     def _create_task_instance(
         operator_class,
@@ -967,7 +967,7 @@ def create_task_instance_of_operator(dag_maker):
     return _create_task_instance
 
 
-@pytest.fixture()
+@pytest.fixture
 def create_task_of_operator(dag_maker):
     def _create_task_of_operator(operator_class, *, dag_id, session=None, **operator_kwargs):
         with dag_maker(dag_id=dag_id, session=session):
@@ -986,7 +986,7 @@ def session():
         session.rollback()
 
 
-@pytest.fixture()
+@pytest.fixture
 def get_test_dag():
     def _get(dag_id):
         from airflow.models.dagbag import DagBag
@@ -1004,7 +1004,7 @@ def get_test_dag():
     return _get
 
 
-@pytest.fixture()
+@pytest.fixture
 def create_log_template(request):
     from airflow import settings
     from airflow.models.tasklog import LogTemplate
@@ -1025,7 +1025,7 @@ def create_log_template(request):
     return _create_log_template
 
 
-@pytest.fixture()
+@pytest.fixture
 def reset_logging_config():
     import logging.config
 
@@ -1112,7 +1112,7 @@ def initialize_providers_manager():
     ProvidersManager().initialize_providers_configuration()
 
 
-@pytest.fixture(autouse=True, scope="function")
+@pytest.fixture(autouse=True)
 def close_all_sqlalchemy_sessions():
     from sqlalchemy.orm import close_all_sessions
 
@@ -1121,7 +1121,7 @@ def close_all_sqlalchemy_sessions():
     close_all_sessions()
 
 
-@pytest.fixture()
+@pytest.fixture
 def cleanup_providers_manager():
     from airflow.providers_manager import ProvidersManager
 

--- a/tests/datasets/test_manager.py
+++ b/tests/datasets/test_manager.py
@@ -32,7 +32,7 @@ from tests.listeners import dataset_listener
 pytestmark = pytest.mark.db_test
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_task_instance():
     mock_ti = mock.Mock()
     mock_ti.task_id = "5"

--- a/tests/decorators/test_bash.py
+++ b/tests/decorators/test_bash.py
@@ -35,7 +35,7 @@ DEFAULT_DATE = timezone.datetime(2023, 1, 1)
 
 @pytest.mark.db_test
 class TestBashDecorator:
-    @pytest.fixture(scope="function", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup(self, dag_maker):
         self.dag_maker = dag_maker
 

--- a/tests/decorators/test_external_python.py
+++ b/tests/decorators/test_external_python.py
@@ -46,14 +46,14 @@ TI_CONTEXT_ENV_VARS = [
 ]
 
 
-@pytest.fixture()
+@pytest.fixture
 def venv_python():
     with TemporaryDirectory() as d:
         venv.create(d, with_pip=False)
         yield Path(d) / "bin" / "python"
 
 
-@pytest.fixture()
+@pytest.fixture
 def venv_python_with_dill():
     with TemporaryDirectory() as d:
         venv.create(d, with_pip=True)

--- a/tests/io/test_path.py
+++ b/tests/io/test_path.py
@@ -116,7 +116,7 @@ class TestFs:
 
         assert not o.exists()
 
-    @pytest.fixture()
+    @pytest.fixture
     def fake_fs(self):
         fs = mock.Mock()
         fs._strip_protocol.return_value = "/"

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -825,7 +825,7 @@ class TestLocalTaskJob:
         assert SIGSEGV_MESSAGE in caplog.messages
 
 
-@pytest.fixture()
+@pytest.fixture
 def clean_db_helper():
     yield
     db.clear_db_jobs()

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -262,11 +262,11 @@ class TestDagBag:
         ):
             dagbag.process_file(os.path.join(TEST_DAGS_FOLDER, "test_default_views.py"))
 
-    @pytest.fixture()
+    @pytest.fixture
     def invalid_cron_dag(self) -> str:
         return os.path.join(TEST_DAGS_FOLDER, "test_invalid_cron.py")
 
-    @pytest.fixture()
+    @pytest.fixture
     def invalid_cron_zipped_dag(self, invalid_cron_dag: str, tmp_path: pathlib.Path) -> Iterator[str]:
         zipped = tmp_path / "test_zip_invalid_cron.zip"
         with zipfile.ZipFile(zipped, "w") as zf:
@@ -385,7 +385,7 @@ class TestDagBag:
         found = dagbag.process_file(str(TEST_DAGS_FOLDER / "test_invalid_dup_task.py"))
         assert [] == found
 
-    @pytest.fixture()
+    @pytest.fixture
     def zip_with_valid_dag_and_dup_tasks(self, tmp_path: pathlib.Path) -> Iterator[str]:
         failing_dag_file = TEST_DAGS_FOLDER / "test_invalid_dup_task.py"
         working_dag_file = TEST_DAGS_FOLDER / "test_example_bash_operator.py"

--- a/tests/models/test_xcom.py
+++ b/tests/models/test_xcom.py
@@ -56,7 +56,7 @@ def reset_db():
         session.query(XCom).delete()
 
 
-@pytest.fixture()
+@pytest.fixture
 def task_instance_factory(request, session: Session):
     def func(*, dag_id, task_id, execution_date):
         run_id = DagRun.generate_run_id(DagRunType.SCHEDULED, execution_date)
@@ -83,7 +83,7 @@ def task_instance_factory(request, session: Session):
     return func
 
 
-@pytest.fixture()
+@pytest.fixture
 def task_instance(task_instance_factory):
     return task_instance_factory(
         dag_id="dag",
@@ -92,7 +92,7 @@ def task_instance(task_instance_factory):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def task_instances(session, task_instance):
     ti2 = TaskInstance(EmptyOperator(task_id="task_2"), run_id=task_instance.run_id)
     ti2.dag_id = task_instance.dag_id
@@ -298,7 +298,7 @@ def setup_xcom_pickling(request):
         yield
 
 
-@pytest.fixture()
+@pytest.fixture
 def push_simple_json_xcom(session):
     def func(*, ti: TaskInstance, key: str, value):
         return XCom.set(
@@ -315,7 +315,7 @@ def push_simple_json_xcom(session):
 
 @pytest.mark.usefixtures("setup_xcom_pickling")
 class TestXComGet:
-    @pytest.fixture()
+    @pytest.fixture
     def setup_for_xcom_get_one(self, task_instance, push_simple_json_xcom):
         push_simple_json_xcom(ti=task_instance, key="xcom_1", value={"key": "value"})
 
@@ -342,7 +342,7 @@ class TestXComGet:
             )
         assert stored_value == {"key": "value"}
 
-    @pytest.fixture()
+    @pytest.fixture
     def tis_for_xcom_get_one_from_prior_date(self, task_instance_factory, push_simple_json_xcom):
         date1 = timezone.datetime(2021, 12, 3, 4, 56)
         ti1 = task_instance_factory(dag_id="dag", execution_date=date1, task_id="task_1")
@@ -387,7 +387,7 @@ class TestXComGet:
             )
         assert retrieved_value == {"key": "value"}
 
-    @pytest.fixture()
+    @pytest.fixture
     def setup_for_xcom_get_many_single_argument_value(self, task_instance, push_simple_json_xcom):
         push_simple_json_xcom(ti=task_instance, key="xcom_1", value={"key": "value"})
 
@@ -418,7 +418,7 @@ class TestXComGet:
         assert stored_xcoms[0].key == "xcom_1"
         assert stored_xcoms[0].value == {"key": "value"}
 
-    @pytest.fixture()
+    @pytest.fixture
     def setup_for_xcom_get_many_multiple_tasks(self, task_instances, push_simple_json_xcom):
         ti1, ti2 = task_instances
         push_simple_json_xcom(ti=ti1, key="xcom_1", value={"key1": "value1"})
@@ -449,7 +449,7 @@ class TestXComGet:
         sorted_values = [x.value for x in sorted(stored_xcoms, key=operator.attrgetter("task_id"))]
         assert sorted_values == [{"key1": "value1"}, {"key2": "value2"}]
 
-    @pytest.fixture()
+    @pytest.fixture
     def tis_for_xcom_get_many_from_prior_dates(self, task_instance_factory, push_simple_json_xcom):
         date1 = timezone.datetime(2021, 12, 3, 4, 56)
         date2 = date1 + datetime.timedelta(days=1)
@@ -530,7 +530,7 @@ class TestXComSet:
         assert stored_xcoms[0].task_id == "task_1"
         assert stored_xcoms[0].execution_date == task_instance.execution_date
 
-    @pytest.fixture()
+    @pytest.fixture
     def setup_for_xcom_set_again_replace(self, task_instance, push_simple_json_xcom):
         push_simple_json_xcom(ti=task_instance, key="xcom_1", value={"key1": "value1"})
 
@@ -564,7 +564,7 @@ class TestXComSet:
 
 @pytest.mark.usefixtures("setup_xcom_pickling")
 class TestXComClear:
-    @pytest.fixture()
+    @pytest.fixture
     def setup_for_xcom_clear(self, task_instance, push_simple_json_xcom):
         push_simple_json_xcom(ti=task_instance, key="xcom_1", value={"key": "value"})
 

--- a/tests/operators/test_bash.py
+++ b/tests/operators/test_bash.py
@@ -37,7 +37,7 @@ END_DATE = datetime(2016, 1, 2, tzinfo=timezone.utc)
 INTERVAL = timedelta(hours=12)
 
 
-@pytest.fixture()
+@pytest.fixture
 def context():
     yield {"ti": mock.Mock()}
 

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -165,7 +165,7 @@ def test_flaskappbuilder_nomenu_views():
 
 
 class TestPluginsManager:
-    @pytest.fixture(autouse=True, scope="function")
+    @pytest.fixture(autouse=True)
     def clean_plugins(self):
         from airflow import plugins_manager
 

--- a/tests/providers/amazon/aws/auth_manager/test_user.py
+++ b/tests/providers/amazon/aws/auth_manager/test_user.py
@@ -21,7 +21,7 @@ import pytest
 from airflow.providers.amazon.aws.auth_manager.user import AwsAuthManagerUser
 
 
-@pytest.fixture()
+@pytest.fixture
 def user():
     return AwsAuthManagerUser(user_id="user_id", groups=[])
 

--- a/tests/providers/amazon/aws/auth_manager/views/test_auth.py
+++ b/tests/providers/amazon/aws/auth_manager/views/test_auth.py
@@ -46,7 +46,7 @@ SAML_METADATA_PARSED = {
 }
 
 
-@pytest.fixture()
+@pytest.fixture
 def aws_app():
     def factory():
         with conf_vars(

--- a/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -831,7 +831,7 @@ class TestAwsEcsExecutor:
 
 
 class TestEcsExecutorConfig:
-    @pytest.fixture()
+    @pytest.fixture
     def assign_subnets(self):
         os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.SUBNETS}".upper()] = "sub1,sub2"
 

--- a/tests/providers/amazon/aws/hooks/test_eks.py
+++ b/tests/providers/amazon/aws/hooks/test_eks.py
@@ -99,7 +99,7 @@ if TYPE_CHECKING:
     from moto.core.exceptions import AWSError
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def cluster_builder():
     """A fixture to generate a batch of EKS Clusters on the mocked backend for testing."""
 
@@ -133,7 +133,7 @@ def cluster_builder():
         yield _execute
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def fargate_profile_builder(cluster_builder):
     """A fixture to generate a batch of EKS Fargate profiles on the mocked backend for testing."""
 
@@ -175,7 +175,7 @@ def fargate_profile_builder(cluster_builder):
     return _execute
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def nodegroup_builder(cluster_builder):
     """A fixture to generate a batch of EKS Managed Nodegroups on the mocked backend for testing."""
 

--- a/tests/providers/amazon/aws/sensors/test_eks.py
+++ b/tests/providers/amazon/aws/sensors/test_eks.py
@@ -68,8 +68,8 @@ NODEGROUP_UNEXPECTED_TERMINAL_STATES = sorted(
 
 
 class TestEksClusterStateSensor:
-    @pytest.fixture(scope="function")
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup_test_cases(self):
         self.target_state = ClusterStates.ACTIVE
         self.sensor = EksClusterStateSensor(
             task_id=TASK_ID,
@@ -78,13 +78,13 @@ class TestEksClusterStateSensor:
         )
 
     @mock.patch.object(EksHook, "get_cluster_state", return_value=ClusterStates.ACTIVE)
-    def test_poke_reached_target_state(self, mock_get_cluster_state, setUp):
+    def test_poke_reached_target_state(self, mock_get_cluster_state):
         assert self.sensor.poke({}) is True
         mock_get_cluster_state.assert_called_once_with(clusterName=CLUSTER_NAME)
 
     @mock.patch("airflow.providers.amazon.aws.hooks.eks.EksHook.get_cluster_state")
     @pytest.mark.parametrize("pending_state", CLUSTER_PENDING_STATES)
-    def test_poke_reached_pending_state(self, mock_get_cluster_state, setUp, pending_state):
+    def test_poke_reached_pending_state(self, mock_get_cluster_state, pending_state):
         mock_get_cluster_state.return_value = pending_state
 
         assert self.sensor.poke({}) is False
@@ -92,9 +92,7 @@ class TestEksClusterStateSensor:
 
     @mock.patch("airflow.providers.amazon.aws.hooks.eks.EksHook.get_cluster_state")
     @pytest.mark.parametrize("unexpected_terminal_state", CLUSTER_UNEXPECTED_TERMINAL_STATES)
-    def test_poke_reached_unexpected_terminal_state(
-        self, mock_get_cluster_state, setUp, unexpected_terminal_state
-    ):
+    def test_poke_reached_unexpected_terminal_state(self, mock_get_cluster_state, unexpected_terminal_state):
         expected_message = (
             f"Terminal state reached. Current state: {unexpected_terminal_state}, "
             f"Expected state: {self.target_state}"
@@ -109,8 +107,8 @@ class TestEksClusterStateSensor:
 
 
 class TestEksFargateProfileStateSensor:
-    @pytest.fixture(scope="function")
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup_test_cases(self):
         self.target_state = FargateProfileStates.ACTIVE
         self.sensor = EksFargateProfileStateSensor(
             task_id=TASK_ID,
@@ -120,7 +118,7 @@ class TestEksFargateProfileStateSensor:
         )
 
     @mock.patch.object(EksHook, "get_fargate_profile_state", return_value=FargateProfileStates.ACTIVE)
-    def test_poke_reached_target_state(self, mock_get_fargate_profile_state, setUp):
+    def test_poke_reached_target_state(self, mock_get_fargate_profile_state):
         assert self.sensor.poke({}) is True
         mock_get_fargate_profile_state.assert_called_once_with(
             clusterName=CLUSTER_NAME, fargateProfileName=FARGATE_PROFILE_NAME
@@ -128,7 +126,7 @@ class TestEksFargateProfileStateSensor:
 
     @mock.patch("airflow.providers.amazon.aws.hooks.eks.EksHook.get_fargate_profile_state")
     @pytest.mark.parametrize("pending_state", FARGATE_PENDING_STATES)
-    def test_poke_reached_pending_state(self, mock_get_fargate_profile_state, setUp, pending_state):
+    def test_poke_reached_pending_state(self, mock_get_fargate_profile_state, pending_state):
         mock_get_fargate_profile_state.return_value = pending_state
 
         assert self.sensor.poke({}) is False
@@ -139,7 +137,7 @@ class TestEksFargateProfileStateSensor:
     @mock.patch("airflow.providers.amazon.aws.hooks.eks.EksHook.get_fargate_profile_state")
     @pytest.mark.parametrize("unexpected_terminal_state", FARGATE_UNEXPECTED_TERMINAL_STATES)
     def test_poke_reached_unexpected_terminal_state(
-        self, mock_get_fargate_profile_state, setUp, unexpected_terminal_state
+        self, mock_get_fargate_profile_state, unexpected_terminal_state
     ):
         expected_message = (
             f"Terminal state reached. Current state: {unexpected_terminal_state}, "
@@ -157,8 +155,8 @@ class TestEksFargateProfileStateSensor:
 
 
 class TestEksNodegroupStateSensor:
-    @pytest.fixture(scope="function")
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup_test_cases(self):
         self.target_state = NodegroupStates.ACTIVE
         self.sensor = EksNodegroupStateSensor(
             task_id=TASK_ID,
@@ -168,7 +166,7 @@ class TestEksNodegroupStateSensor:
         )
 
     @mock.patch.object(EksHook, "get_nodegroup_state", return_value=NodegroupStates.ACTIVE)
-    def test_poke_reached_target_state(self, mock_get_nodegroup_state, setUp):
+    def test_poke_reached_target_state(self, mock_get_nodegroup_state):
         assert self.sensor.poke({}) is True
         mock_get_nodegroup_state.assert_called_once_with(
             clusterName=CLUSTER_NAME, nodegroupName=NODEGROUP_NAME
@@ -176,7 +174,7 @@ class TestEksNodegroupStateSensor:
 
     @mock.patch("airflow.providers.amazon.aws.hooks.eks.EksHook.get_nodegroup_state")
     @pytest.mark.parametrize("pending_state", NODEGROUP_PENDING_STATES)
-    def test_poke_reached_pending_state(self, mock_get_nodegroup_state, setUp, pending_state):
+    def test_poke_reached_pending_state(self, mock_get_nodegroup_state, pending_state):
         mock_get_nodegroup_state.return_value = pending_state
 
         assert self.sensor.poke({}) is False
@@ -187,7 +185,7 @@ class TestEksNodegroupStateSensor:
     @mock.patch("airflow.providers.amazon.aws.hooks.eks.EksHook.get_nodegroup_state")
     @pytest.mark.parametrize("unexpected_terminal_state", NODEGROUP_UNEXPECTED_TERMINAL_STATES)
     def test_poke_reached_unexpected_terminal_state(
-        self, mock_get_nodegroup_state, setUp, unexpected_terminal_state
+        self, mock_get_nodegroup_state, unexpected_terminal_state
     ):
         expected_message = (
             f"Terminal state reached. Current state: {unexpected_terminal_state}, "

--- a/tests/providers/amazon/aws/transfers/test_s3_to_sql.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_sql.py
@@ -64,11 +64,11 @@ class TestS3ToSqlTransfer:
             "commit_every": 5000,
         }
 
-    @pytest.fixture()
+    @pytest.fixture
     def mock_parser(self):
         return MagicMock()
 
-    @pytest.fixture()
+    @pytest.fixture
     def mock_bad_hook(self):
         bad_hook = MagicMock()
         del bad_hook.insert_rows

--- a/tests/providers/amazon/aws/waiters/test_neptune.py
+++ b/tests/providers/amazon/aws/waiters/test_neptune.py
@@ -38,7 +38,7 @@ class TestCustomNeptuneWaiters:
         hook_waiters = NeptuneHook(aws_conn_id=None).list_waiters()
         assert "cluster_available" in hook_waiters
 
-    @pytest.fixture()
+    @pytest.fixture
     def mock_describe_clusters(self):
         with mock.patch.object(self.client, "describe_db_clusters") as m:
             yield m

--- a/tests/providers/apache/impala/hooks/test_impala.py
+++ b/tests/providers/apache/impala/hooks/test_impala.py
@@ -24,7 +24,7 @@ from airflow.models import Connection
 from airflow.providers.apache.impala.hooks.impala import ImpalaHook
 
 
-@pytest.fixture()
+@pytest.fixture
 def impala_hook_fixture() -> ImpalaHook:
     hook = ImpalaHook()
     mock_get_conn = MagicMock()

--- a/tests/providers/apache/spark/hooks/test_spark_jdbc_script.py
+++ b/tests/providers/apache/spark/hooks/test_spark_jdbc_script.py
@@ -32,7 +32,7 @@ from airflow.providers.apache.spark.hooks.spark_jdbc_script import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_spark_session():
     with mock.patch("airflow.providers.apache.spark.hooks.spark_jdbc_script.SparkSession") as mok:
         yield mok

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -57,7 +57,7 @@ class DeprecationRemovalRequired(AirflowException):
 DEFAULT_CONN_ID = "kubernetes_default"
 
 
-@pytest.fixture()
+@pytest.fixture
 def remove_default_conn(session):
     before_conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).one_or_none()
     if before_conn:

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -72,7 +72,7 @@ def temp_override_attr(obj, attr, val):
     setattr(obj, attr, orig)
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def clear_db():
     db.clear_db_dags()
     db.clear_db_runs()

--- a/tests/providers/common/io/xcom/test_backend.py
+++ b/tests/providers/common/io/xcom/test_backend.py
@@ -49,7 +49,7 @@ def reset_db():
         session.query(airflow.models.xcom.XCom).delete()
 
 
-@pytest.fixture()
+@pytest.fixture
 def task_instance_factory(request, session: Session):
     def func(*, dag_id, task_id, execution_date):
         run_id = DagRun.generate_run_id(DagRunType.SCHEDULED, execution_date)
@@ -76,7 +76,7 @@ def task_instance_factory(request, session: Session):
     return func
 
 
-@pytest.fixture()
+@pytest.fixture
 def task_instance(task_instance_factory):
     return task_instance_factory(
         dag_id="dag",

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -138,7 +138,7 @@ def test_on_kill_client_not_created(docker_api_client_patcher):
 
 
 class TestDockerOperator:
-    @pytest.fixture(autouse=True, scope="function")
+    @pytest.fixture(autouse=True)
     def setup_patchers(self, docker_api_client_patcher):
         self.tempdir_patcher = mock.patch("airflow.providers.docker.operators.docker.TemporaryDirectory")
         self.tempdir_mock = self.tempdir_patcher.start()

--- a/tests/providers/docker/test_exceptions.py
+++ b/tests/providers/docker/test_exceptions.py
@@ -46,7 +46,7 @@ EXPECTED_SKIP_MESSAGE = f"Docker container returned exit code {[SKIP_ON_EXIT_COD
     ],
 )
 class TestDockerContainerExceptions:
-    @pytest.fixture(autouse=True, scope="function")
+    @pytest.fixture(autouse=True)
     def setup_patchers(self, docker_api_client_patcher):
         self.client_mock = mock.MagicMock(spec=APIClient)
         self.client_mock.wait.return_value = {"StatusCode": 0}

--- a/tests/providers/elasticsearch/log/test_es_json_formatter.py
+++ b/tests/providers/elasticsearch/log/test_es_json_formatter.py
@@ -39,11 +39,11 @@ class TestElasticsearchJSONFormatter:
         "log_id": "Some_log_id",
     }
 
-    @pytest.fixture()
+    @pytest.fixture
     def es_json_formatter(self):
         return ElasticsearchJSONFormatter()
 
-    @pytest.fixture()
+    @pytest.fixture
     def log_record(self):
         return logging.LogRecord(
             name="test",

--- a/tests/providers/elasticsearch/log/test_es_task_handler.py
+++ b/tests/providers/elasticsearch/log/test_es_task_handler.py
@@ -76,7 +76,7 @@ class TestElasticsearchTaskHandler:
     JSON_LOG_ID = f"{DAG_ID}-{TASK_ID}-{ElasticsearchTaskHandler._clean_date(EXECUTION_DATE)}-1"
     FILENAME_TEMPLATE = "{try_number}.log"
 
-    @pytest.fixture()
+    @pytest.fixture
     def ti(self, create_task_instance, create_log_template):
         create_log_template(self.FILENAME_TEMPLATE, "{dag_id}-{task_id}-{execution_date}-{try_number}")
         yield get_ti(

--- a/tests/providers/fab/auth_manager/api_endpoints/test_user_endpoint.py
+++ b/tests/providers/fab/auth_manager/api_endpoints/test_user_endpoint.py
@@ -347,21 +347,21 @@ def _delete_user(**filters):
         session.delete(user)
 
 
-@pytest.fixture()
+@pytest.fixture
 def autoclean_username():
     _delete_user(username=EXAMPLE_USER_NAME)
     yield EXAMPLE_USER_NAME
     _delete_user(username=EXAMPLE_USER_NAME)
 
 
-@pytest.fixture()
+@pytest.fixture
 def autoclean_email():
     _delete_user(email=EXAMPLE_USER_EMAIL)
     yield EXAMPLE_USER_EMAIL
     _delete_user(email=EXAMPLE_USER_EMAIL)
 
 
-@pytest.fixture()
+@pytest.fixture
 def user_with_same_username(configured_app, autoclean_username):
     user = create_user(
         configured_app,
@@ -373,7 +373,7 @@ def user_with_same_username(configured_app, autoclean_username):
     return user
 
 
-@pytest.fixture()
+@pytest.fixture
 def user_with_same_email(configured_app, autoclean_email):
     user = create_user(
         configured_app,
@@ -385,7 +385,7 @@ def user_with_same_email(configured_app, autoclean_email):
     return user
 
 
-@pytest.fixture()
+@pytest.fixture
 def user_different(configured_app):
     username = "another_user"
     email = "another_user@example.com"
@@ -397,7 +397,7 @@ def user_different(configured_app):
     _delete_user(username=username, email=email)
 
 
-@pytest.fixture()
+@pytest.fixture
 def autoclean_user_payload(autoclean_username, autoclean_email):
     return {
         "username": autoclean_username,
@@ -408,7 +408,7 @@ def autoclean_user_payload(autoclean_username, autoclean_email):
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def autoclean_admin_user(configured_app, autoclean_user_payload):
     security_manager = configured_app.appbuilder.sm
     return security_manager.add_user(

--- a/tests/providers/fab/auth_manager/cli_commands/test_user_command.py
+++ b/tests/providers/fab/auth_manager/cli_commands/test_user_command.py
@@ -36,7 +36,7 @@ TEST_USER2_EMAIL = "test-user2@example.com"
 TEST_USER3_EMAIL = "test-user3@example.com"
 
 
-@pytest.fixture()
+@pytest.fixture
 def parser():
     return cli_parser.get_parser()
 
@@ -354,7 +354,7 @@ class TestCliUsers:
             user_command.users_export(args)
             return f.name
 
-    @pytest.fixture()
+    @pytest.fixture
     def create_user_test4(self):
         args = self.parser.parse_args(
             [

--- a/tests/providers/fab/auth_manager/test_security.py
+++ b/tests/providers/fab/auth_manager/test_security.py
@@ -154,7 +154,7 @@ def clear_db_after_suite():
     _clear_db_dag_and_runs()
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def clear_db_before_test():
     _clear_db_dag_and_runs()
 
@@ -189,7 +189,7 @@ def db(app):
     return SQLA(app)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def role(request, app, security_manager):
     params = request.param
     _role = None
@@ -201,7 +201,7 @@ def role(request, app, security_manager):
     delete_role(app, params["name"])
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def mock_dag_models(request, session, security_manager):
     dags_ids = request.param
     dags = [_create_dag_model(dag_id, session, security_manager) for dag_id in dags_ids]
@@ -212,7 +212,7 @@ def mock_dag_models(request, session, security_manager):
         _delete_dag_model(dag, session, security_manager)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def sample_dags(security_manager):
     dags = [
         DAG("has_access_control", access_control={"Public": {permissions.ACTION_CAN_READ}}),
@@ -1049,14 +1049,14 @@ def test_fab_models_use_airflow_base_meta():
     assert user.metadata is Base.metadata
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_security_manager(app_builder):
     mocked_security_manager = MockSecurityManager(appbuilder=app_builder)
     mocked_security_manager.update_user = mock.MagicMock()
     return mocked_security_manager
 
 
-@pytest.fixture()
+@pytest.fixture
 def new_user():
     user = mock.MagicMock()
     user.login_count = None
@@ -1065,7 +1065,7 @@ def new_user():
     return user
 
 
-@pytest.fixture()
+@pytest.fixture
 def old_user():
     user = mock.MagicMock()
     user.login_count = 42

--- a/tests/providers/fab/auth_manager/views/test_permissions.py
+++ b/tests/providers/fab/auth_manager/views/test_permissions.py
@@ -45,7 +45,7 @@ def user_permissions_reader(fab_app):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_permissions_reader(fab_app, user_permissions_reader):
     fab_app.config["WTF_CSRF_ENABLED"] = False
     return client_with_login(

--- a/tests/providers/fab/auth_manager/views/test_roles_list.py
+++ b/tests/providers/fab/auth_manager/views/test_roles_list.py
@@ -43,7 +43,7 @@ def user_roles_reader(fab_app):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_roles_reader(fab_app, user_roles_reader):
     fab_app.config["WTF_CSRF_ENABLED"] = False
     return client_with_login(

--- a/tests/providers/fab/auth_manager/views/test_user.py
+++ b/tests/providers/fab/auth_manager/views/test_user.py
@@ -43,7 +43,7 @@ def user_user_reader(fab_app):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_user_reader(fab_app, user_user_reader):
     fab_app.config["WTF_CSRF_ENABLED"] = False
     return client_with_login(

--- a/tests/providers/fab/auth_manager/views/test_user_edit.py
+++ b/tests/providers/fab/auth_manager/views/test_user_edit.py
@@ -43,7 +43,7 @@ def user_user_reader(fab_app):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_user_reader(fab_app, user_user_reader):
     fab_app.config["WTF_CSRF_ENABLED"] = False
     return client_with_login(

--- a/tests/providers/fab/auth_manager/views/test_user_stats.py
+++ b/tests/providers/fab/auth_manager/views/test_user_stats.py
@@ -43,7 +43,7 @@ def user_user_stats_reader(fab_app):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_user_stats_reader(fab_app, user_user_stats_reader):
     fab_app.config["WTF_CSRF_ENABLED"] = False
     return client_with_login(

--- a/tests/providers/facebook/ads/hooks/test_ads.py
+++ b/tests/providers/facebook/ads/hooks/test_ads.py
@@ -42,7 +42,7 @@ FIELDS = [
 PARAMS = {"level": "ad", "date_preset": "yesterday"}
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_hook():
     with mock.patch("airflow.hooks.base.BaseHook.get_connection") as conn:
         hook = FacebookAdsReportingHook(api_version=API_VERSION)
@@ -50,7 +50,7 @@ def mock_hook():
         yield hook
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_hook_multiple():
     with mock.patch("airflow.hooks.base.BaseHook.get_connection") as conn:
         hook = FacebookAdsReportingHook(api_version=API_VERSION)

--- a/tests/providers/google/cloud/hooks/test_bigquery_dts.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery_dts.py
@@ -137,7 +137,7 @@ class TestAsyncBiqQueryDataTransferServiceHook:
         with pytest.raises(RuntimeError):
             AsyncBiqQueryDataTransferServiceHook(gcp_conn_id="GCP_CONN_ID", delegate_to="delegate_to")
 
-    @pytest.fixture()
+    @pytest.fixture
     def mock_client(self):
         with mock.patch(
             f"{self.HOOK_MODULE_PATH}.AsyncBiqQueryDataTransferServiceHook._get_conn",

--- a/tests/providers/google/cloud/hooks/test_dataflow.py
+++ b/tests/providers/google/cloud/hooks/test_dataflow.py
@@ -1928,7 +1928,7 @@ class TestDataflow:
             mock_logging.info.assert_called_once_with("Running command: %s", "test cmd")
 
 
-@pytest.fixture()
+@pytest.fixture
 def make_mock_awaitable():
     def func(mock_obj, return_value):
         f = Future()

--- a/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
@@ -497,7 +497,7 @@ class TestGKEPodAsyncHook:
 
         mock_obj.return_value = f
 
-    @pytest.fixture()
+    @pytest.fixture
     def async_hook(self):
         return GKEPodAsyncHook(
             cluster_url=CLUSTER_URL,
@@ -569,7 +569,7 @@ class TestGKEPodAsyncHook:
         assert "Test string #2" in caplog.text
 
 
-@pytest.fixture()
+@pytest.fixture
 def async_gke_hook():
     return GKEAsyncHook(
         gcp_conn_id=GCP_CONN_ID,
@@ -578,7 +578,7 @@ def async_gke_hook():
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_async_gke_cluster_client():
     f = Future()
     f.set_result(None)

--- a/tests/providers/google/cloud/log/test_stackdriver_task_handler.py
+++ b/tests/providers/google/cloud/log/test_stackdriver_task_handler.py
@@ -36,7 +36,7 @@ def _create_list_log_entries_response_mock(messages, token):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def clean_stackdriver_handlers():
     yield
     for handler_ref in reversed(logging._handlerList[:]):

--- a/tests/providers/google/cloud/sensors/test_bigquery.py
+++ b/tests/providers/google/cloud/sensors/test_bigquery.py
@@ -271,7 +271,7 @@ class TestBigqueryTablePartitionExistenceSensor:
         )
 
 
-@pytest.fixture()
+@pytest.fixture
 def context():
     """
     Creates an empty context.

--- a/tests/providers/google/cloud/triggers/test_dataplex.py
+++ b/tests/providers/google/cloud/triggers/test_dataplex.py
@@ -49,7 +49,7 @@ def trigger():
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def async_get_data_scan_job():
     def func(**kwargs):
         m = mock.MagicMock()

--- a/tests/providers/google/cloud/triggers/test_dataproc.py
+++ b/tests/providers/google/cloud/triggers/test_dataproc.py
@@ -99,7 +99,7 @@ def diagnose_operation_trigger():
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def async_get_cluster():
     def func(**kwargs):
         m = mock.MagicMock()
@@ -111,7 +111,7 @@ def async_get_cluster():
     return func
 
 
-@pytest.fixture()
+@pytest.fixture
 def async_get_batch():
     def func(**kwargs):
         m = mock.MagicMock()
@@ -123,7 +123,7 @@ def async_get_batch():
     return func
 
 
-@pytest.fixture()
+@pytest.fixture
 def async_get_operation():
     def func(**kwargs):
         m = mock.MagicMock()

--- a/tests/providers/google/cloud/triggers/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/triggers/test_kubernetes_engine.py
@@ -283,7 +283,7 @@ def operation_trigger():
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def async_get_operation_result():
     def func(**kwargs):
         m = mock.MagicMock()

--- a/tests/providers/microsoft/azure/hooks/test_container_instance.py
+++ b/tests/providers/microsoft/azure/hooks/test_container_instance.py
@@ -32,7 +32,7 @@ from airflow.models import Connection
 from airflow.providers.microsoft.azure.hooks.container_instance import AzureContainerInstanceHook
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def connection_without_login_password_tenant_id(create_mock_connection):
     return create_mock_connection(
         Connection(

--- a/tests/providers/openlineage/extractors/test_bash.py
+++ b/tests/providers/openlineage/extractors/test_bash.py
@@ -43,7 +43,7 @@ with DAG(
     bash_task = BashOperator(task_id="bash-task", bash_command="ls -halt && exit 0", dag=dag)
 
 
-@pytest.fixture(autouse=True, scope="function")
+@pytest.fixture(autouse=True)
 def clear_cache():
     is_source_enabled.cache_clear()
     try:

--- a/tests/providers/openlineage/extractors/test_python.py
+++ b/tests/providers/openlineage/extractors/test_python.py
@@ -58,7 +58,7 @@ def callable():
 CODE = "def callable():\n    print(10)\n"
 
 
-@pytest.fixture(autouse=True, scope="function")
+@pytest.fixture(autouse=True)
 def clear_cache():
     is_source_enabled.cache_clear()
     try:

--- a/tests/providers/snowflake/hooks/test_snowflake.py
+++ b/tests/providers/snowflake/hooks/test_snowflake.py
@@ -50,7 +50,7 @@ BASE_CONNECTION_KWARGS: dict = {
 }
 
 
-@pytest.fixture()
+@pytest.fixture
 def non_encrypted_temporary_private_key(tmp_path: Path) -> Path:
     key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=2048)
     private_key = key.private_bytes(
@@ -61,7 +61,7 @@ def non_encrypted_temporary_private_key(tmp_path: Path) -> Path:
     return test_key_file
 
 
-@pytest.fixture()
+@pytest.fixture
 def encrypted_temporary_private_key(tmp_path: Path) -> Path:
     key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=2048)
     private_key = key.private_bytes(

--- a/tests/providers/snowflake/hooks/test_snowflake_sql_api.py
+++ b/tests/providers/snowflake/hooks/test_snowflake_sql_api.py
@@ -258,7 +258,7 @@ class TestSnowflakeSqlApiHook:
         result = hook.get_headers()
         assert result == HEADERS
 
-    @pytest.fixture()
+    @pytest.fixture
     def non_encrypted_temporary_private_key(self, tmp_path: Path) -> Path:
         """Encrypt the pem file from the path"""
         key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=2048)
@@ -269,7 +269,7 @@ class TestSnowflakeSqlApiHook:
         test_key_file.write_bytes(private_key)
         return test_key_file
 
-    @pytest.fixture()
+    @pytest.fixture
     def encrypted_temporary_private_key(self, tmp_path: Path) -> Path:
         """Encrypt private key from the temp path"""
         key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=2048)

--- a/tests/providers/trino/hooks/test_trino.py
+++ b/tests/providers/trino/hooks/test_trino.py
@@ -37,7 +37,7 @@ JWT_AUTHENTICATION = "airflow.providers.trino.hooks.trino.trino.auth.JWTAuthenti
 CERT_AUTHENTICATION = "airflow.providers.trino.hooks.trino.trino.auth.CertificateAuthentication"
 
 
-@pytest.fixture()
+@pytest.fixture
 def jwt_token_file(tmp_path):
     jwt_file = tmp_path / "jwt.json"
     jwt_file.write_text('{"phony":"jwt"}')

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -349,7 +349,7 @@ def serialize_subprocess(queue, dag_folder):
     queue.put(None)
 
 
-@pytest.fixture()
+@pytest.fixture
 def timetable_plugin(monkeypatch):
     """Patch plugins manager to always and only return our custom timetable."""
     from airflow import plugins_manager

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -45,7 +45,7 @@ from airflow.utils.pydantic import BaseModel
 from tests.test_utils.config import conf_vars
 
 
-@pytest.fixture()
+@pytest.fixture
 def recalculate_patterns():
     _get_patterns.cache_clear()
     _get_regexp_patterns.cache_clear()

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -33,7 +33,7 @@ def use_debug_executor():
         yield
 
 
-@pytest.fixture()
+@pytest.fixture
 def provider_env_vars():
     """Override this fixture in provider's conftest.py"""
     return ()

--- a/tests/system/providers/google/conftest.py
+++ b/tests/system/providers/google/conftest.py
@@ -21,6 +21,6 @@ import pytest
 REQUIRED_ENV_VARS = ("SYSTEM_TESTS_GCP_PROJECT",)
 
 
-@pytest.fixture()
+@pytest.fixture
 def provider_env_vars():
     return REQUIRED_ENV_VARS

--- a/tests/test_utils/system_tests_class.py
+++ b/tests/test_utils/system_tests_class.py
@@ -67,7 +67,7 @@ class SystemTest:
         klass = request.cls
         klass.log = logging.getLogger(klass.__module__ + "." + klass.__name__)
 
-    @pytest.fixture(autouse=True, scope="function")
+    @pytest.fixture(autouse=True)
     def setup_system(self):
         """
         We want to avoid random errors while database got reset - those

--- a/tests/ti_deps/deps/test_not_previously_skipped_dep.py
+++ b/tests/ti_deps/deps/test_not_previously_skipped_dep.py
@@ -31,7 +31,7 @@ from airflow.utils.types import DagRunType
 pytestmark = pytest.mark.db_test
 
 
-@pytest.fixture(autouse=True, scope="function")
+@pytest.fixture(autouse=True)
 def clean_db(session):
     yield
     session.query(DagRun).delete()

--- a/tests/ti_deps/deps/test_runnable_exec_date_dep.py
+++ b/tests/ti_deps/deps/test_runnable_exec_date_dep.py
@@ -31,7 +31,7 @@ from airflow.utils.types import DagRunType
 pytestmark = pytest.mark.db_test
 
 
-@pytest.fixture(autouse=True, scope="function")
+@pytest.fixture(autouse=True)
 def clean_db(session):
     yield
     session.query(DagRun).delete()

--- a/tests/timetables/test_continuous_timetable.py
+++ b/tests/timetables/test_continuous_timetable.py
@@ -31,12 +31,12 @@ END_DATE = pendulum.datetime(2023, 3, 10, tz="UTC")
 AFTER_DATE = pendulum.datetime(2023, 3, 12, tz="UTC")
 
 
-@pytest.fixture()
+@pytest.fixture
 def restriction():
     return TimeRestriction(earliest=START_DATE, latest=END_DATE, catchup=True)
 
 
-@pytest.fixture()
+@pytest.fixture
 def timetable():
     return ContinuousTimetable()
 

--- a/tests/timetables/test_events_timetable.py
+++ b/tests/timetables/test_events_timetable.py
@@ -49,17 +49,17 @@ NON_EVENT_DATE = pendulum.DateTime(2021, 10, 1, tzinfo=utc)
 MOST_RECENT_EVENT = pendulum.DateTime(2021, 9, 10, tzinfo=utc)
 
 
-@pytest.fixture()
+@pytest.fixture
 def restriction():
     return TimeRestriction(earliest=START_DATE, latest=None, catchup=True)
 
 
-@pytest.fixture()
+@pytest.fixture
 def unrestricted_timetable():
     return EventsTimetable(event_dates=EVENT_DATES)
 
 
-@pytest.fixture()
+@pytest.fixture
 def restricted_timetable():
     return EventsTimetable(event_dates=EVENT_DATES, restrict_to_events=True)
 

--- a/tests/timetables/test_workday_timetable.py
+++ b/tests/timetables/test_workday_timetable.py
@@ -42,12 +42,12 @@ WEEK_2_MONDAY = pendulum.DateTime(2021, 9, 13, tzinfo=utc)
 WEEK_2_TUESDAY = pendulum.DateTime(2021, 9, 14, tzinfo=utc)
 
 
-@pytest.fixture()
+@pytest.fixture
 def restriction():
     return TimeRestriction(earliest=START_DATE, latest=None, catchup=True)
 
 
-@pytest.fixture()
+@pytest.fixture
 def timetable():
     return AfterWorkdayTimetable()
 

--- a/tests/utils/log/test_secrets_masker.py
+++ b/tests/utils/log/test_secrets_masker.py
@@ -448,7 +448,7 @@ class TestRedactedIO:
 
 
 class TestMaskSecretAdapter:
-    @pytest.fixture(scope="function", autouse=True)
+    @pytest.fixture(autouse=True)
     def reset_secrets_masker_and_skip_escape(self):
         self.secrets_masker = SecretsMasker()
         with patch("airflow.utils.log.secrets_masker._secrets_masker", return_value=self.secrets_masker):

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -88,7 +88,7 @@ class TestOpenMaybeZipped:
 
 
 class TestListPyFilesPath:
-    @pytest.fixture()
+    @pytest.fixture
     def test_dir(self, tmp_path):
         # create test tree with symlinks
         source = os.path.join(tmp_path, "folder")

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from airflow.jobs.job import Job
 
 
-@pytest.fixture()
+@pytest.fixture
 def clear_db():
     clear_db_runs()
     clear_db_dags()

--- a/tests/utils/test_task_handler_with_custom_formatter.py
+++ b/tests/utils/test_task_handler_with_custom_formatter.py
@@ -58,7 +58,7 @@ def custom_task_log_handler_config():
     logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def task_instance():
     dag = DAG(DAG_ID, start_date=DEFAULT_DATE)
     task = EmptyOperator(task_id=TASK_ID, dag=dag)

--- a/tests/www/test_auth.py
+++ b/tests/www/test_auth.py
@@ -108,17 +108,17 @@ class TestHasAccessNoDetails:
         assert result.status_code == 302
 
 
-@pytest.fixture()
+@pytest.fixture
 def get_connection():
     return [Connection("conn_1"), Connection("conn_2")]
 
 
-@pytest.fixture()
+@pytest.fixture
 def get_pool():
     return [Pool(pool="pool_1"), Pool(pool="pool_2")]
 
 
-@pytest.fixture()
+@pytest.fixture
 def get_variable():
     return [Variable("var_1"), Variable("var_2")]
 

--- a/tests/www/test_security_manager.py
+++ b/tests/www/test_security_manager.py
@@ -32,17 +32,17 @@ from airflow.security.permissions import (
 from airflow.www import app as application
 
 
-@pytest.fixture()
+@pytest.fixture
 def app():
     return application.create_app(testing=True)
 
 
-@pytest.fixture()
+@pytest.fixture
 def app_builder(app):
     return app.appbuilder
 
 
-@pytest.fixture()
+@pytest.fixture
 def security_manager(app_builder):
     return app_builder.sm
 

--- a/tests/www/views/conftest.py
+++ b/tests/www/views/conftest.py
@@ -110,27 +110,27 @@ def app(examples_dag_bag):
         delete_user(app, user_dict["username"])
 
 
-@pytest.fixture()
+@pytest.fixture
 def admin_client(app):
     return client_with_login(app, username="test_admin", password="test_admin")
 
 
-@pytest.fixture()
+@pytest.fixture
 def viewer_client(app):
     return client_with_login(app, username="test_viewer", password="test_viewer")
 
 
-@pytest.fixture()
+@pytest.fixture
 def user_client(app):
     return client_with_login(app, username="test_user", password="test_user")
 
 
-@pytest.fixture()
+@pytest.fixture
 def anonymous_client(app):
     return client_without_login(app)
 
 
-@pytest.fixture()
+@pytest.fixture
 def anonymous_client_as_admin(app):
     return client_without_login_as_admin(app)
 

--- a/tests/www/views/test_anonymous_as_admin_role.py
+++ b/tests/www/views/test_anonymous_as_admin_role.py
@@ -41,7 +41,7 @@ def clear_pools():
         session.query(Pool).delete()
 
 
-@pytest.fixture()
+@pytest.fixture
 def pool_factory(session):
     def factory(**values):
         pool = Pool(**{**POOL, **values})  # Passed in values override defaults.

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -157,17 +157,17 @@ def init_dagruns(acl_app, reset_dagruns):
     clear_db_runs()
 
 
-@pytest.fixture()
+@pytest.fixture
 def dag_test_client(acl_app):
     return client_with_login(acl_app, username="dag_test", password="dag_test")
 
 
-@pytest.fixture()
+@pytest.fixture
 def dag_faker_client(acl_app):
     return client_with_login(acl_app, username="dag_faker", password="dag_faker")
 
 
-@pytest.fixture()
+@pytest.fixture
 def all_dag_user_client(acl_app):
     return client_with_login(
         acl_app,
@@ -225,7 +225,7 @@ def user_all_dags(acl_app):
         yield user
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_all_dags(acl_app, user_all_dags):
     return client_with_login(
         acl_app,
@@ -281,7 +281,7 @@ def test_dag_autocomplete_empty(client_all_dags, query, expected):
     assert resp.json == expected
 
 
-@pytest.fixture()
+@pytest.fixture
 def setup_paused_dag():
     """Pause a DAG so we can test filtering."""
     dag_to_pause = "example_branch_operator"
@@ -326,7 +326,7 @@ def user_all_dags_dagruns(acl_app):
         yield user
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_all_dags_dagruns(acl_app, user_all_dags_dagruns):
     return client_with_login(
         acl_app,
@@ -368,7 +368,7 @@ def user_all_dags_dagruns_tis(acl_app):
         yield user
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_all_dags_dagruns_tis(acl_app, user_all_dags_dagruns_tis):
     return client_with_login(
         acl_app,
@@ -428,7 +428,7 @@ def user_all_dags_codes(acl_app):
         yield user
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_all_dags_codes(acl_app, user_all_dags_codes):
     return client_with_login(
         acl_app,
@@ -485,7 +485,7 @@ def user_all_dags_tis(acl_app):
         yield user
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_all_dags_tis(acl_app, user_all_dags_tis):
     return client_with_login(
         acl_app,
@@ -510,7 +510,7 @@ def user_all_dags_tis_xcom(acl_app):
         yield user
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_all_dags_tis_xcom(acl_app, user_all_dags_tis_xcom):
     return client_with_login(
         acl_app,
@@ -536,7 +536,7 @@ def user_dags_tis_logs(acl_app):
         yield user
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_dags_tis_logs(acl_app, user_dags_tis_logs):
     return client_with_login(
         acl_app,
@@ -692,7 +692,7 @@ def user_all_dags_edit_tis(acl_app):
         yield user
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_all_dags_edit_tis(acl_app, user_all_dags_edit_tis):
     return client_with_login(
         acl_app,
@@ -735,7 +735,7 @@ def user_only_dags_tis(acl_app):
         yield user
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_only_dags_tis(acl_app, user_only_dags_tis):
     return client_with_login(
         acl_app,
@@ -791,7 +791,7 @@ def user_no_roles(acl_app):
         yield user
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_no_roles(acl_app, user_no_roles):
     return client_with_login(
         acl_app,
@@ -810,7 +810,7 @@ def user_no_permissions(acl_app):
         yield user
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_no_permissions(acl_app, user_no_permissions):
     return client_with_login(
         acl_app,
@@ -819,7 +819,7 @@ def client_no_permissions(acl_app, user_no_permissions):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_anonymous(acl_app):
     return acl_app.test_client()
 
@@ -857,7 +857,7 @@ def user_dag_level_access_with_ti_edit(acl_app):
         yield user
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_dag_level_access_with_ti_edit(acl_app, user_dag_level_access_with_ti_edit):
     return client_with_login(
         acl_app,
@@ -896,7 +896,7 @@ def user_ti_edit_without_dag_level_access(acl_app):
         yield user
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_ti_edit_without_dag_level_access(acl_app, user_ti_edit_without_dag_level_access):
     return client_with_login(
         acl_app,

--- a/tests/www/views/test_views_base.py
+++ b/tests/www/views/test_views_base.py
@@ -60,7 +60,7 @@ def test_doc_urls(admin_client, monkeypatch):
     check_content_in_response("/api/v1/ui", resp)
 
 
-@pytest.fixture()
+@pytest.fixture
 def heartbeat_healthy():
     # case-1: healthy scheduler status
     last_heartbeat = timezone.utcnow()
@@ -80,7 +80,7 @@ def heartbeat_healthy():
         ).delete()
 
 
-@pytest.fixture()
+@pytest.fixture
 def heartbeat_too_slow():
     # case-2: unhealthy scheduler status - scenario 1 (SchedulerJob is running too slowly)
     last_heartbeat = timezone.utcnow() - datetime.timedelta(minutes=1)
@@ -103,7 +103,7 @@ def heartbeat_too_slow():
         ).delete()
 
 
-@pytest.fixture()
+@pytest.fixture
 def heartbeat_not_running():
     # case-3: unhealthy scheduler status - scenario 2 (no running SchedulerJob)
     with create_session() as session:
@@ -156,7 +156,7 @@ def delete_role_if_exists(app):
     return func
 
 
-@pytest.fixture()
+@pytest.fixture
 def non_exist_role_name(delete_role_if_exists):
     role_name = "test_roles_create_role"
     delete_role_if_exists(role_name)
@@ -164,7 +164,7 @@ def non_exist_role_name(delete_role_if_exists):
     delete_role_if_exists(role_name)
 
 
-@pytest.fixture()
+@pytest.fixture
 def exist_role_name(app, delete_role_if_exists):
     role_name = "test_roles_create_role_new"
     app.appbuilder.sm.add_role(role_name)
@@ -172,7 +172,7 @@ def exist_role_name(app, delete_role_if_exists):
     delete_role_if_exists(role_name)
 
 
-@pytest.fixture()
+@pytest.fixture
 def exist_role(app, exist_role_name):
     return app.appbuilder.sm.find_role(exist_role_name)
 
@@ -318,7 +318,7 @@ def test_views_post_access_denied(viewer_client, url):
     check_content_in_response("Access is Denied", resp)
 
 
-@pytest.fixture()
+@pytest.fixture
 def non_exist_username(app):
     username = "fake_username"
     user = app.appbuilder.sm.find_user(username)
@@ -348,7 +348,7 @@ def test_create_user(app, admin_client, non_exist_username):
     assert app.appbuilder.sm.find_user(non_exist_username)
 
 
-@pytest.fixture()
+@pytest.fixture
 def exist_username(app, exist_role):
     username = "test_edit_user_user"
     app.appbuilder.sm.add_user(

--- a/tests/www/views/test_views_blocked.py
+++ b/tests/www/views/test_views_blocked.py
@@ -32,7 +32,7 @@ from tests.test_utils.db import clear_db_runs
 pytestmark = pytest.mark.db_test
 
 
-@pytest.fixture()
+@pytest.fixture
 def running_subdag(admin_client, dag_maker):
     with dag_maker(dag_id="running_dag.subdag") as subdag:
         EmptyOperator(task_id="empty")

--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -389,7 +389,7 @@ def test_duplicate_connection_error(admin_client):
     assert expected_connections_ids == connections_ids
 
 
-@pytest.fixture()
+@pytest.fixture
 def connection():
     connection = Connection(
         conn_id="conn1",

--- a/tests/www/views/test_views_dagrun.py
+++ b/tests/www/views/test_views_dagrun.py
@@ -123,7 +123,7 @@ def test_create_dagrun_permission_denied(session, client_dr_without_dag_run_crea
     check_content_in_response("Access is Denied", resp)
 
 
-@pytest.fixture()
+@pytest.fixture
 def running_dag_run(session):
     dag = DagBag().get_dag("example_bash_operator")
     execution_date = timezone.datetime(2016, 1, 9)
@@ -144,7 +144,7 @@ def running_dag_run(session):
     return dr
 
 
-@pytest.fixture()
+@pytest.fixture
 def completed_dag_run_with_missing_task(session):
     dag = DagBag().get_dag("example_bash_operator")
     execution_date = timezone.datetime(2016, 1, 9)

--- a/tests/www/views/test_views_extra_links.py
+++ b/tests/www/views/test_views_extra_links.py
@@ -89,7 +89,7 @@ def create_dag_run(dag):
     return _create_dag_run
 
 
-@pytest.fixture()
+@pytest.fixture
 def dag_run(create_dag_run, session):
     return create_dag_run(execution_date=DEFAULT_DATE, session=session)
 

--- a/tests/www/views/test_views_home.py
+++ b/tests/www/views/test_views_home.py
@@ -125,7 +125,7 @@ def user_no_importerror(app):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_no_importerror(app, user_no_importerror):
     """Client for User that cannot access Import Errors"""
     return client_with_login(
@@ -150,7 +150,7 @@ def user_single_dag(app):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_single_dag(app, user_single_dag):
     """Client for User that can only access the first DAG from TEST_FILTER_DAG_IDS"""
     return client_with_login(
@@ -175,7 +175,7 @@ def user_single_dag_edit(app):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_single_dag_edit(app, user_single_dag_edit):
     """Client for User that can only edit the first DAG from TEST_FILTER_DAG_IDS"""
     return client_with_login(
@@ -194,7 +194,7 @@ def _process_file(file_path, session):
     dag_file_processor.process_file(file_path, [], False, session)
 
 
-@pytest.fixture()
+@pytest.fixture
 def working_dags(tmp_path):
     dag_contents_template = "from airflow import DAG\ndag = DAG('{}', tags=['{}'])"
 
@@ -205,7 +205,7 @@ def working_dags(tmp_path):
             _process_file(path, session)
 
 
-@pytest.fixture()
+@pytest.fixture
 def working_dags_with_read_perm(tmp_path):
     dag_contents_template = "from airflow import DAG\ndag = DAG('{}', tags=['{}'])"
     dag_contents_template_with_read_perm = (
@@ -222,7 +222,7 @@ def working_dags_with_read_perm(tmp_path):
             _process_file(path, session)
 
 
-@pytest.fixture()
+@pytest.fixture
 def working_dags_with_edit_perm(tmp_path):
     dag_contents_template = "from airflow import DAG\ndag = DAG('{}', tags=['{}'])"
     dag_contents_template_with_read_perm = (
@@ -239,7 +239,7 @@ def working_dags_with_edit_perm(tmp_path):
             _process_file(path, session)
 
 
-@pytest.fixture()
+@pytest.fixture
 def broken_dags(tmp_path, working_dags):
     with create_session() as session:
         for dag_id in TEST_FILTER_DAG_IDS:
@@ -248,7 +248,7 @@ def broken_dags(tmp_path, working_dags):
             _process_file(path, session)
 
 
-@pytest.fixture()
+@pytest.fixture
 def broken_dags_with_read_perm(tmp_path, working_dags_with_read_perm):
     with create_session() as session:
         for dag_id in TEST_FILTER_DAG_IDS:
@@ -257,7 +257,7 @@ def broken_dags_with_read_perm(tmp_path, working_dags_with_read_perm):
             _process_file(path, session)
 
 
-@pytest.fixture()
+@pytest.fixture
 def broken_dags_after_working(tmp_path):
     # First create and process a DAG file that works
     path = tmp_path / "all_in_one.py"

--- a/tests/www/views/test_views_log.py
+++ b/tests/www/views/test_views_log.py
@@ -198,7 +198,7 @@ def create_expected_log_file(log_path, tis):
         shutil.rmtree(sub_path)
 
 
-@pytest.fixture()
+@pytest.fixture
 def log_admin_client(log_app):
     return client_with_login(log_app, username="test", password="test")
 
@@ -278,7 +278,7 @@ def test_get_logs_with_metadata_as_download_file(log_admin_client, create_expect
 DIFFERENT_LOG_FILENAME = "{{ ti.dag_id }}/{{ ti.run_id }}/{{ ti.task_id }}/{{ try_number }}.log"
 
 
-@pytest.fixture()
+@pytest.fixture
 def dag_run_with_log_filename(tis):
     run_filters = [DagRun.dag_id == DAG_ID, DagRun.execution_date == DEFAULT_DATE]
     with create_session() as session:

--- a/tests/www/views/test_views_mount.py
+++ b/tests/www/views/test_views_mount.py
@@ -38,7 +38,7 @@ def app():
     return app
 
 
-@pytest.fixture()
+@pytest.fixture
 def client(app):
     return werkzeug.test.Client(app, werkzeug.wrappers.response.Response)
 

--- a/tests/www/views/test_views_pool.py
+++ b/tests/www/views/test_views_pool.py
@@ -41,7 +41,7 @@ def clear_pools():
         session.query(Pool).delete()
 
 
-@pytest.fixture()
+@pytest.fixture
 def pool_factory(session):
     def factory(**values):
         pool = Pool(**{**POOL, **values})  # Passed in values override defaults.

--- a/tests/www/views/test_views_rate_limit.py
+++ b/tests/www/views/test_views_rate_limit.py
@@ -27,7 +27,7 @@ from tests.test_utils.www import client_with_login
 pytestmark = pytest.mark.db_test
 
 
-@pytest.fixture()
+@pytest.fixture
 def app_with_rate_limit_one(examples_dag_bag):
     @dont_initialize_flask_app_submodules(
         skip_all_except=[

--- a/tests/www/views/test_views_rendered.py
+++ b/tests/www/views/test_views_rendered.py
@@ -44,7 +44,7 @@ DEFAULT_DATE = timezone.datetime(2020, 3, 1)
 pytestmark = pytest.mark.db_test
 
 
-@pytest.fixture()
+@pytest.fixture
 def dag():
     return DAG(
         "testdag",
@@ -54,7 +54,7 @@ def dag():
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def task1(dag):
     return BashOperator(
         task_id="task1",
@@ -63,7 +63,7 @@ def task1(dag):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def task2(dag):
     return BashOperator(
         task_id="task2",
@@ -72,7 +72,7 @@ def task2(dag):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def task3(dag):
     class TestOperator(BaseOperator):
         template_fields = ("sql",)
@@ -91,7 +91,7 @@ def task3(dag):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def task4(dag):
     def func(*op_args):
         pass
@@ -105,7 +105,7 @@ def task4(dag):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def task_secret(dag):
     return BashOperator(
         task_id="task_secret",
@@ -133,7 +133,7 @@ def reset_db(dag, task1, task2, task3, task4, task_secret):
     clear_rendered_ti_fields()
 
 
-@pytest.fixture()
+@pytest.fixture
 def create_dag_run(dag, task1, task2, task3, task4, task_secret):
     def _create_dag_run(*, execution_date, session):
         dag_run = dag.create_dagrun(
@@ -159,7 +159,7 @@ def create_dag_run(dag, task1, task2, task3, task4, task_secret):
     return _create_dag_run
 
 
-@pytest.fixture()
+@pytest.fixture
 def patch_app(app, dag):
     with mock.patch.object(app, "dag_bag") as mock_dag_bag:
         mock_dag_bag.get_dag.return_value = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -584,7 +584,7 @@ class _ForceHeartbeatCeleryExecutor(CeleryExecutor):
         return True
 
 
-@pytest.fixture()
+@pytest.fixture
 def new_id_example_bash_operator():
     dag_id = "example_bash_operator"
     test_dag_id = "non_existent_dag"
@@ -608,7 +608,7 @@ def test_delete_dag_button_for_dag_on_scheduler_only(admin_client, new_id_exampl
     check_content_in_response(f"return confirmDeleteDag(this, '{test_dag_id}')", resp)
 
 
-@pytest.fixture()
+@pytest.fixture
 def new_dag_to_delete():
     dag = DAG("new_dag_to_delete", is_paused_upon_creation=True)
     session = settings.Session()
@@ -616,7 +616,7 @@ def new_dag_to_delete():
     return dag
 
 
-@pytest.fixture()
+@pytest.fixture
 def per_dag_perm_user_client(app, new_dag_to_delete):
     sm = app.appbuilder.sm
     perm = f"{permissions.RESOURCE_DAG_PREFIX}{new_dag_to_delete.dag_id}"
@@ -646,7 +646,7 @@ def per_dag_perm_user_client(app, new_dag_to_delete):
     delete_roles(app)
 
 
-@pytest.fixture()
+@pytest.fixture
 def one_dag_perm_user_client(app):
     username = "test_user_one_dag_perm"
     dag_id = "example_bash_operator"

--- a/tests/www/views/test_views_trigger_dag.py
+++ b/tests/www/views/test_views_trigger_dag.py
@@ -37,7 +37,7 @@ from tests.test_utils.www import check_content_in_response, check_content_not_in
 pytestmark = pytest.mark.db_test
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def initialize_one_dag():
     with create_session() as session:
         DagBag().get_dag("example_bash_operator").sync_to_db(session=session)

--- a/tests/www/views/test_views_variable.py
+++ b/tests/www/views/test_views_variable.py
@@ -62,7 +62,7 @@ def user_variable_reader(app):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_variable_reader(app, user_variable_reader):
     """Client for User that can only access the first DAG from TEST_FILTER_DAG_IDS"""
     return client_with_login(
@@ -221,7 +221,7 @@ def test_description_retrieval(session, admin_client):
     assert row.key == "test_key" and row.description == "test_description"
 
 
-@pytest.fixture()
+@pytest.fixture
 def variable(session):
     variable = Variable(
         key=VARIABLE["key"],


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Enable auto-fixable or partially fixable [flake8-pytest-style (PT) rules](https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt)

```console
Run 'ruff' for extremely fast Python linting.............................Failed
- hook id: ruff
- exit code: 1
- files were modified by this hook

tests/cli/commands/test_dag_command.py:25:22: TID251 `unittest.TestCase` is banned: Use pytest compatible classes
tests/cli/commands/test_dag_command.py:601:18: PT027 Use `pytest.raises` instead of unittest-style `assertRaises`
tests/conftest.py:1115:31: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/decorators/test_bash.py:38:21: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/plugins/test_plugins_manager.py:168:35: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/providers/amazon/aws/hooks/test_eks.py:102:17: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/providers/amazon/aws/hooks/test_eks.py:136:17: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/providers/amazon/aws/hooks/test_eks.py:178:17: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/providers/amazon/aws/sensors/test_eks.py:71:21: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/providers/amazon/aws/sensors/test_eks.py:112:21: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/providers/amazon/aws/sensors/test_eks.py:160:21: PT003 `scope='function'` is implied in `@pytest.fixture()`
Found 58 errors (47 fixed, 11 remaining).
No fixes available (9 hidden fixes can be enabled with the `--unsafe-fixes` option).
tests/providers/cncf/kubernetes/operators/test_pod.py:75:17: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/providers/docker/operators/test_docker.py:141:35: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/providers/docker/test_exceptions.py:49:35: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/providers/fab/auth_manager/test_security.py:157:17: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/providers/fab/auth_manager/test_security.py:192:17: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/providers/fab/auth_manager/test_security.py:204:17: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/providers/fab/auth_manager/test_security.py:215:17: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/providers/microsoft/azure/hooks/test_container_instance.py:35:17: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/providers/openlineage/extractors/test_bash.py:46:31: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/providers/openlineage/extractors/test_python.py:61:31: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/test_utils/system_tests_class.py:70:35: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/ti_deps/deps/test_not_previously_skipped_dep.py:34:31: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/ti_deps/deps/test_runnable_exec_date_dep.py:34:31: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/utils/log/test_secrets_masker.py:451:21: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/www/views/test_views_trigger_dag.py:40:17: PT003 `scope='function'` is implied in `@pytest.fixture()`
Found 147 errors (132 fixed, 15 remaining).
No fixes available (15 hidden fixes can be enabled with the `--unsafe-fixes` option).
```

The only one which auto-fixable but not enabled in this PR is [`PT022`](https://docs.astral.sh/ruff/rules/pytest-useless-yield-fixture/)

In some easy cases it produce expected result

```diff
diff --git a/tests/cli/commands/test_info_command.py b/tests/cli/commands/test_info_command.py
index 7203371484..44287bb0ec 100644
--- a/tests/cli/commands/test_info_command.py
+++ b/tests/cli/commands/test_info_command.py
@@ -174,7 +174,7 @@ class TestAirflowInfo:
 
 @pytest.fixture
 def setup_parser():
-    yield cli_parser.get_parser()
+    return cli_parser.get_parser()
```

In another it produces semantically correct replacement but personally I've found it ugly. So better to fix it manually by the separate PR and disable autofix for this rule

```diff
diff --git a/tests/conftest.py b/tests/conftest.py
index 1847e1e909..e41d03411b 100644
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,7 +131,7 @@ def reset_db():
     from airflow.utils import db
 
     db.resetdb()
-    yield
+    return
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
