### PR TITLE
Updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,34 @@ newer versions of ``bazel`` will handle it.
 If you wish to install Airflow using those tools, you should use the constraint files and convert
 them to the appropriate format and workflow that your tool requires.
 
-
 ```bash
-pip install 'apache-airflow==2.8.2' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
+pip install 'apache-airflow==2.8.2' \
+ --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
 ```
 
 2. Installing with extras (i.e., postgres, google)
+
+```bash
+pip install 'apache-airflow[postgres,google]==2.8.2' \
+ --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
+```
+
+In case you encounter the following error
+
+```bash
+At line:2 char:4
++  --constraint "https://raw.githubusercontent.com/apache/airflow/const ...
++    ~
+Missing expression after unary operator '--'.
+At line:2 char:4
++  --constraint "https://raw.githubusercontent.com/apache/airflow/const ...
++    ~~~~~~~~~~
+Unexpected token 'constraint' in expression or statement.
+    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
+    + FullyQualifiedErrorId : MissingExpressionAfterOperator
+```
+
+Try using the command
 
 ```bash
 pip install 'apache-airflow==2.8.2' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"

--- a/README.md
+++ b/README.md
@@ -181,14 +181,14 @@ them to the appropriate format and workflow that your tool requires.
 
 ```bash
 pip install 'apache-airflow==2.8.2'
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
+--constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
 ```
 
 2. Installing with extras (i.e., postgres, google)
 
 ```bash
-pip install 'apache-airflow[postgres,google]==2.8.2'
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
+pip install 'apache-airflow==2.8.2'
+--constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
 ```
 
 For information on installing provider packages, check

--- a/README.md
+++ b/README.md
@@ -180,14 +180,14 @@ them to the appropriate format and workflow that your tool requires.
 
 
 ```bash
-pip install 'apache-airflow==2.8.2' \
+pip install 'apache-airflow==2.8.2'
  --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
 ```
 
 2. Installing with extras (i.e., postgres, google)
 
 ```bash
-pip install 'apache-airflow[postgres,google]==2.8.2' \
+pip install 'apache-airflow[postgres,google]==2.8.2'
  --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
 ```
 

--- a/README.md
+++ b/README.md
@@ -180,15 +180,13 @@ them to the appropriate format and workflow that your tool requires.
 
 
 ```bash
-pip install 'apache-airflow==2.8.2'
---constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
+pip install 'apache-airflow==2.8.2' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
 ```
 
 2. Installing with extras (i.e., postgres, google)
 
 ```bash
-pip install 'apache-airflow==2.8.2'
---constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
+pip install 'apache-airflow==2.8.2' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
 ```
 
 For information on installing provider packages, check


### PR DESCRIPTION
A follow up PR to #37727 . Instead of replacing the command to install Apache Airflow on Windows Environment, I have added the error details and an alternate to the original for anyone who faces the same error. The given PyPI installation command in the documentation throws the following error when one tries to download and install Apache Airflow on windows environment.

## Error Message

```bash
At line:2 char:4
+  --constraint "https://raw.githubusercontent.com/apache/airflow/const ...
+    ~
Missing expression after unary operator '--'.
At line:2 char:4
+  --constraint "https://raw.githubusercontent.com/apache/airflow/const ...
+    ~~~~~~~~~~
Unexpected token 'constraint' in expression or statement.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : MissingExpressionAfterOperator
```

## Solution

The original bash command given in the documentation might not work on windows environment. For which we have an alternate command given by

### Original command
```bash
pip install 'apache-airflow==2.8.2' \
>>  --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
```

### Alternate command
```bash
pip install 'apache-airflow==2.8.2' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.8.txt"
```