### PR TITLE
Ensure "airflow.task" logger used for TaskInstancePydantic and TaskInstance

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1334,6 +1334,7 @@ class TaskInstance(Base, LoggingMixin):
 
     :meta private:
     """
+    _logger_name = "airflow.task"
 
     def __init__(
         self,
@@ -1435,8 +1436,6 @@ class TaskInstance(Base, LoggingMixin):
     @reconstructor
     def init_on_load(self) -> None:
         """Initialize the attributes that aren't stored in the DB."""
-        # correctly config the ti log
-        self._log = logging.getLogger("airflow.task")
         self.test_mode = False  # can be changed when calling 'run'
 
     @hybrid_property

--- a/airflow/serialization/pydantic/taskinstance.py
+++ b/airflow/serialization/pydantic/taskinstance.py
@@ -114,6 +114,10 @@ class TaskInstancePydantic(BaseModelPydantic, LoggingMixin):
 
     model_config = ConfigDict(from_attributes=True, arbitrary_types_allowed=True)
 
+    @property
+    def _logger_name(self):
+        return "airflow.task"
+
     def init_run_context(self, raw: bool = False) -> None:
         """Set the log context."""
         self.raw = raw


### PR DESCRIPTION
Airflow TIs are assumed to log to the "airflow.task" logger.  TaskInstance was configuring this in the "reconstructor", a sqlalchemy thing that is processed on loading from DB.  But there's no equivalent for Pydantic models, and when running a task with TaskInstancePydantic, the wrong logger was used (fully qualified class name).  When looking for a solution, I saw that LoggingMixin will check `_logger_name` and if set will use it.  This works for the pydantic model and seems better for TI anyway so I updated both.
