### PR TITLE
Avoid non-recommended usage of logging

### DIFF
--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -177,7 +177,7 @@ class DagFileProcessorProcess(LoggingMixin, MultiprocessingStartMethodMixin):
                 # gets sent to logs and logs are sent to stdout, this leads to an infinite loop. This
                 # necessitates this conditional based on the value of DAG_PROCESSOR_LOG_TARGET.
                 with redirect_stdout(StreamLogWriter(log, logging.INFO)), redirect_stderr(
-                    StreamLogWriter(log, logging.WARN)
+                    StreamLogWriter(log, logging.WARNING)
                 ), Stats.timer() as timer:
                     _handle_dag_file_processing()
             log.info("Processing %s took %.3f seconds", file_path, timer.duration)

--- a/airflow/jobs/backfill_job_runner.py
+++ b/airflow/jobs/backfill_job_runner.py
@@ -681,11 +681,10 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
                             try:
                                 session.commit()
                             except OperationalError:
-                                self.log.error(
+                                self.log.exception(
                                     "Failed to commit task state due to operational error. "
                                     "The job will retry this operation so if your backfill succeeds, "
                                     "you can safely ignore this message.",
-                                    exc_info=True,
                                 )
                                 session.rollback()
                                 if i == max_attempts - 1:
@@ -986,10 +985,9 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
             # state to failed.
             self._set_unfinished_dag_runs_to_failed(ti_status.active_runs)
         except OperationalError:
-            self.log.error(
+            self.log.exception(
                 "Backfill job dead-locked. The job will retry the job so it is likely "
                 "to heal itself. If your backfill succeeds you can ignore this exception.",
-                exc_info=True,
             )
             raise
         finally:

--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -242,11 +242,15 @@ class Variable(Base, LoggingMixin):
                 try:
                     var_val = secrets_backend.get_variable(key=key)
                     if var_val is not None:
+                        _backend_name = type(secrets_backend).__name__
                         log.warning(
-                            "The variable {key} is defined in the {cls} secrets backend, which takes "
+                            "The variable %s is defined in the %s secrets backend, which takes "
                             "precedence over reading from the database. The value in the database will be "
                             "updated, but to read it you have to delete the conflicting variable "
-                            "from {cls}".format(key=key, cls=secrets_backend.__class__.__name__)
+                            "from %s",
+                            key,
+                            _backend_name,
+                            _backend_name,
                         )
                         return
                 except Exception:

--- a/airflow/providers/amazon/aws/operators/sagemaker.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker.py
@@ -349,13 +349,13 @@ class SageMakerProcessingOperator(SageMakerBaseOperator):
             for processing_input in processing_inputs:
                 inputs.append(self.path_to_s3_dataset(processing_input["S3Input"]["S3Uri"]))
         except KeyError:
-            self.log.exception("Cannot find S3 input details", exc_info=True)
+            self.log.exception("Cannot find S3 input details")
 
         try:
             for processing_output in processing_outputs:
                 outputs.append(self.path_to_s3_dataset(processing_output["S3Output"]["S3Uri"]))
         except KeyError:
-            self.log.exception("Cannot find S3 output details.", exc_info=True)
+            self.log.exception("Cannot find S3 output details.")
         return inputs, outputs
 
 
@@ -777,7 +777,7 @@ class SageMakerTransformOperator(SageMakerBaseOperator):
         try:
             model_package_arn = self.serialized_model["PrimaryContainer"]["ModelPackageName"]
         except KeyError:
-            self.log.error("Cannot find Model Package Name.", exc_info=True)
+            self.log.exception("Cannot find Model Package Name.")
 
         try:
             transform_input = self.serialized_transform["TransformInput"]["DataSource"]["S3DataSource"][
@@ -785,7 +785,7 @@ class SageMakerTransformOperator(SageMakerBaseOperator):
             ]
             transform_output = self.serialized_transform["TransformOutput"]["S3OutputPath"]
         except KeyError:
-            self.log.error("Cannot find some required input/output details.", exc_info=True)
+            self.log.exception("Cannot find some required input/output details.")
 
         inputs = []
 
@@ -813,7 +813,7 @@ class SageMakerTransformOperator(SageMakerBaseOperator):
             for container in model_containers:
                 model_data_urls.append(container["ModelDataUrl"])
         except KeyError:
-            self.log.exception("Cannot retrieve model details.", exc_info=True)
+            self.log.exception("Cannot retrieve model details.")
 
         return model_data_urls
 

--- a/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -431,10 +431,9 @@ class KubernetesExecutor(BaseExecutor):
                     self.kube_scheduler.run_next(task)
                     self.task_publish_retries.pop(key, None)
                 except PodReconciliationError as e:
-                    self.log.error(
+                    self.log.exception(
                         "Pod reconciliation failed, likely due to kubernetes library upgrade. "
                         "Try clearing the task to re-run.",
-                        exc_info=True,
                     )
                     self.fail(task[0], e)
                 except ApiException as e:

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -835,7 +835,7 @@ class DataprocCreateClusterOperator(GoogleCloudBaseOperator):
             except AirflowException as ae_inner:
                 # We could get any number of failures here, including cluster not found and we
                 # can just ignore to ensure we surface the original cluster create failure
-                self.log.error(ae_inner, exc_info=True)
+                self.log.exception(ae_inner)
             finally:
                 raise ae
 

--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
     from airflow.models import Base
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 ARCHIVE_TABLE_PREFIX = "_airflow_deleted__"
 

--- a/airflow/utils/log/task_context_logger.py
+++ b/airflow/utils/log/task_context_logger.py
@@ -143,7 +143,7 @@ class TaskContextLogger:
         :param msg: the message to relay to task context log
         :param ti: the task instance
         """
-        self._log(logging.WARN, msg, *args, ti=ti)
+        self._log(logging.WARNING, msg, *args, ti=ti)
 
     def warning(self, msg: str, *args, ti: TaskInstance):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1303,8 +1303,14 @@ namespace-packages = ["airflow/providers"]
 [tool.ruff.lint]
 typing-modules = ["airflow.typing_compat"]
 extend-select = [
+    # Enable entire ruff rule section
     "I", # Missing required import (auto-fixable)
     "UP", # Pyupgrade
+    "ISC",  # Checks for implicit literal string concatenation (auto-fixable)
+    "TCH", # Rules around TYPE_CHECKING blocks
+    "G", # flake8-logging-format rules
+    "LOG", # flake8-logging rules, most of them autofixable
+    # Per rule enables
     "RUF100", # Unused noqa (auto-fixable)
     # We ignore more pydocstyle than we enable, so be more selective at what we enable
     "D101",
@@ -1321,10 +1327,8 @@ extend-select = [
     "D403",
     "D412",
     "D419",
-    "TCH",  # Rules around TYPE_CHECKING blocks
     "TID251",  # Specific modules or module members that may not be imported or accessed
     "TID253",  # Ban certain modules from being imported at module level
-    "ISC",  # Checks for implicit literal string concatenation (auto-fixable)
     "B006", # Checks for uses of mutable objects as function argument defaults.
     "PT001",
     "PT003",
@@ -1337,6 +1341,8 @@ extend-select = [
     "PT027",
 ]
 ignore = [
+    "G003", # Logging statement uses + (not fixed yet)
+    "G004", # Logging statement uses f-string (not fixed yet)
     "D203",
     "D212",
     "D213",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Enable two `ruff` checks for the logging and usages:
- [flake8-logging-format (G)](https://docs.astral.sh/ruff/rules/#flake8-logging-format-g), skip two rules for now since it required to make more changes, which could make review longer
   - "Logging statement uses +" `G003`
   - "Logging statement uses f-string" `G004`
- [flake8-logging (LOG)](https://docs.astral.sh/ruff/rules/#flake8-logging-log)

Example of rule violations before manual + auto fixes
```console
Run 'ruff' for extremely fast Python linting.............................Failed
- hook id: ruff
- exit code: 1
- files were modified by this hook

airflow/jobs/backfill_job_runner.py:684:42: G201 Logging `.exception(...)` should be used instead of `.error(..., exc_info=True)`
airflow/jobs/backfill_job_runner.py:989:22: G201 Logging `.exception(...)` should be used instead of `.error(..., exc_info=True)`
airflow/models/variable.py:246:29: G001 Logging statement uses `str.format`
airflow/providers/amazon/aws/operators/sagemaker.py:352:64: G202 Logging statement has redundant `exc_info`
airflow/providers/amazon/aws/operators/sagemaker.py:358:66: G202 Logging statement has redundant `exc_info`
airflow/providers/amazon/aws/operators/sagemaker.py:780:22: G201 Logging `.exception(...)` should be used instead of `.error(..., exc_info=True)`
airflow/providers/amazon/aws/operators/sagemaker.py:788:22: G201 Logging `.exception(...)` should be used instead of `.error(..., exc_info=True)`
airflow/providers/amazon/aws/operators/sagemaker.py:816:66: G202 Logging statement has redundant `exc_info`
airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py:434:30: G201 Logging `.exception(...)` should be used instead of `.error(..., exc_info=True)`
airflow/providers/google/cloud/operators/dataproc.py:838:26: G201 Logging `.exception(...)` should be used instead of `.error(..., exc_info=True)`
airflow/utils/db_cleanup.py:52:28: LOG002 Use `__name__` with `logging.getLogger()`
Found 13 errors (2 fixed, 11 remaining).
No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
