### PR TITLE
Session is not used in _do_render_template_fields

### DIFF
--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -33,7 +33,6 @@ from airflow.template.templater import Templater
 from airflow.utils.context import Context
 from airflow.utils.db import exists_query
 from airflow.utils.log.secrets_masker import redact
-from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.setup_teardown import SetupTeardownContext
 from airflow.utils.sqlalchemy import with_row_locks
 from airflow.utils.state import State, TaskInstanceState
@@ -659,7 +658,6 @@ class AbstractOperator(Templater, DAGNode):
             dag = self.get_dag()
         return super().get_template_env(dag=dag)
 
-    @provide_session
     def _do_render_template_fields(
         self,
         parent: Any,
@@ -667,8 +665,6 @@ class AbstractOperator(Templater, DAGNode):
         context: Context,
         jinja_env: jinja2.Environment,
         seen_oids: set[int],
-        *,
-        session: Session = NEW_SESSION,
     ) -> None:
         """Override the base to use custom error logging."""
         for attr_name in template_fields:

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -752,5 +752,4 @@ class MappedOperator(AbstractOperator):
             context=context,
             jinja_env=jinja_env,
             seen_oids=seen_oids,
-            session=session,
         )

--- a/airflow/template/templater.py
+++ b/airflow/template/templater.py
@@ -23,11 +23,9 @@ from typing import TYPE_CHECKING, Any, Collection, Iterable, Sequence
 from airflow.utils.helpers import render_template_as_native, render_template_to_string
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.mixins import ResolveMixin
-from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
     import jinja2
-    from sqlalchemy.orm import Session
 
     from airflow import DAG
     from airflow.models.operator import Operator
@@ -103,7 +101,6 @@ class Templater(LoggingMixin):
                                 self.log.exception("Failed to get source %s", item)
         self.prepare_template()
 
-    @provide_session
     def _do_render_template_fields(
         self,
         parent: Any,
@@ -111,8 +108,6 @@ class Templater(LoggingMixin):
         context: Context,
         jinja_env: jinja2.Environment,
         seen_oids: set[int],
-        *,
-        session: Session = NEW_SESSION,
     ) -> None:
         for attr_name in template_fields:
             value = getattr(parent, attr_name)


### PR DESCRIPTION
It's not used so, we should be able to remove it.  The context here is AIP-44 -- it's important to identify which functions require database access and which don't.
