### PR TITLE
ECS Executor - add support to adopt orphaned tasks.

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -330,6 +330,15 @@ class BaseExecutor(LoggingMixin):
         """
         self.change_state(key, TaskInstanceState.SUCCESS, info)
 
+    def queued(self, key: TaskInstanceKey, info=None) -> None:
+        """
+        Set queued state for the event.
+
+        :param info: Executor information for the task instance
+        :param key: Unique key for the task instance
+        """
+        self.change_state(key, TaskInstanceState.QUEUED, info)
+
     def get_event_buffer(self, dag_ids=None) -> dict[TaskInstanceKey, EventBufferValueType]:
         """
         Return and flush the event buffer.

--- a/airflow/providers/amazon/aws/executors/ecs/utils.py
+++ b/airflow/providers/amazon/aws/executors/ecs/utils.py
@@ -78,22 +78,22 @@ class RunTaskKwargsConfigKeys(BaseConfigKeys):
     ASSIGN_PUBLIC_IP = "assign_public_ip"
     CAPACITY_PROVIDER_STRATEGY = "capacity_provider_strategy"
     CLUSTER = "cluster"
+    CONTAINER_NAME = "container_name"
     LAUNCH_TYPE = "launch_type"
     PLATFORM_VERSION = "platform_version"
     SECURITY_GROUPS = "security_groups"
     SUBNETS = "subnets"
     TASK_DEFINITION = "task_definition"
-    CONTAINER_NAME = "container_name"
 
 
 class AllEcsConfigKeys(RunTaskKwargsConfigKeys):
     """All keys loaded into the config which are related to the ECS Executor."""
 
-    MAX_RUN_TASK_ATTEMPTS = "max_run_task_attempts"
     AWS_CONN_ID = "conn_id"
-    RUN_TASK_KWARGS = "run_task_kwargs"
-    REGION_NAME = "region_name"
     CHECK_HEALTH_ON_STARTUP = "check_health_on_startup"
+    MAX_RUN_TASK_ATTEMPTS = "max_run_task_attempts"
+    REGION_NAME = "region_name"
+    RUN_TASK_KWARGS = "run_task_kwargs"
 
 
 class EcsExecutorException(Exception):
@@ -101,7 +101,7 @@ class EcsExecutorException(Exception):
 
 
 class EcsExecutorTask:
-    """Data Transfer Object for an ECS Fargate Task."""
+    """Data Transfer Object for an ECS Task."""
 
     def __init__(
         self,
@@ -111,6 +111,7 @@ class EcsExecutorTask:
         containers: list[dict[str, Any]],
         started_at: Any | None = None,
         stopped_reason: str | None = None,
+        external_executor_id: str | None = None,
     ):
         self.task_arn = task_arn
         self.last_status = last_status
@@ -118,6 +119,7 @@ class EcsExecutorTask:
         self.containers = containers
         self.started_at = started_at
         self.stopped_reason = stopped_reason
+        self.external_executor_id = external_executor_id
 
     def get_task_state(self) -> str:
         """


### PR DESCRIPTION
~~### Depends on and blocked by https://github.com/apache/airflow/pull/37784~~ <= merged

Once the external_executor_id bug is fixed, this will add the feature to adopt abandoned tasks in the ECS Executor.   To test, you can launch an ECS Executor environment and run a dag which takes a few minutes.  While it is running, kill the scheduler.  Before this change, when you restart the scheduler, the existing ECS job will be terminated and rescheduled/restarted.  After this change, the running task will be adopted; it will finish and be monitored as if it was launched by this executor/scheduler instance.

Was previously https://github.com/apache/airflow/pull/36803

closes: #35491

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
