### PR TITLE
`MappedOperator` setter methods

### DIFF
--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -420,10 +420,18 @@ class MappedOperator(AbstractOperator):
     def depends_on_past(self) -> bool:
         return bool(self.partial_kwargs.get("depends_on_past"))
 
+    @depends_on_past.setter
+    def depends_on_past(self, value: bool) -> None:
+        self.partial_kwargs["depends_on_past"] = value
+
     @property
     def ignore_first_depends_on_past(self) -> bool:
         value = self.partial_kwargs.get("ignore_first_depends_on_past", DEFAULT_IGNORE_FIRST_DEPENDS_ON_PAST)
         return bool(value)
+
+    @ignore_first_depends_on_past.setter
+    def ignore_first_depends_on_past(self, value: bool) -> None:
+        self.partial_kwargs["ignore_first_depends_on_past"] = value
 
     @property
     def wait_for_past_depends_before_skipping(self) -> bool:
@@ -432,61 +440,121 @@ class MappedOperator(AbstractOperator):
         )
         return bool(value)
 
+    @wait_for_past_depends_before_skipping.setter
+    def wait_for_past_depends_before_skipping(self, value: bool) -> None:
+        self.partial_kwargs["wait_for_past_depends_before_skipping"] = value
+
     @property
     def wait_for_downstream(self) -> bool:
         return bool(self.partial_kwargs.get("wait_for_downstream"))
+
+    @wait_for_downstream.setter
+    def wait_for_downstream(self, value: bool) -> None:
+        self.partial_kwargs["wait_for_downstream"] = value
 
     @property
     def retries(self) -> int | None:
         return self.partial_kwargs.get("retries", DEFAULT_RETRIES)
 
+    @retries.setter
+    def retries(self, value: int | None) -> None:
+        self.partial_kwargs["retries"] = value
+
     @property
     def queue(self) -> str:
         return self.partial_kwargs.get("queue", DEFAULT_QUEUE)
+
+    @queue.setter
+    def queue(self, value: str | None) -> None:
+        self.partial_kwargs["queue"] = value
 
     @property
     def pool(self) -> str:
         return self.partial_kwargs.get("pool", Pool.DEFAULT_POOL_NAME)
 
+    @pool.setter
+    def pool(self, value: str | None) -> None:
+        self.partial_kwargs["pool"] = value
+
     @property
     def pool_slots(self) -> str | None:
         return self.partial_kwargs.get("pool_slots", DEFAULT_POOL_SLOTS)
+
+    @pool_slots.setter
+    def pool_slots(self, value: str | None) -> None:
+        self.partial_kwargs["pool_slots"] = value
 
     @property
     def execution_timeout(self) -> datetime.timedelta | None:
         return self.partial_kwargs.get("execution_timeout")
 
+    @execution_timeout.setter
+    def execution_timeout(self, value: datetime.timedelta | None) -> None:
+        self.partial_kwargs["execution_timeout"] = value
+
     @property
     def max_retry_delay(self) -> datetime.timedelta | None:
         return self.partial_kwargs.get("max_retry_delay")
+
+    @max_retry_delay.setter
+    def max_retry_delay(self, value: datetime.timedelta | None) -> None:
+        self.partial_kwargs["max_retry_delay"] = value
 
     @property
     def retry_delay(self) -> datetime.timedelta:
         return self.partial_kwargs.get("retry_delay", DEFAULT_RETRY_DELAY)
 
+    @retry_delay.setter
+    def retry_delay(self, value: datetime.timedelta | None) -> None:
+        self.partial_kwargs["retry_delay"] = value
+
     @property
     def retry_exponential_backoff(self) -> bool:
         return bool(self.partial_kwargs.get("retry_exponential_backoff"))
+
+    @retry_exponential_backoff.setter
+    def retry_exponential_backoff(self, value: bool | None) -> None:
+        self.partial_kwargs["retry_exponential_backoff"] = value
 
     @property
     def priority_weight(self) -> int:  # type: ignore[override]
         return self.partial_kwargs.get("priority_weight", DEFAULT_PRIORITY_WEIGHT)
 
+    @priority_weight.setter
+    def priority_weight(self, value: int | None) -> None:
+        self.partial_kwargs["priority_weight"] = value
+
     @property
     def weight_rule(self) -> str:  # type: ignore[override]
         return self.partial_kwargs.get("weight_rule", DEFAULT_WEIGHT_RULE)
+
+    @weight_rule.setter
+    def weight_rule(self, value: str | None) -> None:
+        self.partial_kwargs["weight_rule"] = value
 
     @property
     def sla(self) -> datetime.timedelta | None:
         return self.partial_kwargs.get("sla")
 
+    @sla.setter
+    def sla(self, value: datetime.timedelta | None) -> None:
+        self.partial_kwargs["sla"] = value
+
     @property
     def max_active_tis_per_dag(self) -> int | None:
         return self.partial_kwargs.get("max_active_tis_per_dag")
 
+    @max_active_tis_per_dag.setter
+    def max_active_tis_per_dag(self, value: int | None) -> None:
+        self.partial_kwargs["max_active_tis_per_dag"] = value
+
     @property
     def max_active_tis_per_dagrun(self) -> int | None:
         return self.partial_kwargs.get("max_active_tis_per_dagrun")
+
+    @max_active_tis_per_dagrun.setter
+    def max_active_tis_per_dagrun(self, value: int | None) -> None:
+        self.partial_kwargs["max_active_tis_per_dagrun"] = value
 
     @property
     def resources(self) -> Resources | None:


### PR DESCRIPTION
Closes #37013 

Addresses this issue referenced that prevents cluster policies from modifying attributes on dynamically mapped tasks by adding lots of additional `setter` methods to the `MappedOperator`.