### PR TITLE
Optimize building images including new uv version release

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -439,10 +439,6 @@ COPY <<"EOF" /common.sh
 #!/usr/bin/env bash
 set -euo pipefail
 
-: "${AIRFLOW_PIP_VERSION:?Should be set}"
-: "${AIRFLOW_UV_VERSION:?Should be set}"
-: "${AIRFLOW_USE_UV:?Should be set}"
-
 function common::get_colors() {
     COLOR_BLUE=$'\e[34m'
     COLOR_GREEN=$'\e[32m'
@@ -457,27 +453,24 @@ function common::get_colors() {
 }
 
 function common::get_packaging_tool() {
+    : "${AIRFLOW_PIP_VERSION:?Should be set}"
+    : "${AIRFLOW_UV_VERSION:?Should be set}"
+    : "${AIRFLOW_USE_UV:?Should be set}"
+
     ## IMPORTANT: IF YOU MODIFY THIS FUNCTION YOU SHOULD ALSO MODIFY CORRESPONDING FUNCTION IN
     ## `scripts/in_container/_in_container_utils.sh`
+    local PYTHON_BIN
+    PYTHON_BIN=$(which python)
     if [[ ${AIRFLOW_USE_UV} == "true" ]]; then
         echo
         echo "${COLOR_BLUE}Using 'uv' to install Airflow${COLOR_RESET}"
         echo
         export PACKAGING_TOOL="uv"
         export PACKAGING_TOOL_CMD="uv pip"
-        export EXTRA_INSTALL_FLAGS=""
-        export EXTRA_UNINSTALL_FLAGS=""
+        export EXTRA_INSTALL_FLAGS="--python ${PYTHON_BIN}"
+        export EXTRA_UNINSTALL_FLAGS="--python ${PYTHON_BIN}"
         export RESOLUTION_HIGHEST_FLAG="--resolution highest"
         export RESOLUTION_LOWEST_DIRECT_FLAG="--resolution lowest-direct"
-        # We need to lie about VIRTUAL_ENV to make uv works
-        # Until https://github.com/astral-sh/uv/issues/1396 is fixed
-        # In case we are running user installation, we need to set VIRTUAL_ENV to user's home + .local
-        if [[ ${PIP_USER=} == "true" ]]; then
-            VIRTUAL_ENV="${HOME}/.local"
-        else
-            VIRTUAL_ENV=$(python -c "import sys; print(sys.prefix)")
-        fi
-        export VIRTUAL_ENV
     else
         echo
         echo "${COLOR_BLUE}Using 'pip' to install Airflow${COLOR_RESET}"
@@ -1110,14 +1103,6 @@ ENV DEV_APT_COMMAND=${DEV_APT_COMMAND} \
 COPY --from=scripts install_os_dependencies.sh /scripts/docker/
 RUN bash /scripts/docker/install_os_dependencies.sh dev
 
-# THE 7 LINES ARE ONLY NEEDED IN ORDER TO MAKE PYMSSQL BUILD WORK WITH LATEST CYTHON
-# AND SHOULD BE REMOVED WHEN WORKAROUND IN install_mssql.sh IS REMOVED
-ARG AIRFLOW_PIP_VERSION=24.0
-ARG AIRFLOW_UV_VERSION=0.1.11
-ARG AIRFLOW_USE_UV="true"
-ENV AIRFLOW_PIP_VERSION=${AIRFLOW_PIP_VERSION} \
-    AIRFLOW_UV_VERSION=${AIRFLOW_UV_VERSION} \
-    AIRFLOW_USE_UV=${AIRFLOW_USE_UV}
 COPY --from=scripts common.sh /scripts/docker/
 
 # Only copy mysql/mssql installation scripts for now - so that changing the other
@@ -1180,7 +1165,7 @@ ARG DEFAULT_CONSTRAINTS_BRANCH="constraints-main"
 ARG AIRFLOW_CI_BUILD_EPOCH="10"
 ARG AIRFLOW_PRE_CACHED_PIP_PACKAGES="true"
 ARG AIRFLOW_PIP_VERSION=24.0
-ARG AIRFLOW_UV_VERSION=0.1.11
+ARG AIRFLOW_UV_VERSION=0.1.12
 ARG AIRFLOW_USE_UV="true"
 # Setup PIP
 # By default PIP install run without cache to make image smaller
@@ -1201,6 +1186,10 @@ ARG AIRFLOW_VERSION=""
 
 # Additional PIP flags passed to all pip install commands except reinstalling pip itself
 ARG ADDITIONAL_PIP_INSTALL_FLAGS=""
+
+ARG AIRFLOW_PIP_VERSION=24.0
+ARG AIRFLOW_UV_VERSION=0.1.12
+ARG AIRFLOW_USE_UV="true"
 
 ENV AIRFLOW_REPO=${AIRFLOW_REPO}\
     AIRFLOW_BRANCH=${AIRFLOW_BRANCH} \

--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -63,25 +63,18 @@ function in_container_go_to_airflow_sources() {
 function in_container_get_packaging_tool() {
     ## IMPORTANT: IF YOU MODIFY THIS FUNCTION YOU SHOULD ALSO MODIFY CORRESPONDING FUNCTION IN
     ## `scripts/docker/common.sh`
+    local PYTHON_BIN
+    PYTHON_BIN=$(which python)
     if [[ ${AIRFLOW_USE_UV} == "true" ]]; then
         echo
         echo "${COLOR_BLUE}Using 'uv' to install Airflow${COLOR_RESET}"
         echo
         export PACKAGING_TOOL=""
         export PACKAGING_TOOL_CMD="uv pip"
-        export EXTRA_INSTALL_FLAGS=""
-        export EXTRA_UNINSTALL_FLAGS=""
+        export EXTRA_INSTALL_FLAGS="--python ${PYTHON_BIN}"
+        export EXTRA_UNINSTALL_FLAGS="--python ${PYTHON_BIN}"
         export RESOLUTION_HIGHEST_FLAG="--resolution highest"
         export RESOLUTION_LOWEST_DIRECT_FLAG="--resolution lowest-direct"
-        # We need to lie about VIRTUAL_ENV to make uv works
-        # Until https://github.com/astral-sh/uv/issues/1396 is fixed
-        # In case we are running user installation, we need to set VIRTUAL_ENV to user's home + .local
-        if [[ ${PIP_USER=} == "true" ]]; then
-            VIRTUAL_ENV="${HOME}/.local"
-        else
-            VIRTUAL_ENV=$(python -c "import sys; print(sys.prefix)")
-        fi
-        export VIRTUAL_ENV
     else
         echo
         echo "${COLOR_BLUE}Using 'pip' to install Airflow${COLOR_RESET}"

--- a/scripts/in_container/run_generate_constraints.py
+++ b/scripts/in_container/run_generate_constraints.py
@@ -131,22 +131,24 @@ class ConfigParams:
 
     @cached_property
     def get_freeze_command(self) -> list[str]:
-        if self.use_uv:
-            return ["uv", "pip", "freeze"]
-        else:
-            return ["pip", "freeze"]
+        # Some day we might use uv instead of pip
+        # if self.use_uv:
+        #     return ["uv", "pip", "freeze", "--python", sys.executable]
+        # else:
+        #     return ["pip", "freeze"]
+        return ["pip", "freeze"]
 
     @cached_property
     def get_install_command(self) -> list[str]:
         if self.use_uv:
-            return ["uv", "pip", "install"]
+            return ["uv", "pip", "install", "--python", sys.executable]
         else:
             return ["pip", "install"]
 
     @cached_property
     def get_uninstall_command(self) -> list[str]:
         if self.use_uv:
-            return ["uv", "pip", "uninstall"]
+            return ["uv", "pip", "uninstall", "--python", sys.executable]
         else:
             return ["pip", "uninstall"]
 


### PR DESCRIPTION
This PR optimizes image building together with upgrading to the new `uv` release 0.1.12. The relese introduces `--python` flag that adds the possibility of installing packages in non-venv environments (which our CI image are) without pretending it's a virtualenv.

It also removes a long standing workaround where we needed to preinstall some python packages for mysql installation - this is not needed any more and we can move PIP and UV args after installing system dependencies which brings back optimized experience of not having to reinstall system packages when only `pip` or `uv` version changes.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
