### PR TITLE
[OpenLineage] feat: Add metrics for event_size and extraction time

### DIFF
--- a/airflow/providers/openlineage/plugins/listener.py
+++ b/airflow/providers/openlineage/plugins/listener.py
@@ -21,15 +21,18 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from openlineage.client.serde import Serde
+
 from airflow.listeners import hookimpl
 from airflow.providers.openlineage.extractors import ExtractorManager
-from airflow.providers.openlineage.plugins.adapter import OpenLineageAdapter
+from airflow.providers.openlineage.plugins.adapter import OpenLineageAdapter, RunState
 from airflow.providers.openlineage.utils.utils import (
     get_airflow_run_facet,
     get_custom_facets,
     get_job_name,
     print_warning,
 )
+from airflow.stats import Stats
 from airflow.utils.timeout import timeout
 
 if TYPE_CHECKING:
@@ -82,8 +85,11 @@ class OpenLineageListener:
                 execution_date=task_instance.execution_date,
                 try_number=task_instance.try_number,
             )
+            event_type = RunState.RUNNING.value.lower()
+            operator_name = task.task_type.lower()
 
-            task_metadata = self.extractor_manager.extract_metadata(dagrun, task)
+            with Stats.timer(f"ol.extract.{event_type}.{operator_name}"):
+                task_metadata = self.extractor_manager.extract_metadata(dagrun, task)
 
             start_date = task_instance.start_date if task_instance.start_date else datetime.now()
             data_interval_start = (
@@ -91,7 +97,7 @@ class OpenLineageListener:
             )
             data_interval_end = dagrun.data_interval_end.isoformat() if dagrun.data_interval_end else None
 
-            self.adapter.start_task(
+            redacted_event = self.adapter.start_task(
                 run_id=task_uuid,
                 job_name=get_job_name(task),
                 job_description=dag.description,
@@ -107,6 +113,10 @@ class OpenLineageListener:
                     **get_custom_facets(task_instance),
                     **get_airflow_run_facet(dagrun, dag, task_instance, task, task_uuid),
                 },
+            )
+            Stats.gauge(
+                f"ol.event.size.{event_type}.{operator_name}",
+                len(Serde.to_json(redacted_event).encode("utf-8")),
             )
 
         on_running()
@@ -129,20 +139,27 @@ class OpenLineageListener:
                 execution_date=task_instance.execution_date,
                 try_number=task_instance.try_number - 1,
             )
+            event_type = RunState.COMPLETE.value.lower()
+            operator_name = task.task_type.lower()
 
-            task_metadata = self.extractor_manager.extract_metadata(
-                dagrun, task, complete=True, task_instance=task_instance
-            )
+            with Stats.timer(f"ol.extract.{event_type}.{operator_name}"):
+                task_metadata = self.extractor_manager.extract_metadata(
+                    dagrun, task, complete=True, task_instance=task_instance
+                )
 
             end_date = task_instance.end_date if task_instance.end_date else datetime.now()
 
-            self.adapter.complete_task(
+            redacted_event = self.adapter.complete_task(
                 run_id=task_uuid,
                 job_name=get_job_name(task),
                 parent_job_name=dag.dag_id,
                 parent_run_id=parent_run_id,
                 end_time=end_date.isoformat(),
                 task=task_metadata,
+            )
+            Stats.gauge(
+                f"ol.event.size.{event_type}.{operator_name}",
+                len(Serde.to_json(redacted_event).encode("utf-8")),
             )
 
         on_success()
@@ -165,20 +182,27 @@ class OpenLineageListener:
                 execution_date=task_instance.execution_date,
                 try_number=task_instance.try_number,
             )
+            event_type = RunState.FAIL.value.lower()
+            operator_name = task.task_type.lower()
 
-            task_metadata = self.extractor_manager.extract_metadata(
-                dagrun, task, complete=True, task_instance=task_instance
-            )
+            with Stats.timer(f"ol.extract.{event_type}.{operator_name}"):
+                task_metadata = self.extractor_manager.extract_metadata(
+                    dagrun, task, complete=True, task_instance=task_instance
+                )
 
             end_date = task_instance.end_date if task_instance.end_date else datetime.now()
 
-            self.adapter.fail_task(
+            redacted_event = self.adapter.fail_task(
                 run_id=task_uuid,
                 job_name=get_job_name(task),
                 parent_job_name=dag.dag_id,
                 parent_run_id=parent_run_id,
                 end_time=end_date.isoformat(),
                 task=task_metadata,
+            )
+            Stats.gauge(
+                f"ol.event.size.{event_type}.{operator_name}",
+                len(Serde.to_json(redacted_event).encode("utf-8")),
             )
 
         on_failure()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Adding metrics. Event size (operator name scope, event type scope), extraction time (operator name scope, event type scope) and sending time (transport scope, event type scope).


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
