### PR TITLE
Fix mypy checks failing in new types-docutils

### DIFF
--- a/docs/exts/substitution_extensions.py
+++ b/docs/exts/substitution_extensions.py
@@ -28,7 +28,7 @@ from sphinx.transforms import SphinxTransform
 from sphinx.transforms.post_transforms.code import HighlightLanguageTransform
 
 if TYPE_CHECKING:
-    from docutils.nodes import Node, system_message
+    from docutils.utils import SystemMessage
     from sphinx.application import Sphinx
 
 LOGGER = logging.getLogger(__name__)
@@ -86,7 +86,7 @@ class SubstitutionCodeBlockTransform(SphinxTransform):
             node.rawsource = node.astext()
 
 
-def substitution_code_role(*args, **kwargs) -> tuple[list[Node], list[system_message]]:
+def substitution_code_role(*args, **kwargs) -> tuple[list, list[SystemMessage]]:
     """Decorate an inline code so that SubstitutionCodeBlockTransform will notice it"""
     [node], system_messages = code_role(*args, **kwargs)
     node[_SUBSTITUTION_OPTION_NAME] = True


### PR DESCRIPTION
The types-docutils clarify type of some objects returned.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
