### PR TITLE
Properly serialize TaskInstancePydantic and DagRunPydantic

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -528,7 +528,7 @@ class BaseSerialization:
             def _pydantic_model_dump(model_cls: type[BaseModel], var: Any) -> dict[str, Any]:
                 return model_cls.model_validate(var).model_dump(mode="json")  # type: ignore[attr-defined]
 
-            if isinstance(var, Job):
+            if isinstance(var, (Job, JobPydantic)):
                 return cls._encode(_pydantic_model_dump(JobPydantic, var), type_=DAT.BASE_JOB)
             elif isinstance(var, (TaskInstance, TaskInstancePydantic)):
                 return cls._encode(_pydantic_model_dump(TaskInstancePydantic, var), type_=DAT.TASK_INSTANCE)
@@ -536,9 +536,9 @@ class BaseSerialization:
                 return cls._encode(_pydantic_model_dump(DagRunPydantic, var), type_=DAT.DAG_RUN)
             elif isinstance(var, Dataset):
                 return cls._encode(_pydantic_model_dump(DatasetPydantic, var), type_=DAT.DATA_SET)
-            elif isinstance(var, DagModel):
+            elif isinstance(var, (DagModel, DagModelPydantic)):
                 return cls._encode(_pydantic_model_dump(DagModelPydantic, var), type_=DAT.DAG_MODEL)
-            elif isinstance(var, LogTemplate):
+            elif isinstance(var, (LogTemplate, LogTemplatePydantic)):
                 return cls._encode(_pydantic_model_dump(LogTemplatePydantic, var), type_=DAT.LOG_TEMPLATE)
             else:
                 return cls.default_serialization(strict, var)

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -315,7 +315,6 @@ _type_to_class = {
     DAT.LOG_TEMPLATE: [LogTemplatePydantic, LogTemplate],
 }
 _class_to_type = {cls_: type_ for type_, classes in _type_to_class.items() for cls_ in classes}
-_to_pydantic = set(_class_to_type.keys())
 
 
 class BaseSerialization:
@@ -546,7 +545,7 @@ class BaseSerialization:
             def _pydantic_model_dump(model_cls: type[BaseModel], var: Any) -> dict[str, Any]:
                 return model_cls.model_validate(var).model_dump(mode="json")  # type: ignore[attr-defined]
 
-            if var.__class__ in _to_pydantic:
+            if var.__class__ in _class_to_type:
                 pyd_mod = _orm_to_model.get(var.__class__, var)
                 mod = _pydantic_model_dump(pyd_mod, var)
                 type_ = _class_to_type[var.__class__]

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -530,9 +530,9 @@ class BaseSerialization:
 
             if isinstance(var, Job):
                 return cls._encode(_pydantic_model_dump(JobPydantic, var), type_=DAT.BASE_JOB)
-            elif isinstance(var, TaskInstance):
+            elif isinstance(var, (TaskInstance, TaskInstancePydantic)):
                 return cls._encode(_pydantic_model_dump(TaskInstancePydantic, var), type_=DAT.TASK_INSTANCE)
-            elif isinstance(var, DagRun):
+            elif isinstance(var, (DagRun, DagRunPydantic)):
                 return cls._encode(_pydantic_model_dump(DagRunPydantic, var), type_=DAT.DAG_RUN)
             elif isinstance(var, Dataset):
                 return cls._encode(_pydantic_model_dump(DatasetPydantic, var), type_=DAT.DATA_SET)

--- a/tests/serialization/test_serialized_objects.py
+++ b/tests/serialization/test_serialized_objects.py
@@ -336,6 +336,7 @@ def test_serialize_deserialize_pydantic(input, pydantic_class, encoded_type, cmp
 
 
 def test_all_pydantic_models_round_trip():
+    pytest.importorskip("pydantic", minversion="2.0.0")
     classes = set()
     mods_folder = REPO_ROOT / "airflow/serialization/pydantic"
     for p in mods_folder.iterdir():

--- a/tests/serialization/test_serialized_objects.py
+++ b/tests/serialization/test_serialized_objects.py
@@ -26,7 +26,6 @@ import pytest
 from dateutil import relativedelta
 from kubernetes.client import models as k8s
 from pendulum.tz.timezone import Timezone
-from pydantic import BaseModel
 
 from airflow.datasets import Dataset
 from airflow.exceptions import SerializationError
@@ -52,6 +51,7 @@ from airflow.serialization.serialized_objects import BaseSerialization
 from airflow.settings import _ENABLE_AIP_44
 from airflow.utils import timezone
 from airflow.utils.operator_resources import Resources
+from airflow.utils.pydantic import BaseModel
 from airflow.utils.state import DagRunState, State
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.types import DagRunType

--- a/tests/serialization/test_serialized_objects.py
+++ b/tests/serialization/test_serialized_objects.py
@@ -304,6 +304,12 @@ def test_serialize_deserialize_pydantic(input, pydantic_class, encoded_type, cmp
     assert isinstance(deserialized, pydantic_class)
     assert cmp_func(input, deserialized)
 
+    # verify that when we round trip a pydantic model we get the same thing
+    reserialized = BaseSerialization.serialize(deserialized, use_pydantic_models=True)
+    dereserialized = BaseSerialization.deserialize(reserialized, use_pydantic_models=True)
+    assert isinstance(dereserialized, pydantic_class)
+    assert dereserialized == deserialized
+
     # Verify recursive behavior
     obj = [[input]]
     BaseSerialization.serialize(obj, use_pydantic_models=True)  # does not raise

--- a/tests/serialization/test_serialized_objects.py
+++ b/tests/serialization/test_serialized_objects.py
@@ -336,15 +336,12 @@ def test_serialize_deserialize_pydantic(input, pydantic_class, encoded_type, cmp
 
 
 def test_all_pydantic_models_round_trip():
-    from pathlib import Path
-
     classes = set()
-    rootdir = Path("../..").resolve()
-    mods_folder = rootdir / "airflow/serialization/pydantic"
+    mods_folder = REPO_ROOT / "airflow/serialization/pydantic"
     for p in mods_folder.iterdir():
         if p.name.startswith("__"):
             continue
-        relpath = str(p.relative_to(rootdir).stem)
+        relpath = str(p.relative_to(REPO_ROOT).stem)
         mod = import_module(f"airflow.serialization.pydantic.{relpath}")
         for name, obj in inspect.getmembers(mod):
             if inspect.isclass(obj) and issubclass(obj, BaseModel):


### PR DESCRIPTION
Previously we handled serialization of TaskInstance and DagRun, converting to the respective pydantic model. E.g. we give a TI and it comes out as TaskInstancePydantic.  But when we passed TaskInstancePydantic to the serializer, we did not encode it, so it hit the default "encoding" which is to simply stringify it.  With this change, TaskInstancePydantic will serialize to TaskInstancePydantic, etc.
