### PR TITLE
Better error message for internal api call error

### DIFF
--- a/airflow/api_internal/internal_api_call.py
+++ b/airflow/api_internal/internal_api_call.py
@@ -103,7 +103,8 @@ def internal_api_call(func: Callable[PS, RT]) -> Callable[PS, RT]:
         response = requests.post(url=internal_api_endpoint, data=json.dumps(data), headers=headers)
         if response.status_code != 200:
             raise AirflowException(
-                f"Got {response.status_code}:{response.reason} when sending the internal api request."
+                f"Got {response.status_code}:{response.reason} when sending "
+                f"the internal api request: {response.text}"
             )
         return response.content
 


### PR DESCRIPTION
Previously would not show the real reason, just e.g. 400:BAD REQUEST
